### PR TITLE
Cdp node children

### DIFF
--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -228,7 +228,7 @@ pub const Writer = struct {
             try w.objectField("children");
             try w.beginArray();
             for (0..child_count) |_| {
-                const child = (try parser.nodeListItem(child_nodes, @intCast(i))) orelse continue;
+                const child = (try parser.nodeListItem(child_nodes, @intCast(i))) orelse break;
                 const child_node = try registry.register(child);
                 try w.beginObject();
                 try writeCommon(child_node, true, w);

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -325,6 +325,14 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             self.node_search_list.reset();
         }
 
+        pub fn nodeWriter(self: *Self, node: *const Node, opts: Node.Writer.Opts) Node.Writer {
+            return .{
+                .node = node,
+                .opts = opts,
+                .registry = &self.node_registry,
+            };
+        }
+
         pub fn onInspectorResponse(ctx: *anyopaque, _: u32, msg: []const u8) void {
             if (std.log.defaultLogEnabled(.debug)) {
                 // msg should be {"id":<id>,...

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -51,7 +51,7 @@ fn getDocument(cmd: anytype) !void {
     const doc = page.doc orelse return error.DocumentNotLoaded;
 
     const node = try bc.node_registry.register(parser.documentToNode(doc));
-    return cmd.sendResult(bc.nodeWriter(node, .{}), .{});
+    return cmd.sendResult(.{ .root = bc.nodeWriter(node, .{}) }, .{});
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-performSearch

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -51,9 +51,7 @@ fn getDocument(cmd: anytype) !void {
     const doc = page.doc orelse return error.DocumentNotLoaded;
 
     const node = try bc.node_registry.register(parser.documentToNode(doc));
-    return cmd.sendResult(.{
-        .root = node,
-    }, .{});
+    return cmd.sendResult(.{ .root = node.writer(.{}) }, .{});
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-performSearch
@@ -118,6 +116,7 @@ fn getSearchResults(cmd: anytype) !void {
 }
 
 const testing = @import("../testing.zig");
+
 test "cdp.dom: getSearchResults unknown search id" {
     var ctx = testing.context();
     defer ctx.deinit();
@@ -149,7 +148,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{ 0, 1 } }, .{ .id = 13 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{ 0, 2 } }, .{ .id = 13 });
 
         // different fromIndex
         try ctx.processMessage(.{
@@ -157,7 +156,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 1, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 14 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{2} }, .{ .id = 14 });
 
         // different toIndex
         try ctx.processMessage(.{

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -51,7 +51,7 @@ fn getDocument(cmd: anytype) !void {
     const doc = page.doc orelse return error.DocumentNotLoaded;
 
     const node = try bc.node_registry.register(parser.documentToNode(doc));
-    return cmd.sendResult(.{ .root = node.writer(.{}) }, .{});
+    return cmd.sendResult(bc.nodeWriter(node, .{}), .{});
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-performSearch
@@ -148,7 +148,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{ 0, 2 } }, .{ .id = 13 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{ 0, 1 } }, .{ .id = 13 });
 
         // different fromIndex
         try ctx.processMessage(.{
@@ -156,7 +156,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 1, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{2} }, .{ .id = 14 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 14 });
 
         // different toIndex
         try ctx.processMessage(.{

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -285,6 +285,7 @@ const TestContext = struct {
             _ = self.client.?.serialized.orderedRemove(i);
             return;
         }
+
         std.debug.print("Error not found. Expecting:\n{s}\n\nGot:\n", .{serialized});
         for (self.client.?.serialized.items, 0..) |sent, i| {
             std.debug.print("#{d}\n{s}\n\n", .{ i, sent });

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -26,11 +26,12 @@ const main = @import("cdp.zig");
 const parser = @import("netsurf");
 const App = @import("../app.zig").App;
 
-pub const allocator = @import("../testing.zig").allocator;
-
-pub const expectEqual = @import("../testing.zig").expectEqual;
-pub const expectError = @import("../testing.zig").expectError;
-pub const expectEqualSlices = @import("../testing.zig").expectEqualSlices;
+const base = @import("../testing.zig");
+pub const allocator = base.allocator;
+pub const expectJson = base.expectJson;
+pub const expectEqual = base.expectEqual;
+pub const expectError = base.expectError;
+pub const expectEqualSlices = base.expectEqualSlices;
 
 pub const Document = @import("../testing.zig").Document;
 
@@ -310,47 +311,5 @@ pub fn context() TestContext {
 fn compareExpectedToSent(expected: []const u8, actual: json.Value) !bool {
     const expected_value = try std.json.parseFromSlice(json.Value, std.testing.allocator, expected, .{});
     defer expected_value.deinit();
-    return compareJsonValues(expected_value.value, actual);
-}
-
-fn compareJsonValues(a: std.json.Value, b: std.json.Value) bool {
-    if (!std.mem.eql(u8, @tagName(a), @tagName(b))) {
-        return false;
-    }
-
-    switch (a) {
-        .null => return true,
-        .bool => return a.bool == b.bool,
-        .integer => return a.integer == b.integer,
-        .float => return a.float == b.float,
-        .number_string => return std.mem.eql(u8, a.number_string, b.number_string),
-        .string => return std.mem.eql(u8, a.string, b.string),
-        .array => {
-            const a_len = a.array.items.len;
-            const b_len = b.array.items.len;
-            if (a_len != b_len) {
-                return false;
-            }
-            for (a.array.items, b.array.items) |a_item, b_item| {
-                if (compareJsonValues(a_item, b_item) == false) {
-                    return false;
-                }
-            }
-            return true;
-        },
-        .object => {
-            var it = a.object.iterator();
-            while (it.next()) |entry| {
-                const key = entry.key_ptr.*;
-                if (b.object.get(key)) |b_item| {
-                    if (compareJsonValues(entry.value_ptr.*, b_item) == false) {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            }
-            return true;
-        },
-    }
+    return base.isEqualJson(expected_value.value, actual);
 }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -17,14 +17,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const parser = @import("netsurf");
 
+const parser = @import("netsurf");
 pub const allocator = std.testing.allocator;
 pub const expectError = std.testing.expectError;
 pub const expectString = std.testing.expectEqualStrings;
 pub const expectEqualSlices = std.testing.expectEqualSlices;
 
 const App = @import("app.zig").App;
+const Allocator = std.mem.Allocator;
 
 // Merged std.testing.expectEqual and std.testing.expectString
 // can be useful when testing fields of an anytype an you don't know
@@ -217,12 +218,93 @@ pub const Document = struct {
 
     pub fn querySelectorAll(self: *Document, selector: []const u8) ![]const *parser.Node {
         const css = @import("dom/css.zig");
-        const node_list = try css.querySelectorAll(self.arena.allocator(), parser.documentToNode(self.doc), selector);
+        const node_list = try css.querySelectorAll(self.arena.allocator(), self.asNode(), selector);
         return node_list.nodes.items;
     }
 
     pub fn querySelector(self: *Document, selector: []const u8) !?*parser.Node {
         const css = @import("dom/css.zig");
-        return css.querySelector(self.arena.allocator(), parser.documentToNode(self.doc), selector);
+        return css.querySelector(self.arena.allocator(), self.asNode(), selector);
+    }
+
+    pub fn asNode(self: *const Document) *parser.Node {
+        return parser.documentToNode(self.doc);
     }
 };
+
+pub fn expectJson(a: anytype, b: anytype) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const aa = arena.allocator();
+
+    const a_value = try convertToJson(aa, a);
+    const b_value = try convertToJson(aa, b);
+
+    errdefer {
+        const a_json = std.json.stringifyAlloc(aa, a_value, .{ .whitespace = .indent_2 }) catch unreachable;
+        const b_json = std.json.stringifyAlloc(aa, b_value, .{ .whitespace = .indent_2 }) catch unreachable;
+        std.debug.print("== Expected ==\n{s}\n\n== Actual ==\n{s}", .{ a_json, b_json });
+    }
+
+    try expectJsonValue(a_value, b_value);
+}
+
+pub fn isEqualJson(a: anytype, b: anytype) !bool {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const aa = arena.allocator();
+    const a_value = try convertToJson(aa, a);
+    const b_value = try convertToJson(aa, b);
+    expectJsonValue(a_value, b_value) catch return false;
+    return true;
+}
+
+fn convertToJson(arena: Allocator, value: anytype) !std.json.Value {
+    const T = @TypeOf(value);
+    if (T == std.json.Value) {
+        return value;
+    }
+
+    var str: []const u8 = undefined;
+    if (T == []u8 or T == []const u8 or comptime isStringArray(T)) {
+        str = value;
+    } else {
+        str = try std.json.stringifyAlloc(arena, value, .{});
+    }
+    return std.json.parseFromSliceLeaky(std.json.Value, arena, str, .{});
+}
+
+fn expectJsonValue(a: std.json.Value, b: std.json.Value) !void {
+    try expectEqual(@tagName(a), @tagName(b));
+
+    // at this point, we know that if a is an int, b must also be an int
+    switch (a) {
+        .null => return,
+        .bool => try expectEqual(a.bool, b.bool),
+        .integer => try expectEqual(a.integer, b.integer),
+        .float => try expectEqual(a.float, b.float),
+        .number_string => try expectEqual(a.number_string, b.number_string),
+        .string => try expectEqual(a.string, b.string),
+        .array => {
+            const a_len = a.array.items.len;
+            const b_len = b.array.items.len;
+            try expectEqual(a_len, b_len);
+            for (a.array.items, b.array.items) |a_item, b_item| {
+                try expectJsonValue(a_item, b_item);
+            }
+        },
+        .object => {
+            var it = a.object.iterator();
+            while (it.next()) |entry| {
+                const key = entry.key_ptr.*;
+                if (b.object.get(key)) |b_item| {
+                    try expectJsonValue(entry.value_ptr.*, b_item);
+                } else {
+                    return error.MissingKey;
+                }
+            }
+        },
+    }
+}


### PR DESCRIPTION
Add child nodes to CDP registry.

Add custom CDP Node writer to deal with different messages requiring a different representation (i.e. differnent child depth) of a node.