### PR TITLE
Work on DDG support (but still not working)

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -267,7 +267,7 @@ pub const Page = struct {
         // load polyfills
         try polyfill.load(self.arena, self.scope);
 
-        _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
+        // _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
     }
 
     fn microtaskCallback(node: *Loop.CallbackNode, repeat_delay: *?u63) void {

--- a/src/browser/html/html.zig
+++ b/src/browser/html/html.zig
@@ -23,6 +23,7 @@ const Window = @import("window.zig").Window;
 const Navigator = @import("navigator.zig").Navigator;
 const History = @import("history.zig").History;
 const Location = @import("location.zig").Location;
+const MediaQueryList = @import("media_query_list.zig").MediaQueryList;
 
 pub const Interfaces = .{
     HTMLDocument,
@@ -34,4 +35,5 @@ pub const Interfaces = .{
     Navigator,
     History,
     Location,
+    MediaQueryList,
 };

--- a/src/browser/html/media_query_list.zig
+++ b/src/browser/html/media_query_list.zig
@@ -1,0 +1,45 @@
+// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const parser = @import("../netsurf.zig");
+const Callback = @import("../env.zig").Callback;
+const EventTarget = @import("../dom/event_target.zig").EventTarget;
+
+// https://drafts.csswg.org/cssom-view/#the-mediaquerylist-interface
+pub const MediaQueryList = struct {
+    pub const prototype = *EventTarget;
+
+    // Extend libdom event target for pure zig struct.
+    // This is not safe as it relies on a structure layout that isn't guaranteed
+    base: parser.EventTargetTBase = parser.EventTargetTBase{},
+
+    matches: bool,
+    media: []const u8,
+
+    pub fn get_matches(self: *const MediaQueryList) bool {
+        return self.matches;
+    }
+
+    pub fn get_media(self: *const MediaQueryList) []const u8 {
+        return self.media;
+    }
+
+    pub fn _addListener(_: *const MediaQueryList, _: Callback) void {}
+
+    pub fn _removeListener(_: *const MediaQueryList, _: Callback) void {}
+};

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -29,6 +29,7 @@ const Location = @import("location.zig").Location;
 const Crypto = @import("../crypto/crypto.zig").Crypto;
 const Console = @import("../console/console.zig").Console;
 const EventTarget = @import("../dom/event_target.zig").EventTarget;
+const MediaQueryList = @import("media_query_list.zig").MediaQueryList;
 
 const storage = @import("../storage/storage.zig");
 
@@ -149,7 +150,14 @@ pub const Window = struct {
         try state.loop.cancel(kv.value.loop_id);
     }
 
-    pub fn createTimeout(self: *Window, cbk: Callback, delay_: ?u32, state: *SessionState, comptime repeat: bool) !u32 {
+    pub fn _matchMedia(_: *const Window, media: []const u8, state: *SessionState) !MediaQueryList {
+        return .{
+            .matches = false, // TODO?
+            .media = try state.arena.dupe(u8, media),
+        };
+    }
+
+    fn createTimeout(self: *Window, cbk: Callback, delay_: ?u32, state: *SessionState, comptime repeat: bool) !u32 {
         if (self.timers.count() > 512) {
             return error.TooManyTimeout;
         }

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -536,7 +536,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
 
             const ModuleLoader = struct {
                 ptr: *anyopaque,
-                func: *const fn (ptr: *anyopaque, specifier: []const u8) anyerror![]const u8,
+                func: *const fn (ptr: *anyopaque, specifier: []const u8) anyerror!?[]const u8,
             };
 
             // no init, started with executor.startScope()
@@ -790,7 +790,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                 const source = module_loader.func(module_loader.ptr, specifier) catch |err| {
                     log.err("fetchModuleSource for '{s}' fetch error: {}", .{ specifier, err });
                     return null;
-                };
+                } orelse return null;
 
                 const m = compileModule(self.isolate, source, specifier) catch |err| {
                     log.err("fetchModuleSource for '{s}' compile error: {}", .{ specifier, err });
@@ -2825,7 +2825,7 @@ const NoopInspector = struct {
 };
 
 const ErrorModuleLoader = struct {
-    pub fn fetchModuleSource(_: *anyopaque, _: []const u8) ![]const u8 {
+    pub fn fetchModuleSource(_: *anyopaque, _: []const u8) !?[]const u8 {
         return error.NoModuleLoadConfigured;
     }
 };


### PR DESCRIPTION
- Add dummy MediaQueryList and window.matchMedia
- Execute deferred scripts after non-deferred I realize this doesn't change much, given how we currently load all scripts after the document is parsed, but scripts _could_ depend on execution order.
- Add support for executing the `onload` attribute of <scripts>

I also cleaned up some of the Script code, i.e. removimg `unknown` kind and simply returning a null script, and removing the EmptyBody error and returning a null body string.