### PR TITLE
dom: processing instruction inherits from node

### DIFF
--- a/src/dom/processing_instruction.zig
+++ b/src/dom/processing_instruction.zig
@@ -2,12 +2,20 @@ const std = @import("std");
 
 const parser = @import("../netsurf.zig");
 
-const CharacterData = @import("character_data.zig").CharacterData;
-
 // https://dom.spec.whatwg.org/#processinginstruction
 pub const ProcessingInstruction = struct {
     pub const Self = parser.ProcessingInstruction;
-    pub const prototype = *CharacterData;
+
+    // TODO for libdom processing instruction inherit from node.
+    // But the spec says it must inherit from CDATA.
+    // Moreover, inherit from Node causes also a crash with cloneNode.
+    // https://github.com/lightpanda-io/browsercore/issues/123
+    //
+    // In consequence, for now, we don't implement all these func for
+    // ProcessingInstruction.
+    //
+    //pub const prototype = *CharacterData;
+
     pub const mem_guarantied = true;
 
     pub fn get_target(self: *parser.ProcessingInstruction) ![]const u8 {


### PR DESCRIPTION
In libdom, processing instruction inherits from Node instead of character data as it's defined in the spec.
So using CDATA crashes.
https://github.com/lightpanda-io/libdom/blob/master/src/core/pi.c#L20

For now I revert to link w/ Node and avoid crashes.



fix #121

Relates with https://github.com/lightpanda-io/browsercore/issues/123