### PR TITLE
Move the call_arena to the page.

### DIFF
--- a/src/browser/browser.zig
+++ b/src/browser/browser.zig
@@ -39,6 +39,7 @@ pub const Browser = struct {
     session: ?Session,
     allocator: Allocator,
     http_client: *HttpClient,
+    call_arena: ArenaAllocator,
     page_arena: ArenaAllocator,
     session_arena: ArenaAllocator,
     transfer_arena: ArenaAllocator,
@@ -63,6 +64,7 @@ pub const Browser = struct {
             .allocator = allocator,
             .notification = notification,
             .http_client = app.http.client,
+            .call_arena = ArenaAllocator.init(allocator),
             .page_arena = ArenaAllocator.init(allocator),
             .session_arena = ArenaAllocator.init(allocator),
             .transfer_arena = ArenaAllocator.init(allocator),
@@ -73,6 +75,7 @@ pub const Browser = struct {
     pub fn deinit(self: *Browser) void {
         self.closeSession();
         self.env.deinit();
+        self.call_arena.deinit();
         self.page_arena.deinit();
         self.session_arena.deinit();
         self.transfer_arena.deinit();

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -178,7 +178,6 @@ pub fn newExecutionWorld(self: *Env) !ExecutionWorld {
     return .{
         .env = self,
         .context = null,
-        .call_arena = ArenaAllocator.init(self.allocator),
         .context_arena = ArenaAllocator.init(self.allocator),
     };
 }

--- a/src/browser/js/Object.zig
+++ b/src/browser/js/Object.zig
@@ -22,7 +22,7 @@ pub fn setIndex(self: Object, index: u32, value: anytype, opts: SetOpts) !void {
     @setEvalBranchQuota(10000);
     const key = switch (index) {
         inline 0...20 => |i| std.fmt.comptimePrint("{d}", .{i}),
-        else => try std.fmt.allocPrint(self.context.context_arena, "{d}", .{index}),
+        else => try std.fmt.allocPrint(self.context.arena, "{d}", .{index}),
     };
     return self.set(key, value, opts);
 }
@@ -76,7 +76,7 @@ pub fn persist(self: Object) !Object {
     const js_obj = self.js_obj;
 
     const persisted = PersistentObject.init(context.isolate, js_obj);
-    try context.js_object_list.append(context.context_arena, persisted);
+    try context.js_object_list.append(context.arena, persisted);
 
     return .{
         .context = context,

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -121,7 +121,7 @@ pub const Page = struct {
         complete,
     };
 
-    pub fn init(self: *Page, arena: Allocator, session: *Session) !void {
+    pub fn init(self: *Page, arena: Allocator, call_arena: Allocator, session: *Session) !void {
         const browser = session.browser;
         const script_manager = ScriptManager.init(browser, self);
 
@@ -131,7 +131,7 @@ pub const Page = struct {
             .window = try Window.create(null, null),
             .arena = arena,
             .session = session,
-            .call_arena = undefined,
+            .call_arena = call_arena,
             .renderer = Renderer.init(arena),
             .state_pool = &browser.state_pool,
             .cookie_jar = &session.cookie_jar,

--- a/src/browser/session.zig
+++ b/src/browser/session.zig
@@ -106,7 +106,7 @@ pub const Session = struct {
 
         self.page = @as(Page, undefined);
         const page = &self.page.?;
-        try Page.init(page, page_arena.allocator(), self);
+        try Page.init(page, page_arena.allocator(), self.browser.call_arena.allocator(), self);
 
         log.debug(.browser, "create page", .{});
         // start JS env

--- a/src/http/Http.zig
+++ b/src/http/Http.zig
@@ -443,7 +443,6 @@ const LineWriter = struct {
     }
 };
 
-
 pub fn debugCallback(_: *c.CURL, msg_type: c.curl_infotype, raw: [*c]u8, len: usize, _: *anyopaque) callconv(.c) void {
     const data = raw[0..len];
     switch (msg_type) {


### PR DESCRIPTION
The call_arena was previously owned by the js.Context, but it has to exist on the page, and the page is created before the context, so it's set to undefined on the page. While this has never caused an issue, there's no reason for the page not to own this, and the context to simply reference it.

Also, renamed the js.Context.context_arena to simply `arena`, which is more consistent with other arena names (e.g. page.arena).