### PR TITLE
Make document.createElement and createElementNS case-insensitive for …

### DIFF
--- a/src/browser/tests/document/create_element.html
+++ b/src/browser/tests/document/create_element.html
@@ -2,12 +2,16 @@
 <body></body>
 <script src="../testing.js"></script>
 <script id=createElement>
-  const div = document.createElement('div');
-  testing.expectEqual("DIV", div.tagName);
-  div.id = "hello";
+  const div1 = document.createElement('div');
+  testing.expectEqual(true, div1 instanceof HTMLDivElement);
+  testing.expectEqual("DIV", div1.tagName);
+  div1.id = "hello";
   testing.expectEqual(null, $('#hello'));
 
-  document.getElementsByTagName('body')[0].appendChild(div);
-  testing.expectEqual(div, $('#hello'));
+  const div2 = document.createElement('DIV');
+  testing.expectEqual(true, div2 instanceof HTMLDivElement);
+
+  document.getElementsByTagName('body')[0].appendChild(div1);
+  testing.expectEqual(div1, $('#hello'));
 </script>
 

--- a/src/browser/tests/document/create_element_ns.html
+++ b/src/browser/tests/document/create_element_ns.html
@@ -2,9 +2,15 @@
 <body></body>
 <script src="../testing.js"></script>
 <script id=createElementNS>
-  const htmlDiv = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-  testing.expectEqual('DIV', htmlDiv.tagName);
-  testing.expectEqual('http://www.w3.org/1999/xhtml', htmlDiv.namespaceURI);
+  const htmlDiv1 = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+  testing.expectEqual('DIV', htmlDiv1.tagName);
+  testing.expectEqual(true, htmlDiv1 instanceof HTMLDivElement);
+  testing.expectEqual('http://www.w3.org/1999/xhtml', htmlDiv1.namespaceURI);
+
+  const htmlDiv2 = document.createElementNS('http://www.w3.org/1999/xhtml', 'DIV');
+  testing.expectEqual('DIV', htmlDiv2.tagName);
+  testing.expectEqual(true, htmlDiv2 instanceof HTMLDivElement);
+  testing.expectEqual('http://www.w3.org/1999/xhtml', htmlDiv2.namespaceURI);
 
   const svgRect = document.createElementNS('http://www.w3.org/2000/svg', 'RecT');
   testing.expectEqual('RecT', svgRect.tagName);


### PR DESCRIPTION
…HTML NS

This could more cleanly be applied to page.createElementNS, but that would add overhead to the parser. Alternative would be to pass a comptime flag to page.createElementNS (e.g. like the from_parser we pass elsewhere).