### PR TITLE
Emits a http_request_done internal notification.

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -455,12 +455,14 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             try self.cdp.browser.notification.register(.http_request_fail, self, onHttpRequestFail);
             try self.cdp.browser.notification.register(.http_request_start, self, onHttpRequestStart);
             try self.cdp.browser.notification.register(.http_headers_done, self, onHttpHeadersDone);
+            try self.cdp.browser.notification.register(.http_request_done, self, onHttpRequestDone);
         }
 
         pub fn networkDisable(self: *Self) void {
             self.cdp.browser.notification.unregister(.http_request_fail, self);
             self.cdp.browser.notification.unregister(.http_request_start, self);
             self.cdp.browser.notification.unregister(.http_headers_done, self);
+            self.cdp.browser.notification.unregister(.http_request_done, self);
         }
 
         pub fn fetchEnable(self: *Self) !void {
@@ -514,6 +516,12 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             const self: *Self = @alignCast(@ptrCast(ctx));
             defer self.resetNotificationArena();
             return @import("domains/network.zig").httpHeadersDone(self.notification_arena, self, data);
+        }
+
+        pub fn onHttpRequestDone(ctx: *anyopaque, data: *const Notification.RequestDone) !void {
+            const self: *Self = @alignCast(@ptrCast(ctx));
+            defer self.resetNotificationArena();
+            return @import("domains/network.zig").httpRequestDone(self.notification_arena, self, data);
         }
 
         fn resetNotificationArena(self: *Self) void {

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -64,6 +64,7 @@ pub const Notification = struct {
         http_request_start: List = .{},
         http_request_intercept: List = .{},
         http_headers_done: List = .{},
+        http_request_done: List = .{},
         notification_created: List = .{},
     };
 
@@ -76,6 +77,7 @@ pub const Notification = struct {
         http_request_start: *const RequestStart,
         http_request_intercept: *const RequestIntercept,
         http_headers_done: *const ResponseHeadersDone,
+        http_request_done: *const RequestDone,
         notification_created: *Notification,
     };
     const EventType = std.meta.FieldEnum(Events);
@@ -103,6 +105,10 @@ pub const Notification = struct {
     };
 
     pub const ResponseHeadersDone = struct {
+        transfer: *Transfer,
+    };
+
+    pub const RequestDone = struct {
         transfer: *Transfer,
     };
 


### PR DESCRIPTION
With networking enabled, CDP listens to this event and emits a `Network.loadingFinished` event. This is event is used by puppeteer to know that details about the response (i.e. the body) can be queries.

Added dummy handling for the Network.getResponseBody message. Returns an empty body. Needed because we emit the loadingFinished event which signals to drivers that they can ask for the body.