### PR TITLE
browser: display js err trace on debug mode

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const Types = @import("root").Types;
 
@@ -384,7 +385,11 @@ pub const Page = struct {
             if (res.success) {
                 log.debug("eval inline: {s}", .{res.result});
             } else {
-                log.info("eval inline: {s}", .{res.result});
+                if (builtin.mode == .Debug and res.stack != null) {
+                    log.info("eval inline: {s}", .{res.stack.?});
+                } else {
+                    log.info("eval inline: {s}", .{res.result});
+                }
             }
 
             return;
@@ -430,7 +435,11 @@ pub const Page = struct {
         if (res.success) {
             log.debug("eval remote {s}: {s}", .{ src, res.result });
         } else {
-            log.info("eval remote {s}: {s}", .{ src, res.result });
+            if (builtin.mode == .Debug and res.stack != null) {
+                log.info("eval remote {s}: {s}", .{ src, res.stack.? });
+            } else {
+                log.info("eval remote {s}: {s}", .{ src, res.result });
+            }
             return FetchError.JsErr;
         }
     }


### PR DESCRIPTION
Before this PR:
```console
$ zig build get -- 'https://hn.algolia.com/'
steps [10/13] debug(browser): starting GET https://hn.algolia.com/
info(browser): GET https://hn.algolia.com/ http.Status.ok
debug(browser): header content-type: text/html; charset=utf-8
debug(browser): parse html with charset utf-8                        
debug(browser): start js env                                          
debug(browser): setup global env                                                                                                             
debug(browser): eval inline: undefined                                                                                                       
debug(browser): starting GET /public/main-9a3290b0988f93446c47.js     
debug(browser): starting fetch script /public/main-9a3290b0988f93446c47.js                                                                   
info(browser): fech script https://hn.algolia.com/public/main-9a3290b0988f93446c47.js: http.Status.ok                                        
debug(browser): cache _public_main-9a3290b0988f93446c47.js.cache
info(browser): eval remote /public/main-9a3290b0988f93446c47.js: TypeError: Cannot read properties of null (reading 'content')               
```

After this PR:
```console
$ zig build get -- 'https://hn.algolia.com/'
steps [10/13] debug(browser): starting GET https://hn.algolia.com/
info(browser): GET https://hn.algolia.com/ http.Status.ok
debug(browser): header content-type: text/html; charset=utf-8
debug(browser): parse html with charset utf-8                        
debug(browser): start js env                                          
debug(browser): setup global env                                                                                                             
debug(browser): eval inline: undefined                                                                                                       
debug(browser): starting GET /public/main-9a3290b0988f93446c47.js     
debug(browser): starting fetch script /public/main-9a3290b0988f93446c47.js                                                                   
info(browser): fech script https://hn.algolia.com/public/main-9a3290b0988f93446c47.js: http.Status.ok                                        
debug(browser): cache _public_main-9a3290b0988f93446c47.js.cache
info(browser): eval remote /public/main-9a3290b0988f93446c47.js: TypeError: Cannot read properties of null (reading 'content')               
    at eval (webpack-internal:///8537:539:30)                   
    at 8537 (/public/main-9a3290b0988f93446c47.js:1:1913823)          
    at __webpack_require__ (/public/main-9a3290b0988f93446c47.js:1:2614143)                                                                  
    at eval (webpack-internal:///7788:639:22)                         
    at 7788 (/public/main-9a3290b0988f93446c47.js:1:1857687)    
    at __webpack_require__ (/public/main-9a3290b0988f93446c47.js:1:2614143)                                                                  
    at /public/main-9a3290b0988f93446c47.js:1:2614961
    at /public/main-9a3290b0988f93446c47.js:1:2614988  
```