### PR TITLE
Don't [try] to run non-tests

### DIFF
--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -148,6 +148,10 @@ pub fn main() !void {
             }
             failures += 1;
             continue;
+        } orelse {
+            // This test should _not_ have been run.
+            run -= 1;
+            continue;
         };
 
         const suite = try Suite.init(alloc, tc, true, res);


### PR DESCRIPTION
Currently, we treat every .html file in tests/wpt as-if it's a test. That isn't always the case. wpt has a manifest tool to generate a manifest (in JSON) of the tests, we should probably use that (but it's quite large).

This PR filters out two groups. First, everything in resources/ appears to be things to _run_ the tests, not actual tests.

Second, any file without a "testharness.js" doesn't appear to be a test either. Note that WPT's own manifest generator looks at this: https://github.com/web-platform-tests/wpt/blob/43a06153617aa58f877f9e5873c0a02290b1c2a8/tools/manifest/sourcefile.py#L676 (which is used later in the file to determine the type of file).