### PR TITLE
Add missing validation to range setStart and setEnd

### DIFF
--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -186,15 +186,19 @@ pub fn compareBoundaryPoints(self: *const Range, how_raw: i32, source_range: *co
 }
 
 pub fn comparePoint(self: *const Range, node: *Node, offset: u32) !i16 {
-    if (offset > node.getLength()) {
-        return error.IndexSizeError;
-    }
-
     // Check if node is in a different tree than the range
     const node_root = node.getRootNode(null);
     const start_root = self._proto._start_container.getRootNode(null);
     if (node_root != start_root) {
         return error.WrongDocument;
+    }
+
+    if (node._type == .document_type) {
+        return error.InvalidNodeType;
+    }
+
+    if (offset > node.getLength()) {
+        return error.IndexSizeError;
     }
 
     // Compare point with start boundary


### PR DESCRIPTION
Fixes the remaining failing cases (400!) of WPT dom/ranges/Range-set.html