### PR TITLE
Enable caller to decide where App lives

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -28,10 +28,7 @@ pub const App = struct {
         run_mode: RunMode,
     };
 
-    pub fn init(allocator: Allocator, config: Config) !*App {
-        const app = try allocator.create(App);
-        errdefer allocator.destroy(app);
-
+    pub fn init(allocator: Allocator, config: Config) !App {
         const loop = try allocator.create(Loop);
         errdefer allocator.destroy(loop);
 
@@ -40,7 +37,7 @@ pub const App = struct {
 
         const app_dir_path = getAndMakeAppDir(allocator);
 
-        app.* = .{
+        var app: App = .{
             .loop = loop,
             .allocator = allocator,
             .telemetry = undefined,
@@ -49,7 +46,7 @@ pub const App = struct {
                 .tls_verify_host = config.tls_verify_host,
             }),
         };
-        app.telemetry = Telemetry.init(app, config.run_mode);
+        app.telemetry = Telemetry.init(&app, config.run_mode);
 
         return app;
     }
@@ -63,7 +60,6 @@ pub const App = struct {
         self.loop.deinit();
         allocator.destroy(self.loop);
         self.http_client.deinit();
-        allocator.destroy(self);
     }
 };
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -138,7 +138,7 @@ const TestCDP = main.CDPT(struct {
 });
 
 const TestContext = struct {
-    app: *App,
+    app: App,
     client: ?Client = null,
     cdp_: ?TestCDP = null,
     arena: std.heap.ArenaAllocator,
@@ -156,7 +156,7 @@ const TestContext = struct {
             self.client = Client.init(self.arena.allocator());
             // Don't use the arena here. We want to detect leaks in CDP.
             // The arena is only for test-specific stuff
-            self.cdp_ = TestCDP.init(self.app, &self.client.?);
+            self.cdp_ = TestCDP.init(&self.app, &self.client.?);
         }
         return &self.cdp_.?;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,7 +79,7 @@ pub fn main() !void {
             app.telemetry.record(.{ .run = {} });
 
             const timeout = std.time.ns_per_s * @as(u64, opts.timeout);
-            server.run(app, address, timeout) catch |err| {
+            server.run(&app, address, timeout) catch |err| {
                 log.err("Server error", .{});
                 return err;
             };
@@ -99,7 +99,7 @@ pub fn main() !void {
             defer vm.deinit();
 
             // browser
-            var browser = Browser.init(app);
+            var browser = Browser.init(&app);
             defer browser.deinit();
 
             var session = try browser.newSession({});

--- a/src/main_unit_tests.zig
+++ b/src/main_unit_tests.zig
@@ -218,7 +218,7 @@ fn serveCDP(address: std.net.Address) !void {
 
     const server = @import("server.zig");
     wg.finish();
-    server.run(app, address, std.time.ns_per_s * 2) catch |err| {
+    server.run(&app, address, std.time.ns_per_s * 2) catch |err| {
         std.debug.print("CDP server error: {}", .{err});
         return err;
     };

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -160,7 +160,7 @@ test "telemetry: sends event to provider" {
     var app = testing.app(.{});
     defer app.deinit();
 
-    var telemetry = TelemetryT(MockProvider).init(app, .serve);
+    var telemetry = TelemetryT(MockProvider).init(&app, .serve);
     defer telemetry.deinit();
     const mock = &telemetry.provider;
 

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -156,7 +156,7 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
 }
 
 // dummy opts incase we want to add something, and not have to break all the callers
-pub fn app(_: anytype) *App {
+pub fn app(_: anytype) App {
     return App.init(allocator, .{ .run_mode = .serve }) catch unreachable;
 }
 


### PR DESCRIPTION
Before App.init would allocate it self on the heap (allocator).
However there appears to be no reason for it not to live on the stack.
This way the caller get's to decide.