### PR TITLE
Remove a std.debug.print

### DIFF
--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -107,7 +107,6 @@ pub const LightPanda = struct {
         }
 
         try self.connection.setBody(aw.written());
-        std.debug.print("{s}\n", .{aw.written()});
         const status = try self.connection.request();
 
         if (status != 200) {


### PR DESCRIPTION
Probably added in the Zig 0.15 migration. Sorry.