### PR TITLE
Provides an PoC of using V8 snapshots

### DIFF
--- a/src/tests/polyfill/webcomponents.html
+++ b/src/tests/polyfill/webcomponents.html
@@ -13,6 +13,8 @@
     }
   }
 
+  testing.expectEqual(73, LightpandaSnapshotPoC());
+
   window.customElements.define("lightpanda-test", LightPanda);
   const main = document.getElementById('main');
   main.appendChild(document.createElement('lightpanda-test'));


### PR DESCRIPTION
Provides a proof of concept on how to use snapshots for #1176. Depends on PR in v8 repository.: https://github.com/lightpanda-io/zig-v8-fork/pull/110

As stated in the documentation, snapshots are serialized state of the V8 heap. We simply execute JavaScript code and save the snapshot (it can be saved to disk if desired). In the PR above, you can see how a snapshot is created at browser startup, which provides the `LightpandaSnapshotPoC` function, later accessible in tests.

Since the polyfill is still JavaScript code, it can only be executed and serialized along with the initialization of window* and other global objects, like this:
- at browser startup, create a clean context
- add global WebAPIs to the context
- add the polyfills to the context
- serialize the snapshot for subsequent pages
- (optional) save the snapshot to disk

Currently, this isn't very convenient to do in code, as the snapshot must be ready before creating the Env. I'd like to discuss the implementation in advance:
- when creating the first page, save a snapshot for subsequent pages in env;
- change Env so that it proactively prepares a snapshot at startup, and only loads Page from the snapshot and completely skips preparing window*

@krichprollsch, wdyt?