### PR TITLE
Make HTTP Response header values mutable

### DIFF
--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -1439,7 +1439,7 @@ pub const ResponseHeader = struct {
 
     // Stored header has already been lower-cased
     // `name` parameter should be passed in lower-cased
-    pub fn get(self: *const ResponseHeader, name: []const u8) ?[]const u8 {
+    pub fn get(self: *const ResponseHeader, name: []const u8) ?[]u8 {
         for (self.headers.items) |h| {
             if (std.mem.eql(u8, name, h.name)) {
                 return h.value;


### PR DESCRIPTION
The HTTP response values _are_ mutable, but because we're using std.http.Header the type is a `[]const u8`. This introduce a custom `Header` type where the value is `[]u8`.

The goal is largely to allow more efficient value-comparison, by allowing calling code to lower-case in-place. I specifically have the Mime parser in mind:

https://github.com/lightpanda-io/browser/blob/25dcae76487ab2aaa8ac8b468f465e55007a76ee/src/browser/mime.zig#L134