### PR TITLE
ci: use macos-14-intel for building macos x86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,12 +138,7 @@ jobs:
       ARCH: x86_64
       OS: macos
 
-    # macos-13 runs on x86 CPU. see
-    # https://github.com/actions/runner-images?tab=readme-ov-file
-    # If we want to build for macos-14 or superior, we need to switch to
-    # macos-14-large.
-    # No need for now, but maybe we will need it in the short term.
-    runs-on: macos-13
+    runs-on: macos-14-large
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
macos-13 is unsupported. We Have to switch for payed instance. see https://github.com/actions/runner-images/issues/13046