### PR TITLE
Re-arrange Caller

### DIFF
--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -148,7 +148,7 @@ const ModuleEntry = struct {
     resolver_promise: ?js.Promise.Global = null,
 };
 
-fn fromC(c_context: *const v8.Context) *Context {
+pub fn fromC(c_context: *const v8.Context) *Context {
     const data = v8.v8__Context__GetEmbedderData(c_context, 1).?;
     const big_int = js.BigInt{ .handle = @ptrCast(data) };
     return @ptrFromInt(big_int.getUint64());


### PR DESCRIPTION
This is preparatory work for re-introducing property caching and pure v8 WebAPIs

It does 3 things:

1 - It removes the duplication of method calling we had in Accessors and
    Functions type briges.

2 - It flattens the method-call chain. It used to be some code in bridge, then
    method, then _method. Most of the code is now in the same place. This will
    be important since caching requires the raw js_value, which we previously
    didn't expose from _method. Now, it's just there.

3 - Caller used to do everything. Then we introduced Local and a lot of Caller
    methods didn't need caller itself, they just needed &self.local. While those
    methods remain in Caller.zig, they now take a *const Local directly and thus
    can be called without Caller, making them usable without a Caller.