### PR TITLE
Add a dumb renderer to get coordinates

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -451,13 +451,14 @@ pub const Page = struct {
 
         const event = try parser.mouseEventCreate();
         defer parser.mouseEventDestroy(event);
-
         try parser.mouseEventInit(event, "click", .{
             .bubbles = true,
             .cancelable = true,
             .x = me.x,
             .y = me.y,
         });
+        _ = try parser.elementDispatchEvent(element, @ptrCast(event));
+
         if ((try parser.mouseEventDefaultPrevented(event)) == true) {
             return null;
         }

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -298,10 +298,14 @@ pub const Page = struct {
     // current_script could by fetch module to resolve module's url to fetch.
     current_script: ?*const Script = null,
 
+    renderer: FlatRenderer,
+
     fn init(session: *Session) Page {
+        const arena = session.browser.page_arena.allocator();
         return .{
+            .arena = arena,
             .session = session,
-            .arena = session.browser.page_arena.allocator(),
+            .renderer = FlatRenderer.init(arena),
         };
     }
 
@@ -423,6 +427,32 @@ pub const Page = struct {
         }
     }
 
+    pub const ClickResult = union(enum) {
+        navigate: std.Uri,
+    };
+
+    pub fn click(self: *Page, allocator: Allocator, x: u32, y: u32) !?ClickResult {
+        const element = self.renderer.getElementAtPosition(x, y) orelse return null;
+
+        const event = try parser.eventCreate();
+        defer parser.eventDestroy(event);
+
+        try parser.eventInit(event, "click", .{ .bubbles = true, .cancelable = true });
+        if ((try parser.eventDefaultPrevented(event)) == true) {
+            return null;
+        }
+
+        const node = parser.elementToNode(element);
+        const tag = try parser.nodeName(node);
+        if (std.ascii.eqlIgnoreCase(tag, "a")) {
+            const href = (try parser.elementGetAttribute(element, "href")) orelse return null;
+            var buf = try allocator.alloc(u8, 1024);
+            return .{ .navigate = try std.Uri.resolve_inplace(self.uri, href, &buf) };
+        }
+
+        return null;
+    }
+
     // https://html.spec.whatwg.org/#read-html
     fn loadHTMLDoc(self: *Page, reader: anytype, charset: []const u8, aux_data: ?[]const u8) !void {
         const arena = self.arena;
@@ -462,6 +492,7 @@ pub const Page = struct {
         try session.env.setUserContext(.{
             .uri = self.uri,
             .document = html_doc,
+            .renderer = @ptrCast(&self.renderer),
             .cookie_jar = @ptrCast(&self.session.cookie_jar),
             .http_client = @ptrCast(self.session.http_client),
         });
@@ -751,6 +782,70 @@ pub const Page = struct {
             }
         }
     };
+};
+
+// provide very poor abstration to the rest of the code. In theory, we can change
+// the FlatRendere to a different implementation, and it'll all just work.
+pub const Renderer = FlatRenderer;
+
+// This "renderer" positions elements in a single row in an unspecified order.
+// The important thing is that elements have a consistent position/index within
+// that row, which can be turned into a rectangle.
+const FlatRenderer = struct {
+    allocator: Allocator,
+
+    // key is a @ptrFromInt of the element
+    // value is the index position
+    positions: std.AutoHashMapUnmanaged(u64, u32),
+
+    // given an index, get the element
+    elements: std.ArrayListUnmanaged(u64),
+
+    const Element = @import("../dom/element.zig").Element;
+
+    // we expect allocator to be an arena
+    pub fn init(allocator: Allocator) FlatRenderer {
+        return .{
+            .elements = .{},
+            .positions = .{},
+            .allocator = allocator,
+        };
+    }
+
+    pub fn getRect(self: *FlatRenderer, e: *parser.Element) !Element.DOMRect {
+        var elements = &self.elements;
+        const gop = try self.positions.getOrPut(self.allocator, @intFromPtr(e));
+        var x: u32 = gop.value_ptr.*;
+        if (gop.found_existing == false) {
+            try elements.append(self.allocator, @intFromPtr(e));
+            x = @intCast(elements.items.len);
+            gop.value_ptr.* = x;
+        }
+
+        return .{
+            .x = @floatFromInt(x),
+            .y = 0.0,
+            .width = 1.0,
+            .height = 1.0,
+        };
+    }
+
+    pub fn width(self: *const FlatRenderer) u32 {
+        return @intCast(self.elements.items.len);
+    }
+
+    pub fn height(_: *const FlatRenderer) u32 {
+        return 1;
+    }
+
+    pub fn getElementAtPosition(self: *const FlatRenderer, x: u32, y: u32) ?*parser.Element {
+        if (y > 1) {
+            return null;
+        }
+
+        const elements = self.elements.items;
+        return if (x < elements.len) @ptrFromInt(elements[x]) else null;
+    }
 };
 
 const NoopInspector = struct {

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -284,8 +284,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         // we should reject it.
         session_id: ?[]const u8,
 
-        // State
-        url: []const u8,
         loader_id: []const u8,
         security_origin: []const u8,
         page_life_cycle_events: bool,
@@ -306,7 +304,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 .cdp = cdp,
                 .target_id = null,
                 .session_id = null,
-                .url = URL_BASE,
                 .security_origin = URL_BASE,
                 .secure_context_type = "Secure", // TODO = enum
                 .loader_id = LOADER_ID,
@@ -334,6 +331,11 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 .opts = opts,
                 .registry = &self.node_registry,
             };
+        }
+
+        pub fn getURL(self: *const Self) ?[]const u8 {
+            const page = self.session.currentPage() orelse return null;
+            return page.rawuri;
         }
 
         pub fn onInspectorResponse(ctx: *anyopaque, _: u32, msg: []const u8) void {

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -37,6 +37,7 @@ pub const CDP = CDPT(struct {
 
 const SessionIdGen = Incrementing(u32, "SID");
 const TargetIdGen = Incrementing(u32, "TID");
+const LoaderIdGen = Incrementing(u32, "LID");
 const BrowserContextIdGen = Incrementing(u32, "BID");
 
 // Generic so that we can inject mocks into it.
@@ -54,6 +55,7 @@ pub fn CDPT(comptime TypeProvider: type) type {
         target_auto_attach: bool = false,
 
         target_id_gen: TargetIdGen = .{},
+        loader_id_gen: LoaderIdGen = .{},
         session_id_gen: SessionIdGen = .{},
         browser_context_id_gen: BrowserContextIdGen = .{},
 
@@ -183,6 +185,7 @@ pub fn CDPT(comptime TypeProvider: type) type {
                 },
                 5 => switch (@as(u40, @bitCast(domain[0..5].*))) {
                     asUint("Fetch") => return @import("domains/fetch.zig").processMessage(command),
+                    asUint("Input") => return @import("domains/input.zig").processMessage(command),
                     else => {},
                 },
                 6 => switch (@as(u48, @bitCast(domain[0..6].*))) {

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -1,0 +1,80 @@
+// Copyright (C) 2023-2024  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+pub fn processMessage(cmd: anytype) !void {
+    const action = std.meta.stringToEnum(enum {
+        dispatchMouseEvent,
+    }, cmd.input.action) orelse return error.UnknownMethod;
+
+    switch (action) {
+        .dispatchMouseEvent => return dispatchMouseEvent(cmd),
+    }
+}
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-dispatchMouseEvent
+fn dispatchMouseEvent(cmd: anytype) !void {
+    const params = (try cmd.params(struct {
+        type: []const u8,
+        x: u32,
+        y: u32,
+    })) orelse return error.InvalidParams;
+
+    try cmd.sendResult(null, .{});
+
+    if (std.ascii.eqlIgnoreCase(params.type, "mousePressed") == false) {
+        return;
+    }
+
+    const bc = cmd.browser_context orelse return;
+    const page = bc.session.currentPage() orelse return;
+    const click_result = (try page.click(cmd.arena, params.x, params.y)) orelse return;
+
+    switch (click_result) {
+        .navigate => |uri| try clickNavigate(cmd, uri),
+    }
+    // result already sent
+}
+
+fn clickNavigate(cmd: anytype, uri: std.Uri) !void {
+    const bc = cmd.browser_context.?;
+
+    var url_buf: std.ArrayListUnmanaged(u8) = .{};
+    try uri.writeToStream(.{
+        .scheme = true,
+        .authentication = true,
+        .authority = true,
+        .port = true,
+        .path = true,
+        .query = true,
+    }, url_buf.writer(cmd.arena));
+    const url = url_buf.items;
+
+    try cmd.sendEvent("Page.frameRequestedNavigation", .{
+        .url = url,
+        .frameId = bc.target_id.?,
+        .reason = "anchorClick",
+        .disposition = "currentTab",
+    }, .{ .session_id = bc.session_id.? });
+
+    bc.session.removePage();
+    _ = try bc.session.createPage(null);
+
+    try @import("page.zig").navigateToUrl(cmd, url, false);
+}

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -61,10 +61,10 @@ fn getFrameTree(cmd: anytype) !void {
     return cmd.sendResult(.{
         .frameTree = .{
             .frame = Frame{
-                .url = bc.url,
                 .id = target_id,
                 .loaderId = bc.loader_id,
                 .securityOrigin = bc.security_origin,
+                .url = bc.getURL() orelse "about:blank",
                 .secureContextType = bc.secure_context_type,
             },
         },
@@ -154,7 +154,6 @@ pub fn navigateToUrl(cmd: anytype, url: []const u8, send_result: bool) !void {
 
     // change state
     bc.reset();
-    bc.url = url;
     bc.loader_id = cmd.cdp.loader_id_gen.next();
 
     const LifecycleEvent = struct {
@@ -285,7 +284,7 @@ test "cdp.page: getFrameTree" {
                 .frame = .{
                     .id = "TID-3",
                     .loaderId = bc.loader_id,
-                    .url = bc.url,
+                    .url = "about:blank",
                     .domainAndRegistry = "",
                     .securityOrigin = bc.security_origin,
                     .mimeType = "text/html",

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -132,7 +132,6 @@ fn createTarget(cmd: anytype) !void {
     _ = try bc.session.createPage(aux_data);
 
     // change CDP state
-    bc.url = "about:blank";
     bc.security_origin = "://";
     bc.secure_context_type = "InsecureScheme";
     bc.loader_id = LOADER_ID;
@@ -142,11 +141,11 @@ fn createTarget(cmd: anytype) !void {
     // has been enabled?
     try cmd.sendEvent("Target.targetCreated", .{
         .targetInfo = TargetInfo{
-            .url = bc.url,
+            .attached = false,
             .targetId = target_id,
             .title = "about:blank",
             .browserContextId = bc.id,
-            .attached = false,
+            .url = "about:blank",
         },
     }, .{});
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -106,10 +106,16 @@ const Page = struct {
     aux_data: []const u8 = "",
     doc: ?*parser.Document = null,
 
-    pub fn navigate(self: *Page, url: []const u8, aux_data: []const u8) !void {
-        _ = self;
+    pub fn navigate(_: *Page, url: []const u8, aux_data: []const u8) !void {
         _ = url;
         _ = aux_data;
+    }
+
+    const ClickResult = @import("../browser/browser.zig").Page.ClickResult;
+    pub fn click(_: *Page, _: Allocator, x: u32, y: u32) !?ClickResult {
+        _ = x;
+        _ = y;
+        return null;
     }
 };
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -85,6 +85,7 @@ const Session = struct {
             return error.MockBrowserPageAlreadyExists;
         }
         self.page = .{
+            .rawuri = "",
             .session = self,
             .aux_data = try self.arena.dupe(u8, aux_data orelse ""),
         };
@@ -103,6 +104,7 @@ const Session = struct {
 
 const Page = struct {
     session: *Session,
+    rawuri: []const u8,
     aux_data: []const u8 = "",
     doc: ?*parser.Document = null,
 
@@ -111,10 +113,9 @@ const Page = struct {
         _ = aux_data;
     }
 
+    const MouseEvent = @import("../browser/browser.zig").Page.MouseEvent;
     const ClickResult = @import("../browser/browser.zig").Page.ClickResult;
-    pub fn click(_: *Page, _: Allocator, x: u32, y: u32) !?ClickResult {
-        _ = x;
-        _ = y;
+    pub fn mouseEvent(_: *Page, _: Allocator, _: MouseEvent) !?ClickResult {
         return null;
     }
 };

--- a/src/main_tests.zig
+++ b/src/main_tests.zig
@@ -25,6 +25,7 @@ const pretty = @import("pretty");
 
 const parser = @import("netsurf");
 const apiweb = @import("apiweb.zig");
+const browser = @import("browser/browser.zig");
 const Window = @import("html/window.zig").Window;
 const xhr = @import("xhr/xhr.zig");
 const storage = @import("storage/storage.zig");
@@ -100,9 +101,14 @@ fn testExecFn(
     var cookie_jar = storage.CookieJar.init(alloc);
     defer cookie_jar.deinit();
 
+    var renderer = browser.Renderer.init(alloc);
+    defer renderer.elements.deinit(alloc);
+    defer renderer.positions.deinit(alloc);
+
     try js_env.setUserContext(.{
         .uri = try std.Uri.parse(url),
         .document = doc,
+        .renderer = &renderer,
         .cookie_jar = &cookie_jar,
         .http_client = &http_client,
     });

--- a/src/netsurf/netsurf.zig
+++ b/src/netsurf/netsurf.zig
@@ -801,6 +801,24 @@ pub fn eventTargetDispatchEvent(et: *EventTarget, event: *Event) !bool {
     return res;
 }
 
+const DispatchOpts = struct {
+    type: []const u8,
+    bubbles: bool = true,
+    cancelable: bool = true,
+};
+pub fn elementDispatchEvent(element: *Element, opts: DispatchOpts) !bool {
+    const event = try eventCreate();
+    defer eventDestroy(event);
+
+    try eventInit(event, opts.type, .{ .bubbles = opts.bubbles, .cancelable = opts.cancelable });
+
+    var res: bool = undefined;
+    const et: *EventTarget = @ptrCast(element);
+    const err = eventTargetVtable(et).dispatch_event.?(et, event, &res);
+    try DOMErr(err);
+    return res;
+}
+
 pub fn eventTargetTBaseFieldName(comptime T: type) ?[]const u8 {
     std.debug.assert(@inComptime());
     switch (@typeInfo(T)) {

--- a/src/netsurf/netsurf.zig
+++ b/src/netsurf/netsurf.zig
@@ -802,18 +802,9 @@ pub fn eventTargetDispatchEvent(et: *EventTarget, event: *Event) !bool {
     return res;
 }
 
-const DispatchOpts = struct {
-    type: []const u8,
-    bubbles: bool = true,
-    cancelable: bool = true,
-};
-pub fn elementDispatchEvent(element: *Element, opts: DispatchOpts) !bool {
-    const event = try eventCreate();
-    defer eventDestroy(event);
-    try eventInit(event, opts.type, .{ .bubbles = opts.bubbles, .cancelable = opts.cancelable });
-
-    const et: *EventTarget = @ptrCast(element);
-    return eventTargetDispatchEvent(et, event);
+pub fn elementDispatchEvent(element: *Element, event: *Event) !bool {
+    const et: *EventTarget = toEventTarget(Element, element);
+    return eventTargetDispatchEvent(et, @ptrCast(event));
 }
 
 pub fn eventTargetTBaseFieldName(comptime T: type) ?[]const u8 {

--- a/src/netsurf/netsurf.zig
+++ b/src/netsurf/netsurf.zig
@@ -24,6 +24,7 @@ const c = @cImport({
     @cInclude("dom/bindings/hubbub/parser.h");
     @cInclude("events/event_target.h");
     @cInclude("events/event.h");
+    @cInclude("events/mouse_event.h");
 });
 
 const mimalloc = @import("mimalloc");
@@ -809,14 +810,10 @@ const DispatchOpts = struct {
 pub fn elementDispatchEvent(element: *Element, opts: DispatchOpts) !bool {
     const event = try eventCreate();
     defer eventDestroy(event);
-
     try eventInit(event, opts.type, .{ .bubbles = opts.bubbles, .cancelable = opts.cancelable });
 
-    var res: bool = undefined;
     const et: *EventTarget = @ptrCast(element);
-    const err = eventTargetVtable(et).dispatch_event.?(et, event, &res);
-    try DOMErr(err);
-    return res;
+    return eventTargetDispatchEvent(et, event);
 }
 
 pub fn eventTargetTBaseFieldName(comptime T: type) ?[]const u8 {
@@ -877,6 +874,61 @@ pub const EventTargetTBase = extern struct {
         return c._dom_event_target_iter_event_listener(self.eti, t, capture, cur, next, l);
     }
 };
+
+// MouseEvent
+
+pub const MouseEvent = c.dom_mouse_event;
+
+pub fn mouseEventCreate() !*MouseEvent {
+    var evt: ?*MouseEvent = undefined;
+    const err = c._dom_mouse_event_create(&evt);
+    try DOMErr(err);
+    return evt.?;
+}
+
+pub fn mouseEventDestroy(evt: *MouseEvent) void {
+    c._dom_mouse_event_destroy(evt);
+}
+
+const MouseEventOpts = struct {
+    x: i32,
+    y: i32,
+    bubbles: bool = false,
+    cancelable: bool = false,
+    ctrl: bool = false,
+    alt: bool = false,
+    shift: bool = false,
+    meta: bool = false,
+    button: u16 = 0,
+    click_count: u16 = 1,
+};
+
+pub fn mouseEventInit(evt: *MouseEvent, typ: []const u8, opts: MouseEventOpts) !void {
+    const s = try strFromData(typ);
+    const err = c._dom_mouse_event_init(
+        evt,
+        s,
+        opts.bubbles,
+        opts.cancelable,
+        null, // dom_abstract_view* ?
+        opts.click_count, // details
+        opts.x, // screen_x
+        opts.y, // screen_y
+        opts.x, // client_x
+        opts.y, // client_y
+        opts.ctrl,
+        opts.alt,
+        opts.shift,
+        opts.meta,
+        opts.button,
+        null, // related target
+    );
+    try DOMErr(err);
+}
+
+pub fn mouseEventDefaultPrevented(evt: *MouseEvent) !bool {
+    return eventDefaultPrevented(@ptrCast(evt));
+}
 
 // NodeType
 

--- a/src/user_context.zig
+++ b/src/user_context.zig
@@ -2,10 +2,12 @@ const std = @import("std");
 const parser = @import("netsurf");
 const storage = @import("storage/storage.zig");
 const Client = @import("http/client.zig").Client;
+const Renderer = @import("browser/browser.zig").Renderer;
 
 pub const UserContext = struct {
-    http_client: *Client,
     uri: std.Uri,
+    http_client: *Client,
     document: *parser.DocumentHTML,
     cookie_jar: *storage.CookieJar,
+    renderer: *Renderer,
 };


### PR DESCRIPTION
This isn't complete.

Can't test because scripts run into other blockers before reaching this point (i.e. Dom.resolveNode). I do think it's pretty safe to merge this as-is though.

Looking for feedback on the `FlatRenderer` in `browser.zig` and Page.click handling (netsurf code is a bit tedious to us).

Besides the inability to manually test. I'm also looking for feedback about how to test this. These flows are starting to get more complicated and I'm not sure they're reasonable for unit tests.