### PR TITLE
Makes build.zig Zig 0.15 ready

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,7 +101,7 @@ pub fn build(b: *Build) !void {
     {
         // wpt
         // -----
-        const wpt_module = b.addModule("lightpanda", .{
+        const wpt_module = b.createModule(.{
             .root_source_file = b.path("src/main_wpt.zig"),
             .target = target,
             .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "tigerbeetle_io-0.0.0-ViLgxjqSBADhuHO_RZm4yNzuoKDXWP39hDn60Kht40OC",
         },
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/4caba1c389af70b5083418da055987ecfd771120.tar.gz",
-            .hash = "v8-0.0.0-xddH6-3DAwAi5Enn3IxrIUvsSa7vBBqxZBAHZzAAyKeq",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/cf412d5b3d9d608582571d821e0d552337ef690d.tar.gz",
+            .hash = "v8-0.0.0-xddH69zDAwA4fp1dBo_jEDjS5bhXycPwRlZHp6_X890t",
         },
         //.v8 = .{ .path = "../zig-v8-fork" },
         //.tigerbeetle_io = .{ .path = "../tigerbeetle-io" },


### PR DESCRIPTION
Our build.zig is using a number of deprecated features, which are removed in 0.15.

This updates build.zig so that it still works in 0.14 and [hopefully] will work in 0.15.

Related: https://github.com/lightpanda-io/zig-v8-fork/pull/87