### PR TITLE
Patchright compatibility

### DIFF
--- a/src/browser/css/parser.zig
+++ b/src/browser/css/parser.zig
@@ -821,7 +821,8 @@ pub const Parser = struct {
 // nameStart returns whether c can be the first character of an identifier
 // (not counting an initial hyphen, or an escape sequence).
 fn nameStart(c: u8) bool {
-    return 'a' <= c and c <= 'z' or 'A' <= c and c <= 'Z' or c == '_' or c > 127;
+    return 'a' <= c and c <= 'z' or 'A' <= c and c <= 'Z' or c == '_' or c > 127 or
+        '0' <= c and c <= '9';
 }
 
 // nameChar returns whether c can be a character within an identifier
@@ -890,7 +891,7 @@ test "parser.parseIdentifier" {
         err: bool = false,
     }{
         .{ .s = "x", .exp = "x" },
-        .{ .s = "96", .exp = "", .err = true },
+        .{ .s = "96", .exp = "96", .err = false },
         .{ .s = "-x", .exp = "-x" },
         .{ .s = "r\\e9 sumé", .exp = "résumé" },
         .{ .s = "r\\0000e9 sumé", .exp = "résumé" },
@@ -975,6 +976,7 @@ test "parser.parse" {
         .{ .s = ":root", .exp = .{ .pseudo_class = .root } },
         .{ .s = ".\\:bar", .exp = .{ .class = ":bar" } },
         .{ .s = ".foo\\:bar", .exp = .{ .class = "foo:bar" } },
+        .{ .s = "[class=75c0fa18a94b9e3a6b8e14d6cbe688a27f5da10a]", .exp = .{ .attribute = .{ .key = "class", .val = "75c0fa18a94b9e3a6b8e14d6cbe688a27f5da10a", .op = .eql } } },
     };
 
     for (testcases) |tc| {

--- a/src/browser/css/selector.zig
+++ b/src/browser/css/selector.zig
@@ -994,6 +994,11 @@ test "Browser.CSS.Selector: matchFirst" {
             .exp = 0,
         },
         .{
+            .q = "[foo=1baz]",
+            .n = .{ .child = &.{ .name = "p", .sibling = &.{ .name = "p", .att = "bar" } } },
+            .exp = 0,
+        },
+        .{
             .q = "[foo!=bar]",
             .n = .{ .child = &.{ .name = "p", .sibling = &.{ .name = "p", .att = "bar" } } },
             .exp = 1,

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -306,11 +306,11 @@ fn describeNode(cmd: anytype) !void {
         nodeId: ?Node.Id = null,
         backendNodeId: ?Node.Id = null,
         objectId: ?[]const u8 = null,
-        depth: u32 = 1,
+        depth: i32 = 1,
         pierce: bool = false,
     })) orelse return error.InvalidParams;
 
-    if (params.depth != 1 or params.pierce) return error.NotImplemented;
+    if (params.pierce) return error.NotImplemented;
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -277,10 +277,15 @@ fn resolveNode(cmd: anytype) !void {
     var js_context = page.main_context;
     if (params.executionContextId) |context_id| {
         if (js_context.v8_context.debugContextId() != context_id) {
-            var isolated_world = bc.isolated_world orelse return error.ContextNotFound;
-            js_context = &(isolated_world.executor.js_context orelse return error.ContextNotFound);
-
-            if (js_context.v8_context.debugContextId() != context_id) return error.ContextNotFound;
+            var found = false;
+            for (bc.isolated_worlds.items) |*isolated_world| {
+                js_context = &(isolated_world.executor.js_context orelse return error.ContextNotFound);
+                if (js_context.v8_context.debugContextId() == context_id) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return error.ContextNotFound;
         }
     }
 

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -277,15 +277,12 @@ fn resolveNode(cmd: anytype) !void {
     var js_context = page.main_context;
     if (params.executionContextId) |context_id| {
         if (js_context.v8_context.debugContextId() != context_id) {
-            var found = false;
             for (bc.isolated_worlds.items) |*isolated_world| {
                 js_context = &(isolated_world.executor.js_context orelse return error.ContextNotFound);
                 if (js_context.v8_context.debugContextId() == context_id) {
-                    found = true;
                     break;
                 }
-            }
-            if (!found) return error.ContextNotFound;
+            } else return error.ContextNotFound;
         }
     }
 

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const log = @import("../../log.zig");
 const Allocator = std.mem.Allocator;
 const Node = @import("../Node.zig");
 const css = @import("../../browser/dom/css.zig");
@@ -68,6 +69,10 @@ fn getDocument(cmd: anytype) !void {
         pierce: bool = false,
     };
     const params = try cmd.params(Params) orelse Params{};
+
+    if (params.pierce) {
+        log.warn(.cdp, "not implemented", .{ .feature = "DOM.getDocument: Not implemented pierce parameter" });
+    }
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
@@ -310,7 +315,9 @@ fn describeNode(cmd: anytype) !void {
         pierce: bool = false,
     })) orelse return error.InvalidParams;
 
-    if (params.pierce) return error.NotImplemented;
+    if (params.pierce) {
+        log.warn(.cdp, "not implemented", .{ .feature = "DOM.describeNode: Not implemented pierce parameter" });
+    }
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -322,7 +322,7 @@ fn describeNode(cmd: anytype) !void {
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
-    return cmd.sendResult(.{ .node = bc.nodeWriter(node, .{}) }, .{});
+    return cmd.sendResult(.{ .node = bc.nodeWriter(node, .{ .depth = params.depth }) }, .{});
 }
 
 // An array of quad vertices, x immediately followed by y for each point, points clock-wise.

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -471,7 +471,7 @@ fn getFrameOwner(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const target_id = bc.target_id orelse return error.TargetNotLoaded;
     if (std.mem.eql(u8, target_id, params.frameId) == false) {
-        return cmd.sendError(-32000, "Frame with the given id does not belong to the target.");
+        return cmd.sendError(-32000, "Frame with the given id does not belong to the target.", .{});
     }
 
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -244,7 +244,14 @@ pub fn httpRequestStart(arena: Allocator, bc: anytype, msg: *const Notification.
 
     const transfer = msg.transfer;
     // We're missing a bunch of fields, but, for now, this seems like enough
-    try bc.cdp.sendEvent("Network.requestWillBeSent", .{ .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{transfer.id}), .frameId = target_id, .loaderId = bc.loader_id, .documentUrl = DocumentUrlWriter.init(&page.url.uri), .request = TransferAsRequestWriter.init(transfer) }, .{ .session_id = session_id });
+    try bc.cdp.sendEvent("Network.requestWillBeSent", .{
+        .requestId = try std.fmt.allocPrint(arena, "REQ-{d}", .{transfer.id}),
+        .frameId = target_id,
+        .loaderId = bc.loader_id,
+        .documentUrl = DocumentUrlWriter.init(&page.url.uri),
+        .request = TransferAsRequestWriter.init(transfer),
+        .initiator = .{ .type = "other" },
+    }, .{ .session_id = session_id });
 }
 
 pub fn httpResponseHeaderDone(arena: Allocator, bc: anytype, msg: *const Notification.ResponseHeaderDone) !void {

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -27,6 +27,7 @@ pub fn processMessage(cmd: anytype) !void {
         addBinding,
         callFunctionOn,
         releaseObject,
+        getProperties,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -79,7 +79,7 @@ fn createBrowserContext(cmd: anytype) !void {
     }
 
     const bc = cmd.createBrowserContext() catch |err| switch (err) {
-        error.AlreadyExists => return cmd.sendError(-32000, "Cannot have more than one browser context at a time"),
+        error.AlreadyExists => return cmd.sendError(-32000, "Cannot have more than one browser context at a time", .{}),
         else => return err,
     };
 
@@ -102,7 +102,7 @@ fn disposeBrowserContext(cmd: anytype) !void {
     })) orelse return error.InvalidParams;
 
     if (cmd.cdp.disposeBrowserContext(params.browserContextId) == false) {
-        return cmd.sendError(-32602, "No browser context with the given id found");
+        return cmd.sendError(-32602, "No browser context with the given id found", .{});
     }
     try cmd.sendResult(null, .{});
 }

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -241,10 +241,10 @@ fn closeTarget(cmd: anytype) !void {
     }
 
     bc.session.removePage();
-    if (bc.isolated_world) |*world| {
+    for (bc.isolated_worlds.items) |*world| {
         world.deinit();
-        bc.isolated_world = null;
     }
+    bc.isolated_worlds.clearRetainingCapacity();
     bc.target_id = null;
 }
 


### PR DESCRIPTION
Adjust CDP support to improve compatibility with [patchright-nodejs](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs) client.

Some issues in progress

### :orange_circle:  `target.createBrowserContext` with `disposeOnDetach: true` parameter

patchright sends `disposeOnDetach: true`. We didn't implement it for now.
:information_source: It raises a warning.

https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createBrowserContext

### :orange_circle:  `DOM.describeNode` with `pierce: true` parameter

patchright sends `pierce: true`. We didn't implement it for now.
:information_source: I turned the error into a log warning.

https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-describeNode

### :heavy_check_mark: Two successive `Page.createIsolatedWorld` calls

 ```console
> {"id":38,"method":"Page.createIsolatedWorld","params":{"frameId":"TID-1","grantUniveralAccess":true,"worldName":"utility"},"sessionId":"SID-1"}
< {"id":38,"result":{"executionContextId":2},"sessionId":"SID-1"}
[...]
> {"id":64,"method":"Page.createIsolatedWorld","params":{"frameId":"TID-1","grantUniveralAccess":true,"worldName":"utility"},"sessionId":"SID-1"}
< {"id":64,"error":{"code":-31998,"message":"CurrentlyOnly1IsolatedWorldSupported"},"sessionId":"SID-1"}
```

Relates with https://github.com/lightpanda-io/project/discussions/163 for the risks of reusing the same world+context.

> In order to support 2 isolated world we only have to change isolated_world: ?IsolatedWorld, to isolated_world: [2]?IsolatedWorld, or a dynamic array, and fix access to it (cdp functions that take an executionContextId).
Lazy creation and of the worlds and such is already prepared for it 

:information_source: implemented in bc1ad98c4259b0d0e85884dbf781aafbffa6e823

### :x: JS exection error `DispatchRequest`

```
INFO  js : function call error . . . . . . . . . . . . . . .  [+1843ms]
      name = browser.dom.event_target.EventTarget._dispatchEvent
      err = DispatchRequest
      args =
        1: #<CustomEvent> (object)
      stack =
        markTargetElements:7436
        eval:3
        evaluate:293
        <anonymous>:1
```

```
< {"id":237,"result":{"result":{"type":"object","className":"DOMException","description":"DOMException","objectId":"5987356902031041503.5.27","preview":{"type":"object","description":"DOMException","overflow":false,"properties":[{"name":"code","type":"number","value":"129"},{"name":"name","type":"string","value":"DispatchRequestError"},{"name":"message","type":"string","value":"Failed to execute 'dispatchEvent' : DispatchRequestError"},{"name":"Symbol(Symbol.toStringTag)","type":"string","value":"DOMException"}]}},"exceptionDetails":{"exceptionId":1,"text":"Uncaught","lineNumber":7435,"columnNumber":16,"scriptId":"8","exception":{"type":"object","className":"DOMException","description":"DOMException","objectId":"5987356902031041503.5.28","preview":{"type":"object","description":"DOMException","overflow":false,"properties":[{"name":"code","type":"number","value":"129"},{"name":"name","type":"string","value":"DispatchRequestError"},{"name":"message","type":"string","value":"Failed to execute 'dispatchEvent' : DispatchRequestError"},{"name":"Symbol(Symbol.toStringTag)","type":"string","value":"DOMException"}]}}}},"sessionId":"SID-1"}
> {"id":238,"method":"Runtime.callFunctionOn","params":{"functionDeclaration":"(utilityScript, ...args) => utilityScript.evaluate(...args)","objectId":"5987356902031041503.5.3","arguments":[{"objectId":"5987356902031041503.5.3"},{"value":true},{"value":false},{"value":"(injected, { error }) => {\n        throw error;\n      }"},{"value":2},{"value":{"h":0}},{"value":{"o":[{"k":"error","v":{"e":{"n":"Error","m":"DOMException","s":"Error: DOMException\n    at CRExecutionContext.evaluateWithArguments (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/chromium/crExecutionContext.js:80:13)\n    at async LongStandingScope._race (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/utils/isomorphic/manualPromise.js:94:14)\n    at async evaluateExpression (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/javascript.js:233:12)\n    at async ElementHandle.evaluateHandleInUtility (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dom.js:133:14)\n    at async Frame._customFindElementsByParsed (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1665:32)\n    at async Frame._retryWithoutProgress (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1546:32)\n    at async Frame.retryWithProgressAndTimeouts (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:943:24)\n    at async FrameDispatcher.textContent (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/frameDispatcher.js:138:19)\n    at async ProgressController.run (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/progress.js:78:22)\n    at async FrameDispatcher._runCommand (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/dispatcher.js:95:14)"}}}],"id":1}},{"objectId":"5987356902031041503.5.1"}],"returnByValue":false,"awaitPromise":true,"userGesture":true},"sessionId":"SID-1"}
```

### :x:  JS execution error `DOMException\n    at CRExecutionContext.evaluateWithArguments`

```
> {"id":238,"method":"Runtime.callFunctionOn","params":{"functionDeclaration":"(utilityScript, ...args) => utilityScript.evaluate(...args)","objectId":"5987356902031041503.5.3","arguments":[{"objectId":"5987356902031041503.5.3"},{"value":true},{"value":false},{"value":"(injected, { error }) => {\n        throw error;\n      }"},{"value":2},{"value":{"h":0}},{"value":{"o":[{"k":"error","v":{"e":{"n":"Error","m":"DOMException","s":"Error: DOMException\n    at CRExecutionContext.evaluateWithArguments (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/chromium/crExecutionContext.js:80:13)\n    at async LongStandingScope._race (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/utils/isomorphic/manualPromise.js:94:14)\n    at async evaluateExpression (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/javascript.js:233:12)\n    at async ElementHandle.evaluateHandleInUtility (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dom.js:133:14)\n    at async Frame._customFindElementsByParsed (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1665:32)\n    at async Frame._retryWithoutProgress (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1546:32)\n    at async Frame.retryWithProgressAndTimeouts (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:943:24)\n    at async FrameDispatcher.textContent (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/frameDispatcher.js:138:19)\n    at async ProgressController.run (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/progress.js:78:22)\n    at async FrameDispatcher._runCommand (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/dispatcher.js:95:14)"}}}],"id":1}},{"objectId":"5987356902031041503.5.1"}],"returnByValue":false,"awaitPromise":true,"userGesture":true},"sessionId":"SID-1"}
< {"id":238,"result":{"result":{"type":"object","subtype":"error","className":"Error","description":"Error: DOMException\n    at CRExecutionContext.evaluateWithArguments (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/chromium/crExecutionContext.js:80:13)\n    at async LongStandingScope._race (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/utils/isomorphic/manualPromise.js:94:14)\n    at async evaluateExpression (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/javascript.js:233:12)\n    at async ElementHandle.evaluateHandleInUtility (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dom.js:133:14)\n    at async Frame._customFindElementsByParsed (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1665:32)\n    at async Frame._retryWithoutProgress (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1546:32)\n    at async Frame.retryWithProgressAndTimeouts (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:943:24)\n    at async FrameDispatcher.textContent (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/frameDispatcher.js:138:19)\n    at async ProgressController.run (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/progress.js:78:22)\n    at async FrameDispatcher._runCommand (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/dispatcher.js:95:14)","objectId":"5987356902031041503.5.29"},"exceptionDetails":{"exceptionId":2,"text":"Uncaught","lineNumber":1,"columnNumber":8,"scriptId":"66","exception":{"type":"object","subtype":"error","className":"Error","description":"Error: DOMException\n    at CRExecutionContext.evaluateWithArguments (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/chromium/crExecutionContext.js:80:13)\n    at async LongStandingScope._race (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/utils/isomorphic/manualPromise.js:94:14)\n    at async evaluateExpression (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/javascript.js:233:12)\n    at async ElementHandle.evaluateHandleInUtility (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dom.js:133:14)\n    at async Frame._customFindElementsByParsed (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1665:32)\n    at async Frame._retryWithoutProgress (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:1546:32)\n    at async Frame.retryWithProgressAndTimeouts (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/frames.js:943:24)\n    at async FrameDispatcher.textContent (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/frameDispatcher.js:138:19)\n    at async ProgressController.run (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/progress.js:78:22)\n    at async FrameDispatcher._runCommand (/home/pierre/wrk/patchright/node_modules/patchright-core/lib/server/dispatchers/dispatcher.js:95:14)","objectId":"5987356902031041503.5.30"}}},"sessionId":"SID-1"}
```