### PR TITLE
Rename to ExecutionWorld

### DIFF
--- a/src/browser/session.zig
+++ b/src/browser/session.zig
@@ -49,14 +49,14 @@ pub const Session = struct {
     // page and start another.
     transfer_arena: Allocator,
 
-    executor: Env.Executor,
+    executor: Env.ExecutionWorld,
     storage_shed: storage.Shed,
     cookie_jar: storage.CookieJar,
 
     page: ?Page = null,
 
     pub fn init(self: *Session, browser: *Browser) !void {
-        var executor = try browser.env.newExecutor();
+        var executor = try browser.env.newExecutionWorld();
         errdefer executor.deinit();
 
         const allocator = browser.app.allocator;

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -372,12 +372,11 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 return error.CurrentlyOnly1IsolatedWorldSupported;
             }
 
-            var executor = try self.cdp.browser.env.newExecutor();
+            var executor = try self.cdp.browser.env.newExecutionWorld();
             errdefer executor.deinit();
 
             self.isolated_world = .{
                 .name = try self.arena.dupe(u8, world_name),
-                .scope = null,
                 .executor = executor,
                 .grant_universal_access = grant_universal_access,
             };
@@ -511,18 +510,15 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 /// An object id is unique across all contexts, different object ids can refer to the same Node in different contexts.
 const IsolatedWorld = struct {
     name: []const u8,
-    scope: ?*Env.Scope,
-    executor: Env.Executor,
+    executor: Env.ExecutionWorld,
     grant_universal_access: bool,
 
     pub fn deinit(self: *IsolatedWorld) void {
         self.executor.deinit();
-        self.scope = null;
     }
     pub fn removeContext(self: *IsolatedWorld) !void {
-        if (self.scope == null) return error.NoIsolatedContextToRemove;
+        if (self.executor.scope == null) return error.NoIsolatedContextToRemove;
         self.executor.endScope();
-        self.scope = null;
     }
 
     // The isolate world must share at least some of the state with the related page, specifically the DocumentHTML
@@ -531,8 +527,8 @@ const IsolatedWorld = struct {
     // This also means this pointer becomes invalid after removePage untill a new page is created.
     // Currently we have only 1 page/frame and thus also only 1 state in the isolate world.
     pub fn createContext(self: *IsolatedWorld, page: *Page) !void {
-        if (self.scope != null) return error.Only1IsolatedContextSupported;
-        self.scope = try self.executor.startScope(&page.window, &page.state, {}, false);
+        if (self.executor.scope != null) return error.Only1IsolatedContextSupported;
+        _ = try self.executor.startScope(&page.window, &page.state, {}, false);
     }
 };
 

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -262,8 +262,8 @@ fn resolveNode(cmd: anytype) !void {
     var scope = page.scope;
     if (params.executionContextId) |context_id| {
         if (scope.context.debugContextId() != context_id) {
-            const isolated_world = bc.isolated_world orelse return error.ContextNotFound;
-            scope = isolated_world.scope orelse return error.ContextNotFound;
+            var isolated_world = bc.isolated_world orelse return error.ContextNotFound;
+            scope = &(isolated_world.executor.scope orelse return error.ContextNotFound);
 
             if (scope.context.debugContextId() != context_id) return error.ContextNotFound;
         }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -115,7 +115,7 @@ fn createIsolatedWorld(cmd: anytype) !void {
     const world = try bc.createIsolatedWorld(params.worldName, params.grantUniveralAccess);
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
     try pageCreated(bc, page);
-    const scope = world.scope.?;
+    const scope = &world.executor.scope.?;
 
     // Create the auxdata json for the contextCreated event
     // Calling contextCreated will assign a Id to the context and send the contextCreated event
@@ -236,7 +236,7 @@ pub fn pageNavigate(bc: anytype, event: *const Notification.PageNavigate) !void 
         const aux_json = try std.fmt.bufPrint(&buffer, "{{\"isDefault\":false,\"type\":\"isolated\",\"frameId\":\"{s}\"}}", .{target_id});
         // Calling contextCreated will assign a new Id to the context and send the contextCreated event
         bc.inspector.contextCreated(
-            isolated_world.scope.?,
+            &isolated_world.executor.scope.?,
             isolated_world.name,
             "://",
             aux_json,
@@ -258,7 +258,7 @@ pub fn pageCreated(bc: anytype, page: *Page) !void {
         try isolated_world.createContext(page);
 
         const polyfill = @import("../../browser/polyfill/polyfill.zig");
-        try polyfill.load(bc.arena, isolated_world.scope.?);
+        try polyfill.load(bc.arena, &isolated_world.executor.scope.?);
     }
 }
 

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -30,7 +30,7 @@ pub fn Runner(comptime State: type, comptime Global: type, comptime types: anyty
     return struct {
         env: *Env,
         scope: *Env.Scope,
-        executor: Env.Executor,
+        executor: Env.ExecutionWorld,
 
         pub const Env = js.Env(State, struct {
             pub const Interfaces = AdjustedTypes;
@@ -45,7 +45,7 @@ pub fn Runner(comptime State: type, comptime Global: type, comptime types: anyty
             self.env = try Env.init(allocator, .{});
             errdefer self.env.deinit();
 
-            self.executor = try self.env.newExecutor();
+            self.executor = try self.env.newExecutionWorld();
             errdefer self.executor.deinit();
 
             self.scope = try self.executor.startScope(

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -383,7 +383,7 @@ pub const JsRunner = struct {
     renderer: Renderer,
     http_client: HttpClient,
     scope: *Env.Scope,
-    executor: Env.Executor,
+    executor: Env.ExecutionWorld,
     storage_shelf: storage.Shelf,
     cookie_jar: storage.CookieJar,
 
@@ -435,7 +435,7 @@ pub const JsRunner = struct {
             .tls_verify_host = false,
         });
 
-        self.executor = try self.env.newExecutor();
+        self.executor = try self.env.newExecutionWorld();
         errdefer self.executor.deinit();
 
         self.scope = try self.executor.startScope(&self.window, &self.state, {}, true);


### PR DESCRIPTION
Renaming Executor to ExecutionWorld, to reduce the number of concepts that we need to learn.

ExecutionWorld closely models a JS World as recognized below:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld

https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/bindings/core/v8/V8BindingDesign.md#World

I see no issue with variables being called executor.