### PR TITLE
add CSS utility interface

### DIFF
--- a/src/browser/css/css.zig
+++ b/src/browser/css/css.zig
@@ -23,6 +23,18 @@ const std = @import("std");
 const Selector = @import("selector.zig").Selector;
 const parser = @import("parser.zig");
 
+pub const Interfaces = .{
+    Css,
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/CSS
+pub const Css = struct {
+    pub fn _supports(_: *Css, _: []const u8, _: ?[]const u8) bool {
+        // TODO: Actually respond with which CSS features we support.
+        return true;
+    }
+};
+
 // parse parse a selector string and returns the parsed result or an error.
 pub fn parse(alloc: std.mem.Allocator, s: []const u8, opts: parser.ParseOptions) parser.ParseError!Selector {
     var p = parser.Parser{ .s = s, .i = 0, .opts = opts };
@@ -173,4 +185,15 @@ test "parse" {
         };
         defer s.deinit(alloc);
     }
+}
+
+const testing = @import("../../testing.zig");
+test "Browser.HTML.CSS" {
+    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
+    defer runner.deinit();
+
+    try runner.testCases(&.{
+        .{ "CSS.supports('display: flex')", "true" },
+        .{ "CSS.supports('text-decoration-style', 'blink')", "true" },
+    }, .{});
 }

--- a/src/browser/env.zig
+++ b/src/browser/env.zig
@@ -22,6 +22,7 @@ const WebApis = struct {
     pub const Interfaces = generate.Tuple(.{
         @import("crypto/crypto.zig").Crypto,
         @import("console/console.zig").Console,
+        @import("css/css.zig").Interfaces,
         @import("cssom/cssom.zig").Interfaces,
         @import("dom/dom.zig").Interfaces,
         @import("encoding/text_encoder.zig").Interfaces,

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -35,6 +35,7 @@ const Performance = @import("../dom/performance.zig").Performance;
 const CSSStyleDeclaration = @import("../cssom/css_style_declaration.zig").CSSStyleDeclaration;
 const CustomElementRegistry = @import("../webcomponents/custom_element_registry.zig").CustomElementRegistry;
 const Screen = @import("screen.zig").Screen;
+const Css = @import("../css/css.zig").Css;
 
 const storage = @import("../storage/storage.zig");
 
@@ -62,6 +63,7 @@ pub const Window = struct {
     performance: Performance,
     custom_elements: CustomElementRegistry = .{},
     screen: Screen = .{},
+    css: Css = .{},
 
     pub fn create(target: ?[]const u8, navigator: ?Navigator) !Window {
         var fbs = std.io.fixedBufferStream("");
@@ -173,6 +175,10 @@ pub const Window = struct {
 
     pub fn get_screen(self: *Window) *Screen {
         return &self.screen;
+    }
+
+    pub fn get_CSS(self: *Window) *Css {
+        return &self.css;
     }
 
     pub fn _requestAnimationFrame(self: *Window, cbk: Function, page: *Page) !u32 {


### PR DESCRIPTION
This adds in a super minimal `CSS` utility interface. It also modifies the `js.zig` and allows for utility interfaces (Interfaces that contain static elements but can't be constructed) to work.