### PR TITLE
Add document.scrollingElement read-only property

### DIFF
--- a/src/browser/tests/document/document.html
+++ b/src/browser/tests/document/document.html
@@ -26,6 +26,7 @@
 
 <script id=documentElement>
   testing.expectEqual($('#the_body').parentNode, document.documentElement);
+  testing.expectEqual(document.documentElement, document.scrollingElement);
 </script>
 
 <script id=title>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -950,6 +950,7 @@ pub const JsApi = struct {
     pub const URL = bridge.accessor(Document.getURL, null, .{});
     pub const documentURI = bridge.accessor(Document.getURL, null, .{});
     pub const documentElement = bridge.accessor(Document.getDocumentElement, null, .{});
+    pub const scrollingElement = bridge.accessor(Document.getDocumentElement, null, .{});
     pub const children = bridge.accessor(Document.getChildren, null, .{});
     pub const readyState = bridge.accessor(Document.getReadyState, null, .{});
     pub const implementation = bridge.accessor(Document.getImplementation, null, .{});


### PR DESCRIPTION
From MDN: In standards mode, this is the root element of the document, document.documentElement.

Easy enough.