### PR TITLE
Implement location.reload(), location.assign() and location setter

### DIFF
--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -174,6 +174,10 @@ pub const HTMLDocument = struct {
         return try parser.documentHTMLGetLocation(Location, self);
     }
 
+    pub fn set_location(_: *const parser.DocumentHTML, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
+    }
+
     pub fn get_designMode(_: *parser.DocumentHTML) []const u8 {
         return "off";
     }

--- a/src/browser/html/location.zig
+++ b/src/browser/html/location.zig
@@ -69,18 +69,17 @@ pub const Location = struct {
         return "";
     }
 
-    // TODO
-    pub fn _assign(_: *Location, url: []const u8) !void {
-        _ = url;
+    pub fn _assign(_: *const Location, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
     }
 
-    // TODO
-    pub fn _replace(_: *Location, url: []const u8) !void {
-        _ = url;
+    pub fn _replace(_: *const Location, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
     }
 
-    // TODO
-    pub fn _reload(_: *Location) !void {}
+    pub fn _reload(_: *const Location, page: *Page) !void {
+        return page.navigateFromWebAPI(page.url.raw);
+    }
 
     pub fn _toString(self: *Location, page: *Page) ![]const u8 {
         return try self.get_href(page);

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -100,6 +100,10 @@ pub const Window = struct {
         return &self.location;
     }
 
+    pub fn set_location(_: *const Window, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
+    }
+
     pub fn get_console(self: *Window) *Console {
         return &self.console;
     }


### PR DESCRIPTION
I'm not sure that _any_ location instance should be able to change the page URL. But you can't create a new location (i.e. new Location() isn't valid), and the only two ways I know of are via `window.location` and `document.location` both of which _should_ alter the location of the window/document.