### PR TITLE
Implement custom isEqualNode

### DIFF
--- a/src/browser/dom/document_fragment.zig
+++ b/src/browser/dom/document_fragment.zig
@@ -34,6 +34,15 @@ pub const DocumentFragment = struct {
             parser.documentHTMLToDocument(state.document.?),
         );
     }
+
+    pub fn _isEqualNode(self: *parser.DocumentFragment, other_node: *parser.Node) !bool {
+        const other_type = try parser.nodeType(other_node);
+        if (other_type != .document_fragment) {
+            return false;
+        }
+        _ = self;
+        return true;
+    }
 };
 
 const testing = @import("../../testing.zig");
@@ -44,5 +53,12 @@ test "Browser.DOM.DocumentFragment" {
     try runner.testCases(&.{
         .{ "const dc = new DocumentFragment()", "undefined" },
         .{ "dc.constructor.name", "DocumentFragment" },
+    }, .{});
+
+    try runner.testCases(&.{
+        .{ "const dc1 = new DocumentFragment()", "undefined" },
+        .{ "const dc2 = new DocumentFragment()", "undefined" },
+        .{ "dc1.isEqualNode(dc1)", "true" },
+        .{ "dc1.isEqualNode(dc2)", "true" },
     }, .{});
 }

--- a/src/browser/dom/document_type.zig
+++ b/src/browser/dom/document_type.zig
@@ -39,4 +39,42 @@ pub const DocumentType = struct {
     pub fn get_systemId(self: *parser.DocumentType) ![]const u8 {
         return try parser.documentTypeGetSystemId(self);
     }
+
+    // netsurf's DocumentType doesn't implement the dom_node_get_attributes
+    // and thus will crash if we try to call nodeIsEqualNode.
+    pub fn _isEqualNode(self: *parser.DocumentType, other_node: *parser.Node) !bool {
+        if (try parser.nodeType(other_node) != .document_type) {
+            return false;
+        }
+
+        const other: *parser.DocumentType = @ptrCast(other_node);
+        if (std.mem.eql(u8, try get_name(self), try get_name(other)) == false) {
+            return false;
+        }
+        if (std.mem.eql(u8, try get_publicId(self), try get_publicId(other)) == false) {
+            return false;
+        }
+        if (std.mem.eql(u8, try get_systemId(self), try get_systemId(other)) == false) {
+            return false;
+        }
+        return true;
+    }
 };
+
+const testing = @import("../../testing.zig");
+test "Browser.DOM.DocumentType" {
+    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
+    defer runner.deinit();
+
+    try runner.testCases(&.{
+        .{ "let dt1 = document.implementation.createDocumentType('qname1', 'pid1', 'sys1');", "undefined" },
+        .{ "let dt2 = document.implementation.createDocumentType('qname2', 'pid2', 'sys2');", "undefined" },
+        .{ "let dt3 = document.implementation.createDocumentType('qname1', 'pid1', 'sys1');", "undefined" },
+        .{ "dt1.isEqualNode(dt1)", "true" },
+        .{ "dt1.isEqualNode(dt3)", "true" },
+        .{ "dt1.isEqualNode(dt2)", "false" },
+        .{ "dt2.isEqualNode(dt3)", "false" },
+        .{ "dt1.isEqualNode(document)", "false" },
+        .{ "document.isEqualNode(dt1)", "false" },
+    }, .{});
+}


### PR DESCRIPTION
Netsurf's dom_node_is_equal appears to be both unsafe and incorrect. It's unsafe because various node types don't have the dom_node_get_attributes implementation so they default to setting the node attributes to null: https://github.com/lightpanda-io/libdom/blob/master/src/core/node.c#L658

However, it doesn't do a NULL check when comparing them, so it crashes: https://github.com/lightpanda-io/libdom/blob/da8b967905a38455e4f6b75cc9ad2767bae3ccde/src/core/namednodemap.c#L312

Furthermore, specific nodes need to be compared using specific attributes/values.

This PR fixes a WPT crash.