### PR TITLE
Mime: charset identification changes

### DIFF
--- a/src/browser/mime.zig
+++ b/src/browser/mime.zig
@@ -123,8 +123,8 @@ pub const Mime = struct {
 
                     const attribute_value = try parseCharset(value);
                     @memcpy(charset[0..attribute_value.len], attribute_value);
-                    // Fill the rest with zeroes.
-                    @memset(charset[attribute_value.len..], 0);
+                    // Null-terminate right after attribute value.
+                    charset[attribute_value.len] = 0;
                 },
             }
         }

--- a/src/browser/mime.zig
+++ b/src/browser/mime.zig
@@ -438,21 +438,33 @@ test "Mime: parse charset" {
 
     try expect(.{
         .content_type = .{ .text_xml = {} },
-        .charset = "UTF-8",
+        .charset = "utf-8",
         .params = "charset=utf-8",
     }, "text/xml; charset=utf-8");
 
     try expect(.{
         .content_type = .{ .text_xml = {} },
-        .charset = "UTF-8",
+        .charset = "utf-8",
         .params = "charset=\"utf-8\"",
-    }, "text/xml;charset=\"utf-8\"");
+    }, "text/xml;charset=\"UTF-8\"");
+
+    try expect(.{
+        .content_type = .{ .text_html = {} },
+        .charset = "iso-8859-1",
+        .params = "charset=\"iso-8859-1\"",
+    }, "text/html; charset=\"iso-8859-1\"");
+
+    try expect(.{
+        .content_type = .{ .text_html = {} },
+        .charset = "iso-8859-1",
+        .params = "charset=\"iso-8859-1\"",
+    }, "text/html; charset=\"ISO-8859-1\"");
 
     try expect(.{
         .content_type = .{ .text_xml = {} },
-        .charset = "lightpanda:UNSUPPORTED",
-        .params = "charset=\"\\\\ \\\" \"",
-    }, "text/xml;charset=\"\\\\ \\\" \"   ");
+        .charset = "custom-non-standard-charset-value",
+        .params = "charset=\"custom-non-standard-charset-value\"",
+    }, "text/xml;charset=\"custom-non-standard-charset-value\"");
 }
 
 test "Mime: isHTML" {
@@ -565,8 +577,10 @@ fn expect(expected: Expectation, input: []const u8) !void {
     try testing.expectEqual(expected.params, actual.params);
 
     if (expected.charset) |ec| {
-        try testing.expectEqual(ec, actual.charset.?);
+        // We remove the null characters for testing purposes here.
+        try testing.expectEqual(ec, actual.charsetString()[0..ec.len]);
     } else {
-        try testing.expectEqual(null, actual.charset);
+        const m: Mime = .unknown;
+        try testing.expectEqual(m.charsetString(), actual.charsetString());
     }
 }

--- a/src/browser/mime.zig
+++ b/src/browser/mime.zig
@@ -69,83 +69,17 @@ pub const Mime = struct {
         // https://datatracker.ietf.org/doc/rfc2978/
         if (value.len > 40) return error.CharsetTooBig;
 
-        // If the first char is not a quote, value can be used directly.
-        // Whitespace is not allowed.
-        if (value[0] != '"') {
-            return value;
+        // If the first char is a quote, look for a pair.
+        if (value[0] == '"') {
+            if (value.len < 3 or value[value.len - 1] != '"') {
+                return error.Invalid;
+            }
+
+            return value[1 .. value.len - 1];
         }
 
-        // Search for second quote begins.
-        // Skip the first character.
-        var offset: usize = 1;
-
-        // Charset values are not so large; 128-bit registers should be
-        // more than enough.
-        const vec_size = 16;
-        const Vec = @Vector(vec_size, u8);
-        const UInt = std.meta.Int(.unsigned, vec_size);
-        const block_size = @sizeOf(u64);
-
-        const charset = blk: {
-            // Vector search.
-            while (value.len - offset >= vec_size) : (offset += vec_size) {
-                // Fill a vector with quotes.
-                const quotes: Vec = @splat('"');
-                const chunk: Vec = value[offset..][0..vec_size].*;
-
-                // Check if chunk has double quote byte.
-                const match = @intFromBool(chunk == quotes);
-                // Create an integer out of match and count how much to skip.
-                const skip_by = @ctz(@as(UInt, @bitCast(match)));
-
-                // Found a match.
-                if (skip_by != vec_size) {
-                    break :blk value[1 .. offset + skip_by];
-                }
-            }
-
-            // SWAR search.
-            while (value.len - offset >= block_size) : (offset += block_size) {
-                // Magic number for integer filled with double quote.
-                // [8]u8{ '"', '"', '"', '"', '"', '"', '"', '"' }.
-                const quotes: u64 = 0x2222222222222222;
-                // Load the next chunk as unsigned 64-bit integer.
-                const chunk: u64 = @bitCast(value[offset..][0..block_size].*);
-
-                // XOR with the pattern - bytes equal to quote become 0.
-                const xor_result = chunk ^ quotes;
-
-                const magic: u64 = 0x8080808080808080; // High bit mask for each byte.
-                const sub_result = xor_result -% 0x0101010101010101; // Subtract 1 from each byte.
-                const and_result = sub_result & (~xor_result); // AND with inverted original.
-                const zero_mask = and_result & magic; // Extract high bits (indicates zero bytes).
-
-                // Found a match.
-                if (zero_mask != 0) {
-                    // * Count trailing zeroes.
-                    // * Dividing by byte size (>> 3) converts the bit position to byte index.
-                    const skip_by = @ctz(zero_mask) >> 3;
-                    break :blk value[1 .. offset + skip_by];
-                }
-            }
-
-            // Fallback to scalar search.
-            for (value[offset..], 0..) |c, i| {
-                if (c == '"') {
-                    break :blk value[1 .. offset + i];
-                }
-            }
-
-            // No quote pairs, something is wrong.
-            return error.Invalid;
-        };
-
-        // Make sure we don't end up w/ empty buffer.
-        if (charset.len == 0) {
-            return error.Invalid;
-        }
-
-        return charset;
+        // No quotes.
+        return value;
     }
 
     pub fn parse(input: []u8) !Mime {

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -672,14 +672,14 @@ pub const Page = struct {
             log.debug(.http, "navigate first chunk", .{ .content_type = mime.content_type, .len = data.len });
 
             self.mode = switch (mime.content_type) {
-                .text_html => .{ .html = try parser.Parser.init(mime.charset orelse "UTF-8") },
+                .text_html => .{ .html = try parser.Parser.init(mime.charsetString()) },
 
                 .application_json,
                 .text_javascript,
                 .text_css,
                 .text_plain,
                 => blk: {
-                    var p = try parser.Parser.init(mime.charset orelse "UTF-8");
+                    var p = try parser.Parser.init(mime.charsetString());
                     try p.process("<html><head><meta charset=\"utf-8\"></head><body><pre>");
                     break :blk .{ .text = p };
                 },

--- a/src/browser/xhr/xhr.zig
+++ b/src/browser/xhr/xhr.zig
@@ -679,7 +679,7 @@ pub const XMLHttpRequest = struct {
         }
 
         var fbs = std.io.fixedBufferStream(self.response_bytes.items);
-        const doc = parser.documentHTMLParse(fbs.reader(), mime.charset orelse "UTF-8") catch {
+        const doc = parser.documentHTMLParse(fbs.reader(), mime.charsetString()) catch {
             self.response_obj = .{ .Failure = {} };
             return;
         };


### PR DESCRIPTION
`Mime` is changed to store the received charset value and use it as-is. We used to match the charset value for pre-known cases. Seem to be solving #1045.

As a follow-up commit, we can add support for charset value validation as specified in [RFC 2978](https://datatracker.ietf.org/doc/rfc2978/).