### PR TITLE
Load about blank doc to set window

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -397,21 +397,11 @@ pub const Page = struct {
 
     // A minimal reader for about:blank such that it can be parsed by loadHTMLDoc.
     pub const AboutBlank = struct {
-        const content =
-            \\ <!DOCTYPE html>
-            \\ <html>
-            \\ <head>
-            \\     <title></title>
-            \\ </head>
-            \\ <body>
-            \\ </body>
-            \\ </html>
-        ;
         done: bool = false,
         pub fn next(self: *AboutBlank) !?[]const u8 {
             if (self.done) return null;
             self.done = true;
-            return AboutBlank.content;
+            return ""; // The contents is blank
         }
     };
 

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -335,6 +335,8 @@ pub const Page = struct {
 
         // if the url is about:blank, nothing to do.
         if (std.mem.eql(u8, "about:blank", request_url.raw)) {
+            var about_blank = AboutBlank{};
+            try self.loadHTMLDoc(&about_blank, "utf-8");
             return;
         }
 
@@ -392,6 +394,26 @@ pub const Page = struct {
             .timestamp = timestamp(),
         });
     }
+
+    // A minimal reader for about:blank such that it can be parsed by loadHTMLDoc.
+    pub const AboutBlank = struct {
+        const content =
+            \\ <!DOCTYPE html>
+            \\ <html>
+            \\ <head>
+            \\     <title></title>
+            \\ </head>
+            \\ <body>
+            \\ </body>
+            \\ </html>
+        ;
+        done: bool = false,
+        pub fn next(self: *AboutBlank) !?[]const u8 {
+            if (self.done) return null;
+            self.done = true;
+            return AboutBlank.content;
+        }
+    };
 
     // https://html.spec.whatwg.org/#read-html
     fn loadHTMLDoc(self: *Page, reader: anytype, charset: []const u8) !void {

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -508,8 +508,8 @@ test "cdp.target: createTarget" {
 
         // Even about:blank should set the window and document
         const page = ctx.cdp().browser_context.?.session.page.?;
-        try testing.expect(page.state.document != null);
-        try testing.expect(page.window.document != null);
+        try std.testing.expect(page.state.document != null);
+        try std.testing.expect(page.window.document != null);
     }
 
     {

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -125,6 +125,10 @@ fn createTarget(cmd: anytype) !void {
     bc.target_id = target_id;
 
     var page = try bc.session.createPage();
+    // Navigate to about:blank such that the window / state.document are created and set
+    // Playwright uses these before navigating to a real URL to detect when they are removed.
+    const url = try @import("../../url.zig").URL.parse("about:blank", "");
+    try page.navigate(url, .{});
     {
         const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
         bc.inspector.contextCreated(
@@ -501,6 +505,11 @@ test "cdp.target: createTarget" {
         // should create a browser context
         const bc = ctx.cdp().browser_context.?;
         try ctx.expectSentEvent("Target.targetCreated", .{ .targetInfo = .{ .url = "about:blank", .title = "about:blank", .attached = false, .type = "page", .canAccessOpener = false, .browserContextId = bc.id, .targetId = bc.target_id.? } }, .{});
+
+        // Even about:blank should set the window and document
+        const page = ctx.cdp().browser_context.?.session.page.?;
+        try testing.expect(page.state.document != null);
+        try testing.expect(page.window.document != null);
     }
 
     {


### PR DESCRIPTION
Playwright uses the window.document to detect when it is removed from the DOM tree.
Before this change we did not load any DOM tree so these were null pointers.
This makes sure that whenever we navigate to about:blank that a default DOM tree is still loaded and the window / document are set.

Note this behavior is in alignment with the spec: https://html.spec.whatwg.org/#read-html
> 2. If document's [URL](https://dom.spec.whatwg.org/#concept-document-url) is [about:blank](https://html.spec.whatwg.org/#about:blank), then [populate with html/head/body](https://html.spec.whatwg.org/#populate-with-html/head/body) given document.