### PR TITLE
Fix a potential segfault on log message for failing to load module

### DIFF
--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -1207,7 +1207,7 @@ fn _resolveModuleCallback(self: *Context, referrer: v8.Module, specifier: []cons
 
     const entry = self.module(true, fetch_result.src(), normalized_specifier, true) catch |err| {
         log.warn(.js, "compile resolved module", .{
-            .specifier = specifier,
+            .specifier = normalized_specifier,
             .stack = try_catch.stack(self.call_arena) catch null,
             .src = try_catch.sourceLine(self.call_arena) catch "err",
             .line = try_catch.sourceLineNumber() orelse 0,


### PR DESCRIPTION
Using the `call_arena` here is unsafe in the case of a failure. It's possible for the call_arena to be reset during module processing, making the log crash.

The issue is that the lifetime of a URL is often conditional. If the stitched URL has already been seen (i.e. is in the module_cache), then it can be short- lived. EXCEPT, URL.stitch might require an allocation..and then you start to think, well, if URL.stitch is going to allocate anyways...If we stitch with the `page.arena`, and end up not needing a long lifetime, we've wasted memory. If we stitch with `page.call_arena` and end up needing a long lifetime, we need to dupe.

It's a bit messy, and I'd like to take a stab at improving it after: https://github.com/lightpanda-io/browser/pull/1127.

I'm thinking that we need a URL intern pool. HashMap with a composite key of base + path -> resolved. Then all URLs are resolved using the page.arena, but we don't have any duplicates, so it isn't wasteful.