### PR TITLE
Handle scripts that don't return a 200 status code

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -590,7 +590,7 @@ fn _documentIsComplete(self: *Page) !void {
     );
 }
 
-fn pageHeaderDoneCallback(transfer: *Http.Transfer) !void {
+fn pageHeaderDoneCallback(transfer: *Http.Transfer) !bool {
     var self: *Page = @ptrCast(@alignCast(transfer.ctx));
 
     // would be different than self.url in the case of a redirect
@@ -607,6 +607,8 @@ fn pageHeaderDoneCallback(transfer: *Http.Transfer) !void {
             .content_type = header.contentType(),
         });
     }
+
+    return true;
 }
 
 fn pageDataCallback(transfer: *Http.Transfer, data: []const u8) !void {

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -89,7 +89,7 @@ pub fn deinit(self: *Fetch) void {
     }
 }
 
-fn httpHeaderDoneCallback(transfer: *Http.Transfer) !void {
+fn httpHeaderDoneCallback(transfer: *Http.Transfer) !bool {
     const self: *Fetch = @ptrCast(@alignCast(transfer.ctx));
 
     if (transfer.getContentLength()) |cl| {
@@ -133,6 +133,8 @@ fn httpHeaderDoneCallback(transfer: *Http.Transfer) !void {
     while (it.next()) |hdr| {
         try res._headers.append(hdr.name, hdr.value, self._page);
     }
+
+    return true;
 }
 
 fn httpDataCallback(transfer: *Http.Transfer, data: []const u8) !void {


### PR DESCRIPTION
This was already being handled for async scripts, but for sync scripts, we'd log the error then proceed to try and execute the body (which would be some error message).

This allows the header_callback to return a boolean to indicate whether or not the http client should continue to process the request or abort it.