### PR TITLE
Add dummy window.opener accessor

### DIFF
--- a/src/browser/tests/window/window.html
+++ b/src/browser/tests/window/window.html
@@ -5,6 +5,7 @@
   testing.expectEqual(window, globalThis);
   testing.expectEqual(window, self);
   testing.expectEqual(window, window.self);
+  testing.expectEqual(null, window.opener);
 
   testing.expectEqual(1080, innerHeight);
   testing.expectEqual(1920, innerWidth);

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
 //
 // Francis Bouvier <francis@lightpanda.io>
 // Pierre Tachoire <pierre@lightpanda.io>
@@ -421,6 +421,12 @@ pub fn getScrollY(self: *const Window) u32 {
     return self._scroll_pos.y;
 }
 
+pub fn getOpener(_: *const Window) ?*Window {
+    // This should return a window-like object in specific conditions. Would be
+    // pretty complicated to properly support I think.
+    return null;
+}
+
 const ScrollToOpts = union(enum) {
     x: i32,
     opts: Opts,
@@ -749,6 +755,7 @@ pub const JsApi = struct {
     pub const pageYOffset = bridge.accessor(Window.getScrollY, null, .{ .cache = "pageYOffset" });
     pub const scrollTo = bridge.function(Window.scrollTo, .{});
     pub const scroll = bridge.function(Window.scrollTo, .{});
+    pub const opener = bridge.accessor(Window.getOpener, null, .{});
 };
 
 const testing = @import("../../testing.zig");


### PR DESCRIPTION
This seems pretty complicated to implement...mostly because we'd have to keep a window around in certain cases and because exactly what's accessible on that window depends on a few factors.