### PR TITLE
always log try/catch error on call function

### DIFF
--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -72,12 +72,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
 pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
     var caught: js.TryCatch.Caught = undefined;
     return self._tryCallWithThis(T, self.getThis(), args, &caught) catch |err| {
-        log.warn(.js, "call caught", .{
-            .err = err,
-            .exception = caught.exception,
-            .line = caught.line orelse 0,
-            .stack = caught.stack orelse "???",
-        });
+        log.warn(.js, "call caught", .{ .err = err, .caught = caught });
         return err;
     };
 }
@@ -85,27 +80,21 @@ pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
 pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
     var caught: js.TryCatch.Caught = undefined;
     return self._tryCallWithThis(T, this, args, &caught) catch |err| {
-        log.warn(.js, "callWithThis caught", .{
-            .err = err,
-            .exception = caught.exception,
-            .line = caught.line orelse 0,
-            .stack = caught.stack orelse "???",
-        });
+        log.warn(.js, "callWithThis caught", .{ .err = err, .caught = caught });
         return err;
     };
 }
 
 pub fn tryCall(self: *const Function, comptime T: type, args: anytype, caught: *js.TryCatch.Caught) !T {
-    caught.* = .{};
     return self._tryCallWithThis(T, self.getThis(), args, caught);
 }
 
 pub fn tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype, caught: *js.TryCatch.Caught) !T {
-    caught.* = .{};
     return self._tryCallWithThis(T, this, args, caught);
 }
 
 pub fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype, caught: *js.TryCatch.Caught) !T {
+    caught.* = .{};
     const local = self.local;
 
     // When we're calling a function from within JavaScript itself, this isn't


### PR DESCRIPTION
We force log of detailled error caught during function call.

**Before**

```
$ zig build  wpt -- --json promise-job-incumbent.html
[WARN  event : page load . . . . . . . . . . . . . . . . . . . [+0ms]
      err = JSExecCallback

{
  "pass": false,
  "crash": false,
  "name": "html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html",
  "cases": [
    {
      "pass": false,
      "name": "no test suite completion",
      "message": "|The test never reaches the completion callback."
    }
  ]
},{"name":"empty","pass": true, "cases": []}]
```

**After**

```
$ zig build  wpt -- --json promise-job-incumbent.html
[WARN  js : callWithThis caught . . . . . . . . . . . . . . .  [+0ms]
      err = JSExecCallback
      caught =
        exception: TypeError: Cannot read properties of undefined (reading 'document')
        stack: TypeError: Cannot read properties of undefined (reading 'document')
    at window.onload (http://localhost:9582/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html:11:36)
        line: 11
        caught: true

WARN  event : page load . . . . . . . . . . . . . . . . . . . [+0ms]
      err = JSExecCallback

{
  "pass": false,
  "crash": false,
  "name": "html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html",
  "cases": [
    {
      "pass": false,
      "name": "no test suite completion",
      "message": "|The test never reaches the completion callback."
    }
  ]
},{"name":"empty","pass": true, "cases": []}]
```