### PR TITLE
Remove the WPT js_env.wait() on error.

### DIFF
--- a/src/wpt/run.zig
+++ b/src/wpt/run.zig
@@ -78,7 +78,6 @@ pub fn run(arena: *std.heap.ArenaAllocator, comptime dir: []const u8, f: []const
         .renderer = &renderer,
     });
     defer js_env.deinit();
-    errdefer js_env.wait() catch unreachable;
 
     var storageShelf = storage.Shelf.init(alloc);
     defer storageShelf.deinit();


### PR DESCRIPTION
https://github.com/lightpanda-io/zig-js-runtime/commit/40c0c7d4218fd6c79775b3751fe5fc4806ea24e8

Makes it unecessary as wait is now always called on deinit.