### PR TITLE
Add an `insecure_disable_tls_host_verification` command line option

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -17,11 +17,18 @@ pub const App = struct {
     app_dir_path: ?[]const u8,
 
     pub const RunMode = enum {
-        serve,
+        help,
         fetch,
+        serve,
+        version,
     };
 
-    pub fn init(allocator: Allocator, run_mode: RunMode) !*App {
+    pub const Config = struct {
+        tls_verify_host: bool = true,
+        run_mode: RunMode,
+    };
+
+    pub fn init(allocator: Allocator, config: Config) !*App {
         const app = try allocator.create(App);
         errdefer allocator.destroy(app);
 
@@ -38,9 +45,11 @@ pub const App = struct {
             .allocator = allocator,
             .telemetry = undefined,
             .app_dir_path = app_dir_path,
-            .http_client = try HttpClient.init(allocator, 5),
+            .http_client = try HttpClient.init(allocator, 5, .{
+                .tls_verify_host = config.tls_verify_host,
+            }),
         };
-        app.telemetry = Telemetry.init(app, run_mode);
+        app.telemetry = Telemetry.init(app, config.run_mode);
 
         return app;
     }

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -281,7 +281,7 @@ const TestContext = struct {
 
 pub fn context() TestContext {
     return .{
-        .app = App.init(std.testing.allocator, .serve) catch unreachable,
+        .app = App.init(std.testing.allocator, .{ .run_mode = .serve }) catch unreachable,
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
     };
 }

--- a/src/main_tests.zig
+++ b/src/main_tests.zig
@@ -88,7 +88,7 @@ fn testExecFn(
         std.debug.print("documentHTMLClose error: {s}\n", .{@errorName(err)});
     };
 
-    var http_client = try @import("http/client.zig").Client.init(alloc, 5);
+    var http_client = try @import("http/client.zig").Client.init(alloc, 5, .{});
     defer http_client.deinit();
 
     try js_env.setUserContext(.{

--- a/src/main_unit_tests.zig
+++ b/src/main_unit_tests.zig
@@ -213,7 +213,7 @@ fn serveHTTPS(address: std.net.Address) !void {
 
 fn serveCDP(address: std.net.Address) !void {
     const App = @import("app.zig").App;
-    var app = try App.init(gpa.allocator(), .serve);
+    var app = try App.init(gpa.allocator(), .{.run_mode = .serve});
     defer app.deinit();
 
     const server = @import("server.zig");

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -157,7 +157,7 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
 
 // dummy opts incase we want to add something, and not have to break all the callers
 pub fn app(_: anytype) *App {
-    return App.init(allocator, .serve) catch unreachable;
+    return App.init(allocator, .{.run_mode = .serve}) catch unreachable;
 }
 
 pub const Random = struct {


### PR DESCRIPTION
When set, this disables the host verification of all HTTP requests. Available for both the fetch and serve mode.

Also introduced an App.Config, for future command line options which need to be passed more deeply into the code.