### PR TITLE
cdp: start nodeId from 1 instead of 0

### DIFF
--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -42,7 +42,7 @@ pub const Registry = struct {
 
     pub fn init(allocator: Allocator) Registry {
         return .{
-            .node_id = 0,
+            .node_id = 1,
             .lookup_by_id = .{},
             .lookup_by_node = .{},
             .allocator = allocator,
@@ -346,24 +346,24 @@ test "cdp Node: Registry register" {
     {
         const n = (try doc.querySelector("#a1")).?;
         const node = try registry.register(n);
-        const n1b = registry.lookup_by_id.get(0).?;
-        const n1c = registry.lookup_by_node.get(node._node).?;
-        try testing.expectEqual(node, n1b);
-        try testing.expectEqual(node, n1c);
-
-        try testing.expectEqual(0, node.id);
-        try testing.expectEqual(n, node._node);
-    }
-
-    {
-        const n = (try doc.querySelector("p")).?;
-        const node = try registry.register(n);
         const n1b = registry.lookup_by_id.get(1).?;
         const n1c = registry.lookup_by_node.get(node._node).?;
         try testing.expectEqual(node, n1b);
         try testing.expectEqual(node, n1c);
 
         try testing.expectEqual(1, node.id);
+        try testing.expectEqual(n, node._node);
+    }
+
+    {
+        const n = (try doc.querySelector("p")).?;
+        const node = try registry.register(n);
+        const n1b = registry.lookup_by_id.get(2).?;
+        const n1c = registry.lookup_by_node.get(node._node).?;
+        try testing.expectEqual(node, n1b);
+        try testing.expectEqual(node, n1c);
+
+        try testing.expectEqual(2, node.id);
         try testing.expectEqual(n, node._node);
     }
 }
@@ -404,18 +404,18 @@ test "cdp Node: search list" {
 
         const s1 = try search_list.create(try doc.querySelectorAll("a"));
         try testing.expectEqual("1", s1.name);
-        try testing.expectEqualSlices(u32, &.{ 0, 1 }, s1.node_ids);
+        try testing.expectEqualSlices(u32, &.{ 1, 2 }, s1.node_ids);
 
         try testing.expectEqual(2, registry.lookup_by_id.count());
         try testing.expectEqual(2, registry.lookup_by_node.count());
 
         const s2 = try search_list.create(try doc.querySelectorAll("#a1"));
         try testing.expectEqual("2", s2.name);
-        try testing.expectEqualSlices(u32, &.{0}, s2.node_ids);
+        try testing.expectEqualSlices(u32, &.{1}, s2.node_ids);
 
         const s3 = try search_list.create(try doc.querySelectorAll("#a2"));
         try testing.expectEqual("3", s3.name);
-        try testing.expectEqualSlices(u32, &.{1}, s3.node_ids);
+        try testing.expectEqualSlices(u32, &.{2}, s3.node_ids);
 
         try testing.expectEqual(2, registry.lookup_by_id.count());
         try testing.expectEqual(2, registry.lookup_by_node.count());
@@ -443,8 +443,8 @@ test "cdp Node: Writer" {
         defer testing.allocator.free(json);
 
         try testing.expectJson(.{
-            .nodeId = 0,
-            .backendNodeId = 0,
+            .nodeId = 1,
+            .backendNodeId = 1,
             .nodeType = 9,
             .nodeName = "#document",
             .localName = "",
@@ -456,8 +456,8 @@ test "cdp Node: Writer" {
             .compatibilityMode = "NoQuirksMode",
             .childNodeCount = 1,
             .children = &.{.{
-                .nodeId = 1,
-                .backendNodeId = 1,
+                .nodeId = 2,
+                .backendNodeId = 2,
                 .nodeType = 1,
                 .nodeName = "HTML",
                 .localName = "html",
@@ -473,7 +473,7 @@ test "cdp Node: Writer" {
     }
 
     {
-        const node = registry.lookup_by_id.get(1).?;
+        const node = registry.lookup_by_id.get(2).?;
         const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
             .root = node,
             .depth = 1,
@@ -483,8 +483,8 @@ test "cdp Node: Writer" {
         defer testing.allocator.free(json);
 
         try testing.expectJson(.{
-            .nodeId = 1,
-            .backendNodeId = 1,
+            .nodeId = 2,
+            .backendNodeId = 2,
             .nodeType = 1,
             .nodeName = "HTML",
             .localName = "html",
@@ -496,8 +496,8 @@ test "cdp Node: Writer" {
             .compatibilityMode = "NoQuirksMode",
             .isScrollable = false,
             .children = &.{ .{
-                .nodeId = 2,
-                .backendNodeId = 2,
+                .nodeId = 3,
+                .backendNodeId = 3,
                 .nodeType = 1,
                 .nodeName = "HEAD",
                 .localName = "head",
@@ -508,10 +508,10 @@ test "cdp Node: Writer" {
                 .xmlVersion = "",
                 .compatibilityMode = "NoQuirksMode",
                 .isScrollable = false,
-                .parentId = 1,
+                .parentId = 2,
             }, .{
-                .nodeId = 3,
-                .backendNodeId = 3,
+                .nodeId = 4,
+                .backendNodeId = 4,
                 .nodeType = 1,
                 .nodeName = "BODY",
                 .localName = "body",
@@ -522,13 +522,13 @@ test "cdp Node: Writer" {
                 .xmlVersion = "",
                 .compatibilityMode = "NoQuirksMode",
                 .isScrollable = false,
-                .parentId = 1,
+                .parentId = 2,
             } },
         }, json);
     }
 
     {
-        const node = registry.lookup_by_id.get(1).?;
+        const node = registry.lookup_by_id.get(2).?;
         const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
             .root = node,
             .depth = -1,
@@ -538,8 +538,8 @@ test "cdp Node: Writer" {
         defer testing.allocator.free(json);
 
         try testing.expectJson(&.{ .{
-            .nodeId = 2,
-            .backendNodeId = 2,
+            .nodeId = 3,
+            .backendNodeId = 3,
             .nodeType = 1,
             .nodeName = "HEAD",
             .localName = "head",
@@ -550,10 +550,10 @@ test "cdp Node: Writer" {
             .xmlVersion = "",
             .compatibilityMode = "NoQuirksMode",
             .isScrollable = false,
-            .parentId = 1,
+            .parentId = 2,
         }, .{
-            .nodeId = 3,
-            .backendNodeId = 3,
+            .nodeId = 4,
+            .backendNodeId = 4,
             .nodeType = 1,
             .nodeName = "BODY",
             .localName = "body",
@@ -565,20 +565,20 @@ test "cdp Node: Writer" {
             .compatibilityMode = "NoQuirksMode",
             .isScrollable = false,
             .children = &.{ .{
-                .nodeId = 4,
+                .nodeId = 5,
                 .localName = "a",
                 .childNodeCount = 0,
-                .parentId = 3,
+                .parentId = 4,
             }, .{
-                .nodeId = 5,
+                .nodeId = 6,
                 .localName = "div",
                 .childNodeCount = 1,
-                .parentId = 3,
+                .parentId = 4,
                 .children = &.{.{
-                    .nodeId = 6,
+                    .nodeId = 7,
                     .localName = "a",
                     .childNodeCount = 0,
-                    .parentId = 5,
+                    .parentId = 6,
                 }},
             } },
         } }, json);

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -527,7 +527,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{ 0, 1 } }, .{ .id = 13 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{ 1, 2 } }, .{ .id = 13 });
 
         // different fromIndex
         try ctx.processMessage(.{
@@ -535,7 +535,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 1, .toIndex = 2 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 14 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{2} }, .{ .id = 14 });
 
         // different toIndex
         try ctx.processMessage(.{
@@ -543,7 +543,7 @@ test "cdp.dom: search flow" {
             .method = "DOM.getSearchResults",
             .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 1 },
         });
-        try ctx.expectSentResult(.{ .nodeIds = &.{0} }, .{ .id = 15 });
+        try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 15 });
     }
 
     try ctx.processMessage(.{
@@ -588,7 +588,7 @@ test "cdp.dom: querySelector Node not found" {
 
     _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .html = "<p>1</p> <p>2</p>" });
 
-    try ctx.processMessage(.{ // Hacky way to make sure nodeId 0 exists in the registry
+    try ctx.processMessage(.{ // Hacky way to make sure nodeId 1 exists in the registry
         .id = 3,
         .method = "DOM.performSearch",
         .params = .{ .query = "p" },
@@ -598,13 +598,13 @@ test "cdp.dom: querySelector Node not found" {
     try testing.expectError(error.NodeNotFoundForGivenId, ctx.processMessage(.{
         .id = 4,
         .method = "DOM.querySelector",
-        .params = .{ .nodeId = 0, .selector = "a" },
+        .params = .{ .nodeId = 1, .selector = "a" },
     }));
 
     try ctx.processMessage(.{
         .id = 5,
         .method = "DOM.querySelectorAll",
-        .params = .{ .nodeId = 0, .selector = "a" },
+        .params = .{ .nodeId = 1, .selector = "a" },
     });
     try ctx.expectSentResult(.{ .nodeIds = &[_]u32{} }, .{ .id = 5 });
 }
@@ -615,7 +615,7 @@ test "cdp.dom: querySelector Nodes found" {
 
     _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .html = "<div><p>2</p></div>" });
 
-    try ctx.processMessage(.{ // Hacky way to make sure nodeId 0 exists in the registry
+    try ctx.processMessage(.{ // Hacky way to make sure nodeId 1 exists in the registry
         .id = 3,
         .method = "DOM.performSearch",
         .params = .{ .query = "div" },
@@ -625,18 +625,18 @@ test "cdp.dom: querySelector Nodes found" {
     try ctx.processMessage(.{
         .id = 4,
         .method = "DOM.querySelector",
-        .params = .{ .nodeId = 0, .selector = "p" },
+        .params = .{ .nodeId = 1, .selector = "p" },
     });
     try ctx.expectSentEvent("DOM.setChildNodes", null, .{});
-    try ctx.expectSentResult(.{ .nodeId = 5 }, .{ .id = 4 });
+    try ctx.expectSentResult(.{ .nodeId = 6 }, .{ .id = 4 });
 
     try ctx.processMessage(.{
         .id = 5,
         .method = "DOM.querySelectorAll",
-        .params = .{ .nodeId = 0, .selector = "p" },
+        .params = .{ .nodeId = 1, .selector = "p" },
     });
     try ctx.expectSentEvent("DOM.setChildNodes", null, .{});
-    try ctx.expectSentResult(.{ .nodeIds = &.{5} }, .{ .id = 5 });
+    try ctx.expectSentResult(.{ .nodeIds = &.{6} }, .{ .id = 5 });
 }
 
 test "cdp.dom: getBoxModel" {
@@ -645,7 +645,7 @@ test "cdp.dom: getBoxModel" {
 
     _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .html = "<div><p>2</p></div>" });
 
-    try ctx.processMessage(.{ // Hacky way to make sure nodeId 0 exists in the registry
+    try ctx.processMessage(.{ // Hacky way to make sure nodeId 1 exists in the registry
         .id = 3,
         .method = "DOM.getDocument",
     });
@@ -653,14 +653,14 @@ test "cdp.dom: getBoxModel" {
     try ctx.processMessage(.{
         .id = 4,
         .method = "DOM.querySelector",
-        .params = .{ .nodeId = 0, .selector = "p" },
+        .params = .{ .nodeId = 1, .selector = "p" },
     });
-    try ctx.expectSentResult(.{ .nodeId = 2 }, .{ .id = 4 });
+    try ctx.expectSentResult(.{ .nodeId = 3 }, .{ .id = 4 });
 
     try ctx.processMessage(.{
         .id = 5,
         .method = "DOM.getBoxModel",
-        .params = .{ .nodeId = 5 },
+        .params = .{ .nodeId = 6 },
     });
     try ctx.expectSentResult(.{ .model = BoxModel{
         .content = Quad{ 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0 },


### PR DESCRIPTION
chromedp expects the nodeId starts to 1.
A start to 0 make it enter in infinite loop b/c it expects the Go's default int, ie 0, to be nil from a map to stop the loop. If the 0 index is set, it will loop...