### PR TITLE
Expose Script.text property

### DIFF
--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -100,7 +100,6 @@ pub fn setInnerText(self: *Script, text: []const u8, page: *Page) !void {
     try self.asNode().setTextContent(text, page);
 }
 
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Script);
 


### PR DESCRIPTION
This should fix a number of rendering issues, but was specifically added while investigating issues rendering sites that used knockout.js