### PR TITLE
dom: attr: fix crash w/o parent

### DIFF
--- a/src/netsurf.zig
+++ b/src/netsurf.zig
@@ -863,6 +863,11 @@ pub fn attributeGetValue(a: *Attribute) !?[]const u8 {
 }
 
 pub fn attributeSetValue(a: *Attribute, v: []const u8) !void {
+    // if the attribute has no owner/parent, the function crashes.
+    if (try attributeGetOwnerElement(a) == null) {
+        return DOMError.NotSupported;
+    }
+
     const err = attributeVtable(a).dom_attr_set_value.?(a, try strFromData(v));
     try DOMErr(err);
 }


### PR DESCRIPTION
libdom crashes when setting the value on an attr w/o parent.
The root cause is here: https://github.com/lightpanda-io/libdom/blob/master/src/core/attr.c#L560

I don't really know how to fix it, so I do prefer return a proper error in this case.
I could change netsurf itself, but I think it's better/easier to do this test in zig instead.

WDYT @francisbouvier ?