### PR TITLE
Add internal field caching (for window.document and window.console)

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -160,10 +160,12 @@ pub const Constructor = struct {
 pub const Function = struct {
     static: bool,
     arity: usize,
+    cache: ?Caller.Function.Opts.Caching = null,
     func: *const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void,
 
     fn init(comptime T: type, comptime func: anytype, comptime opts: Caller.Function.Opts) Function {
         return .{
+            .cache = opts.cache,
             .static = opts.static,
             .arity = getArity(@TypeOf(func)),
             .func = struct {
@@ -193,11 +195,13 @@ pub const Function = struct {
 
 pub const Accessor = struct {
     static: bool = false,
+    cache: ?Caller.Function.Opts.Caching = null,
     getter: ?*const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void = null,
     setter: ?*const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void = null,
 
     fn init(comptime T: type, comptime getter: anytype, comptime setter: anytype, comptime opts: Caller.Function.Opts) Accessor {
         var accessor = Accessor{
+            .cache = opts.cache,
             .static = opts.static,
         };
 

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -713,18 +713,19 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    pub const document = bridge.accessor(Window.getDocument, null, .{ .cache = .{ .internal = 1 } });
+    pub const console = bridge.accessor(Window.getConsole, null, .{ .cache = .{ .internal = 2 } });
+
     pub const top = bridge.accessor(Window.getWindow, null, .{});
     pub const self = bridge.accessor(Window.getWindow, null, .{});
     pub const window = bridge.accessor(Window.getWindow, null, .{});
     pub const parent = bridge.accessor(Window.getWindow, null, .{});
-    pub const console = bridge.accessor(Window.getConsole, null, .{});
     pub const navigator = bridge.accessor(Window.getNavigator, null, .{});
     pub const screen = bridge.accessor(Window.getScreen, null, .{});
     pub const visualViewport = bridge.accessor(Window.getVisualViewport, null, .{});
     pub const performance = bridge.accessor(Window.getPerformance, null, .{});
     pub const localStorage = bridge.accessor(Window.getLocalStorage, null, .{});
     pub const sessionStorage = bridge.accessor(Window.getSessionStorage, null, .{});
-    pub const document = bridge.accessor(Window.getDocument, null, .{});
     pub const location = bridge.accessor(Window.getLocation, Window.setLocation, .{});
     pub const history = bridge.accessor(Window.getHistory, null, .{});
     pub const navigation = bridge.accessor(Window.getNavigation, null, .{});


### PR DESCRIPTION
This expands the caching capabilities which were first added in https://github.com/lightpanda-io/browser/pull/1552

Internal field caching requires up-front memory, but is faster. It is currently enabled for window.document and window.console - two very frequently accessed values.

Implementations must correctly provide an internal field index, with consideration for index 0 which may or may not be reserved for the type (it depends on the type). comptime checks run to make sure this is correct, but it would probably be nice to at least let them be declared in any order.

This commit also removes the special handling for loading the window. This used to rely on the window not having any internal fields, but it now has them for caching so it can't be detected that way. Instead, the window is loaded like any other object. (But now we have to special case the initial window TAO creation to make it behave like any other Zig instance).