### PR TITLE
Leverage finalizers and ArenaPool in Intersction and Mutation Observer

### DIFF
--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -244,6 +244,18 @@ pub fn weakRef(self: *Context, obj: anytype) void {
     v8.v8__Global__SetWeakFinalizer(global, obj, bridge.Struct(@TypeOf(obj)).JsApi.Meta.finalizer.from_v8, v8.kParameter);
 }
 
+pub fn safeWeakRef(self: *Context, obj: anytype) void {
+    const global = self.identity_map.getPtr(@intFromPtr(obj)) orelse {
+        if (comptime IS_DEBUG) {
+            // should not be possible
+            std.debug.assert(false);
+        }
+        return;
+    };
+    v8.v8__Global__ClearWeak(global);
+    v8.v8__Global__SetWeakFinalizer(global, obj, bridge.Struct(@TypeOf(obj)).JsApi.Meta.finalizer.from_v8, v8.kParameter);
+}
+
 pub fn strongRef(self: *Context, obj: anytype) void {
     const global = self.identity_map.getPtr(@intFromPtr(obj)) orelse {
         if (comptime IS_DEBUG) {


### PR DESCRIPTION
Both of these become self-contained with their own arena, which can be cleaned up when (a) we don't need it anymore and (b) v8 doens't need it. The "we don't need it anymore" is true when there's nothing being observed.

The underlying records also get their own arena and are handed off to v8 to finalize whenever they fall out of scope.