### PR TITLE
pumpMessageLoop before inspector deinit

### DIFF
--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -160,10 +160,8 @@ pub fn deinit(self: *Env) void {
     self.allocator.destroy(self.isolate_params);
 }
 
-pub fn newInspector(self: *Env, arena: Allocator, ctx: anytype) !*Inspector {
-    const inspector = try arena.create(Inspector);
+pub fn newInspector(self: *Env, inspector: *Inspector, ctx: anytype) !void {
     try Inspector.init(inspector, self.isolate.handle, ctx);
-    return inspector;
 }
 
 pub fn runMicrotasks(self: *const Env) void {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -190,7 +190,7 @@ fn createIsolatedWorld(cmd: anytype) !void {
 
     const world = try bc.createIsolatedWorld(params.worldName, params.grantUniveralAccess);
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
-    try world.createContextAndLoadPolyfills(page);
+    try world.createContext(page);
     const js_context = &world.executor.context.?;
 
     // Create the auxdata json for the contextCreated event
@@ -292,7 +292,7 @@ pub fn pageRemove(bc: anytype) !void {
 
 pub fn pageCreated(bc: anytype, page: *Page) !void {
     for (bc.isolated_worlds.items) |*isolated_world| {
-        try isolated_world.createContextAndLoadPolyfills(page);
+        try isolated_world.createContext(page);
     }
 }
 


### PR DESCRIPTION
Inspector has weak references to v8::Context, if we deinit the inspector and then shutdown contexts, we risk getting a use-after-free as those weak reference callback their finalizers on an inspector which no longer exists.

To some degree, this means the Inspector doesn't clean up its weak references on shutdown. I assume this is because it expects us to always clean them up with destroyContext.

This also keeps the inspector around until AFTER the page is killed (thus it's still alive to get the finalizer callback) and moves it off the session arena onto the browser context itself.