### PR TITLE
Take scope out of scope

### DIFF
--- a/src/browser/session.zig
+++ b/src/browser/session.zig
@@ -109,7 +109,11 @@ pub const Session = struct {
         std.debug.assert(self.page != null);
         // Reset all existing callbacks.
         self.browser.app.loop.reset();
+
+        self.executor.scope.?.exit();
         self.executor.endScope();
+
+        self.page.?.handle_scope.deinit();
         self.page = null;
 
         // clear netsurf memory arena.

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -555,7 +555,7 @@ const IsolatedWorld = struct {
     // Currently we have only 1 page/frame and thus also only 1 state in the isolate world.
     pub fn createContext(self: *IsolatedWorld, page: *Page) !void {
         if (self.executor.scope != null) return error.Only1IsolatedContextSupported;
-        _ = try self.executor.startScope(&page.window, page, {}, false);
+        _ = try self.executor.startScope(&page.window, page, {});
     }
 };
 

--- a/src/runtime/testing.zig
+++ b/src/runtime/testing.zig
@@ -30,6 +30,7 @@ pub fn Runner(comptime State: type, comptime Global: type, comptime types: anyty
     return struct {
         env: *Env,
         scope: *Env.Scope,
+        handle_scope: Env.HandleScope,
         executor: Env.ExecutionWorld,
 
         pub const Env = js.Env(State, struct {
@@ -52,8 +53,13 @@ pub fn Runner(comptime State: type, comptime Global: type, comptime types: anyty
                 if (Global == void) &default_global else global,
                 state,
                 {},
-                true,
             );
+            self.scope.enter();
+
+            // Start a scope (stackframe) for JS Local variables.
+            Env.HandleScope.init(&self.handle_scope, self.executor.env.isolate);
+            errdefer self.handle_scope.deinit();
+
             return self;
         }
 


### PR DESCRIPTION
Decouples, scope & context creation & entering
- Moves the HandleScope out of the Scope as it is not possible to have 1 HandleScope per Context.
- Exposes the main context's responsibility to enter and exit it's v8_context
- Any additional Locals remaining during context creation have their lifetime limited (previously was page length, now just temp scope)