### PR TITLE
lit compatibility

### DIFF
--- a/src/browser/State.zig
+++ b/src/browser/State.zig
@@ -31,6 +31,7 @@ const parser = @import("netsurf.zig");
 const DataSet = @import("html/DataSet.zig");
 const ShadowRoot = @import("dom/shadow_root.zig").ShadowRoot;
 const StyleSheet = @import("cssom/StyleSheet.zig");
+const CSSStyleSheet = @import("cssom/CSSStyleSheet.zig");
 const CSSStyleDeclaration = @import("cssom/CSSStyleDeclaration.zig");
 
 // for HTMLScript (but probably needs to be added to more)
@@ -53,6 +54,7 @@ style_sheet: ?*StyleSheet = null,
 
 // for dom/document
 active_element: ?*parser.Element = null,
+adopted_style_sheets: ?Env.JsObject = null,
 
 // for HTMLSelectElement
 // By default, if no option is explicitly selected, the first option should

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -1454,6 +1454,12 @@ test "Browser.HTML.HTMLTemplateElement" {
         .{ "document.getElementById('abc')", "null" },
         .{ "document.getElementById('c').appendChild(t.content.cloneNode(true))", null },
         .{ "document.getElementById('abc').id", "abc" },
+        .{ "t.innerHTML = '<span>over</span><p>9000!</p>';", null },
+        .{ "t.content.childNodes.length", "2" },
+        .{ "t.content.childNodes[0].tagName", "SPAN" },
+        .{ "t.content.childNodes[0].innerHTML", "over" },
+        .{ "t.content.childNodes[1].tagName", "P" },
+        .{ "t.content.childNodes[1].innerHTML", "9000!" },
     }, .{});
 }
 

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -142,8 +142,10 @@ pub const Page = struct {
     }
 
     pub const DumpOpts = struct {
-        exclude_scripts: bool = false,
+        // set to include element shadowroots in the dump
+        page: ?*const Page = null,
         with_base: bool = false,
+        exclude_scripts: bool = false,
     };
 
     // dump writes the page content into the given file.
@@ -162,6 +164,7 @@ pub const Page = struct {
         }
 
         try Dump.writeHTML(doc, .{
+            .page = opts.page,
             .exclude_scripts = opts.exclude_scripts,
         }, out);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -135,8 +135,9 @@ fn run(alloc: Allocator) !void {
             // dump
             if (opts.dump) {
                 try page.dump(.{
-                    .exclude_scripts = opts.noscript,
+                    .page = page,
                     .with_base = opts.withbase,
+                    .exclude_scripts = opts.noscript,
                 }, std.io.getStdOut());
             }
         },

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -799,6 +799,14 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
                 return promise;
             }
 
+            pub fn newArray(self: *JsContext, len: u32) JsObject {
+                const arr = v8.Array.init(self.isolate, len);
+                return .{
+                    .js_context = self,
+                    .js_obj = arr.castTo(v8.Object),
+                };
+            }
+
             // Wrap a v8.Exception
             fn createException(self: *const JsContext, e: v8.Value) Exception {
                 return .{


### PR DESCRIPTION
Aims to improve compatibility for the lit framework (e.g. what Reddit is using).

1 - Adds support for adoptedStyleSheets to the Document and ShadowRoot 
2 - Adds mock support for replace and replaceSync to the CSSStyleSheet 
3 - Optionally include shadowroot in dump
4 - Special-case setting innerHTML on a TemplateElement