### PR TITLE
Ability to return typed arrays

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,7 +17,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.1.20'
+    default: 'v0.1.21'
   v8:
     description: 'v8 version to install'
     required: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ZIG=0.14.0
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG ARCH=x86_64
 ARG V8=11.1.134
-ARG ZIG_V8=v0.1.20
+ARG ZIG_V8=v0.1.21
 
 RUN apt-get update -yq && \
     apt-get install -yq xz-utils \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "tigerbeetle_io-0.0.0-ViLgxpyRBAB5BMfIcj3KMXfbJzwARs9uSl8aRy2OXULd",
         },
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/f0c7eaaffe39f2f1a224fbe97e550daca0ca1801.tar.gz",
-            .hash = "v8-0.0.0-xddH62T4IADchAHFgo4nx79w1VedNDhIVErtSNgup-Tk",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/fc764e7d29bc1514924e8df09255a057e03d453a.tar.gz",
+            .hash = "v8-0.0.0-xddH6zUZIQBJf109L94sC-mWH1NJXWCnOJGJttKtfasI",
         },
         //.v8 = .{ .path = "../zig-v8-fork" },
         //.tigerbeetle_io = .{ .path = "../tigerbeetle-io" },

--- a/src/runtime/test_primitive_types.zig
+++ b/src/runtime/test_primitive_types.zig
@@ -17,6 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // TODO: use functions instead of "fake" struct once we handle function API generation
+
+const Runner = testing.Runner(void, void, .{Primitives});
+const Env = Runner.Env;
+
 const Primitives = struct {
     pub fn constructor() Primitives {
         return .{};
@@ -114,6 +118,46 @@ const Primitives = struct {
         }
     }
 
+    pub fn _returnUint8(_: *const Primitives) Env.TypedArray(u8) {
+        return .{ .values = &.{ 10, 20, 250 } };
+    }
+
+    pub fn _returnInt8(_: *const Primitives) Env.TypedArray(i8) {
+        return .{ .values = &.{ 10, -20, -120 } };
+    }
+
+    pub fn _returnUint16(_: *const Primitives) Env.TypedArray(u16) {
+        return .{ .values = &.{ 10, 200, 2050 } };
+    }
+
+    pub fn _returnInt16(_: *const Primitives) Env.TypedArray(i16) {
+        return .{ .values = &.{ 10, -420, 0 } };
+    }
+
+    pub fn _returnUint32(_: *const Primitives) Env.TypedArray(u32) {
+        return .{ .values = &.{ 10, 2444343, 43432432 } };
+    }
+
+    pub fn _returnInt32(_: *const Primitives) Env.TypedArray(i32) {
+        return .{ .values = &.{ 10, -20, -495929123 } };
+    }
+
+    pub fn _returnUint64(_: *const Primitives) Env.TypedArray(u64) {
+        return .{ .values = &.{ 10, 495812375924, 0 } };
+    }
+
+    pub fn _returnInt64(_: *const Primitives) Env.TypedArray(i64) {
+        return .{ .values = &.{ 10, -49283838122, -2 } };
+    }
+
+    pub fn _returnFloat32(_: *const Primitives) Env.TypedArray(f32) {
+        return .{ .values = &.{ 1.1, -200.035, 0.0003 } };
+    }
+
+    pub fn _returnFloat64(_: *const Primitives) Env.TypedArray(f64) {
+        return .{ .values = &.{ 8881.22284, -4928.3838122, -0.00004 } };
+    }
+
     pub fn _int16(_: *const Primitives, arr: []i16) void {
         for (arr) |*a| {
             a.* -= @intCast(arr.len);
@@ -153,7 +197,7 @@ const Primitives = struct {
 
 const testing = @import("testing.zig");
 test "JS: primitive types" {
-    var runner = try testing.Runner(void, void, .{Primitives}).init({}, {});
+    var runner = try Runner.init({}, {});
     defer runner.deinit();
 
     // constructor
@@ -280,5 +324,16 @@ test "JS: primitive types" {
         .{ "try { p.int64(arr_u64) } catch(e) { e instanceof TypeError; }", "true" },
         .{ "try { p.intu64(arr_i64) } catch(e) { e instanceof TypeError; }", "true" },
         .{ "try { p.intu64(arr_u32) } catch(e) { e instanceof TypeError; }", "true" },
+
+        .{ "p.returnUint8()", "10,20,250" },
+        .{ "p.returnInt8()", "10,-20,-120" },
+        .{ "p.returnUint16()", "10,200,2050" },
+        .{ "p.returnInt16()", "10,-420,0" },
+        .{ "p.returnUint32()", "10,2444343,43432432" },
+        .{ "p.returnInt32()", "10,-20,-495929123" },
+        .{ "p.returnUint64()", "10,495812375924,0" },
+        .{ "p.returnInt64()", "10,-49283838122,-2" },
+        .{ "p.returnFloat32()", "1.100000023841858,-200.03500366210938,0.0003000000142492354" },
+        .{ "p.returnFloat64()", "8881.22284,-4928.3838122,-0.00004" },
     }, .{});
 }

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -26,14 +26,15 @@ pub const allocator = std.testing.allocator;
 // browser.Env or the browser.SessionState
 pub fn Runner(comptime State: type, comptime Global: type, comptime types: anytype) type {
     const AdjustedTypes = if (Global == void) generate.Tuple(.{ types, DefaultGlobal }) else types;
-    const Env = js.Env(State, struct {
-        pub const Interfaces = AdjustedTypes;
-    });
 
     return struct {
         env: *Env,
         scope: *Env.Scope,
         executor: Env.Executor,
+
+        pub const Env = js.Env(State, struct {
+            pub const Interfaces = AdjustedTypes;
+        });
 
         const Self = @This();
 


### PR DESCRIPTION

```zig
    pub fn _returnUint32(_: *const Primitives) Env.TypedArray(u32) {
        return .{ .values = &.{ 10, 2444343, 43432432 } };
    }
```

