### PR TITLE
Make stacktraces available in debug via `page.stackTrace()`

### DIFF
--- a/src/browser/console/console.zig
+++ b/src/browser/console/console.zig
@@ -66,7 +66,11 @@ pub const Console = struct {
         if (values.len == 0) {
             return;
         }
-        log.info(.console, "error", .{ .args = try serializeValues(values, page) });
+
+        log.info(.console, "error", .{
+            .args = try serializeValues(values, page),
+            .stack = page.stackTrace() catch "???",
+        });
     }
 
     pub fn _clear(_: *const Console) void {}

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -666,6 +666,13 @@ pub const Page = struct {
         const form = (try Element._closest(element, "form", self)) orelse return null;
         return @ptrCast(form);
     }
+
+    pub fn stackTrace(self: *Page) !?[]const u8 {
+        if (comptime builtin.mode == .Debug) {
+            return self.scope.stackTrace();
+        }
+        return null;
+    }
 };
 
 const DelayedNavigation = struct {

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -601,6 +601,10 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                 return persistent_object.castToObject();
             }
 
+            pub fn stackTrace(self: *const Scope) !?[]const u8 {
+                return stackForLogs(self.call_arena, self.isolate);
+            }
+
             // Executes the src
             pub fn exec(self: *Scope, src: []const u8, name: ?[]const u8) !Value {
                 const isolate = self.isolate;


### PR DESCRIPTION
Automatically include the stack trace in a `console.error` output. This is useful because code frequently does:

```
  try blah();
  catch (e) console.log(e);
```

Which we log, but, without this, don't get the stack.