### PR TITLE
Ensure extra_socket can't happen when exit_when_done == true

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -312,6 +312,12 @@ pub const Page = struct {
                     // mode with an extra socket. Either way, we're waiting
                     // for http traffic
                     if (try http_client.tick(ms_remaining) == .extra_socket) {
+                        // exit_when_done is explicitly set when there isn't
+                        // an extra socket, so it should not be possibl to
+                        // get an extra_socket message when exit_when_done
+                        // is true.
+                        std.debug.assert(exit_when_done == false);
+
                         // data on a socket we aren't handling, return to caller
                         return .extra_socket;
                     }


### PR DESCRIPTION
exit_when_done is pretty much a sneaky way to get CDP knowledge into the page. exit_when_done == true means "this isn't a CDP session".

extra_socket is another sneaky weay to get CDP knowledge into the page. When we get an `extra_socket` message it means "Return control to the CDP server".

Therefore it should be impossible to get an `extra_socket` message (return to CDP) when `exit_when_done == true` (this isn't a CDP session).