### PR TITLE
Form submit

### DIFF
--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -174,6 +174,10 @@ pub const HTMLDocument = struct {
         return try parser.documentHTMLGetLocation(Location, self);
     }
 
+    pub fn set_location(_: *const parser.DocumentHTML, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
+    }
+
     pub fn get_designMode(_: *parser.DocumentHTML) []const u8 {
         return "off";
     }

--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -175,7 +175,7 @@ pub const HTMLDocument = struct {
     }
 
     pub fn set_location(_: *const parser.DocumentHTML, url: []const u8, page: *Page) !void {
-        return page.navigateFromWebAPI(url);
+        return page.navigateFromWebAPI(url, .{ .reason = .script });
     }
 
     pub fn get_designMode(_: *parser.DocumentHTML) []const u8 {

--- a/src/browser/html/form.zig
+++ b/src/browser/html/form.zig
@@ -19,6 +19,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const parser = @import("../netsurf.zig");
+const Page = @import("../page.zig").Page;
 const HTMLElement = @import("elements.zig").HTMLElement;
 const FormData = @import("../xhr/form_data.zig").FormData;
 
@@ -26,6 +27,10 @@ pub const HTMLFormElement = struct {
     pub const Self = parser.Form;
     pub const prototype = *HTMLElement;
     pub const subtype = .node;
+
+    pub fn _submit(self: *parser.Form, page: *Page) !void {
+        return page.submitForm(self, null);
+    }
 
     pub fn _requestSubmit(self: *parser.Form) !void {
         try parser.formElementSubmit(self);
@@ -35,20 +40,3 @@ pub const HTMLFormElement = struct {
         try parser.formElementReset(self);
     }
 };
-
-pub const Submission = struct {
-    method: ?[]const u8,
-    form_data: FormData,
-};
-
-pub fn processSubmission(arena: Allocator, form: *parser.Form) !?Submission {
-    const form_element: *parser.Element = @ptrCast(form);
-    const method = try parser.elementGetAttribute(form_element, "method");
-
-    return .{
-        .method = method,
-        .form_data = try FormData.fromForm(arena, form),
-    };
-}
-
-// Check xhr/form_data.zig for tests

--- a/src/browser/html/location.zig
+++ b/src/browser/html/location.zig
@@ -69,18 +69,17 @@ pub const Location = struct {
         return "";
     }
 
-    // TODO
-    pub fn _assign(_: *Location, url: []const u8) !void {
-        _ = url;
+    pub fn _assign(_: *const Location, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
     }
 
-    // TODO
-    pub fn _replace(_: *Location, url: []const u8) !void {
-        _ = url;
+    pub fn _replace(_: *const Location, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
     }
 
-    // TODO
-    pub fn _reload(_: *Location) !void {}
+    pub fn _reload(_: *const Location, page: *Page) !void {
+        return page.navigateFromWebAPI(page.url.raw);
+    }
 
     pub fn _toString(self: *Location, page: *Page) ![]const u8 {
         return try self.get_href(page);

--- a/src/browser/html/location.zig
+++ b/src/browser/html/location.zig
@@ -70,15 +70,15 @@ pub const Location = struct {
     }
 
     pub fn _assign(_: *const Location, url: []const u8, page: *Page) !void {
-        return page.navigateFromWebAPI(url);
+        return page.navigateFromWebAPI(url, .{ .reason = .script });
     }
 
     pub fn _replace(_: *const Location, url: []const u8, page: *Page) !void {
-        return page.navigateFromWebAPI(url);
+        return page.navigateFromWebAPI(url, .{ .reason = .script });
     }
 
     pub fn _reload(_: *const Location, page: *Page) !void {
-        return page.navigateFromWebAPI(page.url.raw);
+        return page.navigateFromWebAPI(page.url.raw, .{ .reason = .script });
     }
 
     pub fn _toString(self: *Location, page: *Page) ![]const u8 {

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -101,7 +101,7 @@ pub const Window = struct {
     }
 
     pub fn set_location(_: *const Window, url: []const u8, page: *Page) !void {
-        return page.navigateFromWebAPI(url);
+        return page.navigateFromWebAPI(url, .{ .reason = .script });
     }
 
     pub fn get_console(self: *Window) *Console {

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -100,6 +100,10 @@ pub const Window = struct {
         return &self.location;
     }
 
+    pub fn set_location(_: *const Window, url: []const u8, page: *Page) !void {
+        return page.navigateFromWebAPI(url);
+    }
+
     pub fn get_console(self: *Window) *Console {
         return &self.console;
     }

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -199,8 +199,9 @@ pub const Page = struct {
         self.url = request_url;
 
         // load the data
-        var request = try self.newHTTPRequest(.GET, &self.url, .{ .navigation = true });
+        var request = try self.newHTTPRequest(opts.method, &self.url, .{ .navigation = true });
         defer request.deinit();
+        request.body = opts.body;
         request.notification = notification;
 
         notification.dispatch(.page_navigate, &.{
@@ -541,7 +542,7 @@ pub const Page = struct {
             .a => {
                 const element: *parser.Element = @ptrCast(node);
                 const href = (try parser.elementGetAttribute(element, "href")) orelse return;
-                try self.navigateFromWebAPI(href);
+                try self.navigateFromWebAPI(href, .{});
             },
             else => {},
         }
@@ -550,10 +551,11 @@ pub const Page = struct {
     // As such we schedule the function to be called as soon as possible.
     // The page.arena is safe to use here, but the transfer_arena exists
     // specifically for this type of lifetime.
-    pub fn navigateFromWebAPI(self: *Page, url: []const u8) !void {
+    pub fn navigateFromWebAPI(self: *Page, url: []const u8, opts: NavigateOpts) !void {
         const arena = self.session.transfer_arena;
         const navi = try arena.create(DelayedNavigation);
         navi.* = .{
+            .opts = opts,
             .session = self.session,
             .url = try arena.dupe(u8, url),
         };
@@ -578,17 +580,45 @@ pub const Page = struct {
         }
         return null;
     }
+
+    pub fn submitForm(self: *Page, form: *parser.Form, submitter: ?*parser.ElementHTML) !void {
+        const FormData = @import("xhr/form_data.zig").FormData;
+
+        const transfer_arena = self.session.transfer_arena;
+        var form_data = try FormData.fromForm(form, submitter, self);
+
+        const encoding = try parser.elementGetAttribute(@ptrCast(form), "enctype");
+
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        try form_data.write(encoding, buf.writer(transfer_arena));
+
+        const method = try parser.elementGetAttribute(@ptrCast(form), "method") orelse "";
+        var action = try parser.elementGetAttribute(@ptrCast(form), "action") orelse self.url.raw;
+
+        var opts = NavigateOpts{
+            .reason = .form,
+        };
+        if (std.ascii.eqlIgnoreCase(method, "post")) {
+            opts.method = .POST;
+            opts.body = buf.items;
+        } else {
+            action = try URL.concatQueryString(transfer_arena, action, buf.items);
+        }
+
+        try self.navigateFromWebAPI(action, opts);
+    }
 };
 
 const DelayedNavigation = struct {
     url: []const u8,
     session: *Session,
+    opts: NavigateOpts,
     navigate_node: Loop.CallbackNode = .{ .func = delayNavigate },
 
     fn delayNavigate(node: *Loop.CallbackNode, repeat_delay: *?u63) void {
         _ = repeat_delay;
         const self: *DelayedNavigation = @fieldParentPtr("navigate_node", node);
-        self.session.pageNavigate(self.url) catch |err| {
+        self.session.pageNavigate(self.url, self.opts) catch |err| {
             log.err(.page, "delayed navigation error", .{ .err = err, .url = self.url });
         };
     }
@@ -697,11 +727,15 @@ const Script = struct {
 pub const NavigateReason = enum {
     anchor,
     address_bar,
+    form,
+    script,
 };
 
 pub const NavigateOpts = struct {
     cdp_id: ?i64 = null,
     reason: NavigateReason = .address_bar,
+    method: http.Request.Method = .GET,
+    body: ?[]const u8 = null,
 };
 
 fn timestamp() u32 {

--- a/src/browser/session.zig
+++ b/src/browser/session.zig
@@ -23,6 +23,7 @@ const Allocator = std.mem.Allocator;
 const Env = @import("env.zig").Env;
 const Page = @import("page.zig").Page;
 const Browser = @import("browser.zig").Browser;
+const NavigateOpts = @import("page.zig").NavigateOpts;
 
 const log = @import("../log.zig");
 const parser = @import("netsurf.zig");
@@ -122,7 +123,7 @@ pub const Session = struct {
         return &(self.page orelse return null);
     }
 
-    pub fn pageNavigate(self: *Session, url_string: []const u8) !void {
+    pub fn pageNavigate(self: *Session, url_string: []const u8, opts: NavigateOpts) !void {
         // currently, this is only called from the page, so let's hope
         // it isn't null!
         std.debug.assert(self.page != null);
@@ -136,8 +137,6 @@ pub const Session = struct {
 
         self.removePage();
         var page = try self.createPage();
-        return page.navigate(url, .{
-            .reason = .anchor,
-        });
+        return page.navigate(url, opts);
     }
 };


### PR DESCRIPTION
This builds on top of https://github.com/lightpanda-io/browser/pull/715

Supports GET and POST, but only supports the default encoding type, i.e. `application/x-www-form-urlencoded`.  Currently can only be triggered by the `sumbit()` JavaScript function. Extending it to button click is the next step and should be a relatively simple addition.