### PR TITLE
Communicate page navigation state via notifications

### DIFF
--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -198,7 +198,7 @@ pub fn pageNavigate(bc: anytype, event: *const Notification.PageEvent) !void {
             .name = "init",
             .frameId = target_id,
             .loaderId = loader_id,
-            .timestamp = event.ts,
+            .timestamp = event.timestamp,
         }, .{ .session_id = session_id });
     }
 
@@ -213,7 +213,7 @@ pub fn pageNavigated(bc: anytype, event: *const Notification.PageEvent) !void {
     std.debug.assert(bc.session.page != null);
 
     var cdp = bc.cdp;
-    const ts = event.ts;
+    const timestamp = event.timestamp;
     const loader_id = bc.loader_id;
     const target_id = bc.target_id orelse unreachable;
     const session_id = bc.session_id orelse unreachable;
@@ -236,7 +236,7 @@ pub fn pageNavigated(bc: anytype, event: *const Notification.PageEvent) !void {
     // TODO: partially hard coded
     try cdp.sendEvent(
         "Page.domContentEventFired",
-        .{ .timestamp = ts },
+        .{ .timestamp = timestamp },
         .{ .session_id = session_id },
     );
 
@@ -244,7 +244,7 @@ pub fn pageNavigated(bc: anytype, event: *const Notification.PageEvent) !void {
     // TODO: partially hard coded
     if (bc.page_life_cycle_events) {
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
-            .timestamp = ts,
+            .timestamp = timestamp,
             .name = "DOMContentLoaded",
             .frameId = target_id,
             .loaderId = loader_id,
@@ -254,14 +254,14 @@ pub fn pageNavigated(bc: anytype, event: *const Notification.PageEvent) !void {
     // loadEventFired event
     try cdp.sendEvent(
         "Page.loadEventFired",
-        .{ .timestamp = ts },
+        .{ .timestamp = timestamp },
         .{ .session_id = session_id },
     );
 
     // lifecycle DOMContentLoaded event
     if (bc.page_life_cycle_events) {
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
-            .timestamp = ts,
+            .timestamp = timestamp,
             .name = "load",
             .frameId = target_id,
             .loaderId = loader_id,

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -161,7 +161,7 @@ const Page = struct {
     aux_data: []const u8 = "",
     doc: ?*parser.Document = null,
 
-    pub fn navigate(_: *Page, url: []const u8, aux_data: []const u8) !void {
+    pub fn navigate(_: *Page, url: URL, aux_data: []const u8) !void {
         _ = url;
         _ = aux_data;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -86,6 +86,7 @@ pub fn main() !void {
         },
         .fetch => |opts| {
             log.debug("Fetch mode: url {s}, dump {any}", .{ opts.url, opts.dump });
+            const url = try @import("url.zig").URL.parse(opts.url, null);
 
             var app = try App.init(alloc, .{
                 .run_mode = args.mode,
@@ -107,13 +108,13 @@ pub fn main() !void {
             // page
             const page = try session.createPage(null);
 
-            _ = page.navigate(opts.url, null) catch |err| switch (err) {
+            _ = page.navigate(url, null) catch |err| switch (err) {
                 error.UnsupportedUriScheme, error.UriMissingHost => {
-                    log.err("'{s}' is not a valid URL ({any})\n", .{ opts.url, err });
+                    log.err("'{s}' is not a valid URL ({any})\n", .{ url, err });
                     return args.printUsageAndExit(false);
                 },
                 else => {
-                    log.err("'{s}' fetching error ({any})\n", .{ opts.url, err });
+                    log.err("'{s}' fetching error ({any})\n", .{ url, err });
                     return err;
                 },
             };

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -1,0 +1,11 @@
+const URL = @import("url.zig").URL;
+
+pub const Notification = union(enum) {
+    page_navigate: PageEvent,
+    page_navigated: PageEvent,
+
+    pub const PageEvent = struct {
+        ts: u32,
+        url: *const URL,
+    };
+};

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -5,7 +5,7 @@ pub const Notification = union(enum) {
     page_navigated: PageEvent,
 
     pub const PageEvent = struct {
-        ts: u32,
+        timestamp: u32,
         url: *const URL,
     };
 };


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/516 needs a way for the page/session to communicate with CDP (i.e. the client). This adds a very simple mechanism for the page/session to callback into CDP. 

The `Page.navigate` CDP message has been changed to use the new notification appraoch. Page.navigate just signals the navigation request, and it's only via notifications from the page/session that page lifecycle events are sent back to the client.

I know this isn't the holistic event system that we want. This isn't something that the HTTP client can use to emit events nor is it something that telemetry can register listeners with. My goal is to get clicks working (from mouse events and javascript), then add some type of integration testing. Most of our recent additions don't have great code coverage, and events are hard to unit test. So I think this is the right time to add something to help increase our coverage around these more complicated cases.