### PR TITLE
Adds `Response.type`

### DIFF
--- a/src/runtime/js.zig
+++ b/src/runtime/js.zig
@@ -2843,7 +2843,7 @@ pub fn Env(comptime State: type, comptime WebApis: type) type {
 
             const T = @TypeOf(value);
             switch (@typeInfo(T)) {
-                .void, .bool, .int, .comptime_int, .float, .comptime_float, .@"enum" => {
+                .void, .bool, .int, .comptime_int, .float, .comptime_float, .@"enum", .null => {
                     // Need to do this to keep the compiler happy
                     // simpleZigValueToJs handles all of these cases.
                     unreachable;
@@ -3634,6 +3634,7 @@ fn jsUnsignedIntToZig(comptime T: type, max: comptime_int, maybe: u32) !T {
 fn simpleZigValueToJs(isolate: v8.Isolate, value: anytype, comptime fail: bool) if (fail) v8.Value else ?v8.Value {
     switch (@typeInfo(@TypeOf(value))) {
         .void => return v8.initUndefined(isolate).toValue(),
+        .null => return v8.initNull(isolate).toValue(),
         .bool => return v8.getValue(if (value) v8.initTrue(isolate) else v8.initFalse(isolate)),
         .int => |n| switch (n.signedness) {
             .signed => {

--- a/src/tests/fetch/response.html
+++ b/src/tests/fetch/response.html
@@ -25,6 +25,7 @@
   testing.expectEqual("no-cache", response2.headers.get("cache-control"));
         
   let response3 = new Response("Created", { status: 201, statusText: "Created" });
+  testing.expectEqual("basic", response3.type);
   testing.expectEqual(201, response3.status);
   testing.expectEqual("Created", response3.statusText);
   testing.expectEqual(true, response3.ok);


### PR DESCRIPTION
This adds `Response.type`, supporting most of the ResponseType values. It does not implement `.error` (because it seems to only be used in `Response.error()` which we don't support right now) and `.opaqueredirect` (because I don't currently track redirects in the fetch flow.