### PR TITLE
Reject constructor calls without new

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -77,6 +77,10 @@ const FunctionCallbackInfo = struct {
         v8.v8__FunctionCallbackInfo__GetReturnValue(self.handle, &rv);
         return .{ .handle = rv };
     }
+
+    fn isConstructCall(self: FunctionCallbackInfo) bool {
+        return v8.v8__FunctionCallbackInfo__IsConstructCall(self.handle);
+    }
 };
 
 const PropertyCallbackInfo = struct {
@@ -171,6 +175,11 @@ pub const Caller = struct {
     };
 
     pub fn constructor(self: *Caller, comptime T: type, func: anytype, info: FunctionCallbackInfo, comptime opts: CallOpts) void {
+        if (!info.isConstructCall()) {
+            self.handleError(T, @TypeOf(func), error.InvalidArgument, info, opts);
+            return;
+        }
+
         self._constructor(func, info) catch |err| {
             self.handleError(T, @TypeOf(func), err, info, opts);
         };

--- a/src/browser/tests/events.html
+++ b/src/browser/tests/events.html
@@ -630,3 +630,8 @@
   let bubbledEvent = new Event('bubble', {bubbles: true});
   testing.expectEqual(false, bubbledEvent.isTrusted);
 </script>
+
+<script id=emptyMessageEvent>
+  // https://github.com/lightpanda-io/browser/pull/1316
+  testing.expectError('TypeError', () => MessageEvent(''));
+</script>


### PR DESCRIPTION
This was previously a fixed bug, but it got lost in the direct_v8 merging.

https://github.com/lightpanda-io/browser/pull/1316