### PR TITLE
Internal navigation should change the CDP loader-id

### DIFF
--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -1369,9 +1369,7 @@ test "Browser.HTML.HtmlInputElement.propeties.form" {
 
     try runner.testCases(&.{
         .{ "let elem_input = document.querySelector('input')", null },
-    }, .{});
-    try runner.testCases(&.{.{ "elem_input.form", "[object HTMLFormElement]" }}, .{}); // Initial value
-    try runner.testCases(&.{
+        .{ "elem_input.form", "[object HTMLFormElement]" }, // Initial value
         .{ "elem_input.form = 'foo'", null },
         .{ "elem_input.form", "[object HTMLFormElement]" }, // Invalid
     }, .{});

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -163,6 +163,11 @@ pub fn pageNavigate(arena: Allocator, bc: anytype, event: *const Notification.Pa
     std.debug.assert(bc.session.page != null);
 
     var cdp = bc.cdp;
+
+    if (event.opts.reason != .address_bar) {
+        bc.loader_id = bc.cdp.loader_id_gen.next();
+    }
+
     const loader_id = bc.loader_id;
     const target_id = bc.target_id orelse unreachable;
     const session_id = bc.session_id orelse unreachable;


### PR DESCRIPTION
This is one of the ways that puppeteer knows that navigation happened and is needed to support `waitForNavigation` which compares the existing loader-id with the new one, so it has to change.

Also, fix a crash that could happen if CDP disconnects while connections are being aborted.