### PR TITLE
test: re-introduce js source name

### DIFF
--- a/src/browser/dom/node.zig
+++ b/src/browser/dom/node.zig
@@ -415,7 +415,7 @@ test "Browser.DOM.node" {
             \\   str = str.trim();
             \\   return str;
             \\ }
-        , &err_out);
+        , "trimAndReplace", &err_out);
     }
 
     try runner.testCases(&.{

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -468,16 +468,16 @@ pub const JsRunner = struct {
         }
     }
 
-    pub fn exec(self: *JsRunner, src: []const u8, err_msg: *?[]const u8) !void {
-        _ = try self.eval(src, err_msg);
+    pub fn exec(self: *JsRunner, src: []const u8, name: ?[]const u8, err_msg: *?[]const u8) !void {
+        _ = try self.eval(src, name, err_msg);
     }
 
-    pub fn eval(self: *JsRunner, src: []const u8, err_msg: *?[]const u8) !Env.Value {
+    pub fn eval(self: *JsRunner, src: []const u8, name: ?[]const u8, err_msg: *?[]const u8) !Env.Value {
         var try_catch: Env.TryCatch = undefined;
         try_catch.init(self.executor);
         defer try_catch.deinit();
 
-        return self.executor.exec(src, null) catch |err| {
+        return self.executor.exec(src, name) catch |err| {
             if (try try_catch.err(self.arena)) |msg| {
                 err_msg.* = msg;
                 std.debug.print("Error running script: {s}\n", .{msg});

--- a/src/wpt/run.zig
+++ b/src/wpt/run.zig
@@ -48,7 +48,7 @@ pub fn run(arena: Allocator, comptime dir: []const u8, f: []const u8, loader: *F
 
     // display console logs
     defer {
-        const res = runner.eval("console.join('\\n');", err_msg) catch unreachable;
+        const res = runner.eval("console.join('\\n');", "console", err_msg) catch unreachable;
         const log = res.toString(arena) catch unreachable;
         if (log.len > 0) {
             std.debug.print("-- CONSOLE LOG\n{s}\n--\n", .{log});
@@ -63,7 +63,7 @@ pub fn run(arena: Allocator, comptime dir: []const u8, f: []const u8, loader: *F
         \\  console.debug = function () {
         \\    console.push("debug", ...arguments);
         \\  };
-    , err_msg);
+    , "init", err_msg);
 
     // loop over the scripts.
     const doc = parser.documentHTMLToDocument(runner.state.document.?);
@@ -79,12 +79,12 @@ pub fn run(arena: Allocator, comptime dir: []const u8, f: []const u8, loader: *F
                 // no need to free path, thanks to the arena.
                 path = try fspath.join(arena, &.{ "/", dirname, path });
             }
-            try runner.exec(try loader.get(path), err_msg);
+            try runner.exec(try loader.get(path), src, err_msg);
         }
 
         // If the script as a source text, execute it.
         const src = try parser.nodeTextContent(s) orelse continue;
-        try runner.exec(src, err_msg);
+        try runner.exec(src, null, err_msg);
     }
 
     // Mark tests as ready to run.
@@ -111,10 +111,10 @@ pub fn run(arena: Allocator, comptime dir: []const u8, f: []const u8, loader: *F
     }
 
     // Check the final test status.
-    try runner.exec("report.status;", err_msg);
+    try runner.exec("report.status", "teststatus", err_msg);
 
     // return the detailed result.
-    const res = try runner.eval("report.log", err_msg);
+    const res = try runner.eval("report.log", "report", err_msg);
     return res.toString(arena);
 }
 


### PR DESCRIPTION
Having a js source name is useful to detect where the error comes from.

Using `null` generates messages with `<anonymous>` source name.
eg. `ReferenceError: report is not defined\n    at <anonymous>:1:1`
vs. `ReferenceError: report is not defined\n    at teststatus:1:1`