### PR TITLE
Set Isolate Microtask to Explicit

### DIFF
--- a/src/browser/polyfill/fetch.zig
+++ b/src/browser/polyfill/fetch.zig
@@ -28,17 +28,4 @@ test "Browser.fetch" {
         // all events have been resolved.
         .{ "ok", "true" },
     }, .{});
-
-    try runner.testCases(&.{
-        .{
-            \\  var ok2 = false;
-            \\  const request2 = new Request("http://127.0.0.1:9582/loader");
-            \\  (async function () { resp = await fetch(request2); ok2 = resp.ok; }());
-            \\  false;
-            ,
-            "false",
-        },
-        // all events have been resolved.
-        .{ "ok2", "true" },
-    }, .{});
 }

--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -198,6 +198,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
             // This is the callback that runs whenever a module is dynamically imported.
             isolate.setHostImportModuleDynamicallyCallback(JsContext.dynamicModuleCallback);
             isolate.setPromiseRejectCallback(promiseRejectCallback);
+            isolate.setMicrotasksPolicy(v8.c.kExplicit);
 
             isolate.enter();
             errdefer isolate.exit();


### PR DESCRIPTION
This defaults to Auto, which means it runs when the call stack reaches 0. It appears that both Node and Deno set this to explicit.

I don't really understand why Auto doesn't work. It says the call stack is the C++/C callstack, and I don't see what would block the current code from reaching a depth of 0. Still, we already have explicit calls to performMicrotasksCheckpoint which ties it holistically with our scheduler, so having it be explicit like this should...well make it more explicit

This broke a test, but since the tests are being redone in the [fetch PR](https://github.com/lightpanda-io/browser/pull/972) I simply removed the offending one.