### PR TITLE
Better support for Uint8Array in ReadableStream

### DIFF
--- a/src/browser/fetch/Request.zig
+++ b/src/browser/fetch/Request.zig
@@ -181,7 +181,7 @@ pub fn constructor(input: RequestInput, _options: ?RequestInit, page: *Page) !Re
 pub fn get_body(self: *const Request, page: *Page) !?*ReadableStream {
     if (self.body) |body| {
         const stream = try ReadableStream.constructor(null, null, page);
-        try stream.queue.append(page.arena, body);
+        try stream.queue.append(page.arena, .{ .string = body });
         return stream;
     } else return null;
 }

--- a/src/browser/fetch/Response.zig
+++ b/src/browser/fetch/Response.zig
@@ -109,7 +109,7 @@ pub fn constructor(_input: ?ResponseBody, _options: ?ResponseOptions, page: *Pag
 pub fn get_body(self: *const Response, page: *Page) !*ReadableStream {
     const stream = try ReadableStream.constructor(null, null, page);
     if (self.body) |body| {
-        try stream.queue.append(page.arena, body);
+        try stream.queue.append(page.arena, .{ .string = body });
     }
     return stream;
 }

--- a/src/browser/streams/ReadableStreamDefaultController.zig
+++ b/src/browser/streams/ReadableStreamDefaultController.zig
@@ -51,17 +51,17 @@ pub fn _close(self: *ReadableStreamDefaultController, _reason: ?[]const u8, page
     // to discard, must use cancel.
 }
 
-pub fn _enqueue(self: *ReadableStreamDefaultController, chunk: []const u8, page: *Page) !void {
+pub fn _enqueue(self: *ReadableStreamDefaultController, chunk: ReadableStream.Chunk, page: *Page) !void {
     const stream = self.stream;
 
     if (stream.state != .readable) {
         return error.TypeError;
     }
 
-    const duped_chunk = try page.arena.dupe(u8, chunk);
+    const duped_chunk = try chunk.dupe(page.arena);
 
     if (self.stream.reader_resolver) |*rr| {
-        try rr.resolve(ReadableStreamReadResult{ .value = .{ .data = duped_chunk }, .done = false });
+        try rr.resolve(ReadableStreamReadResult.init(duped_chunk, false));
         self.stream.reader_resolver = null;
     }
 

--- a/src/browser/streams/ReadableStreamDefaultReader.zig
+++ b/src/browser/streams/ReadableStreamDefaultReader.zig
@@ -49,7 +49,7 @@ pub fn _read(self: *const ReadableStreamDefaultReader, page: *Page) !Env.Promise
                 const data = self.stream.queue.orderedRemove(0);
                 const resolver = page.main_context.createPromiseResolver();
 
-                try resolver.resolve(ReadableStreamReadResult{ .value = .{ .data = data }, .done = false });
+                try resolver.resolve(ReadableStreamReadResult.init(data, false));
                 try self.stream.pullIf();
                 return resolver.promise();
             } else {
@@ -67,9 +67,9 @@ pub fn _read(self: *const ReadableStreamDefaultReader, page: *Page) !Env.Promise
 
             if (stream.queue.items.len > 0) {
                 const data = self.stream.queue.orderedRemove(0);
-                try resolver.resolve(ReadableStreamReadResult{ .value = .{ .data = data }, .done = false });
+                try resolver.resolve(ReadableStreamReadResult.init(data, false));
             } else {
-                try resolver.resolve(ReadableStreamReadResult{ .value = .empty, .done = true });
+                try resolver.resolve(ReadableStreamReadResult{ .done = true });
             }
 
             return resolver.promise();

--- a/src/tests/streams/readable_stream.html
+++ b/src/tests/streams/readable_stream.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <script src="../testing.js"></script>
 
 <script id=readable_stream>
@@ -13,6 +14,22 @@
 
   testing.async(reader.read(), (data) => {
     testing.expectEqual("hello", data.value);
+    testing.expectEqual(false, data.done);
+  });
+</script>
+
+<script id=readable_stream_binary>
+  const input = new TextEncoder().encode('over 9000!');
+  const binStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(input);
+      controller.enqueue("world");
+      controller.close();
+    }
+  });
+
+  testing.async(binStream.getReader().read(), (data) => {
+    testing.expectEqual(input, data.value);
     testing.expectEqual(false, data.done);
   });
 </script>


### PR DESCRIPTION
There's always going to be ambiguity between a string and a Uint8Array. We already had TypedArray(u8) as a discriminator when _returning_ values. But now the type is also used by mapping JS values to Zig. To support this efficiently when probing the union, the typed array mapping logic was extracted into its own function (so that it can be used by the probe).