### PR TITLE
use js.Value when input can be a value

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -204,7 +204,6 @@ pub fn deinit(self: *Page) void {
         // stats.print(&stream) catch unreachable;
     }
 
-
     // some MicroTasks might be referencing the page, we need to drain it while
     // the page still exists
     self.js.runMicrotasks();

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -235,7 +235,6 @@ fn _toString(self: Value, comptime null_terminate: bool, opts: js.String.ToZigOp
     return js.String.toZig(str, opts);
 }
 
-
 pub fn fromJson(ctx: *js.Context, json: []const u8) !Value {
     const v8_isolate = v8.Isolate{ .handle = ctx.isolate.handle };
     const json_string = v8.String.initUtf8(v8_isolate, json);

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -314,10 +314,10 @@ pub const Entry = struct {
 
 pub const Mark = struct {
     _proto: *Entry,
-    _detail: ?js.Object,
+    _detail: ?js.Value,
 
     const Options = struct {
-        detail: ?js.Object = null,
+        detail: ?js.Value = null,
         startTime: ?f64 = null,
     };
 
@@ -344,7 +344,7 @@ pub const Mark = struct {
         return m;
     }
 
-    pub fn getDetail(self: *const Mark) ?js.Object {
+    pub fn getDetail(self: *const Mark) ?js.Value {
         return self._detail;
     }
 

--- a/src/browser/webapi/event/CustomEvent.zig
+++ b/src/browser/webapi/event/CustomEvent.zig
@@ -27,11 +27,11 @@ const Allocator = std.mem.Allocator;
 const CustomEvent = @This();
 
 _proto: *Event,
-_detail: ?js.Object = null,
+_detail: ?js.Value = null,
 _arena: Allocator,
 
 const CustomEventOptions = struct {
-    detail: ?js.Object = null,
+    detail: ?js.Value = null,
 };
 
 const Options = Event.inheritOptions(CustomEvent, CustomEventOptions);
@@ -58,7 +58,7 @@ pub fn initCustomEvent(
     event_string: []const u8,
     bubbles: ?bool,
     cancelable: ?bool,
-    detail_: ?js.Object,
+    detail_: ?js.Value,
     page: *Page,
 ) !void {
     // This function can only be called after the constructor has called.
@@ -76,7 +76,7 @@ pub fn asEvent(self: *CustomEvent) *Event {
     return self._proto;
 }
 
-pub fn getDetail(self: *const CustomEvent) ?js.Object {
+pub fn getDetail(self: *const CustomEvent) ?js.Value {
     return self._detail;
 }
 


### PR DESCRIPTION
We previously treated v8::Object and v8::Values interchangeably, and would just ptrCast one to the other. So, if an API was defined with a js.Object but was given a non-object value, e.g. 9001, it would still work.

This has since been tightened. If an API takes a js.Object, than the v8 value must be an object. Passing a non-object will result in a InvalidArgument error.

CustomEvent.detail and PerformanceMark.detail can both be any value, so the apis/fields have been updated from js.Object -> js.Value.