### PR TITLE
Replace HTMLCollection postAttach's with indexed/named getter

### DIFF
--- a/src/tests/html/select.html
+++ b/src/tests/html/select.html
@@ -55,6 +55,7 @@
   o3.value = 'o3';
   options.add(o3)
   testing.expectEqual(3, options.length);
+  testing.expectEqual('o3', options[2].value);
   testing.expectEqual('o3', options.item(2).value);
 
   let o4 = document.createElement('option');
@@ -71,5 +72,9 @@
 
   options.remove(3)
   testing.expectEqual(4, options.length);
+  testing.expectEqual('o3', options[3].value);
   testing.expectEqual('o3', options.item(3).value);
+
+  testing.expectEqual(undefined, options[10]);
+  testing.expectEqual(null, options.item(10));
 </script>


### PR DESCRIPTION
This solves two issues. First, it's more correct, the indexers should be live. Second, it makes sure that anything with an HTMLCollection prototype, like HTMLOptionsCollection, also gets access to the index getters.

We could solve the 2nd issue by making `postAttach` work up the prototype chain, but since postAttach is wrong (not live), I prefer this solution.