### PR TITLE
Relaxed `MessagePort.postMessage`

### DIFF
--- a/src/browser/dom/MessageChannel.zig
+++ b/src/browser/dom/MessageChannel.zig
@@ -94,7 +94,6 @@ pub const MessagePort = struct {
 
         if (opts_ != null) {
             log.warn(.web_api, "not implemented", .{ .feature = "MessagePort postMessage options" });
-            return error.NotImplemented;
         }
 
         try self.pair.dispatchOrQueue(obj, page.arena);


### PR DESCRIPTION
Removes error return in `postMessage`, we still missing the implementation for `transfer` & `options` but function seem to work for other cases.