### PR TITLE
Abort controller

### DIFF
--- a/src/browser/console/console.zig
+++ b/src/browser/console/console.zig
@@ -30,39 +30,39 @@ pub const Console = struct {
     timers: std.StringHashMapUnmanaged(u32) = .{},
     counts: std.StringHashMapUnmanaged(u32) = .{},
 
-    pub fn static_lp(values: []JsObject, page: *Page) !void {
+    pub fn _lp(values: []JsObject, page: *Page) !void {
         if (values.len == 0) {
             return;
         }
         log.fatal(.console, "lightpanda", .{ .args = try serializeValues(values, page) });
     }
 
-    pub fn static_log(values: []JsObject, page: *Page) !void {
+    pub fn _log(values: []JsObject, page: *Page) !void {
         if (values.len == 0) {
             return;
         }
         log.info(.console, "info", .{ .args = try serializeValues(values, page) });
     }
 
-    pub fn static_info(values: []JsObject, page: *Page) !void {
-        return static_log(values, page);
+    pub fn _info(values: []JsObject, page: *Page) !void {
+        return _log(values, page);
     }
 
-    pub fn static_debug(values: []JsObject, page: *Page) !void {
+    pub fn _debug(values: []JsObject, page: *Page) !void {
         if (values.len == 0) {
             return;
         }
         log.debug(.console, "debug", .{ .args = try serializeValues(values, page) });
     }
 
-    pub fn static_warn(values: []JsObject, page: *Page) !void {
+    pub fn _warn(values: []JsObject, page: *Page) !void {
         if (values.len == 0) {
             return;
         }
         log.warn(.console, "warn", .{ .args = try serializeValues(values, page) });
     }
 
-    pub fn static_error(values: []JsObject, page: *Page) !void {
+    pub fn _error(values: []JsObject, page: *Page) !void {
         if (values.len == 0) {
             return;
         }
@@ -73,7 +73,7 @@ pub const Console = struct {
         });
     }
 
-    pub fn static_clear() void {}
+    pub fn _clear() void {}
 
     pub fn _count(self: *Console, label_: ?[]const u8, page: *Page) !void {
         const label = label_ orelse "default";
@@ -134,7 +134,7 @@ pub const Console = struct {
         log.warn(.console, "timer stop", .{ .label = label, .elapsed = elapsed - kv.value });
     }
 
-    pub fn static_assert(assertion: JsObject, values: []JsObject, page: *Page) !void {
+    pub fn _assert(assertion: JsObject, values: []JsObject, page: *Page) !void {
         if (assertion.isTruthy()) {
             return;
         }

--- a/src/browser/events/event.zig
+++ b/src/browser/events/event.zig
@@ -54,7 +54,7 @@ pub const Event = struct {
 
     pub fn toInterface(evt: *parser.Event) !Union {
         return switch (try parser.eventGetInternalType(evt)) {
-            .event => .{ .Event = evt },
+            .event, .abort_signal => .{ .Event = evt },
             .custom_event => .{ .CustomEvent = @as(*CustomEvent, @ptrCast(evt)).* },
             .progress_event => .{ .ProgressEvent = @as(*ProgressEvent, @ptrCast(evt)).* },
             .mouse_event => .{ .MouseEvent = @as(*parser.MouseEvent, @ptrCast(evt)) },
@@ -77,13 +77,13 @@ pub const Event = struct {
     pub fn get_target(self: *parser.Event, page: *Page) !?EventTargetUnion {
         const et = try parser.eventTarget(self);
         if (et == null) return null;
-        return try EventTarget.toInterface(et.?, page);
+        return try EventTarget.toInterface(self, et.?, page);
     }
 
     pub fn get_currentTarget(self: *parser.Event, page: *Page) !?EventTargetUnion {
         const et = try parser.eventCurrentTarget(self);
         if (et == null) return null;
-        return try EventTarget.toInterface(et.?, page);
+        return try EventTarget.toInterface(self, et.?, page);
     }
 
     pub fn get_eventPhase(self: *parser.Event) !u8 {

--- a/src/browser/html/AbortController.zig
+++ b/src/browser/html/AbortController.zig
@@ -17,71 +17,130 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const log = @import("../../log.zig");
 const parser = @import("../netsurf.zig");
+const Env = @import("../env.zig").Env;
+const Page = @import("../page.zig").Page;
+const Loop = @import("../../runtime/loop.zig").Loop;
 const EventTarget = @import("../dom/event_target.zig").EventTarget;
 
 pub const Interfaces = .{
     AbortController,
-    Signal,
+    AbortSignal,
 };
 
 const AbortController = @This();
 
-signal: ?Signal = null,
+signal: *AbortSignal,
 
-pub fn constructor() AbortController {
-    return .{};
+pub fn constructor(page: *Page) !AbortController {
+    // Why do we allocate this rather than storing directly in the struct?
+    // https://github.com/lightpanda-io/project/discussions/165
+    const signal = try page.arena.create(AbortSignal);
+    signal.* = .init;
+
+    return .{
+        .signal = signal,
+    };
 }
 
-pub fn get_signal(self: *AbortController) *Signal {
-    if (self.signal) |*s| {
-        return s;
-    }
-    self.signal = .init;
-    return &self.signal.?;
+pub fn get_signal(self: *AbortController) *AbortSignal {
+    return self.signal;
 }
 
-pub fn abort(self: *AbortController, reason_: ?[]const u8) void {
-    const signal = &self.signal;
-
-    signal.aborted = true;
-    signal.reason = reason_ orelse "AbortError";
-
-    const abort_event = try parser.eventCreate();
-    defer parser.eventDestroy(abort_event);
-    try parser.eventInit(abort_event, "abort", .{});
-    _ = try parser.eventTargetDispatchEvent(
-        parser.toEventTarget(Signal, signal),
-        abort_event,
-    );
+pub fn _abort(self: *AbortController, reason_: ?[]const u8) !void {
+    return self.signal.abort(reason_);
 }
 
-pub const Signal = struct {
+pub const AbortSignal = struct {
+    const DEFAULT_REASON = "AbortError";
+
     pub const prototype = *EventTarget;
+    proto: parser.EventTargetTBase = .{},
 
     aborted: bool,
     reason: ?[]const u8,
-    proto: parser.EventTargetTBase,
 
-    pub const init: Signal = .{
+    pub const init: AbortSignal = .{
         .proto = .{},
         .reason = null,
         .aborted = false,
     };
 
-    pub fn get_aborted(self: *const Signal) bool {
+    pub fn static_abort(reason_: ?[]const u8) AbortSignal {
+        return .{
+            .aborted = true,
+            .reason = reason_ orelse DEFAULT_REASON,
+        };
+    }
+
+    pub fn static_timeout(delay: u32, page: *Page) !*AbortSignal {
+        const callback = try page.arena.create(TimeoutCallback);
+        callback.* = .{
+            .signal = .init,
+            .node = .{ .func = TimeoutCallback.run },
+        };
+
+        const delay_ms: u63 = @as(u63, delay) * std.time.ns_per_ms;
+        _ = try page.loop.timeout(delay_ms, &callback.node);
+        return &callback.signal;
+    }
+
+    pub fn get_aborted(self: *const AbortSignal) bool {
         return self.aborted;
+    }
+
+    fn abort(self: *AbortSignal, reason_: ?[]const u8) !void {
+        self.aborted = true;
+        self.reason = reason_ orelse DEFAULT_REASON;
+
+        const abort_event = try parser.eventCreate();
+        try parser.eventSetInternalType(abort_event, .abort_signal);
+
+        defer parser.eventDestroy(abort_event);
+        try parser.eventInit(abort_event, "abort", .{});
+        _ = try parser.eventTargetDispatchEvent(
+            parser.toEventTarget(AbortSignal, self),
+            abort_event,
+        );
     }
 
     const Reason = union(enum) {
         reason: []const u8,
         undefined: void,
     };
-    pub fn get_reason(self: *const Signal) Reason {
+    pub fn get_reason(self: *const AbortSignal) Reason {
         if (self.reason) |r| {
             return .{ .reason = r };
         }
         return .{ .undefined = {} };
+    }
+
+    const ThrowIfAborted = union(enum) {
+        exception: Env.Exception,
+        undefined: void,
+    };
+    pub fn _throwIfAborted(self: *const AbortSignal, page: *Page) ThrowIfAborted {
+        if (self.aborted) {
+            const ex = page.main_context.throw(self.reason orelse DEFAULT_REASON);
+            return .{ .exception = ex };
+        }
+        return .{ .undefined = {} };
+    }
+};
+
+const TimeoutCallback = struct {
+    signal: AbortSignal,
+
+    // This is the internal data that the event loop tracks. We'll get this
+    // back in run and, from it, can get our TimeoutCallback instance
+    node: Loop.CallbackNode = undefined,
+
+    fn run(node: *Loop.CallbackNode, _: *?u63) void {
+        const self: *TimeoutCallback = @fieldParentPtr("node", node);
+        self.signal.abort("TimeoutError") catch |err| {
+            log.warn(.app, "abort signal timeout", .{ .err = err });
+        };
     }
 };
 
@@ -91,22 +150,39 @@ test "Browser.HTML.AbortController" {
     defer runner.deinit();
 
     try runner.testCases(&.{
-        .{ "var called = false", null },
+        .{ "var called = 0", null },
         .{ "var a1 = new AbortController()", null },
         .{ "var s1 = a1.signal", null },
+        .{ "s1.throwIfAborted()", "undefined" },
         .{ "s1.reason", "undefined" },
         .{ "var target;", null },
         .{
             \\ s1.addEventListener('abort', (e) => {
-            \\   called = 1;
+            \\   called += 1;
             \\   target = e.target;
             \\
             \\ });
-            \\ target == s1
-            , "true" },
+            ,
+            null,
+        },
         .{ "a1.abort()", null },
         .{ "s1.aborted", "true" },
-        .{ "s1.reason", "undefined" },
+        .{ "target == s1", "true" },
+        .{ "s1.reason", "AbortError" },
         .{ "called", "1" },
+    }, .{});
+
+    try runner.testCases(&.{
+        .{ "var s2 = AbortSignal.abort('over 9000')", null },
+        .{ "s2.aborted", "true" },
+        .{ "s2.reason", "over 9000" },
+        .{ "AbortSignal.abort().reason", "AbortError" },
+    }, .{});
+
+    try runner.testCases(&.{
+        .{ "var s3 = AbortSignal.timeout(10)", null },
+        .{ "s3.aborted", "true" },
+        .{ "s3.reason", "TimeoutError" },
+        .{ "try { s3.throwIfAborted() } catch (e) { e }", "Error: TimeoutError" },
     }, .{});
 }

--- a/src/browser/html/AbortController.zig
+++ b/src/browser/html/AbortController.zig
@@ -1,0 +1,112 @@
+// Copyright (C) 2023-2024  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const parser = @import("../netsurf.zig");
+const EventTarget = @import("../dom/event_target.zig").EventTarget;
+
+pub const Interfaces = .{
+    AbortController,
+    Signal,
+};
+
+const AbortController = @This();
+
+signal: ?Signal = null,
+
+pub fn constructor() AbortController {
+    return .{};
+}
+
+pub fn get_signal(self: *AbortController) *Signal {
+    if (self.signal) |*s| {
+        return s;
+    }
+    self.signal = .init;
+    return &self.signal.?;
+}
+
+pub fn abort(self: *AbortController, reason_: ?[]const u8) void {
+    const signal = &self.signal;
+
+    signal.aborted = true;
+    signal.reason = reason_ orelse "AbortError";
+
+    const abort_event = try parser.eventCreate();
+    defer parser.eventDestroy(abort_event);
+    try parser.eventInit(abort_event, "abort", .{});
+    _ = try parser.eventTargetDispatchEvent(
+        parser.toEventTarget(Signal, signal),
+        abort_event,
+    );
+}
+
+pub const Signal = struct {
+    pub const prototype = *EventTarget;
+
+    aborted: bool,
+    reason: ?[]const u8,
+    proto: parser.EventTargetTBase,
+
+    pub const init: Signal = .{
+        .proto = .{},
+        .reason = null,
+        .aborted = false,
+    };
+
+    pub fn get_aborted(self: *const Signal) bool {
+        return self.aborted;
+    }
+
+    const Reason = union(enum) {
+        reason: []const u8,
+        undefined: void,
+    };
+    pub fn get_reason(self: *const Signal) Reason {
+        if (self.reason) |r| {
+            return .{ .reason = r };
+        }
+        return .{ .undefined = {} };
+    }
+};
+
+const testing = @import("../../testing.zig");
+test "Browser.HTML.AbortController" {
+    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
+    defer runner.deinit();
+
+    try runner.testCases(&.{
+        .{ "var called = false", null },
+        .{ "var a1 = new AbortController()", null },
+        .{ "var s1 = a1.signal", null },
+        .{ "s1.reason", "undefined" },
+        .{ "var target;", null },
+        .{
+            \\ s1.addEventListener('abort', (e) => {
+            \\   called = 1;
+            \\   target = e.target;
+            \\
+            \\ });
+            \\ target == s1
+            , "true" },
+        .{ "a1.abort()", null },
+        .{ "s1.aborted", "true" },
+        .{ "s1.reason", "undefined" },
+        .{ "called", "1" },
+    }, .{});
+}

--- a/src/browser/html/html.zig
+++ b/src/browser/html/html.zig
@@ -39,4 +39,5 @@ pub const Interfaces = .{
     @import("DataSet.zig"),
     @import("screen.zig").Interfaces,
     @import("error_event.zig").ErrorEvent,
+    @import("AbortController.zig").Interfaces,
 };

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -526,6 +526,7 @@ pub const EventType = enum(u8) {
     custom_event = 2,
     mouse_event = 3,
     error_event = 4,
+    abort_signal = 5,
 };
 
 pub const MutationEvent = c.dom_mutation_event;


### PR DESCRIPTION
Missing the [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) API.

This API is superficially simple, but required a number of deeper changes.

1 - The poor support for namespace/static functions introduced in https://github.com/lightpanda-io/browser/pull/749 has been improved. Static functions, like `AbortSignal.timeout`, are now correctly supported. 

I still think the `console` behavior is weird, but it's now implemented as a receiver-less method (which is now supported for all methods). Possibly still not correct, but at least it's simpler and and better aligned with how we structure our code.

2 - Like the `Window` before, this introduces an EventTarget which is not a libdom node, an AbortSignal. Unlike `Window`, this isn't a singleton and can't be easily detected. I corrupted the internal event type to serve as a discriminator to the event target. If this doesn't work for future cases, we'll have to come up with a more general solution, like attaching some internal_type_id to the event_target.

3 - Ran into a variation of the empty-struct identity map issue (see: https://github.com/lightpanda-io/browser/pull/812). This time I tried to solve this properly, but it turns out that making the identity map type-aware isn't without its challenges and drawback. Instead, I solved this specific by forcing unique addresses between conflicted objects. As punishment for my failure, I documented the issue: https://github.com/lightpanda-io/project/discussions/165

4 - I believe this is the first case where we've had to raise an arbitrary exception from Zig code (with a user-defined message). My solution exposes the underlying JS context (aka scope), which I don't like, but I don't expect this to be a common requirement, so if we need to change things around, it shouldn't be a problem.