### PR TITLE
Populate Response.statusText for network responses

### DIFF
--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -117,6 +117,7 @@ fn httpHeaderDoneCallback(transfer: *Http.Transfer) !bool {
     }
 
     res._status = header.status;
+    res._status_text = std.http.Status.phrase(@enumFromInt(header.status)) orelse "";
     res._url = try arena.dupeZ(u8, std.mem.span(header.url));
     res._is_redirected = header.redirect_count > 0;
 

--- a/src/browser/webapi/net/Response.zig
+++ b/src/browser/webapi/net/Response.zig
@@ -95,10 +95,6 @@ pub fn getStatus(self: *const Response) u16 {
 }
 
 pub fn getStatusText(self: *const Response) []const u8 {
-    // @TODO
-    // This property is meant to actually capture the response status text, not
-    // just return the text representation of self._status. If we do,
-    // new Response(null, {status: 200}).statusText, we should get empty string.
     return self._status_text;
 }
 


### PR DESCRIPTION
## Summary
- Network responses from `fetch()` now have `statusText` populated using `std.http.Status.phrase()`
- Matches the Fetch spec: constructed responses keep their explicit statusText (or empty), network responses get the HTTP reason phrase
- Same approach already used by `XMLHttpRequest.getStatusText()`
- Removed the stale TODO comment in `Response.getStatusText()`

## Test plan
- [x] All 238 unit tests pass (`make test`)
- [x] CDP integration test: `new Response(null, {status: 200}).statusText` → `""` (correct)
- [x] CDP integration test: `new Response(null, {status: 404, statusText: "Not Found"}).statusText` → `"Not Found"` (correct)
- [x] CDP integration test: `fetch(url).then(r => r.statusText)` → `"OK"` (correct)
- [x] Official nightly returns `""` for network fetch statusText (baseline)