### PR TITLE
Fix crash when event.currentTarget is used with EventTargetTBase

### DIFF
--- a/src/browser/dom/event_target.zig
+++ b/src/browser/dom/event_target.zig
@@ -39,7 +39,7 @@ pub const EventTarget = struct {
         // Ideally, we'd remove this duality. Failing that, we'll need to embed
         // data into the *parser.EventTarget should we need this for other types.
         // For now, for the Window, which is a singleton, we can do this:
-        if (@intFromPtr(et) == @intFromPtr(&page.window.base.target)) {
+        if (@intFromPtr(et) == @intFromPtr(&page.window.base)) {
             return .{ .Window = &page.window };
         }
         return Nod.Node.toInterface(@as(*parser.Node, @ptrCast(et)));

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -775,7 +775,6 @@ pub const EventTargetTBase = extern struct {
         .add_event_listener = add_event_listener,
         .iter_event_listener = iter_event_listener,
     },
-    eti: c.dom_event_target_internal = c.dom_event_target_internal{ .listeners = null },
 
     // When we dispatch the event, we need to provide a target. In reality, the
     // target is the container of this EventTargetTBase. But we can't pass that
@@ -785,12 +784,9 @@ pub const EventTargetTBase = extern struct {
     // as the target, what happens if libdom calls dom_node_ref(window)? If
     // you're lucky, you'll crash. If you're unlucky, you'll increment a random
     // part of the window structure.
-    target: DummyTarget = .{},
+    refcnt: u32 = 0,
 
-    const DummyTarget = extern struct {
-        vtable: usize = undefined,
-        refcnt: u32 = 0,
-    };
+    eti: c.dom_event_target_internal = c.dom_event_target_internal{ .listeners = null },
 
     pub fn add_event_listener(et: [*c]c.dom_event_target, t: [*c]c.dom_string, l: ?*c.struct_dom_event_listener, capture: bool) callconv(.C) c.dom_exception {
         const self = @as(*Self, @ptrCast(et));
@@ -800,11 +796,11 @@ pub const EventTargetTBase = extern struct {
     pub fn dispatch_event(et: [*c]c.dom_event_target, evt: ?*c.struct_dom_event, res: [*c]bool) callconv(.C) c.dom_exception {
         const self = @as(*Self, @ptrCast(et));
         // Set the event target to the target dispatched.
-        const e = c._dom_event_set_target(evt, @ptrCast(&self.target));
+        const e = c._dom_event_set_target(evt, et);
         if (e != c.DOM_NO_ERR) {
             return e;
         }
-        return c._dom_event_target_dispatch(@ptrCast(&self.target), &self.eti, evt, c.DOM_AT_TARGET, res);
+        return c._dom_event_target_dispatch(et, &self.eti, evt, c.DOM_AT_TARGET, res);
     }
 
     pub fn remove_event_listener(et: [*c]c.dom_event_target, t: [*c]c.dom_string, l: ?*c.struct_dom_event_listener, capture: bool) callconv(.C) c.dom_exception {


### PR DESCRIPTION
When EventTargetTBase is used, we pass the container as the target to libdom. This is not safe, as libdom is expecting an event_target. We see, for example that when _dom_event_get_current_target is called, the refcnt is increased. This works if the current_target is a valid event_target, but if it's a Zig instance (like the Window) ... we're just altering some bits of the window instance.

This attempts to add a dummy target to EventTargetTBase which can acts as a real event_targt in place of the Zig instance.