### PR TITLE
cdp: don't navigate for about:blank

### DIFF
--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -178,9 +178,11 @@ fn createTarget(cmd: anytype) !void {
         try doAttachtoTarget(cmd, target_id);
     }
 
-    try page.navigate(params.url, .{
-        .reason = .address_bar,
-    });
+    if (!std.mem.eql(u8, "about:blank", params.url)) {
+        try page.navigate(params.url, .{
+            .reason = .address_bar,
+        });
+    }
 
     try cmd.sendResult(.{
         .targetId = target_id,


### PR DESCRIPTION
If the create target url is `about:blank`, don't navigate. Indeed, Chrome doesn't navigate if the url is blank.

Relates with #1208 and #1171