### PR TITLE
Handle immediate call to Script.errorCallback

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -239,8 +239,17 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
     };
 
     const is_blocking = script.mode == .normal;
+    if (is_blocking == false) {
+        self.scriptList(script).append(&script.node);
+    }
+
     if (remote_url) |url| {
-        errdefer script.deinit(true);
+        errdefer {
+            if (is_blocking == false) {
+                self.scriptList(script).remove(&script.node);
+            }
+            script.deinit(true);
+        }
 
         var headers = try self.client.newHeaders();
         try page.requestCookie(.{}).headersForRequest(page.arena, url, &headers);
@@ -271,8 +280,6 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
     }
 
     if (is_blocking == false) {
-        const list = self.scriptList(script);
-        list.append(&script.node);
         return;
     }
 


### PR DESCRIPTION
It's possible for Script.errorCallback to be called as part of the call to `client.request`. This happens because we eagerly pump the libcurl message loop to get the request going ASAP. For very obvious failures (e.g. an invalid URL) this means that the error callback can be called from `client.request`.

Previously, we were only adding the script to its list _after_ the call to `client.request`, but the error handler tries to remove the script from the list .

This commit changes the order so that the script is first added to the list and then the request is made.

I think this is a better way of handing this than `https://github.com/lightpanda-io/browser/pull/1314` as it preserves the eager cleanup of the script (Rather than waiting for page end).