### PR TITLE
Add basic support for key events

### DIFF
--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -243,17 +243,23 @@ pub const Document = struct {
         return try TreeWalker.init(root, what_to_show, filter);
     }
 
-    pub fn get_activeElement(self: *parser.Document, page: *Page) !?ElementUnion {
-        const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
-        if (state.active_element) |ae| {
-            return try Element.toInterface(ae);
+    pub fn getActiveElement(self: *parser.Document, page: *Page) !?*parser.Element {
+        if (page.getNodeState(@alignCast(@ptrCast(self)))) |state| {
+            if (state.active_element) |ae| {
+                return ae;
+            }
         }
 
         if (try parser.documentHTMLBody(page.window.document)) |body| {
-            return try Element.toInterface(@alignCast(@ptrCast(body)));
+            return @alignCast(@ptrCast(body));
         }
 
-        return get_documentElement(self);
+        return try parser.documentGetDocumentElement(self);
+    }
+
+    pub fn get_activeElement(self: *parser.Document, page: *Page) !?ElementUnion {
+        const ae = (try getActiveElement(self, page)) orelse return null;
+        return try Element.toInterface(ae);
     }
 
     // TODO: some elements can't be focused, like if they're disabled

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -2834,3 +2834,11 @@ pub fn inputSetValue(input: *Input, value: []const u8) !void {
     const err = c.dom_html_input_element_set_value(input, try strFromData(value));
     try DOMErr(err);
 }
+
+pub fn buttonGetType(button: *Button) ![]const u8 {
+    var s_: ?*String = null;
+    const err = c.dom_html_button_element_get_type(button, &s_);
+    try DOMErr(err);
+    const s = s_ orelse return "button";
+    return strToData(s);
+}

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -25,6 +25,7 @@ const c = @cImport({
     @cInclude("events/event_target.h");
     @cInclude("events/event.h");
     @cInclude("events/mouse_event.h");
+    @cInclude("events/keyboard_event.h");
     @cInclude("utils/validate.h");
     @cInclude("html/html_element.h");
     @cInclude("html/html_document.h");
@@ -862,6 +863,59 @@ pub fn mouseEventInit(evt: *MouseEvent, typ: []const u8, opts: MouseEventOpts) !
 
 pub fn mouseEventDefaultPrevented(evt: *MouseEvent) !bool {
     return eventDefaultPrevented(@ptrCast(evt));
+}
+
+// KeyboardEvent
+
+pub const KeyboardEvent = c.dom_keyboard_event;
+
+pub fn keyboardEventCreate() !*KeyboardEvent {
+    var evt: ?*KeyboardEvent = undefined;
+    const err = c._dom_keyboard_event_create(&evt);
+    try DOMErr(err);
+    return evt.?;
+}
+
+pub fn keyboardEventDestroy(evt: *KeyboardEvent) void {
+    c._dom_keyboard_event_destroy(evt);
+}
+
+const KeyboardEventOpts = struct {
+    key: []const u8,
+    code: []const u8,
+    bubbles: bool = false,
+    cancelable: bool = false,
+    ctrl: bool = false,
+    alt: bool = false,
+    shift: bool = false,
+    meta: bool = false,
+};
+
+pub fn keyboardEventInit(evt: *KeyboardEvent, typ: []const u8, opts: KeyboardEventOpts) !void {
+    const s = try strFromData(typ);
+    const err = c._dom_keyboard_event_init(
+        evt,
+        s,
+        opts.bubbles,
+        opts.cancelable,
+        null, // dom_abstract_view* ?
+        try strFromData(opts.key),
+        try strFromData(opts.code),
+        0, // location 0 == standard
+        opts.ctrl,
+        opts.shift,
+        opts.alt,
+        opts.meta,
+        false, // repease
+        false, // is_composiom
+    );
+    try DOMErr(err);
+}
+
+pub fn keyboardEventGetKey(evt: *KeyboardEvent) ![]const u8 {
+    var s: ?*String = undefined;
+    _ = c._dom_keyboard_event_get_key(evt, &s);
+    return strToData(s.?);
 }
 
 // NodeType
@@ -2391,6 +2445,11 @@ pub fn textareaGetValue(textarea: *TextArea) ![]const u8 {
     try DOMErr(err);
     const s = s_ orelse return "";
     return strToData(s);
+}
+
+pub fn textareaSetValue(textarea: *TextArea, value: []const u8) !void {
+    const err = c.dom_html_text_area_element_set_value(textarea, try strFromData(value));
+    try DOMErr(err);
 }
 
 // Select

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -582,14 +582,14 @@ pub const Page = struct {
             },
             .input => {
                 const element: *parser.Element = @ptrCast(node);
-                const input_type = (try parser.elementGetAttribute(element, "type")) orelse return;
+                const input_type = try parser.inputGetType(@ptrCast(element));
                 if (std.ascii.eqlIgnoreCase(input_type, "submit")) {
                     return self.elementSubmitForm(element);
                 }
             },
             .button => {
                 const element: *parser.Element = @ptrCast(node);
-                const button_type = (try parser.elementGetAttribute(element, "type")) orelse return;
+                const button_type = try parser.buttonGetType(@ptrCast(element));
                 if (std.ascii.eqlIgnoreCase(button_type, "submit")) {
                     return self.elementSubmitForm(element);
                 }
@@ -661,7 +661,7 @@ pub const Page = struct {
         switch (tag) {
             .input => {
                 const element: *parser.Element = @ptrCast(node);
-                const input_type = (try parser.elementGetAttribute(element, "type")) orelse "text";
+                const input_type = try parser.inputGetType(@ptrCast(element));
                 if (std.mem.eql(u8, input_type, "text")) {
                     if (std.mem.eql(u8, new_key, "Enter")) {
                         const form = (try self.formForElement(element)) orelse return;

--- a/src/browser/xhr/form_data.zig
+++ b/src/browser/xhr/form_data.zig
@@ -137,7 +137,7 @@ fn collectForm(form: *parser.Form, submitter_: ?*parser.ElementHTML, page: *Page
         const tag = try parser.elementHTMLGetTagType(@as(*parser.ElementHTML, @ptrCast(element)));
         switch (tag) {
             .input => {
-                const tpe = try parser.elementGetAttribute(element, "type") orelse "";
+                const tpe = try parser.inputGetType(@ptrCast(element));
                 if (std.ascii.eqlIgnoreCase(tpe, "image")) {
                     if (submitter_name_) |submitter_name| {
                         if (std.mem.eql(u8, submitter_name, name)) {
@@ -249,7 +249,7 @@ fn getSubmitterName(submitter_: ?*parser.ElementHTML) !?[]const u8 {
     switch (tag) {
         .button => return name,
         .input => {
-            const tpe = (try parser.elementGetAttribute(element, "type")) orelse "";
+            const tpe = try parser.inputGetType(@ptrCast(element));
             // only an image type can be a sumbitter
             if (std.ascii.eqlIgnoreCase(tpe, "image") or std.ascii.eqlIgnoreCase(tpe, "submit")) {
                 return name;

--- a/src/browser/xhr/form_data.zig
+++ b/src/browser/xhr/form_data.zig
@@ -162,7 +162,7 @@ fn collectForm(form: *parser.Form, submitter_: ?*parser.ElementHTML, page: *Page
                     }
                     submitter_included = true;
                 }
-                const value = (try parser.elementGetAttribute(element, "value")) orelse "";
+                const value = try parser.inputGetValue(@ptrCast(element));
                 try entries.appendOwned(arena, name, value);
             },
             .select => {
@@ -189,11 +189,11 @@ fn collectForm(form: *parser.Form, submitter_: ?*parser.ElementHTML, page: *Page
     }
 
     if (submitter_included == false) {
-        if (submitter_) |submitter| {
+        if (submitter_name_) |submitter_name| {
             // this can happen if the submitter is outside the form, but associated
             // with the form via a form=ID attribute
-            const value = (try parser.elementGetAttribute(@ptrCast(submitter), "value")) orelse "";
-            try entries.appendOwned(arena, submitter_name_.?, value);
+            const value = (try parser.elementGetAttribute(@ptrCast(submitter_.?), "value")) orelse "";
+            try entries.appendOwned(arena, submitter_name, value);
         }
     }
 

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -35,9 +35,9 @@ pub fn processMessage(cmd: anytype) !void {
 fn dispatchKeyEvent(cmd: anytype) !void {
     const params = (try cmd.params(struct {
         type: Type,
-        key: []const u8,
-        code: []const u8,
-        modifiers: u4,
+        key: []const u8 = "",
+        code: []const u8 = "",
+        modifiers: u4 = 0,
         // Many optional parameters are not implemented yet, see documentation url.
 
         const Type = enum {


### PR DESCRIPTION
Support CDP's Input.dispatchKeyEvent and DOM key events. Currently only keydown is supported and expects every key to be a displayable character.

It turns out that manipulating the DOM via key events isn't great because the behavior really depends on the cursor. So, to do this more accurately, we'd have to introduce some concept of a cursor.

Personally, I don't think we'll run into many pages that are purposefully using keyboard events. But driver (puppeteer/playwright) scripts might be another issue.