### PR TITLE
Fix HTMLCollection named property issues

### DIFF
--- a/src/browser/dom/html_collection.zig
+++ b/src/browser/dom/html_collection.zig
@@ -406,10 +406,16 @@ pub const HTMLCollection = struct {
         for (0..len) |i| {
             const node = try self.item(@intCast(i)) orelse unreachable;
             const e = @as(*parser.Element, @ptrCast(node));
-            try js_this.setIndex(@intCast(i), e);
+            try js_this.setIndex(@intCast(i), e, .{});
 
             if (try item_name(e)) |name| {
-                try js_this.set(name, e);
+                // Even though an entry might have an empty id, the spec says
+                // that namedItem("") should always return null
+                if (name.len > 0) {
+                    // Named fields should not be enumerable (it is defined with
+                    // the LegacyUnenumerableNamedProperties flag.)
+                    try js_this.set(name, e, .{ .DONT_ENUM = true });
+                }
             }
         }
     }

--- a/src/browser/dom/nodelist.zig
+++ b/src/browser/dom/nodelist.zig
@@ -173,7 +173,7 @@ pub const NodeList = struct {
         const len = self.get_length();
         for (0..len) |i| {
             const node = try self._item(@intCast(i)) orelse unreachable;
-            try js_this.setIndex(i, node);
+            try js_this.setIndex(@intCast(i), node, .{});
         }
     }
 };


### PR DESCRIPTION
1 - Named properties should not be enumerable
2 - Empty key should always result in a null/undefined (depending on the API)
    even if there's an element with an empty id/name

To address the first issue, we now require PropertyAttributes to be specified when setting an object's value.