### PR TITLE
Rework MutationObserver callback.

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -122,10 +122,10 @@ pub const Page = struct {
         // load polyfills
         try polyfill.load(self.arena, self.main_context);
 
-        _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
         // message loop must run only non-test env
         if (comptime !builtin.is_test) {
-            _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.messageloop_node);
+            _ = try session.browser.app.loop.timeout(1 * std.time.ns_per_ms, &self.microtask_node);
+            _ = try session.browser.app.loop.timeout(100 * std.time.ns_per_ms, &self.messageloop_node);
         }
     }
 


### PR DESCRIPTION
Previously, MutationObserver callbacks where called using the `jsCallScopeEnd` mechanism. This was slow and resulted in records split in a way that callers might not expect. `jsCallScopeEnd` has been removed.

The new approach uses the loop.timeout mechanism, much like a window.setTimeout and only registers a timeout when events have been handled. It should perform much better.

Exactly how MutationRecords are supposed to be grouped is still a mystery to me. This new grouping is still wrong in many cases (according to WPT), but appears slightly less wrong; I'm pretty hopeful clients don't really have hard-coded expectations for this though.

Also implement the attributeFilter option of MutationObserver. (Github)