### PR TITLE
isDone must be run after script's deinit

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -602,8 +602,9 @@ pub const PendingScript = struct {
             return;
         }
         // async script can be evaluated immediately
-        defer self.deinit();
         self.script.eval(manager.page);
+        self.deinit();
+        // asyncScriptIsDone must be run after the pending script is deinit.
         manager.asyncScriptIsDone();
     }
 


### PR DESCRIPTION
before this change, isDone was run before the pending script deinit. So the `asyncs` list wasn't yet cleared and the document never completed...

I was abe to reproduce by fetching amazon.pl

Relates with #1116