### PR TITLE
cdp: accept multiple attachToTarget calls

### DIFF
--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -199,11 +199,9 @@ fn attachToTarget(cmd: anytype) !void {
         return error.UnknownTargetId;
     }
 
-    if (bc.session_id != null) {
-        return error.SessionAlreadyLoaded;
+    if (bc.session_id == null) {
+        try doAttachtoTarget(cmd, target_id);
     }
-
-    try doAttachtoTarget(cmd, target_id);
 
     return cmd.sendResult(
         .{ .sessionId = bc.session_id },


### PR DESCRIPTION
Extracted from #1217

I see no reason to error if we try to attach again to the same target 