### PR TITLE
Make removeIds lookup own the key

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -204,7 +204,6 @@ pub fn deinit(self: *Page) void {
         // stats.print(&stream) catch unreachable;
     }
 
-
     // some MicroTasks might be referencing the page, we need to drain it while
     // the page still exists
     self.js.runMicrotasks();
@@ -1051,7 +1050,7 @@ pub fn removeElementId(self: *Page, element: *Element, id: []const u8) void {
 
 pub fn removeElementIdWithMaps(self: *Page, id_maps: ElementIdMaps, id: []const u8) void {
     if (id_maps.lookup.remove(id)) {
-        id_maps.removed_ids.put(self.arena, id, {}) catch {};
+        id_maps.removed_ids.put(self.arena, self.dupeString(id) catch return, {}) catch {};
     }
 }
 


### PR DESCRIPTION
Virtually all string are page-owned (in the page.arena), but because of the Small String Optimization we use (string.zig), a string could be stack-allocated

The correct solution is probably to change the key to be a string.String. But I want to give more thought to memory in general, and strings specifically need to be thought about. So this is a quick fix for crashing.