### PR TITLE
Allow any 2xx status code for scripts

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -470,7 +470,7 @@ pub const Page = struct {
         var header = response.header;
         try self.session.cookie_jar.populateFromResponse(&url.uri, &header);
 
-        if (header.status != 200) {
+        if (header.status < 200 or header.status > 299) {
             return error.BadStatusCode;
         }
 


### PR DESCRIPTION
DDG will sometimes return a 202 for its result javascript, meaning it isn't ready and the rest of the JS will then handle that case. It's weird, but there's no reason for us to abort on a 2xx code.