### PR TITLE
Reduce some debug logs

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -92,7 +92,7 @@ pub const Callback = union(enum) {
 
 pub fn register(self: *EventManager, target: *EventTarget, typ: []const u8, callback: Callback, opts: RegisterOptions) !void {
     if (comptime IS_DEBUG) {
-        log.debug(.event, "eventManager.register", .{ .type = typ, .capture = opts.capture, .once = opts.once, .target = target });
+        log.debug(.event, "eventManager.register", .{ .type = typ, .capture = opts.capture, .once = opts.once, .target = target.toString() });
     }
 
     // If a signal is provided and already aborted, don't register the listener

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -713,10 +713,6 @@ fn _documentIsComplete(self: *Page) !void {
             ls.toLocal(maybe_inline_listener),
             .{ .context = "Page dispatch load events" },
         );
-
-        if (comptime IS_DEBUG) {
-            log.debug(.page, "load event for element", .{ .element = element });
-        }
     }
 
     // `_to_load` can be cleaned here.

--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -137,7 +137,7 @@ pub fn format(self: *EventTarget, writer: *std.Io.Writer) !void {
 
 pub fn toString(self: *EventTarget) []const u8 {
     return switch (self._type) {
-        .node => |n| return n.className(),
+        .node => return "[object Node]",
         .generic => return "[object EventTarget]",
         .window => return "[object Window]",
         .xhr => return "[object XMLHttpRequestEventTarget]",


### PR DESCRIPTION
1 - Remove the double logging of "load" dispatch

2 - On even registration, just log the event target type, not the full node 

3 - Most significantly, rather than logging unknown properties (both global and
    per object) as they happen, collect them and log the on context ends. This
    log includes a count of how often it happened. On some pages, this reduces
    the number of unknown property messages by thousands.