### PR TITLE
handle text content type with HTML

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -1111,6 +1111,6 @@ pub export fn scriptAddedCallback(ctx: ?*anyopaque, element: ?*parser.Element) c
     }
 
     self.script_manager.addFromElement(element.?) catch |err| {
-        log.warn(.browser, "dynamcic script", .{ .err = err });
+        log.warn(.browser, "dynamic script", .{ .err = err });
     };
 }


### PR DESCRIPTION
For text content type (and application/json) we create a pseudo HTML tree with the text value in a `<pre>` tag.

It allows CDP clients to interact with text content easily.

Relates with #824