### PR TITLE
return CSSStyleSheet from HTMLStyleElement.sheet

### DIFF
--- a/src/browser/tests/element/html/style.html
+++ b/src/browser/tests/element/html/style.html
@@ -38,6 +38,11 @@
     testing.expectEqual(true, tempStyle.sheet instanceof CSSStyleSheet);
     document.head.removeChild(tempStyle);
     testing.expectEqual(null, tempStyle.sheet);
+
+    // ownerNode points back to the style element
+    const ownStyle = document.createElement('style');
+    document.head.appendChild(ownStyle);
+    testing.expectEqual(true, ownStyle.sheet.ownerNode === ownStyle);
   }
 </script>
 

--- a/src/browser/webapi/css/CSSStyleSheet.zig
+++ b/src/browser/webapi/css/CSSStyleSheet.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Element = @import("../Element.zig");
 const CSSRuleList = @import("CSSRuleList.zig");
 const CSSRule = @import("CSSRule.zig");
 
@@ -11,14 +12,18 @@ _title: []const u8 = "",
 _disabled: bool = false,
 _css_rules: ?*CSSRuleList = null,
 _owner_rule: ?*CSSRule = null,
+_owner_node: ?*Element = null,
 
 pub fn init(page: *Page) !*CSSStyleSheet {
     return page._factory.create(CSSStyleSheet{});
 }
 
-pub fn getOwnerNode(self: *const CSSStyleSheet) ?*CSSStyleSheet {
-    _ = self;
-    return null;
+pub fn initWithOwner(owner: *Element, page: *Page) !*CSSStyleSheet {
+    return page._factory.create(CSSStyleSheet{ ._owner_node = owner });
+}
+
+pub fn getOwnerNode(self: *const CSSStyleSheet) ?*Element {
+    return self._owner_node;
 }
 
 pub fn getHref(self: *const CSSStyleSheet) ?[]const u8 {

--- a/src/browser/webapi/element/html/Style.zig
+++ b/src/browser/webapi/element/html/Style.zig
@@ -92,7 +92,7 @@ pub fn getSheet(self: *Style, page: *Page) !?*CSSStyleSheet {
     }
 
     if (self._sheet) |sheet| return sheet;
-    const sheet = try CSSStyleSheet.init(page);
+    const sheet = try CSSStyleSheet.initWithOwner(self.asElement(), page);
     self._sheet = sheet;
     return sheet;
 }


### PR DESCRIPTION
## Summary

- Connected `<style>` elements with `type="text/css"` (or default) now return a `CSSStyleSheet` from the `.sheet` property
- Disconnected elements or non-CSS types correctly return `null`
- Sheet is lazily created and cached on first access

Per [MDN spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/sheet), a `StyleSheet` is always associated with an `HTMLStyleElement` unless its `type` attribute is not `text/css`.

## Test plan

- [x] Unit test: disconnected → null, connected → CSSStyleSheet, non-CSS type → null, same instance on repeat
- [x] CDP integration test: dev build passes all checks, official nightly returns null (confirms new feature)
- [x] All 238 unit tests pass