### PR TITLE
Disable JS object cache

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -160,18 +160,6 @@ fn _method(self: *Caller, comptime T: type, func: anytype, info: FunctionCallbac
     const mapped = try self.local.zigValueToJs(res, opts);
     const return_value = info.getReturnValue();
     return_value.set(mapped);
-
-    if (comptime opts.cache != null) {
-        // store the return value directly in the JS object for faster subsequent
-        // calls. We only do this for a few frequently used properties (e.g. window.document)
-        const local = self.local;
-        const key_handle = local.isolate.initStringHandle(opts.cache.?);
-        var out: v8.MaybeBool = undefined;
-        v8.v8__Object__DefineOwnProperty(js_this, local.handle, key_handle, mapped.handle, 0, &out);
-        if (comptime IS_DEBUG) {
-            std.debug.assert(out.has_value and out.value);
-        }
-    }
 }
 
 pub fn function(self: *Caller, comptime T: type, func: anytype, handle: *const v8.FunctionCallbackInfo, comptime opts: CallOpts) void {


### PR DESCRIPTION
Was added here https://github.com/lightpanda-io/browser/pull/1382/changes/43805ad69807e3bfc8394131b7b7ec729ca846e5

But causes segfaults. The issue is hard to understand. At first, it seemed like the value cached in a v8::Object was persisting through v8::contexts of the same isolate. Set window.document to the current &document, and in a different context, it retrieves that cached value (which is now an invalid pointers).

However, upon further investigation, this appears to be limited to a mix of navigation (which causes a new context to be created, and old values to be invalidated) + Inspector which continues to send commands to the old context.

Since contextDestroyed is something we're aware of and planning to do shortly, I think we can disable the cache until that's fixed.