### PR TITLE
Don't load script tags with the nomodule attribute

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -759,6 +759,12 @@ pub const Page = struct {
                 return null;
             }
 
+            if (try parser.elementGetAttribute(e, "nomodule") != null) {
+                // these scripts should only be loaded if we don't support modules
+                // but since we do support modules, we can just skip them.
+                return null;
+            }
+
             const kind = parseKind(try parser.elementGetAttribute(e, "type")) orelse {
                 return null;
             };


### PR DESCRIPTION
These tags should not be loaded as we support ES modules.