### PR TITLE
Fix non-tls forward-proxy

### DIFF
--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -711,12 +711,7 @@ pub const Request = struct {
                     }
                 }
             }
-
-
-            if (
-                (self._request_secure and !self._proxy_secure) and
-                (!self._client.isForwardProxy() or self._proxy_secure)
-            ) {
+            if (self._request_secure and !self._proxy_secure and !self._client.isForwardProxy()) {
                 self._connection.?.tls = .{
                     .blocking = try tls.client(std.net.Stream{ .handle = socket }, tls_config),
                 };


### PR DESCRIPTION
Also renamed `isSimpleProxy` -> `isForwardProxy` for consistent with the proxy type name.