### PR TITLE
Improve compliance of DOMTokenList

### DIFF
--- a/src/browser/tests/element/class_list.html
+++ b/src/browser/tests/element/class_list.html
@@ -93,6 +93,29 @@
 }
 </script>
 
+<script id=replace_errors>
+{
+  const div = document.createElement('div');
+  div.className = 'foo bar';
+
+  testing.withError((err) => {
+    testing.expectEqual('SyntaxError', err.name);
+  }, () => div.classList.replace('', 'baz'));
+
+  testing.withError((err) => {
+    testing.expectEqual('SyntaxError', err.name);
+  }, () => div.classList.replace('foo', ''));
+
+  testing.withError((err) => {
+    testing.expectEqual('InvalidCharacterError', err.name);
+  }, () => div.classList.replace('foo bar', 'baz'));
+
+  testing.withError((err) => {
+    testing.expectEqual('InvalidCharacterError', err.name);
+  }, () => div.classList.replace('foo', 'bar baz'));
+}
+</script>
+
 <script id=item>
 {
   const div = document.createElement('div');
@@ -163,6 +186,29 @@
   testing.expectEqual('test1 test2', div.classList.value);
   testing.expectEqual('test1 test2', div.className);
   testing.expectEqual(2, div.classList.length);
+}
+</script>
+
+<script id=classList_assignment>
+{
+  const div = document.createElement('div');
+
+  // Direct assignment should work (equivalent to classList.value = ...)
+  div.classList = 'foo bar baz';
+  testing.expectEqual('foo bar baz', div.className);
+  testing.expectEqual(3, div.classList.length);
+  testing.expectEqual(true, div.classList.contains('foo'));
+
+  // Assigning again should replace
+  div.classList = 'qux';
+  testing.expectEqual('qux', div.className);
+  testing.expectEqual(1, div.classList.length);
+  testing.expectEqual(false, div.classList.contains('foo'));
+
+  // Empty assignment
+  div.classList = '';
+  testing.expectEqual('', div.className);
+  testing.expectEqual(0, div.classList.length);
 }
 </script>
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -674,6 +674,11 @@ pub fn getClassList(self: *Element, page: *Page) !*collections.DOMTokenList {
     return gop.value_ptr.*;
 }
 
+pub fn setClassList(self: *Element, value: String, page: *Page) !void {
+    const class_list = try self.getClassList(page);
+    try class_list.setValue(value, page);
+}
+
 pub fn getRelList(self: *Element, page: *Page) !*collections.DOMTokenList {
     const gop = try page._element_rel_lists.getOrPut(page.arena, self);
     if (!gop.found_existing) {
@@ -1480,7 +1485,7 @@ pub const JsApi = struct {
     pub const slot = bridge.accessor(Element.getSlot, Element.setSlot, .{});
     pub const dir = bridge.accessor(Element.getDir, Element.setDir, .{});
     pub const className = bridge.accessor(Element.getClassName, Element.setClassName, .{});
-    pub const classList = bridge.accessor(Element.getClassList, null, .{});
+    pub const classList = bridge.accessor(Element.getClassList, Element.setClassList, .{});
     pub const dataset = bridge.accessor(Element.getDataset, null, .{});
     pub const style = bridge.accessor(Element.getStyle, null, .{});
     pub const attributes = bridge.accessor(Element.getAttributeNamedNodeMap, null, .{});


### PR DESCRIPTION
1 - Make element.classList settable
2 - On replace, validate in expected order
3 - On replace, fire mutation observer even if new == old 
4 - On replace, handle duplicate values