### PR TITLE
Update the transfer.uri on redirect

### DIFF
--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -845,6 +845,7 @@ pub const Transfer = struct {
 
         const url = try urlStitch(arena, hlocation.?.value, std.mem.span(baseurl), .{});
         const uri = try std.Uri.parse(url);
+        transfer.uri = uri;
 
         var cookies: std.ArrayListUnmanaged(u8) = .{};
         try req.cookie_jar.forRequest(&uri, cookies.writer(arena), .{


### PR DESCRIPTION
Ensures that cookies set on the redirect page use the correct host and we don't incorrectly reject cookies.

https://github.com/lightpanda-io/browser/issues/947