### PR TITLE
A few small tweaks

### DIFF
--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -85,7 +85,7 @@ pub fn startSession(self: *Inspector, ctx: anytype) *Session {
         std.debug.assert(self.session == null);
     }
 
-    self.session = undefined;
+    self.session = @as(Session, undefined);
     Session.init(&self.session.?, self, ctx);
     return &self.session.?;
 }


### PR DESCRIPTION
1 - Embed Page into Session, avoids having to allocate/deallocate the page 
2 - Fix false-positive arena pool leak detection
3 - On form submit, pre-check if navigation will allowed before building the
    contents
4 - Make sure QueuedNavigation structure isn't use after page is removed