### PR TITLE
Fix document.domain

### DIFF
--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -42,8 +42,12 @@ pub const HTMLDocument = struct {
     // JS funcs
     // --------
 
-    pub fn get_domain(self: *parser.DocumentHTML) ![]const u8 {
-        return try parser.documentHTMLGetDomain(self);
+    pub fn get_domain(self: *parser.DocumentHTML, page: *Page) ![]const u8 {
+        // libdom's document_html get_domain always returns null, this is
+        // the way MDN recommends getting the domain anyways, since document.domain
+        // is deprecated.
+        const location = try parser.documentHTMLGetLocation(Location, self) orelse return "";
+        return location.get_host(page);
     }
 
     pub fn set_domain(_: *parser.DocumentHTML, _: []const u8) ![]const u8 {
@@ -307,7 +311,7 @@ test "Browser.HTML.Document" {
     }, .{});
 
     try runner.testCases(&.{
-        .{ "document.domain", "" },
+        .{ "document.domain", "lightpanda.io" },
         .{ "document.referrer", "" },
         .{ "document.title", "" },
         .{ "document.body.localName", "body" },

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -2369,14 +2369,6 @@ pub inline fn documentHTMLSetBody(doc_html: *DocumentHTML, elt: ?*ElementHTML) !
     try DOMErr(err);
 }
 
-pub inline fn documentHTMLGetDomain(doc: *DocumentHTML) ![]const u8 {
-    var s: ?*String = undefined;
-    const err = documentHTMLVtable(doc).get_domain.?(doc, &s);
-    try DOMErr(err);
-    if (s == null) return "";
-    return strToData(s.?);
-}
-
 pub inline fn documentHTMLGetReferrer(doc: *DocumentHTML) ![]const u8 {
     var s: ?*String = undefined;
     const err = documentHTMLVtable(doc).get_referrer.?(doc, &s);


### PR DESCRIPTION
Currently seems to always return null. Doesn't seem to be a way in libdom to change this. The property is deprecated, and MDN recommends using location.host instead, so change document.get_domain to wrap location.host.