### PR TITLE
implementation: remove the setTitle method call

### DIFF
--- a/src/browser/dom/implementation.zig
+++ b/src/browser/dom/implementation.zig
@@ -61,7 +61,10 @@ test "Browser.DOM.Implementation" {
     try runner.testCases(&.{
         .{ "let impl = document.implementation", "undefined" },
         .{ "impl.createHTMLDocument();", "[object HTMLDocument]" },
-        .{ "impl.createHTMLDocument('foo');", "[object HTMLDocument]" },
+        .{ "const doc = impl.createHTMLDocument('foo');", "undefined" },
+        .{ "doc", "[object HTMLDocument]" },
+        .{ "doc.title", "foo" },
+        .{ "doc.body", "[object HTMLBodyElement]" },
         .{ "impl.createDocument(null, 'foo');", "[object Document]" },
         .{ "impl.createDocumentType('foo', 'bar', 'baz')", "[object DocumentType]" },
         .{ "impl.hasFeature()", "true" },

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -1912,7 +1912,6 @@ pub inline fn domImplementationCreateHTMLDocument(title: ?[]const u8) !*Document
     _ = try nodeAppendChild(elementToNode(html), elementToNode(head));
 
     if (title) |t| {
-        try documentHTMLSetTitle(doc_html, t);
         const htitle = try documentCreateElement(doc, "title");
         const txt = try documentCreateTextNode(doc, t);
         _ = try nodeAppendChild(elementToNode(htitle), @as(*Node, @ptrCast(txt)));


### PR DESCRIPTION
Libdom uses the doc's body and title attributes by default. But it fallback to the DOM tree if the attributes are NULL.

I think it's better to have only the DOM tree set on document creation.