### PR TITLE
Make the CDP read buffer heap allocated & dynamic

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -1057,8 +1057,8 @@ test "Client: read invalid websocket message" {
         );
     }
 
-    // length of message is 0000 0401, i.e: 1024 * 512 + 1
-    try assertWebSocketError(1009, &.{ 129, 255, 0, 0, 0, 0, 0, 8, 0, 1, 'm', 'a', 's', 'k' });
+    // length of message is 0000 0810, i.e: 1024 * 512 + 265
+    try assertWebSocketError(1009, &.{ 129, 255, 0, 0, 0, 0, 0, 8, 1, 0, 'm', 'a', 's', 'k' });
 
     // continuation type message must come after a normal message
     // even when not a fin frame
@@ -1280,7 +1280,10 @@ fn createTestClient() !TestClient {
     try posix.setsockopt(stream.handle, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &timeout);
     return .{
         .stream = stream,
-        .reader = .{ .allocator = testing.allocator },
+        .reader = .{
+            .allocator = testing.allocator,
+            .buf = try testing.allocator.alloc(u8, 1024 * 16),
+        },
     };
 }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -785,6 +785,8 @@ fn growBuffer(allocator: Allocator, buf: []u8, required_capacity: usize) ![]u8 {
         if (new_capacity >= required_capacity) break;
     }
 
+    log.debug(.app, "CDP buffer growth", .{ .from = buf.len, .to = new_capacity });
+
     if (allocator.resize(buf, new_capacity)) {
         return buf.ptr[0..new_capacity];
     }


### PR DESCRIPTION
Rather than stack-allocating MAX_MESSAGE_SIZE upfront, we now allocate 32KB and grow the buffer as needed for larger messages, up to MAX_MESSAGE_SIZE.

This will reduce memory usage for drivers that don't send huge payloads (like playwright does).

While not implemented, this would also enable us to set the MAX_MESSAGE_SIZE at runtime (e.g. via a command line option).