### PR TITLE
Remove custom-arenas, use ArenaPool instead

### DIFF
--- a/src/ArenaPool.zig
+++ b/src/ArenaPool.zig
@@ -85,3 +85,8 @@ pub fn release(self: *ArenaPool, allocator: Allocator) void {
     self.free_list_len = free_list_len + 1;
     self.free_list = entry;
 }
+
+pub fn reset(_: *const ArenaPool, allocator: Allocator, retain: usize) void {
+    const arena: *std.heap.ArenaAllocator = @ptrCast(@alignCast(allocator.ptr));
+    _ = arena.reset(.{ .retain_with_limit = retain });
+}

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -44,10 +44,6 @@ session: ?Session,
 allocator: Allocator,
 arena_pool: *ArenaPool,
 http_client: *HttpClient,
-call_arena: ArenaAllocator,
-page_arena: ArenaAllocator,
-session_arena: ArenaAllocator,
-transfer_arena: ArenaAllocator,
 
 const InitOpts = struct {
     env: js.Env.InitOpts = .{},
@@ -66,20 +62,12 @@ pub fn init(app: *App, opts: InitOpts) !Browser {
         .allocator = allocator,
         .arena_pool = &app.arena_pool,
         .http_client = app.http.client,
-        .call_arena = ArenaAllocator.init(allocator),
-        .page_arena = ArenaAllocator.init(allocator),
-        .session_arena = ArenaAllocator.init(allocator),
-        .transfer_arena = ArenaAllocator.init(allocator),
     };
 }
 
 pub fn deinit(self: *Browser) void {
     self.closeSession();
     self.env.deinit();
-    self.call_arena.deinit();
-    self.page_arena.deinit();
-    self.session_arena.deinit();
-    self.transfer_arena.deinit();
 }
 
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {
@@ -94,7 +82,6 @@ pub fn closeSession(self: *Browser) void {
     if (self.session) |*session| {
         session.deinit();
         self.session = null;
-        _ = self.session_arena.reset(.{ .retain_with_limit = 1 * 1024 * 1024 });
         self.env.memoryPressureNotification(.critical);
     }
 }

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -1255,7 +1255,6 @@ pub const Transfer = struct {
             client.endTransfer(self);
         }
         self.deinit();
-
     }
 
     pub fn terminate(self: *Transfer) void {


### PR DESCRIPTION
This removes the browser-specific arenas (session, transfer, page, call) in favor of the arena pool.

This is a bit of a win-lose commit. It exists as (the last?) step before I can really start working on frames. Frames will require their own "page" and "call" arenas, so there isn't just 1 per browser now, but rather N, where N is the number of frames + 1 page. This change was already done for Contexts when ExecutionWorld was removed, and the idea is the same: making these units more self contained so to support cases where we break out of the "1" model we currently have (1 browser, 1 session, 1 page, 1 context, ...).

But it's a bit of a step backwards because the ArenaPool is dumb and just resets everything to a single hard-coded (for now) value: 16KB. But in my mind, an arena that's used for 1 thing (e.g. the page or call arenas) is more likely to be well-sized for that specific role in the future, even on a different page/navigate.

I think ultimately, we'll move to an ArenaPool that has different levels, e.g. acquire() and acquireLarge() which can reset to different sizes, so that a page arena can use acquireLarge() and retain a larger amount of memory between use.