### PR TITLE
Fix activeElement

### DIFF
--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -42,7 +42,8 @@ pub const Document = struct {
     pub const prototype = *Node;
     pub const subtype = .node;
 
-    active_element: ?*parser.Element = null,
+    // DO NOT ADD STATE HERE
+    // ADD IT TO html/document
 
     pub fn constructor(page: *const Page) !*parser.DocumentHTML {
         const doc = try parser.documentCreateDocument(
@@ -246,8 +247,9 @@ pub const Document = struct {
     }
 
     pub fn get_activeElement(doc: *parser.Document, page: *Page) !?ElementUnion {
-        const self = try page.getOrCreateNodeWrapper(Document, @ptrCast(doc));
-        if (self.active_element) |ae| {
+        const HTMLDocument = @import("../html/document.zig").HTMLDocument;
+        const html_doc = try page.getOrCreateNodeWrapper(HTMLDocument, @ptrCast(doc));
+        if (html_doc.active_element) |ae| {
             return try Element.toInterface(ae);
         }
 

--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -40,6 +40,7 @@ pub const HTMLDocument = struct {
     pub const subtype = .node;
 
     ready_state: ReadyState = .loading,
+    active_element: ?*parser.Element = null,
 
     const ReadyState = enum {
         loading,

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -161,14 +161,14 @@ pub const HTMLElement = struct {
 
         const root_node = try parser.nodeGetRootNode(@ptrCast(e));
 
-        const Document = @import("../dom/document.zig").Document;
-        const document = try page.getOrCreateNodeWrapper(Document, @ptrCast(root_node));
+        const HTMLDocument = @import("../html/document.zig").HTMLDocument;
+        const html_doc = try page.getOrCreateNodeWrapper(HTMLDocument, @ptrCast(root_node));
 
         // TODO: some elements can't be focused, like if they're disabled
         // but there doesn't seem to be a generic way to check this. For example
         // we could look for the "disabled" attribute, but that's only meaningful
         // on certain types, and libdom's vtable doesn't seem to expose this.
-        document.active_element = @ptrCast(e);
+        html_doc.active_element = @ptrCast(e);
     }
 };
 


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/742 was only correct in isolation.

The problem is that both html/document and dom/document are now attempting to attach state to the same *parser.Node. This is a problem because they're two different types of state. If an HTMLDocument is attached to the node, and you then try to access that as a DOMDocument, it'll crash.

I moved the dom/document state (active_element) into the html/document.

The other option is to introduce something like src/browser/state/document.zig and have both HTMLDocument and DOMDocument share/load that.