### PR TITLE
Use cgroups for RAM mesurement

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -215,8 +215,9 @@ jobs:
         run: |
           export AVG_DURATION=`cat puppeteer.out|grep 'avg run'|sed 's/avg run duration (ms) //'`
           export TOTAL_DURATION=`cat puppeteer.out|grep 'total duration'|sed 's/total duration (ms) //'`
-          export LPD_MEM_PEAK_KB=$(( $(cat $CG/memory.peak) / 1024 ))
-          echo "{\"duration_total\":${TOTAL_DURATION},\"duration_avg\":${AVG_DURATION},\"mem_peak\":${LPD_MEM_PEAK_KB}}" > bench.json
+          export LPD_VmHWM=`cat LPD.VmHWM`
+          export LPD_CG_PEAK_KB=$(( $(cat $CG/memory.peak) / 1024 ))
+          echo "{\"duration_total\":${TOTAL_DURATION},\"duration_avg\":${AVG_DURATION},\"mem_peak\":${LPD_VmHWM},\"cg_mem_peak\":${LPD_MEM_CG_KB}}" > bench.json
           cat bench.json
 
       - name: run hyperfine


### PR DESCRIPTION
I was currently investigating why CI was crashing in the multithread due to a memory usage error in CI.

The current approach uses RSS (`Maximum Resident Set Size`). This metric measures the number of pages, not actual memory usage. These numbers are close, but don't necessarily match – memory pages can be swapped out and/or deduplicated with other processes. This also doesn't take into account short peaks, virtual memory, or page cache.

A more reliable way to measure per-process memory usage (or something else in future) is `cgroups v2`. It allows you to explicitly separate a process (and its child processes) and measure memory usage with sufficient accuracy.