### PR TITLE
ci: increase timeout limit for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           allowUpdates: true
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           tag: ${{ env.RELEASE }}
+          makeLatest: true
 
   build-linux-aarch64:
     env:
@@ -104,6 +105,7 @@ jobs:
           allowUpdates: true
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           tag: ${{ env.RELEASE }}
+          makeLatest: true
 
   build-macos-aarch64:
     env:
@@ -148,6 +150,7 @@ jobs:
           allowUpdates: true
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           tag: ${{ env.RELEASE }}
+          makeLatest: true
 
   build-macos-x86_64:
     env:
@@ -190,3 +193,4 @@ jobs:
           allowUpdates: true
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           tag: ${{ env.RELEASE }}
+          makeLatest: true


### PR DESCRIPTION
Relates with https://github.com/lightpanda-io/browser/actions/runs/20839467695

```
build-macos-x86_64
The job has exceeded the maximum execution time of 15m0s
```