### PR TITLE
Improve clocks

### DIFF
--- a/src/browser/console/console.zig
+++ b/src/browser/console/console.zig
@@ -165,8 +165,7 @@ pub const Console = struct {
 };
 
 fn timestamp() u32 {
-    const ts = std.posix.clock_gettime(std.posix.CLOCK.MONOTONIC) catch unreachable;
-    return @intCast(ts.sec);
+    return @import("../../datetime.zig").timestamp();
 }
 
 var test_capture = TestCapture{};

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -76,7 +76,7 @@ pub const Window = struct {
             .document = html_doc,
             .target = target orelse "",
             .navigator = navigator orelse .{},
-            .performance = .{ .time_origin = try std.time.Timer.start() },
+            .performance = Performance.init(),
         };
     }
 
@@ -86,7 +86,7 @@ pub const Window = struct {
     }
 
     pub fn replaceDocument(self: *Window, doc: *parser.DocumentHTML) !void {
-        self.performance.time_origin.reset(); // When to reset see: https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
+        self.performance.reset(); // When to reset see: https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
         self.document = doc;
         try parser.documentHTMLSetLocation(Location, doc, &self.location);
     }

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -1101,8 +1101,7 @@ pub const NavigateOpts = struct {
 };
 
 fn timestamp() u32 {
-    const ts = std.posix.clock_gettime(std.posix.CLOCK.MONOTONIC) catch unreachable;
-    return @intCast(ts.sec);
+    return @import("../datetime.zig").timestamp();
 }
 
 // A callback from libdom whenever a script tag is added to the DOM.

--- a/src/log.zig
+++ b/src/log.zig
@@ -321,14 +321,14 @@ fn writeString(comptime format: Format, value: []const u8, writer: anytype) !voi
     return writer.writeByte('"');
 }
 
-fn timestamp() i64 {
+fn timestamp() u64 {
     if (comptime @import("builtin").is_test) {
         return 1739795092929;
     }
-    return std.time.milliTimestamp();
+    return @import("datetime.zig").milliTimestamp();
 }
 
-var first_log: i64 = 0;
+var first_log: u64 = 0;
 fn elapsed() struct { time: f64, unit: []const u8 } {
     const now = timestamp();
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -897,8 +897,7 @@ fn buildJSONVersionResponse(
 }
 
 fn timestamp() u32 {
-    const ts = std.posix.clock_gettime(std.posix.CLOCK.MONOTONIC) catch unreachable;
-    return @intCast(ts.sec);
+    return @import("datetime.zig").timestamp();
 }
 
 // In-place string lowercase


### PR DESCRIPTION
There's a flaky performance test that I wanted to fix (1). This led to a couple changes.

1 - Add timestamp() and milliTimestamp() to datetime.zig. Reduce some code
    duplication and use better clock_ids where available

2 - Change Performance API to use milliTimestamp and store a u64 instead of a
    f64. While the spec says a float, Firefox deals with u64 and implicit
    conversion is always available. Makes our APIs simpler.

(1) - https://github.com/lightpanda-io/browser/actions/runs/17313296490/job/49151366798#step:4:131