### PR TITLE
We cannot have empty Zig structs mapping to JS instances

### DIFF
--- a/src/browser/crypto/crypto.zig
+++ b/src/browser/crypto/crypto.zig
@@ -21,6 +21,8 @@ const uuidv4 = @import("../../id.zig").uuidv4;
 
 // https://w3c.github.io/webcrypto/#crypto-interface
 pub const Crypto = struct {
+    _not_empty: bool = true,
+
     pub fn _getRandomValues(_: *const Crypto, into: RandomValues) !RandomValues {
         const buf = into.asBuffer();
         if (buf.len > 65_536) {

--- a/src/browser/css/css.zig
+++ b/src/browser/css/css.zig
@@ -29,6 +29,8 @@ pub const Interfaces = .{
 
 // https://developer.mozilla.org/en-US/docs/Web/API/CSS
 pub const Css = struct {
+    _not_empty: bool = true,
+
     pub fn _supports(_: *Css, _: []const u8, _: ?[]const u8) bool {
         // TODO: Actually respond with which CSS features we support.
         return true;


### PR DESCRIPTION
An empty struct will share the same address as its sibling (1) which will cause an collision in the identity map.

(1) - This depends on Zig's non-guaranteed layout, so the collision might not be with its sibling, but rather some other [seemingly random] field.