### PR TITLE
Implement Network.getResponseBody

### DIFF
--- a/src/notification.zig
+++ b/src/notification.zig
@@ -63,8 +63,9 @@ pub const Notification = struct {
         http_request_fail: List = .{},
         http_request_start: List = .{},
         http_request_intercept: List = .{},
-        http_headers_done: List = .{},
         http_request_done: List = .{},
+        http_response_data: List = .{},
+        http_response_header_done: List = .{},
         notification_created: List = .{},
     };
 
@@ -76,8 +77,9 @@ pub const Notification = struct {
         http_request_fail: *const RequestFail,
         http_request_start: *const RequestStart,
         http_request_intercept: *const RequestIntercept,
-        http_headers_done: *const ResponseHeadersDone,
         http_request_done: *const RequestDone,
+        http_response_data: *const ResponseData,
+        http_response_header_done: *const ResponseHeaderDone,
         notification_created: *Notification,
     };
     const EventType = std.meta.FieldEnum(Events);
@@ -104,7 +106,12 @@ pub const Notification = struct {
         wait_for_interception: *bool,
     };
 
-    pub const ResponseHeadersDone = struct {
+    pub const ResponseData = struct {
+        data: []const u8,
+        transfer: *Transfer,
+    };
+
+    pub const ResponseHeaderDone = struct {
         transfer: *Transfer,
     };
 


### PR DESCRIPTION
Add response_data event, CDP now captures the full body so that it can respond to the Network.getResponseBody. This isn't memory efficient, but I don't see another way to do it. At least this way, it's only capturing/storing every response body when (a) CDP is used and (b) Network.enabled is called. That is, as opposed to baking this into Http/Client.zig, which would force the memory consumption for all use-cases.

There's arguably some optimizations we could make for XHR requests, which also dupe/own the response. As of now, the response is dupe'd separately for CDP and XHR.