### PR TITLE
browser: fix invalid deinit order

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -125,10 +125,10 @@ pub const Session = struct {
         self.env.deinit();
         self.arena.deinit();
 
-        self.loader.deinit();
-        self.loop.deinit();
-        self.storageShed.deinit();
         self.httpClient.deinit();
+        self.loader.deinit();
+        self.storageShed.deinit();
+        self.loop.deinit();
         self.alloc.destroy(self);
     }
 


### PR DESCRIPTION
http client depends on io loop and must be deinit before.

fix #261 