### PR TITLE
add direct http proxy support

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -30,6 +30,7 @@ pub const App = struct {
         run_mode: RunMode,
         gc_hints: bool = false,
         tls_verify_host: bool = true,
+        http_proxy: ?std.Uri = null,
     };
 
     pub fn init(allocator: Allocator, config: Config) !*App {
@@ -54,6 +55,7 @@ pub const App = struct {
             .app_dir_path = app_dir_path,
             .notification = notification,
             .http_client = try HttpClient.init(allocator, 5, .{
+                .http_proxy = config.http_proxy,
                 .tls_verify_host = config.tls_verify_host,
             }),
             .config = config,

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -356,7 +356,7 @@ pub const Page = struct {
         var response = try request.sendSync(.{});
 
         // would be different than self.url in the case of a redirect
-        self.url = try URL.fromURI(arena, request.uri);
+        self.url = try URL.fromURI(arena, request.request_uri);
 
         const header = response.header;
         try session.cookie_jar.populateFromResponse(&self.url.uri, &header);

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -497,7 +497,7 @@ pub const XMLHttpRequest = struct {
             self.state = .loading;
             self.dispatchEvt("readystatechange");
 
-            try self.cookie_jar.populateFromResponse(self.request.?.uri, &header);
+            try self.cookie_jar.populateFromResponse(self.request.?.request_uri, &header);
         }
 
         if (progress.data) |data| {


### PR DESCRIPTION
There are at least two types of proxies we should support, relaying and MITM (I don't know what it's actually supposed to be called).

This adds support for MITM, which means that our HTTP client does a normal HTTP request to the proxy server, but the request path is the full URL. The upstream proxy then issues its own HTTP request to the destination. The benefit of this approach is that the proxy can easily modify the request/response, which is the behavior I currently need.