### PR TITLE
call env.lowMemoryNotification() during page reset

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -225,6 +225,7 @@ fn reset(self: *Page, comptime initializing: bool) !void {
         self._session.browser.http_client.abort();
         self._script_manager.deinit();
         _ = self._session.browser.page_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
+        self._session.browser.env.lowMemoryNotification();
     }
 
     self._factory = Factory.init(self);


### PR DESCRIPTION
calling env.lowMemoryNotification() on page reset encourages v8 to free memory and keep low usage.

On the crawler benchmark, we peak at ~70MB vs ~22MB with this change. 