### PR TITLE
Return TypeError if trying to turn an unknown v8.Object into a toa

### DIFF
--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -1340,6 +1340,13 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
                 return @constCast(@as(*const T, &.{}));
             }
 
+            // if it isn't an empty struct, then the v8.Object should have an
+            // InternalFieldCount > 0, since our toa pointer should be embedded
+            // at index 0 of the internal field count.
+            if (js_obj.internalFieldCount() == 0) {
+                return error.InvalidArgument;
+            }
+
             const type_name = @typeName(T);
             if (@hasField(TypeLookup, type_name) == false) {
                 @compileError(std.fmt.comptimePrint(


### PR DESCRIPTION
Fixes some WPT crashes, i.e. `zig build wpt -- tests/wpt/dom/collections/HTMLCollection-as-prototype.html`

Still fails, but that should be fixed by https://github.com/lightpanda-io/browser/pull/548