### PR TITLE
Fix non-probing of union array failure

### DIFF
--- a/src/browser/css/parser.zig
+++ b/src/browser/css/parser.zig
@@ -605,6 +605,7 @@ pub const Parser = struct {
             .after, .backdrop, .before, .cue, .first_letter => return .{ .pseudo_element = pseudo_class },
             .first_line, .grammar_error, .marker, .placeholder => return .{ .pseudo_element = pseudo_class },
             .selection, .spelling_error => return .{ .pseudo_element = pseudo_class },
+            .modal => return .{ .pseudo_element = pseudo_class },
         }
     }
 

--- a/src/browser/css/selector.zig
+++ b/src/browser/css/selector.zig
@@ -98,6 +98,7 @@ pub const PseudoClass = enum {
     placeholder,
     selection,
     spelling_error,
+    modal,
 
     pub const Error = error{
         InvalidPseudoClass,
@@ -154,6 +155,7 @@ pub const PseudoClass = enum {
         if (std.ascii.eqlIgnoreCase(s, "placeholder")) return .placeholder;
         if (std.ascii.eqlIgnoreCase(s, "selection")) return .selection;
         if (std.ascii.eqlIgnoreCase(s, "spelling-error")) return .spelling_error;
+        if (std.ascii.eqlIgnoreCase(s, "modal")) return .modal;
         return Error.InvalidPseudoClass;
     }
 };

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -1158,7 +1158,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                             }
 
                             if (!js_value.isArray()) {
-                                return error.InvalidArgument;
+                                return .{.invalid = {}};
                             }
 
                             // This can get tricky.


### PR DESCRIPTION
Probing a union match for an possible value should rarely hard-fail. Instead, it should return an .{.invalid = {}} response to let the prober decide how to proceed. This fixes a hard-fail when a JS value fails to probe as an array.

Also, add :modal pseudo-class.

(both issues came up looking at github integration)