### PR TITLE
Unify the Zig and JS events using an intrusive node.

### DIFF
--- a/src/browser/dom/event_target.zig
+++ b/src/browser/dom/event_target.zig
@@ -46,7 +46,7 @@ pub const EventTarget = struct {
 
     pub fn _addEventListener(
         self: *parser.EventTarget,
-        eventType: []const u8,
+        typ: []const u8,
         cbk: Env.Callback,
         capture: ?bool,
         state: *SessionState,
@@ -56,7 +56,7 @@ pub const EventTarget = struct {
         // check if event target has already this listener
         const lst = try parser.eventTargetHasListener(
             self,
-            eventType,
+            typ,
             capture orelse false,
             cbk.id,
         );
@@ -64,29 +64,28 @@ pub const EventTarget = struct {
             return;
         }
 
+        const eh = try EventHandler.init(state.arena, try cbk.withThis(self));
+
         try parser.eventTargetAddEventListener(
             self,
-            state.arena,
-            eventType,
-            EventHandler,
-            .{ .cbk = cbk },
+            typ,
+            &eh.node,
             capture orelse false,
         );
     }
 
     pub fn _removeEventListener(
         self: *parser.EventTarget,
-        eventType: []const u8,
+        typ: []const u8,
         cbk: Env.Callback,
         capture: ?bool,
-        state: *SessionState,
         // TODO: hanle EventListenerOptions
         // see #https://github.com/lightpanda-io/jsruntime-lib/issues/114
     ) !void {
         // check if event target has already this listener
         const lst = try parser.eventTargetHasListener(
             self,
-            eventType,
+            typ,
             capture orelse false,
             cbk.id,
         );
@@ -97,8 +96,7 @@ pub const EventTarget = struct {
         // remove listener
         try parser.eventTargetRemoveEventListener(
             self,
-            state.arena,
-            eventType,
+            typ,
             lst.?,
             capture orelse false,
         );

--- a/src/browser/xhr/event_target.zig
+++ b/src/browser/xhr/event_target.zig
@@ -48,25 +48,25 @@ pub const XMLHttpRequestEventTarget = struct {
         typ: []const u8,
         cbk: Callback,
     ) !void {
+        const target = @as(*parser.EventTarget, @ptrCast(self));
+        const eh = try EventHandler.init(alloc, try cbk.withThis(target));
         try parser.eventTargetAddEventListener(
-            @as(*parser.EventTarget, @ptrCast(self)),
-            alloc,
+            target,
             typ,
-            EventHandler,
-            .{ .cbk = cbk },
+            &eh.node,
             false,
         );
     }
-    fn unregister(self: *XMLHttpRequestEventTarget, alloc: std.mem.Allocator, typ: []const u8, cbk: Callback) !void {
+    fn unregister(self: *XMLHttpRequestEventTarget, typ: []const u8, cbk_id: usize) !void {
         const et = @as(*parser.EventTarget, @ptrCast(self));
         // check if event target has already this listener
-        const lst = try parser.eventTargetHasListener(et, typ, false, cbk.id);
+        const lst = try parser.eventTargetHasListener(et, typ, false, cbk_id);
         if (lst == null) {
             return;
         }
 
         // remove listener
-        try parser.eventTargetRemoveEventListener(et, alloc, typ, lst.?, false);
+        try parser.eventTargetRemoveEventListener(et, typ, lst.?, false);
     }
 
     pub fn get_onloadstart(self: *XMLHttpRequestEventTarget) ?Callback {
@@ -89,39 +89,33 @@ pub const XMLHttpRequestEventTarget = struct {
     }
 
     pub fn set_onloadstart(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.onloadstart_cbk) |cbk| try self.unregister(arena, "loadstart", cbk);
-        try self.register(arena, "loadstart", handler);
+        if (self.onloadstart_cbk) |cbk| try self.unregister("loadstart", cbk.id);
+        try self.register(state.arena, "loadstart", handler);
         self.onloadstart_cbk = handler;
     }
     pub fn set_onprogress(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.onprogress_cbk) |cbk| try self.unregister(arena, "progress", cbk);
-        try self.register(arena, "progress", handler);
+        if (self.onprogress_cbk) |cbk| try self.unregister("progress", cbk.id);
+        try self.register(state.arena, "progress", handler);
         self.onprogress_cbk = handler;
     }
     pub fn set_onabort(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.onabort_cbk) |cbk| try self.unregister(arena, "abort", cbk);
-        try self.register(arena, "abort", handler);
+        if (self.onabort_cbk) |cbk| try self.unregister("abort", cbk.id);
+        try self.register(state.arena, "abort", handler);
         self.onabort_cbk = handler;
     }
     pub fn set_onload(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.onload_cbk) |cbk| try self.unregister(arena, "load", cbk);
-        try self.register(arena, "load", handler);
+        if (self.onload_cbk) |cbk| try self.unregister("load", cbk.id);
+        try self.register(state.arena, "load", handler);
         self.onload_cbk = handler;
     }
     pub fn set_ontimeout(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.ontimeout_cbk) |cbk| try self.unregister(arena, "timeout", cbk);
-        try self.register(arena, "timeout", handler);
+        if (self.ontimeout_cbk) |cbk| try self.unregister("timeout", cbk.id);
+        try self.register(state.arena, "timeout", handler);
         self.ontimeout_cbk = handler;
     }
     pub fn set_onloadend(self: *XMLHttpRequestEventTarget, handler: Callback, state: *SessionState) !void {
-        const arena = state.arena;
-        if (self.onloadend_cbk) |cbk| try self.unregister(arena, "loadend", cbk);
-        try self.register(arena, "loadend", handler);
+        if (self.onloadend_cbk) |cbk| try self.unregister("loadend", cbk.id);
+        try self.register(state.arena, "loadend", handler);
         self.onloadend_cbk = handler;
     }
 

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -1200,7 +1200,7 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
         pub const Callback = struct {
             id: usize,
             executor: *Executor,
-            _this: ?v8.Object = null,
+            this: ?v8.Object = null,
             func: PersistentFunction,
 
             // We use this when mapping a JS value to a Zig object. We can't
@@ -1215,8 +1215,13 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
                 exception: []const u8,
             };
 
-            pub fn setThis(self: *Callback, value: anytype) !void {
-                self._this = try self.executor.valueToExistingObject(value);
+            pub fn withThis(self: *const Callback, value: anytype) !Callback {
+                return .{
+                    .id = self.id,
+                    .func = self.func,
+                    .executor = self.executor,
+                    .this = try self.executor.valueToExistingObject(value),
+                };
             }
 
             pub fn call(self: *const Callback, args: anytype) !void {
@@ -1264,7 +1269,7 @@ pub fn Env(comptime S: type, comptime types: anytype) type {
             }
 
             fn getThis(self: *const Callback) v8.Object {
-                return self._this orelse self.executor.context.getGlobal();
+                return self.this orelse self.executor.context.getGlobal();
             }
 
             // debug/helper to print the source of the JS callback


### PR DESCRIPTION
The approach borrows heavily from Zig's new LinkedList API.

The main benefit is that it unifies how event callbacks are done. When the Page.windowClick event was added, the Event structure was changed to a union, supporting a distinct Zig and JS event.

This new approach more or less treats everything like a Zig event. A JS event is just a Zig struct that has a Env.Callback which it can invoke in its handle method.

The intrusive nature of the EventNode means that what used to be 1 or 2 allocations is now 0 or 1.

It also has the benefit of making netsurf completely unaware of Env.Callbacks.