### PR TITLE
Remove logs interceptors feature

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -31,7 +31,6 @@ const Session = @import("../browser/Session.zig");
 const Page = @import("../browser/Page.zig");
 const Incrementing = @import("../id.zig").Incrementing;
 const Notification = @import("../Notification.zig");
-const LogInterceptor = @import("domains/log.zig").LogInterceptor;
 const InterceptState = @import("domains/fetch.zig").InterceptState;
 
 pub const URL_BASE = "chrome://newtab/";
@@ -378,8 +377,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         intercept_state: InterceptState,
 
-        log_interceptor: LogInterceptor(Self),
-
         // When network is enabled, we'll capture the transfer.id -> body
         // This is awfully memory intensive, but our underlying http client and
         // its users (script manager and page) correctly do not hold the body
@@ -428,7 +425,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
                 .notification_arena = cdp.notification_arena.allocator(),
                 .intercept_state = try InterceptState.init(allocator),
                 .captured_responses = .empty,
-                .log_interceptor = LogInterceptor(Self).init(allocator, self),
                 .notification = notification,
             };
             self.node_search_list = Node.Search.List.init(allocator, &self.node_registry);
@@ -441,9 +437,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            // safe to call even if never registered
-            log.unregisterInterceptor();
-            self.log_interceptor.deinit();
             const browser = &self.cdp.browser;
 
             // Drain microtasks makes sure we don't have inspector's callback
@@ -583,18 +576,6 @@ pub fn BrowserContext(comptime CDP_T: type) type {
             self.page_life_cycle_events = false;
             self.notification.unregister(.page_network_idle, self);
             self.notification.unregister(.page_network_almost_idle, self);
-        }
-
-        pub fn logEnable(self: *Self) void {
-            log.registerInterceptor(.{
-                .ctx = &self.log_interceptor,
-                .done = LogInterceptor(Self).done,
-                .writer = LogInterceptor(Self).writer,
-            });
-        }
-
-        pub fn logDisable(_: *const Self) void {
-            log.unregisterInterceptor();
         }
 
         pub fn onPageRemove(ctx: *anyopaque, _: Notification.PageRemove) !void {

--- a/src/cdp/domains/log.zig
+++ b/src/cdp/domains/log.zig
@@ -17,9 +17,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
-
-const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: anytype) !void {
     const action = std.meta.stringToEnum(enum {
@@ -28,86 +25,6 @@ pub fn processMessage(cmd: anytype) !void {
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
-        .enable => return enable(cmd),
-        .disable => return disable(cmd),
+        .enable, .disable => return cmd.sendResult(null, .{}),
     }
-}
-fn enable(cmd: anytype) !void {
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    bc.logEnable();
-    return cmd.sendResult(null, .{});
-}
-
-fn disable(cmd: anytype) !void {
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    bc.logDisable();
-    return cmd.sendResult(null, .{});
-}
-
-pub fn LogInterceptor(comptime BC: type) type {
-    return struct {
-        bc: *BC,
-        allocating: std.Io.Writer.Allocating,
-
-        const Self = @This();
-
-        pub fn init(allocator: Allocator, bc: *BC) Self {
-            return .{
-                .bc = bc,
-                .allocating = .init(allocator),
-            };
-        }
-
-        pub fn deinit(self: *Self) void {
-            return self.allocating.deinit();
-        }
-
-        pub fn writer(ctx: *anyopaque, scope: log.Scope, level: log.Level) ?*std.Io.Writer {
-            if (scope == .unknown_prop or scope == .telemetry) {
-                return null;
-            }
-
-            // DO NOT REMOVE this. This prevents a log message caused from a failure
-            // to intercept to trigger another intercept, which could result in an
-            // endless cycle.
-            if (scope == .interceptor) {
-                return null;
-            }
-
-            if (level == .debug) {
-                return null;
-            }
-            const self: *Self = @ptrCast(@alignCast(ctx));
-            return &self.allocating.writer;
-        }
-
-        pub fn done(ctx: *anyopaque, scope: log.Scope, level: log.Level) void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
-            defer self.allocating.clearRetainingCapacity();
-
-            self.bc.cdp.sendEvent("Log.entryAdded", .{
-                .entry = .{
-                    .source = switch (scope) {
-                        .js, .console => "javascript",
-                        .http => "network",
-                        .telemetry, .unknown_prop, .interceptor => unreachable, // filtered out in writer above
-                        else => "other",
-                    },
-                    .level = switch (level) {
-                        .debug => "verbose",
-                        .info => "info",
-                        .warn => "warning",
-                        .err => "error",
-                        .fatal => "error",
-                    },
-                    .text = self.allocating.written(),
-                    .timestamp = @import("../../datetime.zig").milliTimestamp(.monotonic),
-                },
-            }, .{
-                .session_id = self.bc.session_id,
-            }) catch |err| {
-                log.err(.interceptor, "failed to send", .{ .err = err });
-            };
-        }
-    };
 }


### PR DESCRIPTION
Removes the system log interception logic but retains the CDP commands themselves.

While working on multiple connections, we encountered limitations of this implementation (only one interceptor, direct writing to the Client and interceptors).

We're removing this so we can redesign it from scratch after implementing multiple contexts.