### PR TITLE
ci: target cpu x86_64 to improve CPU compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/install
 
       - name: zig build
-        run: zig build --release=safe -Doptimize=ReleaseSafe -Dengine=v8 -Dcpu=x86_64_v3+aes
+        run: zig build --release=safe -Doptimize=ReleaseSafe -Dengine=v8 -Dcpu=x86_64
 
       - name: Rename binary
         run: mv zig-out/bin/browsercore-get lightpanda-get-${{ env.ARCH }}-${{ env.OS }}


### PR DESCRIPTION
The `-Dcpu` option force compiling using less CPU's capabilities. This will improve the binary compatibility with older CPUs.

Relates with #264 