### PR TITLE
add cookie size to CDP response

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -502,7 +502,7 @@ test "cdp.Network: cookies" {
     });
     try ctx.expectSentResult(.{
         .cookies = &[_]ResCookie{
-            .{ .name = "test3", .value = "value3", .domain = "car.example.com", .path = "/", .secure = true }, // No Pancakes!
+            .{ .name = "test3", .value = "value3", .domain = "car.example.com", .path = "/", .size = 11, .secure = true }, // No Pancakes!
         },
     }, .{ .id = 6 });
 
@@ -519,7 +519,7 @@ test "cdp.Network: cookies" {
         .params = .{ .browserContextId = "BID-S" },
     });
     // Just the untouched test4 should be in the result
-    try ctx.expectSentResult(.{ .cookies = &[_]ResCookie{.{ .name = "test4", .value = "value4", .domain = ".example.com", .path = "/mango" }} }, .{ .id = 8 });
+    try ctx.expectSentResult(.{ .cookies = &[_]ResCookie{.{ .name = "test4", .value = "value4", .domain = ".example.com", .path = "/mango", .size = 11 }} }, .{ .id = 8 });
 
     // Empty after clearBrowserCookies
     try ctx.processMessage(.{

--- a/src/cdp/domains/storage.zig
+++ b/src/cdp/domains/storage.zig
@@ -209,7 +209,8 @@ pub fn writeCookie(cookie: *const Cookie, w: anytype) !void {
         try w.objectField("expires");
         try w.write(cookie.expires orelse -1);
 
-        // TODO size
+        try w.objectField("size");
+        try w.write(cookie.name.len + cookie.value.len);
 
         try w.objectField("httpOnly");
         try w.write(cookie.http_only);
@@ -267,8 +268,8 @@ test "cdp.Storage: cookies" {
     });
     try ctx.expectSentResult(.{
         .cookies = &[_]ResCookie{
-            .{ .name = "test", .value = "value", .domain = ".example.com", .path = "/mango" },
-            .{ .name = "test2", .value = "value2", .domain = "car.example.com", .path = "/", .secure = true }, // No Pancakes!
+            .{ .name = "test", .value = "value", .domain = ".example.com", .path = "/mango", .size = 9 },
+            .{ .name = "test2", .value = "value2", .domain = "car.example.com", .path = "/", .size = 11, .secure = true }, // No Pancakes!
         },
     }, .{ .id = 5 });
 
@@ -293,6 +294,7 @@ pub const ResCookie = struct {
     domain: []const u8,
     path: []const u8 = "/",
     expires: f64 = -1,
+    size: usize = 0,
     httpOnly: bool = false,
     secure: bool = false,
     sameSite: []const u8 = "None",


### PR DESCRIPTION
## Summary

- Compute and include the `size` field in `Storage.getCookies` and `Network.getCookies` CDP responses
- Size is calculated as `name.len + value.len`, matching Chrome's behavior
- Update test expectations for both storage and network cookie tests

## Test plan

- [x] 238/238 unit tests pass
- [x] `zig fmt` passes
- [x] Verified via CDP websocket: cookies now include correct `size` values
- [x] Confirmed official release binary returns `MISSING` for `size` (expected)