### PR TITLE
Fixes a 'leak' with telemetry

### DIFF
--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -76,6 +76,7 @@ pub const LightPanda = struct {
 
     fn run(self: *LightPanda) void {
         var aw = std.Io.Writer.Allocating.init(self.allocator);
+        defer aw.deinit();
 
         var batch: [MAX_BATCH_SIZE]*LightPandaEvent = undefined;
         self.mutex.lock();


### PR DESCRIPTION
This isn't a "real" leak...it's just a missing deinit on exit...so the OS would reclaim the memory anyways. But I rather be explicit.