### PR TITLE
Small URL & Location changes

### DIFF
--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -281,7 +281,7 @@ pub const HTMLAnchorElement = struct {
     // TODO return a disposable string
     pub fn get_protocol(self: *parser.Anchor, page: *Page) ![]const u8 {
         var u = try url(self, page);
-        return u.get_protocol(page);
+        return u.get_protocol();
     }
 
     pub fn set_protocol(self: *parser.Anchor, v: []const u8, page: *Page) !void {

--- a/src/browser/html/location.zig
+++ b/src/browser/html/location.zig
@@ -29,6 +29,10 @@ pub const Location = struct {
         return "";
     }
 
+    pub fn set_href(_: *const Location, href: []const u8, page: *Page) !void {
+        return page.navigate(href, .{ .reason = .script });
+    }
+
     pub fn get_protocol(self: *Location) []const u8 {
         if (self.url) |*u| return u.get_protocol();
         return "";

--- a/src/browser/html/location.zig
+++ b/src/browser/html/location.zig
@@ -29,8 +29,8 @@ pub const Location = struct {
         return "";
     }
 
-    pub fn get_protocol(self: *Location, page: *Page) ![]const u8 {
-        if (self.url) |*u| return u.get_protocol(page);
+    pub fn get_protocol(self: *Location) []const u8 {
+        if (self.url) |*u| return u.get_protocol();
         return "";
     }
 

--- a/src/browser/url/url.zig
+++ b/src/browser/url/url.zig
@@ -160,8 +160,11 @@ pub const URL = struct {
         return aw.written();
     }
 
-    pub fn get_protocol(self: *URL, page: *Page) ![]const u8 {
-        return try std.mem.concat(page.arena, u8, &[_][]const u8{ self.uri.scheme, ":" });
+    pub fn get_protocol(self: *const URL) []const u8 {
+        // std.Uri keeps a pointer to "https", "http" (scheme part) so we know
+        // its followed by ':'.
+        const scheme = self.uri.scheme;
+        return scheme.ptr[0 .. scheme.len + 1];
     }
 
     pub fn get_username(self: *URL) []const u8 {

--- a/src/tests/url/url.html
+++ b/src/tests/url/url.html
@@ -76,3 +76,8 @@
   testing.expectEqual("", sk.hostname);
   testing.expectEqual("sveltekit-internal://", sk.href);
 </script>
+
+<script id=invalidUrl>
+  let u = new URL("://foo.bar/path?query#fragment");
+  testing.expectEqual(":", u.protocol);
+</script>


### PR DESCRIPTION
This PR;
* adds `href` setter to location,
* removes allocation for `protocol` getter of url,
* adds an invalid (which should not be passing) URL test.