### PR TITLE
Cleanup js -> string

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -276,7 +276,6 @@ fn reset(self: *Page, comptime initializing: bool) !void {
             self._arena_pool_leak_track.clearRetainingCapacity();
         }
 
-
         // We force a garbage collection between page navigations to keep v8
         // memory usage as low as possible.
         self._session.browser.env.memoryPressureNotification(.moderate);

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -314,14 +314,14 @@ fn isInErrorSet(err: anyerror, comptime T: type) bool {
 }
 
 fn nameToString(self: *const Caller, comptime T: type, name: *const v8.Name) !T {
-    const v8_string = @as(*const v8.String, @ptrCast(name));
+    const handle = @as(*const v8.String, @ptrCast(name));
     if (T == string.String) {
-        return self.local.jsStringToStringSSO(v8_string, .{});
+        return js.String.toSSO(.{ .local = &self.local, .handle = handle }, false);
     }
     if (T == string.Global) {
-        return self.local.jsStringToStringSSO(v8_string, .{ .allocator = self.local.ctx.allocator });
+        return js.String.toSSO(.{ .local = &self.local, .handle = handle }, true);
     }
-    return try self.local.valueHandleToString(v8_string, .{});
+    return try js.String.toSlice(.{ .local = &self.local, .handle = handle });
 }
 
 fn handleError(self: *Caller, comptime T: type, comptime F: type, err: anyerror, info: anytype, comptime opts: CallOpts) void {

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -254,8 +254,7 @@ fn promiseRejectCallback(message_handle: v8.PromiseRejectMessage) callconv(.c) v
 
     const value =
         if (v8.v8__PromiseRejectMessage__GetValue(&message_handle)) |v8_value|
-            // @HandleScope - no reason to create a js.Context here
-            local.valueHandleToString(v8_value, .{}) catch |err| @errorName(err)
+            js.Value.toStringSlice(.{ .local = &local, .handle = v8_value }) catch |err| @errorName(err)
         else
             "no value";
 

--- a/src/browser/js/Module.zig
+++ b/src/browser/js/Module.zig
@@ -131,7 +131,7 @@ const Requests = struct {
 const Request = struct {
     handle: *const v8.ModuleRequest,
 
-    pub fn specifier(self: Request) *const v8.String {
-        return v8.v8__ModuleRequest__GetSpecifier(self.handle).?;
+    pub fn specifier(self: Request, local: *const js.Local) js.String {
+        return .{ .local = local, .handle = v8.v8__ModuleRequest__GetSpecifier(self.handle).? };
     }
 };

--- a/src/browser/js/Object.zig
+++ b/src/browser/js/Object.zig
@@ -201,8 +201,8 @@ pub const NameIterator = struct {
         }
         self.idx += 1;
 
-        const js_val_handle = v8.v8__Object__GetIndex(@ptrCast(self.handle), self.local.handle, idx) orelse return error.JsException;
-        const js_val = js.Value{ .local = self.local, .handle = js_val_handle };
-        return try self.local.valueToString(js_val, .{});
+        const local = self.local;
+        const js_val_handle = v8.v8__Object__GetIndex(@ptrCast(self.handle), local.handle, idx) orelse return error.JsException;
+        return try js.Value.toStringSlice(.{ .local = local, .handle = js_val_handle });
     }
 };

--- a/src/browser/js/TryCatch.zig
+++ b/src/browser/js/TryCatch.zig
@@ -46,12 +46,12 @@ pub fn caught(self: TryCatch, allocator: Allocator) ?Caught {
 
     const exception: ?[]const u8 = blk: {
         const handle = v8.v8__TryCatch__Exception(&self.handle) orelse break :blk null;
-        break :blk l.valueHandleToString(@ptrCast(handle), .{ .allocator = allocator }) catch |err| @errorName(err);
+        break :blk js.String.toSliceWithAlloc(.{ .local = l, .handle = @ptrCast(handle) }, allocator) catch |err| @errorName(err);
     };
 
     const stack: ?[]const u8 = blk: {
         const handle = v8.v8__TryCatch__StackTrace(&self.handle, l.handle) orelse break :blk null;
-        break :blk l.valueHandleToString(@ptrCast(handle), .{ .allocator = allocator }) catch |err| @errorName(err);
+        break :blk js.String.toSliceWithAlloc(.{ .local = l, .handle = @ptrCast(handle) }, allocator) catch |err| @errorName(err);
     };
 
     return .{

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -422,7 +422,7 @@ pub fn unknownPropertyCallback(c_name: ?*const v8.Name, handle: ?*const v8.Prope
     hs.init(local.isolate);
     defer hs.deinit();
 
-    const property: []const u8 = local.valueHandleToString(@ptrCast(c_name.?), .{}) catch {
+    const property: []const u8 = js.String.toSlice(.{ .local = local, .handle = @ptrCast(c_name.?) }) catch {
         return 0;
     };
 

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -116,7 +116,7 @@ pub fn throwIfAborted(self: *const AbortSignal, page: *Page) !ThrowIfAborted {
     if (self._aborted) {
         const exception = switch (self._reason) {
             .string => |str| local.throw(str),
-            .js_val => |js_val| local.throw(try local.toLocal(js_val).toString(.{ .allocator = page.call_arena })),
+            .js_val => |js_val| local.throw(try local.toLocal(js_val).toStringSlice()),
             .undefined => local.throw("AbortError"),
         };
         return .{ .exception = exception };

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -146,7 +146,7 @@ const ValueWriter = struct {
         var buf: [32]u8 = undefined;
         for (self.values, 0..) |value, i| {
             const name = try std.fmt.bufPrint(&buf, "param.{d}", .{i});
-            try writer.write(name, try value.toString(.{}));
+            try writer.write(name, value);
         }
     }
 

--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -73,9 +73,8 @@ pub fn define(self: *CustomElementRegistry, name: []const u8, constructor: js.Fu
             var js_arr = observed_attrs.toArray();
             for (0..js_arr.len()) |i| {
                 const attr_val = js_arr.get(@intCast(i)) catch continue;
-                const attr_name = attr_val.toString(.{ .allocator = page.arena }) catch continue;
-                const owned_attr = page.dupeString(attr_name) catch continue;
-                definition.observed_attributes.put(page.arena, owned_attr, {}) catch continue;
+                const attr_name = attr_val.toStringSliceWithAlloc(page.arena) catch continue;
+                definition.observed_attributes.put(page.arena, attr_name, {}) catch continue;
             }
         }
     }

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -68,12 +68,11 @@ pub fn fromJsObject(arena: Allocator, js_obj: js.Object, comptime normalizer: ?N
 
     while (try it.next()) |name| {
         const js_value = try js_obj.get(name);
-        const value = try js_value.toString(.{});
         const normalized = if (comptime normalizer) |n| n(name, page) else name;
 
         list._entries.appendAssumeCapacity(.{
             .name = try String.init(arena, normalized, .{}),
-            .value = try String.init(arena, value, .{}),
+            .value = try js_value.toSSOWithAlloc(arena),
         });
     }
 

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -277,7 +277,7 @@ pub fn cancelIdleCallback(self: *Window, id: u32) void {
 pub fn reportError(self: *Window, err: js.Value, page: *Page) !void {
     const error_event = try ErrorEvent.initTrusted("error", .{
         .@"error" = try err.persist(),
-        .message = err.toString(.{}) catch "Unknown error",
+        .message = err.toStringSlice() catch "Unknown error",
         .bubbles = false,
         .cancelable = true,
     }, page);

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -49,8 +49,8 @@ pub fn init(opts_: ?InitOpts, page: *Page) !*URLSearchParams {
                 if (js_val.isObject()) {
                     break :blk try KeyValueList.fromJsObject(arena, js_val.toObject(), null, page);
                 }
-                if (js_val.isString()) {
-                    break :blk try paramsFromString(arena, try js_val.toString(.{ .allocator = arena }), &page.buf);
+                if (js_val.isString()) |js_str| {
+                    break :blk try paramsFromString(arena, try js_str.toSliceWithAlloc(arena), &page.buf);
                 }
                 return error.InvalidArgument;
             },

--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -140,7 +140,7 @@ fn run(
         return err;
     };
 
-    return value.toString(.{ .allocator = arena });
+    return value.toStringSliceWithAlloc(arena);
 }
 
 const Writer = struct {


### PR DESCRIPTION
Converting a JS value to a string is a bit messy right now. There's duplication between string helpers in js.Local, and what js.String and js.Value provide.

Now, all stringifying functions are in js.String, with some helpers in js.Value.

Also tried to streamline the APIs around most common-cases (e.g. js.String -> []u8 using call_arena). js.String now also implements format, so it can be used as-is in some cases.