### PR TITLE
Fix schedule navigation

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -205,7 +205,6 @@ fn readLoop(self: *Server, socket: posix.socket_t, timeout_ms: u32) !void {
                 }
                 ms_remaining -= @intCast(elapsed);
             },
-            .navigate => unreachable, // must have been handled by the session
         }
     }
 }

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -969,7 +969,7 @@ fn _wait(self: *Page, wait_ms: u32) !Session.WaitResult {
             },
             .html, .complete => {
                 if (self._queued_navigation != null) {
-                    return .navigate;
+                    return .done;
                 }
 
                 // The HTML page was parsed. We now either have JS scripts to

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -135,14 +135,18 @@ pub const WaitResult = enum {
     done,
     no_page,
     cdp_socket,
-    navigate,
 };
 
 pub fn wait(self: *Session, wait_ms: u32) WaitResult {
     while (true) {
         if (self.page) |*page| {
             switch (page.wait(wait_ms)) {
-                .navigate => self.processScheduledNavigation() catch return .done,
+                .done => {
+                    if (page._queued_navigation == null) {
+                        return .done;
+                    }
+                    self.processScheduledNavigation() catch return .done;
+                },
                 else => |result| return result,
             }
         } else {


### PR DESCRIPTION
Previously, the Session depended on the page to return a .navigate state when a secondary navigation should take place. There were a lot of places where the page returned .done rather than .navigate.

To simplify the code, .navigate is no longer a WaitResult. The page now just has to return .done, and the Session will check if there's a queued sub-navigation.

This will fix cases where sub-navigation is triggered by a script being executed as the last step of page loading.