### PR TITLE
Add document.readyState

### DIFF
--- a/src/browser/env.zig
+++ b/src/browser/env.zig
@@ -62,4 +62,16 @@ pub const SessionState = struct {
     // shorter-lived than the arena above, which
     // exists for the entire rendering of the page
     call_arena: std.mem.Allocator = undefined,
+
+    pub fn getNodeWrapper(self: *SessionState, comptime T: type, node: *parser.Node) !*T {
+        if (parser.nodeGetEmbedderData(node)) |wrap| {
+            return @alignCast(@ptrCast(wrap));
+        }
+
+        const wrap = try self.arena.create(T);
+        wrap.* = T{};
+
+        parser.nodeSetEmbedderData(node, wrap);
+        return wrap;
+    }
 };

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -1274,6 +1274,14 @@ pub fn nodeGetPrefix(node: *Node) !?[]const u8 {
     return strToData(s.?);
 }
 
+pub fn nodeGetEmbedderData(node: *Node) ?*anyopaque {
+    return c._dom_node_get_embedder_data(node);
+}
+
+pub fn nodeSetEmbedderData(node: *Node, data: *anyopaque) void {
+    c._dom_node_set_embedder_data(node, data);
+}
+
 // nodeToElement is an helper to convert a node to an element.
 pub inline fn nodeToElement(node: *Node) *Element {
     return @as(*Element, @ptrCast(node));


### PR DESCRIPTION
This feature is implemented by embedding the Zig instance into a libdom node, allowing us to extend the functionality of libdom without having to change it. This was made possible by https://github.com/lightpanda-io/libdom/pull/26