### PR TITLE
wpt: allow mjs serve through test web server

### DIFF
--- a/src/TestHTTPServer.zig
+++ b/src/TestHTTPServer.zig
@@ -100,6 +100,11 @@ fn getContentType(file_path: []const u8) []const u8 {
         return "application/json";
     }
 
+    if (std.mem.endsWith(u8, file_path, ".mjs")) {
+        // mjs are ECMAScript modules
+        return "application/json";
+    }
+
     if (std.mem.endsWith(u8, file_path, ".html")) {
         return "text/html";
     }


### PR DESCRIPTION
fix
```
TestHTTPServer asked to serve an unknown file type: tests/wpt/navigation-api/ordering-and-transition/resources/helpers.mjs
TestHTTPServer asked to serve an unknown file type: tests/wpt/navigation-api/ordering-and-transition/resources/helpers.mjs
TestHTTPServer asked to serve an unknown file type: tests/wpt/navigation-api/ordering-and-transition/resources/helpers.mjs
TestHTTPServer asked to serve an unknown file type: tests/wpt/navigation-api/ordering-and-transition/resources/helpers.mjs
TestHTTPServer asked to serve an unknown file type: tests/wpt/navigation-api/ordering-and-transition/resources/helpers.mjs
```