### PR TITLE
ci: remove useless token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 
@@ -52,7 +51,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -48,7 +48,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 
@@ -69,7 +68,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 
@@ -90,7 +88,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_CI_PAT }}
           # fetch submodules recusively, to get zig-js-runtime submodules also.
           submodules: recursive
 


### PR DESCRIPTION
The repos are public now, we don't need the token anymore to fetch.