### PR TITLE
Remove potential recursive abort call in curl

### DIFF
--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -252,4 +252,3 @@
     testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
   });
 </script>
- -->


### PR DESCRIPTION
Curl doesn't like recursive calls. For example, you can't call curl_multi_remove_handle from within a dataCallback.

This specifically means that, as-is, transfer.abort() calls aren't safe to be called during a libcurl callback. Consider this code:

```
req.open('GET', 'http://127.0.0.1:9582/xhr');
req.onreadystatechange = (e) => {
  req.abort();
}
req.send();
```

onreadystatechange is triggered by network events, i.e. it executes in libcurl callback. Thus, the above code fails to truly "abort" the request with `curl_multi_remove_handle` error, saying it's a recursive call.

To solve this, transfer.abort() now sets an `aborted = true` flag. Callbacks can now use this flag to signal to libcurl to stop the transfer.

A test was added which reproduced this issue, but this comes from: https://github.com/lightpanda-io/browser/issues/1527  which I wasn't able to reliably reproduce. I did see it happen regularly, just not always. It seems like this commit fixes that issue.