### PR TITLE
Add Usage Telemetry

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -64,6 +64,7 @@ jobs:
     env:
       MAX_MEMORY: 28000
       MAX_AVG_DURATION: 24
+      LIGHTPANDA_DISABLE_TELEMETRY: true
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-cache
 zig-out
 /vendor/netsurf/out
 /vendor/libiconv/
+lightpanda.id

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ await context.close();
 await browser.disconnect();
 ```
 
+### Telemetry
+By default, Lightpanda collects and sends usage telemetry. This can be disabled by setting an environment variable `LIGHTPANDA_DISABLE_TELEMETRY=true`. You can read Lightpanda's privacy policy at: [https://lightpanda.io/privacy-policy](https://lightpanda.io/privacy-policy).
+
 ## Status
 
 Lightpanda is still a work in progress and is currently at a Beta stage.

--- a/src/app.zig
+++ b/src/app.zig
@@ -4,6 +4,11 @@ const Loop = @import("jsruntime").Loop;
 const Allocator = std.mem.Allocator;
 const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 
+pub const RunMode = enum {
+    serve,
+    fetch,
+};
+
 // Container for global state / objects that various parts of the system
 // might need.
 pub const App = struct {
@@ -11,14 +16,14 @@ pub const App = struct {
     allocator: Allocator,
     telemetry: Telemetry,
 
-    pub fn init(allocator: Allocator) !App {
+    pub fn init(allocator: Allocator, run_mode: RunMode) !App {
         const loop = try allocator.create(Loop);
         errdefer allocator.destroy(loop);
 
         loop.* = try Loop.init(allocator);
         errdefer loop.deinit();
 
-        const telemetry = Telemetry.init(allocator, loop);
+        const telemetry = Telemetry.init(allocator, loop, run_mode);
         errdefer telemetry.deinit();
 
         return .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -4,6 +4,8 @@ const Loop = @import("jsruntime").Loop;
 const Allocator = std.mem.Allocator;
 const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 
+const log = std.log.scoped(.app);
+
 pub const RunMode = enum {
     serve,
     fetch,
@@ -13,6 +15,7 @@ pub const RunMode = enum {
 // might need.
 pub const App = struct {
     loop: *Loop,
+    app_dir_path: ?[]const u8,
     allocator: Allocator,
     telemetry: Telemetry,
 
@@ -23,19 +26,42 @@ pub const App = struct {
         loop.* = try Loop.init(allocator);
         errdefer loop.deinit();
 
-        const telemetry = Telemetry.init(allocator, run_mode);
+        const app_dir_path = getAndMakeAppDir(allocator);
+        const telemetry = Telemetry.init(allocator, run_mode, app_dir_path);
         errdefer telemetry.deinit();
 
         return .{
             .loop = loop,
             .allocator = allocator,
             .telemetry = telemetry,
+            .app_dir_path = app_dir_path,
         };
     }
 
     pub fn deinit(self: *App) void {
+        if (self.app_dir_path) |app_dir_path| {
+            self.allocator.free(app_dir_path);
+        }
+
         self.telemetry.deinit();
         self.loop.deinit();
         self.allocator.destroy(self.loop);
     }
 };
+
+fn getAndMakeAppDir(allocator: Allocator) ?[]const u8 {
+    const app_dir_path = std.fs.getAppDataDir(allocator, "lightpanda") catch |err| {
+        log.warn("failed to get lightpanda data dir: {}", .{err});
+        return null;
+    };
+
+    std.fs.makeDirAbsolute(app_dir_path) catch |err| switch (err) {
+        error.PathAlreadyExists => return app_dir_path,
+        else => {
+            allocator.free(app_dir_path);
+            log.warn("failed to create lightpanda data dir: {}", .{err});
+            return null;
+        }
+    };
+    return app_dir_path;
+}

--- a/src/app.zig
+++ b/src/app.zig
@@ -23,7 +23,7 @@ pub const App = struct {
         loop.* = try Loop.init(allocator);
         errdefer loop.deinit();
 
-        const telemetry = Telemetry.init(allocator, loop, run_mode);
+        const telemetry = Telemetry.init(allocator, run_mode);
         errdefer telemetry.deinit();
 
         return .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const Loop = @import("jsruntime").Loop;
 const Allocator = std.mem.Allocator;
 const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 
@@ -8,8 +9,8 @@ const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 pub const App = struct {
     telemetry: Telemetry,
 
-    pub fn init(allocator: Allocator) !App {
-        const telemetry = Telemetry.init(allocator);
+    pub fn init(allocator: Allocator, loop: *Loop) !App {
+        const telemetry = Telemetry.init(allocator, loop);
         errdefer telemetry.deinit();
 
         return .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
+
+// Container for global state / objects that various parts of the system
+// might need.
+pub const App = struct {
+    telemetry: Telemetry,
+
+    pub fn init(allocator: Allocator) !App {
+        const telemetry = Telemetry.init(allocator);
+        errdefer telemetry.deinit();
+
+        return .{
+            .telemetry = telemetry,
+        };
+    }
+
+    pub fn deinit(self: *App) void {
+        self.telemetry.deinit();
+    }
+};

--- a/src/app.zig
+++ b/src/app.zig
@@ -61,7 +61,7 @@ fn getAndMakeAppDir(allocator: Allocator) ?[]const u8 {
             allocator.free(app_dir_path);
             log.warn("failed to create lightpanda data dir: {}", .{err});
             return null;
-        }
+        },
     };
     return app_dir_path;
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -7,18 +7,30 @@ const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 // Container for global state / objects that various parts of the system
 // might need.
 pub const App = struct {
+    loop: *Loop,
+    allocator: Allocator,
     telemetry: Telemetry,
 
-    pub fn init(allocator: Allocator, loop: *Loop) !App {
+    pub fn init(allocator: Allocator) !App {
+        const loop = try allocator.create(Loop);
+        errdefer allocator.destroy(loop);
+
+        loop.* = try Loop.init(allocator);
+        errdefer loop.deinit();
+
         const telemetry = Telemetry.init(allocator, loop);
         errdefer telemetry.deinit();
 
         return .{
+            .loop = loop,
+            .allocator = allocator,
             .telemetry = telemetry,
         };
     }
 
     pub fn deinit(self: *App) void {
         self.telemetry.deinit();
+        self.loop.deinit();
+        self.allocator.destroy(self.loop);
     }
 };

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -33,6 +33,7 @@ const Loop = jsruntime.Loop;
 const Env = jsruntime.Env;
 const Module = jsruntime.Module;
 
+const App = @import("../app.zig").App;
 const apiweb = @import("../apiweb.zig");
 
 const Window = @import("../html/window.zig").Window;
@@ -59,7 +60,7 @@ pub const user_agent = "Lightpanda/1.0";
 // A browser contains only one session.
 // TODO allow multiple sessions per browser.
 pub const Browser = struct {
-    loop: *Loop,
+    app: *App,
     session: ?*Session,
     allocator: Allocator,
     http_client: HttpClient,
@@ -68,9 +69,10 @@ pub const Browser = struct {
 
     const SessionPool = std.heap.MemoryPool(Session);
 
-    pub fn init(allocator: Allocator, loop: *Loop) Browser {
+    pub fn init(app: *App) Browser {
+        const allocator = app.allocator;
         return .{
-            .loop = loop,
+            .app = app,
             .session = null,
             .allocator = allocator,
             .http_client = .{ .allocator = allocator },
@@ -109,6 +111,8 @@ pub const Browser = struct {
 // You can create successively multiple pages for a session, but you must
 // deinit a page before running another one.
 pub const Session = struct {
+    app: *App,
+
     browser: *Browser,
 
     // The arena is used only to bound the js env init b/c it leaks memory.
@@ -133,8 +137,10 @@ pub const Session = struct {
     jstypes: [Types.len]usize = undefined,
 
     fn init(self: *Session, browser: *Browser, ctx: anytype) !void {
-        const allocator = browser.allocator;
+        const app = browser.app;
+        const allocator = app.allocator;
         self.* = .{
+            .app = app,
             .env = undefined,
             .browser = browser,
             .inspector = undefined,
@@ -145,7 +151,7 @@ pub const Session = struct {
         };
 
         const arena = self.arena.allocator();
-        Env.init(&self.env, arena, browser.loop, null);
+        Env.init(&self.env, arena, app.loop, null);
         errdefer self.env.deinit();
         try self.env.load(&self.jstypes);
 
@@ -238,7 +244,7 @@ pub const Session = struct {
         std.debug.assert(self.page != null);
 
         // Reset all existing callbacks.
-        self.browser.loop.reset();
+        self.app.loop.reset();
 
         self.env.stop();
         // TODO unload document: https://html.spec.whatwg.org/#unloading-documents
@@ -333,6 +339,7 @@ pub const Page = struct {
     // see Inspector.contextCreated
     pub fn navigate(self: *Page, uri: []const u8, aux_data: ?[]const u8) !void {
         const arena = self.arena;
+        self.session.app.telemetry.record(.{ .navigate = {} });
 
         log.debug("starting GET {s}", .{uri});
 

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -339,7 +339,6 @@ pub const Page = struct {
     // see Inspector.contextCreated
     pub fn navigate(self: *Page, uri: []const u8, aux_data: ?[]const u8) !void {
         const arena = self.arena;
-        self.session.app.telemetry.record(.{ .navigate = {} });
 
         log.debug("starting GET {s}", .{uri});
 
@@ -365,6 +364,11 @@ pub const Page = struct {
         self.origin = buf.items;
 
         // TODO handle fragment in url.
+
+        self.session.app.telemetry.record(.{ .navigate = .{
+            .proxy = false,
+            .tls = std.ascii.eqlIgnoreCase(self.uri.scheme, "https"),
+        } });
 
         // load the data
         var resp = try self.session.loader.get(arena, self.uri);

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -263,7 +263,7 @@ const TestContext = struct {
 
 pub fn context() TestContext {
     return .{
-        .app = App.init(std.testing.allocator) catch unreachable,
+        .app = App.init(std.testing.allocator, .serve) catch unreachable,
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
     };
 }

--- a/src/id.zig
+++ b/src/id.zig
@@ -66,7 +66,7 @@ pub fn Incrementing(comptime T: type, comptime prefix: []const u8) type {
     };
 }
 
-fn uuidv4(hex: []u8) void {
+pub fn uuidv4(hex: []u8) void {
     std.debug.assert(hex.len == 36);
 
     var bin: [16]u8 = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,9 +70,9 @@ pub fn main() !void {
                 return args.printUsageAndExit(false);
             };
 
-            var app = try @import("app.zig").App.init(alloc);
+            var app = try @import("app.zig").App.init(alloc, .serve);
             defer app.deinit();
-            app.telemetry.record(.{ .run = .{ .mode = .serve, .version = version } });
+            app.telemetry.record(.{ .run = {} });
 
             const timeout = std.time.ns_per_s * @as(u64, opts.timeout);
             server.run(&app, address, timeout) catch |err| {
@@ -83,9 +83,9 @@ pub fn main() !void {
         .fetch => |opts| {
             log.debug("Fetch mode: url {s}, dump {any}", .{ opts.url, opts.dump });
 
-            var app = try @import("app.zig").App.init(alloc);
+            var app = try @import("app.zig").App.init(alloc, .fetch);
             defer app.deinit();
-            app.telemetry.record(.{ .run = .{ .mode = .fetch, .version = version } });
+            app.telemetry.record(.{ .run = {} });
 
             // vm
             const vm = jsruntime.VM.init();

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,15 +70,12 @@ pub fn main() !void {
                 return args.printUsageAndExit(false);
             };
 
-            var loop = try jsruntime.Loop.init(alloc);
-            defer loop.deinit();
-
-            var app = try @import("app.zig").App.init(alloc, &loop);
+            var app = try @import("app.zig").App.init(alloc);
             defer app.deinit();
             app.telemetry.record(.{ .run = .{ .mode = .serve, .version = version } });
 
             const timeout = std.time.ns_per_s * @as(u64, opts.timeout);
-            server.run(alloc, address, timeout, &loop, &app) catch |err| {
+            server.run(&app, address, timeout) catch |err| {
                 log.err("Server error", .{});
                 return err;
             };
@@ -86,11 +83,7 @@ pub fn main() !void {
         .fetch => |opts| {
             log.debug("Fetch mode: url {s}, dump {any}", .{ opts.url, opts.dump });
 
-            // loop
-            var loop = try jsruntime.Loop.init(alloc);
-            defer loop.deinit();
-
-            var app = try @import("app.zig").App.init(alloc, &loop);
+            var app = try @import("app.zig").App.init(alloc);
             defer app.deinit();
             app.telemetry.record(.{ .run = .{ .mode = .fetch, .version = version } });
 
@@ -99,7 +92,7 @@ pub fn main() !void {
             defer vm.deinit();
 
             // browser
-            var browser = Browser.init(alloc, &loop);
+            var browser = Browser.init(&app);
             defer browser.deinit();
 
             var session = try browser.newSession({});

--- a/src/server.zig
+++ b/src/server.zig
@@ -34,6 +34,7 @@ const CloseError = jsruntime.IO.CloseError;
 const CancelError = jsruntime.IO.CancelOneError;
 const TimeoutError = jsruntime.IO.TimeoutError;
 
+const App = @import("app.zig").App;
 const CDP = @import("cdp/cdp.zig").CDP;
 
 const TimeoutCheck = std.time.ns_per_ms * 100;
@@ -48,6 +49,7 @@ const MAX_HTTP_REQUEST_SIZE = 2048;
 const MAX_MESSAGE_SIZE = 256 * 1024 + 14;
 
 const Server = struct {
+    app: *App,
     allocator: Allocator,
     loop: *jsruntime.Loop,
 
@@ -1018,6 +1020,7 @@ pub fn run(
     address: net.Address,
     timeout: u64,
     loop: *jsruntime.Loop,
+    app: *App,
 ) !void {
     // create socket
     const flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
@@ -1043,6 +1046,7 @@ pub fn run(
     const json_version_response = try buildJSONVersionResponse(allocator, address);
 
     var server = Server{
+        .app = app,
         .loop = loop,
         .timeout = timeout,
         .listener = listener,

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -9,7 +9,7 @@ const telemetry = @import("telemetry.zig");
 const RunMode = @import("../app.zig").RunMode;
 
 const log = std.log.scoped(.telemetry);
-const URL = "https://lightpanda.io/browser-stats";
+const URL = "https://telemetry.lightpanda.io";
 
 pub const LightPanda = struct {
     uri: std.Uri,

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -30,7 +30,10 @@ pub const Lightpanda = struct {
     }
 
     pub fn send(self: *Lightpanda, iid: ?[]const u8, eid: []const u8, events: []Event) !void {
-        std.debug.print("SENDING: {s} {s} {d}", .{iid, eid, events.len})
+        _ = self;
+        _ = iid;
+        _ = eid;
+        _ = events;
         // defer _ = self.arena.reset(.{ .retain_capacity = {} });
         // const body = try std.json.stringifyAlloc(self.arena.allocator(), PlausibleEvent{ .event = event }, .{});
 
@@ -57,31 +60,31 @@ pub const Lightpanda = struct {
 };
 
 // wraps a telemetry event so that we can serialize it to plausible's event endpoint
-const PlausibleEvent = struct {
-    event: Event,
+// const PlausibleEvent = struct {
+//     event: Event,
 
-    pub fn jsonStringify(self: PlausibleEvent, jws: anytype) !void {
-        try jws.beginObject();
-        try jws.objectField("name");
-        try jws.write(@tagName(self.event));
-        try jws.objectField("url");
-        try jws.write(EVENT_URL);
-        try jws.objectField("domain");
-        try jws.write(DOMAIN_KEY);
-        try jws.objectField("props");
-        switch (self.event) {
-            inline else => |props| try jws.write(props),
-        }
-        try jws.endObject();
-    }
-};
+//     pub fn jsonStringify(self: PlausibleEvent, jws: anytype) !void {
+//         try jws.beginObject();
+//         try jws.objectField("name");
+//         try jws.write(@tagName(self.event));
+//         try jws.objectField("url");
+//         try jws.write(EVENT_URL);
+//         try jws.objectField("domain");
+//         try jws.write(DOMAIN_KEY);
+//         try jws.objectField("props");
+//         switch (self.event) {
+//             inline else => |props| try jws.write(props),
+//         }
+//         try jws.endObject();
+//     }
+// };
 
-const testing = std.testing;
-test "plausible: json event" {
-    const json = try std.json.stringifyAlloc(testing.allocator, PlausibleEvent{ .event = .{ .run = .{ .mode = .serve, .version = "over 9000!" } } }, .{});
-    defer testing.allocator.free(json);
+// const testing = std.testing;
+// test "plausible: json event" {
+//     const json = try std.json.stringifyAlloc(testing.allocator, PlausibleEvent{ .event = .{ .run = .{ .mode = .serve, .version = "over 9000!" } } }, .{});
+//     defer testing.allocator.free(json);
 
-    try testing.expectEqualStrings(
-        \\{"name":"run","url":"https://lightpanda.io/browser-stats","domain":"localhost","props":{"version":"over 9000!","mode":"serve"}}
-    , json);
-}
+//     try testing.expectEqualStrings(
+//         \\{"name":"run","url":"https://lightpanda.io/browser-stats","domain":"localhost","props":{"version":"over 9000!","mode":"serve"}}
+//     , json);
+// }

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -9,7 +9,7 @@ const telemetry = @import("telemetry.zig");
 const RunMode = @import("../app.zig").RunMode;
 
 const log = std.log.scoped(.telemetry);
-const URL = "https://telemetry.lightpanda.io";
+const URL = "https://lightpanda.io/browser-stats";
 
 pub const LightPanda = struct {
     uri: std.Uri,

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -7,7 +7,7 @@ const Client = @import("asyncio").Client;
 
 const log = std.log.scoped(.telemetry);
 
-const URL = "https://stats.lightpanda.io";
+const URL = "https://telemetry.lightpanda.io/";
 
 pub const LightPanda = struct {
     uri: std.Uri,

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -98,7 +98,6 @@ pub const LightPanda = struct {
         try std.json.stringify(event, .{ .emit_null_optional_fields = false }, arr.writer(self.allocator));
 
         var response_header_buffer: [2048]u8 = undefined;
-
         const result = try client.fetch(.{
             .method = .POST,
             .payload = arr.items,

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -2,75 +2,176 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArenAallocator = std.heap.ArenaAllocator;
 
-const Event = @import("telemetry.zig").Event;
+const Loop = @import("jsruntime").Loop;
+const Client = @import("asyncio").Client;
+
 const log = std.log.scoped(.telemetry);
 
-const URL = "https://lightpanda.io/browser-stats";
+const URL = "https://stats.lightpanda.io";
 
-pub const Lightpanda = struct {
+pub const LightPanda = struct {
     uri: std.Uri,
-    arena: ArenAallocator,
-    client: std.http.Client,
-    headers: [1]std.http.Header,
+    io: Client.IO,
+    client: Client,
+    allocator: Allocator,
+    sending_pool: std.heap.MemoryPool(Sending),
+    client_context_pool: std.heap.MemoryPool(Client.Ctx),
 
-    pub fn init(allocator: Allocator) !Lightpanda {
+    pub fn init(allocator: Allocator, loop: *Loop) !LightPanda {
         return .{
+            .allocator = allocator,
+            .io = Client.IO.init(loop),
             .client = .{ .allocator = allocator },
-            .arena = std.heap.ArenaAllocator.init(allocator),
             .uri = std.Uri.parse(URL) catch unreachable,
-            .headers = [1]std.http.Header{
-                .{ .name = "Content-Type", .value = "application/json" },
-            },
+            .sending_pool = std.heap.MemoryPool(Sending).init(allocator),
+            .client_context_pool = std.heap.MemoryPool(Client.Ctx).init(allocator),
         };
     }
 
-    pub fn deinit(self: *Lightpanda) void {
-        self.arena.deinit();
+    pub fn deinit(self: *LightPanda) void {
         self.client.deinit();
+        self.sending_pool.deinit();
+        self.client_context_pool.deinit();
     }
 
-    pub fn send(self: *Lightpanda, iid: ?[]const u8, eid: []const u8, events: []Event) !void {
-        _ = self;
-        _ = iid;
-        _ = eid;
-        _ = events;
-        // defer _ = self.arena.reset(.{ .retain_capacity = {} });
-        // const body = try std.json.stringifyAlloc(self.arena.allocator(), PlausibleEvent{ .event = event }, .{});
+    pub fn send(self: *LightPanda, iid: ?[]const u8, eid: []const u8, event: anytype) !void {
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        errdefer arena.deinit();
 
-        // var server_headers: [2048]u8 = undefined;
-        // var req = try self.client.open(.POST, self.uri, .{
-        //     .redirect_behavior = .not_allowed,
-        //     .extra_headers = &self.headers,
-        //     .server_header_buffer = &server_headers,
-        // });
-        // req.transfer_encoding = .{ .content_length = body.len };
-        // try req.send();
+        const resp_header_buffer = try arena.allocator().alloc(u8, 4096);
+        const body = try std.json.stringifyAlloc(arena.allocator(), .{
+            .iid = iid,
+            .eid = eid,
+            .event = event,
+        }, .{});
 
-        // try req.writeAll(body);
-        // try req.finish();
-        // try req.wait();
+        const sending = try self.sending_pool.create();
+        errdefer self.sending_pool.destroy(sending);
 
-        // const status = req.response.status;
-        // if (status != .accepted) {
-        //     log.warn("telemetry '{s}' event error: {d}", .{ @tagName(event), @intFromEnum(status) });
-        // } else {
-        //     log.warn("telemetry '{s}' sent", .{@tagName(event)});
-        // }
+        sending.* = .{
+            .body = body,
+            .arena = arena,
+            .lightpanda = self,
+            .request = try self.client.create(.POST, self.uri, .{
+                .server_header_buffer = resp_header_buffer,
+            }),
+        };
+        errdefer sending.request.deinit();
+
+        const ctx = try self.client_context_pool.create();
+        errdefer self.client_context_pool.destroy(ctx);
+
+        ctx.* = try Client.Ctx.init(&self.io, &sending.request);
+        ctx.userData = sending;
+
+        try self.client.async_open(
+            .POST,
+            self.uri,
+            .{ .server_header_buffer = resp_header_buffer },
+            ctx,
+            onRequestConnect,
+        );
+    }
+
+    fn handleError(self: *LightPanda, ctx: *Client.Ctx, err: anyerror) anyerror!void {
+        ctx.deinit();
+        self.client_context_pool.destroy(ctx);
+
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        sending.deinit();
+        self.sending_pool.destroy(sending);
+        log.info("request failure: {}", .{err});
+    }
+
+    fn onRequestConnect(ctx: *Client.Ctx, res: anyerror!void) anyerror!void {
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        res catch |err| return sending.lightpanda.handleError(ctx, err);
+
+        ctx.req.transfer_encoding = .{ .content_length = sending.body.len };
+        return ctx.req.async_send(ctx, onRequestSend) catch |err| {
+            return sending.lightpanda.handleError(ctx, err);
+        };
+    }
+
+    fn onRequestSend(ctx: *Client.Ctx, res: anyerror!void) anyerror!void {
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        res catch |err| return sending.lightpanda.handleError(ctx, err);
+
+        return ctx.req.async_writeAll(sending.body, ctx, onRequestWrite) catch |err| {
+            return sending.lightpanda.handleError(ctx, err);
+        };
+    }
+
+    fn onRequestWrite(ctx: *Client.Ctx, res: anyerror!void) anyerror!void {
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        res catch |err| return sending.lightpanda.handleError(ctx, err);
+        return ctx.req.async_finish(ctx, onRequestFinish) catch |err| {
+            return sending.lightpanda.handleError(ctx, err);
+        };
+    }
+
+    fn onRequestFinish(ctx: *Client.Ctx, res: anyerror!void) anyerror!void {
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        res catch |err| return sending.lightpanda.handleError(ctx, err);
+        return ctx.req.async_wait(ctx, onRequestWait) catch |err| {
+            return sending.lightpanda.handleError(ctx, err);
+        };
+    }
+
+    fn onRequestWait(ctx: *Client.Ctx, res: anyerror!void) anyerror!void {
+        var sending: *Sending = @ptrCast(@alignCast(ctx.userData));
+        res catch |err| return sending.lightpanda.handleError(ctx, err);
+
+        const lightpanda = sending.lightpanda;
+
+        defer {
+            ctx.deinit();
+            lightpanda.client_context_pool.destroy(ctx);
+
+            sending.deinit();
+            lightpanda.sending_pool.destroy(sending);
+        }
+
+        var buffer: [2048]u8 = undefined;
+        const reader = ctx.req.reader();
+        while (true) {
+            const n = reader.read(&buffer) catch 0;
+            if (n == 0) {
+                break;
+            }
+        }
+        if (ctx.req.response.status != .ok) {
+            log.info("invalid response: {d}", .{@intFromEnum(ctx.req.response.status)});
+        }
     }
 };
 
-// wraps a telemetry event so that we can serialize it to plausible's event endpoint
-// const PlausibleEvent = struct {
-//     event: Event,
+const Sending = struct {
+    body: []const u8,
+    request: Client.Request,
+    lightpanda: *LightPanda,
+    arena: std.heap.ArenaAllocator,
 
-//     pub fn jsonStringify(self: PlausibleEvent, jws: anytype) !void {
+    pub fn deinit(self: *Sending) void {
+        self.arena.deinit();
+        self.request.deinit();
+    }
+};
+
+// // wraps a telemetry event so that we can serialize it to plausible's event endpoint
+// const EventWrap = struct {
+//     iid: ?[]const u8,
+//     eid: []const u8,
+//     event: *const Event,
+
+//     pub fn jsonStringify(self: *const EventWrap, jws: anytype) !void {
 //         try jws.beginObject();
-//         try jws.objectField("name");
-//         try jws.write(@tagName(self.event));
-//         try jws.objectField("url");
-//         try jws.write(EVENT_URL);
-//         try jws.objectField("domain");
-//         try jws.write(DOMAIN_KEY);
+//         try jws.objectField("iid");
+//         try jws.write(self.iid);
+//         try jws.objectField("eid");
+//         try jws.write(self.eid);
+//         try jws.objectField("event");
+//         try jws.write(@tagName(self.event.*));
 //         try jws.objectField("props");
 //         switch (self.event) {
 //             inline else => |props| try jws.write(props),
@@ -80,11 +181,15 @@ pub const Lightpanda = struct {
 // };
 
 // const testing = std.testing;
-// test "plausible: json event" {
-//     const json = try std.json.stringifyAlloc(testing.allocator, PlausibleEvent{ .event = .{ .run = .{ .mode = .serve, .version = "over 9000!" } } }, .{});
+// test "telemetry: lightpanda json event" {
+//     const json = try std.json.stringifyAlloc(testing.allocator, EventWrap{
+//         .iid = "1234",
+//         .eid = "abc!",
+//         .event = .{ .run = .{ .mode = .serve, .version = "over 9000!" } }
+//     }, .{});
 //     defer testing.allocator.free(json);
 
 //     try testing.expectEqualStrings(
-//         \\{"name":"run","url":"https://lightpanda.io/browser-stats","domain":"localhost","props":{"version":"over 9000!","mode":"serve"}}
+//         \\{"event":"run","iid""1234","eid":"abc!","props":{"version":"over 9000!","mode":"serve"}}
 //     , json);
 // }

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArenAallocator = std.heap.ArenaAllocator;
+
+const Event = @import("telemetry.zig").Event;
+const log = std.log.scoped(.telemetry);
+
+const URL = "https://lightpanda.io/browser-stats";
+
+pub const Lightpanda = struct {
+    uri: std.Uri,
+    arena: ArenAallocator,
+    client: std.http.Client,
+    headers: [1]std.http.Header,
+
+    pub fn init(allocator: Allocator) !Lightpanda {
+        return .{
+            .client = .{ .allocator = allocator },
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .uri = std.Uri.parse(URL) catch unreachable,
+            .headers = [1]std.http.Header{
+                .{ .name = "Content-Type", .value = "application/json" },
+            },
+        };
+    }
+
+    pub fn deinit(self: *Lightpanda) void {
+        self.arena.deinit();
+        self.client.deinit();
+    }
+
+    pub fn send(self: *Lightpanda, iid: ?[]const u8, eid: []const u8, events: []Event) !void {
+        std.debug.print("SENDING: {s} {s} {d}", .{iid, eid, events.len})
+        // defer _ = self.arena.reset(.{ .retain_capacity = {} });
+        // const body = try std.json.stringifyAlloc(self.arena.allocator(), PlausibleEvent{ .event = event }, .{});
+
+        // var server_headers: [2048]u8 = undefined;
+        // var req = try self.client.open(.POST, self.uri, .{
+        //     .redirect_behavior = .not_allowed,
+        //     .extra_headers = &self.headers,
+        //     .server_header_buffer = &server_headers,
+        // });
+        // req.transfer_encoding = .{ .content_length = body.len };
+        // try req.send();
+
+        // try req.writeAll(body);
+        // try req.finish();
+        // try req.wait();
+
+        // const status = req.response.status;
+        // if (status != .accepted) {
+        //     log.warn("telemetry '{s}' event error: {d}", .{ @tagName(event), @intFromEnum(status) });
+        // } else {
+        //     log.warn("telemetry '{s}' sent", .{@tagName(event)});
+        // }
+    }
+};
+
+// wraps a telemetry event so that we can serialize it to plausible's event endpoint
+const PlausibleEvent = struct {
+    event: Event,
+
+    pub fn jsonStringify(self: PlausibleEvent, jws: anytype) !void {
+        try jws.beginObject();
+        try jws.objectField("name");
+        try jws.write(@tagName(self.event));
+        try jws.objectField("url");
+        try jws.write(EVENT_URL);
+        try jws.objectField("domain");
+        try jws.write(DOMAIN_KEY);
+        try jws.objectField("props");
+        switch (self.event) {
+            inline else => |props| try jws.write(props),
+        }
+        try jws.endObject();
+    }
+};
+
+const testing = std.testing;
+test "plausible: json event" {
+    const json = try std.json.stringifyAlloc(testing.allocator, PlausibleEvent{ .event = .{ .run = .{ .mode = .serve, .version = "over 9000!" } } }, .{});
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"name":"run","url":"https://lightpanda.io/browser-stats","domain":"localhost","props":{"version":"over 9000!","mode":"serve"}}
+    , json);
+}

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -93,8 +93,13 @@ fn getOrCreateId(app_dir_path_: ?[]const u8) ?[36]u8 {
 
 pub const Event = union(enum) {
     run: void,
-    navigate: void,
+    navigate: Navigate,
     flag: []const u8, // used for testing
+
+    const Navigate = struct {
+        tls: bool,
+        proxy: bool,
+    };
 };
 
 const NoopProvider = struct {

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -99,6 +99,7 @@ pub const Event = union(enum) {
     const Navigate = struct {
         tls: bool,
         proxy: bool,
+        driver: []const u8 = "cdp",
     };
 };
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Allocator = std.mem.Allocator;
+const uuidv4 = @import("../id.zig").uuidv4;
+
+const log = std.log.scoped(.telemetry);
+
+const BATCH_SIZE = 5;
+const BATCH_END = BATCH_SIZE - 1;
+const ID_FILE = "lightpanda.id";
+
+pub const Telemetry = TelemetryT(blk: {
+    if (builtin.mode == .Debug or builtin.is_test) break :blk NoopProvider;
+    break :blk @import("ligtpanda.zig").Lightpanda;
+});
+
+fn TelemetryT(comptime P: type) type {
+    return struct {
+        // an "install" id that we [try to] persist and re-use between runs
+        // null on IO error
+        iid: ?[36]u8,
+
+        // a "execution" id is an id that represents this specific run
+        eid: [36]u8,
+        provider: P,
+
+        // batch of events, pending[0..count] are pending
+        pending: [BATCH_SIZE]Event,
+        count: usize,
+        disabled: bool,
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator) Self {
+            const disabled = std.process.hasEnvVarConstant("LIGHTPANDA_DISABLE_TELEMETRY");
+
+            var eid: [36]u8 = undefined;
+            uuidv4(&eid)
+
+            return .{
+                .eid = eid,
+                .iid = if (disabled) null else getOrCreateId(),
+                .disabled = disabled,
+                .provider = try P.init(allocator),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.provider.deinit();
+        }
+
+        pub fn record(self: *Self, event: Event) void {
+            if (self.disabled) {
+                return;
+            }
+
+            const count = self.count;
+            self.pending[count] = event;
+            if (count < BATCH_END) {
+                self.count = count + 1;
+                return;
+            }
+
+            const iid = if (self.iid) |*iid| *iid else null;
+            self.provider.send(iid, &self.eid, &self.pending) catch |err| {
+                log.warn("failed to record event: {}", .{err});
+            };
+            self.count = 0;
+        }
+    };
+}
+
+fn getOrCreateId() ?[36]u8 {
+    var buf: [37]u8 = undefined;
+    const data = std.fs.cwd().readFile(ID_FILE, &buf) catch |err| switch (err) blk: {
+        error.FileNotFound => break :bkl &.{},
+        else => {
+            log.warn("failed to open id file: {}", .{err});
+            return null,
+        },
+    }
+
+    var id: [36]u8 = undefined;
+    if (data.len == 36) {
+        @memcpy(id[0..36], data)
+        return id;
+    }
+
+    uuidv4(&id);
+    std.fs.cwd().writeFile(.{.sub_path = ID_FILE, .data = buf[0..36]}) catch |err| {
+        log.warn("failed to write to id file: {}", .{err});
+        return null;
+    };
+    return id;
+}
+
+pub const Event = union(enum) {
+    run: Run,
+
+    const Run = struct {
+        version: []const u8,
+        mode: RunMode,
+
+        const RunMode = enum {
+            fetch,
+            serve,
+        };
+    };
+};
+
+const NoopProvider = struct {
+    fn init(_: Allocator) !NoopProvider {
+        return .{};
+    }
+    fn deinit(_: NoopProvider) void {}
+    pub fn record(_: NoopProvider, _: Event) !void {}
+};
+
+extern fn setenv(name: [*:0]u8, value: [*:0]u8, override: c_int) c_int;
+extern fn unsetenv(name: [*:0]u8) c_int;
+const testing = std.testing;
+test "telemetry: disabled by environment" {
+    _ = setenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"), @constCast(""), 0);
+    defer _ = unsetenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"));
+
+    const FailingProvider = struct {
+        fn init(_: Allocator) !@This() {
+            return .{};
+        }
+        fn deinit(_: @This()) void {}
+        pub fn record(_: @This(), _: Event) !void {
+            unreachable;
+        }
+    };
+
+    var telemetry = TelemetryT(FailingProvider).init(testing.allocator);
+    defer telemetry.deinit();
+    telemetry.record(.{ .run = .{ .mode = .serve, .version = "123" } });
+}

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -29,7 +29,7 @@ fn TelemetryT(comptime P: type) type {
 
         const Self = @This();
 
-        pub fn init(allocator: Allocator, loop: *Loop, run_mode: RunMode) Self {
+        pub fn init(allocator: Allocator, run_mode: RunMode) Self {
             const disabled = std.process.hasEnvVarConstant("LIGHTPANDA_DISABLE_TELEMETRY");
             if (builtin.mode != .Debug and builtin.is_test == false) {
                 log.info("telemetry {s}", .{if (disabled) "disabled" else "enabled"});
@@ -38,8 +38,8 @@ fn TelemetryT(comptime P: type) type {
             return .{
                 .disabled = disabled,
                 .run_mode = run_mode,
+                .provider = try P.init(allocator),
                 .iid = if (disabled) null else getOrCreateId(),
-                .provider = try P.init(allocator, loop),
             };
         }
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -90,7 +90,7 @@ pub const Event = union(enum) {
 };
 
 const NoopProvider = struct {
-    fn init(_: Allocator, _: *Loop) !NoopProvider {
+    fn init(_: Allocator) !NoopProvider {
         return .{};
     }
     fn deinit(_: NoopProvider) void {}
@@ -106,7 +106,7 @@ test "telemetry: disabled by environment" {
     defer _ = unsetenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"));
 
     const FailingProvider = struct {
-        fn init(_: Allocator, _: *Loop) !@This() {
+        fn init(_: Allocator) !@This() {
             return .{};
         }
         fn deinit(_: @This()) void {}
@@ -115,7 +115,7 @@ test "telemetry: disabled by environment" {
         }
     };
 
-    var telemetry = TelemetryT(FailingProvider).init(testing.allocator, undefined, .serve);
+    var telemetry = TelemetryT(FailingProvider).init(testing.allocator, .serve);
     defer telemetry.deinit();
     telemetry.record(.{ .run = {} });
 }
@@ -138,7 +138,7 @@ test "telemetry: sends event to provider" {
     defer std.fs.cwd().deleteFile(ID_FILE) catch {};
     std.fs.cwd().deleteFile(ID_FILE) catch {};
 
-    var telemetry = TelemetryT(MockProvider).init(testing.allocator, undefined, .serve);
+    var telemetry = TelemetryT(MockProvider).init(testing.allocator, .serve);
     defer telemetry.deinit();
     const mock = &telemetry.provider;
 
@@ -158,7 +158,7 @@ const MockProvider = struct {
     allocator: Allocator,
     events: std.ArrayListUnmanaged(Event),
 
-    fn init(allocator: Allocator, _: *Loop) !@This() {
+    fn init(allocator: Allocator) !@This() {
         return .{
             .iid = null,
             .run_mode = null,

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -10,7 +10,7 @@ const log = std.log.scoped(.telemetry);
 const ID_FILE = "lightpanda.id";
 
 pub const Telemetry = TelemetryT(blk: {
-    // if (builtin.mode == .Debug or builtin.is_test) break :blk NoopProvider;
+    if (builtin.mode == .Debug or builtin.is_test) break :blk NoopProvider;
     break :blk @import("lightpanda.zig").LightPanda;
 });
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -10,7 +10,7 @@ const log = std.log.scoped(.telemetry);
 const ID_FILE = "lightpanda.id";
 
 pub const Telemetry = TelemetryT(blk: {
-    if (builtin.mode == .Debug or builtin.is_test) break :blk NoopProvider;
+    // if (builtin.mode == .Debug or builtin.is_test) break :blk NoopProvider;
     break :blk @import("lightpanda.zig").LightPanda;
 });
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -52,7 +52,7 @@ fn TelemetryT(comptime P: type) type {
                 return;
             }
             const iid: ?[]const u8 = if (self.iid) |*iid| iid else null;
-            self.provider.send(iid, self.run_mode, &event) catch |err| {
+            self.provider.send(iid, self.run_mode, event) catch |err| {
                 log.warn("failed to record event: {}", .{err});
             };
         }
@@ -94,7 +94,7 @@ const NoopProvider = struct {
         return .{};
     }
     fn deinit(_: NoopProvider) void {}
-    pub fn send(_: NoopProvider, _: ?[]const u8, _: RunMode, _: *const Event) !void {}
+    pub fn send(_: NoopProvider, _: ?[]const u8, _: RunMode, _: Event) !void {}
 };
 
 extern fn setenv(name: [*:0]u8, value: [*:0]u8, override: c_int) c_int;
@@ -110,7 +110,7 @@ test "telemetry: disabled by environment" {
             return .{};
         }
         fn deinit(_: @This()) void {}
-        pub fn send(_: @This(), _: ?[]const u8, _: RunMode, _: *const Event) !void {
+        pub fn send(_: @This(), _: ?[]const u8, _: RunMode, _: Event) !void {
             unreachable;
         }
     };
@@ -169,7 +169,7 @@ const MockProvider = struct {
     fn deinit(self: *MockProvider) void {
         self.events.deinit(self.allocator);
     }
-    pub fn send(self: *MockProvider, iid: ?[]const u8, run_mode: RunMode, events: *const Event) !void {
+    pub fn send(self: *MockProvider, iid: ?[]const u8, run_mode: RunMode, events: Event) !void {
         if (self.iid == null) {
             try testing.expectEqual(null, self.run_mode);
             self.iid = iid.?;
@@ -178,6 +178,6 @@ const MockProvider = struct {
             try testing.expectEqualStrings(self.iid.?, iid.?);
             try testing.expectEqual(self.run_mode.?, run_mode);
         }
-        try self.events.append(self.allocator, events.*);
+        try self.events.append(self.allocator, events);
     }
 };

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -31,6 +31,9 @@ fn TelemetryT(comptime P: type) type {
 
         pub fn init(allocator: Allocator, loop: *Loop, run_mode: RunMode) Self {
             const disabled = std.process.hasEnvVarConstant("LIGHTPANDA_DISABLE_TELEMETRY");
+            if (builtin.mode != .Debug and builtin.is_test == false) {
+                log.info("telemetry {s}", .{if (disabled) "disabled" else "enabled"});
+            }
 
             return .{
                 .disabled = disabled,

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -384,4 +384,5 @@ test {
     std.testing.refAllDecls(@import("cdp/cdp.zig"));
     std.testing.refAllDecls(@import("log.zig"));
     std.testing.refAllDecls(@import("datetime.zig"));
+    std.testing.refAllDecls(@import("telemetry/telemetry.zig"));
 }

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
 
-    var app = try App.init(allocator);
+    var app = try App.init(allocator, .serve);
     defer app.deinit();
 
     const env = Env.init(allocator);

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -45,10 +45,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
 
-    var loop = try jsruntime.Loop.init(allocator);
-    defer loop.deinit();
-
-    var app = try App.init(allocator, &loop);
+    var app = try App.init(allocator);
     defer app.deinit();
 
     const env = Env.init(allocator);
@@ -71,7 +68,10 @@ pub fn main() !void {
 
     const cdp_thread = blk: {
         const address = try std.net.Address.parseIp("127.0.0.1", 9583);
-        const thread = try std.Thread.spawn(.{}, serveCDP, .{ allocator, address, &loop, &app });
+        const thread = try std.Thread.spawn(.{}, serveCDP, .{
+            &app,
+            address,
+        });
         break :blk thread;
     };
     defer cdp_thread.join();
@@ -353,9 +353,9 @@ fn serveHTTP(address: std.net.Address) !void {
     }
 }
 
-fn serveCDP(allocator: Allocator, address: std.net.Address, loop: *jsruntime.Loop, app: *App) !void {
+fn serveCDP(app: *App, address: std.net.Address) !void {
     const server = @import("server.zig");
-    server.run(allocator, address, std.time.ns_per_s * 2, loop, app) catch |err| {
+    server.run(app, address, std.time.ns_per_s * 2) catch |err| {
         std.debug.print("CDP server error: {}", .{err});
         return err;
     };


### PR DESCRIPTION
Sends basic usage telemetry. Final URL will need to be changed (probably).

Added Telemetry section to readme (please review). And I the Privacy Policy (linked from the readme)  might need updating to reflect this collection?

Currently, most things need an `Allocator` and `Loop` to run. Now we also need a `Telemetry`, and it isn't hard to imagine a not-so-distant future where various parts also need access to a `Config`. Rather than adding more and more parameters, I've introduced an `App` which is meant to group global data into a single variable, so that future additions are less likely to require touching so much code. Besides this change, the Telemetry code is relatively standalone.