### PR TITLE
server: implement /json/list

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -578,6 +578,16 @@ fn Client(comptime S: type) type {
                 return self.send(self.server.json_version_response, false);
             }
 
+            const json_list_response =
+                "HTTP/1.1 200 OK\r\n" ++
+                "Content-Length: 47\r\n" ++
+                "Content-Type: application/json; charset=UTF-8\r\n\r\n" ++
+                "[{\"id\":\"1\",\"type\":\"page\",\"url\":\"abount:blank\"}]";
+
+            if (std.mem.eql(u8, url, "/json/list")) {
+                return self.send(json_list_response, false);
+            }
+
             return error.NotFound;
         }
 
@@ -1123,12 +1133,12 @@ pub fn run(
 
 // Utils
 // --------
-
+//
 fn buildJSONVersionResponse(
     allocator: Allocator,
     address: net.Address,
 ) ![]const u8 {
-    const body_format = "{{\"webSocketDebuggerUrl\": \"ws://{}/\"}}";
+    const body_format = "{{\"Browser\": \"Chrome/132.0.6834.110\", \"WebKit-Version\": \"537.36 (@df453a35f099772fdb954e33551388add2ca3cde)\", \"webSocketDebuggerUrl\": \"ws://{}/\"}}";
     const body_len = std.fmt.count(body_format, .{address});
 
     const response_format =


### PR DESCRIPTION
Mimic Chrome's endpoints to enable Selenium CDP connection.

Selenium requires:

On `/json/version`, `Browser` with a Chrome version and `WebkitVersion`.
On `json/list`, at least one item containing `id`, `url` and `type`.

:warning: This PR blocks on WS connection.