### PR TITLE
Fix sendError message's format

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -733,8 +733,7 @@ pub fn Command(comptime CDP_T: type, comptime Sender: type) type {
         pub fn sendError(self: *Self, code: i32, message: []const u8) !void {
             return self.sender.sendJSON(.{
                 .id = self.input.id,
-                .code = code,
-                .message = message,
+                .@"error" = .{ .code = code, .message = message },
             });
         }
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -180,8 +180,7 @@ const TestContext = struct {
     pub fn expectSentError(self: *TestContext, code: i32, message: []const u8, opts: ExpectErrorOpts) !void {
         const expected_message = .{
             .id = opts.id,
-            .code = code,
-            .message = message,
+            .@"error" = .{ .code = code, .message = message },
         };
         try self.expectSent(expected_message, .{ .index = opts.index });
     }


### PR DESCRIPTION
Our error message did not have the right format this caused Playwright to error on it even if it was not important anymore.
Now:
`{"id":40,"error":{"code":-32001,"message":"Unknown sessionId"}}`
Before:
`{"id":41,"code":-32001,"message":"Unknown sessionId"}`
