### PR TITLE
Remove CDP FrameId

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -28,7 +28,6 @@ const log = std.log.scoped(.cdp);
 
 pub const URL_BASE = "chrome://newtab/";
 pub const LOADER_ID = "LOADERID24DD2FD56CF1EF33C965C79C";
-pub const FRAME_ID = "FRAMEIDD8AED408A0467AC93100BCDBE";
 
 pub const TimestampEvent = struct {
     timestamp: f64,
@@ -282,7 +281,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         // State
         url: []const u8,
-        frame_id: []const u8,
         loader_id: []const u8,
         security_origin: []const u8,
         page_life_cycle_events: bool,
@@ -301,7 +299,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 .target_id = null,
                 .session_id = null,
                 .url = URL_BASE,
-                .frame_id = FRAME_ID,
                 .security_origin = URL_BASE,
                 .secure_context_type = "Secure", // TODO = enum
                 .loader_id = LOADER_ID,

--- a/src/cdp/page.zig
+++ b/src/cdp/page.zig
@@ -274,13 +274,13 @@ test "cdp.page: getFrameTree" {
         try ctx.expectSentError(-31998, "BrowserContextNotLoaded", .{ .id = 10 });
     }
 
-    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9" });
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9", .target_id = "TID-3" });
     {
         try ctx.processMessage(.{ .id = 11, .method = "Page.getFrameTree" });
         try ctx.expectSentResult(.{
             .frameTree = .{
                 .frame = .{
-                    .id = bc.frame_id,
+                    .id = "TID-3",
                     .loaderId = bc.loader_id,
                     .url = bc.url,
                     .domainAndRegistry = "",

--- a/src/cdp/runtime.zig
+++ b/src/cdp/runtime.zig
@@ -70,7 +70,7 @@ pub const ExecutionContextCreated = struct {
     pub const AuxData = struct {
         isDefault: bool = true,
         type: []const u8 = "default",
-        frameId: []const u8 = cdp.FRAME_ID,
+        frameId: []const u8,
     };
 };
 

--- a/src/cdp/target.zig
+++ b/src/cdp/target.zig
@@ -231,7 +231,7 @@ fn getTargetInfo(cmd: anytype) !void {
         }
 
         return cmd.sendResult(.{
-            .targetInfo = .{
+            .targetInfo = TargetInfo{
                 .targetId = target_id,
                 .type = "page",
                 .title = "",
@@ -243,7 +243,8 @@ fn getTargetInfo(cmd: anytype) !void {
     }
 
     return cmd.sendResult(.{
-        .targetInfo = .{
+        .targetInfo = TargetInfo{
+            .targetId = "TID-STARTUP-B",
             .type = "browser",
             .title = "",
             .url = "",
@@ -342,9 +343,9 @@ fn setAutoAttach(cmd: anytype) !void {
     try cmd.sendEvent("Target.attachedToTarget", AttachToTarget{
         .sessionId = "STARTUP",
         .targetInfo = TargetInfo{
-            .type = "browser",
-            .targetId = "TID-STARTUP",
-            .title = "about:blank",
+            .type = "page",
+            .targetId = "TID-STARTUP-P",
+            .title = "New Private Tab",
             .url = "chrome://newtab/",
             .browserContextId = "BID-STARTUP",
         },
@@ -382,7 +383,7 @@ const TargetInfo = struct {
     attached: bool = true,
     type: []const u8 = "page",
     canAccessOpener: bool = false,
-    browserContextId: []const u8,
+    browserContextId: ?[]const u8 = null,
 };
 
 const testing = @import("testing.zig");

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -147,6 +147,7 @@ const TestContext = struct {
 
     const BrowserContextOpts = struct {
         id: ?[]const u8 = null,
+        target_id: ?[]const u8 = null,
         session_id: ?[]const u8 = null,
     };
     pub fn loadBrowserContext(self: *TestContext, opts: BrowserContextOpts) !*main.BrowserContext(TestCDP) {
@@ -161,6 +162,10 @@ const TestContext = struct {
 
         if (opts.id) |id| {
             bc.id = id;
+        }
+
+        if (opts.target_id) |tid| {
+            bc.target_id = tid;
         }
 
         if (opts.session_id) |sid| {


### PR DESCRIPTION
I don't know if FrameId is related to an <iframe>, and whether each Page has 1 implicit "frame". But, playwright seems to treat frameId and targetId as interchangeable, and chrome seems to agree (at leas to some degree); chrome will return a targetId and reuse that value for the frameId.

So the simplest solution is just to remove our concept of a frameId and use targetId exclusively. This doesn't seem to cause any issues with puppeteer.