### PR TITLE
request interception

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -57,7 +57,6 @@ deferreds: OrderList,
 
 shutdown: bool = false,
 
-
 client: *HttpClient,
 allocator: Allocator,
 buffer_pool: BufferPool,
@@ -234,6 +233,7 @@ pub fn addFromElement(self: *ScriptManager, element: *parser.Element) !void {
         .url = remote_url.?,
         .ctx = pending_script,
         .method = .GET,
+        .headers = try HttpClient.Headers.init(),
         .cookie = page.requestCookie(.{}),
         .start_callback = if (log.enabled(.http, .debug)) startCallback else null,
         .header_done_callback = headerCallback,
@@ -297,6 +297,7 @@ pub fn blockingGet(self: *ScriptManager, url: [:0]const u8) !BlockingResult {
     try client.blockingRequest(.{
         .url = url,
         .method = .GET,
+        .headers = try HttpClient.Headers.init(),
         .ctx = &blocking,
         .cookie = self.page.requestCookie(.{}),
         .start_callback = if (log.enabled(.http, .debug)) Blocking.startCallback else null,

--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -52,6 +52,8 @@ pub const Browser = struct {
         errdefer env.deinit();
 
         const notification = try Notification.init(allocator, app.notification);
+        app.http.client.notification = notification;
+        app.http.client.next_request_id = 0; // Should we track ids in CDP only?
         errdefer notification.deinit();
 
         return .{
@@ -74,6 +76,7 @@ pub const Browser = struct {
         self.page_arena.deinit();
         self.session_arena.deinit();
         self.transfer_arena.deinit();
+        self.http_client.notification = null;
         self.notification.deinit();
         self.state_pool.deinit();
     }

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -467,12 +467,15 @@ pub const Page = struct {
         const owned_url = try self.arena.dupeZ(u8, request_url);
         self.url = try URL.parse(owned_url, null);
 
+        var headers = try HttpClient.Headers.init();
+        if (opts.header) |hdr| try headers.add(hdr);
+
         self.http_client.request(.{
             .ctx = self,
             .url = owned_url,
             .method = opts.method,
+            .headers = headers,
             .body = opts.body,
-            .header = opts.header,
             .cookie = self.requestCookie(.{ .is_navigation = true }),
             .header_done_callback = pageHeaderDoneCallback,
             .data_callback = pageDataCallback,

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -469,6 +469,7 @@ pub const Page = struct {
 
         var headers = try HttpClient.Headers.init();
         if (opts.header) |hdr| try headers.add(hdr);
+        try self.requestCookie(.{ .is_navigation = true }).headersForRequest(self.arena, owned_url, &headers);
 
         self.http_client.request(.{
             .ctx = self,
@@ -476,7 +477,7 @@ pub const Page = struct {
             .method = opts.method,
             .headers = headers,
             .body = opts.body,
-            .cookie = self.requestCookie(.{ .is_navigation = true }),
+            .cookie_jar = self.cookie_jar,
             .header_done_callback = pageHeaderDoneCallback,
             .data_callback = pageDataCallback,
             .done_callback = pageDoneCallback,

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -370,10 +370,16 @@ pub const XMLHttpRequest = struct {
             }
         }
 
+        var headers = try HttpClient.Headers.init();
+        for (self.headers.items) |hdr| {
+            try headers.add(hdr);
+        }
+
         try page.http_client.request(.{
             .ctx = self,
             .url = self.url.?,
             .method = self.method,
+            .headers = headers,
             .body = self.request_body,
             .cookie = page.requestCookie(.{}),
             .start_callback = httpStartCallback,
@@ -387,11 +393,6 @@ pub const XMLHttpRequest = struct {
 
     fn httpStartCallback(transfer: *HttpClient.Transfer) !void {
         const self: *XMLHttpRequest = @alignCast(@ptrCast(transfer.ctx));
-
-        for (self.headers.items) |hdr| {
-            try transfer.addHeader(hdr);
-        }
-
         log.debug(.http, "request start", .{ .method = self.method, .url = self.url, .source = "xhr" });
         self.transfer = transfer;
     }

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -374,6 +374,7 @@ pub const XMLHttpRequest = struct {
         for (self.headers.items) |hdr| {
             try headers.add(hdr);
         }
+        try page.requestCookie(.{}).headersForRequest(self.arena, self.url.?, &headers);
 
         try page.http_client.request(.{
             .ctx = self,
@@ -381,7 +382,7 @@ pub const XMLHttpRequest = struct {
             .method = self.method,
             .headers = headers,
             .body = self.request_body,
-            .cookie = page.requestCookie(.{}),
+            .cookie_jar = page.cookie_jar,
             .start_callback = httpStartCallback,
             .header_callback = httpHeaderCallback,
             .header_done_callback = httpHeaderDoneCallback,

--- a/src/cdp/domains/fetch.zig
+++ b/src/cdp/domains/fetch.zig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024  Lightpanda (Selecy SAS)
+// Copyright (C) 2023-2025    Lightpanda (Selecy SAS)
 //
 // Francis Bouvier <francis@lightpanda.io>
 // Pierre Tachoire <pierre@lightpanda.io>
@@ -17,13 +17,211 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Notification = @import("../../notification.zig").Notification;
+const log = @import("../../log.zig");
+const Request = @import("../../http/Client.zig").Request;
+const Method = @import("../../http/Client.zig").Method;
 
 pub fn processMessage(cmd: anytype) !void {
     const action = std.meta.stringToEnum(enum {
         disable,
+        enable,
+        continueRequest,
+        failRequest,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
-        .disable => return cmd.sendResult(null, .{}),
+        .disable => return disable(cmd),
+        .enable => return enable(cmd),
+        .continueRequest => return continueRequest(cmd),
+        .failRequest => return failRequest(cmd),
     }
+}
+
+// Stored in CDP
+pub const InterceptState = struct {
+    const Self = @This();
+    waiting: std.AutoArrayHashMap(u64, Request),
+
+    pub fn init(allocator: Allocator) !InterceptState {
+        return .{
+            .waiting = std.AutoArrayHashMap(u64, Request).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.waiting.deinit();
+    }
+};
+
+const RequestPattern = struct {
+    urlPattern: []const u8 = "*", // Wildcards ('*' -> zero or more, '?' -> exactly one) are allowed. Escape character is backslash. Omitting is equivalent to "*".
+    resourceType: ?ResourceType = null,
+    requestStage: RequestStage = .Request,
+};
+const ResourceType = enum {
+    Document,
+    Stylesheet,
+    Image,
+    Media,
+    Font,
+    Script,
+    TextTrack,
+    XHR,
+    Fetch,
+    Prefetch,
+    EventSource,
+    WebSocket,
+    Manifest,
+    SignedExchange,
+    Ping,
+    CSPViolationReport,
+    Preflight,
+    FedCM,
+    Other,
+};
+const RequestStage = enum {
+    Request,
+    Response,
+};
+
+const EnableParam = struct {
+    patterns: []RequestPattern = &.{},
+    handleAuthRequests: bool = false,
+};
+const ErrorReason = enum {
+    Failed,
+    Aborted,
+    TimedOut,
+    AccessDenied,
+    ConnectionClosed,
+    ConnectionReset,
+    ConnectionRefused,
+    ConnectionAborted,
+    ConnectionFailed,
+    NameNotResolved,
+    InternetDisconnected,
+    AddressUnreachable,
+    BlockedByClient,
+    BlockedByResponse,
+};
+
+fn disable(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.fetchDisable();
+    return cmd.sendResult(null, .{});
+}
+
+fn enable(cmd: anytype) !void {
+    const params = (try cmd.params(EnableParam)) orelse EnableParam{};
+    if (params.patterns.len != 0) log.warn(.cdp, "Fetch.enable No patterns yet", .{});
+    if (params.handleAuthRequests) log.warn(.cdp, "Fetch.enable No auth yet", .{});
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    try bc.fetchEnable();
+
+    return cmd.sendResult(null, .{});
+}
+
+pub fn requestPaused(arena: Allocator, bc: anytype, intercept: *const Notification.RequestIntercept) !void {
+    var cdp = bc.cdp;
+
+    // unreachable because we _have_ to have a page.
+    const session_id = bc.session_id orelse unreachable;
+    const target_id = bc.target_id orelse unreachable;
+
+    // We keep it around to wait for modifications to the request.
+    // NOTE: we assume whomever created the request created it with a lifetime of the Page.
+    // TODO: What to do when receiving replies for a previous page's requests?
+
+    try cdp.intercept_state.waiting.put(intercept.request.id.?, intercept.request.*);
+
+    // NOTE: .request data preparation is duped from network.zig
+    const full_request_url = try std.Uri.parse(intercept.request.url);
+    const request_url = try @import("network.zig").urlToString(arena, &full_request_url, .{
+        .scheme = true,
+        .authentication = true,
+        .authority = true,
+        .path = true,
+        .query = true,
+    });
+    const request_fragment = try @import("network.zig").urlToString(arena, &full_request_url, .{
+        .fragment = true,
+    });
+    const headers = try intercept.request.headers.asHashMap(arena);
+    // End of duped code
+
+    try cdp.sendEvent("Fetch.requestPaused", .{
+        .requestId = try std.fmt.allocPrint(arena, "INTERCEPT-{d}", .{intercept.request.id.?}),
+        .request = .{
+            .url = request_url,
+            .urlFragment = request_fragment,
+            .method = @tagName(intercept.request.method),
+            .hasPostData = intercept.request.body != null,
+            .headers = std.json.ArrayHashMap([]const u8){ .map = headers },
+        },
+        .frameId = target_id,
+        .resourceType = ResourceType.Document, //  TODO!
+        .networkId = try std.fmt.allocPrint(arena, "REQ-{d}", .{intercept.request.id.?}),
+    }, .{ .session_id = session_id });
+
+    // Await either continueRequest, failRequest or fulfillRequest
+    intercept.wait_for_interception.* = true;
+}
+
+const HeaderEntry = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+fn continueRequest(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const params = (try cmd.params(struct {
+        requestId: []const u8, // "INTERCEPT-{d}"
+        url: ?[]const u8 = null,
+        method: ?[]const u8 = null,
+        postData: ?[]const u8 = null,
+        headers: ?[]const HeaderEntry = null,
+        interceptResponse: bool = false,
+    })) orelse return error.InvalidParams;
+    if (params.postData != null or params.headers != null or params.interceptResponse) return error.NotYetImplementedParams;
+
+    const request_id = try idFromRequestId(params.requestId);
+    var waiting_request = (bc.cdp.intercept_state.waiting.fetchSwapRemove(request_id) orelse return error.RequestNotFound).value;
+
+    // Update the request with the new parameters
+    if (params.url) |url| {
+        // The request url must be modified in a way that's not observable by page. So page.url is not updated.
+        waiting_request.url = try bc.cdp.browser.page_arena.allocator().dupeZ(u8, url);
+    }
+    if (params.method) |method| {
+        waiting_request.method = std.meta.stringToEnum(Method, method) orelse return error.InvalidParams;
+    }
+
+    log.info(.cdp, "Request continued by intercept", .{ .id = params.requestId });
+    try bc.cdp.browser.http_client.request(waiting_request);
+
+    return cmd.sendResult(null, .{});
+}
+
+fn failRequest(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    var state = &bc.cdp.intercept_state;
+    const params = (try cmd.params(struct {
+        requestId: []const u8, // "INTERCEPT-{d}"
+        errorReason: ErrorReason,
+    })) orelse return error.InvalidParams;
+
+    const request_id = try idFromRequestId(params.requestId);
+    if (state.waiting.fetchSwapRemove(request_id) == null) return error.RequestNotFound;
+
+    log.info(.cdp, "Request aborted by intercept", .{ .reason = params.errorReason });
+    return cmd.sendResult(null, .{});
+}
+
+// Get u64 from requestId which is formatted as: "INTERCEPT-{d}"
+fn idFromRequestId(request_id: []const u8) !u64 {
+    if (!std.mem.startsWith(u8, request_id, "INTERCEPT-")) return error.InvalidParams;
+    return std.fmt.parseInt(u64, request_id[10..], 10) catch return error.InvalidParams;
 }

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -203,7 +203,7 @@ fn putAssumeCapacity(headers: *std.ArrayListUnmanaged(std.http.Header), extra: s
     return true;
 }
 
-pub fn httpRequestFail(arena: Allocator, bc: anytype, request: *const Notification.RequestFail) !void {
+pub fn httpRequestFail(arena: Allocator, bc: anytype, data: *const Notification.RequestFail) !void {
     // It's possible that the request failed because we aborted when the client
     // sent Target.closeTarget. In that case, bc.session_id will be cleared
     // already, and we can skip sending these messages to the client.
@@ -215,10 +215,10 @@ pub fn httpRequestFail(arena: Allocator, bc: anytype, request: *const Notificati
 
     // We're missing a bunch of fields, but, for now, this seems like enough
     try bc.cdp.sendEvent("Network.loadingFailed", .{
-        .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{request.id}),
+        .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{data.request.id.?}),
         // Seems to be what chrome answers with. I assume it depends on the type of error?
         .type = "Ping",
-        .errorText = request.err,
+        .errorText = data.err,
         .canceled = false,
     }, .{ .session_id = session_id });
 }

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -20,6 +20,8 @@ const std = @import("std");
 const log = @import("../log.zig");
 const builtin = @import("builtin");
 const Http = @import("Http.zig");
+pub const Headers = Http.Headers;
+const Notification = @import("../notification.zig").Notification;
 
 const c = Http.c;
 
@@ -57,6 +59,9 @@ multi: *c.CURLM,
 // of easys.
 handles: Handles,
 
+// Use to generate the next request ID
+next_request_id: u64 = 0,
+
 // When handles has no more available easys, requests get queued.
 queue: RequestQueue,
 
@@ -73,6 +78,9 @@ transfer_pool: std.heap.MemoryPool(Transfer),
 
 // see ScriptManager.blockingGet
 blocking: Handle,
+
+// To notify registered subscribers of events, the browser sets/nulls this for us.
+notification: ?*Notification = null,
 
 // The only place this is meant to be used is in `makeRequest` BEFORE `perform`
 // is called. It is used to generate our Cookie header. It can be used for other
@@ -184,12 +192,26 @@ pub fn tick(self: *Client, timeout_ms: usize) !void {
 }
 
 pub fn request(self: *Client, req: Request) !void {
+    var req_copy = req; // We need it mutable
+
+    if (req_copy.id == null) { // If the ID has already been set that means the request was previously intercepted
+        req_copy.id = self.next_request_id;
+        self.next_request_id += 1;
+        if (self.notification) |notification| {
+            notification.dispatch(.http_request_start, &.{ .request = &req_copy });
+
+            var wait_for_interception = false;
+            notification.dispatch(.http_request_intercept, &.{ .request = &req_copy, .wait_for_interception = &wait_for_interception });
+            if (wait_for_interception) return; // The user is send an invitation to intercept this request.
+        }
+    }
+
     if (self.handles.getFreeHandle()) |handle| {
-        return self.makeRequest(handle, req);
+        return self.makeRequest(handle, req_copy);
     }
 
     const node = try self.queue_node_pool.create();
-    node.data = req;
+    node.data = req_copy;
     self.queue.append(node);
 }
 
@@ -239,7 +261,8 @@ fn makeRequest(self: *Client, handle: *Handle, req: Request) !void {
         return;
     };
 
-    const header_list = blk: {
+    var header_list = req.headers;
+    {
         errdefer self.handles.release(handle);
         try conn.setMethod(req.method);
         try conn.setURL(req.url);
@@ -248,31 +271,23 @@ fn makeRequest(self: *Client, handle: *Handle, req: Request) !void {
             try conn.setBody(b);
         }
 
-        var header_list = conn.commonHeaders();
-        errdefer c.curl_slist_free_all(header_list);
+        // { // TODO move up to `fn request()`
+        //     const aa = self.arena.allocator();
+        //     var arr: std.ArrayListUnmanaged(u8) = .{};
+        //     try req.cookie.forRequest(&uri, arr.writer(aa));
 
-        if (req.header) |hdr| {
-            header_list = c.curl_slist_append(header_list, hdr);
-        }
+        //     if (arr.items.len > 0) {
+        //         try arr.append(aa, 0); //null terminate
 
-        {
-            const aa = self.arena.allocator();
-            var arr: std.ArrayListUnmanaged(u8) = .{};
-            try req.cookie.forRequest(&uri, arr.writer(aa));
+        //         // copies the value
+        //         header_list = c.curl_slist_append(header_list, @ptrCast(arr.items.ptr));
+        //         defer _ = self.arena.reset(.{ .retain_with_limit = 2048 });
+        //     }
+        // }
 
-            if (arr.items.len > 0) {
-                try arr.append(aa, 0); //null terminate
-
-                // copies the value
-                header_list = c.curl_slist_append(header_list, @ptrCast(arr.items.ptr));
-                defer _ = self.arena.reset(.{ .retain_with_limit = 2048 });
-            }
-        }
-
-        try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_HTTPHEADER, header_list));
-
-        break :blk header_list;
-    };
+        try conn.secretHeaders(&header_list); // Add headers that must be hidden from intercepts
+        try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_HTTPHEADER, header_list.headers));
+    }
 
     {
         errdefer self.handles.release(handle);
@@ -284,7 +299,7 @@ fn makeRequest(self: *Client, handle: *Handle, req: Request) !void {
             .req = req,
             .ctx = req.ctx,
             .handle = handle,
-            ._request_header_list = header_list,
+            ._request_header_list = header_list.headers,
         };
         errdefer self.transfer_pool.destroy(transfer);
 
@@ -471,10 +486,11 @@ pub const RequestCookie = struct {
 };
 
 pub const Request = struct {
+    id: ?u64 = null,
     method: Method,
     url: [:0]const u8,
+    headers: Headers,
     body: ?[]const u8 = null,
-    header: ?[:0]const u8 = null,
     cookie: RequestCookie,
 
     // arbitrary data that can be associated with this request

--- a/src/http/Http.zig
+++ b/src/http/Http.zig
@@ -224,6 +224,7 @@ pub const Headers = struct {
     }
 
     pub fn add(self: *Headers, header: [*c]const u8) !void {
+        // Copies the value
         const updated_headers = c.curl_slist_append(self.headers, header);
         if (updated_headers == null) return error.OutOfMemory;
         self.headers = updated_headers;

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -103,9 +103,8 @@ pub const Notification = struct {
     };
 
     pub const RequestFail = struct {
-        id: usize,
-        url: *const std.Uri,
-        err: []const u8,
+        request: *Request,
+        err: anyerror,
     };
 
     pub const RequestComplete = struct {

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -4,6 +4,7 @@ const log = @import("log.zig");
 const URL = @import("url.zig").URL;
 const page = @import("browser/page.zig");
 const Http = @import("http/Http.zig");
+const Request = @import("http/Client.zig").Request;
 
 const Allocator = std.mem.Allocator;
 
@@ -61,6 +62,7 @@ pub const Notification = struct {
         page_navigated: List = .{},
         http_request_fail: List = .{},
         http_request_start: List = .{},
+        http_request_intercept: List = .{},
         http_request_complete: List = .{},
         notification_created: List = .{},
     };
@@ -72,6 +74,7 @@ pub const Notification = struct {
         page_navigated: *const PageNavigated,
         http_request_fail: *const RequestFail,
         http_request_start: *const RequestStart,
+        http_request_intercept: *const RequestIntercept,
         http_request_complete: *const RequestComplete,
         notification_created: *Notification,
     };
@@ -91,11 +94,12 @@ pub const Notification = struct {
     };
 
     pub const RequestStart = struct {
-        arena: Allocator,
-        id: usize,
-        url: *const std.Uri,
-        method: Http.Method,
-        has_body: bool,
+        request: *Request,
+    };
+
+    pub const RequestIntercept = struct {
+        request: *Request,
+        wait_for_interception: *bool,
     };
 
     pub const RequestFail = struct {


### PR DESCRIPTION
Depends on: https://github.com/lightpanda-io/browser/pull/922
Also reenables: `http_request_start`

TODO:
- [ ] Enable: patterns
- [ ] continueWithAuth also Enable.handleAuthRequests
- [ ] fulfillRequest
- [ ] InterceptResponse, also in continueRequest
- [ ] continueRequest.postData
- [ ] continueRequest.headers
- [ ] Common headers and start_callback before intercept
- [ ] Confirm string lifetime of waiting Requests

Example playwright fragment:
```js

const page = await context.newPage();

await page.route('**/*', (route, request) => {
  console.log(`Request ROUTE: ${request.method()} ${request.url()}`);
  route.continue({url: "http://lightpanda.io/", method: "GET"});// or route.abort();
});

await page.goto('/campfire-commerce/');
```