### PR TITLE
Load aboutblank doc

### DIFF
--- a/src/url.zig
+++ b/src/url.zig
@@ -9,6 +9,7 @@ pub const URL = struct {
     raw: []const u8,
 
     pub const empty = URL{ .uri = .{ .scheme = "" }, .raw = "" };
+    pub const about_blank = URL{ .uri = .{ .scheme = "" }, .raw = "about:blank" };
 
     // We assume str will last as long as the URL
     // In some cases, this is safe to do, because we know the URL is short lived.


### PR DESCRIPTION
Replaces PR:https://github.com/lightpanda-io/browser/pull/630

Loads the about:blank window / document when creating a target. Scripts evaluated before navigating to a page will now have access to a #document.