### PR TITLE
handle template's original content

### DIFF
--- a/src/browser/dom/node.zig
+++ b/src/browser/dom/node.zig
@@ -390,7 +390,23 @@ pub const Node = struct {
         return parser.nodeHasChildNodes(self);
     }
 
+    fn is_template(self: *parser.Node) !bool {
+        if (parser.nodeType(self) != .element) {
+            return false;
+        }
+
+        const e = parser.nodeToElement(self);
+        return try parser.elementTag(e) == .template;
+    }
+
     pub fn get_childNodes(self: *parser.Node, page: *Page) !NodeList {
+        // special case for template:
+        // > The Node.childNodes property of the <template> element is always empty
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#usage_notes
+        if (try is_template(self)) {
+            return .{};
+        }
+
         const allocator = page.arena;
         var list: NodeList = .{};
 

--- a/src/tests/html/template.html
+++ b/src/tests/html/template.html
@@ -20,3 +20,19 @@
   testing.expectEqual('P', t.content.childNodes[1].tagName);
   testing.expectEqual('9000!', t.content.childNodes[1].innerHTML);
 </script>
+
+<template id="hello"><p>hello, world</p></template>
+
+<script id=template_parsing>
+  const tt = document.getElementById('hello');
+  testing.expectEqual('<p>hello, world</p>', tt.innerHTML);
+
+  // > The Node.childNodes property of the <template> element is always empty
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#usage_notes
+  testing.expectEqual(0, tt.childNodes.length);
+
+  let out = document.createElement('div');
+  out.appendChild(tt.content.cloneNode(true));
+
+  testing.expectEqual('<p>hello, world</p>', out.innerHTML);
+</script>


### PR DESCRIPTION
When the document fragment is called via the content method on a templat, it must contain the original template's HTML nodes.

fix #1172