### PR TITLE
Switch mimalloc guards to assertions

### DIFF
--- a/src/browser/mimalloc.zig
+++ b/src/browser/mimalloc.zig
@@ -20,6 +20,7 @@
 // management.
 // We replace the libdom default usage of allocations with mimalloc heap
 // allocation to be able to free all memory used at once, like an arena usage.
+const std = @import("std");
 
 const c = @cImport({
     @cInclude("mimalloc.h");
@@ -33,39 +34,39 @@ const Error = error{
 var heap: ?*c.mi_heap_t = null;
 
 pub fn create() Error!void {
-    if (heap != null) return Error.HeapNotNull;
+    std.debug.assert(heap == null);
     heap = c.mi_heap_new();
-    if (heap == null) return Error.HeapNull;
+    std.debug.assert(heap != null);
 }
 
 pub fn destroy() void {
-    if (heap == null) return;
+    std.debug.assert(heap != null);
     c.mi_heap_destroy(heap.?);
     heap = null;
 }
 
 pub export fn m_alloc(size: usize) callconv(.c) ?*anyopaque {
-    if (heap == null) return null;
+    std.debug.assert(heap != null);
     return c.mi_heap_malloc(heap.?, size);
 }
 
 pub export fn re_alloc(ptr: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
-    if (heap == null) return null;
+    std.debug.assert(heap != null);
     return c.mi_heap_realloc(heap.?, ptr, size);
 }
 
 pub export fn c_alloc(nmemb: usize, size: usize) callconv(.c) ?*anyopaque {
-    if (heap == null) return null;
+    std.debug.assert(heap != null);
     return c.mi_heap_calloc(heap.?, nmemb, size);
 }
 
 pub export fn str_dup(s: [*c]const u8) callconv(.c) [*c]u8 {
-    if (heap == null) return null;
+    std.debug.assert(heap != null);
     return c.mi_heap_strdup(heap.?, s);
 }
 
 pub export fn strn_dup(s: [*c]const u8, size: usize) callconv(.c) [*c]u8 {
-    if (heap == null) return null;
+    std.debug.assert(heap != null);
     return c.mi_heap_strndup(heap.?, s, size);
 }
 

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -331,6 +331,9 @@ pub const Writer = struct {
 
 const testing = @import("testing.zig");
 test "cdp Node: Registry register" {
+    try parser.init();
+    defer parser.deinit();
+
     var registry = Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -366,6 +369,9 @@ test "cdp Node: Registry register" {
 }
 
 test "cdp Node: search list" {
+    try parser.init();
+    defer parser.deinit();
+
     var registry = Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -417,6 +423,9 @@ test "cdp Node: search list" {
 }
 
 test "cdp Node: Writer" {
+    try parser.init();
+    defer parser.deinit();
+
     var registry = Registry.init(testing.allocator);
     defer registry.deinit();
 

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -121,7 +121,6 @@ const TestContext = struct {
 
         if (opts.html) |html| {
             if (bc.session_id == null) bc.session_id = "SID-X";
-            parser.deinit();
             const page = try bc.session.createPage();
             page.window.document = (try Document.init(html)).doc;
         }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -211,9 +211,6 @@ pub const Document = struct {
     arena: std.heap.ArenaAllocator,
 
     pub fn init(html: []const u8) !Document {
-        parser.deinit();
-        try parser.init();
-
         var fbs = std.io.fixedBufferStream(html);
         const html_doc = try parser.documentHTMLParse(fbs.reader(), "utf-8");
 
@@ -224,7 +221,6 @@ pub const Document = struct {
     }
 
     pub fn deinit(self: *Document) void {
-        parser.deinit();
         self.arena.deinit();
     }
 
@@ -375,8 +371,6 @@ pub const JsRunner = struct {
     allocator: Allocator,
 
     fn init(alloc: Allocator, opts: RunnerOpts) !JsRunner {
-        parser.deinit();
-
         const browser = try alloc.create(Browser);
         errdefer alloc.destroy(browser);
 
@@ -493,14 +487,11 @@ var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
 pub var test_app: *App = undefined;
 
 pub fn setup() !void {
-    try parser.init();
-
     test_app = try App.init(gpa.allocator(), .{
         .run_mode = .serve,
         .tls_verify_host = false,
     });
 }
 pub fn shutdown() void {
-    parser.deinit();
     test_app.deinit();
 }


### PR DESCRIPTION
The thin mimalloc API is currently defensive around incorrect setup/teardown by guarding against using/destroying the arena when the heap is null, or creating an arena when it already exists.

The only time these checks will fail is when the code is wrong, e.g. trying to use libdom before or after freeing the arena. The current behavior can mask these errors, plus add runtime overhead.