### PR TITLE
Not optional document

### DIFF
--- a/src/browser/dom/comment.zig
+++ b/src/browser/dom/comment.zig
@@ -30,7 +30,7 @@ pub const Comment = struct {
 
     pub fn constructor(data: ?[]const u8, state: *const SessionState) !*parser.Comment {
         return parser.documentCreateComment(
-            parser.documentHTMLToDocument(state.window.document.?),
+            parser.documentHTMLToDocument(state.window.document),
             data orelse "",
         );
     }

--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -41,12 +41,12 @@ pub const Document = struct {
 
     pub fn constructor(state: *const SessionState) !*parser.DocumentHTML {
         const doc = try parser.documentCreateDocument(
-            try parser.documentHTMLGetTitle(state.window.document.?),
+            try parser.documentHTMLGetTitle(state.window.document),
         );
 
         // we have to work w/ document instead of html document.
         const ddoc = parser.documentHTMLToDocument(doc);
-        const ccur = parser.documentHTMLToDocument(state.window.document.?);
+        const ccur = parser.documentHTMLToDocument(state.window.document);
         try parser.documentSetDocumentURI(ddoc, try parser.documentGetDocumentURI(ccur));
         try parser.documentSetInputEncoding(ddoc, try parser.documentGetInputEncoding(ccur));
 

--- a/src/browser/dom/document_fragment.zig
+++ b/src/browser/dom/document_fragment.zig
@@ -29,7 +29,7 @@ pub const DocumentFragment = struct {
 
     pub fn constructor(state: *const SessionState) !*parser.DocumentFragment {
         return parser.documentCreateDocumentFragment(
-            parser.documentHTMLToDocument(state.window.document.?),
+            parser.documentHTMLToDocument(state.window.document),
         );
     }
 

--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -370,7 +370,7 @@ pub const Element = struct {
     pub fn _getBoundingClientRect(self: *parser.Element, state: *SessionState) !DOMRect {
         // Since we are lazy rendering we need to do this check. We could store the renderer in a viewport such that it could cache these, but it would require tracking changes.
         const root = try parser.nodeGetRootNode(parser.elementToNode(self));
-        if (root != parser.documentToNode(parser.documentHTMLToDocument(state.window.document.?))) {
+        if (root != parser.documentToNode(parser.documentHTMLToDocument(state.window.document))) {
             return DOMRect{ .x = 0, .y = 0, .width = 0, .height = 0 };
         }
         return state.renderer.getRect(self);
@@ -381,7 +381,7 @@ pub const Element = struct {
     // Returns an empty array if the element is eventually detached from the main window
     pub fn _getClientRects(self: *parser.Element, state: *SessionState) ![]DOMRect {
         const root = try parser.nodeGetRootNode(parser.elementToNode(self));
-        if (root != parser.documentToNode(parser.documentHTMLToDocument(state.window.document.?))) {
+        if (root != parser.documentToNode(parser.documentHTMLToDocument(state.window.document))) {
             return &.{};
         }
         const heap_ptr = try state.call_arena.create(DOMRect);

--- a/src/browser/dom/intersection_observer.zig
+++ b/src/browser/dom/intersection_observer.zig
@@ -50,7 +50,7 @@ pub const IntersectionObserver = struct {
     // new IntersectionObserver(callback, options) [not supported yet]
     pub fn constructor(callback: Env.Callback, options_: ?IntersectionObserverOptions, state: *SessionState) !IntersectionObserver {
         var options = IntersectionObserverOptions{
-            .root = parser.documentToNode(parser.documentHTMLToDocument(state.window.document.?)),
+            .root = parser.documentToNode(parser.documentHTMLToDocument(state.window.document)),
             .rootMargin = "0px 0px 0px 0px",
             .threshold = &.{0.0},
         };
@@ -142,7 +142,7 @@ pub const IntersectionObserverEntry = struct {
     // Returns a DOMRectReadOnly for the intersection observer's root.
     pub fn get_rootBounds(self: *const IntersectionObserverEntry) !Element.DOMRect {
         const root = self.options.root.?;
-        if (@intFromPtr(root) == @intFromPtr(self.state.window.document.?)) {
+        if (@intFromPtr(root) == @intFromPtr(self.state.window.document)) {
             return self.state.renderer.boundingRect();
         }
 

--- a/src/browser/dom/processing_instruction.zig
+++ b/src/browser/dom/processing_instruction.zig
@@ -41,7 +41,7 @@ pub const ProcessingInstruction = struct {
     // a simple workaround.
     pub fn _cloneNode(self: *parser.ProcessingInstruction, _: ?bool, state: *SessionState) !*parser.ProcessingInstruction {
         return try parser.documentCreateProcessingInstruction(
-            @ptrCast(state.window.document.?),
+            @ptrCast(state.window.document),
             try get_target(self),
             (try get_data(self)) orelse "",
         );

--- a/src/browser/dom/text.zig
+++ b/src/browser/dom/text.zig
@@ -34,7 +34,7 @@ pub const Text = struct {
 
     pub fn constructor(data: ?[]const u8, state: *const SessionState) !*parser.Text {
         return parser.documentCreateTextNode(
-            parser.documentHTMLToDocument(state.window.document.?),
+            parser.documentHTMLToDocument(state.window.document),
             data orelse "",
         );
     }

--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -255,10 +255,10 @@ pub const HTMLDocument = struct {
         // Thus we can add the HtmlHtmlElement and it's child HTMLBodyElement to the returned list.
         // TBD Should we instead return every parent that is an element? Note that a child does not physically need to be overlapping the parent.
         // Should we do a render pass on demand?
-        const doc_elem = try parser.documentGetDocumentElement(parser.documentHTMLToDocument(state.window.document.?)) orelse {
+        const doc_elem = try parser.documentGetDocumentElement(parser.documentHTMLToDocument(state.window.document)) orelse {
             return list.items;
         };
-        if (try parser.documentHTMLBody(state.window.document.?)) |body| {
+        if (try parser.documentHTMLBody(state.window.document)) |body| {
             list.appendAssumeCapacity(try Element.toInterface(parser.bodyToElement(body)));
         }
         list.appendAssumeCapacity(try Element.toInterface(doc_elem));
@@ -383,12 +383,12 @@ test "Browser.HTML.Document" {
         .{ "document.readyState", "loading" },
     }, .{});
 
-    try HTMLDocument.documentIsLoaded(runner.window.document.?, &runner.state);
+    try HTMLDocument.documentIsLoaded(runner.window.document, &runner.state);
     try runner.testCases(&.{
         .{ "document.readyState", "interactive" },
     }, .{});
 
-    try HTMLDocument.documentIsComplete(runner.window.document.?, &runner.state);
+    try HTMLDocument.documentIsComplete(runner.window.document, &runner.state);
     try runner.testCases(&.{
         .{ "document.readyState", "complete" },
     }, .{});

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -59,7 +59,7 @@ fn getDocument(cmd: anytype) !void {
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
-    const doc = page.doc orelse return error.DocumentNotLoaded;
+    const doc = parser.documentHTMLToDocument(page.window.document);
 
     const node = try bc.node_registry.register(parser.documentToNode(doc));
     return cmd.sendResult(.{ .root = bc.nodeWriter(node, .{}) }, .{});
@@ -74,7 +74,7 @@ fn performSearch(cmd: anytype) !void {
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
-    const doc = page.doc orelse return error.DocumentNotLoaded;
+    const doc = parser.documentHTMLToDocument(page.window.document);
 
     const allocator = cmd.cdp.allocator;
     var list = try css.querySelectorAll(allocator, parser.documentToNode(doc), params.query);

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -125,9 +125,6 @@ fn createTarget(cmd: anytype) !void {
     bc.target_id = target_id;
 
     var page = try bc.session.createPage();
-    // Navigate to about:blank such that the window.document are created and set
-    const url = @import("../../url.zig").URL.about_blank;
-    try page.navigate(url, .{});
     {
         const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
         bc.inspector.contextCreated(
@@ -504,10 +501,6 @@ test "cdp.target: createTarget" {
         // should create a browser context
         const bc = ctx.cdp().browser_context.?;
         try ctx.expectSentEvent("Target.targetCreated", .{ .targetInfo = .{ .url = "about:blank", .title = "about:blank", .attached = false, .type = "page", .canAccessOpener = false, .browserContextId = bc.id, .targetId = bc.target_id.? } }, .{});
-
-        // Even about:blank should set the window.document
-        const page = ctx.cdp().browser_context.?.session.page.?;
-        try testing.expect(page.window.document != null);
     }
 
     {

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -123,7 +123,7 @@ const TestContext = struct {
             if (bc.session_id == null) bc.session_id = "SID-X";
             parser.deinit();
             const page = try bc.session.createPage();
-            page.doc = (try Document.init(html)).doc;
+            page.window.document = (try Document.init(html)).doc;
         }
         return bc;
     }

--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -116,7 +116,7 @@ fn run(arena: Allocator, test_file: []const u8, loader: *FileLoader, err_out: *?
     try polyfill.load(arena, runner.scope);
 
     // loop over the scripts.
-    const doc = parser.documentHTMLToDocument(runner.state.window.document.?);
+    const doc = parser.documentHTMLToDocument(runner.state.window.document);
     const scripts = try parser.documentGetElementsByTagName(doc, "script");
     const script_count = try parser.nodeListLength(scripts);
     for (0..script_count) |i| {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -207,7 +207,7 @@ pub const Random = struct {
 };
 
 pub const Document = struct {
-    doc: *parser.Document,
+    doc: *parser.DocumentHTML,
     arena: std.heap.ArenaAllocator,
 
     pub fn init(html: []const u8) !Document {
@@ -219,7 +219,7 @@ pub const Document = struct {
 
         return .{
             .arena = std.heap.ArenaAllocator.init(allocator),
-            .doc = parser.documentHTMLToDocument(html_doc),
+            .doc = html_doc,
         };
     }
 
@@ -240,7 +240,7 @@ pub const Document = struct {
     }
 
     pub fn asNode(self: *const Document) *parser.Node {
-        return parser.documentToNode(self.doc);
+        return parser.documentHTMLToNode(self.doc);
     }
 };
 

--- a/src/url.zig
+++ b/src/url.zig
@@ -9,6 +9,7 @@ pub const URL = struct {
     raw: []const u8,
 
     pub const empty = URL{ .uri = .{ .scheme = "" }, .raw = "" };
+    pub const about_blank = URL{ .uri = .{ .scheme = "" }, .raw = "about:blank" };
 
     // We assume str will last as long as the URL
     // In some cases, this is safe to do, because we know the URL is short lived.


### PR DESCRIPTION
Builds on loading document for about:blank: https://github.com/lightpanda-io/browser/pull/668

Since half the code of that PR is removed again, might as well just review this one.
This make the window.document not optional, and sets it to about:blank by default.