### PR TITLE
Setting innerHTML now captures head elements

### DIFF
--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -1925,18 +1925,6 @@ pub inline fn documentFragmentToNode(doc: *DocumentFragment) *Node {
     return @as(*Node, @alignCast(@ptrCast(doc)));
 }
 
-pub fn documentFragmentBodyChildren(doc: *DocumentFragment) !?*NodeList {
-    const node = documentFragmentToNode(doc);
-    const html = try nodeFirstChild(node) orelse return null;
-    // TODO unref
-    const head = try nodeFirstChild(html) orelse return null;
-    // TODO unref
-    const body = try nodeNextSibling(head) orelse return null;
-    // TODO unref
-
-    return try nodeGetChildNodes(body);
-}
-
 // Document Position
 
 pub const DocumentPosition = enum(u32) {


### PR DESCRIPTION
I couldn't find where the behavior is described. AND, browsers seem to behave differently depending on the state of the page (blank document vs actual page).

Still, some sites use innerHTML to load <script> tags, and, in libdom at least, these are created in the implicit head. We cannot just copy the body nodes. To keep it simple, I now copy all head and body elements.