### PR TITLE
Prefer `RAND_bytes` from BoringSSL for random

### DIFF
--- a/src/boringssl.zig
+++ b/src/boringssl.zig
@@ -1,0 +1,21 @@
+// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Externs some of the utilities provided by libssl and libcrypto.
+
+pub extern fn RAND_bytes(buf: [*]u8, len: usize) c_int;

--- a/src/browser/webapi/Crypto.zig
+++ b/src/browser/webapi/Crypto.zig
@@ -19,6 +19,8 @@
 const std = @import("std");
 const js = @import("../js/js.zig");
 
+const RAND_bytes = @import("../../boringssl.zig").RAND_bytes;
+
 const Crypto = @This();
 _pad: bool = false,
 
@@ -32,7 +34,7 @@ pub fn getRandomValues(_: *const Crypto, js_obj: js.Object) !js.Object {
     if (buf.len > 65_536) {
         return error.QuotaExceededError;
     }
-    std.crypto.random.bytes(buf);
+    _ = RAND_bytes(buf.ptr, buf.len);
     return js_obj;
 }
 

--- a/src/id.zig
+++ b/src/id.zig
@@ -18,6 +18,8 @@
 
 const std = @import("std");
 
+const RAND_bytes = @import("boringssl.zig").RAND_bytes;
+
 // Generates incrementing prefixed integers, i.e. CTX-1, CTX-2, CTX-3.
 // Wraps to 0 on overflow.
 // Many caveats for using this:
@@ -88,7 +90,7 @@ pub fn uuidv4(hex: []u8) void {
     std.debug.assert(hex.len == 36);
 
     var bin: [16]u8 = undefined;
-    std.crypto.random.bytes(&bin);
+    _ = RAND_bytes(&bin, bin.len);
     bin[6] = (bin[6] & 0x0f) | 0x40;
     bin[8] = (bin[8] & 0x3f) | 0x80;
 


### PR DESCRIPTION
Zig will integrate random to `Io` interface soon; I think this is cleaner to do since we already have such symbol.