### PR TITLE
Improve prototype resolution for native types

### DIFF
--- a/src/browser/dom/performance.zig
+++ b/src/browser/dom/performance.zig
@@ -162,7 +162,7 @@ test "Performance: get_timeOrigin" {
     try testing.expect(time_origin >= 0);
 
     // Check resolution
-    try testing.expectDelta(@rem(time_origin * std.time.us_per_ms, 100.0), 0.0, 0.1);
+    try testing.expectDelta(@rem(time_origin * std.time.us_per_ms, 100.0), 0.0, 0.2);
 }
 
 test "Performance: now" {


### PR DESCRIPTION
Prototype resolution of Zig types previously had 2 limitations (bug?). The first was that the Zig prototype chain could only be 1 deep. You couldn't do A->B->C where each of those was a Zig type (but you could do A->B->C->D->E ... so long as every other type was a C opaque value).

The other limitation was that Zig prototypes only worked when the nested field was directly embedded in the struct (i.e. not a pointer). So you could do:

```zig
const X = struct {
   proto: XParent,
};
```

But not:

```zig
const X = struct {
   proto: *XParent,
};
```

This addresses both limitations. The first issue is solved by keeping track of the cumulative offset