### PR TITLE
Re-enable cached property support

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
 //
 // Francis Bouvier <francis@lightpanda.io>
 // Pierre Tachoire <pierre@lightpanda.io>
@@ -164,7 +164,7 @@ pub const Accessor = struct {
 
     const Opts = struct {
         static: bool = false,
-        cache: ?[]const u8 = null, // @ZIGDOM
+        cache: ?[]const u8 = null,
         as_typed_array: bool = false,
         null_as_undefined: bool = false,
     };
@@ -184,11 +184,13 @@ pub const Accessor = struct {
 
                     if (comptime opts.static) {
                         caller.function(T, getter, handle.?, .{
+                            .cache = opts.cache,
                             .as_typed_array = opts.as_typed_array,
                             .null_as_undefined = opts.null_as_undefined,
                         });
                     } else {
                         caller.method(T, getter, handle.?, .{
+                            .cache = opts.cache,
                             .as_typed_array = opts.as_typed_array,
                             .null_as_undefined = opts.null_as_undefined,
                         });

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -261,7 +261,7 @@ pub const JsApi = struct {
     pub const applets = bridge.accessor(HTMLDocument.getApplets, null, .{});
     pub const plugins = bridge.accessor(HTMLDocument.getEmbeds, null, .{});
     pub const currentScript = bridge.accessor(HTMLDocument.getCurrentScript, null, .{});
-    pub const location = bridge.accessor(HTMLDocument.getLocation, HTMLDocument.setLocation, .{ .cache = "location" });
+    pub const location = bridge.accessor(HTMLDocument.getLocation, HTMLDocument.setLocation, .{});
     pub const all = bridge.accessor(HTMLDocument.getAll, null, .{});
     pub const cookie = bridge.accessor(HTMLDocument.getCookie, HTMLDocument.setCookie, .{});
     pub const doctype = bridge.accessor(HTMLDocument.getDocType, null, .{});

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -651,7 +651,7 @@ pub const JsApi = struct {
     pub const localStorage = bridge.accessor(Window.getLocalStorage, null, .{ .cache = "localStorage" });
     pub const sessionStorage = bridge.accessor(Window.getSessionStorage, null, .{ .cache = "sessionStorage" });
     pub const document = bridge.accessor(Window.getDocument, null, .{ .cache = "document" });
-    pub const location = bridge.accessor(Window.getLocation, Window.setLocation, .{ .cache = "location" });
+    pub const location = bridge.accessor(Window.getLocation, Window.setLocation, .{});
     pub const history = bridge.accessor(Window.getHistory, null, .{});
     pub const navigation = bridge.accessor(Window.getNavigation, null, .{});
     pub const crypto = bridge.accessor(Window.getCrypto, null, .{ .cache = "crypto" });


### PR DESCRIPTION
The idea is that frequently accessed properties, e.g. window.document, can be cached directly as data properties on the underlying v8::Object, removing the need for the access call into Zig. This is only used on a handful of properties, almost all of which are on the Window. It is important that the property be read-only. For example, window.location cannot be cached this way because window.location is writable (e.g. window.location.hash = '#blah').

This existed briefly before Zigdom, but was removed as part of the migration. The implementation has changed. This previously relied on a "postAttach" feature which no longer exists. It is not integrated in the bridge/callback directly and lazily applied after the first access.