### PR TITLE
Revert "document.documentElement returns a *parser.Element"

### DIFF
--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -66,8 +66,10 @@ pub const Document = struct {
         return DOMImplementation{};
     }
 
-    pub fn get_documentElement(self: *parser.Document) !?*parser.Element {
-        return try parser.documentGetDocumentElement(self);
+    pub fn get_documentElement(self: *parser.Document) !?ElementUnion {
+        const e = try parser.documentGetDocumentElement(self);
+        if (e == null) return null;
+        return try Element.toInterface(e.?);
     }
 
     pub fn get_documentURI(self: *parser.Document) ![]const u8 {


### PR DESCRIPTION
This reverts commit c1752ae5eb31fb74db08dbad33b9b95792aad859.

Fix duckduckgo rendering results