### PR TITLE
Trigger the DOMContentLoaded on the Window

### DIFF
--- a/src/browser/html/document.zig
+++ b/src/browser/html/document.zig
@@ -278,15 +278,17 @@ pub const HTMLDocument = struct {
         const state = try page.getOrCreateNodeState(@alignCast(@ptrCast(self)));
         state.ready_state = .interactive;
 
-        const evt = try parser.eventCreate();
-        defer parser.eventDestroy(evt);
-
         log.debug(.script_event, "dispatch event", .{
             .type = "DOMContentLoaded",
             .source = "document",
         });
+
+        const evt = try parser.eventCreate();
+        defer parser.eventDestroy(evt);
         try parser.eventInit(evt, "DOMContentLoaded", .{ .bubbles = true, .cancelable = true });
         _ = try parser.eventTargetDispatchEvent(parser.toEventTarget(parser.DocumentHTML, self), evt);
+
+        try page.window.dispatchForDocumentTarget(evt);
     }
 
     pub fn documentIsComplete(self: *parser.DocumentHTML, page: *Page) !void {

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -846,6 +846,14 @@ pub const EventTargetTBase = extern struct {
         internal_type_.* = @intFromEnum(self.internal_target_type);
         return c.DOM_NO_ERR;
     }
+
+    // Called to simulate bubbling from a libdom node (e.g. the Document) to a
+    // Zig instance (e.g. the Window).
+    pub fn redispatchEvent(self: *EventTargetTBase, evt: *Event) !void {
+        var res: bool = undefined;
+        const err = c._dom_event_target_dispatch(@ptrCast(self), &self.eti, evt, c.DOM_BUBBLING_PHASE, &res);
+        try DOMErr(err);
+    }
 };
 
 // MouseEvent

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -474,6 +474,12 @@ pub const JsRunner = struct {
             return err;
         };
     }
+
+    pub fn dispatchDOMContentLoaded(self: *JsRunner) !void {
+        const HTMLDocument = @import("browser/html/document.zig").HTMLDocument;
+        const html_doc = self.page.window.document;
+        try HTMLDocument.documentIsLoaded(html_doc, self.page);
+    }
 };
 
 const RunnerOpts = struct {


### PR DESCRIPTION
This is hacky, but it's inspired by how NetSurf does it. While the Window isn't the parent of the Document, many events should bubble from the Document to the Window. libdom simply doesn't handle this (it has no concept of a Window, and the Document has no parent).

We potentially need to do this for multiple event types (NetSurf only does it for the 'load' event as far as I can tell). It would be nice to find a generic way to do this...maybe intercept any addEventListener on the body and registering special events on the Window? For now, `DOMContentLoaded` is the blocking (for finance.yahoo.com) and we can see if this is really an issue for other event types.