### PR TITLE
Dispatch play, pause, and emptied events from HTMLMediaElement

### DIFF
--- a/src/browser/tests/element/html/media.html
+++ b/src/browser/tests/element/html/media.html
@@ -76,21 +76,21 @@
     audio.pause();
     testing.expectEqual('play,playing,pause', events.join(','));
 
-    // Third play: resume from pause, fires play only (not playing)
+    // Third play: resume from pause, fires play + playing (verified in Chrome)
     audio.play();
-    testing.expectEqual('play,playing,pause,play', events.join(','));
+    testing.expectEqual('play,playing,pause,play,playing', events.join(','));
 
     // Pause again
     audio.pause();
-    testing.expectEqual('play,playing,pause,play,pause', events.join(','));
+    testing.expectEqual('play,playing,pause,play,playing,pause', events.join(','));
 
     // Load: resets state, fires emptied
     audio.load();
-    testing.expectEqual('play,playing,pause,play,pause,emptied', events.join(','));
+    testing.expectEqual('play,playing,pause,play,playing,pause,emptied', events.join(','));
 
-    // Play after load: fires play + playing again (fresh start)
+    // Play after load: fires play + playing
     audio.play();
-    testing.expectEqual('play,playing,pause,play,pause,emptied,play,playing', events.join(','));
+    testing.expectEqual('play,playing,pause,play,playing,pause,emptied,play,playing', events.join(','));
   }
 </script>
 

--- a/src/browser/webapi/element/html/Media.zig
+++ b/src/browser/webapi/element/html/Media.zig
@@ -61,7 +61,6 @@ _playback_rate: f64 = 1.0,
 _ready_state: ReadyState = .HAVE_NOTHING,
 _network_state: NetworkState = .NETWORK_EMPTY,
 _error: ?*MediaError = null,
-_playing: bool = false,
 
 pub fn asElement(self: *Media) *Element {
     return self._proto._proto;
@@ -145,10 +144,7 @@ pub fn play(self: *Media, page: *Page) !void {
     self._network_state = .NETWORK_IDLE;
     if (was_paused) {
         try self.dispatchEvent("play", page);
-        if (!self._playing) {
-            self._playing = true;
-            try self.dispatchEvent("playing", page);
-        }
+        try self.dispatchEvent("playing", page);
     }
 }
 
@@ -161,7 +157,6 @@ pub fn pause(self: *Media, page: *Page) !void {
 
 pub fn load(self: *Media, page: *Page) !void {
     self._paused = true;
-    self._playing = false;
     self._current_time = 0;
     self._ready_state = .HAVE_NOTHING;
     self._network_state = .NETWORK_LOADING;


### PR DESCRIPTION
## Summary
- `play()` now dispatches `play` and `playing` events
- `pause()` now dispatches `pause` event
- `load()` now dispatches `emptied` event
- Follows the existing event dispatch pattern (Event.init + page._event_manager.dispatch)
- Added test for event listener callbacks on play/pause/load

## Test plan
- [x] All 238 unit tests pass (`make test`)
- [x] New `play_pause_events` test verifies event listener callbacks
- [x] CDP integration test confirms events fire on patched build
- [x] Official container confirmed to NOT fire events (baseline)