### PR TITLE
feat: support listening on IPv6

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -108,7 +108,7 @@ fn run(gpa: Allocator, arena: Allocator, sighandler: *SigHandler) !void {
     switch (args.mode) {
         .serve => |opts| {
             log.debug(.app, "startup", .{ .mode = "serve" });
-            const address = std.net.Address.parseIp4(opts.host, opts.port) catch |err| {
+            const address = std.net.Address.parseIp(opts.host, opts.port) catch |err| {
                 log.fatal(.app, "invalid server address", .{ .err = err, .host = opts.host, .port = opts.port });
                 return args.printUsageAndExit(false);
             };


### PR DESCRIPTION
- Add IPv6 support to the server by using `std.net.Address.parseIp()`.
- `parseIp()` automatically detects and handles both IPv4 and IPv6 addresses.