### PR TITLE
Inline script tags ignore defer/async

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -162,8 +162,8 @@ pub fn addFromElement(self: *ScriptManager, element: *parser.Element) !void {
         .element = element,
         .source = source,
         .url = remote_url orelse page.url.raw,
-        .is_defer = try parser.elementGetAttribute(element, "defer") != null,
-        .is_async = try parser.elementGetAttribute(element, "async") != null,
+        .is_defer = if (remote_url == null) false else try parser.elementGetAttribute(element, "defer") != null,
+        .is_async = if (remote_url == null) false else try parser.elementGetAttribute(element, "async") != null,
     };
 
     if (source == .@"inline" and self.scripts.first == null) {

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -1480,6 +1480,10 @@ test "Browser.HTML.HTMLStyleElement" {
     }, .{});
 }
 
+test "Browser: HTML.HTMLScriptElement" {
+    try testing.htmlRunner("html/script/inline_defer.html");
+}
+
 const Check = struct {
     input: []const u8,
     expected: ?[]const u8 = null, // Needed when input != expected

--- a/src/tests/html/script/inline_defer.html
+++ b/src/tests/html/script/inline_defer.html
@@ -1,0 +1,27 @@
+<head>
+  <script>
+    let dyn1_loaded = 0;
+    function loadScript(src) {
+      const script = document.createElement('script');
+      script.src = src;
+      document.getElementsByTagName("head")[0].appendChild(script)
+    }
+  </script>
+</head>
+
+<script src="../../testing.js"></script>
+
+<script defer>
+  loadScript('inline_defer.js');
+</script>
+
+<script async>
+  loadScript('inline_defer.js');
+</script>
+
+<script id=inline_defer>
+  // inline script should ignore defer and async attributes. If we don't do
+  // this correctly, we'd end up in an infinite loop
+  // https://github.com/lightpanda-io/browser/issues/1014
+  testing.eventually(() => testing.expectEqual(2, dyn1_loaded));
+</script>

--- a/src/tests/html/script/inline_defer.js
+++ b/src/tests/html/script/inline_defer.js
@@ -1,0 +1,1 @@
+dyn1_loaded += 1;


### PR DESCRIPTION
According to MDN, inline script tags should not have defer/async attributes. But some do. This ignores those attributes for inline script tags.

(Previously, we were only half ignoring them. We were treating them as inline, but flagging them as deferred or async, which was causing issues with cleanup)

Fixes: https://github.com/lightpanda-io/browser/issues/1014