### PR TITLE
Detach attached nodes on appendBeforeSibling callback

### DIFF
--- a/src/browser/tests/custom_elements/registry.html
+++ b/src/browser/tests/custom_elements/registry.html
@@ -119,3 +119,33 @@
 }
 </script>
 
+<script id="constructor_self_insert_foster_parent">
+{
+    // Regression: custom element constructor inserting itself (via appendChild) during
+    // innerHTML parsing. When the element is not valid table content, the HTML5 parser
+    // foster-parents it before the <table> via appendBeforeSiblingCallback. That callback
+    // previously didn't check for an existing _parent before calling insertNodeRelative,
+    // causing the "Page.insertNodeRelative parent" assertion to fire.
+    let constructorCalled = 0;
+    let container;
+
+    class CtorSelfInsert extends HTMLElement {
+        constructor() {
+            super();
+            constructorCalled++;
+            // Insert self into container so _parent is set before the parser
+            // officially places this element via appendBeforeSiblingCallback.
+            if (container) container.appendChild(this);
+        }
+    }
+    customElements.define('ctor-self-insert', CtorSelfInsert);
+
+    container = document.createElement('div');
+    // ctor-self-insert is not valid table content; the parser foster-parents it
+    // before the <table>, calling appendBeforeSiblingCallback(sibling=table, node=element).
+    // At that point the element already has _parent=container from the constructor.
+    container.innerHTML = '<table><ctor-self-insert></ctor-self-insert></table>';
+
+    testing.expectEqual(1, constructorCalled);
+}
+</script>

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -1417,7 +1417,7 @@ pub const Transfer = struct {
             header_len = buf_len - 1;
         }
 
-        const header = buffer[0 .. header_len];
+        const header = buffer[0..header_len];
 
         // We need to parse the first line headers for each request b/c curl's
         // CURLINFO_RESPONSE_CODE returns the status code of the final request.


### PR DESCRIPTION
html5ever generally makes guarantees about nodes being parentless when appending, but we've already seen 1 case where appendCallback receives a connected node.

We're now seeing something in appendBeforeSiblingCallback, but we have a clearer picture of how this is happening. In this case, it's via custom element upgrading and the custom element constructor has already placed the node in the document.

It's worth pointing, html5ever just has an opaque reference to our node. While it guarantees that it will give us parent-less nodes, it doesn't actually know anything about our nodes, or our node._parent. The guarantee is only from its own point of view. There's nothing stopping us from giving a node a default parent as soon as html5ever asks us to create a new node, in which case, the node _will_ have a parent.