### PR TITLE
Allow root modules to imported modules

### DIFF
--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -728,7 +728,9 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                 if (try m.instantiate(v8_context, resolveModuleCallback) == false) {
                     return error.ModuleInstantiationError;
                 }
-
+                const arena = self.context_arena;
+                const owned_url = try arena.dupe(u8, url);
+                try self.module_identifier.putNoClobber(arena, m.getIdentityHash(), owned_url);
                 _ = try m.evaluate(v8_context);
             }
 


### PR DESCRIPTION
Root modules (non-cacheable) should register their module_id -> URL so that, if they load a nested module, we can get the full URL of the nested module.