### PR TITLE
Remove Page.reset

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -66,13 +66,13 @@ lookup: std.HashMapUnmanaged(
 dispatch_depth: usize,
 deferred_removals: std.ArrayList(struct { list: *std.DoublyLinkedList, listener: *Listener }),
 
-pub fn init(page: *Page) EventManager {
+pub fn init(arena: Allocator, page: *Page) EventManager {
     return .{
         .page = page,
         .lookup = .{},
-        .arena = page.arena,
-        .list_pool = std.heap.MemoryPool(std.DoublyLinkedList).init(page.arena),
-        .listener_pool = std.heap.MemoryPool(Listener).init(page.arena),
+        .arena = arena,
+        .list_pool = .init(arena),
+        .listener_pool = .init(arena),
         .dispatch_depth = 0,
         .deferred_removals = .{},
     };

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -43,7 +43,9 @@ const IS_DEBUG = builtin.mode == .Debug;
 const assert = std.debug.assert;
 
 const Factory = @This();
+
 _page: *Page,
+_arena: Allocator,
 _slab: SlabAllocator,
 
 fn PrototypeChain(comptime types: []const type) type {
@@ -149,10 +151,11 @@ fn AutoPrototypeChain(comptime types: []const type) type {
     };
 }
 
-pub fn init(page: *Page) Factory {
+pub fn init(arena: Allocator, page: *Page) Factory {
     return .{
         ._page = page,
-        ._slab = SlabAllocator.init(page.arena, 128),
+        ._arena = arena,
+        ._slab = SlabAllocator.init(arena, 128),
     };
 }
 
@@ -329,7 +332,7 @@ pub fn svgElement(self: *Factory, tag_name: []const u8, child: anytype) !*@TypeO
     chain.setMiddle(2, Element.Type);
 
     // will never allocate, can't fail
-    const tag_name_str = String.init(self._page.arena, tag_name, .{}) catch unreachable;
+    const tag_name_str = String.init(self._arena, tag_name, .{}) catch unreachable;
 
     // Manually set Element.Svg with the tag_name
     chain.set(3, .{

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -83,10 +83,7 @@ imported_modules: std.StringHashMapUnmanaged(ImportedModule),
 // importmap contains resolved urls.
 importmap: std.StringHashMapUnmanaged([:0]const u8),
 
-pub fn init(page: *Page) ScriptManager {
-    // page isn't fully initialized, we can setup our reference, but that's it.
-    const browser = page._session.browser;
-    const allocator = browser.allocator;
+pub fn init(allocator: Allocator, http_client: *Http.Client, page: *Page) ScriptManager {
     return .{
         .page = page,
         .async_scripts = .{},
@@ -96,7 +93,7 @@ pub fn init(page: *Page) ScriptManager {
         .is_evaluating = false,
         .allocator = allocator,
         .imported_modules = .empty,
-        .client = browser.http_client,
+        .client = http_client,
         .static_scripts_done = false,
         .buffer_pool = BufferPool.init(allocator, 5),
         .script_pool = std.heap.MemoryPool(Script).init(allocator),

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -127,6 +127,23 @@ pub fn removePage(self: *Session) void {
     }
 }
 
+pub fn replacePage(self: *Session) !*Page {
+    if (comptime IS_DEBUG) {
+        log.debug(.browser, "replace page", .{});
+    }
+
+    lp.assert(self.page != null, "Session.replacePage null page", .{});
+    self.page.?.deinit();
+
+    _ = self.browser.page_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
+    self.browser.env.memoryPressureNotification(.moderate);
+
+    self.page = @as(Page, undefined);
+    const page = &self.page.?;
+    try Page.init(page, self);
+    return page;
+}
+
 pub fn currentPage(self: *Session) ?*Page {
     return &(self.page orelse return null);
 }

--- a/src/browser/webapi/Screen.zig
+++ b/src/browser/webapi/Screen.zig
@@ -32,13 +32,6 @@ const Screen = @This();
 _proto: *EventTarget,
 _orientation: ?*Orientation = null,
 
-pub fn init(page: *Page) !*Screen {
-    return page._factory.eventTarget(Screen{
-        ._proto = undefined,
-        ._orientation = null,
-    });
-}
-
 pub fn asEventTarget(self: *Screen) *EventTarget {
     return self._proto;
 }

--- a/src/browser/webapi/VisualViewport.zig
+++ b/src/browser/webapi/VisualViewport.zig
@@ -25,12 +25,6 @@ const VisualViewport = @This();
 
 _proto: *EventTarget,
 
-pub fn init(page: *Page) !*VisualViewport {
-    return page._factory.eventTarget(VisualViewport{
-        ._proto = undefined,
-    });
-}
-
 pub fn asEventTarget(self: *VisualViewport) *EventTarget {
     return self._proto;
 }

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -60,7 +60,7 @@ _navigator: Navigator = .init,
 _screen: *Screen,
 _visual_viewport: *VisualViewport,
 _performance: Performance,
-_storage_bucket: *storage.Bucket,
+_storage_bucket: storage.Bucket = .{},
 _on_load: ?js.Function.Global = null,
 _on_pageshow: ?js.Function.Global = null,
 _on_popstate: ?js.Function.Global = null,
@@ -128,11 +128,11 @@ pub fn getPerformance(self: *Window) *Performance {
     return &self._performance;
 }
 
-pub fn getLocalStorage(self: *const Window) *storage.Lookup {
+pub fn getLocalStorage(self: *Window) *storage.Lookup {
     return &self._storage_bucket.local;
 }
 
-pub fn getSessionStorage(self: *const Window) *storage.Lookup {
+pub fn getSessionStorage(self: *Window) *storage.Lookup {
     return &self._storage_bucket.session;
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -213,7 +213,12 @@ fn navigate(cmd: anytype) !void {
         return error.SessionIdNotLoaded;
     }
 
-    var page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    const session = bc.session;
+    var page = session.currentPage() orelse return error.PageNotLoaded;
+
+    if (page._load_state != .waiting) {
+        page = try session.replacePage();
+    }
 
     try page.navigate(params.url, .{
         .reason = .address_bar,


### PR DESCRIPTION
Page.reset exists for 1 use case: multiple calls to the Page.navigate CDP method. At an extreme, something like this in puppeteer:

```
await page.goto(baseURL + '/campfire-commerce/');
await page.goto(baseURL + '/campfire-commerce/');
```

Rather than handling this generically in Page, we now handle this case specifically at the CDP layer. If the page isn't in its initial load state, i.e. page._load_state != .waiting, then we reload the page from the session.

For reloading, my initial inclination was to do session.removePage then session.createPage(). This behavior still seems potentially correct to me, but compared to our `reset`, this would trigger extra notifications, namely:

self.notification.dispatch(.page_remove, .{});

and

self.notification.dispatch(.page_created, page);

Bacause of https://github.com/lightpanda-io/browser/pull/1265/ I guess that could have side effects. So, to keep the behavior as close to the current "reset", a new `session.replacePage()` has been added which behaves a lot like removePage + createPage, but without the notifications being sent.

While I generally think this is just cleaner, this was largely driven by some planning for frame support. The entity for a Frame will share a lot with the Page (we'll extract that logic), so simplifying the Page, especially around initialization, helps simplify frame support.