### PR TITLE
MouseEvent Interface

### DIFF
--- a/src/browser/events/event.zig
+++ b/src/browser/events/event.zig
@@ -29,6 +29,7 @@ const EventTargetUnion = @import("../dom/event_target.zig").Union;
 
 const CustomEvent = @import("custom_event.zig").CustomEvent;
 const ProgressEvent = @import("../xhr/progress_event.zig").ProgressEvent;
+const MouseEvent = @import("mouse_event.zig").MouseEvent;
 
 const log = std.log.scoped(.events);
 
@@ -37,6 +38,7 @@ pub const Interfaces = .{
     Event,
     CustomEvent,
     ProgressEvent,
+    MouseEvent,
 };
 
 pub const Union = generate.Union(Interfaces);
@@ -60,6 +62,7 @@ pub const Event = struct {
             .event => .{ .Event = evt },
             .custom_event => .{ .CustomEvent = @as(*CustomEvent, @ptrCast(evt)).* },
             .progress_event => .{ .ProgressEvent = @as(*ProgressEvent, @ptrCast(evt)).* },
+            .mouse_event => .{ .MouseEvent = @as(**parser.MouseEvent, @ptrCast(evt)).* },
         };
     }
 

--- a/src/browser/events/mouse_event.zig
+++ b/src/browser/events/mouse_event.zig
@@ -1,0 +1,105 @@
+// Copyright (C) 2023-2024  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const parser = @import("../netsurf.zig");
+const Event = @import("event.zig").Event;
+const JsObject = @import("../env.zig").JsObject;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
+pub const MouseEvent = struct {
+    pub const Self = parser.MouseEvent;
+    pub const prototype = *Event;
+
+    const MouseEventInit = struct {
+        screenX: i32 = 0,
+        screenY: i32 = 0,
+        clientX: i32 = 0,
+        clientY: i32 = 0,
+        ctrlKey: bool = false,
+        shiftKey: bool = false,
+        altKey: bool = false,
+        metaKey: bool = false,
+        button: u16 = 0,
+    };
+
+    pub fn constructor(event_type: []const u8, opts_: ?MouseEventInit) !*Self {
+        const opts = opts_ orelse MouseEventInit{};
+
+        const mouse_event = try parser.mouseEventCreate();
+
+        try parser.mouseEventInit(mouse_event, event_type, .{
+            .x = opts.clientX,
+            .y = opts.clientY,
+            .ctrl = opts.ctrlKey,
+            .shift = opts.shiftKey,
+            .alt = opts.altKey,
+            .meta = opts.metaKey,
+            .button = opts.button,
+        });
+
+        return mouse_event;
+    }
+
+    // These is just an alias for clientX.
+    pub fn get_x(self: *Self) !i32 {
+        return self.cx;
+    }
+
+    // These is just an alias for clientY.
+    pub fn get_y(self: *Self) !i32 {
+        return self.cy;
+    }
+
+    pub fn get_clientX(self: *Self) !i32 {
+        return self.cx;
+    }
+
+    pub fn get_clientY(self: *Self) !i32 {
+        return self.cy;
+    }
+
+    pub fn get_screenX(self: *Self) !i32 {
+        return self.sx;
+    }
+
+    pub fn get_screenY(self: *Self) !i32 {
+        return self.sy;
+    }
+};
+
+const testing = @import("../../testing.zig");
+test "Browser.MouseEvent" {
+    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
+    defer runner.deinit();
+
+    try runner.testCases(&.{
+        .{ "let event = new MouseEvent('click')", "undefined" },
+        .{ "event.type", "click" },
+        .{ "event instanceof MouseEvent", "true" },
+        .{ "event instanceof Event", "true" },
+        .{ "event.clientX", "0" },
+        .{ "event.clientY", "0" },
+        .{ "event.screenX", "0" },
+        .{ "event.screenY", "0" },
+        .{ "let new_event = new MouseEvent('click2', { 'clientX': 10, 'clientY': 20 })", "undefined" },
+        .{ "new_event.x", "10" },
+        .{ "new_event.y", "20" },
+        .{ "new_event.screenX", "10" },
+        .{ "new_event.screenY", "20" },
+    }, .{});
+}

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -521,6 +521,7 @@ pub const EventType = enum(u8) {
     event = 0,
     progress_event = 1,
     custom_event = 2,
+    mouse_event = 3,
 };
 
 pub const MutationEvent = c.dom_mutation_event;


### PR DESCRIPTION
Adds the interface for the `MouseEvent`. it wraps the `parser.MouseEvent` as this seems like the correct procedure for this.

It includes the subset of functionality needed to continue making progress on Reddit fetching.