### PR TITLE
Upgrade tlz.zig to latest version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0xda130f3af836cea0,
     .dependencies = .{
         .tls = .{
-            .url = "https://github.com/ianic/tls.zig/archive/b29a8b45fc59fc2d202769c4f54509bb9e17d0a2.tar.gz",
-            .hash = "tls-0.1.0-ER2e0uAxBQDm_TmSDdbiiyvAZoh4ejlDD4hW8Fl813xE",
+            .url = "https://github.com/ianic/tls.zig/archive/8250aa9184fbad99983b32411bbe1a5d2fd6f4b7.tar.gz",
+            .hash = "tls-0.1.0-ER2e0pU3BQB-UD2_s90uvppceH_h4KZxtHCrCct8L054",
         },
         .tigerbeetle_io = .{
             .url = "https://github.com/lightpanda-io/tigerbeetle-io/archive/61d9652f1a957b7f4db723ea6aa0ce9635e840ce.tar.gz",

--- a/src/browser/mime.zig
+++ b/src/browser/mime.zig
@@ -218,7 +218,9 @@ pub const Mime = struct {
 
     fn parseAttributeValue(arena: Allocator, value: []const u8) ![]const u8 {
         if (value[0] != '"') {
-            return value;
+            // almost certainly referenced from an http.Request which has its
+            // own lifetime.
+            return arena.dupe(u8, value);
         }
 
         // 1 to skip the opening quote


### PR DESCRIPTION
Was seeing pretty frequent TLS errors on reddit. I think I had the wrong max TLS record size, but figured this was an opportunity to upgrade tls.zig, which has seen quite a few changes since our last upgrade.

Specifically, the nonblocking TLS logic has been split into two structs: one for handshaking, and then another to be used to encrypt/decrypt after the h andshake is complete. The biggest impact here is with respect to keepalive, since what we want to keepalive is the connection post-handshake, but we don't have this object until much later.

There was also some general API changes, with respect to state and partially encrypted/decrypted data which we must now maintain.