### PR TITLE
use temporary handle scope to deinit inspector

### DIFF
--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -63,6 +63,10 @@ pub fn init(allocator: Allocator, isolate: v8.Isolate, ctx: anytype) !Inspector 
 }
 
 pub fn deinit(self: *const Inspector) void {
+    var temp_scope: v8.HandleScope = undefined;
+    v8.HandleScope.init(&temp_scope, self.isolate);
+    defer temp_scope.deinit();
+
     self.session.deinit();
     self.inner.deinit();
 }


### PR DESCRIPTION
Fix handle scope error during Inspector deinit with `quickstart_hn.js` integration test.

```
DEBUG page : page.deinit . . . . . . . . . . . . . . . . . .  [+9315ms]
      url = https://hn.algolia.com/?q=lightpanda

DEBUG browser : remove page . . . . . . . . . . . . . . . . . [+9316ms]


#
# Fatal error in v8::HandleScope::CreateHandle()
# Cannot create a handle without a HandleScope
#

run
└─ run exe lightpanda failure
error: the following command terminated unexpectedly:
./.zig-cache/o/d4e0b0cb35dd4c2dea41273863078318/lightpanda serve --log_level debug
```