### PR TITLE
Remove unused cache v8 bridge hint.

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -86,7 +86,6 @@ pub fn deinit(self: *Caller) void {
 }
 
 pub const CallOpts = struct {
-    cache: ?[]const u8 = null,
     dom_exception: bool = false,
     null_as_undefined: bool = false,
     as_typed_array: bool = false,

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -222,7 +222,6 @@ pub const Accessor = struct {
 
     const Opts = struct {
         static: bool = false,
-        cache: ?[]const u8 = null,
         as_typed_array: bool = false,
         null_as_undefined: bool = false,
         dom_exception: bool = false,
@@ -243,14 +242,12 @@ pub const Accessor = struct {
 
                     if (comptime opts.static) {
                         caller.function(T, getter, handle.?, .{
-                            .cache = opts.cache,
                             .dom_exception = opts.dom_exception,
                             .as_typed_array = opts.as_typed_array,
                             .null_as_undefined = opts.null_as_undefined,
                         });
                     } else {
                         caller.method(T, getter, handle.?, .{
-                            .cache = opts.cache,
                             .dom_exception = opts.dom_exception,
                             .as_typed_array = opts.as_typed_array,
                             .null_as_undefined = opts.null_as_undefined,

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -991,7 +991,7 @@ pub const JsApi = struct {
         fn defaultView(_: *const Document, page: *Page) *@import("Window.zig") {
             return page.window;
         }
-    }.defaultView, null, .{ .cache = "defaultView" });
+    }.defaultView, null, .{});
     pub const hasFocus = bridge.function(Document.hasFocus, .{});
 
     pub const prerendering = bridge.property(false, .{ .template = false });

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -683,23 +683,23 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const top = bridge.accessor(Window.getWindow, null, .{ .cache = "top" });
-    pub const self = bridge.accessor(Window.getWindow, null, .{ .cache = "self" });
-    pub const window = bridge.accessor(Window.getWindow, null, .{ .cache = "window" });
-    pub const parent = bridge.accessor(Window.getWindow, null, .{ .cache = "parent" });
-    pub const console = bridge.accessor(Window.getConsole, null, .{ .cache = "console" });
-    pub const navigator = bridge.accessor(Window.getNavigator, null, .{ .cache = "navigator" });
-    pub const screen = bridge.accessor(Window.getScreen, null, .{ .cache = "screen" });
-    pub const performance = bridge.accessor(Window.getPerformance, null, .{ .cache = "performance" });
-    pub const localStorage = bridge.accessor(Window.getLocalStorage, null, .{ .cache = "localStorage" });
-    pub const sessionStorage = bridge.accessor(Window.getSessionStorage, null, .{ .cache = "sessionStorage" });
-    pub const document = bridge.accessor(Window.getDocument, null, .{ .cache = "document" });
+    pub const top = bridge.accessor(Window.getWindow, null, .{});
+    pub const self = bridge.accessor(Window.getWindow, null, .{});
+    pub const window = bridge.accessor(Window.getWindow, null, .{});
+    pub const parent = bridge.accessor(Window.getWindow, null, .{});
+    pub const console = bridge.accessor(Window.getConsole, null, .{});
+    pub const navigator = bridge.accessor(Window.getNavigator, null, .{});
+    pub const screen = bridge.accessor(Window.getScreen, null, .{});
+    pub const performance = bridge.accessor(Window.getPerformance, null, .{});
+    pub const localStorage = bridge.accessor(Window.getLocalStorage, null, .{});
+    pub const sessionStorage = bridge.accessor(Window.getSessionStorage, null, .{});
+    pub const document = bridge.accessor(Window.getDocument, null, .{});
     pub const location = bridge.accessor(Window.getLocation, Window.setLocation, .{});
     pub const history = bridge.accessor(Window.getHistory, null, .{});
     pub const navigation = bridge.accessor(Window.getNavigation, null, .{});
-    pub const crypto = bridge.accessor(Window.getCrypto, null, .{ .cache = "crypto" });
-    pub const CSS = bridge.accessor(Window.getCSS, null, .{ .cache = "CSS" });
-    pub const customElements = bridge.accessor(Window.getCustomElements, null, .{ .cache = "customElements" });
+    pub const crypto = bridge.accessor(Window.getCrypto, null, .{});
+    pub const CSS = bridge.accessor(Window.getCSS, null, .{});
+    pub const customElements = bridge.accessor(Window.getCustomElements, null, .{});
     pub const onload = bridge.accessor(Window.getOnLoad, Window.setOnLoad, .{});
     pub const onpageshow = bridge.accessor(Window.getOnPageShow, Window.setOnPageShow, .{});
     pub const onpopstate = bridge.accessor(Window.getOnPopState, Window.setOnPopState, .{});
@@ -725,13 +725,13 @@ pub const JsApi = struct {
     pub const getComputedStyle = bridge.function(Window.getComputedStyle, .{});
     pub const getSelection = bridge.function(Window.getSelection, .{});
 
-    pub const frames = bridge.accessor(Window.getWindow, null, .{ .cache = "frames" });
+    pub const frames = bridge.accessor(Window.getWindow, null, .{});
     pub const index = bridge.indexed(Window.getFrame, .{ .null_as_undefined = true });
-    pub const length = bridge.accessor(Window.getFramesLength, null, .{ .cache = "length" });
-    pub const scrollX = bridge.accessor(Window.getScrollX, null, .{ .cache = "scrollX" });
-    pub const scrollY = bridge.accessor(Window.getScrollY, null, .{ .cache = "scrollY" });
-    pub const pageXOffset = bridge.accessor(Window.getScrollX, null, .{ .cache = "pageXOffset" });
-    pub const pageYOffset = bridge.accessor(Window.getScrollY, null, .{ .cache = "pageYOffset" });
+    pub const length = bridge.accessor(Window.getFramesLength, null, .{});
+    pub const scrollX = bridge.accessor(Window.getScrollX, null, .{});
+    pub const scrollY = bridge.accessor(Window.getScrollY, null, .{});
+    pub const pageXOffset = bridge.accessor(Window.getScrollX, null, .{});
+    pub const pageYOffset = bridge.accessor(Window.getScrollY, null, .{});
     pub const scrollTo = bridge.function(Window.scrollTo, .{});
     pub const scroll = bridge.function(Window.scrollTo, .{});
 


### PR DESCRIPTION
Pre-zigdom, we could use the postAttach behavior to store commonly accessed and never-changed accessors directly on the v8::object. I've tried to re-enable this feature a couple times, and have failed.

Between the new Snapshot and the always-on unhandled property handler for Window it never seems to work very well. Plus, Gemini continues to insist that changing the shape of the Object is more like to hurt than help performance.

There's possibly an optimization here worth revisiting in the future, but for the time being, this code does nothing except for possibly deceive a reader that some optimization is going on when it isn't.