### PR TITLE
fix slice alias crash after same document navigation

### DIFF
--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -271,8 +271,15 @@ pub fn navigateInner(
     const committed = local.createPromiseResolver();
     const finished = local.createPromiseResolver();
 
-    const new_url = try URL.resolve(arena, page.url, url, .{});
+    var new_url = try URL.resolve(arena, page.url, url, .{});
     const is_same_document = URL.eqlDocument(new_url, page.url);
+
+    // In case of navigation to the same document, we force an url duplication.
+    // Keeping the same url generates a crash during WPT test navigate-history-push-same-url.html.
+    // When building a script's src, script's base and page url overlap.
+    if (is_same_document) {
+        new_url = try arena.dupeZ(u8, new_url);
+    }
 
     const previous = self.getCurrentEntry();
 


### PR DESCRIPTION
The WPT tests navigation-api/navigation-methods/navigate-history-push-same-url.html crashed with a @memcpy arguments alias error.

It seems to be due to the reuse of the previous page.url string. Forcing to duplicate it fixes the crash.

```
$ make wpt -- navigation-api/navigation-methods/navigate-history-push-same-url.html
thread 1083076 panic: @memcpy arguments alias
/usr/local/zig-0.15.2/lib/std/mem.zig:3259:42: 0x3a1ae2f in joinMaybeZ (lightpanda-wpt)
    @memcpy(buf[0..slices[0].len], slices[0]);
                                         ^
/usr/local/zig-0.15.2/lib/std/mem.zig:3242:31: 0x35dd112 in joinZ (lightpanda-wpt)
    const out = try joinMaybeZ(allocator, separator, slices, true);
                              ^
/home/pierre/wrk/browser-review/src/browser/URL.zig:69:29: 0x35dbba1 in resolve__anon_80404 (lightpanda-wpt)
        return std.mem.joinZ(allocator, "", &.{ base[0..path_start], path });
                            ^
/home/pierre/wrk/browser-review/src/browser/webapi/element/html/Script.zig:52:27: 0x38667b3 in getSrc (lightpanda-wpt)
    return try URL.resolve(page.call_arena, page.base(), self._src, .{});
                          ^
/home/pierre/wrk/browser-review/src/browser/js/Caller.zig:158:5: 0x3866dba in _method__anon_128825 (lightpanda-wpt)
    const res = @call(.auto, func, args);
    ^
/home/pierre/wrk/browser-review/src/browser/js/Caller.zig:146:17: 0x3566501 in method__anon_79455 (lightpanda-wpt)
    self._method(T, func, info, opts) catch |err| {
                ^
/home/pierre/wrk/browser-review/src/browser/js/bridge.zig:222:38: 0x35663e8 in wrap (lightpanda-wpt)
                        caller.method(T, getter, handle.?, .{
                                     ^
???:?:?: 0x6eb50c6 in ??? (???)
Unwind error at address `:0x6eb50c6` (error.MissingFDE), trace may be incomplete
```