### PR TITLE
add 'node' subtype to htmldocument

### DIFF
--- a/src/html/document.zig
+++ b/src/html/document.zig
@@ -39,6 +39,8 @@ pub const HTMLDocument = struct {
     pub const prototype = *Document;
     pub const mem_guarantied = true;
 
+    pub const sub_type = "node";
+
     // JS funcs
     // --------
 


### PR DESCRIPTION
Subtype is now supported in zig-v8-fork and zig-js-runtime, adding the declaration to the HTMLDocument which is unblocks the `DOM.getDocument` cdp message.