### PR TITLE
Fix typo in 'input' selector check

### DIFF
--- a/src/browser/css/selector.zig
+++ b/src/browser/css/selector.zig
@@ -562,7 +562,7 @@ pub const Selector = union(enum) {
 
                         const ntag = try n.tag();
 
-                        if (std.ascii.eqlIgnoreCase("intput", ntag)) {
+                        if (std.ascii.eqlIgnoreCase("input", ntag)) {
                             const ntype = try n.attr("type");
                             if (ntype == null) return false;
 


### PR DESCRIPTION
This PR fixes a small typo in selector check for tag name looking at `intput` instead of `input`