### PR TITLE
Fix HTMLImageElement

### DIFF
--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -57,6 +57,7 @@ pub const Interfaces = .{
     HTMLHtmlElement,
     HTMLIFrameElement,
     HTMLImageElement,
+    HTMLImageElement.Factory,
     HTMLInputElement,
     HTMLLIElement,
     HTMLLabelElement,
@@ -565,15 +566,6 @@ pub const HTMLImageElement = struct {
     pub const Self = parser.Image;
     pub const prototype = *HTMLElement;
     pub const subtype = .node;
-    pub const js_name = "Image";
-
-    pub fn constructor(width: ?u32, height: ?u32, page: *const Page) !*parser.Image {
-        const element = try parser.documentCreateElement(parser.documentHTMLToDocument(page.window.document), "img");
-        const image: *parser.Image = @ptrCast(element);
-        if (width) |width_| try parser.imageSetWidth(image, width_);
-        if (height) |height_| try parser.imageSetHeight(image, height_);
-        return image;
-    }
 
     pub fn get_alt(self: *parser.Image) ![]const u8 {
         return try parser.imageGetAlt(self);
@@ -611,6 +603,21 @@ pub const HTMLImageElement = struct {
     pub fn set_isMap(self: *parser.Image, is_map: bool) !void {
         try parser.imageSetIsMap(self, is_map);
     }
+
+    pub const Factory = struct {
+        pub const js_name = "Image";
+        pub const subtype = .node;
+        pub const js_legacy_factory = true;
+        pub const prototype = *HTMLImageElement;
+
+        pub fn constructor(width: ?u32, height: ?u32, page: *const Page) !*parser.Image {
+            const element = try parser.documentCreateElement(parser.documentHTMLToDocument(page.window.document), "img");
+            const image: *parser.Image = @ptrCast(element);
+            if (width) |width_| try parser.imageSetWidth(image, width_);
+            if (height) |height_| try parser.imageSetHeight(image, height_);
+            return image;
+        }
+    };
 };
 
 pub const HTMLInputElement = struct {

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -2222,8 +2222,14 @@ const TypeMeta = struct {
     subtype: ?SubType,
 };
 
+// When we map a Zig instance into a JsObject, we'll normally store the a
+// TaggedAnyOpaque (TAO) inside of the JsObject's internal field. This requires
+// ensuring that the instance template has an InternalFieldCount of 1. However,
+// for empty objects, we don't need to store the TAO, because we can't just cast
+// one empty object to another, so for those, as an optimization, we do not set
+// the InternalFieldCount.
 fn isEmpty(comptime T: type) bool {
-    return @typeInfo(T) != .@"opaque" and @sizeOf(T) == 0;
+    return @typeInfo(T) != .@"opaque" and @sizeOf(T) == 0 and @hasDecl(T, "js_legacy_factory") == false;
 }
 
 // Responsible for calling Zig functions from JS invokations. This could


### PR DESCRIPTION
HTMLImageElement is the correct class name. However, it has a "legacy factory": Image (i.e. new Image()).