### PR TITLE
Make CDP less generic.

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -97,7 +97,7 @@ pub const Browser = struct {
         return session;
     }
 
-    fn closeSession(self: *Browser) void {
+    pub fn closeSession(self: *Browser) void {
         if (self.session) |session| {
             session.deinit();
             self.session_pool.destroy(session);

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -58,7 +58,6 @@ pub const Browser = struct {
     http_client: *http.Client,
     session_pool: SessionPool,
     page_arena: std.heap.ArenaAllocator,
-    pub const EnvType = Env;
 
     const SessionPool = std.heap.MemoryPool(Session);
 

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -22,6 +22,8 @@ const json = std.json;
 
 const App = @import("../app.zig").App;
 const asUint = @import("../str/parser.zig").asUint;
+const Browser = @import("../browser/browser.zig").Browser;
+const Session = @import("../browser/browser.zig").Session;
 const Incrementing = @import("../id.zig").Incrementing;
 const Notification = @import("../notification.zig").Notification;
 
@@ -32,8 +34,6 @@ pub const LOADER_ID = "LOADERID24DD2FD56CF1EF33C965C79C";
 
 pub const CDP = CDPT(struct {
     const Client = *@import("../server.zig").Client;
-    const Browser = @import("../browser/browser.zig").Browser;
-    const Session = @import("../browser/browser.zig").Session;
 });
 
 const SessionIdGen = Incrementing(u32, "SID");
@@ -69,8 +69,6 @@ pub fn CDPT(comptime TypeProvider: type) type {
         message_arena: std.heap.ArenaAllocator,
 
         const Self = @This();
-        pub const Browser = TypeProvider.Browser;
-        pub const Session = TypeProvider.Session;
 
         pub fn init(app: *App, client: TypeProvider.Client) !Self {
             const allocator = app.allocator;
@@ -247,6 +245,7 @@ pub fn CDPT(comptime TypeProvider: type) type {
                 return false;
             }
             bc.deinit();
+            self.browser.closeSession();
             self.browser_context_pool.destroy(bc);
             self.browser_context = null;
             return true;
@@ -282,7 +281,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         // all intents and purpose, from CDP's point of view our Browser and
         // our Session more or less maps to a BrowserContext. THIS HAS ZERO
         // RELATION TO SESSION_ID
-        session: *CDP_T.Session,
+        session: *Session,
 
         // Points to the session arena
         arena: Allocator,
@@ -309,7 +308,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         node_registry: Node.Registry,
         node_search_list: Node.Search.List,
 
-        isolated_world: ?IsolatedWorld(CDP_T.Browser.EnvType),
+        isolated_world: ?IsolatedWorld(Browser.EnvType),
 
         const Self = @This();
 

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -21,6 +21,7 @@ const Allocator = std.mem.Allocator;
 const json = std.json;
 
 const App = @import("../app.zig").App;
+const Env = @import("../browser/env.zig").Env;
 const asUint = @import("../str/parser.zig").asUint;
 const Browser = @import("../browser/browser.zig").Browser;
 const Session = @import("../browser/browser.zig").Session;
@@ -308,7 +309,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         node_registry: Node.Registry,
         node_search_list: Node.Search.List,
 
-        isolated_world: ?IsolatedWorld(Browser.EnvType),
+        isolated_world: ?IsolatedWorld(Env),
 
         const Self = @This();
 

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -522,7 +522,7 @@ test "cdp.target: createTarget" {
         try testing.expectEqual(true, bc.target_id != null);
         try testing.expectEqual(
             \\{"isDefault":true,"type":"default","frameId":"TID-1"}
-        , bc.session.page.?.aux_data);
+        , bc.session.aux_data);
 
         try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 10 });
         try ctx.expectSentEvent("Target.targetCreated", .{ .targetInfo = .{ .url = "about:blank", .title = "about:blank", .attached = false, .type = "page", .canAccessOpener = false, .browserContextId = "BID-9", .targetId = bc.target_id.? } }, .{});


### PR DESCRIPTION
It's still generic over the client - we need to assert messages written to and be able to send specific commands, but it's no longer generic over Browser/ Session/Page/etc..