### PR TITLE
Emit http_request_fail notification

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -247,6 +247,8 @@ pub const Page = struct {
                 .content_type = content_type,
                 .charset = mime.charset,
                 .url = request_url,
+                .method = opts.method,
+                .reason = opts.reason,
             });
 
             if (!mime.isHTML()) {
@@ -597,6 +599,10 @@ pub const Page = struct {
     // The page.arena is safe to use here, but the transfer_arena exists
     // specifically for this type of lifetime.
     pub fn navigateFromWebAPI(self: *Page, url: []const u8, opts: NavigateOpts) !void {
+        log.debug(.browser, "delayed navigation", .{
+            .url = url,
+            .reason = opts.reason,
+        });
         self.delayed_navigation = true;
         const arena = self.session.transfer_arena;
         const navi = try arena.create(DelayedNavigation);

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -338,7 +338,11 @@ pub const XMLHttpRequest = struct {
     // dispatch request event.
     // errors are logged only.
     fn dispatchEvt(self: *XMLHttpRequest, typ: []const u8) void {
-        log.debug(.script_event, "dispatch event", .{ .type = typ, .source = "xhr" });
+        log.debug(.script_event, "dispatch event", .{
+            .type = typ,
+            .source = "xhr",
+            .url = self.url,
+        });
         self._dispatchEvt(typ) catch |err| {
             log.err(.app, "dispatch event error", .{ .err = err, .type = typ, .source = "xhr" });
         };
@@ -358,7 +362,11 @@ pub const XMLHttpRequest = struct {
         typ: []const u8,
         opts: ProgressEvent.EventInit,
     ) void {
-        log.debug(.script_event, "dispatch progress event", .{ .type = typ, .source = "xhr" });
+        log.debug(.script_event, "dispatch progress event", .{
+            .type = typ,
+            .source = "xhr",
+            .url = self.url,
+        });
         self._dispatchProgressEvent(typ, opts) catch |err| {
             log.err(.app, "dispatch progress event error", .{ .err = err, .type = typ, .source = "xhr" });
         };

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -412,11 +412,13 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         }
 
         pub fn networkEnable(self: *Self) !void {
+            try self.cdp.browser.notification.register(.http_request_fail, self, onHttpRequestFail);
             try self.cdp.browser.notification.register(.http_request_start, self, onHttpRequestStart);
             try self.cdp.browser.notification.register(.http_request_complete, self, onHttpRequestComplete);
         }
 
         pub fn networkDisable(self: *Self) void {
+            self.cdp.browser.notification.unregister(.http_request_fail, self);
             self.cdp.browser.notification.unregister(.http_request_start, self);
             self.cdp.browser.notification.unregister(.http_request_complete, self);
         }
@@ -446,6 +448,12 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             const self: *Self = @alignCast(@ptrCast(ctx));
             defer self.resetNotificationArena();
             return @import("domains/network.zig").httpRequestStart(self.notification_arena, self, data);
+        }
+
+        pub fn onHttpRequestFail(ctx: *anyopaque, data: *const Notification.RequestFail) !void {
+            const self: *Self = @alignCast(@ptrCast(ctx));
+            defer self.resetNotificationArena();
+            return @import("domains/network.zig").httpRequestFail(self.notification_arena, self, data);
         }
 
         pub fn onHttpRequestComplete(ctx: *anyopaque, data: *const Notification.RequestComplete) !void {

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -59,6 +59,7 @@ pub const Notification = struct {
         page_created: List = .{},
         page_navigate: List = .{},
         page_navigated: List = .{},
+        http_request_fail: List = .{},
         http_request_start: List = .{},
         http_request_complete: List = .{},
         notification_created: List = .{},
@@ -69,6 +70,7 @@ pub const Notification = struct {
         page_created: *page.Page,
         page_navigate: *const PageNavigate,
         page_navigated: *const PageNavigated,
+        http_request_fail: *const RequestFail,
         http_request_start: *const RequestStart,
         http_request_complete: *const RequestComplete,
         notification_created: *Notification,
@@ -95,6 +97,12 @@ pub const Notification = struct {
         method: http_client.Request.Method,
         headers: *std.ArrayListUnmanaged(std.http.Header),
         has_body: bool,
+    };
+
+    pub const RequestFail = struct {
+        id: usize,
+        url: *const std.Uri,
+        err: []const u8,
     };
 
     pub const RequestComplete = struct {

--- a/src/runtime/loop.zig
+++ b/src/runtime/loop.zig
@@ -127,7 +127,6 @@ pub const Loop = struct {
         }
     }
 
-
     // JS callbacks APIs
     // -----------------
 
@@ -254,7 +253,6 @@ pub const Loop = struct {
                 cbk(@alignCast(@ptrCast(callback.ctx)), completion_, res);
             }
         }.onConnect;
-
 
         const callback = try self.event_callback_pool.create();
         errdefer self.event_callback_pool.destroy(callback);


### PR DESCRIPTION
CDP translate this into a Network.loadingFailed. This is necessary to make sure every Network.requestWillBeSent is paired with either a Network.loadingFailed or a Network.responseReceived.