### PR TITLE
Fix `Document.currentScript.html` WPT

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -728,17 +728,17 @@ pub const Script = struct {
 
         const manager = self.manager;
         manager.scriptList(self).remove(&self.node);
-        if (manager.shutdown) {
-            self.deinit(true);
-            return;
-        }
 
         if (self.mode == .import) {
             const entry = self.manager.imported_modules.getPtr(self.url).?;
             entry.state = .err;
         }
-        self.deinit(true);
-        manager.evaluate();
+
+        self.complete = true;
+
+        if (!manager.shutdown) {
+            manager.evaluate();
+        }
     }
 
     fn eval(self: *Script, page: *Page) void {


### PR DESCRIPTION
This should fix the crash with the `html/dom/documents/dom-tree-accessors/Document.currentScript.html` by not double de-initializing Scripts in the `errorCallback`.