### PR TITLE
Remove the "TODO-CUSTOM-NAME" name on custom elements

### DIFF
--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -241,7 +241,6 @@ pub const JsApi = struct {
     pub const bridge = js.Bridge(Custom);
 
     pub const Meta = struct {
-        pub const name = "TODO-CUSTOM-NAME";
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };


### PR DESCRIPTION
Giving a WebAPI a JsApi.Meta.name registers that name on the global object, e.g window['TODO-CUSTOM-NAME'] becomes a type.