### PR TITLE
add PerformanceEntry and PerformanceMark

### DIFF
--- a/src/browser/dom/dom.zig
+++ b/src/browser/dom/dom.zig
@@ -28,7 +28,6 @@ const IntersectionObserver = @import("intersection_observer.zig");
 const DOMParser = @import("dom_parser.zig").DOMParser;
 const TreeWalker = @import("tree_walker.zig").TreeWalker;
 const NodeFilter = @import("node_filter.zig").NodeFilter;
-const Performance = @import("performance.zig").Performance;
 const PerformanceObserver = @import("performance_observer.zig").PerformanceObserver;
 
 pub const Interfaces = .{
@@ -46,6 +45,6 @@ pub const Interfaces = .{
     DOMParser,
     TreeWalker,
     NodeFilter,
-    Performance,
+    @import("performance.zig").Interfaces,
     PerformanceObserver,
 };

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -2201,7 +2201,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
 
             const T = @TypeOf(value);
             switch (@typeInfo(T)) {
-                .void, .bool, .int, .comptime_int, .float, .comptime_float => {
+                .void, .bool, .int, .comptime_int, .float, .comptime_float, .@"enum" => {
                     // Need to do this to keep the compiler happy
                     // simpleZigValueToJs handles all of these cases.
                     unreachable;
@@ -3084,6 +3084,12 @@ fn simpleZigValueToJs(isolate: v8.Isolate, value: anytype, comptime fail: bool) 
             }
         },
         .@"union" => return simpleZigValueToJs(isolate, std.meta.activeTag(value), fail),
+        .@"enum" => {
+            const T = @TypeOf(value);
+            if (@hasDecl(T, "toString")) {
+                return simpleZigValueToJs(isolate, value.toString(), fail);
+            }
+        },
         else => {},
     }
     if (fail) {


### PR DESCRIPTION
This adds the `PerformanceEntry` and `PerformanceMark` interfaces. This also adds the ability to return enums as long as they have a `toString()` in `js.zig`.