### PR TITLE
Init netsurf at page creation

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -152,6 +152,10 @@ pub const Session = struct {
     pub fn createPage(self: *Session) !*Page {
         std.debug.assert(self.page == null);
 
+        // Start netsurf memory arena.
+        // We need to init this early as JS event handlers may be registered through Runtime.evaluate before the first html doc is loaded
+        try parser.init();
+
         const page_arena = &self.browser.page_arena;
         _ = page_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
 
@@ -392,9 +396,6 @@ pub const Page = struct {
     // https://html.spec.whatwg.org/#read-html
     fn loadHTMLDoc(self: *Page, reader: anytype, charset: []const u8) !void {
         const arena = self.arena;
-
-        // start netsurf memory arena.
-        try parser.init();
 
         log.debug("parse html with charset {s}", .{charset});
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -121,7 +121,6 @@ const TestContext = struct {
         if (opts.html) |html| {
             if (bc.session_id == null) bc.session_id = "SID-X";
             parser.deinit();
-            try parser.init();
             const page = try bc.session.createPage();
             page.doc = (try Document.init(html)).doc;
         }


### PR DESCRIPTION
Playwright registers event handlers using Runtime.evaluate in the isolated world before any htmldoc is loaded.
Malloc would fail if netsurf was not initialized. This change initializes the parser on page create which is called when the Page.createTarget. It is ensured that this is called before createIsolatedWorld as createIsolatedWorld requires a main page to be created.
An additional benefit is that it is now symmetric with page removal where the parser is deinited.

![image](https://github.com/user-attachments/assets/7f34c65f-7d79-45c4-9bfe-f3c1e36c7a98)
_addEventListener (for Window)
   eventTargetHasListener
      strFromData
         dom_string_create