### PR TITLE
Introduce a "transfer_arena"

### DIFF
--- a/src/browser/session.zig
+++ b/src/browser/session.zig
@@ -126,7 +126,7 @@ pub const Session = struct {
         // it isn't null!
         std.debug.assert(self.page != null);
 
-        _ = self.browser.transfer_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
+        defer _ = self.browser.transfer_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
 
         // it's safe to use the transfer arena here, because the page will
         // eventually clone the URL using its own page_arena (after it gets

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -314,7 +314,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             const allocator = cdp.allocator;
 
             const session = try cdp.browser.newSession();
-            const arena = session.arena.allocator();
+            const arena = session.arena;
 
             const inspector = try cdp.browser.env.newInspector(arena, self);
 


### PR DESCRIPTION
Some data has to exist specifically for the navigation of one page to another. For example, if a hyperlink is clicked, the URL begins its life with the original page, but is transferred to the new page. The page_arena cannot be used for such data.

It's possible to use the session_arena, but it's lifetime is much longer and, given enough navigation, could accumulate a lot of memory.

The new transfer_arena exists within the session, but only exists until the next navigation.

While currently only used for the navigation URL, the main goal here is to have a place to put the request body on form submission, which has a lifetime similar to a click url.

While I'm at it, I promoted the existing session arena and the new transfer arena to the browser, allowing better memory re-use between sessions.