### PR TITLE
browser context proxyServer

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -319,6 +319,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         inspector: Inspector,
         isolated_world: ?IsolatedWorld,
+        http_proxy_before: ??std.Uri = null,
 
         const Self = @This();
 
@@ -373,6 +374,8 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             self.node_registry.deinit();
             self.node_search_list.deinit();
             self.cdp.browser.notification.unregisterAll(self);
+
+            if (self.http_proxy_before) |prev_proxy| self.cdp.browser.http_client.http_proxy = prev_proxy;
         }
 
         pub fn reset(self: *Self) void {


### PR DESCRIPTION
Currently we rely on there existing only 1 browser context. We just need to make sure that we set it back after the session ends

Additional:
Should we rename `--http-proxy` to `--proxy-server` to align with chromium?