### PR TITLE
Rework Inspector usage

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -50,10 +50,14 @@ session_arena: ArenaAllocator,
 transfer_arena: ArenaAllocator,
 notification: *Notification,
 
-pub fn init(app: *App) !Browser {
+const InitOpts = struct {
+    env: js.Env.InitOpts = .{},
+};
+
+pub fn init(app: *App, opts: InitOpts) !Browser {
     const allocator = app.allocator;
 
-    var env = try js.Env.init(app);
+    var env = try js.Env.init(app, opts.env);
     errdefer env.deinit();
 
     const notification = try Notification.init(allocator, app.notification);

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -305,7 +305,7 @@ fn resolveNode(cmd: anytype) !void {
 
     // node._node is a *DOMNode we need this to be able to find its most derived type e.g. Node -> Element -> HTMLElement
     // So we use the Node.Union when retrieve the value from the environment
-    const remote_object = try bc.inspector.getRemoteObject(
+    const remote_object = try bc.inspector_session.getRemoteObject(
         &ls.?.local,
         params.objectGroup orelse "",
         node.dom,
@@ -404,7 +404,7 @@ fn getNode(arena: Allocator, bc: anytype, node_id: ?Node.Id, backend_node_id: ?N
         defer ls.deinit();
 
         // Retrieve the object from which ever context it is in.
-        const parser_node = try bc.inspector.getNodePtr(arena, object_id_, &ls.local);
+        const parser_node = try bc.inspector_session.getNodePtr(arena, object_id_, &ls.local);
         return try bc.node_registry.register(@ptrCast(@alignCast(parser_node)));
     }
     return error.MissingParams;

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -182,7 +182,7 @@ fn createTarget(cmd: anytype) !void {
         defer ls.deinit();
 
         const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
-        bc.inspector.contextCreated(
+        bc.inspector_session.inspector.contextCreated(
             &ls.local,
             "",
             "", // @ZIGDOM

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -37,7 +37,7 @@ pub const FetchOpts = struct {
     writer: ?*std.Io.Writer = null,
 };
 pub fn fetch(app: *App, url: [:0]const u8, opts: FetchOpts) !void {
-    var browser = try Browser.init(app);
+    var browser = try Browser.init(app, .{});
     defer browser.deinit();
 
     var session = try browser.newSession();

--- a/src/main_legacy_test.zig
+++ b/src/main_legacy_test.zig
@@ -43,7 +43,7 @@ pub fn main() !void {
     var test_arena = std.heap.ArenaAllocator.init(allocator);
     defer test_arena.deinit();
 
-    var browser = try lp.Browser.init(app);
+    var browser = try lp.Browser.init(app, .{});
     defer browser.deinit();
 
     const session = try browser.newSession();

--- a/src/main_wpt.zig
+++ b/src/main_wpt.zig
@@ -65,7 +65,7 @@ pub fn main() !void {
     });
     defer app.deinit();
 
-    var browser = try lp.Browser.init(app);
+    var browser = try lp.Browser.init(app, .{});
     defer browser.deinit();
 
     // An arena for running each tests. Is reset after every test.

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -460,7 +460,7 @@ test "tests:beforeAll" {
     });
     errdefer test_app.deinit();
 
-    test_browser = try Browser.init(test_app);
+    test_browser = try Browser.init(test_app, .{});
     errdefer test_browser.deinit();
 
     test_session = try test_browser.newSession();


### PR DESCRIPTION
V8's inspector world is made up of 4 components: Inspector, Client, Channel and Session. Currently, we treat all 4 components as a single unit which is tied to the lifetime of CDP BrowserContext - or, loosely speaking, 1 "Inspector Unit" per page / v8::Context.

According to https://web.archive.org/web/20210622022956/https://hyperandroid.com/2020/02/12/v8-inspector-from-an-embedder-standpoint/ and conversation with Gemini, it's more typical to have 1 inspector per isolate. The general breakdown is the Inspector is the top-level manager, the Client is our implementation which control how the Inspector works (its function we expose that v8 calls into). These should be tied to the Isolate. Channels and Sessions are more closely tied to Context, where the Channel is v8->zig and the Session us zig->v8.

This PR does a few things
1 - It creates 1 Inspector and Client per Isolate (Env.js) 2 - It creates 1 Session/Channel per BrowserContext 3 - It merges v8::Session and v8::Channel into Inspector.Session 4 - It moves the Inspector instance directly into the Env 5 - BrowserContext interacts with the Inspector.Session, not the Inspector

4 is arguably unnecessary with respect to the main goal of this commit, but the end-goal is to tighten the integration. Specifically, rather than CDP having to inform the inspector that a context was created/destroyed, the Env which manages Contexts directly (https://github.com/lightpanda-io/browser/pull/1432) and which now has direct access to the Inspector, is now equipped to keep this in sync.