### PR TITLE
make: add NDEBUG option to netsurf build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ install-netsurf: install-libiconv
 	ls $(ICONV) 1> /dev/null || (printf "\e[33mERROR: you need to install libiconv in your system (on MacOS on with Homebrew)\e[0m\n"; exit 1;) && \
 	export PREFIX=$(BC_NS) && \
 	export OPTLDFLAGS="-L$(ICONV)/lib" && \
-	export OPTCFLAGS="-I$(ICONV)/include" && \
+	export OPTCFLAGS="-DNDEBUG -I$(ICONV)/include" && \
 	printf "\e[33mInstalling libwapcaplet...\e[0m\n" && \
 	cd vendor/netsurf/libwapcaplet && \
 	BUILDDIR=$(BC_NS)/build/libwapcaplet make install && \


### PR DESCRIPTION
In order to remove the debug output from the parser.

```
$ make shell 
Building shell...
JS Repl
exit with Ctrl+D or "exit"
> 
Goodbye...
```

How to fix locally?
```
rm -fr vendor/netsurf/{lib,include}/* && make install-netsurf
```
