### PR TITLE
Add URL struct

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -335,7 +335,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         pub fn getURL(self: *const Self) ?[]const u8 {
             const page = self.session.currentPage() orelse return null;
-            return page.rawuri;
+            return if (page.url) |*url| url.raw else null;
         }
 
         pub fn onInspectorResponse(ctx: *anyopaque, _: u32, msg: []const u8) void {

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -64,11 +64,7 @@ fn dispatchMouseEvent(cmd: anytype) !void {
             else => unreachable,
         },
     };
-    const click_result = (try page.mouseEvent(cmd.arena, mouse_event)) orelse return;
-
-    switch (click_result) {
-        .navigate => |uri| try clickNavigate(cmd, uri),
-    }
+    try page.mouseEvent(mouse_event);
     // result already sent
 }
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -24,6 +24,7 @@ const Testing = @This();
 
 const main = @import("cdp.zig");
 const parser = @import("netsurf");
+const URL = @import("../url.zig").URL;
 const App = @import("../app.zig").App;
 
 const base = @import("../testing.zig");
@@ -85,8 +86,8 @@ const Session = struct {
             return error.MockBrowserPageAlreadyExists;
         }
         self.page = .{
-            .rawuri = "",
             .session = self,
+            .url = URL.parse("https://lightpanda.io/", null) catch unreachable,
             .aux_data = try self.arena.dupe(u8, aux_data orelse ""),
         };
         return &self.page.?;
@@ -104,7 +105,7 @@ const Session = struct {
 
 const Page = struct {
     session: *Session,
-    rawuri: []const u8,
+    url: ?URL = null,
     aux_data: []const u8 = "",
     doc: ?*parser.Document = null,
 
@@ -114,10 +115,7 @@ const Page = struct {
     }
 
     const MouseEvent = @import("../browser/browser.zig").Page.MouseEvent;
-    const ClickResult = @import("../browser/browser.zig").Page.ClickResult;
-    pub fn mouseEvent(_: *Page, _: Allocator, _: MouseEvent) !?ClickResult {
-        return null;
-    }
+    pub fn mouseEvent(_: *Page, _: MouseEvent) !void {}
 };
 
 const Client = struct {

--- a/src/html/location.zig
+++ b/src/html/location.zig
@@ -30,60 +30,60 @@ const checkCases = jsruntime.test_utils.checkCases;
 pub const Location = struct {
     pub const mem_guarantied = true;
 
-    url: ?*URL = null,
+    url: ?URL = null,
 
     pub fn deinit(_: *Location, _: std.mem.Allocator) void {}
 
     pub fn get_href(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_href(alloc);
+        if (self.url) |*u| return u.get_href(alloc);
 
         return "";
     }
 
     pub fn get_protocol(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_protocol(alloc);
+        if (self.url) |*u| return u.get_protocol(alloc);
 
         return "";
     }
 
     pub fn get_host(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_host(alloc);
+        if (self.url) |*u| return u.get_host(alloc);
 
         return "";
     }
 
     pub fn get_hostname(self: *Location) []const u8 {
-        if (self.url) |u| return u.get_hostname();
+        if (self.url) |*u| return u.get_hostname();
 
         return "";
     }
 
     pub fn get_port(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_port(alloc);
+        if (self.url) |*u| return u.get_port(alloc);
 
         return "";
     }
 
     pub fn get_pathname(self: *Location) []const u8 {
-        if (self.url) |u| return u.get_pathname();
+        if (self.url) |*u| return u.get_pathname();
 
         return "";
     }
 
     pub fn get_search(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_search(alloc);
+        if (self.url) |*u| return u.get_search(alloc);
 
         return "";
     }
 
     pub fn get_hash(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_hash(alloc);
+        if (self.url) |*u| return u.get_hash(alloc);
 
         return "";
     }
 
     pub fn get_origin(self: *Location, alloc: std.mem.Allocator) ![]const u8 {
-        if (self.url) |u| return u.get_origin(alloc);
+        if (self.url) |*u| return u.get_origin(alloc);
 
         return "";
     }

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -102,7 +102,7 @@ pub const LightPanda = struct {
             try writer.writeByte('\n');
         }
 
-        var req = try self.client.request(.POST, self.uri);
+        var req = try self.client.request(.POST, &self.uri);
         defer req.deinit();
         req.body = arr.items;
 

--- a/src/url.zig
+++ b/src/url.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+
+const Uri = std.Uri;
+const Allocator = std.mem.Allocator;
+const WebApiURL = @import("url/url.zig").URL;
+
+pub const URL = struct {
+    uri: Uri,
+    raw: []const u8,
+
+    // We assume str will last as long as the URL
+    // In some cases, this is safe to do, because we know the URL is short lived.
+    // In most cases though, we assume the caller will just dupe the string URL
+    // into an arena
+    pub fn parse(str: []const u8, default_scheme: ?[]const u8) !URL {
+        const uri = Uri.parse(str) catch try Uri.parseAfterScheme(default_scheme orelse "https", str);
+        if (uri.host == null) {
+            return error.MissingHost;
+        }
+
+        std.debug.assert(uri.host.? == .percent_encoded);
+
+        return .{
+            .uri = uri,
+            .raw = str,
+        };
+    }
+
+    pub fn fromURI(arena: Allocator, uri: *const Uri) !URL {
+        // This is embarrassing.
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        try uri.writeToStream(.{
+            .scheme = true,
+            .authentication = true,
+            .authority = true,
+            .path = true,
+            .query = true,
+            .fragment = true,
+        }, buf.writer(arena));
+
+        return parse(buf.items, null);
+    }
+
+    // Above, in `parse, we error if a host doesn't exist
+    // In other words, we can't have a URL with a null host.
+    pub fn host(self: *const URL) []const u8 {
+        return self.uri.host.?.percent_encoded;
+    }
+
+    pub fn port(self: *const URL) ?u16 {
+        return self.uri.port;
+    }
+
+    pub fn scheme(self: *const URL) []const u8 {
+        return self.uri.scheme;
+    }
+
+    pub fn origin(self: *const URL, writer: anytype) !void {
+        return self.uri.writeToStream(.{ .scheme = true, .authority = true }, writer);
+    }
+
+    pub fn resolve(self: *const URL, arena: Allocator, url: []const u8) !URL {
+        var buf = try arena.alloc(u8, 1024);
+        const new_uri = try self.uri.resolve_inplace(url, &buf);
+        return fromURI(arena, &new_uri);
+    }
+
+    pub fn format(self: *const URL, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        return writer.writeAll(self.raw);
+    }
+
+    pub fn toWebApi(self: *const URL, allocator: Allocator) !WebApiURL {
+        return WebApiURL.init(allocator, self.uri);
+    }
+};

--- a/src/user_context.zig
+++ b/src/user_context.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
 const parser = @import("netsurf");
+const URL = @import("url.zig").URL;
 const storage = @import("storage/storage.zig");
 const Client = @import("http/client.zig").Client;
 const Renderer = @import("browser/browser.zig").Renderer;
 
 pub const UserContext = struct {
-    uri: std.Uri,
+    url: *const URL,
     http_client: *Client,
     document: *parser.DocumentHTML,
     cookie_jar: *storage.CookieJar,

--- a/src/wpt/run.zig
+++ b/src/wpt/run.zig
@@ -26,6 +26,7 @@ const parser = @import("netsurf");
 const jsruntime = @import("jsruntime");
 const Loop = jsruntime.Loop;
 const Env = jsruntime.Env;
+const URL = @import("../url.zig").URL;
 const browser = @import("../browser/browser.zig");
 const Window = @import("../html/window.zig").Window;
 const storage = @import("../storage/storage.zig");
@@ -66,12 +67,14 @@ pub fn run(arena: *std.heap.ArenaAllocator, comptime dir: []const u8, f: []const
     defer renderer.elements.deinit(alloc);
     defer renderer.positions.deinit(alloc);
 
+    const url = try URL.parse("https://lightpanda.io", null);
+
     var js_env: Env = undefined;
     Env.init(&js_env, alloc, &loop, UserContext{
+        .url = &url,
         .document = html_doc,
         .cookie_jar = &cookie_jar,
         .http_client = &http_client,
-        .uri = try std.Uri.parse("https://lightpanda.io"),
         .renderer = &renderer,
     });
     defer js_env.deinit();


### PR DESCRIPTION
`Page` currently contains 5 URL-ish related fields:

```zig
    rawuri: ?[]const u8 = null,
    uri: std.Uri = undefined,
    origin: ?[]const u8 = null,

    url: ?URL = null,
    location: Location = .{},
```

This PR adds a new URL struct which contains both the raw string and the `std.Uri`, and encapsulates some of the `std.Uri` API. It also tries to clean up some of the ownership. For example, `page` no longer has a `location` field. Instead, the window owns the location. Similarly, `page` no longer has a `url` field, the location now owns its url.

I original made http/client.zig and storage/cookie.zig use the new URL struct, but I backed away from that change in this PR. However, I did change those two classes to use  `*const std.Uri` rather than a `std.Uri`, again to try to clean up ownership.

I think there's more cleanup we can do around URI - the `std.Uri` API isn't great - so starting to encapsulate access through this custom struct is the first step.