### PR TITLE
fix Node.replaceChild when of new child equals old

### DIFF
--- a/src/browser/tests/node/replace_child.html
+++ b/src/browser/tests/node/replace_child.html
@@ -37,4 +37,7 @@
   testing.expectEqual(null, c2.parentNode);
   assertChildren([c3, c4], d1)
   assertChildren([], d2)
+
+  testing.expectEqual(c3, d1.replaceChild(c3, c3));
+  assertChildren([c3, c4], d1)
 </script>

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -500,6 +500,21 @@ pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, page: *Page
 
     try validateNodeInsertion(self, new_child);
 
+    // special case: we replace a node by itself
+    if (new_child == old_child) {
+        page.domChanged();
+
+        if (page.hasMutationObservers()) {
+            const parent = new_child._parent.?;
+            const previous_sibling = new_child.previousSibling();
+            const next_sibling = new_child.nextSibling();
+            const replaced = [_]*Node{new_child};
+            page.childListChange(parent, &replaced, &replaced, previous_sibling, next_sibling);
+        }
+
+        return old_child;
+    }
+
     _ = try self.insertBefore(new_child, old_child, page);
     page.removeNode(self, old_child, .{ .will_be_reconnected = false });
     return old_child;


### PR DESCRIPTION
Fix `dom/nodes/MutationObserver-childList.html` WPT crash

```
thread 96676 panic: attempt to use null value
/home/pierre/wrk/browser-review/src/browser/Page.zig:2245:46: 0x350ce7a in _insertNodeRelative__anon_82129 (lightpanda-wpt)
            std.debug.assert(ref_node._parent.? == parent);
                                             ^
/home/pierre/wrk/browser-review/src/browser/Page.zig:2205:36: 0x350ddd4 in insertNodeRelative (lightpanda-wpt)
    return self._insertNodeRelative(false, parent, child, relative, opts);
                                   ^
/home/pierre/wrk/browser-review/src/browser/webapi/Node.zig:483:32: 0x350edea in insertBefore (lightpanda-wpt)
    try page.insertNodeRelative(
                               ^
/home/pierre/wrk/browser-review/src/browser/webapi/Node.zig:503:30: 0x3639f6d in replaceChild (lightpanda-wpt)
    _ = try self.insertBefore(new_child, old_child, page);
                             ^
/home/pierre/wrk/browser-review/src/browser/js/Caller.zig:138:5: 0x3803c1a in _method__anon_125367 (lightpanda-wpt)
    const res = @call(.auto, func, args);
    ^
/home/pierre/wrk/browser-review/src/browser/js/Caller.zig:125:17: 0x34b08b7 in method__anon_70966 (lightpanda-wpt)
    self._method(T, func, info, opts) catch |err| {
```