### PR TITLE
This is the last of the big changes to the js code

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -663,7 +663,7 @@ const Script = struct {
             .cacheable = cacheable,
         });
 
-        const js_context = page.main_context;
+        const js_context = page.js;
         var try_catch: js.TryCatch = undefined;
         try_catch.init(js_context);
         defer try_catch.deinit();
@@ -707,10 +707,10 @@ const Script = struct {
         switch (callback) {
             .string => |str| {
                 var try_catch: js.TryCatch = undefined;
-                try_catch.init(page.main_context);
+                try_catch.init(page.js);
                 defer try_catch.deinit();
 
-                _ = page.main_context.exec(str, typ) catch |err| {
+                _ = page.js.exec(str, typ) catch |err| {
                     const msg = try_catch.err(page.arena) catch @errorName(err) orelse "unknown";
                     log.warn(.user_script, "script callback", .{
                         .url = self.url,

--- a/src/browser/cssom/CSSStyleSheet.zig
+++ b/src/browser/cssom/CSSStyleSheet.zig
@@ -79,9 +79,7 @@ pub fn _replace(self: *CSSStyleSheet, text: []const u8, page: *Page) !js.Promise
     // TODO: clear self.css_rules
     // parse text and re-populate self.css_rules
 
-    const resolver = page.main_context.createPromiseResolver();
-    try resolver.resolve({});
-    return resolver.promise();
+    return page.js.resolvePromise({});
 }
 
 pub fn _replaceSync(self: *CSSStyleSheet, text: []const u8) !void {

--- a/src/browser/dom/Animation.zig
+++ b/src/browser/dom/Animation.zig
@@ -49,7 +49,7 @@ pub fn get_pending(self: *const Animation) bool {
 
 pub fn get_finished(self: *Animation, page: *Page) !js.Promise {
     if (self.finished_resolver == null) {
-        const resolver = page.main_context.createPromiseResolver();
+        const resolver = page.js.createPromiseResolver(.none);
         try resolver.resolve(self);
         self.finished_resolver = resolver;
     }
@@ -59,7 +59,7 @@ pub fn get_finished(self: *Animation, page: *Page) !js.Promise {
 pub fn get_ready(self: *Animation, page: *Page) !js.Promise {
     // never resolved, because we're always "finished"
     if (self.ready_resolver == null) {
-        const resolver = page.main_context.createPromiseResolver();
+        const resolver = page.js.createPromiseResolver(.none);
         self.ready_resolver = resolver;
     }
     return self.ready_resolver.?.promise();

--- a/src/browser/dom/document.zig
+++ b/src/browser/dom/document.zig
@@ -304,7 +304,7 @@ pub const Document = struct {
             return obj;
         }
 
-        const obj = try page.main_context.newArray(0).persist();
+        const obj = try page.js.createArray(0).persist();
         state.adopted_style_sheets = obj;
         return obj;
     }

--- a/src/browser/dom/shadow_root.zig
+++ b/src/browser/dom/shadow_root.zig
@@ -50,7 +50,7 @@ pub const ShadowRoot = struct {
             return obj;
         }
 
-        const obj = try page.main_context.newArray(0).persist();
+        const obj = try page.js.createArray(0).persist();
         self.adopted_style_sheets = obj;
         return obj;
     }

--- a/src/browser/fetch/Headers.zig
+++ b/src/browser/fetch/Headers.zig
@@ -24,7 +24,6 @@ const Page = @import("../page.zig").Page;
 
 const iterator = @import("../iterator/iterator.zig");
 
-const v8 = @import("v8");
 // https://developer.mozilla.org/en-US/docs/Web/API/Headers
 const Headers = @This();
 

--- a/src/browser/fetch/Request.zig
+++ b/src/browser/fetch/Request.zig
@@ -27,8 +27,6 @@ const Response = @import("./Response.zig");
 const Http = @import("../../http/Http.zig");
 const ReadableStream = @import("../streams/ReadableStream.zig");
 
-const v8 = @import("v8");
-
 const Headers = @import("Headers.zig");
 const HeadersInit = @import("Headers.zig").HeadersInit;
 
@@ -245,20 +243,15 @@ pub fn _bytes(self: *Response, page: *Page) !js.Promise {
     if (self.body_used) {
         return error.TypeError;
     }
-
-    const resolver = page.main_context.createPromiseResolver();
-
-    try resolver.resolve(self.body);
     self.body_used = true;
-    return resolver.promise();
+    return page.js.resolvePromise(self.body);
 }
 
 pub fn _json(self: *Response, page: *Page) !js.Promise {
     if (self.body_used) {
         return error.TypeError;
     }
-
-    const resolver = page.main_context.createPromiseResolver();
+    self.body_used = true;
 
     if (self.body) |body| {
         const p = std.json.parseFromSliceLeaky(
@@ -271,25 +264,17 @@ pub fn _json(self: *Response, page: *Page) !js.Promise {
             return error.SyntaxError;
         };
 
-        try resolver.resolve(p);
-    } else {
-        try resolver.resolve(null);
+        return page.js.resolvePromise(p);
     }
-
-    self.body_used = true;
-    return resolver.promise();
+    return page.js.resolvePromise(null);
 }
 
 pub fn _text(self: *Response, page: *Page) !js.Promise {
     if (self.body_used) {
         return error.TypeError;
     }
-
-    const resolver = page.main_context.createPromiseResolver();
-
-    try resolver.resolve(self.body);
     self.body_used = true;
-    return resolver.promise();
+    return page.js.resolvePromise(self.body);
 }
 
 const testing = @import("../../testing.zig");

--- a/src/browser/fetch/fetch.zig
+++ b/src/browser/fetch/fetch.zig
@@ -131,7 +131,7 @@ pub fn fetch(input: RequestInput, options: ?RequestInit, page: *Page) !js.Promis
 
     try page.requestCookie(.{}).headersForRequest(arena, req.url, &headers);
 
-    const resolver = try page.main_context.createPersistentPromiseResolver(.page);
+    const resolver = try page.js.createPromiseResolver(.page);
 
     const fetch_ctx = try arena.create(FetchContext);
     fetch_ctx.* = .{

--- a/src/browser/html/AbortController.zig
+++ b/src/browser/html/AbortController.zig
@@ -118,7 +118,7 @@ pub const AbortSignal = struct {
     };
     pub fn _throwIfAborted(self: *const AbortSignal, page: *Page) ThrowIfAborted {
         if (self.aborted) {
-            const ex = page.main_context.throw(self.reason orelse DEFAULT_REASON);
+            const ex = page.js.throw(self.reason orelse DEFAULT_REASON);
             return .{ .exception = ex };
         }
         return .{ .undefined = {} };

--- a/src/browser/html/History.zig
+++ b/src/browser/html/History.zig
@@ -71,7 +71,7 @@ pub fn get_state(self: *History, page: *Page) !?js.Value {
     if (self.current) |curr| {
         const entry = self.stack.items[curr];
         if (entry.state) |state| {
-            const value = try js.Value.fromJson(page.main_context, state);
+            const value = try js.Value.fromJson(page.js, state);
             return value;
         } else {
             return null;
@@ -201,7 +201,7 @@ pub const PopStateEvent = struct {
 
     pub fn get_state(self: *const PopStateEvent, page: *Page) !?js.Value {
         if (self.state) |state| {
-            const value = try js.Value.fromJson(page.main_context, state);
+            const value = try js.Value.fromJson(page.js, state);
             return value;
         } else {
             return null;

--- a/src/browser/html/window.zig
+++ b/src/browser/html/window.zig
@@ -37,7 +37,6 @@ const domcss = @import("../dom/css.zig");
 const Css = @import("../css/css.zig").Css;
 const EventHandler = @import("../events/event.zig").EventHandler;
 
-const v8 = @import("v8");
 const Request = @import("../fetch/Request.zig");
 const fetchFn = @import("../fetch/fetch.zig").fetch;
 

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -22,7 +22,7 @@ pub const Result = struct {
 
 pub fn getName(self: *const Function, allocator: Allocator) ![]const u8 {
     const name = self.func.castToFunction().getName();
-    return js.valueToString(allocator, name, self.context.isolate, self.context.v8_context);
+    return self.context.valueToString(name, .{ .allocator = allocator });
 }
 
 pub fn setName(self: *const Function, name: []const u8) void {

--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -80,7 +80,7 @@ pub fn contextCreated(
 // we'll create it and track it for cleanup when the context ends.
 pub fn getRemoteObject(
     self: *const Inspector,
-    context: *const Context,
+    context: *Context,
     group: []const u8,
     value: anytype,
 ) !RemoteObject {

--- a/src/browser/js/This.zig
+++ b/src/browser/js/This.zig
@@ -23,7 +23,3 @@ pub fn setIndex(self: This, index: u32, value: anytype, opts: js.Object.SetOpts)
 pub fn set(self: This, key: []const u8, value: anytype, opts: js.Object.SetOpts) !void {
     return self.obj.set(key, value, opts);
 }
-
-pub fn constructorName(self: This, allocator: Allocator) ![]const u8 {
-    return try self.obj.constructorName(allocator);
-}

--- a/src/browser/js/TryCatch.zig
+++ b/src/browser/js/TryCatch.zig
@@ -21,15 +21,14 @@ pub fn hasCaught(self: TryCatch) bool {
 // the caller needs to deinit the string returned
 pub fn exception(self: TryCatch, allocator: Allocator) !?[]const u8 {
     const msg = self.inner.getException() orelse return null;
-    const context = self.context;
-    return try js.valueToString(allocator, msg, context.isolate, context.v8_context);
+    return try self.context.valueToString(msg, .{ .allocator = allocator });
 }
 
 // the caller needs to deinit the string returned
 pub fn stack(self: TryCatch, allocator: Allocator) !?[]const u8 {
     const context = self.context;
     const s = self.inner.getStackTrace(context.v8_context) orelse return null;
-    return try js.valueToString(allocator, s, context.isolate, context.v8_context);
+    return try context.valueToString(s, .{ .allocator = allocator });
 }
 
 // the caller needs to deinit the string returned
@@ -37,7 +36,7 @@ pub fn sourceLine(self: TryCatch, allocator: Allocator) !?[]const u8 {
     const context = self.context;
     const msg = self.inner.getMessage() orelse return null;
     const sl = msg.getSourceLine(context.v8_context) orelse return null;
-    return try js.stringToZig(allocator, sl, context.isolate);
+    return try context.jsStringToZig(sl, .{ .allocator = allocator });
 }
 
 pub fn sourceLineNumber(self: TryCatch) ?u32 {

--- a/src/browser/streams/ReadableStream.zig
+++ b/src/browser/streams/ReadableStream.zig
@@ -105,8 +105,8 @@ const QueueingStrategy = struct {
 pub fn constructor(underlying: ?UnderlyingSource, _strategy: ?QueueingStrategy, page: *Page) !*ReadableStream {
     const strategy: QueueingStrategy = _strategy orelse .{};
 
-    const cancel_resolver = try page.main_context.createPersistentPromiseResolver(.self);
-    const closed_resolver = try page.main_context.createPersistentPromiseResolver(.self);
+    const cancel_resolver = try page.js.createPromiseResolver(.self);
+    const closed_resolver = try page.js.createPromiseResolver(.self);
 
     const stream = try page.arena.create(ReadableStream);
     stream.* = ReadableStream{

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -690,9 +690,7 @@ const IsolatedWorld = struct {
             return;
         }
         _ = try self.executor.createContext(
-            &page.window,
             page,
-            null,
             false,
             js.GlobalMissingCallback.init(&self.polyfill_loader),
         );

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -274,7 +274,7 @@ fn resolveNode(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
 
-    var js_context = page.main_context;
+    var js_context = page.js;
     if (params.executionContextId) |context_id| {
         if (js_context.v8_context.debugContextId() != context_id) {
             for (bc.isolated_worlds.items) |*isolated_world| {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -251,7 +251,7 @@ pub fn pageNavigate(arena: Allocator, bc: anytype, event: *const Notification.Pa
         const page = bc.session.currentPage() orelse return error.PageNotLoaded;
         const aux_data = try std.fmt.allocPrint(arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
         bc.inspector.contextCreated(
-            page.main_context,
+            page.js,
             "",
             try page.origin(arena),
             aux_data,

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -147,7 +147,7 @@ fn createTarget(cmd: anytype) !void {
     {
         const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
         bc.inspector.contextCreated(
-            page.main_context,
+            page.js,
             "",
             try page.origin(cmd.arena),
             aux_data,

--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -123,7 +123,7 @@ fn run(
 
     _ = page.wait(2000);
 
-    const js_context = page.main_context;
+    const js_context = page.js;
     var try_catch: js.TryCatch = undefined;
     try_catch.init(js_context);
     defer try_catch.deinit();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -395,7 +395,7 @@ pub fn htmlRunner(file: []const u8) !void {
 
     page.arena = @import("root").tracking_allocator;
 
-    const js_context = page.main_context;
+    const js_context = page.js;
     var try_catch: js.TryCatch = undefined;
     try_catch.init(js_context);
     defer try_catch.deinit();
@@ -409,7 +409,7 @@ pub fn htmlRunner(file: []const u8) !void {
     page.session.browser.runMessageLoop();
 
     const needs_second_wait = try js_context.exec("testing._onPageWait.length > 0", "check_onPageWait");
-    if (needs_second_wait.value.toBool(page.main_context.isolate)) {
+    if (needs_second_wait.value.toBool(page.js.isolate)) {
         // sets the isSecondWait flag in testing.
         _ = js_context.exec("testing._isSecondWait = true", "set_second_wait_flag") catch {};
         _ = page.wait(2000);


### PR DESCRIPTION
This Pr largely tightens up a lot of the code. 'v8' is no longer imported outside of js. A number of helper functions have been moved to the js.Context. For example, js.Function.getName used to call:

```zig
return js.valueToString(allocator, name, self.context.isolate, self.context.v8_context);
```

It now calls:

```zig
return self.context.valueToString(name, .{ .allocator = allocator });
```

Page.main_context has been renamed to `Page.js`. This, in combination with new promise helpers, turns:

```zig
const resolver = page.main_context.createPromiseResolver();
try resolver.resolve({});
return resolver.promise();
```

into:

```zig
return page.js.resolvePromise({});
```