### PR TITLE
Fix double-free of XHR on double client abort

### DIFF
--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -233,6 +233,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
         .data_callback = httpDataCallback,
         .done_callback = httpDoneCallback,
         .error_callback = httpErrorCallback,
+        .shutdown_callback = httpShutdownCallback,
     });
 
     page.js.strongRef(self);
@@ -461,6 +462,11 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     self._transfer = null;
     self.handleError(err);
     self._page.js.weakRef(self);
+}
+
+fn httpShutdownCallback(ctx: *anyopaque) void {
+    const self: *XMLHttpRequest = @ptrCast(@alignCast(ctx));
+    self._transfer = null;
 }
 
 pub fn abort(self: *XMLHttpRequest) void {

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -39,9 +39,10 @@ pub const FetchOpts = struct {
     writer: ?*std.Io.Writer = null,
 };
 pub fn fetch(app: *App, url: [:0]const u8, opts: FetchOpts) !void {
-    var browser = try Browser.init(app, .{});
     const notification = try Notification.init(app.allocator);
     defer notification.deinit();
+
+    var browser = try Browser.init(app, .{});
     defer browser.deinit();
 
     var session = try browser.newSession(notification);


### PR DESCRIPTION
It's possible (in fact normal) for client.abort to be called twice on a schedule navigation. We immediately abort any pending requests once a secondary navigation is called (is that right?), and then again when the page shuts down.

The first abort will kill the transfer, so the XHR object has to null this value so that, on context shutdown, when the finalizer is called, we don't try to free it again.