### PR TITLE
Run microtasks before `onload`

### DIFF
--- a/src/browser/page.zig
+++ b/src/browser/page.zig
@@ -662,6 +662,9 @@ pub const Page = struct {
     }
 
     fn _documentIsComplete(self: *Page) !void {
+        self.session.browser.runMicrotasks();
+        self.session.browser.runMessageLoop();
+
         try HTMLDocument.documentIsComplete(self.window.document, self);
 
         // dispatch window.load event


### PR DESCRIPTION
It is expected for microtasks to be ran before we fire the onload event for the page (https://html.spec.whatwg.org/multipage/parsing.html#the-end). Certain Web Platform tests depend on this functionality, resulting in a good chunk of them timing out.