### PR TITLE
Mouse event fixes

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -268,7 +268,7 @@ pub const Page = struct {
         // load polyfills
         try polyfill.load(self.arena, self.scope);
 
-        _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
+        // _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
     }
 
     fn microtaskCallback(node: *Loop.CallbackNode, repeat_delay: *?u63) void {

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -193,7 +193,7 @@ pub const Session = struct {
         // can't use the page arena, because we're about to reset it
         // and don't want to use the session's arena, because that'll start to
         // look like a leak if we navigate from page to page a lot.
-        var buf: [4096]u8 = undefined;
+        var buf: [2048]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buf);
         const url = try self.page.?.url.resolve(fba.allocator(), url_string);
 
@@ -732,7 +732,7 @@ pub const Page = struct {
             _ = repeat_delay;
             const self: *DelayedNavigation = @fieldParentPtr("navigate_node", node);
             self.session.pageNavigate(self.href) catch |err| {
-                log.err("Delayed navigation error {}", .{err});
+                log.err("Delayed navigation error {}", .{err}); // TODO: should we trigger a specific event here?
             };
         }
     };

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -731,7 +731,9 @@ pub const Page = struct {
         fn delay_navigate(node: *Loop.CallbackNode, repeat_delay: *?u63) void {
             _ = repeat_delay;
             const self: *DelayedNavigation = @fieldParentPtr("navigate_node", node);
-            self.session.pageNavigate(self.href) catch unreachable;
+            self.session.pageNavigate(self.href) catch |err| {
+                log.err("Delayed navigation error {}", .{err});
+            };
         }
     };
 

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -268,7 +268,7 @@ pub const Page = struct {
         // load polyfills
         try polyfill.load(self.arena, self.scope);
 
-        // _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
+        _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
     }
 
     fn microtaskCallback(node: *Loop.CallbackNode, repeat_delay: *?u63) void {

--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -500,24 +500,24 @@ test "Browser.DOM.Element" {
         .{ "document.getElementById('para').clientHeight", "1" },
 
         .{ "let r1 = document.getElementById('para').getBoundingClientRect()", "undefined" },
-        .{ "r1.x", "1" },
+        .{ "r1.x", "0" },
         .{ "r1.y", "0" },
         .{ "r1.width", "1" },
         .{ "r1.height", "1" },
 
         .{ "let r2 = document.getElementById('content').getBoundingClientRect()", "undefined" },
-        .{ "r2.x", "2" },
+        .{ "r2.x", "1" },
         .{ "r2.y", "0" },
         .{ "r2.width", "1" },
         .{ "r2.height", "1" },
 
         .{ "let r3 = document.getElementById('para').getBoundingClientRect()", "undefined" },
-        .{ "r3.x", "1" },
+        .{ "r3.x", "0" },
         .{ "r3.y", "0" },
         .{ "r3.width", "1" },
         .{ "r3.height", "1" },
 
-        .{ "document.getElementById('para').clientWidth", "3" },
+        .{ "document.getElementById('para').clientWidth", "2" },
         .{ "document.getElementById('para').clientHeight", "1" },
     }, .{});
 

--- a/src/browser/dom/intersection_observer.zig
+++ b/src/browser/dom/intersection_observer.zig
@@ -247,16 +247,16 @@ test "Browser.DOM.IntersectionObserver" {
     try runner.testCases(&.{
         .{ "let entry;", "undefined" },
         .{ "new IntersectionObserver(entries => { entry = entries[0]; }).observe(document.createElement('div'));", "undefined" },
-        .{ "entry.boundingClientRect.x;", "1" },
+        .{ "entry.boundingClientRect.x;", "0" },
         .{ "entry.intersectionRatio;", "1" },
-        .{ "entry.intersectionRect.x;", "1" },
+        .{ "entry.intersectionRect.x;", "0" },
         .{ "entry.intersectionRect.y;", "0" },
         .{ "entry.intersectionRect.width;", "1" },
         .{ "entry.intersectionRect.height;", "1" },
         .{ "entry.isIntersecting;", "true" },
         .{ "entry.rootBounds.x;", "0" },
         .{ "entry.rootBounds.y;", "0" },
-        .{ "entry.rootBounds.width;", "2" },
+        .{ "entry.rootBounds.width;", "1" },
         .{ "entry.rootBounds.height;", "1" },
         .{ "entry.target;", "[object HTMLDivElement]" },
     }, .{});
@@ -273,6 +273,6 @@ test "Browser.DOM.IntersectionObserver" {
             "undefined",
         },
         .{ "new_observer.observe(document.createElement('div'));", "undefined" },
-        .{ "new_entry.rootBounds.x;", "2" },
+        .{ "new_entry.rootBounds.x;", "1" },
     }, .{});
 }

--- a/src/url.zig
+++ b/src/url.zig
@@ -82,3 +82,19 @@ pub const URL = struct {
         return WebApiURL.init(allocator, self.uri);
     }
 };
+
+test "Url resolve size" {
+    const base = "https://www.lightpande.io";
+    const url = try URL.parse(base, null);
+
+    var url_string: [511]u8 = undefined; // Currently this is the largest url we support, it is however recommmended to at least support 2000 characters
+    @memset(&url_string, 'a');
+
+    var buf: [2048]u8 = undefined; // This is approximately the required size to support the current largest supported URL
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    const out_url = try url.resolve(fba.allocator(), &url_string);
+
+    try std.testing.expectEqualStrings(out_url.raw[0..25], base);
+    try std.testing.expectEqual(out_url.raw[25], '/');
+    try std.testing.expectEqualStrings(out_url.raw[26..], &url_string);
+}


### PR DESCRIPTION
Several issues prevents MouserPressed commands from working:
- URL buffer of 1kb resulted in OutOfMemory error for puppeteer click.js
- of by 1 errors in renderer's pixel location -> rendered now starts at x=0 instead of x=1
- Delay navigation as otherwise the dom tree was deleted during the event causing a crash