### PR TITLE
Fix race condition in sighandler

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -83,7 +83,8 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
 
     switch (args.mode) {
         .serve => |opts| {
-            var sighandler = SigHandler{ .arena = main_arena };
+            const sighandler = try main_arena.create(SigHandler);
+            sighandler.* = .{ .arena = main_arena };
             try sighandler.install();
 
             log.debug(.app, "startup", .{ .mode = "serve", .snapshot = app.snapshot.fromEmbedded() });


### PR DESCRIPTION
`SigHandler` was allocated on the stack of `run()`. Its `install()` method spawns a  detached thread that holds a pointer to the struct (`self`). When `run()` returns on error, the stack frame is destroyed, but the detached thread continues to call `sigwait(&self.sigset, ...)` through a dangling pointer. Meanwhile, the main thread reuses the same stack region for `log.fatal` → `var buf: [4096]u8`, causing a simultaneous read/write to the same address.