### PR TITLE
HTTP request notification

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -63,7 +63,7 @@ jobs:
     needs: zig-build-release
 
     env:
-      MAX_MEMORY: 28000
+      MAX_MEMORY: 29000
       MAX_AVG_DURATION: 24
       LIGHTPANDA_DISABLE_TELEMETRY: true
 

--- a/src/browser/env.zig
+++ b/src/browser/env.zig
@@ -7,7 +7,7 @@ const storage = @import("storage/storage.zig");
 const generate = @import("../runtime/generate.zig");
 const Renderer = @import("renderer.zig").Renderer;
 const Loop = @import("../runtime/loop.zig").Loop;
-const HttpClient = @import("../http/client.zig").Client;
+const RequestFactory = @import("../http/client.zig").RequestFactory;
 
 const WebApis = struct {
     // Wrapped like this for debug ergonomics.
@@ -54,8 +54,8 @@ pub const SessionState = struct {
     window: *Window,
     renderer: *Renderer,
     arena: std.mem.Allocator,
-    http_client: *HttpClient,
     cookie_jar: *storage.CookieJar,
+    request_factory: RequestFactory,
 
     // dangerous, but set by the JS framework
     // shorter-lived than the arena above, which

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -80,7 +80,6 @@ const XMLHttpRequestBodyInit = union(enum) {
 pub const XMLHttpRequest = struct {
     proto: XMLHttpRequestEventTarget = XMLHttpRequestEventTarget{},
     arena: Allocator,
-    client: *http.Client,
     request: ?http.Request = null,
 
     priv_state: PrivState = .new,
@@ -252,7 +251,6 @@ pub const XMLHttpRequest = struct {
             .state = .unsent,
             .url = null,
             .origin_url = session_state.url,
-            .client = session_state.http_client,
             .cookie_jar = session_state.cookie_jar,
         };
     }
@@ -420,7 +418,7 @@ pub const XMLHttpRequest = struct {
         self.send_flag = true;
         self.priv_state = .open;
 
-        self.request = try self.client.request(self.method, &self.url.?.uri);
+        self.request = try session_state.request_factory.create(self.method, &self.url.?.uri);
         var request = &self.request.?;
         errdefer request.deinit();
 

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -17,15 +17,130 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const Notification = @import("../../notification.zig").Notification;
+
+const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: anytype) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
+        disable,
         setCacheDisabled,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
-        .enable => return cmd.sendResult(null, .{}),
+        .enable => return enable(cmd),
+        .disable => return disable(cmd),
         .setCacheDisabled => return cmd.sendResult(null, .{}),
     }
+}
+
+fn enable(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    try bc.networkEnable();
+    return cmd.sendResult(null, .{});
+}
+
+fn disable(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.networkDisable();
+    return cmd.sendResult(null, .{});
+}
+
+pub fn httpRequestStart(arena: Allocator, bc: anytype, request: *const Notification.RequestStart) !void {
+    // Isn't possible to do a network request within a Browser (which our
+    // notification is tied to), without a page.
+    std.debug.assert(bc.session.page != null);
+
+    var cdp = bc.cdp;
+
+    // all unreachable because we _have_ to have a page.
+    const session_id = bc.session_id orelse unreachable;
+    const target_id = bc.target_id orelse unreachable;
+    const page = bc.session.currentPage() orelse unreachable;
+
+    const document_url = try urlToString(arena, &page.url.uri, .{
+        .scheme = true,
+        .authentication = true,
+        .authority = true,
+        .path = true,
+        .query = true,
+    });
+
+    const request_url = try urlToString(arena, request.url, .{
+        .scheme = true,
+        .authentication = true,
+        .authority = true,
+        .path = true,
+        .query = true,
+    });
+
+    const request_fragment = try urlToString(arena, request.url, .{
+        .fragment = true,
+    });
+
+    var headers: std.StringArrayHashMapUnmanaged([]const u8) = .empty;
+    try headers.ensureTotalCapacity(arena, request.headers.len);
+    for (request.headers) |header| {
+        headers.putAssumeCapacity(header.name, header.value);
+    }
+
+    // We're missing a bunch of fields, but, for now, this seems like enough
+    try cdp.sendEvent("Network.requestWillBeSent", .{
+        .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{request.id}),
+        .frameId = target_id,
+        .loaderId = bc.loader_id,
+        .documentUrl = document_url,
+        .request = .{
+            .url = request_url,
+            .urlFragment = request_fragment,
+            .method = @tagName(request.method),
+            .hasPostData = request.has_body,
+            .headers = std.json.ArrayHashMap([]const u8){ .map = headers },
+        },
+    }, .{ .session_id = session_id });
+}
+
+pub fn httpRequestComplete(arena: Allocator, bc: anytype, request: *const Notification.RequestComplete) !void {
+    // Isn't possible to do a network request within a Browser (which our
+    // notification is tied to), without a page.
+    std.debug.assert(bc.session.page != null);
+
+    var cdp = bc.cdp;
+
+    // all unreachable because we _have_ to have a page.
+    const session_id = bc.session_id orelse unreachable;
+    const target_id = bc.target_id orelse unreachable;
+
+    const url = try urlToString(arena, request.url, .{
+        .scheme = true,
+        .authentication = true,
+        .authority = true,
+        .path = true,
+        .query = true,
+    });
+
+    var headers: std.StringArrayHashMapUnmanaged([]const u8) = .empty;
+    try headers.ensureTotalCapacity(arena, request.headers.len);
+    for (request.headers) |header| {
+        headers.putAssumeCapacity(header.name, header.value);
+    }
+
+    // We're missing a bunch of fields, but, for now, this seems like enough
+    try cdp.sendEvent("Network.responseReceived", .{
+        .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{request.id}),
+        .frameId = target_id,
+        .loaderId = bc.loader_id,
+        .response = .{
+            .url = url,
+            .status = request.status,
+            .headers = std.json.ArrayHashMap([]const u8){ .map = headers },
+        },
+    }, .{ .session_id = session_id });
+}
+
+fn urlToString(arena: Allocator, url: *const std.Uri, opts: std.Uri.WriteToStreamOptions) ![]const u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    try url.writeToStream(opts, buf.writer(arena));
+    return buf.items;
 }

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -895,6 +895,10 @@ fn AsyncHandler(comptime H: type, comptime L: type) type {
             }
 
             const status = self.conn.received(self.read_buf[0 .. self.read_pos + n]) catch |err| {
+                if (err == error.TlsAlertCloseNotify and self.state == .handshake and self.maybeRetryRequest()) {
+                    return;
+                }
+
                 self.handleError("data processing", err);
                 return;
             };

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -29,6 +29,7 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const tls = @import("tls");
 const IO = @import("../runtime/loop.zig").IO;
 const Loop = @import("../runtime/loop.zig").Loop;
+const Notification = @import("../notification.zig").Notification;
 
 const log = std.log.scoped(.http_client);
 
@@ -44,6 +45,7 @@ const MAX_HEADER_LINE_LEN = 4096;
 // Thread-safe. Holds our root certificate, connection pool and state pool
 // Used to create Requests.
 pub const Client = struct {
+    req_id: usize,
     allocator: Allocator,
     state_pool: StatePool,
     http_proxy: ?Uri,
@@ -68,6 +70,7 @@ pub const Client = struct {
         errdefer connection_manager.deinit();
 
         return .{
+            .req_id = 0,
             .root_ca = root_ca,
             .allocator = allocator,
             .state_pool = state_pool,
@@ -95,6 +98,25 @@ pub const Client = struct {
         }
 
         return Request.init(self, state, method, uri);
+    }
+
+    pub fn requestFactory(self: *Client, notification: ?*Notification) RequestFactory {
+        return .{
+            .client = self,
+            .notification = notification,
+        };
+    }
+};
+
+// A factory for creating requests with a given set of options.
+pub const RequestFactory = struct {
+    client: *Client,
+    notification: ?*Notification,
+
+    pub fn create(self: RequestFactory, method: Request.Method, uri: *const Uri) !Request {
+        var req = try self.client.request(method, uri);
+        req.notification = self.notification;
+        return req;
     }
 };
 
@@ -146,10 +168,12 @@ const Connection = struct {
 // (but request.deinit() should still be called to discard the request
 // before the `sendAsync` is called).
 pub const Request = struct {
+    id: usize,
+
     // The HTTP Method to use
     method: Method,
 
-    // The URI we're requested
+    // The URI we requested
     request_uri: *const Uri,
 
     // The URI that we're connecting to. Can be different than request_uri when
@@ -211,6 +235,16 @@ pub const Request = struct {
     // Whether or not we should verify that the host matches the certificate CN
     _tls_verify_host: bool,
 
+    // We only want to emit a start / complete notifications once per request.
+    // Because of things like redirects and error handling, it is possible for
+    // the notification functions to be called multiple times, so we guard them
+    // with these booleans
+    _notified_start: bool,
+    _notified_complete: bool,
+
+    // The notifier that we emit request notifications to, if any.
+    notification: ?*Notification,
+
     pub const Method = enum {
         GET,
         PUT,
@@ -230,12 +264,18 @@ pub const Request = struct {
 
     fn init(client: *Client, state: *State, method: Method, uri: *const Uri) !Request {
         const decomposed = try decomposeURL(client, uri);
+
+        const id = client.req_id + 1;
+        client.req_id = id;
+
         return .{
+            .id = id,
             .request_uri = uri,
             .connect_uri = decomposed.connect_uri,
             .body = null,
             .headers = .{},
             .method = method,
+            .notification = null,
             .arena = state.arena.allocator(),
             ._secure = decomposed.secure,
             ._connect_host = decomposed.connect_host,
@@ -247,6 +287,8 @@ pub const Request = struct {
             ._keepalive = false,
             ._redirect_count = 0,
             ._has_host_header = false,
+            ._notified_start = false,
+            ._notified_complete = false,
             ._connection_from_keepalive = false,
             ._tls_verify_host = client.tls_verify_host,
         };
@@ -525,6 +567,7 @@ pub const Request = struct {
         }
 
         try self.headers.append(arena, .{ .name = "User-Agent", .value = "Lightpanda/1.0" });
+        self.requestStarting();
     }
 
     // Sets up the request for redirecting.
@@ -640,6 +683,35 @@ pub const Request = struct {
         }
         try writer.writeAll("\r\n");
         return buf[0..fbs.pos];
+    }
+
+    fn requestStarting(self: *Request) void {
+        const notification = self.notification orelse return;
+        if (self._notified_start) {
+            return;
+        }
+        self._notified_start = true;
+        notification.dispatch(.http_request_start, &.{
+            .id = self.id,
+            .url = self.request_uri,
+            .method = self.method,
+            .headers = self.headers.items,
+            .has_body = self.body != null,
+        });
+    }
+
+    fn requestCompleted(self: *Request, response: ResponseHeader) void {
+        const notification = self.notification orelse return;
+        if (self._notified_complete) {
+            return;
+        }
+        self._notified_complete = true;
+        notification.dispatch(.http_request_complete, &.{
+            .id = self.id,
+            .url = self.request_uri,
+            .status = response.status,
+            .headers = response.headers.items,
+        });
     }
 };
 
@@ -832,6 +904,7 @@ fn AsyncHandler(comptime H: type, comptime L: type) type {
                 .need_more => self.receive(),
                 .done => {
                     const redirect = self.redirect orelse {
+                        self.request.requestCompleted(self.reader.response);
                         self.deinit();
                         return;
                     };
@@ -1235,6 +1308,8 @@ const SyncHandler = struct {
                 var body: std.ArrayListUnmanaged(u8) = .{};
                 var decompressor = std.compress.gzip.decompressor(compress_reader.reader());
                 try decompressor.decompress(body.writer(request.arena));
+
+                self.request.requestCompleted(reader.response);
 
                 return .{
                     .header = reader.response,
@@ -1939,7 +2014,7 @@ pub const ResponseHeader = struct {
 // value in-place.
 // The value (and key) are both safe to mutate because they're cloned from
 // the byte stream by our arena.
-const Header = struct {
+pub const Header = struct {
     name: []const u8,
     value: []u8,
 };
@@ -2024,6 +2099,7 @@ pub const Response = struct {
                 return data;
             }
             if (self._done) {
+                self._request.requestCompleted(self.header);
                 return null;
             }
 

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -418,6 +418,10 @@ pub const JsRunner = struct {
             .url = try self.url.toWebApi(arena),
         });
 
+        self.http_client = try HttpClient.init(arena, 1, .{
+            .tls_verify_host = false,
+        });
+
         self.state = .{
             .arena = arena,
             .loop = &self.loop,
@@ -425,15 +429,11 @@ pub const JsRunner = struct {
             .window = &self.window,
             .renderer = &self.renderer,
             .cookie_jar = &self.cookie_jar,
-            .http_client = &self.http_client,
+            .request_factory = self.http_client.requestFactory(null),
         };
 
         self.storage_shelf = storage.Shelf.init(arena);
         self.window.setStorageShelf(&self.storage_shelf);
-
-        self.http_client = try HttpClient.init(arena, 1, .{
-            .tls_verify_host = false,
-        });
 
         self.executor = try self.env.newExecutionWorld();
         errdefer self.executor.deinit();


### PR DESCRIPTION
- Add 2 internal notifications 1 - http_request_start 2 - http_request_complete

- When Network.enable CDP message is received, browser context registers for these 2 events (when Network.disable is called, it unregisters)

- On http_request_start, CDP will emit a Network.requestWillBeSent message. This _does not_ include all the fields, but what we have appears to be enough for puppeteer.waitForNetworkIdle.

- On http_request_complete, CDP will emit a Network.responseReceived message. This _does not_ include all the fields, bu what we have appears to be enough for puppeteer.waitForNetworkIdle.

We currently don't emit any other new events, including any network-specific lifecycleEvent (i.e. Chrome will emit an networkIdle and networkAlmostIdle).

To support this, the following other things were done:
- CDP now has a `notification_arena` which is re-used between browser contexts. Normally, CDP code runs based on a "cmd" which has its own message_arena, but these notifications happen out-of-band, so we needed a new arena which is valid for handling 1 notification.

- HTTP Client is notification-aware. The SessionState no longer includes the *http.Client directly. It instead includes an http.RequestFactory which is the combination fo the client + a specific configuration (i.e. *Notification). This ensures that all requests made from that factory have the same settings.

- However, despite the above, _some_ requests do not appear to emit CDP events, such as loading a <script src="X">. So the page still deals directly with the *http.Client.

- Playwright and Puppeteer (but Playwright in particular) are very sensitive to event ordering. These new events have introduced additional sensitivity. The result sent to Page.navigate had to be moved to inside the navigate event handler, which meant passing some cdp-specific data (the input.id) into the NavigateOpts. This is the only way I found to keep both happy - the sequence of events is closer (but still pretty far) from what Chrome does.