### PR TITLE
URLSearchParam constructor support for object initialization

### DIFF
--- a/src/browser/key_value.zig
+++ b/src/browser/key_value.zig
@@ -102,6 +102,13 @@ pub const List = struct {
         });
     }
 
+    pub fn appendOwnedAssumeCapacity(self: *List, key: []const u8, value: []const u8) void {
+        self.entries.appendAssumeCapacity(.{
+            .key = key,
+            .value = value,
+        });
+    }
+
     pub fn delete(self: *List, key: []const u8) void {
         var i: usize = 0;
         while (i < self.entries.items.len) {


### PR DESCRIPTION
This adds support for:

```
new URLSearchParams({over: 9000});
```

The spec says that any thing that produces/iterates a sequence of string pairs is valid. By using the lower-level JsObject, this hopefully takes care of the most common cases. But I don't think it's complete, and I don't think we currently capture enough data to make this work. There's no way for the JS runtime to know if a value (say, a netsurf instance, or even a Zig instance) provides an string=>string iterator.