### PR TITLE
Fix URL Resolving

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -205,44 +205,6 @@ pub const Session = struct {
     }
 };
 
-// Properly stitches two URLs together.
-//
-// For URLs with a path, it will replace the last entry with the src.
-// For URLs without a path, it will add src as the path.
-fn stitchUrl(allocator: std.mem.Allocator, src: []const u8, base: []const u8) ![]const u8 {
-    // Traversing until the path
-    var slash_iter = std.mem.splitScalar(u8, base, '/');
-    _ = slash_iter.next();
-    _ = slash_iter.next();
-    _ = slash_iter.next();
-
-    if (slash_iter.index) |path_index| {
-        // Remove final slash from pathless base slice.
-        const pathless_base = base[0 .. path_index - 1];
-        const path = slash_iter.rest();
-
-        if (path.len > 0) {
-            var split_halves = std.mem.splitBackwardsScalar(u8, path, '/');
-            _ = split_halves.first();
-            const stripped_path = split_halves.rest();
-
-            if (stripped_path.len > 0) {
-                // Multi path entry
-                return try std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ pathless_base, stripped_path, src });
-            } else {
-                // Single path entry
-                return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pathless_base, src });
-            }
-        } else {
-            // Slash at the end case
-            return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pathless_base, src });
-        }
-    } else {
-        // No path case
-        return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, src });
-    }
-}
-
 // Page navigates to an url.
 // You can navigates multiple urls with the same page, but you have to call
 // end() to stop the previous navigation before starting a new one.
@@ -637,7 +599,7 @@ pub const Page = struct {
 
         // if a base path is given, we resolve src using base.
         if (base) |_base| {
-            res_src = try stitchUrl(arena, src, _base);
+            res_src = try URL.stitch(arena, src, _base);
         }
 
         var origin_url = &self.url;
@@ -933,34 +895,4 @@ test "Browser" {
     try runner.testCases(&.{
         .{ "new Intl.DateTimeFormat()", "[object Intl.DateTimeFormat]" },
     }, .{});
-}
-
-test "Stitching Base & Src URLs (Basic)" {
-    const allocator = testing.allocator;
-
-    const base = "https://www.google.com/xyz/abc/123";
-    const src = "something.js";
-    const result = try stitchUrl(allocator, src, base);
-    defer allocator.free(result);
-    try testing.expectString("https://www.google.com/xyz/abc/something.js", result);
-}
-
-test "Stitching Base & Src URLs (Just Ending Slash)" {
-    const allocator = testing.allocator;
-
-    const base = "https://www.google.com/";
-    const src = "something.js";
-    const result = try stitchUrl(allocator, src, base);
-    defer allocator.free(result);
-    try testing.expectString("https://www.google.com/something.js", result);
-}
-
-test "Stitching Base & Src URLs (No Ending Slash)" {
-    const allocator = testing.allocator;
-
-    const base = "https://www.google.com";
-    const src = "something.js";
-    const result = try stitchUrl(allocator, src, base);
-    defer allocator.free(result);
-    try testing.expectString("https://www.google.com/something.js", result);
 }


### PR DESCRIPTION
This fixes the issue with URLs being resolved resulting in a weird single slash case. It introduces a `stichUrl` function that basically does what the old resolve was supposed to do.

This was present here and was the cause of the `error.MissingHost`:
```$ zig build run -- fetch   'https://www.reddit.com/r/Zig/comments/1ke7bau/zig_has_great_potential_for_async/'
info(http_client): redirecting to: GET https://www.reddit.com/r/Zig/comments/1ke7bau/zig_has_great_potential_for_async/?rdt=45651
info(browser): GET https://www.reddit.com/r/Zig/comments/1ke7bau/zig_has_great_potential_for_async/?rdt=45651 200
info(browser): fetch https://www.redditstatic.com/shreddit/en-US/icon-97fc6e52.js: 200
info(browser): fetch https://www.redditstatic.com/shreddit/en-US/shell-ff439fbd.js: 200
error(js): fetchModuleSource for './icon-97fc6e52.js' fetch error: error.MissingHost


#
# Fatal error in ../../../../src/src/execution/isolate-inl.h, line 98
# Debug check failed: has_scheduled_exception().
#
#
#
#FailureMessage Object: 0x7fff872fd110
==== C stack trace ===============================

    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2b3a513]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2b385bd]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2be57e2]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2be5215]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2ca7f13]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x3f9b3b1]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x3fab444]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x3faae39]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2c174e7]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2b2abc0]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248b2cb]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248b533]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248bed7]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248c1dc]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248c77b]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248daf7]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x248f068]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2493bc9]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2495008]
    /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca) [0x7d080aa2a1ca]
    /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x7d080aa2a28b]
    /home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda() [0x2398025]
run
└─ run lightpanda failure
error: the following command terminated unexpectedly:
/home/pierre/wrk/browser/.zig-cache/o/e8a82428b898dfe03a772bfde98d5109/lightpanda fetch https://www.reddit.com/r/Zig/comments/1ke7bau/zig_has_great_potential_for_async/
Build Summary: 3/5 steps succeeded; 1 failed
run transitive failure
└─ run lightpanda failure
error: the following build command failed with exit code 1:
/home/pierre/wrk/browser/.zig-cache/o/99705665cadf0f1fc911ec9c0358adb5/build /usr/local/zig-0.14.0/zig /usr/local/zig-0.14.0/lib /home/pierre/wrk/browser /home/pierre/wrk/browser/.zig-cache /home/pierre/.cache/zig --seed 0x2cc86eb5 -Z7fd4f6f6d1706933 run -- fetch https://www.reddit.com/r/Zig/comments/1ke7bau/zig_has_great_potential_for_async/
```