### PR TITLE
Fixes a few context issues.

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -234,15 +234,6 @@ pub fn deinit(self: *Page) void {
         // stats.print(&stream) catch unreachable;
     }
 
-    {
-        // some MicroTasks might be referencing the page, we need to drain it while
-        // the page still exists
-        var ls: JS.Local.Scope = undefined;
-        self.js.localScope(&ls);
-        defer ls.deinit();
-        ls.local.runMicrotasks();
-    }
-
     const session = self._session;
     session.browser.env.destroyContext(self.js);
 

--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -74,9 +74,15 @@ pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts
     });
 }
 
+
 pub fn run(self: *Scheduler) !?u64 {
     _ = try self.runQueue(&self.low_priority);
     return self.runQueue(&self.high_priority);
+}
+
+pub fn hasReadyTasks(self: *Scheduler) bool {
+    const now = milliTimestamp(.monotonic);
+    return queueuHasReadyTask(&self.low_priority, now) or queueuHasReadyTask(&self.high_priority, now);
 }
 
 fn runQueue(self: *Scheduler, queue: *Queue) !?u64 {
@@ -110,6 +116,11 @@ fn runQueue(self: *Scheduler, queue: *Queue) !?u64 {
         }
     }
     return null;
+}
+
+fn queueuHasReadyTask(queue: *Queue, now: u64) bool {
+    const task = queue.peek() orelse return false;
+    return task.run_at <= now;
 }
 
 fn finalizeTasks(queue: *Queue) void {


### PR DESCRIPTION
First, for macrotasks, it ensures that the correct context is entered.

More important, for microtasks, it protects against use-after-free. This is something we already did, to some degree, in page.deinit: we would run microtasks before erasing the page, in case any microtasks referenced the page.

The new approach moves the guard to the context (since we have multiple contexts) and protects against a microtasks enqueue a new task during shutdown (something the original never did).