### PR TITLE
docker: use absolute path with WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ EOF
 # clone lightpanda
 RUN git clone git@github.com:lightpanda-io/browser.git
 
-WORKDIR browser
+WORKDIR /browser
 
 # install deps
 RUN git submodule init && \


### PR DESCRIPTION
remove following the warning
```
 1 warning found (use docker --debug to expand):
 - WorkdirRelativePath: Relative workdir "browser" can have unexpected results if the base image changes (line 48)
 ```