### PR TITLE
include OS in libc_v8 lib path

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,7 +17,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.1.23'
+    default: 'v0.1.24'
   v8:
     description: 'v8 version to install'
     required: false
@@ -59,11 +59,11 @@ runs:
     - name: install v8
       shell: bash
       run: |
-        mkdir -p v8/out/debug/obj/zig/
-        ln -s ${{ inputs.cache-dir }}/v8/libc_v8.a v8/out/debug/obj/zig/libc_v8.a
+        mkdir -p v8/out/${{ inputs.os }}/debug/obj/zig/
+        ln -s ${{ inputs.cache-dir }}/v8/libc_v8.a v8/out/${{ inputs.os }}/debug/obj/zig/libc_v8.a
 
-        mkdir -p v8/out/release/obj/zig/
-        ln -s ${{ inputs.cache-dir }}/v8/libc_v8.a v8/out/release/obj/zig/libc_v8.a
+        mkdir -p v8/out/${{ inputs.os }}/release/obj/zig/
+        ln -s ${{ inputs.cache-dir }}/v8/libc_v8.a v8/out/${{ inputs.os }}/release/obj/zig/libc_v8.a
 
     - name: libiconv
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ZIG=0.14.0
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG ARCH=x86_64
 ARG V8=11.1.134
-ARG ZIG_V8=v0.1.23
+ARG ZIG_V8=v0.1.24
 
 RUN apt-get update -yq && \
     apt-get install -yq xz-utils \
@@ -57,8 +57,8 @@ RUN make install-libiconv && \
 
 # download and install v8
 RUN curl --fail -L -o libc_v8.a https://github.com/lightpanda-io/zig-v8-fork/releases/download/${ZIG_V8}/libc_v8_${V8}_linux_${ARCH}.a && \
-    mkdir -p v8/build/${ARCH}-linux/release/ninja/obj/zig/ && \
-    mv libc_v8.a v8/build/${ARCH}-linux/release/ninja/obj/zig/libc_v8.a
+    mkdir -p v8/out/linux/release/obj/zig/ && \
+    mv libc_v8.a v8/out/linux/release/obj/zig/libc_v8.a
 
 # build release
 RUN make build

--- a/build.zig
+++ b/build.zig
@@ -179,20 +179,21 @@ fn common(b: *std.Build, opts: *std.Build.Step.Options, step: *std.Build.Step.Co
             .macos => "macos",
             else => return error.UnsupportedPlatform,
         };
-        var lib_path = try std.fmt.allocPrint(mod.owner.allocator,
+        var lib_path = try std.fmt.allocPrint(
+            mod.owner.allocator,
             "v8/out/{s}/{s}/obj/zig/libc_v8.a",
-            .{os, release_dir},
+            .{ os, release_dir },
         );
         std.fs.cwd().access(lib_path, .{}) catch {
             // legacy path
-            lib_path = try std.fmt.allocPrint(mod.owner.allocator,
+            lib_path = try std.fmt.allocPrint(
+                mod.owner.allocator,
                 "v8/out/{s}/obj/zig/libc_v8.a",
                 .{release_dir},
             );
         };
         mod.addObjectFile(mod.owner.path(lib_path));
     }
-
 
     switch (target.result.os.tag) {
         .macos => {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "tigerbeetle_io-0.0.0-ViLgxpyRBAB5BMfIcj3KMXfbJzwARs9uSl8aRy2OXULd",
         },
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/240140e5b3e5a8e5e51cbdd36bc120bf28ae5c31.tar.gz",
-            .hash = "v8-0.0.0-xddH64eyAwBcX7e2x5tv9MhT0MgQbshP2rb19blo06Db",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/e38cb27ddb044c6afbf8a938b293721b9804405e.tar.gz",
+            .hash = "v8-0.0.0-xddH6_GzAwCaz83JWuw3sepOGq0I7C_CmfOwA1Gb9q3y",
         },
         //.v8 = .{ .path = "../zig-v8-fork" },
         //.tigerbeetle_io = .{ .path = "../tigerbeetle-io" },


### PR DESCRIPTION
This will fallback to the current directory structure (without the OS in the path), so that it shouldn't break anyone's development environment. Next time we do a big upgrade that requires everyone to rebuild-v8, we can remove the fallback code.