### PR TITLE
Input element properties

### DIFF
--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -626,6 +626,85 @@ pub const HTMLInputElement = struct {
     pub const Self = parser.Input;
     pub const prototype = *HTMLElement;
     pub const subtype = .node;
+
+    pub fn get_defaultValue(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetDefaultValue(self);
+    }
+    pub fn set_defaultValue(self: *parser.Input, default_value: []const u8) !void {
+        try parser.inputSetDefaultValue(self, default_value);
+    }
+    pub fn get_defaultChecked(self: *parser.Input) !bool {
+        return try parser.inputGetDefaultChecked(self);
+    }
+    pub fn set_defaultChecked(self: *parser.Input, default_checked: bool) !void {
+        try parser.inputSetDefaultChecked(self, default_checked);
+    }
+    pub fn get_from(self: *parser.Input) !?*parser.Form {
+        return try parser.inputGetForm(self);
+    }
+    pub fn get_accept(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetAccept(self);
+    }
+    pub fn set_accept(self: *parser.Input, accept: []const u8) !void {
+        try parser.inputSetAccept(self, accept);
+    }
+    pub fn get_alt(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetAlt(self);
+    }
+    pub fn set_alt(self: *parser.Input, alt: []const u8) !void {
+        try parser.inputSetAlt(self, alt);
+    }
+    pub fn get_checked(self: *parser.Input) !bool {
+        return try parser.inputGetChecked(self);
+    }
+    pub fn set_checked(self: *parser.Input, checked: bool) !void {
+        try parser.inputSetChecked(self, checked);
+    }
+    pub fn get_disabled(self: *parser.Input) !bool {
+        return try parser.inputGetDisabled(self);
+    }
+    pub fn set_disabled(self: *parser.Input, disabled: bool) !void {
+        try parser.inputSetDisabled(self, disabled);
+    }
+    pub fn get_maxLength(self: *parser.Input) !i32 {
+        return try parser.inputGetMaxLength(self);
+    }
+    pub fn set_maxLength(self: *parser.Input, max_length: u32) !void {
+        try parser.inputSetMaxLength(self, max_length);
+    }
+    pub fn get_name(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetName(self);
+    }
+    pub fn set_name(self: *parser.Input, name: []const u8) !void {
+        try parser.inputSetName(self, name);
+    }
+    pub fn get_readOnly(self: *parser.Input) !bool {
+        return try parser.inputGetReadOnly(self);
+    }
+    pub fn set_readOnly(self: *parser.Input, read_only: bool) !void {
+        try parser.inputSetReadOnly(self, read_only);
+    }
+    pub fn get_size(self: *parser.Input) !u32 {
+        return try parser.inputGetSize(self);
+    }
+    pub fn set_size(self: *parser.Input, size: u32) !void {
+        try parser.inputSetSize(self, size);
+    }
+    pub fn get_src(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetSrc(self);
+    }
+    pub fn set_src(self: *parser.Input, src: []const u8) !void {
+        try parser.inputSetSrc(self, src);
+    }
+    pub fn get_type(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetType(self);
+    }
+    pub fn get_value(self: *parser.Input) ![]const u8 {
+        return try parser.inputGetValue(self);
+    }
+    pub fn set_value(self: *parser.Input, value: []const u8) !void {
+        try parser.inputSetValue(self, value);
+    }
 };
 
 pub const HTMLLIElement = struct {

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -2498,14 +2498,6 @@ pub fn optionSetSelected(option: *Option, selected: bool) !void {
     try DOMErr(err);
 }
 
-// Input
-pub fn inputGetChecked(input: *Input) !bool {
-    var b: bool = false;
-    const err = c.dom_html_input_element_get_checked(input, &b);
-    try DOMErr(err);
-    return b;
-}
-
 // HtmlCollection
 pub fn htmlCollectionGetLength(collection: *HTMLCollection) !u32 {
     var len: u32 = 0;
@@ -2599,5 +2591,168 @@ pub fn imageGetIsMap(image: *Image) !bool {
 }
 pub fn imageSetIsMap(image: *Image, is_map: bool) !void {
     const err = c.dom_html_image_element_set_is_map(image, is_map);
+    try DOMErr(err);
+}
+
+// Input
+// - Input.align is deprecated
+// - Input.useMap is deprecated
+// - HTMLElement.access_key
+// - HTMLElement.tabIndex
+// TODO methods:
+// - HTMLElement.blur
+// - HTMLElement.focus
+// - select
+// - HTMLElement.click
+
+pub fn inputGetDefaultValue(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_default_value(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetDefaultValue(input: *Input, default_value: []const u8) !void {
+    const err = c.dom_html_input_element_set_default_value(input, try strFromData(default_value));
+    try DOMErr(err);
+}
+
+pub fn inputGetDefaultChecked(input: *Input) !bool {
+    var default_checked: bool = false;
+    const err = c.dom_html_input_element_get_default_checked(input, &default_checked);
+    try DOMErr(err);
+    return default_checked;
+}
+pub fn inputSetDefaultChecked(input: *Input, default_checked: bool) !void {
+    const err = c.dom_html_input_element_set_default_checked(input, default_checked);
+    try DOMErr(err);
+}
+
+pub fn inputGetForm(input: *Input) !?*Form {
+    var form: ?*Form = null;
+    const err = c.dom_html_input_element_get_form(input, &form);
+    try DOMErr(err);
+    return form;
+}
+
+pub fn inputGetAccept(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_accept(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetAccept(input: *Input, accept: []const u8) !void {
+    const err = c.dom_html_input_element_set_accept(input, try strFromData(accept));
+    try DOMErr(err);
+}
+
+pub fn inputGetAlt(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_alt(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetAlt(input: *Input, alt: []const u8) !void {
+    const err = c.dom_html_input_element_set_alt(input, try strFromData(alt));
+    try DOMErr(err);
+}
+
+pub fn inputGetChecked(input: *Input) !bool {
+    var checked: bool = false;
+    const err = c.dom_html_input_element_get_checked(input, &checked);
+    try DOMErr(err);
+    return checked;
+}
+pub fn inputSetChecked(input: *Input, checked: bool) !void {
+    const err = c.dom_html_input_element_set_checked(input, checked);
+    try DOMErr(err);
+}
+
+pub fn inputGetDisabled(input: *Input) !bool {
+    var disabled: bool = false;
+    const err = c.dom_html_input_element_get_disabled(input, &disabled);
+    try DOMErr(err);
+    return disabled;
+}
+pub fn inputSetDisabled(input: *Input, disabled: bool) !void {
+    const err = c.dom_html_input_element_set_disabled(input, disabled);
+    try DOMErr(err);
+}
+
+pub fn inputGetMaxLength(input: *Input) !i32 {
+    var max_length: i32 = 0;
+    const err = c.dom_html_input_element_get_max_length(input, &max_length);
+    try DOMErr(err);
+    return max_length;
+}
+pub fn inputSetMaxLength(input: *Input, max_length: u32) !void {
+    const err = c.dom_html_input_element_set_max_length(input, max_length);
+    try DOMErr(err);
+}
+
+pub fn inputGetName(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_name(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetName(input: *Input, name: []const u8) !void {
+    const err = c.dom_html_input_element_set_name(input, try strFromData(name));
+    try DOMErr(err);
+}
+pub fn inputGetReadOnly(input: *Input) !bool {
+    var read_only: bool = false;
+    const err = c.dom_html_input_element_get_read_only(input, &read_only);
+    try DOMErr(err);
+    return read_only;
+}
+pub fn inputSetReadOnly(input: *Input, read_only: bool) !void {
+    const err = c.dom_html_input_element_set_read_only(input, read_only);
+    try DOMErr(err);
+}
+pub fn inputGetSize(input: *Input) !u32 {
+    var size: u32 = 0;
+    const err = c.dom_html_input_element_get_size(input, &size);
+    try DOMErr(err);
+    if (size == ulongNegativeOne) return 20; // 20
+    return size;
+}
+pub fn inputSetSize(input: *Input, size: u32) !void {
+    const err = c.dom_html_input_element_set_size(input, size);
+    try DOMErr(err);
+}
+
+pub fn inputGetSrc(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_src(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetSrc(input: *Input, src: []const u8) !void {
+    const err = c.dom_html_input_element_set_src(input, try strFromData(src));
+    try DOMErr(err);
+}
+
+pub fn inputGetType(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_type(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+
+pub fn inputGetValue(input: *Input) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_input_element_get_value(input, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "";
+    return strToData(s);
+}
+pub fn inputSetValue(input: *Input, value: []const u8) !void {
+    const err = c.dom_html_input_element_set_value(input, try strFromData(value));
     try DOMErr(err);
 }

--- a/src/url.zig
+++ b/src/url.zig
@@ -114,6 +114,7 @@ pub const URL = struct {
             if (opts.alloc == .always) {
                 return allocator.dupe(u8, base);
             }
+            return base;
         }
 
         const protocol_end: usize = blk: {
@@ -266,7 +267,7 @@ test "URL: Stitching Base & Src URLs (empty src)" {
 
     const base = "https://www.google.com/xyz/abc/123";
     const src = "";
-    const result = try URL.stitch(allocator, src, base);
+    const result = try URL.stitch(allocator, src, base, .{});
     defer allocator.free(result);
     try testing.expectString("https://www.google.com/xyz/abc/123", result);
 }

--- a/src/url.zig
+++ b/src/url.zig
@@ -110,6 +110,11 @@ pub const URL = struct {
             }
             return src;
         }
+        if (src.len == 0) {
+            if (opts.alloc == .always) {
+                return allocator.dupe(u8, base);
+            }
+        }
 
         const protocol_end: usize = blk: {
             if (std.mem.indexOf(u8, base, "://")) |protocol_index| {
@@ -254,6 +259,16 @@ test "URL: Stiching src as full path" {
     const src = "https://lightpanda.io/something.js";
     const result = try URL.stitch(allocator, src, base, .{ .alloc = .if_needed });
     try testing.expectString("https://lightpanda.io/something.js", result);
+}
+
+test "URL: Stitching Base & Src URLs (empty src)" {
+    const allocator = testing.allocator;
+
+    const base = "https://www.google.com/xyz/abc/123";
+    const src = "";
+    const result = try URL.stitch(allocator, src, base);
+    defer allocator.free(result);
+    try testing.expectString("https://www.google.com/xyz/abc/123", result);
 }
 
 test "URL: concatQueryString" {


### PR DESCRIPTION
Depends on: https://github.com/lightpanda-io/libdom/pull/28

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
Properties that are implemented by Netsurf, not deprecated, and not inherited from HTMLElement.

With these we probable have enough examples to make a generic implementation, for that note that there are some special cases:
- Some netsurf properties are deprecated
- Netsurf does not support all properties
- Some properties are inherited through the prototype chain
- Some properties have default values if the netsurf says null or the unsigned version of -1
- The initial value and the default value do not need to be the same. init -1 default 0 for example.
- The set and get types may be different get may return -1 `i32`, but set must be positive `u32`
- Some specific values instead of defaulting throw an error.
- Sometimes the Set functions is not implemented bynetsurf even if the property is not readonly
- The default initialization and reverting to default on bad value assignment also needs to work for `Element.setAttribute` and `Element.getAttribute` 
- Values may related default value properties used until the value itself is set.
- src properties need to be stiched with the pages url.
- Netsurf may create more DOM events than defined by the spec upon setting a property without using setAttribute. TBD

PR created to make Playwright `page.getByRole` work.