### PR TITLE
Attempt to add more context to debug logs.

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0xda130f3af836cea0,
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/7a1beb016efcb2bd66c0b46b5fc6bcd04fa72db8.tar.gz",
-            .hash = "v8-0.0.0-xddH6_PFAwAqwLMWbF7S0rAZzRbN8zmf2GhLH_ThdMSR",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/5ce9ade6c6d7f7ab9ab4582a6b1b36fdc8e246e2.tar.gz",
+            .hash = "v8-0.0.0-xddH6yTGAwA__kfiDozsVXL2_jnycrtDUfR8kIADQFUz",
         },
         //.v8 = .{ .path = "../zig-v8-fork" }
     },

--- a/src/browser/html/elements.zig
+++ b/src/browser/html/elements.zig
@@ -887,7 +887,7 @@ pub const HTMLScriptElement = struct {
             //    s.src = '...';
             // This should load the script.
             // addFromElement protects against double execution.
-            try page.script_manager.addFromElement(@ptrCast(@alignCast(self)));
+            try page.script_manager.addFromElement(@ptrCast(@alignCast(self)), "dynamic");
         }
     }
 

--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -785,7 +785,7 @@ pub const Page = struct {
                         // ignore non-js script.
                         continue;
                     }
-                    try self.script_manager.addFromElement(@ptrCast(node));
+                    try self.script_manager.addFromElement(@ptrCast(node), "page");
                 }
 
                 self.script_manager.staticScriptsDone();
@@ -1250,7 +1250,7 @@ pub export fn scriptAddedCallback(ctx: ?*anyopaque, element: ?*parser.Element) c
     // here, else the script_manager will flag it as already-processed.
     _ = parser.elementGetAttribute(element.?, "src") catch return orelse return;
 
-    self.script_manager.addFromElement(element.?) catch |err| {
+    self.script_manager.addFromElement(element.?, "dynamic") catch |err| {
         log.warn(.browser, "dynamic script", .{ .err = err });
     };
 }

--- a/src/browser/polyfill/polyfill.zig
+++ b/src/browser/polyfill/polyfill.zig
@@ -69,6 +69,7 @@ pub const Loader = struct {
         if (comptime builtin.mode == .Debug) {
             log.debug(.unknown_prop, "unkown global property", .{
                 .info = "but the property can exist in pure JS",
+                .stack = js_context.stackTrace() catch "???",
                 .property = name,
             });
         }

--- a/src/http/Http.zig
+++ b/src/http/Http.zig
@@ -443,7 +443,6 @@ const LineWriter = struct {
     }
 };
 
-
 pub fn debugCallback(_: *c.CURL, msg_type: c.curl_infotype, raw: [*c]u8, len: usize, _: *anyopaque) callconv(.c) void {
     const data = raw[0..len];
     switch (msg_type) {


### PR DESCRIPTION
1 - On `unkown global property`, include the stack trace (this might be WAY too verbose)

2 - On script get, include stack trace (when available)

3 - On script get, include referrer

4 - Stack traces will now include the script name/src when available