### PR TITLE
Support `Element#insertAdjacentHTML`

### DIFF
--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -273,12 +273,22 @@ pub const Element = struct {
             if (std.mem.eql(u8, position, "beforebegin")) {
                 // The node must have a parent node in order to use this variant.
                 const parent = parser.nodeParentNode(self_node) orelse return error.NoModificationAllowed;
+                // Parent cannot be Document.
+                // Should have checks for document_fragment and document_type?
+                if (parser.nodeType(parent) == .document) {
+                    return error.NoModificationAllowed;
+                }
+
                 break :blk .{ parent, self_node };
             }
 
             if (std.mem.eql(u8, position, "afterend")) {
                 // The node must have a parent node in order to use this variant.
                 const parent = parser.nodeParentNode(self_node) orelse return error.NoModificationAllowed;
+                // Parent cannot be Document.
+                if (parser.nodeType(parent) == .document) {
+                    return error.NoModificationAllowed;
+                }
                 // Get the next sibling or null; null indicates our node is the only one.
                 const sibling = parser.nodeNextSibling(self_node);
                 break :blk .{ parent, sibling };

--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -251,11 +251,11 @@ pub const Element = struct {
         // None of the following can be null.
         const maybe_html = parser.nodeFirstChild(fragment_node);
         std.debug.assert(maybe_html != null);
-        const html = maybe_html.?;
+        const html = maybe_html orelse return;
 
         const maybe_body = parser.nodeLastChild(html);
         std.debug.assert(maybe_body != null);
-        const body = maybe_body.?;
+        const body = maybe_body orelse return;
 
         const children = try parser.nodeGetChildNodes(body);
 

--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -231,7 +231,7 @@ pub const Element = struct {
         }
     }
 
-    /// Parses the given `input` string and inserts it's children to an element at given `position`.
+    /// Parses the given `input` string and inserts its children to an element at given `position`.
     /// https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML
     ///
     /// TODO: Support for XML parsing and `TrustedHTML` instances.

--- a/src/browser/dom/element.zig
+++ b/src/browser/dom/element.zig
@@ -249,8 +249,13 @@ pub const Element = struct {
         // We always get it wrapped like so:
         // <html><head></head><body>{ ... }</body></html>
         // None of the following can be null.
-        const html = parser.nodeFirstChild(fragment_node).?;
-        const body = parser.nodeLastChild(html).?;
+        const maybe_html = parser.nodeFirstChild(fragment_node);
+        std.debug.assert(maybe_html != null);
+        const html = maybe_html.?;
+
+        const maybe_body = parser.nodeLastChild(html);
+        std.debug.assert(maybe_body != null);
+        const body = maybe_body.?;
 
         const children = try parser.nodeGetChildNodes(body);
 

--- a/src/browser/netsurf.zig
+++ b/src/browser/netsurf.zig
@@ -1363,7 +1363,7 @@ pub fn nodeHasChildNodes(node: *Node) bool {
     return res;
 }
 
-pub fn nodeInsertBefore(node: *Node, new_node: *Node, ref_node: *Node) !*Node {
+pub fn nodeInsertBefore(node: *Node, new_node: *Node, ref_node: ?*Node) !*Node {
     var res: ?*Node = null;
     const err = nodeVtable(node).dom_node_insert_before.?(node, new_node, ref_node, &res);
     try DOMErr(err);

--- a/src/tests/dom/element.html
+++ b/src/tests/dom/element.html
@@ -290,16 +290,39 @@
   testing.expectEqual("stylesheet", linkElement.rel);
 </script>
 
+<!-- This structure will get mutated by insertAdjacentHTML test -->
+<div id="insert-adjacent-html-outer-wrapper">
+    <div id="insert-adjacent-html-inner-wrapper">
+        <span></span>
+        <p>content</p>
+    </div>
+</div>
+
 <script id=insertAdjacentHTML>
-  const el4 = document.createElement("div");
+  // Insert "beforeend".
+  const wrapper = document.querySelector("div#insert-adjacent-html-inner-wrapper");
+  wrapper.insertAdjacentHTML("beforeend", "<h1>title</h1>");
+  let newElement = wrapper.lastElementChild;
+  testing.expectEqual("H1", newElement.tagName);
+  testing.expectEqual("title", newElement.innerText);
 
-  const el5 = document.createElement("span");
-  el4.appendChild(el5);
+  // Insert "beforebegin".
+  wrapper.insertAdjacentHTML("beforebegin", "<h2>small title</h2>");
+  newElement = wrapper.previousElementSibling;
+  testing.expectEqual("H2", newElement.tagName);
+  testing.expectEqual("small title", newElement.innerText);
 
-  const el6 = document.createElement("p");
-  el6.innerText = "content";
-  el4.appendChild(el6);
+  // Insert "afterend".
+  wrapper.insertAdjacentHTML("afterend", "<div id=\"afterend\">after end</div>");
+  newElement = wrapper.nextElementSibling;
+  testing.expectEqual("DIV", newElement.tagName);
+  testing.expectEqual("after end", newElement.innerText);
+  testing.expectEqual("afterend", newElement.id);
 
-  el5.insertAdjacentHTML("beforebegin", "<h1>title</h1>");
-  testing.expectEqual("<h1>title</h1><span></span><p>content</p>", el4.innerHTML);
+  // Insert "afterbegin".
+  wrapper.insertAdjacentHTML("afterbegin", "<div class=\"afterbegin\">after begin</div><yy></yy>");
+  newElement = wrapper.firstElementChild;
+  testing.expectEqual("DIV", newElement.tagName);
+  testing.expectEqual("after begin", newElement.innerText);
+  testing.expectEqual("afterbegin", newElement.className);
 </script>

--- a/src/tests/dom/element.html
+++ b/src/tests/dom/element.html
@@ -300,7 +300,7 @@
 
 <script id=insertAdjacentHTML>
   // Insert "beforeend".
-  const wrapper = document.querySelector("div#insert-adjacent-html-inner-wrapper");
+  const wrapper = $("#insert-adjacent-html-inner-wrapper");
   wrapper.insertAdjacentHTML("beforeend", "<h1>title</h1>");
   let newElement = wrapper.lastElementChild;
   testing.expectEqual("H1", newElement.tagName);

--- a/src/tests/dom/element.html
+++ b/src/tests/dom/element.html
@@ -289,3 +289,17 @@
   linkElement.rel = "stylesheet";
   testing.expectEqual("stylesheet", linkElement.rel);
 </script>
+
+<script id=insertAdjacentHTML>
+  const el4 = document.createElement("div");
+
+  const el5 = document.createElement("span");
+  el4.appendChild(el5);
+
+  const el6 = document.createElement("p");
+  el6.innerText = "content";
+  el4.appendChild(el6);
+
+  el5.insertAdjacentHTML("beforebegin", "<h1>title</h1>");
+  testing.expectEqual("<h1>title</h1><span></span><p>content</p>", el4.innerHTML);
+</script>


### PR DESCRIPTION
This PR adds support for `insertAdjacentHTML`. It currently missing XML parsing and `TrustedHTML` support, yet sites seem to prefer HTML and string variant only.