### PR TITLE
Log unknown object properties in debug builds

### DIFF
--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -142,7 +142,7 @@ pub fn init(app: *App, opts: InitOpts) !Env {
 
         const global_template_local = v8.v8__FunctionTemplate__InstanceTemplate(js_global).?;
         v8.v8__ObjectTemplate__SetNamedHandler(global_template_local, &.{
-            .getter = bridge.unknownPropertyCallback,
+            .getter = bridge.unknownWindowPropertyCallback,
             .setter = null,
             .query = null,
             .deleter = null,


### PR DESCRIPTION
We currently log any unknown property access on the global (window). This has proven pretty useful when debugging, often letting us know a type we're completely missing.

However, it isn't just about what types we have, it's also about the properties those types expose. Inspired by the wasted time spent on https://github.com/lightpanda-io/browser/pull/1473, this commit adds the same type of logging for unknown properties on objects. In debug mode only. This is only done for objects which don't have their own NamedIndexer.