### PR TITLE
run v8 micro tasks

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -100,6 +100,13 @@ pub const Browser = struct {
             self.session = null;
         }
     }
+
+    pub fn runMicrotasks(self: *const Browser) void {
+        // if no session exists, there is nothing to do.
+        if (self.session == null) return;
+
+        return self.session.?.env.runMicrotasks();
+    }
 };
 
 // Session is like a browser's tab.

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -244,7 +244,7 @@ pub const Session = struct {
         std.debug.assert(self.page != null);
 
         // Reset all existing callbacks.
-        self.app.loop.reset();
+        self.app.loop.resetJS();
 
         self.env.stop();
         // TODO unload document: https://html.spec.whatwg.org/#unloading-documents

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -64,6 +64,8 @@ const Browser = struct {
         const session = self.session orelse return false;
         return std.mem.eql(u8, session.id, session_id);
     }
+
+    pub fn runMicrotasks(_: *const Browser) void {}
 };
 
 const Session = struct {


### PR DESCRIPTION
This PR run v8 micro tasks after we send a script to the inspector and removes the `async=false` cdp hack.
It depends on https://github.com/lightpanda-io/zig-js-runtime/pull/291 which also runs the micro tasks every  millisecond.