### PR TITLE
Deduplicate document

### DIFF
--- a/src/browser/dom/comment.zig
+++ b/src/browser/dom/comment.zig
@@ -30,7 +30,7 @@ pub const Comment = struct {
 
     pub fn constructor(data: ?[]const u8, state: *const SessionState) !*parser.Comment {
         return parser.documentCreateComment(
-            parser.documentHTMLToDocument(state.document.?),
+            parser.documentHTMLToDocument(state.window.document.?),
             data orelse "",
         );
     }

--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -41,12 +41,12 @@ pub const Document = struct {
 
     pub fn constructor(state: *const SessionState) !*parser.DocumentHTML {
         const doc = try parser.documentCreateDocument(
-            try parser.documentHTMLGetTitle(state.document.?),
+            try parser.documentHTMLGetTitle(state.window.document.?),
         );
 
         // we have to work w/ document instead of html document.
         const ddoc = parser.documentHTMLToDocument(doc);
-        const ccur = parser.documentHTMLToDocument(state.document.?);
+        const ccur = parser.documentHTMLToDocument(state.window.document.?);
         try parser.documentSetDocumentURI(ddoc, try parser.documentGetDocumentURI(ccur));
         try parser.documentSetInputEncoding(ddoc, try parser.documentGetInputEncoding(ccur));
 

--- a/src/browser/dom/document_fragment.zig
+++ b/src/browser/dom/document_fragment.zig
@@ -29,7 +29,7 @@ pub const DocumentFragment = struct {
 
     pub fn constructor(state: *const SessionState) !*parser.DocumentFragment {
         return parser.documentCreateDocumentFragment(
-            parser.documentHTMLToDocument(state.document.?),
+            parser.documentHTMLToDocument(state.window.document.?),
         );
     }
 

--- a/src/browser/dom/intersection_observer.zig
+++ b/src/browser/dom/intersection_observer.zig
@@ -50,7 +50,7 @@ pub const IntersectionObserver = struct {
     // new IntersectionObserver(callback, options) [not supported yet]
     pub fn constructor(callback: Env.Callback, options_: ?IntersectionObserverOptions, state: *SessionState) !IntersectionObserver {
         var options = IntersectionObserverOptions{
-            .root = parser.documentToNode(parser.documentHTMLToDocument(state.document.?)),
+            .root = parser.documentToNode(parser.documentHTMLToDocument(state.window.document.?)),
             .rootMargin = "0px 0px 0px 0px",
             .threshold = &.{0.0},
         };
@@ -142,7 +142,7 @@ pub const IntersectionObserverEntry = struct {
     // Returns a DOMRectReadOnly for the intersection observer's root.
     pub fn get_rootBounds(self: *const IntersectionObserverEntry) !Element.DOMRect {
         const root = self.options.root.?;
-        if (@intFromPtr(root) == @intFromPtr(self.state.document.?)) {
+        if (@intFromPtr(root) == @intFromPtr(self.state.window.document.?)) {
             return self.state.renderer.boundingRect();
         }
 

--- a/src/browser/dom/processing_instruction.zig
+++ b/src/browser/dom/processing_instruction.zig
@@ -41,7 +41,7 @@ pub const ProcessingInstruction = struct {
     // a simple workaround.
     pub fn _cloneNode(self: *parser.ProcessingInstruction, _: ?bool, state: *SessionState) !*parser.ProcessingInstruction {
         return try parser.documentCreateProcessingInstruction(
-            @ptrCast(state.document),
+            @ptrCast(state.window.document.?),
             try get_target(self),
             (try get_data(self)) orelse "",
         );

--- a/src/browser/dom/text.zig
+++ b/src/browser/dom/text.zig
@@ -34,7 +34,7 @@ pub const Text = struct {
 
     pub fn constructor(data: ?[]const u8, state: *const SessionState) !*parser.Text {
         return parser.documentCreateTextNode(
-            parser.documentHTMLToDocument(state.document.?),
+            parser.documentHTMLToDocument(state.window.document.?),
             data orelse "",
         );
     }

--- a/src/browser/env.zig
+++ b/src/browser/env.zig
@@ -56,7 +56,6 @@ pub const SessionState = struct {
     arena: std.mem.Allocator,
     http_client: *HttpClient,
     cookie_jar: *storage.CookieJar,
-    document: ?*parser.DocumentHTML,
 
     // dangerous, but set by the JS framework
     // shorter-lived than the arena above, which

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -95,7 +95,6 @@ pub const Page = struct {
             .window_clicked_event_node = .{ .func = windowClicked },
             .state = .{
                 .arena = arena,
-                .document = null,
                 .url = &self.url,
                 .window = &self.window,
                 .renderer = &self.renderer,
@@ -276,9 +275,6 @@ pub const Page = struct {
         );
 
         // https://html.spec.whatwg.org/#read-html
-
-        // update the sessions state
-        self.state.document = html_doc;
 
         // browse the DOM tree to retrieve scripts
         // TODO execute the synchronous scripts during the HTL parsing.

--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -116,7 +116,7 @@ fn run(arena: Allocator, test_file: []const u8, loader: *FileLoader, err_out: *?
     try polyfill.load(arena, runner.scope);
 
     // loop over the scripts.
-    const doc = parser.documentHTMLToDocument(runner.state.document.?);
+    const doc = parser.documentHTMLToDocument(runner.state.window.document.?);
     const scripts = try parser.documentGetElementsByTagName(doc, "script");
     const script_count = try parser.nodeListLength(scripts);
     for (0..script_count) |i| {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -421,7 +421,6 @@ pub const JsRunner = struct {
         self.state = .{
             .arena = arena,
             .loop = &self.loop,
-            .document = document,
             .url = &self.url,
             .window = &self.window,
             .renderer = &self.renderer,


### PR DESCRIPTION
document was stored both in Window as well as the SessionState.
Since Window is not in the SessionState we can duplicate and no longer need to keep them in sync.

Convenience accessor was not added as we have enough indirection.
```zig
pub fn document(self: *SessionState) ?*parser.Document {
    return self.window.document;
}
```