### PR TITLE
Fix insecure_disable_tls_host_verification in serve more

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -333,7 +333,7 @@ fn parseServeArgs(
             continue;
         }
 
-        if (std.mem.eql(u8, "--insecure_tls_verify_host", opt)) {
+        if (std.mem.eql(u8, "--insecure_disable_tls_host_verification", opt)) {
             tls_verify_host = false;
             continue;
         }


### PR DESCRIPTION
It's currently using `--insecure_tls_verify_host` which is inconsistent with fetch-mode and not what the help text says.