### PR TITLE
Add explicit commands to binary

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: run puppeteer
         run: |
           python3 -m http.server 1234 -d ./public & echo $! > PYTHON.pid
-          ./lightpanda & echo $! > LPD.pid
+          ./lightpanda serve & echo $! > LPD.pid
           RUNS=100 npm run bench-puppeteer-cdp > puppeteer.out || exit 1
           cat /proc/`cat LPD.pid`/status |grep VmHWM|grep -oP '\d+' > LPD.VmHWM
           kill `cat LPD.pid` `cat PYTHON.pid`

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ COPY --from=0 /browser/zig-out/bin/lightpanda /bin/lightpanda
 
 EXPOSE 9222/tcp
 
-CMD ["/bin/lightpanda", "--host", "0.0.0.0", "--port", "9222"]
+CMD ["/bin/lightpanda", "serve", "--host", "0.0.0.0", "--port", "9222"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ chmod a+x ./lightpanda
 ### Dump an URL
 
 ```console
-./lightpanda --dump https://lightpanda.io
+./lightpanda fetch --dump https://lightpanda.io
 ```
 ```console
 info(browser): GET https://lightpanda.io/ http.Status.ok
@@ -73,7 +73,7 @@ info(browser): eval remote https://api.website.lightpanda.io/js/script.js: TypeE
 ### Start a CDP server
 
 ```console
-./lightpanda --host 127.0.0.1 --port 9222
+./lightpanda serve --host 127.0.0.1 --port 9222
 ```
 ```console
 info(websocket): starting blocking worker to listen on 127.0.0.1:9222


### PR DESCRIPTION
Changes are fairly superfluous. I wanted to remove the error.NoError, but then thought having more explicit command -> options might be good (especially if we add more command and/or options).

I also dupe the string arguments (i.e. `host`). While not duping them is safe on linux/darwin, it isn't clear to me from the documentation that this is guaranteed.