### PR TITLE
setExtraHTTPHeaders

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -71,6 +71,9 @@ pub fn CDPT(comptime TypeProvider: type) type {
         // Used for processing notifications within a browser context.
         notification_arena: std.heap.ArenaAllocator,
 
+        // Extra headers to add to all requests. TBD under which conditions this should be reset.
+        extra_headers: std.ArrayListUnmanaged(std.http.Header) = .empty,
+
         const Self = @This();
 
         pub fn init(app: *App, client: TypeProvider.Client) !Self {

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const Notification = @import("../../notification.zig").Notification;
+const log = @import("../../log.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -26,12 +27,14 @@ pub fn processMessage(cmd: anytype) !void {
         enable,
         disable,
         setCacheDisabled,
+        setExtraHTTPHeaders,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
         .setCacheDisabled => return cmd.sendResult(null, .{}),
+        .setExtraHTTPHeaders => return setExtraHTTPHeaders(cmd),
     }
 }
 
@@ -47,6 +50,27 @@ fn disable(cmd: anytype) !void {
     return cmd.sendResult(null, .{});
 }
 
+fn setExtraHTTPHeaders(cmd: anytype) !void {
+    const params = (try cmd.params(struct {
+        headers: std.json.ArrayHashMap([]const u8),
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+
+    // Copy the headers onto the browser context arena
+    const arena = bc.arena;
+    const extra_headers = &bc.cdp.extra_headers;
+
+    extra_headers.clearRetainingCapacity();
+    try extra_headers.ensureTotalCapacity(arena, params.headers.map.count());
+    var it = params.headers.map.iterator();
+    while (it.next()) |header| {
+        extra_headers.appendAssumeCapacity(.{ .name = try arena.dupe(u8, header.key_ptr.*), .value = try arena.dupe(u8, header.value_ptr.*) });
+    }
+
+    return cmd.sendResult(null, .{});
+}
+
 pub fn httpRequestStart(arena: Allocator, bc: anytype, request: *const Notification.RequestStart) !void {
     // Isn't possible to do a network request within a Browser (which our
     // notification is tied to), without a page.
@@ -58,6 +82,21 @@ pub fn httpRequestStart(arena: Allocator, bc: anytype, request: *const Notificat
     const session_id = bc.session_id orelse unreachable;
     const target_id = bc.target_id orelse unreachable;
     const page = bc.session.currentPage() orelse unreachable;
+
+    // Modify request with extra CDP headers
+    const original_len = request.headers.items.len;
+    try request.headers.ensureTotalCapacity(arena, original_len + cdp.extra_headers.items.len);
+    outer: for (cdp.extra_headers.items) |extra| {
+        for (request.headers.items[0..original_len]) |*existing_header| {
+            if (std.mem.eql(u8, existing_header.name, extra.name)) {
+                // If the header already exists, we overwrite it
+                log.debug(.cdp, "request header overwritten", .{ .name = extra.name });
+                existing_header.value = extra.value;
+                continue :outer;
+            }
+        }
+        request.headers.appendAssumeCapacity(extra);
+    }
 
     const document_url = try urlToString(arena, &page.url.uri, .{
         .scheme = true,
@@ -80,8 +119,8 @@ pub fn httpRequestStart(arena: Allocator, bc: anytype, request: *const Notificat
     });
 
     var headers: std.StringArrayHashMapUnmanaged([]const u8) = .empty;
-    try headers.ensureTotalCapacity(arena, request.headers.len);
-    for (request.headers) |header| {
+    try headers.ensureTotalCapacity(arena, request.headers.items.len);
+    for (request.headers.items) |header| {
         headers.putAssumeCapacity(header.name, header.value);
     }
 
@@ -129,13 +168,13 @@ pub fn httpRequestComplete(arena: Allocator, bc: anytype, request: *const Notifi
     // We're missing a bunch of fields, but, for now, this seems like enough
     try cdp.sendEvent("Network.responseReceived", .{
         .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{request.id}),
-        .frameId = target_id,
         .loaderId = bc.loader_id,
         .response = .{
             .url = url,
             .status = request.status,
             .headers = std.json.ArrayHashMap([]const u8){ .map = headers },
         },
+        .frameId = target_id,
     }, .{ .session_id = session_id });
 }
 
@@ -143,4 +182,27 @@ fn urlToString(arena: Allocator, url: *const std.Uri, opts: std.Uri.WriteToStrea
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     try url.writeToStream(opts, buf.writer(arena));
     return buf.items;
+}
+
+const testing = @import("../testing.zig");
+test "cdp.network setExtraHTTPHeaders" {
+    var ctx = testing.context();
+    defer ctx.deinit();
+
+    // _ = try ctx.loadBrowserContext(.{ .id = "NID-A", .session_id = "NESI-A" });
+    try ctx.processMessage(.{ .id = 10, .method = "Target.createTarget", .params = .{ .url = "about/blank" } });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{ .foo = "bar" } },
+    });
+
+    try ctx.processMessage(.{
+        .id = 4,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{ .food = "bars" } },
+    });
+
+    try testing.expectEqual(ctx.cdp_.?.browser_context.?.cdp.extra_headers.items.len, 1);
 }

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -736,10 +736,11 @@ pub const Request = struct {
         }
         self._notified_start = true;
         notification.dispatch(.http_request_start, &.{
+            .arena = self.arena,
             .id = self.id,
             .url = self.request_uri,
             .method = self.method,
-            .headers = self.headers.items,
+            .headers = &self.headers,
             .has_body = self.body != null,
         });
     }

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -89,10 +89,11 @@ pub const Notification = struct {
     };
 
     pub const RequestStart = struct {
+        arena: Allocator,
         id: usize,
         url: *const std.Uri,
         method: http_client.Request.Method,
-        headers: []std.http.Header,
+        headers: *std.ArrayListUnmanaged(std.http.Header),
         has_body: bool,
     };
 


### PR DESCRIPTION
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setExtraHTTPHeaders

Confirmed working via puppeteer script. 
```
await page.setExtraHTTPHeaders({ 'food': 'bard', 'foods': 'bars' })
console.log((await page.goto('https://example.org/')));
```
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/7660d684-aa59-48af-bcd1-094cedf17e6a" />


Would want to test it from puppeteer by inspecting the headers of the response, but `response` is null for LP (works with chromium)
```
let response = await page.goto('https://example.org/');
console.log(response.request().headers());
```
A good way to test suggestion is welcome, can't Page.navigate afaik