### PR TITLE
Visible Psuedoclass

### DIFF
--- a/src/browser/css/parser.zig
+++ b/src/browser/css/parser.zig
@@ -582,6 +582,7 @@ pub const Parser = struct {
             .only_of_type => return .{ .pseudo_class_only_child = true },
             .input, .empty, .root, .link => return .{ .pseudo_class = pseudo_class },
             .enabled, .disabled, .checked => return .{ .pseudo_class = pseudo_class },
+            .visible => return .{ .pseudo_class = pseudo_class },
             .lang => {
                 if (!p.consumeParenthesis()) return ParseError.ExpectedParenthesis;
                 if (p.i == p.s.len) return ParseError.UnmatchParenthesis;

--- a/src/browser/css/selector.zig
+++ b/src/browser/css/selector.zig
@@ -100,6 +100,7 @@ pub const PseudoClass = enum {
     spelling_error,
     modal,
     popover_open,
+    visible,
 
     pub const Error = error{
         InvalidPseudoClass,
@@ -157,6 +158,7 @@ pub const PseudoClass = enum {
                 asUint(u56, "enabled") => return .enabled,
                 asUint(u56, "matches") => return .matches,
                 asUint(u56, "visited") => return .visited,
+                asUint(u56, "visible") => return .visible,
                 else => {},
             },
             8 => switch (@as(u64, @bitCast(selector[0..8].*))) {
@@ -567,6 +569,8 @@ pub const Selector = union(enum) {
                     // TODO implement using the url fragment.
                     // see https://developer.mozilla.org/en-US/docs/Web/CSS/:target
                     .target => return false,
+                    // visible always returns true.
+                    .visible => return true,
 
                     // all others pseudo class are handled by specialized
                     // pseudo_class_X selectors.


### PR DESCRIPTION
This adds very basic support for the visible CSS pseudoclass. It just assumes that everything on the page is visible.