### PR TITLE
Fix class name iterator

### DIFF
--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -239,7 +239,7 @@ pub fn getElementsByClassName(self: *Document, class_name: []const u8, page: *Pa
 
     // Parse space-separated class names
     var class_names: std.ArrayList([]const u8) = .empty;
-    var it = std.mem.tokenizeAny(u8, class_name, &std.ascii.whitespace);
+    var it = std.mem.tokenizeAny(u8, class_name, "\t\n\x0C\r ");
     while (it.next()) |name| {
         try class_names.append(arena, try page.dupeString(name));
     }

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1138,7 +1138,7 @@ pub fn getElementsByClassName(self: *Element, class_name: []const u8, page: *Pag
 
     // Parse space-separated class names
     var class_names: std.ArrayList([]const u8) = .empty;
-    var it = std.mem.tokenizeAny(u8, class_name, &std.ascii.whitespace);
+    var it = std.mem.tokenizeAny(u8, class_name, "\t\n\x0C\r ");
     while (it.next()) |name| {
         try class_names.append(arena, try page.dupeString(name));
     }


### PR DESCRIPTION
Used to use std.ascii.whitespace, but per spec, it's only a subset of that which are valid separators. Other characters, line line tabulation, are valid class names.