### PR TITLE
Use performance.now() for IntersectionObserverEntry.time

### DIFF
--- a/src/browser/tests/intersection_observer/basic.html
+++ b/src/browser/tests/intersection_observer/basic.html
@@ -25,6 +25,8 @@
         testing.expectEqual('number', typeof entry.intersectionRatio);
         testing.expectEqual('object', typeof entry.boundingClientRect);
         testing.expectEqual('object', typeof entry.intersectionRect);
+        testing.expectEqual('number', typeof entry.time);
+        testing.expectEqual(true, entry.time > 0);
 
         observer.disconnect();
     });

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -246,7 +246,7 @@ fn checkIntersection(self: *IntersectionObserver, target: *Element, page: *Page)
             ._page = page,
             ._arena = arena,
             ._target = target,
-            ._time = 0.0, // TODO: Get actual timestamp
+            ._time = page.window._performance.now(),
             ._bounding_client_rect = data.bounding_client_rect,
             ._intersection_rect = data.intersection_rect,
             ._root_bounds = data.root_bounds,


### PR DESCRIPTION
## Summary
- Replace hardcoded `0.0` with `page.window._performance.now()` for `IntersectionObserverEntry.time`
- Provides a real DOMHighResTimeStamp matching the W3C IntersectionObserver spec
- Added test assertions for `entry.time` being a positive number

## Test plan
- [x] All 238 unit tests pass (`make test`)
- [x] CDP integration test: dev build returns positive timestamp (~15ms)
- [x] Official nightly confirmed to return 0 (baseline)