### PR TITLE
Import html_element

### DIFF
--- a/src/browser/dom/character_data.zig
+++ b/src/browser/dom/character_data.zig
@@ -101,7 +101,7 @@ pub const CharacterData = struct {
     // netsurf's CharacterData (text, comment) doesn't implement the
     // dom_node_get_attributes and thus will crash if we try to call nodeIsEqualNode.
     pub fn _isEqualNode(self: *parser.CharacterData, other_node: *parser.Node) !bool {
-        if (try parser.nodeType(@ptrCast(self)) != try parser.nodeType(other_node)) {
+        if (try parser.nodeType(@alignCast(@ptrCast(self))) != try parser.nodeType(other_node)) {
             return false;
         }
 

--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -244,13 +244,13 @@ pub const Document = struct {
     }
 
     pub fn get_activeElement(self: *parser.Document, page: *Page) !?ElementUnion {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         if (state.active_element) |ae| {
             return try Element.toInterface(ae);
         }
 
         if (try parser.documentHTMLBody(page.window.document)) |body| {
-            return try Element.toInterface(@ptrCast(body));
+            return try Element.toInterface(@alignCast(@ptrCast(body)));
         }
 
         return get_documentElement(self);
@@ -261,7 +261,7 @@ pub const Document = struct {
     // we could look for the "disabled" attribute, but that's only meaningful
     // on certain types, and libdom's vtable doesn't seem to expose this.
     pub fn setFocus(self: *parser.Document, e: *parser.ElementHTML, page: *Page) !void {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.active_element = @ptrCast(e);
     }
 };

--- a/src/browser/dom/node.zig
+++ b/src/browser/dom/node.zig
@@ -496,7 +496,7 @@ pub const Node = struct {
         fn toNode(self: NodeOrText, doc: *parser.Document) !*parser.Node {
             return switch (self) {
                 .node => |n| n,
-                .text => |txt| @ptrCast(try parser.documentCreateTextNode(doc, txt)),
+                .text => |txt| @alignCast(@ptrCast(try parser.documentCreateTextNode(doc, txt))),
             };
         }
 

--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -184,7 +184,7 @@ pub const HTMLDocument = struct {
     }
 
     pub fn get_readyState(self: *parser.DocumentHTML, page: *Page) ![]const u8 {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         return @tagName(state.ready_state);
     }
 
@@ -263,7 +263,7 @@ pub const HTMLDocument = struct {
     }
 
     pub fn documentIsLoaded(self: *parser.DocumentHTML, page: *Page) !void {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.ready_state = .interactive;
 
         const evt = try parser.eventCreate();
@@ -278,7 +278,7 @@ pub const HTMLDocument = struct {
     }
 
     pub fn documentIsComplete(self: *parser.DocumentHTML, page: *Page) !void {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.ready_state = .complete;
     }
 };

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -133,7 +133,7 @@ pub const HTMLElement = struct {
         try Node.removeChildren(n);
 
         // attach the text node.
-        _ = try parser.nodeAppendChild(n, @as(*parser.Node, @ptrCast(t)));
+        _ = try parser.nodeAppendChild(n, @as(*parser.Node, @alignCast(@ptrCast(t))));
     }
 
     pub fn _click(e: *parser.ElementHTML) !void {
@@ -245,7 +245,7 @@ pub const HTMLAnchorElement = struct {
     }
 
     inline fn url(self: *parser.Anchor, page: *Page) !URL {
-        return URL.constructor(.{ .element = @ptrCast(self) }, null, page); // TODO inject base url
+        return URL.constructor(.{ .element = @alignCast(@ptrCast(self)) }, null, page); // TODO inject base url
     }
 
     // TODO return a disposable string
@@ -945,22 +945,22 @@ pub const HTMLScriptElement = struct {
     }
 
     pub fn get_onload(self: *parser.Script, page: *Page) !?Env.Function {
-        const state = page.getNodeState(@ptrCast(self)) orelse return null;
+        const state = page.getNodeState(@alignCast(@ptrCast(self))) orelse return null;
         return state.onload;
     }
 
     pub fn set_onload(self: *parser.Script, function: ?Env.Function, page: *Page) !void {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.onload = function;
     }
 
     pub fn get_onerror(self: *parser.Script, page: *Page) !?Env.Function {
-        const state = page.getNodeState(@ptrCast(self)) orelse return null;
+        const state = page.getNodeState(@alignCast(@ptrCast(self))) orelse return null;
         return state.onerror;
     }
 
     pub fn set_onerror(self: *parser.Script, function: ?Env.Function, page: *Page) !void {
-        const state = try page.getOrCreateNodeState(@ptrCast(self));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.onerror = function;
     }
 };

--- a/src/browser/html/select.zig
+++ b/src/browser/html/select.zig
@@ -56,7 +56,7 @@ pub const HTMLSelectElement = struct {
     }
 
     pub fn get_selectedIndex(select: *parser.Select, page: *Page) !i32 {
-        const state = try page.getOrCreateNodeState(@ptrCast(select));
+        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(select)));
         const selected_index = try parser.selectGetSelectedIndex(select);
 
         // See the explicit_index_set field documentation
@@ -75,7 +75,7 @@ pub const HTMLSelectElement = struct {
     // Libdom's dom_html_select_select_set_selected_index will crash if index
     // is out of range, and it doesn't properly unset options
     pub fn set_selectedIndex(select: *parser.Select, index: i32, page: *Page) !void {
-        var state = try page.getOrCreateNodeState(@ptrCast(select));
+        var state = try page.getOrCreateNodeState(@alignCast(@ptrCast(select)));
         state.explicit_index_set = true;
 
         const options = try parser.selectGetOptions(select);

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -26,6 +26,8 @@ const c = @cImport({
     @cInclude("events/event.h");
     @cInclude("events/mouse_event.h");
     @cInclude("utils/validate.h");
+    @cInclude("html/html_element.h");
+    @cInclude("html/html_document.h");
 });
 
 const mimalloc = @import("mimalloc.zig");
@@ -550,7 +552,7 @@ pub fn mutationEventRelatedNode(evt: *MutationEvent) !?*Node {
     const err = c._dom_mutation_event_get_related_node(evt, &n);
     try DOMErr(err);
     if (n == null) return null;
-    return @as(*Node, @ptrCast(n));
+    return @as(*Node, @alignCast(@ptrCast(n)));
 }
 
 // EventListener
@@ -565,7 +567,7 @@ fn eventListenerGetData(lst: *EventListener) ?*anyopaque {
 pub const EventTarget = c.dom_event_target;
 
 pub fn eventTargetToNode(et: *EventTarget) *Node {
-    return @as(*Node, @ptrCast(et));
+    return @as(*Node, @alignCast(@ptrCast(et)));
 }
 
 fn eventTargetVtable(et: *EventTarget) c.dom_event_target_vtable {
@@ -894,7 +896,7 @@ pub fn nodeListItem(nodeList: *NodeList, index: u32) !?*Node {
     const err = c._dom_nodelist_item(nodeList, index, &n);
     try DOMErr(err);
     if (n == null) return null;
-    return @as(*Node, @ptrCast(n));
+    return @as(*Node, @alignCast(@ptrCast(n)));
 }
 
 // NodeExternal is the libdom public representation of a Node.
@@ -1323,7 +1325,7 @@ fn characterDataVtable(data: *CharacterData) c.dom_characterdata_vtable {
 }
 
 pub inline fn characterDataToNode(cdata: *CharacterData) *Node {
-    return @as(*Node, @ptrCast(cdata));
+    return @as(*Node, @alignCast(@ptrCast(cdata)));
 }
 
 pub fn characterDataData(cdata: *CharacterData) ![]const u8 {
@@ -1408,7 +1410,7 @@ pub const ProcessingInstruction = c.dom_processing_instruction;
 
 // processingInstructionToNode is an helper to convert an ProcessingInstruction to a node.
 pub inline fn processingInstructionToNode(pi: *ProcessingInstruction) *Node {
-    return @as(*Node, @ptrCast(pi));
+    return @as(*Node, @alignCast(@ptrCast(pi)));
 }
 
 pub fn processInstructionCopy(pi: *ProcessingInstruction) !*ProcessingInstruction {
@@ -1463,7 +1465,7 @@ pub fn attributeGetOwnerElement(a: *Attribute) !?*Element {
 
 // attributeToNode is an helper to convert an attribute to a node.
 pub inline fn attributeToNode(a: *Attribute) *Node {
-    return @as(*Node, @ptrCast(a));
+    return @as(*Node, @alignCast(@ptrCast(a)));
 }
 
 // Element
@@ -1601,7 +1603,7 @@ pub fn elementHasClass(elem: *Element, class: []const u8) !bool {
 
 // elementToNode is an helper to convert an element to a node.
 pub inline fn elementToNode(e: *Element) *Node {
-    return @as(*Node, @ptrCast(e));
+    return @as(*Node, @alignCast(@ptrCast(e)));
 }
 
 // TokenList
@@ -1685,14 +1687,14 @@ pub fn elementHTMLGetTagType(elem_html: *ElementHTML) !Tag {
 
 // scriptToElt is an helper to convert an script to an element.
 pub inline fn scriptToElt(s: *Script) *Element {
-    return @as(*Element, @ptrCast(s));
+    return @as(*Element, @alignCast(@ptrCast(s)));
 }
 
 // HTMLAnchorElement
 
 // anchorToNode is an helper to convert an anchor to a node.
 pub inline fn anchorToNode(a: *Anchor) *Node {
-    return @as(*Node, @ptrCast(a));
+    return @as(*Node, @alignCast(@ptrCast(a)));
 }
 
 pub fn anchorGetTarget(a: *Anchor) ![]const u8 {
@@ -1837,7 +1839,7 @@ pub const OptionCollection = c.dom_html_options_collection;
 pub const DocumentFragment = c.dom_document_fragment;
 
 pub inline fn documentFragmentToNode(doc: *DocumentFragment) *Node {
-    return @as(*Node, @ptrCast(doc));
+    return @as(*Node, @alignCast(@ptrCast(doc)));
 }
 
 pub fn documentFragmentBodyChildren(doc: *DocumentFragment) !?*NodeList {
@@ -1947,7 +1949,7 @@ pub inline fn domImplementationCreateHTMLDocument(title: ?[]const u8) !*Document
     if (title) |t| {
         const htitle = try documentCreateElement(doc, "title");
         const txt = try documentCreateTextNode(doc, t);
-        _ = try nodeAppendChild(elementToNode(htitle), @as(*Node, @ptrCast(txt)));
+        _ = try nodeAppendChild(elementToNode(htitle), @as(*Node, @alignCast(@ptrCast(txt))));
         _ = try nodeAppendChild(elementToNode(head), elementToNode(htitle));
     }
 
@@ -1965,7 +1967,7 @@ fn documentVtable(doc: *Document) c.dom_document_vtable {
 }
 
 pub inline fn documentToNode(doc: *Document) *Node {
-    return @as(*Node, @ptrCast(doc));
+    return @as(*Node, @alignCast(@ptrCast(doc)));
 }
 
 pub inline fn documentGetElementById(doc: *Document, id: []const u8) !?*Element {
@@ -2103,7 +2105,7 @@ pub inline fn documentImportNode(doc: *Document, node: *Node, deep: bool) !*Node
     const nodeext = toNodeExternal(Node, node);
     const err = documentVtable(doc).dom_document_import_node.?(doc, nodeext, deep, &res);
     try DOMErr(err);
-    return @as(*Node, @ptrCast(res));
+    return @as(*Node, @alignCast(@ptrCast(res)));
 }
 
 pub inline fn documentAdoptNode(doc: *Document, node: *Node) !*Node {
@@ -2111,7 +2113,7 @@ pub inline fn documentAdoptNode(doc: *Document, node: *Node) !*Node {
     const nodeext = toNodeExternal(Node, node);
     const err = documentVtable(doc).dom_document_adopt_node.?(doc, nodeext, &res);
     try DOMErr(err);
-    return @as(*Node, @ptrCast(res));
+    return @as(*Node, @alignCast(@ptrCast(res)));
 }
 
 pub inline fn documentCreateAttribute(doc: *Document, name: []const u8) !*Attribute {
@@ -2146,7 +2148,7 @@ pub const DocumentHTML = c.dom_html_document;
 
 // documentHTMLToNode is an helper to convert a documentHTML to an node.
 pub inline fn documentHTMLToNode(doc: *DocumentHTML) *Node {
-    return @as(*Node, @ptrCast(doc));
+    return @as(*Node, @alignCast(@ptrCast(doc)));
 }
 
 fn documentHTMLVtable(doc_html: *DocumentHTML) c.dom_html_document_vtable {
@@ -2291,7 +2293,7 @@ pub inline fn documentHTMLBody(doc_html: *DocumentHTML) !?*Body {
 }
 
 pub inline fn bodyToElement(body: *Body) *Element {
-    return @as(*Element, @ptrCast(body));
+    return @as(*Element, @alignCast(@ptrCast(body)));
 }
 
 pub inline fn documentHTMLSetBody(doc_html: *DocumentHTML, elt: ?*ElementHTML) !void {
@@ -2330,7 +2332,7 @@ pub inline fn documentHTMLSetTitle(doc: *DocumentHTML, v: []const u8) !void {
 
 pub fn documentHTMLSetCurrentScript(doc: *DocumentHTML, script: ?*Script) !void {
     var s: ?*ElementHTML = null;
-    if (script != null) s = @ptrCast(script.?);
+    if (script != null) s = @alignCast(@ptrCast(script.?));
     const err = documentHTMLVtable(doc).set_current_script.?(doc, s);
     try DOMErr(err);
 }
@@ -2759,7 +2761,7 @@ pub fn inputSetType(input: *Input, type_: []const u8) !void {
         }
     }
     const new_type = if (found) type_ else "text";
-    try elementSetAttribute(@ptrCast(input), "type", new_type);
+    try elementSetAttribute(@alignCast(@ptrCast(input)), "type", new_type);
 }
 
 pub fn inputGetValue(input: *Input) ![]const u8 {

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -633,13 +633,13 @@ pub const Page = struct {
         const transfer_arena = self.session.transfer_arena;
         var form_data = try FormData.fromForm(form, submitter, self);
 
-        const encoding = try parser.elementGetAttribute(@ptrCast(form), "enctype");
+        const encoding = try parser.elementGetAttribute(@alignCast(@ptrCast(form)), "enctype");
 
         var buf: std.ArrayListUnmanaged(u8) = .empty;
         try form_data.write(encoding, buf.writer(transfer_arena));
 
-        const method = try parser.elementGetAttribute(@ptrCast(form), "method") orelse "";
-        var action = try parser.elementGetAttribute(@ptrCast(form), "action") orelse self.url.raw;
+        const method = try parser.elementGetAttribute(@alignCast(@ptrCast(form)), "method") orelse "";
+        var action = try parser.elementGetAttribute(@alignCast(@ptrCast(form)), "action") orelse self.url.raw;
 
         var opts = NavigateOpts{
             .reason = .form,

--- a/src/browser/xhr/form_data.zig
+++ b/src/browser/xhr/form_data.zig
@@ -216,7 +216,7 @@ fn collectSelectValues(arena: Allocator, select: *parser.Select, name: []const u
     if (is_multiple == false) {
         const option = try parser.optionCollectionItem(options, @intCast(selected_index));
 
-        if (try parser.elementGetAttribute(@ptrCast(option), "disabled") != null) {
+        if (try parser.elementGetAttribute(@alignCast(@ptrCast(option)), "disabled") != null) {
             return;
         }
         const value = try parser.optionGetValue(option);
@@ -228,7 +228,7 @@ fn collectSelectValues(arena: Allocator, select: *parser.Select, name: []const u
     // we can go directly to the first one
     for (@intCast(selected_index)..len) |i| {
         const option = try parser.optionCollectionItem(options, @intCast(i));
-        if (try parser.elementGetAttribute(@ptrCast(option), "disabled") != null) {
+        if (try parser.elementGetAttribute(@alignCast(@ptrCast(option)), "disabled") != null) {
             continue;
         }
 

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -368,7 +368,7 @@ fn getNode(arena: Allocator, browser_context: anytype, node_id: ?Node.Id, backen
     if (object_id) |object_id_| {
         // Retrieve the object from which ever context it is in.
         const parser_node = try browser_context.inspector.getNodePtr(arena, object_id_);
-        return try browser_context.node_registry.register(@ptrCast(parser_node));
+        return try browser_context.node_registry.register(@alignCast(@ptrCast(parser_node)));
     }
     return error.MissingParams;
 }


### PR DESCRIPTION
Turns HtmlElement from an `opaque` type to an `extern struct`, this also bring in some others most notable `Node` and `HtmlDocument` are now also no longer opaque.

This change allows us to embed these DOM objects directly into zig structs.