### PR TITLE
Don't allow timeouts to be registered when shutting down

### DIFF
--- a/src/runtime/loop.zig
+++ b/src/runtime/loop.zig
@@ -187,6 +187,12 @@ pub const Loop = struct {
     }
 
     pub fn timeout(self: *Self, nanoseconds: u63, callback_node: ?*CallbackNode) !usize {
+        if (self.stopping) {
+            // Prevents a timeout callback from creating a new timeout, which
+            // would make `loop.run` run forever.
+            return 0;
+        }
+
         const completion = try self.alloc.create(Completion);
         errdefer self.alloc.destroy(completion);
         completion.* = undefined;


### PR DESCRIPTION
Currently, a timeout that sets a timeout can cause loop.run to block forever.

Also, cleanup URL stitch with leading './'. The resulting URL was valid, but since we use the URL as the module cache key, it's important to resolve various representations of the same URL in the same way.