### PR TITLE
netsurf: fix documentHTMLParseFromStr

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -64,7 +64,7 @@ pub fn main() !void {
     const file = try std.fs.cwd().openFile("test.html", .{});
     defer file.close();
 
-    doc = try parser.documentHTMLParseFromFile(file);
+    doc = try parser.documentHTMLParse(file.reader());
     defer parser.documentHTMLClose(doc) catch |err| {
         std.debug.print("documentHTMLClose error: {s}\n", .{@errorName(err)});
     };

--- a/src/main_shell.zig
+++ b/src/main_shell.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
     const file = try std.fs.cwd().openFile("test.html", .{});
     defer file.close();
 
-    doc = try parser.documentHTMLParseFromFile(file);
+    doc = try parser.documentHTMLParse(file.reader());
     defer parser.documentHTMLClose(doc) catch |err| {
         std.debug.print("documentHTMLClose error: {s}\n", .{@errorName(err)});
     };

--- a/src/netsurf.zig
+++ b/src/netsurf.zig
@@ -1393,12 +1393,6 @@ fn parserErr(err: HubbubErr) ParserError!void {
     };
 }
 
-// documentHTMLParseFromFile parses the given HTML file.
-// The caller is responsible for closing the document.
-pub fn documentHTMLParseFromFile(file: std.fs.File) !*DocumentHTML {
-    return try documentHTMLParse(file.reader());
-}
-
 // documentHTMLParseFromStr parses the given HTML string.
 // The caller is responsible for closing the document.
 pub fn documentHTMLParseFromStr(str: []const u8) !*DocumentHTML {

--- a/src/run_tests.zig
+++ b/src/run_tests.zig
@@ -41,7 +41,7 @@ fn testExecFn(
     const file = try std.fs.cwd().openFile("test.html", .{});
     defer file.close();
 
-    doc = try parser.documentHTMLParseFromFile(file);
+    doc = try parser.documentHTMLParse(file.reader());
     defer parser.documentHTMLClose(doc) catch |err| {
         std.debug.print("documentHTMLClose error: {s}\n", .{@errorName(err)});
     };

--- a/src/wpt/run.zig
+++ b/src/wpt/run.zig
@@ -20,7 +20,7 @@ pub fn run(arena: *std.heap.ArenaAllocator, comptime apis: []jsruntime.API, comp
     const file = try std.fs.cwd().openFile(f, .{});
     defer file.close();
 
-    const html_doc = try parser.documentHTMLParseFromFile(file);
+    const html_doc = try parser.documentHTMLParse(file.reader());
     const doc = parser.documentHTMLToDocument(html_doc);
 
     const dirname = fspath.dirname(f[dir.len..]) orelse unreachable;


### PR DESCRIPTION
Also replace `documentHTMLParseFromFile` with `documentHTMLParse` with a reader argument