### PR TITLE
Support dynamic scripts which are added to the DOM before src is set

### DIFF
--- a/src/browser/events/event.zig
+++ b/src/browser/events/event.zig
@@ -262,7 +262,6 @@ pub const EventHandler = struct {
                 },
             }
         }
-
         const callback = (try listener.callback(target)) orelse return null;
 
         if (signal) |s| {

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -862,12 +862,23 @@ pub const HTMLScriptElement = struct {
         ) orelse "";
     }
 
-    pub fn set_src(self: *parser.Script, v: []const u8) !void {
-        return try parser.elementSetAttribute(
+    pub fn set_src(self: *parser.Script, v: []const u8, page: *Page) !void {
+        try parser.elementSetAttribute(
             parser.scriptToElt(self),
             "src",
             v,
         );
+
+        if (try Node.get_isConnected(@alignCast(@ptrCast(self)))) {
+            // There are sites which do set the src AFTER appending the script
+            // tag to the document:
+            //    const s = document.createElement('script');
+            //    document.getElementsByTagName('body')[0].appendChild(s);
+            //    s.src = '...';
+            // This should load the script.
+            // addFromElement protects against double execution.
+            try page.script_manager.addFromElement(@alignCast(@ptrCast(self)));
+        }
     }
 
     pub fn get_type(self: *parser.Script) !?[]const u8 {
@@ -878,7 +889,7 @@ pub const HTMLScriptElement = struct {
     }
 
     pub fn set_type(self: *parser.Script, v: []const u8) !void {
-        return try parser.elementSetAttribute(
+        try parser.elementSetAttribute(
             parser.scriptToElt(self),
             "type",
             v,
@@ -893,7 +904,7 @@ pub const HTMLScriptElement = struct {
     }
 
     pub fn set_text(self: *parser.Script, v: []const u8) !void {
-        return try parser.elementSetAttribute(
+        try parser.elementSetAttribute(
             parser.scriptToElt(self),
             "text",
             v,
@@ -908,7 +919,7 @@ pub const HTMLScriptElement = struct {
     }
 
     pub fn set_integrity(self: *parser.Script, v: []const u8) !void {
-        return try parser.elementSetAttribute(
+        try parser.elementSetAttribute(
             parser.scriptToElt(self),
             "integrity",
             v,

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -1103,12 +1103,21 @@ fn timestamp() u32 {
 // so that's handled. And because we're only executing the inline <script> tags
 // after the document is loaded, it's ok to execute any async and defer scripts
 // immediately.
-pub export fn scriptAddedCallback(ctx: ?*anyopaque, element: ?*parser.Element) callconv(.C) void {
+pub export fn scriptAddedCallback(ctx: ?*anyopaque, element: ?*parser.Element) callconv(.c) void {
     const self: *Page = @alignCast(@ptrCast(ctx.?));
+
     if (self.delayed_navigation) {
         // if we're planning on navigating to another page, don't run this script
         return;
     }
+
+    // It's posisble for a script to be dynamically added without a src.
+    //   const s = document.createElement('script');
+    //   document.getElementsByTagName('body')[0].appendChild(s);
+    // The src can be set after. We handle that in HTMLScriptElement.set_src,
+    // but it's important we don't pass such elements to the script_manager
+    // here, else the script_manager will flag it as already-processed.
+    _ = parser.elementGetAttribute(element.?, "src") catch return orelse return;
 
     self.script_manager.addFromElement(element.?) catch |err| {
         log.warn(.browser, "dynamic script", .{ .err = err });


### PR DESCRIPTION
This should load the "src.js":

```
const s = document.createElement('script');
document.getElementsByTagName('body')[0].appendChild(s);
s.src = "src.js"
```

Notice that src is set AFTER the element is added to the DOM. This PR enables the above, by
1 - skipping dynamically added scripts which don't have a src 2 - trying to load a script whenever `set_src` is called.

(2) is safe because the ScriptManager already prevents scripts from being processed multiple times.

Additionally, not only can the src be set after the script is added to the DOM, but onload and onerror can be set after the src:

```
s.src = "src.js"
s.onload = ...;
s.onerror = ...;
```

This PR also delays reading the onload/onerror callbacks until the script is done loading.

This behavior is seen on reddit.