### PR TITLE
Remove className function from every type

### DIFF
--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -55,15 +55,6 @@ pub fn is(self: *CData, comptime T: type) ?*T {
     return null;
 }
 
-pub fn className(self: *const CData) []const u8 {
-    return switch (self._type) {
-        .text => "[object Text]",
-        .comment => "[object Comment]",
-        .cdata_section => "[object CDATASection]",
-        .processing_instruction => "[object ProcessingInstruction]",
-    };
-}
-
 pub fn getData(self: *const CData) []const u8 {
     return self._data;
 }

--- a/src/browser/webapi/DOMException.zig
+++ b/src/browser/webapi/DOMException.zig
@@ -127,10 +127,6 @@ pub fn toString(self: *const DOMException, page: *Page) ![]const u8 {
     return std.fmt.bufPrint(&page.buf, "{s}: {s}", .{ self.getName(), msg }) catch return msg;
 }
 
-pub fn className(_: *const DOMException) []const u8 {
-    return "[object DOMException]";
-}
-
 const Code = enum(u8) {
     none = 0,
     index_size_error = 1,

--- a/src/browser/webapi/DOMImplementation.zig
+++ b/src/browser/webapi/DOMImplementation.zig
@@ -102,10 +102,6 @@ pub fn hasFeature(_: *const DOMImplementation, _: ?[]const u8, _: ?[]const u8) b
     return true;
 }
 
-pub fn className(_: *const DOMImplementation) []const u8 {
-    return "[object DOMImplementation]";
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(DOMImplementation);
 

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -275,14 +275,6 @@ pub fn querySelectorAll(self: *Document, input: []const u8, page: *Page) !*Selec
     return Selector.querySelectorAll(self.asNode(), input, page);
 }
 
-pub fn className(self: *const Document) []const u8 {
-    return switch (self._type) {
-        .generic => "[object Document]",
-        .html => "[object HTMLDocument]",
-        .xml => "[object XMLDocument]",
-    };
-}
-
 pub fn getImplementation(_: *const Document) DOMImplementation {
     return .{};
 }

--- a/src/browser/webapi/DocumentFragment.zig
+++ b/src/browser/webapi/DocumentFragment.zig
@@ -67,10 +67,6 @@ pub fn asEventTarget(self: *DocumentFragment) *@import("EventTarget.zig") {
     return self._proto.asEventTarget();
 }
 
-pub fn className(_: *const DocumentFragment) []const u8 {
-    return "[object DocumentFragment]";
-}
-
 pub fn getElementById(self: *DocumentFragment, id: []const u8) ?*Element {
     if (id.len == 0) {
         return null;

--- a/src/browser/webapi/DocumentType.zig
+++ b/src/browser/webapi/DocumentType.zig
@@ -48,10 +48,6 @@ pub fn getSystemId(self: *const DocumentType) []const u8 {
     return self._system_id;
 }
 
-pub fn className(_: *const DocumentType) []const u8 {
-    return "[object DocumentType]";
-}
-
 pub fn isEqualNode(self: *const DocumentType, other: *const DocumentType) bool {
     return std.mem.eql(u8, self._name, other._name) and
         std.mem.eql(u8, self._public_id, other._public_id) and

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -113,12 +113,6 @@ pub fn asConstNode(self: *const Element) *const Node {
     return self._proto;
 }
 
-pub fn className(self: *const Element) []const u8 {
-    return switch (self._type) {
-        inline else => |c| return c.className(),
-    };
-}
-
 pub fn attributesEql(self: *const Element, other: *Element) bool {
     if (self._attributes) |attr_list| {
         const other_list = other._attributes orelse return false;

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -44,10 +44,6 @@ pub fn asEventTarget(self: *HTMLDocument) *@import("EventTarget.zig") {
     return self._proto.asEventTarget();
 }
 
-pub fn className(_: *const HTMLDocument) []const u8 {
-    return "[object HTMLDocument]";
-}
-
 // HTML-specific accessors
 pub fn getHead(self: *HTMLDocument) ?*Element.Html.Head {
     const doc_el = self._proto.getDocumentElement() orelse return null;

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -659,12 +659,6 @@ pub fn setData(self: *Node, data: []const u8) void {
     }
 }
 
-pub fn className(self: *const Node) []const u8 {
-    switch (self._type) {
-        inline else => |c| return c.className(),
-    }
-}
-
 pub fn normalize(self: *Node, page: *Page) !void {
     var buffer: std.ArrayListUnmanaged(u8) = .empty;
     return self._normalize(page.call_arena, &buffer, page);

--- a/src/browser/webapi/ShadowRoot.zig
+++ b/src/browser/webapi/ShadowRoot.zig
@@ -61,10 +61,6 @@ pub fn asEventTarget(self: *ShadowRoot) *@import("EventTarget.zig") {
     return self.asNode().asEventTarget();
 }
 
-pub fn className(_: *const ShadowRoot) []const u8 {
-    return "[object ShadowRoot]";
-}
-
 pub fn getMode(self: *const ShadowRoot) []const u8 {
     return @tagName(self._mode);
 }

--- a/src/browser/webapi/XMLDocument.zig
+++ b/src/browser/webapi/XMLDocument.zig
@@ -37,10 +37,6 @@ pub fn asEventTarget(self: *XMLDocument) *@import("EventTarget.zig") {
     return self._proto.asEventTarget();
 }
 
-pub fn className(_: *const XMLDocument) []const u8 {
-    return "[object XMLDocument]";
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(XMLDocument);
 

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -45,10 +45,6 @@ pub fn format(self: *const Attribute, writer: *std.Io.Writer) !void {
     return formatAttribute(self._name, self._value, writer);
 }
 
-pub fn className(_: *const Attribute) []const u8 {
-    return "[object Attr]";
-}
-
 pub fn getName(self: *const Attribute) []const u8 {
     return self._name;
 }

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -125,51 +125,6 @@ pub fn is(self: *HtmlElement, comptime T: type) ?*T {
     return null;
 }
 
-pub fn className(self: *const HtmlElement) []const u8 {
-    return switch (self._type) {
-        .anchor => "[object HTMLAnchorElement]",
-        .body => "[object HTMLBodyElement]",
-        .br => "[object HTMLBRElement]",
-        .button => "[object HTMLButtonElement]",
-        .canvas => "[object HTMLCanvasElement]",
-        .custom => "[object CUSTOM-TODO]",
-        .data => "[object HTMLDataElement]",
-        .dialog => "[object HTMLDialogElement]",
-        .div => "[object HTMLDivElement]",
-        .embed => "[object HTMLEmbedElement]",
-        .form => "[object HTMLFormElement]",
-        .generic => "[object HTMLElement]",
-        .head => "[object HTMLHeadElement]",
-        .heading => "[object HTMLHeadingElement]",
-        .hr => "[object HTMLHRElement]",
-        .html => "[object HTMLHtmlElement]",
-        .iframe => "[object HTMLIFrameElement]",
-        .img => "[object HTMLImageElement]",
-        .input => "[object HTMLInputElement]",
-        .li => "[object HTMLLIElement]",
-        .link => "[object HTMLLinkElement]",
-        .meta => "[object HTMLMetaElement]",
-        .media => |m| switch (m._type) {
-            .audio => "[object HTMLAudioElement]",
-            .video => "[object HTMLVideoElement]",
-            .generic => "[object HTMLMediaElement]",
-        },
-        .ol => "[object HTMLOLElement]",
-        .option => "[object HTMLOptionElement]",
-        .p => "[object HTMLParagraphElement]",
-        .script => "[object HTMLScriptElement]",
-        .select => "[object HTMLSelectElement]",
-        .slot => "[object HTMLSlotElement]",
-        .span => "[object HTMLSpanElement]",
-        .style => "[object HTMLSyleElement]",
-        .template => "[object HTMLTemplateElement]",
-        .textarea => "[object HTMLTextAreaElement]",
-        .title => "[object HTMLTitleElement]",
-        .ul => "[object HTMLULElement]",
-        .unknown => "[object HTMLUnknownElement]",
-    };
-}
-
 pub fn asElement(self: *HtmlElement) *Element {
     return self._proto;
 }

--- a/src/browser/webapi/element/Svg.zig
+++ b/src/browser/webapi/element/Svg.zig
@@ -56,13 +56,6 @@ pub fn asNode(self: *Svg) *Node {
     return self.asElement().asNode();
 }
 
-pub fn className(self: *const Svg) []const u8 {
-    return switch (self._type) {
-        .svg => "SVGElement",
-        inline else => |svg| svg.className(),
-    };
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Svg);
 

--- a/src/browser/webapi/element/svg/Generic.zig
+++ b/src/browser/webapi/element/svg/Generic.zig
@@ -32,10 +32,6 @@ pub fn asNode(self: *Generic) *Node {
     return self.asElement().asNode();
 }
 
-pub fn className(_: *const Generic) []const u8 {
-    return "SVGGenericElement";
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Generic);
 

--- a/src/browser/webapi/element/svg/Rect.zig
+++ b/src/browser/webapi/element/svg/Rect.zig
@@ -31,10 +31,6 @@ pub fn asNode(self: *Rect) *Node {
     return self.asElement().asNode();
 }
 
-pub fn className(_: *const Rect) []const u8 {
-    return "SVGRectElement";
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Rect);
 


### PR DESCRIPTION
The toString symbol is now automatically implemented on any type with a JsApi.Meta.Name, so className is no longer used.