### PR TITLE
[ON HOLD] docker: upgrade deps build to zig 0.12.0-dev.3518+d2be725e4

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -13,7 +13,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: lightpanda-io/browsercore-deps
-  ZIG_DOCKER_VERSION: 0.12.0-dev.1773-8a8fd47d2
+  ZIG_DOCKER_VERSION: 0.12.0-dev.3518-d2be725e4
 
 jobs:
   build-deps:

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,7 +1,7 @@
 # This dockerfile is used to build browsercore vendor dependencies except
 # jsruntime-lib v8.
 # jsruntime-lib v8 is built via zig-v8-fork/Dockerfile.
-ARG ZIG_DOCKER_VERSION=0.11.0
+ARG ZIG_DOCKER_VERSION=0.12.0-dev.3518-d2be725e4
 FROM ghcr.io/lightpanda-io/zig:${ZIG_DOCKER_VERSION} as build
 
 # Install required dependencies


### PR DESCRIPTION
:warning: This PR is on hold, see https://github.com/lightpanda-io/project/issues/97 for details