### PR TITLE
Allow webapis to register a destructor to do cleanup on scope (page) end

### DIFF
--- a/src/browser/dom/mutation_observer.zig
+++ b/src/browser/dom/mutation_observer.zig
@@ -103,7 +103,7 @@ pub const MutationObserver = struct {
         }
     }
 
-    pub fn jsCallScopeEnd(self: *MutationObserver, _: anytype) void {
+    pub fn jsCallScopeEnd(self: *MutationObserver) void {
         const record = self.observed.items;
         if (record.len == 0) {
             return;

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -258,8 +258,7 @@ pub const XMLHttpRequest = struct {
     }
 
     pub fn destructor(self: *XMLHttpRequest, _: anytype) void {
-        const request = &(self.request orelse return);
-        request.abort();
+        self._abort();
     }
 
     pub fn reset(self: *XMLHttpRequest) void {
@@ -516,7 +515,6 @@ pub const XMLHttpRequest = struct {
             return;
         }
 
-        self.request = null;
         self.state = .done;
         self.send_flag = false;
         self.dispatchEvt("readystatechange");
@@ -541,6 +539,10 @@ pub const XMLHttpRequest = struct {
     }
 
     pub fn _abort(self: *XMLHttpRequest) void {
+        const request = &(self.request orelse return);
+        // safe to call even if the request is complete
+        request.abort();
+
         self.onErr(DOMError.Abort);
     }
 

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -257,6 +257,11 @@ pub const XMLHttpRequest = struct {
         };
     }
 
+    pub fn destructor(self: *XMLHttpRequest, _: anytype) void {
+        const request = &(self.request orelse return);
+        request.abort();
+    }
+
     pub fn reset(self: *XMLHttpRequest) void {
         self.url = null;
 
@@ -276,13 +281,6 @@ pub const XMLHttpRequest = struct {
         self.send_flag = false;
 
         self.priv_state = .new;
-    }
-
-    pub fn deinit(self: *XMLHttpRequest, alloc: Allocator) void {
-        if (self.response_obj) |v| {
-            v.deinit();
-        }
-        self.proto.deinit(alloc);
     }
 
     pub fn get_readyState(self: *XMLHttpRequest) u16 {
@@ -518,6 +516,7 @@ pub const XMLHttpRequest = struct {
             return;
         }
 
+        self.request = null;
         self.state = .done;
         self.send_flag = false;
         self.dispatchEvt("readystatechange");

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -257,10 +257,6 @@ pub const XMLHttpRequest = struct {
         };
     }
 
-    pub fn destructor(self: *XMLHttpRequest, _: anytype) void {
-        self._abort();
-    }
-
     pub fn reset(self: *XMLHttpRequest) void {
         self.url = null;
 
@@ -539,10 +535,6 @@ pub const XMLHttpRequest = struct {
     }
 
     pub fn _abort(self: *XMLHttpRequest) void {
-        const request = &(self.request orelse return);
-        // safe to call even if the request is complete
-        request.abort();
-
         self.onErr(DOMError.Abort);
     }
 

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -261,13 +261,6 @@ pub const Request = struct {
         self._client.state_pool.release(self._state);
     }
 
-    pub fn abort(self: *Request) void {
-        const connection = self._connection orelse return;
-        self.destroyConnection(connection);
-        self._connection = null;
-        self.deinit();
-    }
-
     const DecomposedURL = struct {
         secure: bool,
         connect_port: u16,

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -261,6 +261,13 @@ pub const Request = struct {
         self._client.state_pool.release(self._state);
     }
 
+    pub fn abort(self: *Request) void {
+        const connection = self._connection orelse return;
+        self.destroyConnection(connection);
+        self._connection = null;
+        self.deinit();
+    }
+
     const DecomposedURL = struct {
         secure: bool,
         connect_port: u16,


### PR DESCRIPTION
Add destructor to XHR to abort any inflight requests.