### PR TITLE
Scope a request entry

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,10 +13,10 @@
             .hash = "tigerbeetle_io-0.0.0-ViLgxpyRBAB5BMfIcj3KMXfbJzwARs9uSl8aRy2OXULd",
         },
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/97bcfb61da8c97de1321d677a6727a927a9db9a4.tar.gz",
-            .hash = "v8-0.0.0-xddH69DoIADZ8YXZ_EIx_tKdQKEoGsgob_3_ZIi0O_nV",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/363e2899e6d782ad999edbfae048228871230467.tar.gz",
+            .hash = "v8-0.0.0-xddH6wHzIAARDy1uFvPqqBpTXzhlnEGDTuX9IAUQz3oU",
         },
-        //.v8 = .{ .path = "../zig-v8-fork" },
+        // .v8 = .{ .path = "../zig-v8-fork" },
         //.tigerbeetle_io = .{ .path = "../tigerbeetle-io" },
     },
 }

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -193,7 +193,7 @@ pub const Session = struct {
         self.state.cookie_jar = &self.cookie_jar;
         errdefer self.arena.deinit();
 
-        self.executor = try browser.env.startExecutor(Window, &self.state, self, .main);
+        self.executor = try browser.env.startExecutor(Window, &self.state, self);
         errdefer browser.env.stopExecutor(self.executor);
         self.inspector = try Env.Inspector.init(self.arena.allocator(), self.executor, ctx);
 

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -168,6 +168,11 @@ pub fn CDPT(comptime TypeProvider: type) type {
         }
 
         fn dispatchCommand(command: anytype, method: []const u8) !void {
+            const v8 = @import("v8");
+            var temp_scope: v8.HandleScope = undefined;
+            v8.HandleScope.init(&temp_scope, command.cdp.browser.env.isolate);
+            defer temp_scope.deinit();
+
             const domain = blk: {
                 const i = std.mem.indexOfScalarPos(u8, method, 0, '.') orelse {
                     return error.InvalidMethod;

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -114,12 +114,11 @@ const Session = struct {
 
 const Env = struct {
     pub const Executor = MockExecutor;
-    pub fn startExecutor(self: *Env, comptime Global: type, state: anytype, module_loader: anytype, kind: anytype) !*Executor {
+    pub fn startExecutor(self: *Env, comptime Global: type, state: anytype, module_loader: anytype) !*Executor {
         _ = self;
         _ = Global;
         _ = state;
         _ = module_loader;
-        _ = kind;
         return error.MockExecutor;
     }
     pub fn stopExecutor(self: *Env, executor: *Executor) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -97,6 +97,11 @@ pub fn main() !void {
             var browser = try Browser.init(app);
             defer browser.deinit();
 
+            const v8 = @import("v8");
+            var temp_scope: v8.HandleScope = undefined;
+            v8.HandleScope.init(&temp_scope, browser.env.isolate);
+            defer temp_scope.deinit();
+
             var session = try browser.newSession({});
 
             // page

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -1137,22 +1137,26 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
             }
 
             pub fn call(self: *const Callback, args: anytype) !void {
-                // const v8 = @import("v8");
                 var temp_scope: v8.HandleScope = undefined;
                 v8.HandleScope.init(&temp_scope, self.executor.isolate);
                 defer temp_scope.deinit();
+
                 return self.callWithThis(self.getThis(), args);
             }
 
             pub fn tryCall(self: *const Callback, args: anytype, result: *Result) !void {
-                // const v8 = @import("v8");
                 var temp_scope: v8.HandleScope = undefined;
                 v8.HandleScope.init(&temp_scope, self.executor.isolate);
                 defer temp_scope.deinit();
+
                 return self.tryCallWithThis(self.getThis(), args, result);
             }
 
             pub fn tryCallWithThis(self: *const Callback, this: anytype, args: anytype, result: *Result) !void {
+                var temp_scope: v8.HandleScope = undefined;
+                v8.HandleScope.init(&temp_scope, self.executor.isolate);
+                defer temp_scope.deinit();
+
                 var try_catch: TryCatch = undefined;
                 try_catch.init(self.executor);
                 defer try_catch.deinit();
@@ -1171,6 +1175,10 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
             }
 
             pub fn callWithThis(self: *const Callback, this: anytype, args: anytype) !void {
+                var temp_scope: v8.HandleScope = undefined;
+                v8.HandleScope.init(&temp_scope, self.executor.isolate);
+                defer temp_scope.deinit();
+
                 const executor = self.executor;
 
                 const js_this = try executor.valueToExistingObject(this);

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -43,7 +43,7 @@ pub fn Runner(comptime State: type, comptime Global: type, comptime types: anyty
 
             const G = if (Global == void) DefaultGlobal else Global;
 
-            runner.executor = try runner.env.startExecutor(G, state, runner, .main);
+            runner.executor = try runner.env.startExecutor(G, state, runner);
             errdefer runner.env.stopExecutor(runner.executor);
 
             try runner.executor.startScope(if (Global == void) &default_global else global);

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -433,7 +433,7 @@ pub const JsRunner = struct {
             .tls_verify_host = false,
         });
 
-        runner.executor = try runner.env.startExecutor(Window, &runner.state, runner, .main);
+        runner.executor = try runner.env.startExecutor(Window, &runner.state, runner);
         errdefer runner.env.stopExecutor(runner.executor);
 
         try runner.executor.startScope(&runner.window);


### PR DESCRIPTION
Instead of maintaining a scop in Env, Executor and for a Page we enter and exit a scope upon receiving a call or a command.
The problem is that an Isolate has only 1 scope stack, but we have multiple contexts in flight at the same time.
This caused a problem where a page would close the scope, which would also remove the context that the isolatedworld put in there.

By closing all the scopes on exit of a command or call this should not be an issue.
Instead of storing globals in the Env scope, they are now persisted.
Also the context itself needs to persist, so we need to manually reset it when the context is deleted.