### PR TITLE
Add a --noscript option to "improve" --dump

### DIFF
--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -110,13 +110,13 @@ pub const Element = struct {
 
     pub fn get_innerHTML(self: *parser.Element, page: *Page) ![]const u8 {
         var buf = std.ArrayList(u8).init(page.arena);
-        try dump.writeChildren(parser.elementToNode(self), buf.writer());
+        try dump.writeChildren(parser.elementToNode(self), .{}, buf.writer());
         return buf.items;
     }
 
     pub fn get_outerHTML(self: *parser.Element, page: *Page) ![]const u8 {
         var buf = std.ArrayList(u8).init(page.arena);
-        try dump.writeNode(parser.elementToNode(self), buf.writer());
+        try dump.writeNode(parser.elementToNode(self), .{}, buf.writer());
         return buf.items;
     }
 

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -247,6 +247,6 @@ fn testWriteFullHTML(comptime expected: []const u8, src: []const u8) !void {
     defer parser.documentHTMLClose(doc_html) catch {};
 
     const doc = parser.documentHTMLToDocument(doc_html);
-    try writeHTML(doc, buf.writer(testing.allocator));
+    try writeHTML(doc, .{}, buf.writer(testing.allocator));
     try testing.expectEqualStrings(expected, buf.items);
 }

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -142,7 +142,7 @@ pub const Page = struct {
     }
 
     // dump writes the page content into the given file.
-    pub fn dump(self: *const Page, out: std.fs.File) !void {
+    pub fn dump(self: *const Page, opts: Dump.Opts, out: std.fs.File) !void {
         if (self.raw_data) |raw_data| {
             // raw_data was set if the document was not HTML, dump the data content only.
             return try out.writeAll(raw_data);
@@ -150,7 +150,7 @@ pub const Page = struct {
 
         // if the page has a pointer to a document, dumps the HTML.
         const doc = parser.documentHTMLToDocument(self.window.document);
-        try Dump.writeHTML(doc, out);
+        try Dump.writeHTML(doc, opts, out);
     }
 
     pub fn fetchModuleSource(ctx: *anyopaque, src: []const u8) !?[]const u8 {

--- a/src/browser/xmlserializer/xmlserializer.zig
+++ b/src/browser/xmlserializer/xmlserializer.zig
@@ -36,9 +36,9 @@ pub const XMLSerializer = struct {
     pub fn _serializeToString(_: *const XMLSerializer, root: *parser.Node, page: *Page) ![]const u8 {
         var buf = std.ArrayList(u8).init(page.arena);
         switch (try parser.nodeType(root)) {
-            .document => try dump.writeHTML(@as(*parser.Document, @ptrCast(root)), buf.writer()),
+            .document => try dump.writeHTML(@as(*parser.Document, @ptrCast(root)), .{}, buf.writer()),
             .document_type => try dump.writeDocType(@as(*parser.DocumentType, @ptrCast(root)), buf.writer()),
-            else => try dump.writeNode(root, buf.writer()),
+            else => try dump.writeNode(root, .{}, buf.writer()),
         }
         return buf.items;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,7 +134,7 @@ fn run(alloc: Allocator) !void {
 
             // dump
             if (opts.dump) {
-                try page.dump(std.io.getStdOut());
+                try page.dump(.{ .exclude_scripts = opts.noscript }, std.io.getStdOut());
             }
         },
         else => unreachable,
@@ -212,6 +212,7 @@ const Command = struct {
         url: []const u8,
         dump: bool = false,
         common: Common,
+        noscript: bool = false,
     };
 
     const Common = struct {
@@ -275,6 +276,7 @@ const Command = struct {
             \\Options:
             \\--dump          Dumps document to stdout.
             \\                Defaults to false.
+            \\--noscript      Exclude <script> tags in dump. Defaults to false.
             \\
         ++ common_options ++
             \\
@@ -350,6 +352,9 @@ fn inferMode(opt: []const u8) ?App.RunMode {
     }
 
     if (std.mem.eql(u8, opt, "--dump")) {
+        return .fetch;
+    }
+    if (std.mem.eql(u8, opt, "--noscript")) {
         return .fetch;
     }
     if (std.mem.startsWith(u8, opt, "--") == false) {
@@ -437,12 +442,18 @@ fn parseFetchArgs(
     args: *std.process.ArgIterator,
 ) !Command.Fetch {
     var dump: bool = false;
+    var noscript: bool = true;
     var url: ?[]const u8 = null;
     var common: Command.Common = .{};
 
     while (args.next()) |opt| {
         if (std.mem.eql(u8, "--dump", opt)) {
             dump = true;
+            continue;
+        }
+
+        if (std.mem.eql(u8, "--noscript", opt)) {
+            noscript = true;
             continue;
         }
 
@@ -471,6 +482,7 @@ fn parseFetchArgs(
         .url = url.?,
         .dump = dump,
         .common = common,
+        .noscript = noscript,
     };
 }
 


### PR DESCRIPTION
Currently, fetch --dump includes <script> tag (either inline or with src). I don't know what use-case this is the desired behavior. Excluding them, via the new --noscript option has benefit that if you --dump --noscript and open the resulting page in the browser, you don't re-execute JavaScript, which is likely to break the page.

For example, opening a --dump of github makes it look like the page is broken because it re-executes JavaScript that isn't meant to be re-executed.

Similarly, opening a --dump in a browser might execute JavaScript that lightpanda browser failed to execute, making it looks like it worked better than it did.