### PR TITLE
Timouts for all GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       OS: linux
 
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
       OS: linux
 
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -81,6 +83,7 @@ jobs:
       OS: macos
 
     runs-on: macos-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -113,6 +116,7 @@ jobs:
       OS: macos
 
     runs-on: macos-13
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,6 +36,7 @@ jobs:
     name: zig build release
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -67,6 +68,7 @@ jobs:
       LIGHTPANDA_DISABLE_TELEMETRY: true
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -111,6 +113,7 @@ jobs:
     needs: zig-build-release
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -45,6 +45,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +104,8 @@ jobs:
     if: github.event_name != 'pull_request'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     container:
       image: ghcr.io/lightpanda-io/perf-fmt:latest
       credentials:

--- a/.github/workflows/zig-fmt.yml
+++ b/.github/workflows/zig-fmt.yml
@@ -29,6 +29,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: mlugg/setup-zig@v1

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -87,6 +87,7 @@ jobs:
 
   zig-test:
     name: zig test
+    timeout-minutes: 15
 
     # Don't run the CI with draft PR.
     if: github.event.pull_request.draft == false
@@ -126,6 +127,8 @@ jobs:
     if: github.event_name != 'pull_request'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     container:
       image: ghcr.io/lightpanda-io/perf-fmt:latest
       credentials:


### PR DESCRIPTION
By default the timeout is 6 hours, for most workflows this is much higher than needed.
In cases where we hit infinite loops it may take a while to realize what is going on, by having the workflow fail after a reasonable timeout less time/resources are waisted. The timeout should still be lenient to not be annoying.

For more info see:
[GHA Job Timeout](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)