### PR TITLE
Replace --noscript with more advanced --strip_mode

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -181,7 +181,7 @@ pub const Page = struct {
         // set to include element shadowroots in the dump
         page: ?*const Page = null,
         with_base: bool = false,
-        exclude_scripts: bool = false,
+        strip_mode: Dump.Opts.StripMode = .{},
     };
 
     // dump writes the page content into the given file.
@@ -228,7 +228,7 @@ pub const Page = struct {
 
         try Dump.writeHTML(doc, .{
             .page = opts.page,
-            .exclude_scripts = opts.exclude_scripts,
+            .strip_mode = opts.strip_mode,
         }, out);
     }
 


### PR DESCRIPTION
--noscript is deprecated (warning) and automatically maps to --strip_mode js

--strip_mode takes a comma separated list of values. From the help:

- "js" script and link[as=script, rel=preload]
- "ui" includes img, picture, video, css and svg
- "css" includes style and link[rel=stylesheet]
- "full" includes js, ui and css

Maybe this is overkill, but i sometimes find myself looking --dump outputs over and over again, and removing noise (like HUGE svgs) seems like a small improvement.