### PR TITLE
Svgelement

### DIFF
--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -48,6 +48,7 @@ pub const Element = struct {
 
     pub fn toInterface(e: *parser.Element) !Union {
         return try HTMLElem.toInterface(Union, e);
+        // SVGElement and MathML are not supported yet.
     }
 
     // JS funcs

--- a/src/browser/html/svg_elements.zig
+++ b/src/browser/html/svg_elements.zig
@@ -29,3 +29,13 @@ pub const SVGElement = struct {
     // a Self type to cast to.
     pub const subtype = .node;
 };
+
+const testing = @import("../../testing.zig");
+test "Browser.HTML.SVGElement" {
+    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
+    defer runner.deinit();
+
+    try runner.testCases(&.{
+        .{ "'AString' instanceof SVGElement", "false" },
+    }, .{});
+}

--- a/src/browser/html/svg_elements.zig
+++ b/src/browser/html/svg_elements.zig
@@ -16,22 +16,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const HTMLDocument = @import("document.zig").HTMLDocument;
-const HTMLElem = @import("elements.zig");
-const SVGElem = @import("svg_elements.zig");
-const Window = @import("window.zig").Window;
-const Navigator = @import("navigator.zig").Navigator;
-const History = @import("history.zig").History;
-const Location = @import("location.zig").Location;
+const Element = @import("../dom/element.zig").Element;
 
-pub const Interfaces = .{
-    HTMLDocument,
-    HTMLElem.HTMLElement,
-    HTMLElem.HTMLMediaElement,
-    HTMLElem.Interfaces,
-    SVGElem.SVGElement,
-    Window,
-    Navigator,
-    History,
-    Location,
+// Support for SVGElements is very limited, this is a dummy implementation.
+// This is here no to be able to support `element instanceof SVGElement;` in JavaScript.
+// https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
+pub const SVGElement = struct {
+    // Currently the prototype chain is not implemented (will not be returned by toInterface())
+    // For that we need parser.SvgElement and the derived types with tags in the v-table.
+    pub const prototype = *Element;
+    // While this is a Node, could consider not exposing the subtype untill we have
+    // a Self type to cast to.
+    pub const subtype = .node;
 };


### PR DESCRIPTION
Dummy implementations to support `element instanceof SVGElement;`

SVGElement has many derived types below it, see for example: https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimateElement.
