### PR TITLE
Run microtasks after each script execution

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -947,16 +947,6 @@ fn printWaitAnalysis(self: *Page) void {
     }
 }
 
-pub fn tick(self: *Page) void {
-    if (comptime IS_DEBUG) {
-        log.debug(.page, "tick", .{});
-    }
-    _ = self.scheduler.run() catch |err| {
-        log.err(.page, "tick", .{ .err = err });
-    };
-    self.js.runMicrotasks();
-}
-
 pub fn isGoingAway(self: *const Page) bool {
     return self._queued_navigation != null;
 }

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -801,8 +801,13 @@ pub const Script = struct {
             log.debug(.browser, "executed script", .{ .src = url, .success = success, .on_load = script_element._on_load != null });
         }
 
-        // We should run microtasks even if script execution fails.
-        defer page.js.runMicrotasks();
+        defer {
+            // We should run microtasks even if script execution fails.
+            page.js.runMicrotasks();
+            _ = page.scheduler.run() catch |err| {
+                log.err(.page, "scheduler", .{ .err = err });
+            };
+        }
 
         if (success) {
             self.executeCallback("load", script_element._on_load, page);


### PR DESCRIPTION
This don't change the behavior for async and deferred scripts.