### PR TITLE
ci: add --security-opt seccomp=unconfined docker option

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -50,6 +50,11 @@ jobs:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker blocks io_uring syscalls by default now.
+      # see https://github.com/tigerbeetle/tigerbeetle/pull/1995
+      # see https://github.com/moby/moby/pull/46762
+      options: "--security-opt seccomp=unconfined"
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -17,6 +17,7 @@ on:
       - "src/*.zig"
       - "tests/wpt/**"
       - "vendor/**"
+      - ".github/**"
   pull_request:
 
     # By default GH trigger on types opened, synchronize and reopened.
@@ -33,6 +34,7 @@ on:
       - "src/*.zig"
       - "tests/wpt/**"
       - "vendor/**"
+      - ".github/**"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -100,6 +100,11 @@ jobs:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker blocks io_uring syscalls by default now.
+      # see https://github.com/tigerbeetle/tigerbeetle/pull/1995
+      # see https://github.com/moby/moby/pull/46762
+      options: "--security-opt seccomp=unconfined"
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -16,6 +16,7 @@ on:
       - "src/**/*.zig"
       - "src/*.zig"
       - "vendor/zig-js-runtime"
+      - ".github/**"
   pull_request:
 
     # By default GH trigger on types opened, synchronize and reopened.
@@ -31,6 +32,7 @@ on:
       - "src/**/*.zig"
       - "src/*.zig"
       - "vendor/**"
+      - ".github/**"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
It seems docker blocks io_uring by default using seccomp.

see tigerbeetle/tigerbeetle#1995 and moby/moby#46762

relates with https://github.com/lightpanda-io/zig-js-runtime/issues/232