### PR TITLE
Add finalizer to Response and use an pooled arena

### DIFF
--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -37,6 +37,8 @@ const XMLHttpRequestEventTarget = @import("webapi/net/XMLHttpRequestEventTarget.
 const Blob = @import("webapi/Blob.zig");
 const AbstractRange = @import("webapi/AbstractRange.zig");
 
+const Allocator = std.mem.Allocator;
+
 const IS_DEBUG = builtin.mode == .Debug;
 const assert = std.debug.assert;
 
@@ -344,9 +346,7 @@ pub fn svgElement(self: *Factory, tag_name: []const u8, child: anytype) !*@TypeO
     return chain.get(4);
 }
 
-pub fn xhrEventTarget(self: *Factory, child: anytype) !*@TypeOf(child) {
-    const allocator = self._slab.allocator();
-
+pub fn xhrEventTarget(_: *const Factory, allocator: Allocator, child: anytype) !*@TypeOf(child) {
     return try AutoPrototypeChain(
         &.{ EventTarget, XMLHttpRequestEventTarget, @TypeOf(child) },
     ).create(allocator, child);

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -754,7 +754,7 @@ pub const Script = struct {
             return;
         }
 
-         switch (self.mode) {
+        switch (self.mode) {
             .import_async => |ia| ia.callback(ia.data, error.FailedToLoad),
             .import => {
                 const entry = manager.imported_modules.getPtr(self.url).?;

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -92,7 +92,7 @@ pub fn Builder(comptime T: type) type {
             return entries;
         }
 
-        pub fn finalizer(comptime func: *const fn (self: *T, comptime shutdown: bool) void) Finalizer {
+        pub fn finalizer(comptime func: *const fn (self: *T, shutdown: bool) void) Finalizer {
             return .{
                 .from_zig = struct {
                     fn wrap(ptr: *anyopaque) void {

--- a/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
+++ b/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
@@ -26,13 +26,13 @@ const XMLHttpRequestEventTarget = @This();
 
 _type: Type,
 _proto: *EventTarget,
-_on_abort: ?js.Function.Global = null,
-_on_error: ?js.Function.Global = null,
-_on_load: ?js.Function.Global = null,
-_on_load_end: ?js.Function.Global = null,
-_on_load_start: ?js.Function.Global = null,
-_on_progress: ?js.Function.Global = null,
-_on_timeout: ?js.Function.Global = null,
+_on_abort: ?js.Function.Temp = null,
+_on_error: ?js.Function.Temp = null,
+_on_load: ?js.Function.Temp = null,
+_on_load_end: ?js.Function.Temp = null,
+_on_load_start: ?js.Function.Temp = null,
+_on_progress: ?js.Function.Temp = null,
+_on_timeout: ?js.Function.Temp = null,
 
 pub const Type = union(enum) {
     request: *@import("XMLHttpRequest.zig"),
@@ -71,85 +71,85 @@ pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchT
     );
 }
 
-pub fn getOnAbort(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnAbort(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_abort;
 }
 
 pub fn setOnAbort(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_abort = try cb.persistWithThis(self);
+        self._on_abort = try cb.tempWithThis(self);
     } else {
         self._on_abort = null;
     }
 }
 
-pub fn getOnError(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnError(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_error;
 }
 
 pub fn setOnError(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_error = try cb.persistWithThis(self);
+        self._on_error = try cb.tempWithThis(self);
     } else {
         self._on_error = null;
     }
 }
 
-pub fn getOnLoad(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnLoad(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_load;
 }
 
 pub fn setOnLoad(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_load = try cb.persistWithThis(self);
+        self._on_load = try cb.tempWithThis(self);
     } else {
         self._on_load = null;
     }
 }
 
-pub fn getOnLoadEnd(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnLoadEnd(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_load_end;
 }
 
 pub fn setOnLoadEnd(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_load_end = try cb.persistWithThis(self);
+        self._on_load_end = try cb.tempWithThis(self);
     } else {
         self._on_load_end = null;
     }
 }
 
-pub fn getOnLoadStart(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnLoadStart(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_load_start;
 }
 
 pub fn setOnLoadStart(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_load_start = try cb.persistWithThis(self);
+        self._on_load_start = try cb.tempWithThis(self);
     } else {
         self._on_load_start = null;
     }
 }
 
-pub fn getOnProgress(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnProgress(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_progress;
 }
 
 pub fn setOnProgress(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_progress = try cb.persistWithThis(self);
+        self._on_progress = try cb.tempWithThis(self);
     } else {
         self._on_progress = null;
     }
 }
 
-pub fn getOnTimeout(self: *const XMLHttpRequestEventTarget) ?js.Function.Global {
+pub fn getOnTimeout(self: *const XMLHttpRequestEventTarget) ?js.Function.Temp {
     return self._on_timeout;
 }
 
 pub fn setOnTimeout(self: *XMLHttpRequestEventTarget, cb_: ?js.Function) !void {
     if (cb_) |cb| {
-        self._on_timeout = try cb.persistWithThis(self);
+        self._on_timeout = try cb.tempWithThis(self);
     } else {
         self._on_timeout = null;
     }


### PR DESCRIPTION
Unlike XHR, Response is a bit more complicated as it can exist in Zig code without ever being given to v8. So we need to track this handoff to know who is responsible for freeing it (zig code, on error/shutdown) or v8 code after promise resolution.

This also cleansup a bad merge for the XHR finalizer and adds cleaning up the `XMLHttpRequestEventTarget` callbacks.