### PR TITLE
cdp: browserContextId is optional in Target.createTarget

### DIFF
--- a/src/cdp/target.zig
+++ b/src/cdp/target.zig
@@ -278,7 +278,7 @@ fn createTarget(
         url: []const u8,
         width: ?u64 = null,
         height: ?u64 = null,
-        browserContextId: []const u8,
+        browserContextId: ?[]const u8 = null,
         enableBeginFrameControl: bool = false,
         newWindow: bool = false,
         background: bool = false,

--- a/src/cdp/target.zig
+++ b/src/cdp/target.zig
@@ -301,7 +301,7 @@ fn createTarget(
             .targetId = ctx.state.frameID,
             .title = "",
             .url = ctx.state.url,
-            .browserContextId = ContextID,
+            .browserContextId = msg.params.?.browserContextId orelse ContextID,
         },
         .waitingForDebugger = true,
     };


### PR DESCRIPTION
https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createTarget