### PR TITLE
Optimize memory usage

### DIFF
--- a/src/html/window.zig
+++ b/src/html/window.zig
@@ -58,17 +58,17 @@ pub const Window = struct {
     navigator: Navigator,
 
     pub fn create(target: ?[]const u8, navigator: ?Navigator) Window {
-        return Window{
+        return .{
             .target = target orelse "",
             .navigator = navigator orelse .{},
         };
     }
 
-    pub fn replaceLocation(self: *Window, loc: *Location) !void {
-        self.location = loc;
+    pub fn replaceLocation(self: *Window, loc: ?*Location) !void {
+        self.location = loc orelse &emptyLocation;
 
-        if (self.document != null) {
-            try parser.documentHTMLSetLocation(Location, self.document.?, self.location);
+        if (self.document) |doc| {
+            try parser.documentHTMLSetLocation(Location, doc, self.location);
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,9 +96,7 @@ pub fn main() !void {
             var session = try browser.newSession({});
 
             // page
-            const page = try session.createPage();
-            try page.start(null);
-            defer page.end();
+            const page = try session.createPage(null);
 
             _ = page.navigate(opts.url, null) catch |err| switch (err) {
                 error.UnsupportedUriScheme, error.UriMissingHost => {


### PR DESCRIPTION
The two bigger changes here are:

1- The http_client has been moved from the Session to the Browser, allowing
   its connection pool to be re-used across multiple sessions

2- The browser now has a page_arena which is used for all page-level allocation
   and which can be re-used between pages (currently retains 1MB of memory).
   Previously, pages uses an arena that was tied to the lifetime of the page,
   thus it could not be re-used.

Using the Bench allocator for zig-js-runtime, allocated bytes went from 1347037879 to 834932438 (in a RUNS=1000 of puppeteer demo).

Various other changes to try to simplify the API and remove the possibility of invalid states. For example, session.newPage() now includes the logic for page.start() so that there should now never be a page that wasn't started.