### PR TITLE
Disable crash report in debug

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
+const IS_DEBUG = builtin.mode == .Debug;
+
 const abort = std.posix.abort;
 
 // tracks how deep within a panic we're panicling
@@ -70,6 +72,10 @@ pub noinline fn crash(
 }
 
 fn report(reason: []const u8, begin_addr: usize) !void {
+    if (comptime IS_DEBUG) {
+        return;
+    }
+
     if (@import("telemetry/telemetry.zig").isDisabled()) {
         return;
     }


### PR DESCRIPTION
Crashing when developing is more noise than signal