### PR TITLE
Emit Log.addEntry

### DIFF
--- a/src/browser/events/mouse_event.zig
+++ b/src/browser/events/mouse_event.zig
@@ -68,7 +68,7 @@ pub const MouseEvent = struct {
         });
 
         if (!std.mem.eql(u8, event_type, "click")) {
-            log.warn(.mouse_event, "unsupported mouse event", .{ .event = event_type });
+            log.warn(.browser, "unsupported mouse event", .{ .event = event_type });
         }
 
         return mouse_event;

--- a/src/cdp/domains/log.zig
+++ b/src/cdp/domains/log.zig
@@ -17,13 +17,97 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const log = @import("../../log.zig");
+
+const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: anytype) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
+        disable,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
-        .enable => return cmd.sendResult(null, .{}),
+        .enable => return enable(cmd),
+        .disable => return disable(cmd),
     }
+}
+fn enable(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.logEnable();
+    return cmd.sendResult(null, .{});
+}
+
+fn disable(cmd: anytype) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.logDisable();
+    return cmd.sendResult(null, .{});
+}
+
+pub fn LogInterceptor(comptime BC: type) type {
+    return struct {
+        bc: *BC,
+        allocating: std.Io.Writer.Allocating,
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator, bc: *BC) Self {
+            return .{
+                .bc = bc,
+                .allocating = .init(allocator),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            return self.allocating.deinit();
+        }
+
+        pub fn writer(ctx: *anyopaque, scope: log.Scope, level: log.Level) ?*std.Io.Writer {
+            if (scope == .unknown_prop or scope == .telemetry) {
+                return null;
+            }
+
+            // DO NOT REMOVE this. This prevents a log message caused from a failure
+            // to intercept to trigger another intercept, which could result in an
+            // endless cycle.
+            if (scope == .interceptor) {
+                return null;
+            }
+
+            if (level == .debug) {
+                return null;
+            }
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            return &self.allocating.writer;
+        }
+
+        pub fn done(ctx: *anyopaque, scope: log.Scope, level: log.Level) void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            defer self.allocating.clearRetainingCapacity();
+
+            self.bc.cdp.sendEvent("Log.entryAdded", .{
+                .entry = .{
+                    .source = switch (scope) {
+                        .js, .user_script, .console, .web_api, .script_event => "javascript",
+                        .http, .fetch, .xhr => "network",
+                        .telemetry, .unknown_prop, .interceptor => unreachable, // filtered out in writer above
+                        else => "other",
+                    },
+                    .level = switch (level) {
+                        .debug => "verbose",
+                        .info => "info",
+                        .warn => "warning",
+                        .err => "error",
+                        .fatal => "error",
+                    },
+                    .text = self.allocating.written(),
+                    .timestamp = @import("../../datetime.zig").milliTimestamp(),
+                },
+            }, .{
+                .session_id = self.bc.session_id,
+            }) catch |err| {
+                log.err(.interceptor, "failed to send", .{.err = err});
+            };
+        }
+    };
 }

--- a/src/log.zig
+++ b/src/log.zig
@@ -29,7 +29,6 @@ pub const Scope = enum {
     cdp,
     console,
     http,
-    http_client,
     js,
     loop,
     script_event,
@@ -40,7 +39,7 @@ pub const Scope = enum {
     xhr,
     fetch,
     polyfill,
-    mouse_event,
+    interceptor,
 };
 
 const Opts = struct {
@@ -148,6 +147,13 @@ fn logTo(comptime scope: Scope, level: Level, comptime msg: []const u8, data: an
         .pretty => try logPretty(scope, level, msg, data, out),
     }
     out.flush() catch return;
+
+    const interceptor = _interceptor orelse return;
+    if (interceptor.writer(interceptor.ctx, scope, level)) |iwriter| {
+        try logLogfmt(scope, level, msg, data, iwriter);
+        try iwriter.flush();
+        interceptor.done(interceptor.ctx, scope, level);
+    }
 }
 
 fn logLogfmt(comptime scope: Scope, level: Level, comptime msg: []const u8, data: anytype, writer: anytype) !void {
@@ -345,6 +351,24 @@ fn elapsed() struct { time: f64, unit: []const u8 } {
     }
     return .{ .time = @as(f64, @floatFromInt(e)) / @as(f64, 1000), .unit = "s" };
 }
+
+var _interceptor: ?Interceptor = null;
+pub fn registerInterceptor(interceptor: Interceptor) void {
+    _interceptor = interceptor;
+}
+
+pub fn unregisterInterceptor() void {
+    _interceptor = null;
+}
+
+const Interceptor = struct {
+    ctx: *anyopaque,
+    done: DoneFunc,
+    writer: WriterFunc,
+
+    const DoneFunc = *const fn (ctx: *anyopaque, scope: Scope, level: Level) void;
+    const WriterFunc = *const fn (ctx: *anyopaque, scope: Scope, level: Level) ?*std.Io.Writer;
+};
 
 const testing = @import("testing.zig");
 test "log: data" {


### PR DESCRIPTION
Currently, this hooks a single log.Interceptor into the logging framework, but changing it to take a list shouldn't be too hard. Biggest issue is who will own it, as we'd need an allocator to maintain a list / lookup (which log doesn't currently have).

Uses logFmt format, and, for now, always filters out debug messages and a few particularly verbose scopes.