### PR TITLE
Improve the debug ergonomics of the Env generic.

### DIFF
--- a/src/browser/env.zig
+++ b/src/browser/env.zig
@@ -9,23 +9,39 @@ const Loop = @import("../runtime/loop.zig").Loop;
 const HttpClient = @import("../http/client.zig").Client;
 const Renderer = @import("browser.zig").Renderer;
 
-const Interfaces = generate.Tuple(.{
-    @import("crypto/crypto.zig").Crypto,
-    @import("console/console.zig").Console,
-    @import("dom/dom.zig").Interfaces,
-    @import("events/event.zig").Interfaces,
-    @import("html/html.zig").Interfaces,
-    @import("iterator/iterator.zig").Interfaces,
-    @import("storage/storage.zig").Interfaces,
-    @import("url/url.zig").Interfaces,
-    @import("xhr/xhr.zig").Interfaces,
-    @import("xmlserializer/xmlserializer.zig").Interfaces,
-});
+const WebApis = struct {
+    // Wrapped like this for debug ergonomics.
+    // When we create our Env, a few lines down, we define it as:
+    //   pub const Env = js.Env(*SessionState, WebApis);
+    //
+    // If there's a compile time error witht he Env, it's type will be readable,
+    // i.e.: runtime.js.Env(*browser.env.SessionState, browser.env.WebApis)
+    //
+    // But if we didn't wrap it in the struct, like we once didn't, and defined
+    // env as:
+    //   pub const Env = js.Env(*SessionState, Interfaces);
+    //
+    // Because Interfaces is an anynoumous type, it doesn't have a friendly name
+    // and errors would be something like:
+    //   runtime.js.Env(*browser.env.SessionState, .{...A HUNDRED TYPES...})
+    pub const Interfaces = generate.Tuple(.{
+        @import("crypto/crypto.zig").Crypto,
+        @import("console/console.zig").Console,
+        @import("dom/dom.zig").Interfaces,
+        @import("events/event.zig").Interfaces,
+        @import("html/html.zig").Interfaces,
+        @import("iterator/iterator.zig").Interfaces,
+        @import("storage/storage.zig").Interfaces,
+        @import("url/url.zig").Interfaces,
+        @import("xhr/xhr.zig").Interfaces,
+        @import("xmlserializer/xmlserializer.zig").Interfaces,
+    });
+};
 
 pub const JsThis = Env.JsThis;
 pub const JsObject = Env.JsObject;
 pub const Callback = Env.Callback;
-pub const Env = js.Env(*SessionState, Interfaces{});
+pub const Env = js.Env(*SessionState, WebApis);
 pub const Global = @import("html/window.zig").Window;
 
 pub const SessionState = struct {

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -26,7 +26,7 @@ pub const allocator = std.testing.allocator;
 // browser.Env or the browser.SessionState
 pub fn Runner(comptime State: type, comptime Global: type, comptime types: anytype) type {
     const AdjustedTypes = if (Global == void) generate.Tuple(.{ types, DefaultGlobal }) else types;
-    const Env = js.Env(State, AdjustedTypes{});
+    const Env = js.Env(State, struct {pub const Interfaces = AdjustedTypes;});
 
     return struct {
         env: *Env,


### PR DESCRIPTION
Previously, we were passing our WebAPIs directly as an anonymous tuple. This resulted in Env(T) having an _awful_ name - a name composed of hundreds of classes.

By wrapping the anonymous tuple into a normal struct, the Env now gets a sane name which helps improve stack traces (and profiling, and debugging, ...)