### PR TITLE
fix `dom/nodes/Document-getElementById` WPT

### DIFF
--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -163,8 +163,8 @@ pub fn createAttributeNS(_: *const Document, namespace: []const u8, name: []cons
     });
 }
 
-pub fn getElementById(self: *const Document, id_: ?[]const u8) ?*Element {
-    const id = id_ orelse return null;
+pub fn getElementById(self: *const Document, id: []const u8) ?*Element {
+    if (id.len == 0) return null;
     return self._elements_by_id.get(id);
 }
 


### PR DESCRIPTION
This fixes the `dom/nodes/Document-getElementById` WPT by properly handling the id argument. Two of the other failing tests are also resolved by having `setOuterHTML` from https://github.com/lightpanda-io/browser/pull/1328.