### PR TITLE
handle cookies on redirection manually

### DIFF
--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -85,12 +85,6 @@ blocking: Handle,
 // To notify registered subscribers of events, the browser sets/nulls this for us.
 notification: ?*Notification = null,
 
-// The only place this is meant to be used is in `makeRequest` BEFORE `perform`
-// is called. It is used to generate our Cookie header. It can be used for other
-// purposes, but keep in mind that, while single-threaded, calls like makeRequest
-// can result in makeRequest being re-called (from a doneCallback).
-arena: ArenaAllocator,
-
 // only needed for CDP which can change the proxy and then restore it. When
 // restoring, this originally-configured value is what it goes to.
 http_proxy: ?[:0]const u8 = null,
@@ -128,7 +122,6 @@ pub fn init(allocator: Allocator, ca_blob: ?c.curl_blob, opts: Http.Opts) !*Clie
         .http_proxy = opts.http_proxy,
         .transfer_pool = transfer_pool,
         .queue_node_pool = queue_node_pool,
-        .arena = ArenaAllocator.init(allocator),
     };
 
     return client;
@@ -143,7 +136,6 @@ pub fn deinit(self: *Client) void {
 
     self.transfer_pool.deinit();
     self.queue_node_pool.deinit();
-    self.arena.deinit();
     self.allocator.destroy(self);
 }
 

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -24,7 +24,7 @@ pub const Headers = Http.Headers;
 const Notification = @import("../notification.zig").Notification;
 const storage = @import("../browser/storage/storage.zig");
 
-const urlStitch = @import("../url.zig").URL.stitch;
+const urlStitch = @import("../url.zig").stitch;
 
 const c = Http.c;
 
@@ -598,7 +598,7 @@ pub const Transfer = struct {
     // redirectionCookies manages cookies during redirections handled by Curl.
     // It sets the cookies from the current response to the cookie jar.
     // It also immediately sets cookies for the following request.
-    fn redirectionCookies(arena: std.mem.Allocator, easy: *c.CURL, cookie_jar: *storage.CookieJar, origin: *const std.Uri) !void {
+    fn redirectionCookies(arena: Allocator, easy: *c.CURL, cookie_jar: *storage.CookieJar, origin: *const std.Uri) !void {
         // retrieve cookies from the redirect's response.
         var i: usize = 0;
         while (true) {

--- a/src/http/Http.zig
+++ b/src/http/Http.zig
@@ -110,9 +110,6 @@ pub const Connection = struct {
         try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_FOLLOWLOCATION, @as(c_long, 2)));
         try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_REDIR_PROTOCOLS_STR, "HTTP,HTTPS")); // remove FTP and FTPS from the default
 
-        // enable cookie engine for redirections handled directly by Curl.
-        try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_COOKIEFILE, ""));
-
         // proxy
         if (opts.http_proxy) |proxy| {
             try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_PROXY, proxy.ptr));
@@ -205,8 +202,6 @@ pub const Connection = struct {
         try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_HTTPHEADER, header_list.headers));
 
         // Add cookies.
-        // Clear cookies from Curl's engine.
-        try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_COOKIELIST, "ALL"));
         if (header_list.cookies) |cookies| {
             try errorCheck(c.curl_easy_setopt(easy, c.CURLOPT_COOKIE, cookies));
         }


### PR DESCRIPTION
This PR fixes the cookies handling on redirection.

The original problem was:

> It seems to work correctly except one case: if you set manually a cookie (A=A) and the server sets one with the same name (A=B) and it redirects, then the redirect request will send the cookie twice with the 2 values (eg. Cookie: A=A; A=B).

This PR de-activate the Curl's cookie engine.
We now set cookies manually in redirection to ensure only once `Cookie:` is set.

relates with #940 