### PR TITLE
Call Inpsector::ContextDestroyed

### DIFF
--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -264,8 +264,17 @@ pub fn destroyContext(self: *Env, context: *Context) void {
             @panic("Tried to remove unknown context");
         }
     }
+
+    const isolate = self.isolate;
+    if (self.inspector) |inspector| {
+        var hs: js.HandleScope = undefined;
+        hs.init(isolate);
+        defer hs.deinit();
+        inspector.contextDestroyed(@ptrCast(v8.v8__Global__Get(&context.handle, isolate.handle)));
+    }
+
     context.deinit();
-    self.isolate.notifyContextDisposed();
+    isolate.notifyContextDisposed();
 }
 
 pub fn runMicrotasks(self: *const Env) void {

--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -128,8 +128,8 @@ pub fn contextCreated(
     }
 }
 
-pub fn contextDestroyed(self: *Inspector, local: *const js.Local) void {
-    v8.v8_inspector__Inspector__ContextDestroyed(self.handle, local.handle);
+pub fn contextDestroyed(self: *Inspector, context: *const v8.Context) void {
+    v8.v8_inspector__Inspector__ContextDestroyed(self.handle, context);
 }
 
 pub fn resetContextGroup(self: *const Inspector) void {


### PR DESCRIPTION
This seems to solve some potential use-after-free issues. By informing the Inspector that the context is gone, it seems to effectively ensure that no more messages are sent from the inspector for things related to the context.