### PR TITLE
Recreate fake isolated world when cleared

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -303,6 +303,9 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         node_registry: Node.Registry,
         node_search_list: Node.Search.List,
 
+        // Holds the data to be able recreate the fake isolated world, see: @isolated_world
+        fake_isolatedworld: ?@import("domains/runtime.zig").ExecutionContextCreated,
+
         const Self = @This();
 
         fn init(self: *Self, id: []const u8, cdp: *CDP_T) !void {
@@ -323,6 +326,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 .page_life_cycle_events = false, // TODO; Target based value
                 .node_registry = registry,
                 .node_search_list = undefined,
+                .fake_isolatedworld = null,
             };
             self.node_search_list = Node.Search.List.init(allocator, &self.node_registry);
         }


### PR DESCRIPTION
Based on https://github.com/lightpanda-io/browser/pull/524 as describeNode is needed to recreate the issue this solves.

When executionContextsCleared is called puppetteer drops all references to contexts it had.
When navigating we already send a executionContextCreated message for the main context, however we did not in the case the client had requested an isolated world.

Puppetteer seems to be using the isolated world to make sure that what it is doing does not interfere with the variables of the actual page. We however still us the main context to do everything, and send a fake context id 0.
This PR continues the hack by making sure we resend the isolated context right after send the executionContextsCleared  event.

NOTE: Likely need to change the target before merging!
