### PR TITLE
Move call/control of gc_hint to browser.

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -60,9 +60,7 @@ pub const Browser = struct {
     pub fn init(app: *App) !Browser {
         const allocator = app.allocator;
 
-        const env = try Env.init(allocator, .{
-            .gc_hints = app.config.gc_hints,
-        });
+        const env = try Env.init(allocator, .{});
         errdefer env.deinit();
 
         const notification = try Notification.init(allocator, app.notification);
@@ -98,6 +96,9 @@ pub const Browser = struct {
         if (self.session) |*session| {
             session.deinit();
             self.session = null;
+            if (self.app.config.gc_hints) {
+                self.env.lowMemoryNotification();
+            }
         }
     }
 


### PR DESCRIPTION
The browser has more context than the env about when this should be called. 

Specifically it can be called once per session, whereas, in the env, we can only call it once per context - which could be too often. I was hoping this would improve some of the isolated world performance regression, since this was now being called 2x as often, but it seems to have little impact. I still prefer it in the browser.