### PR TITLE
Fix the Screen and ScreenOrientation prototype

### DIFF
--- a/src/browser/dom/event_target.zig
+++ b/src/browser/dom/event_target.zig
@@ -31,6 +31,10 @@ pub const Union = union(enum) {
     xhr: *@import("../xhr/xhr.zig").XMLHttpRequest,
     plain: *parser.EventTarget,
     message_port: *@import("MessageChannel.zig").MessagePort,
+    screen: *@import("../html/screen.zig").Screen,
+    screen_orientation: *@import("../html/screen.zig").ScreenOrientation,
+    performance: *@import("performance.zig").Performance,
+    media_query_list: *@import("../html/media_query_list.zig").MediaQueryList,
 };
 
 // EventTarget implementation
@@ -67,7 +71,18 @@ pub const EventTarget = struct {
             .message_port => {
                 return .{ .message_port = @fieldParentPtr("proto", @as(*parser.EventTargetTBase, @ptrCast(et))) };
             },
-            else => return error.MissingEventTargetType,
+            .screen => {
+                return .{ .screen = @fieldParentPtr("proto", @as(*parser.EventTargetTBase, @ptrCast(et))) };
+            },
+            .screen_orientation => {
+                return .{ .screen_orientation = @fieldParentPtr("proto", @as(*parser.EventTargetTBase, @ptrCast(et))) };
+            },
+            .performance => {
+                return .{ .performance = @fieldParentPtr("base", @as(*parser.EventTargetTBase, @ptrCast(et))) };
+            },
+            .media_query_list => {
+                return .{ .media_query_list = @fieldParentPtr("base", @as(*parser.EventTargetTBase, @ptrCast(et))) };
+            },
         }
     }
 

--- a/src/browser/html/error_event.zig
+++ b/src/browser/html/error_event.zig
@@ -81,34 +81,6 @@ pub const ErrorEvent = struct {
 };
 
 const testing = @import("../../testing.zig");
-test "Browser.HTML.ErrorEvent" {
-    var runner = try testing.jsRunner(testing.tracking_allocator, .{ .html = "<div id=c></div>" });
-    defer runner.deinit();
-
-    try runner.testCases(&.{
-        .{ "let e1 = new ErrorEvent('err1')", null },
-        .{ "e1.message", "" },
-        .{ "e1.filename", "" },
-        .{ "e1.lineno", "0" },
-        .{ "e1.colno", "0" },
-        .{ "e1.error", "undefined" },
-
-        .{
-            \\ let e2 = new ErrorEvent('err1', {
-            \\    message: 'm1',
-            \\    filename: 'fx19',
-            \\    lineno: 443,
-            \\    colno: 8999,
-            \\    error: 'under 9000!',
-            \\
-            \\})
-            ,
-            null,
-        },
-        .{ "e2.message", "m1" },
-        .{ "e2.filename", "fx19" },
-        .{ "e2.lineno", "443" },
-        .{ "e2.colno", "8999" },
-        .{ "e2.error", "under 9000!" },
-    }, .{});
+test "Browser: HTML.ErrorEvent" {
+    try testing.htmlRunner("html/error_event.html");
 }

--- a/src/browser/html/screen.zig
+++ b/src/browser/html/screen.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 
+const parser = @import("../netsurf.zig");
 const EventTarget = @import("../dom/event_target.zig").EventTarget;
 
 pub const Interfaces = .{
@@ -28,6 +29,8 @@ pub const Interfaces = .{
 // https://developer.mozilla.org/en-US/docs/Web/API/Screen
 pub const Screen = struct {
     pub const prototype = *EventTarget;
+
+    proto: parser.EventTargetTBase = .{ .internal_target_type = .screen },
 
     height: u32 = 1080,
     width: u32 = 1920,
@@ -83,6 +86,7 @@ pub const ScreenOrientation = struct {
 
     angle: u32 = 0,
     type: ScreenOrientationType,
+    proto: parser.EventTargetTBase = .{ .internal_target_type = .screen_orientation },
 
     pub fn get_angle(self: *const ScreenOrientation) u32 {
         return self.angle;
@@ -94,16 +98,6 @@ pub const ScreenOrientation = struct {
 };
 
 const testing = @import("../../testing.zig");
-test "Browser.HTML.Screen" {
-    var runner = try testing.jsRunner(testing.tracking_allocator, .{});
-    defer runner.deinit();
-
-    try runner.testCases(&.{
-        .{ "let screen = window.screen", "undefined" },
-        .{ "screen.width === 1920", "true" },
-        .{ "screen.height === 1080", "true" },
-        .{ "let orientation = screen.orientation", "undefined" },
-        .{ "orientation.angle === 0", "true" },
-        .{ "orientation.type === \"landscape-primary\"", "true" },
-    }, .{});
+test "Browser: HTML.Screen" {
+    try testing.htmlRunner("html/screen.html");
 }

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -677,8 +677,9 @@ pub fn eventTargetHasListener(
     var lst: ?*EventListener = null;
 
     // iterate over the EventTarget's listeners
+    const iter_event_listener = eventTargetVtable(et).iter_event_listener.?;
     while (true) {
-        const err = eventTargetVtable(et).iter_event_listener.?(
+        const err = iter_event_listener(
             et,
             str,
             capture,
@@ -728,8 +729,9 @@ pub fn eventTargetRemoveAllEventListeners(et: *EventTarget) !void {
     var lst: ?*EventListener = null;
 
     // iterate over the EventTarget's listeners
+    const iter_event_listener = eventTargetVtable(et).iter_event_listener.?;
     while (true) {
-        const errIter = eventTargetVtable(et).iter_event_listener.?(
+        const errIter = iter_event_listener(
             et,
             null,
             false,
@@ -806,6 +808,8 @@ pub const EventTargetTBase = extern struct {
         performance = 5,
         media_query_list = 6,
         message_port = 7,
+        screen = 8,
+        screen_orientation = 9,
     };
 
     vtable: ?*const c.struct_dom_event_target_vtable = &c.struct_dom_event_target_vtable{

--- a/src/tests/html/error_event.html
+++ b/src/tests/html/error_event.html
@@ -1,0 +1,29 @@
+<script src="../testing.js"></script>
+
+<script id=ErrorEvent>
+  let e1 = new ErrorEvent('err1')
+  testing.expectEqual('', e1.message);
+  testing.expectEqual('', e1.filename);
+  testing.expectEqual(0, e1.lineno);
+  testing.expectEqual(0, e1.colno);
+  testing.expectEqual(undefined, e1.error);
+
+  let e2 = new ErrorEvent('err1', {
+     message: 'm1',
+     filename: 'fx19',
+     lineno: 443,
+     colno: 8999,
+     error: 'under 9000!',
+   });
+
+  testing.expectEqual('m1', e2.message);
+  testing.expectEqual('fx19', e2.filename);
+  testing.expectEqual(443, e2.lineno);
+  testing.expectEqual(8999, e2.colno);
+  testing.expectEqual('under 9000!', e2.error);
+</script>
+
+<script id=ErrorEvent>
+  let e3 = new ErrorEvent('err3')
+  e3.addEventListener('change', () => {});
+</script>

--- a/src/tests/html/screen.html
+++ b/src/tests/html/screen.html
@@ -1,0 +1,20 @@
+<script src="../testing.js"></script>
+
+<script id=screen>
+  let screen = window.screen;
+  testing.expectEqual(1920, screen.width);
+  testing.expectEqual(1080, screen.height);
+
+  let orientation = screen.orientation;
+  testing.expectEqual(0, orientation.angle);
+  testing.expectEqual('landscape-primary', orientation.type);
+
+  // this shouldn't crash (it used to)
+  screen.addEventListener('change', () => {});
+</script>
+
+<script id=orientation>
+  screen.orientation.addEventListener('change', () => {})
+  // above shouldn't crash (it used to)
+  testing.skip();
+</script>


### PR DESCRIPTION
I initially thought the bug was related to `error_event`, so I moved the tests to the htmlRunner. Then I realized it wasn't related, but I kept that change in this PR.

https://github.com/lightpanda-io/browser/issues/1015