### PR TITLE
Fix auth interception integer overflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -108,6 +108,15 @@ jobs:
           go run runner/main.go
           kill `cat LPD.pid` `cat PROXY.id`
 
+      - name: run request interception through proxy
+        run: |
+          export PROXY_USERNAME=username PROXY_PASSWORD=password
+          ./proxy/proxy & echo $! > PROXY.id
+          ./lightpanda serve & echo $! > LPD.pid
+          URL=https://demo-browser.lightpanda.io/campfire-commerce/ node puppeteer/proxy_auth.js
+          BASE_URL=https://demo-browser.lightpanda.io/ node playwright/proxy_auth.js
+          kill `cat LPD.pid` `cat PROXY.id`
+
   cdp-and-hyperfine-bench:
     name: cdp-and-hyperfine-bench
     needs: zig-build-release

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -820,6 +820,11 @@ pub const Transfer = struct {
     // abort. We don't call self.client.endTransfer here b/c it has been done
     // before interception process.
     pub fn abortAuthChallenge(self: *Transfer) void {
+        if (builtin.mode == .Debug) {
+            std.debug.assert(self._intercepted);
+        }
+        self.client.intercepted -= 1;
+        log.debug(.http, "abort auth transfer", .{ .intercepted = self.client.intercepted });
         self.client.requestFailed(self, error.AbortAuthChallenge);
         self.deinit();
     }

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -202,6 +202,7 @@ pub fn request(self: *Client, req: Request) !void {
         notification.dispatch(.http_request_intercept, &.{ .transfer = transfer, .wait_for_interception = &wait_for_interception });
         if (wait_for_interception) {
             self.intercepted += 1;
+            log.debug(.http, "wait for interception", .{ .intercepted = self.intercepted });
             if (builtin.mode == .Debug) {
                 transfer._intercepted = true;
             }
@@ -230,6 +231,7 @@ pub fn continueTransfer(self: *Client, transfer: *Transfer) !void {
         std.debug.assert(transfer._intercepted);
     }
     self.intercepted -= 1;
+    log.debug(.http, "continue transfer", .{ .intercepted = self.intercepted });
     return self.process(transfer);
 }
 
@@ -239,6 +241,7 @@ pub fn abortTransfer(self: *Client, transfer: *Transfer) void {
         std.debug.assert(transfer._intercepted);
     }
     self.intercepted -= 1;
+    log.debug(.http, "abort transfer", .{ .intercepted = self.intercepted });
     transfer.abort();
 }
 
@@ -248,6 +251,7 @@ pub fn fulfillTransfer(self: *Client, transfer: *Transfer, status: u16, headers:
         std.debug.assert(transfer._intercepted);
     }
     self.intercepted -= 1;
+    log.debug(.http, "filfull transfer", .{ .intercepted = self.intercepted });
     return transfer.fulfill(status, headers, body);
 }
 
@@ -440,6 +444,11 @@ fn processMessages(self: *Client) !void {
                     // In this case we ignore callbacks for now.
                     // Note: we don't deinit transfer on purpose: we want to keep
                     // using it for the following request.
+                    self.intercepted += 1;
+                    log.debug(.http, "wait for auth interception", .{ .intercepted = self.intercepted });
+                    if (builtin.mode == .Debug) {
+                        transfer._intercepted = true;
+                    }
                     self.endTransfer(transfer);
                     continue;
                 }


### PR DESCRIPTION
With proxy auth interception we had a crash (with puppeteer or playwright scenarios)

```
DEBUG cdp : request intercept . . . . . . . . . . . . . . . . [+2411ms]
      state = continue with auth
      id = 1
      response = ProvideCredentials

thread 173974 panic: integer overflow
/home/pierre/wrk/browser/src/http/Client.zig:233:22: 0x3268ee5 in continueTransfer (lightpanda)
    self.intercepted -= 1;
                     ^
/home/pierre/wrk/browser/src/cdp/domains/fetch.zig:316:52: 0x3269eba in continueWithAuth__anon_129776 (lightpanda)
    try bc.cdp.browser.http_client.continueTransfer(transfer);
                                                   ^
/home/pierre/wrk/browser/src/cdp/domains/fetch.zig:42:53: 0x31e5012 in processMessage__anon_114148 (lightpanda)
        .continueWithAuth => return continueWithAuth(cmd),
                                                    ^
/home/pierre/wrk/browser/src/cdp/cdp.zig:206:95: 0x31e4339 in dispatchCommand__anon_114026 (lightpanda)
                    asUint(u40, "Fetch") => return @import("domains/fetch.zig").processMessage(command),
                                                                                              ^
/home/pierre/wrk/browser/src/cdp/cdp.zig:164:32: 0x31e6b37 in dispatch__anon_113835 (lightpanda)
                dispatchCommand(&command, input.method) catch |err| {
                               ^
/home/pierre/wrk/browser/src/cdp/cdp.zig:112:33: 0x31e6f87 in processMessage (lightpanda)
            return self.dispatch(arena.allocator(), self, msg);
                                ^
/home/pierre/wrk/browser/src/cdp/cdp.zig:105:32: 0x316e497 in handleMessage (lightpanda)
            self.processMessage(msg) catch return false;
                               ^
/home/pierre/wrk/browser/src/server.zig:462:56: 0x316e36d in processWebsocketMessage (lightpanda)
                .text, .binary => if (cdp.handleMessage(msg.data) == false) {
                                                       ^
/home/pierre/wrk/browser/src/server.zig:256:63: 0x3182651 in processData (lightpanda)
            .cdp => |*cdp| return self.processWebsocketMessage(cdp),
                                                              ^
/home/pierre/wrk/browser/src/server.zig:245:32: 0x318281f in readSocket (lightpanda)
        return self.processData(n) catch false;
                               ^
/home/pierre/wrk/browser/src/server.zig:153:46: 0x3182d43 in readLoop (lightpanda)
                    if (try client.readSocket() == false) {
                                             ^
/home/pierre/wrk/browser/src/server.zig:111:26: 0x31839bc in run (lightpanda)
            self.readLoop(socket, timeout_ms) catch |err| {
                         ^
/home/pierre/wrk/browser/src/main.zig:142:23: 0x31be511 in run (lightpanda)
            server.run(address, timeout) catch |err| {
                      ^
/home/pierre/wrk/browser/src/main.zig:46:8: 0x31c01e3 in main (lightpanda)
    run(alloc) catch |err| {
       ^
/usr/local/zig-0.15.1/lib/std/start.zig:627:37: 0x31c09bd in main (lightpanda)
            const result = root.main() catch |err| {
                                    ^
../sysdeps/nptl/libc_start_call_main.h:58:16: 0x72165622a1c9 in __libc_start_call_main (../sysdeps/x86/libc-start.c)
../csu/libc-start.c:360:3: 0x72165622a28a in __libc_start_main_impl (../sysdeps/x86/libc-start.c)
???:?:?: 0x294c024 in ??? (???)
???:?:?: 0x0 in ??? (???)
run
└─ run exe lightpanda failure
error: the following command terminated unexpectedly:
./.zig-cache/o/84f9c4fd4a9a28567aebbb9f2fab8dec/lightpanda serve --port 9223 --http_proxy http://127.0.0.1:3000 --log_level debug
```