### PR TITLE
Optimize intervals, and make sure they're probably cleaned up.

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -267,7 +267,7 @@ pub const Page = struct {
         // load polyfills
         try polyfill.load(self.arena, self.scope);
 
-        // _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
+        _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
     }
 
     fn microtaskCallback(node: *Loop.CallbackNode, repeat_delay: *?u63) void {


### PR DESCRIPTION
A loop interval will no longer stop the loop from returning from `run`, and no longer requires mutating event_nb on each iteration.

Re-enable microtask loop, which I accidentally stopped in a previous commit.