### PR TITLE
Add a fast path for validating cookie strings

### DIFF
--- a/src/browser/storage/cookie.zig
+++ b/src/browser/storage/cookie.zig
@@ -315,7 +315,7 @@ pub const Cookie = struct {
     const ValidateCookieError = error{ Empty, InvalidByteSequence };
 
     /// Returns an error if cookie str length is 0
-    /// or contains characters between 32...126.
+    /// or contains characters outside of the ascii range 32...126.
     fn validateCookieString(str: []const u8) ValidateCookieError!void {
         if (str.len == 0) {
             return error.Empty;


### PR DESCRIPTION
This prefers `suggestVectorLength` in order to pick a vector size; for cookie strings shorter than, say 64, this might cause it to fallback to slow path on architectures that support larger vector sizes (like AVX-512). We may also add checks for smaller vector sizes if desired in the future.