### PR TITLE
basic/bearer proxy authentication

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -31,6 +31,7 @@ pub const App = struct {
         tls_verify_host: bool = true,
         http_proxy: ?std.Uri = null,
         proxy_type: ?http.ProxyType = null,
+        proxy_auth: ?http.ProxyAuth = null,
     };
 
     pub fn init(allocator: Allocator, config: Config) !*App {
@@ -58,6 +59,7 @@ pub const App = struct {
                 .max_concurrent = 3,
                 .http_proxy = config.http_proxy,
                 .proxy_type = config.proxy_type,
+                .proxy_auth = config.proxy_auth,
                 .tls_verify_host = config.tls_verify_host,
             }),
             .config = config,

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -66,7 +66,10 @@ pub fn expectEqual(expected: anytype, actual: anytype) !void {
             if (@typeInfo(@TypeOf(expected)) == .null) {
                 return std.testing.expectEqual(null, actual);
             }
-            return expectEqual(expected, actual.?);
+            if (actual) |_actual| {
+                return expectEqual(expected, _actual);
+            }
+            return std.testing.expectEqual(expected, null);
         },
         .@"union" => |union_info| {
             if (union_info.tag_type == null) {


### PR DESCRIPTION
- `--proxy_bearer_token token`
               The token to send for bearer authentication with the proxy
               `Proxy-Authorization: Bearer <token>`

- `--proxy_basic_auth user:password`
               The user:password to send for basic authentication with the proxy
              `Proxy-Authorization: Basic <base64(user:password)>`