### PR TITLE
implement MouseEvent.buttons property

### DIFF
--- a/src/browser/tests/event/mouse.html
+++ b/src/browser/tests/event/mouse.html
@@ -10,11 +10,13 @@
   testing.expectEqual(0, event.clientY);
   testing.expectEqual(0, event.screenX);
   testing.expectEqual(0, event.screenY);
+  testing.expectEqual(0, event.buttons);
 </script>
 
 <script id=parameters>
-  let new_event = new MouseEvent('click', { 'button': 0, 'clientX': 10, 'clientY': 20, screenX: 200, screenY: 500 });
+  let new_event = new MouseEvent('click', { 'button': 0, 'clientX': 10, 'clientY': 20, screenX: 200, screenY: 500, buttons: 5 });
   testing.expectEqual(0, new_event.button);
+  testing.expectEqual(5, new_event.buttons);
   testing.expectEqual(10, new_event.x);
   testing.expectEqual(20, new_event.y);
   testing.expectEqual(10, new_event.pageX);

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -48,7 +48,7 @@ _proto: *UIEvent,
 
 _alt_key: bool,
 _button: MouseButton,
-// TODO: _buttons
+_buttons: u16,
 _client_x: f64,
 _client_y: f64,
 _ctrl_key: bool,
@@ -69,7 +69,7 @@ pub const MouseEventOptions = struct {
     altKey: bool = false,
     metaKey: bool = false,
     button: i32 = 0,
-    // TODO: buttons
+    buttons: u16 = 0,
     relatedTarget: ?*EventTarget = null,
 };
 
@@ -100,6 +100,7 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*MouseEvent {
             ._alt_key = opts.altKey,
             ._meta_key = opts.metaKey,
             ._button = std.meta.intToEnum(MouseButton, opts.button) catch return error.TypeError,
+            ._buttons = opts.buttons,
             ._related_target = opts.relatedTarget,
         },
     );
@@ -135,6 +136,10 @@ pub fn getAltKey(self: *const MouseEvent) bool {
 
 pub fn getButton(self: *const MouseEvent) u8 {
     return @intFromEnum(self._button);
+}
+
+pub fn getButtons(self: *const MouseEvent) u16 {
+    return self._buttons;
 }
 
 pub fn getClientX(self: *const MouseEvent) f64 {
@@ -193,6 +198,7 @@ pub const JsApi = struct {
     pub const constructor = bridge.constructor(MouseEvent.init, .{});
     pub const altKey = bridge.accessor(getAltKey, null, .{});
     pub const button = bridge.accessor(getButton, null, .{});
+    pub const buttons = bridge.accessor(getButtons, null, .{});
     pub const clientX = bridge.accessor(getClientX, null, .{});
     pub const clientY = bridge.accessor(getClientY, null, .{});
     pub const ctrlKey = bridge.accessor(getCtrlKey, null, .{});

--- a/src/browser/webapi/event/PointerEvent.zig
+++ b/src/browser/webapi/event/PointerEvent.zig
@@ -103,6 +103,7 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*PointerEvent {
             ._alt_key = opts.altKey,
             ._meta_key = opts.metaKey,
             ._button = std.meta.intToEnum(MouseEvent.MouseButton, opts.button) catch return error.TypeError,
+            ._buttons = opts.buttons,
             ._related_target = opts.relatedTarget,
         },
         PointerEvent{

--- a/src/browser/webapi/event/WheelEvent.zig
+++ b/src/browser/webapi/event/WheelEvent.zig
@@ -70,6 +70,7 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*WheelEvent {
             ._alt_key = opts.altKey,
             ._meta_key = opts.metaKey,
             ._button = std.meta.intToEnum(MouseEvent.MouseButton, opts.button) catch return error.TypeError,
+            ._buttons = opts.buttons,
             ._related_target = opts.relatedTarget,
         },
         WheelEvent{


### PR DESCRIPTION
## Summary

- Add the `buttons` read-only property to `MouseEvent` as specified by the [W3C UI Events spec](https://w3c.github.io/uievents/#dom-mouseevent-buttons) (`unsigned short` bitmask of currently pressed buttons)
- Propagate the field through `PointerEvent` and `WheelEvent` constructors which inherit from `MouseEvent`
- Add test coverage for default value (0) and constructor initialization

## Test plan

- [x] Existing 238/238 tests pass
- [x] New test: default `MouseEvent('click')` has `buttons === 0`
- [x] New test: `MouseEvent('click', { buttons: 5 })` returns `5` (left + middle)
- [x] `zig fmt` passes