### PR TITLE
Remove potential processing blocking with CDP

### DIFF
--- a/src/cdp/domains/log.zig
+++ b/src/cdp/domains/log.zig
@@ -106,7 +106,7 @@ pub fn LogInterceptor(comptime BC: type) type {
             }, .{
                 .session_id = self.bc.session_id,
             }) catch |err| {
-                log.err(.interceptor, "failed to send", .{.err = err});
+                log.err(.interceptor, "failed to send", .{ .err = err });
             };
         }
     };


### PR DESCRIPTION
When using CDP, we poll the HTTP clients along with the CDP socket. Because this polling can be long, we first process any pending message. This can end up processing _all_ messages, in which case the poll will block for a long time.

This change makes it so that when the initial processing processes 1+ message, we do not poll, but rather return. This allows the page lifecycle to be processed normally (and not just blocking on poll, waiting for the CDP client to send data).

Without this PR, this very simple CDP script timesout: https://github.com/lightpanda-io/demo/pull/79