### PR TITLE
Reduce perf regression max

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -124,8 +124,8 @@ jobs:
     needs: zig-build-release
 
     env:
-      MAX_MEMORY: 28000
-      MAX_AVG_DURATION: 23
+      MAX_MEMORY: 26000
+      MAX_AVG_DURATION: 17
       LIGHTPANDA_DISABLE_TELEMETRY: true
 
     # use a self host runner.


### PR DESCRIPTION
Mem 28MB -> 26MB  (currently a 24.1MB)
Time 23 -> 17  (currently at 14)

We've made some memory and performance optimization gains lately. Lowering these will let us spot incremental changes better.