### PR TITLE
Crypto.getRandomValues consistency

### DIFF
--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -1601,6 +1601,11 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                 const str = try self.js_obj.getConstructorName();
                 return jsStringToZig(allocator, str, self.js_context.isolate);
             }
+
+            pub fn toZig(self: JsObject, comptime Struct: type, comptime name: []const u8, comptime T: type) !T {
+                const named_function = comptime NamedFunction.init(Struct, name);
+                return self.js_context.jsValueToZig(named_function, T, self.js_obj.toValue());
+            }
         };
 
         // This only exists so that we know whether a function wants the opaque


### PR DESCRIPTION
Crypto.getRandomValues should mutate the given parameter as well as return the value. This return value must be the same (JsObject) as the input parameter.

There might be more magical ways to solve this, but I opted for both the simplest and most flexible: adding a `toZig` function to JsObject which does what js.zig does internally when mapping js values to Zig (and, of course, it uses the same code).

This allows a caller to receive a JsObject (not too common, but we already do that in a few places) and return that same JsObject (again, not too common, but we do have support for returning JsObject directly already). With the main addition that the JsObjet can now be turned into a Zig type by the caller.