### PR TITLE
pass null namespace/prefix to libdom

### DIFF
--- a/src/browser/dom/node.zig
+++ b/src/browser/dom/node.zig
@@ -289,8 +289,7 @@ pub const Node = struct {
         return try parser.nodeInsertBefore(self, new_node, ref_node);
     }
 
-    pub fn _isDefaultNamespace(self: *parser.Node, namespace: []const u8) !bool {
-        // TODO: namespace is not an optional parameter, but can be null.
+    pub fn _isDefaultNamespace(self: *parser.Node, namespace: ?[]const u8) !bool {
         return try parser.nodeIsDefaultNamespace(self, namespace);
     }
 

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -1273,8 +1273,8 @@ pub fn nodeInsertBefore(node: *Node, new_node: *Node, ref_node: *Node) !*Node {
     return res.?;
 }
 
-pub fn nodeIsDefaultNamespace(node: *Node, namespace: []const u8) !bool {
-    const s = try strFromData(namespace);
+pub fn nodeIsDefaultNamespace(node: *Node, namespace_: ?[]const u8) !bool {
+    const s = if (namespace_) |n| try strFromData(n) else null;
     var res: bool = undefined;
     const err = nodeVtable(node).dom_node_is_default_namespace.?(node, s, &res);
     try DOMErr(err);
@@ -1303,9 +1303,10 @@ pub fn nodeLookupPrefix(node: *Node, namespace: []const u8) !?[]const u8 {
     return strToData(s.?);
 }
 
-pub fn nodeLookupNamespaceURI(node: *Node, prefix: ?[]const u8) !?[]const u8 {
+pub fn nodeLookupNamespaceURI(node: *Node, prefix_: ?[]const u8) !?[]const u8 {
     var s: ?*String = undefined;
-    const err = nodeVtable(node).dom_node_lookup_namespace.?(node, try strFromData(prefix.?), &s);
+    const prefix: ?*String = if (prefix_) |p| try strFromData(p) else null;
+    const err = nodeVtable(node).dom_node_lookup_namespace.?(node, prefix, &s);
     try DOMErr(err);
     if (s == null) return null;
     return strToData(s.?);

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -163,12 +163,14 @@ const Inspector = struct {
         _ = object_id;
         return try alloc.create(i32);
     }
-    pub fn contextCreated(self: *const Inspector,
-                executor: *const Env.Executor,
-                name: []const u8,
-                origin: []const u8,
-                aux_data: ?[]const u8,
-                is_default_context: bool,) void {
+    pub fn contextCreated(
+        self: *const Inspector,
+        executor: *const Env.Executor,
+        name: []const u8,
+        origin: []const u8,
+        aux_data: ?[]const u8,
+        is_default_context: bool,
+    ) void {
         _ = self;
         _ = executor;
         _ = name;


### PR DESCRIPTION
This change, in combination with https://github.com/lightpanda-io/libdom/pull/22 fixes a number of crashes when using these functions.