### PR TITLE
Rework CDP frameIds (and loaderIds and requestIds and interceptorIds)

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -102,24 +102,30 @@ const EventType = std.meta.FieldEnum(Events);
 pub const PageRemove = struct {};
 
 pub const PageNavigate = struct {
-    req_id: usize,
+    req_id: u32,
+    page_id: u32,
     timestamp: u64,
     url: [:0]const u8,
     opts: Page.NavigateOpts,
 };
 
 pub const PageNavigated = struct {
-    req_id: usize,
+    req_id: u32,
+    page_id: u32,
     timestamp: u64,
     url: [:0]const u8,
     opts: Page.NavigatedOpts,
 };
 
 pub const PageNetworkIdle = struct {
+    req_id: u32,
+    page_id: u32,
     timestamp: u64,
 };
 
 pub const PageNetworkAlmostIdle = struct {
+    req_id: u32,
+    page_id: u32,
     timestamp: u64,
 };
 
@@ -305,6 +311,7 @@ test "Notification" {
 
     // noop
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 0,
         .req_id = 1,
         .timestamp = 4,
         .url = undefined,
@@ -315,6 +322,7 @@ test "Notification" {
 
     try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 0,
         .req_id = 1,
         .timestamp = 4,
         .url = undefined,
@@ -324,6 +332,7 @@ test "Notification" {
 
     notifier.unregisterAll(&tc);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 0,
         .req_id = 1,
         .timestamp = 10,
         .url = undefined,
@@ -334,23 +343,25 @@ test "Notification" {
     try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
     try notifier.register(.page_navigated, &tc, TestClient.pageNavigated);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 0,
         .req_id = 1,
         .timestamp = 10,
         .url = undefined,
         .opts = .{},
     });
-    notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 6, .url = undefined, .opts = .{} });
+    notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 6, .url = undefined, .opts = .{} });
     try testing.expectEqual(14, tc.page_navigate);
     try testing.expectEqual(6, tc.page_navigated);
 
     notifier.unregisterAll(&tc);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 0,
         .req_id = 1,
         .timestamp = 100,
         .url = undefined,
         .opts = .{},
     });
-    notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+    notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
     try testing.expectEqual(14, tc.page_navigate);
     try testing.expectEqual(6, tc.page_navigated);
 
@@ -358,27 +369,27 @@ test "Notification" {
         // unregister
         try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
         try notifier.register(.page_navigated, &tc, TestClient.pageNavigated);
-        notifier.dispatch(.page_navigate, &.{ .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(1006, tc.page_navigated);
 
         notifier.unregister(.page_navigate, &tc);
-        notifier.dispatch(.page_navigate, &.{ .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
 
         notifier.unregister(.page_navigated, &tc);
-        notifier.dispatch(.page_navigate, &.{ .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
 
         // already unregistered, try anyways
         notifier.unregister(.page_navigated, &tc);
-        notifier.dispatch(.page_navigate, &.{ .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
     }

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -259,6 +259,7 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
             .url = url,
             .ctx = script,
             .method = .GET,
+            .page_id = page.id,
             .headers = try self.getHeaders(url),
             .blocking = is_blocking,
             .cookie_jar = &page._session.cookie_jar,
@@ -358,9 +359,11 @@ pub fn preloadImport(self: *ScriptManager, url: [:0]const u8, referrer: []const 
         .manager = self,
     };
 
+    const page = self.page;
+
     if (comptime IS_DEBUG) {
         var ls: js.Local.Scope = undefined;
-        self.page.js.localScope(&ls);
+        page.js.localScope(&ls);
         defer ls.deinit();
 
         log.debug(.http, "script queue", .{
@@ -375,10 +378,11 @@ pub fn preloadImport(self: *ScriptManager, url: [:0]const u8, referrer: []const 
         .url = url,
         .ctx = script,
         .method = .GET,
+        .page_id = page.id,
         .headers = try self.getHeaders(url),
-        .cookie_jar = &self.page._session.cookie_jar,
+        .cookie_jar = &page._session.cookie_jar,
         .resource_type = .script,
-        .notification = self.page._session.notification,
+        .notification = page._session.notification,
         .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
         .header_callback = Script.headerCallback,
         .data_callback = Script.dataCallback,
@@ -451,9 +455,10 @@ pub fn getAsyncImport(self: *ScriptManager, url: [:0]const u8, cb: ImportAsync.C
         } },
     };
 
+    const page = self.page;
     if (comptime IS_DEBUG) {
         var ls: js.Local.Scope = undefined;
-        self.page.js.localScope(&ls);
+        page.js.localScope(&ls);
         defer ls.deinit();
 
         log.debug(.http, "script queue", .{
@@ -476,11 +481,12 @@ pub fn getAsyncImport(self: *ScriptManager, url: [:0]const u8, cb: ImportAsync.C
     try self.client.request(.{
         .url = url,
         .method = .GET,
+        .page_id = page.id,
         .headers = try self.getHeaders(url),
         .ctx = script,
         .resource_type = .script,
-        .cookie_jar = &self.page._session.cookie_jar,
-        .notification = self.page._session.notification,
+        .cookie_jar = &page._session.cookie_jar,
+        .notification = page._session.notification,
         .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
         .header_callback = Script.headerCallback,
         .data_callback = Script.dataCallback,

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -72,6 +72,7 @@ pub fn init(input: Input, options: ?InitOpts, page: *Page) !js.Promise {
 
     try http_client.request(.{
         .ctx = fetch,
+        .page_id = page.id,
         .url = request._url,
         .method = request._method,
         .body = request._body,

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -223,6 +223,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
     try http_client.request(.{
         .ctx = self,
         .url = self._url,
+        .page_id = page.id,
         .method = self._method,
         .headers = headers,
         .body = self._request_body,

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const id = @import("../id.zig");
 const log = @import("../../log.zig");
 const Node = @import("../Node.zig");
 const DOMNode = @import("../../browser/webapi/Node.zig");
@@ -499,12 +500,11 @@ fn getFrameOwner(cmd: anytype) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const target_id = bc.target_id orelse return error.TargetNotLoaded;
-    if (std.mem.eql(u8, target_id, params.frameId) == false) {
-        return cmd.sendError(-32000, "Frame with the given id does not belong to the target.", .{});
-    }
+    const page_id = try id.toPageId(.frame_id, params.frameId);
 
-    const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    const page = bc.session.findPage(page_id) orelse {
+        return cmd.sendError(-32000, "Frame with the given id does not belong to the target.", .{});
+    };
 
     const node = try bc.node_registry.register(page.window._document.asNode());
     return cmd.sendResult(.{ .nodeId = node.id, .backendNodeId = node.id }, .{});

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -116,30 +116,3 @@ fn insertText(cmd: anytype) !void {
 
     try cmd.sendResult(null, .{});
 }
-
-fn clickNavigate(cmd: anytype, uri: std.Uri) !void {
-    const bc = cmd.browser_context.?;
-
-    var url_buf: std.ArrayList(u8) = .{};
-    try uri.writeToStream(.{
-        .scheme = true,
-        .authentication = true,
-        .authority = true,
-        .port = true,
-        .path = true,
-        .query = true,
-    }, url_buf.writer(cmd.arena));
-    const url = url_buf.items;
-
-    try cmd.sendEvent("Page.frameRequestedNavigation", .{
-        .url = url,
-        .frameId = bc.target_id.?,
-        .reason = "anchorClick",
-        .disposition = "currentTab",
-    }, .{ .session_id = bc.session_id.? });
-
-    try bc.session.removePage();
-    _ = try bc.session.createPage(null);
-
-    try @import("page.zig").navigateToUrl(cmd, url, false);
-}

--- a/src/cdp/id.zig
+++ b/src/cdp/id.zig
@@ -1,0 +1,184 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const IS_DEBUG = @import("builtin").mode == .Debug;
+
+pub fn toPageId(comptime id_type: enum { frame_id, loader_id }, input: []const u8) !u32 {
+    const err = switch (comptime id_type) {
+        .frame_id => error.InvalidFrameId,
+        .loader_id => error.InvalidLoaderId,
+    };
+
+    if (input.len < 4) {
+        return err;
+    }
+
+    return std.fmt.parseInt(u32, input[4..], 10) catch err;
+}
+
+pub fn toFrameId(page_id: u32) [14]u8 {
+    var buf: [14]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "FID-{d:0>10}", .{page_id}) catch unreachable;
+    return buf;
+}
+
+pub fn toLoaderId(page_id: u32) [14]u8 {
+    var buf: [14]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "LID-{d:0>10}", .{page_id}) catch unreachable;
+    return buf;
+}
+
+pub fn toRequestId(page_id: u32) [14]u8 {
+    var buf: [14]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "RID-{d:0>10}", .{page_id}) catch unreachable;
+    return buf;
+}
+
+pub fn toInterceptId(page_id: u32) [14]u8 {
+    var buf: [14]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "INT-{d:0>10}", .{page_id}) catch unreachable;
+    return buf;
+}
+
+// Generates incrementing prefixed integers, i.e. CTX-1, CTX-2, CTX-3.
+// Wraps to 0 on overflow.
+// Many caveats for using this:
+// - Not thread-safe.
+// - Information leaking
+// - The slice returned by next() is only valid:
+//   - while incrementor is valid
+//   - until the next call to next()
+// On the positive, it's zero allocation
+pub fn Incrementing(comptime T: type, comptime prefix: []const u8) type {
+    // +1 for the '-' separator
+    const NUMERIC_START = prefix.len + 1;
+    const MAX_BYTES = NUMERIC_START + switch (T) {
+        u8 => 3,
+        u16 => 5,
+        u32 => 10,
+        u64 => 20,
+        else => @compileError("Incrementing must be given an unsigned int type, got: " ++ @typeName(T)),
+    };
+
+    const buffer = blk: {
+        var b = [_]u8{0} ** MAX_BYTES;
+        @memcpy(b[0..prefix.len], prefix);
+        b[prefix.len] = '-';
+        break :blk b;
+    };
+
+    const PrefixIntType = @Type(.{ .int = .{
+        .bits = NUMERIC_START * 8,
+        .signedness = .unsigned,
+    } });
+
+    const PREFIX_INT_CODE: PrefixIntType = @bitCast(buffer[0..NUMERIC_START].*);
+
+    return struct {
+        counter: T = 0,
+        buffer: [MAX_BYTES]u8 = buffer,
+
+        const Self = @This();
+
+        pub fn next(self: *Self) []const u8 {
+            const counter = self.counter;
+            const n = counter +% 1;
+            defer self.counter = n;
+
+            const size = std.fmt.printInt(self.buffer[NUMERIC_START..], n, 10, .lower, .{});
+            return self.buffer[0 .. NUMERIC_START + size];
+        }
+
+        // extracts the numeric portion from an ID
+        pub fn parse(str: []const u8) !T {
+            if (str.len <= NUMERIC_START) {
+                return error.InvalidId;
+            }
+
+            if (@as(PrefixIntType, @bitCast(str[0..NUMERIC_START].*)) != PREFIX_INT_CODE) {
+                return error.InvalidId;
+            }
+
+            return std.fmt.parseInt(T, str[NUMERIC_START..], 10) catch {
+                return error.InvalidId;
+            };
+        }
+    };
+}
+
+const testing = @import("../testing.zig");
+test "id: Incrementing.next" {
+    var id = Incrementing(u16, "IDX"){};
+    try testing.expectEqual("IDX-1", id.next());
+    try testing.expectEqual("IDX-2", id.next());
+    try testing.expectEqual("IDX-3", id.next());
+
+    // force a wrap
+    id.counter = 65533;
+    try testing.expectEqual("IDX-65534", id.next());
+    try testing.expectEqual("IDX-65535", id.next());
+    try testing.expectEqual("IDX-0", id.next());
+}
+
+test "id: Incrementing.parse" {
+    const ReqId = Incrementing(u32, "REQ");
+    try testing.expectError(error.InvalidId, ReqId.parse(""));
+    try testing.expectError(error.InvalidId, ReqId.parse("R"));
+    try testing.expectError(error.InvalidId, ReqId.parse("RE"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ-"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ--1"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ--"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ-Nope"));
+    try testing.expectError(error.InvalidId, ReqId.parse("REQ-4294967296"));
+
+    try testing.expectEqual(0, try ReqId.parse("REQ-0"));
+    try testing.expectEqual(99, try ReqId.parse("REQ-99"));
+    try testing.expectEqual(4294967295, try ReqId.parse("REQ-4294967295"));
+}
+
+test "id: toPageId" {
+    try testing.expectEqual(0, toPageId(.frame_id, "FID-0"));
+    try testing.expectEqual(0, toPageId(.loader_id, "LID-0"));
+
+    try testing.expectEqual(4294967295, toPageId(.frame_id, "FID-4294967295"));
+    try testing.expectEqual(4294967295, toPageId(.loader_id, "LID-4294967295"));
+    try testing.expectError(error.InvalidFrameId, toPageId(.frame_id, ""));
+    try testing.expectError(error.InvalidLoaderId, toPageId(.loader_id, "LID-NOPE"));
+}
+
+test "id: toFrameId" {
+    try testing.expectEqual("FID-0000000000", toFrameId(0));
+    try testing.expectEqual("FID-4294967295", toFrameId(4294967295));
+}
+
+test "id: toLoaderId" {
+    try testing.expectEqual("LID-0000000000", toLoaderId(0));
+    try testing.expectEqual("LID-4294967295", toLoaderId(4294967295));
+}
+
+test "id: toRequestId" {
+    try testing.expectEqual("RID-0000000000", toRequestId(0));
+    try testing.expectEqual("RID-4294967295", toRequestId(4294967295));
+}
+
+test "id: toInterceptId" {
+    try testing.expectEqual("INT-0000000000", toInterceptId(0));
+    try testing.expectEqual("INT-4294967295", toInterceptId(4294967295));
+}

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -92,7 +92,7 @@ const TestContext = struct {
 
     const BrowserContextOpts = struct {
         id: ?[]const u8 = null,
-        target_id: ?[]const u8 = null,
+        target_id: ?[14]u8 = null,
         session_id: ?[]const u8 = null,
         url: ?[:0]const u8 = null,
     };
@@ -122,7 +122,7 @@ const TestContext = struct {
                 bc.session_id = "SID-X";
             }
             if (bc.target_id == null) {
-                bc.target_id = "TID-X";
+                bc.target_id = "TID-000000000Z".*;
             }
             const page = try bc.session.createPage();
             const full_url = try std.fmt.allocPrintSentinel(

--- a/src/http/Client.zig
+++ b/src/http/Client.zig
@@ -79,7 +79,7 @@ multi: *c.CURLM,
 handles: Handles,
 
 // Use to generate the next request ID
-next_request_id: u64 = 0,
+next_request_id: u32 = 0,
 
 // When handles has no more available easys, requests get queued.
 queue: TransferQueue,
@@ -336,6 +336,7 @@ fn fetchRobotsThenProcessRequest(self: *Client, robots_url: [:0]const u8, req: R
             .method = .GET,
             .headers = headers,
             .blocking = false,
+            .page_id = req.page_id,
             .cookie_jar = req.cookie_jar,
             .notification = req.notification,
             .resource_type = .fetch,
@@ -562,12 +563,12 @@ pub fn fulfillTransfer(self: *Client, transfer: *Transfer, status: u16, headers:
     transfer._intercept_state = .fulfilled;
 }
 
-pub fn nextReqId(self: *Client) usize {
-    return self.next_request_id + 1;
+pub fn nextReqId(self: *Client) u32 {
+    return self.next_request_id +% 1;
 }
 
-pub fn incrReqId(self: *Client) usize {
-    const id = self.next_request_id + 1;
+pub fn incrReqId(self: *Client) u32 {
+    const id = self.next_request_id +% 1;
     self.next_request_id = id;
     return id;
 }
@@ -1003,6 +1004,7 @@ pub const RequestCookie = struct {
 };
 
 pub const Request = struct {
+    page_id: u32,
     method: Method,
     url: [:0]const u8,
     headers: Http.Headers,
@@ -1093,7 +1095,7 @@ pub const AuthChallenge = struct {
 
 pub const Transfer = struct {
     arena: ArenaAllocator,
-    id: usize = 0,
+    id: u32 = 0,
     req: Request,
     url: [:0]const u8,
     ctx: *anyopaque, // copied from req.ctx to make it easier for callback handlers

--- a/src/id.zig
+++ b/src/id.zig
@@ -19,72 +19,6 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-// Generates incrementing prefixed integers, i.e. CTX-1, CTX-2, CTX-3.
-// Wraps to 0 on overflow.
-// Many caveats for using this:
-// - Not thread-safe.
-// - Information leaking
-// - The slice returned by next() is only valid:
-//   - while incrementor is valid
-//   - until the next call to next()
-// On the positive, it's zero allocation
-pub fn Incrementing(comptime T: type, comptime prefix: []const u8) type {
-    // +1 for the '-' separator
-    const NUMERIC_START = prefix.len + 1;
-    const MAX_BYTES = NUMERIC_START + switch (T) {
-        u8 => 3,
-        u16 => 5,
-        u32 => 10,
-        u64 => 20,
-        else => @compileError("Incrementing must be given an unsigned int type, got: " ++ @typeName(T)),
-    };
-
-    const buffer = blk: {
-        var b = [_]u8{0} ** MAX_BYTES;
-        @memcpy(b[0..prefix.len], prefix);
-        b[prefix.len] = '-';
-        break :blk b;
-    };
-
-    const PrefixIntType = @Type(.{ .int = .{
-        .bits = NUMERIC_START * 8,
-        .signedness = .unsigned,
-    } });
-
-    const PREFIX_INT_CODE: PrefixIntType = @bitCast(buffer[0..NUMERIC_START].*);
-
-    return struct {
-        counter: T = 0,
-        buffer: [MAX_BYTES]u8 = buffer,
-
-        const Self = @This();
-
-        pub fn next(self: *Self) []const u8 {
-            const counter = self.counter;
-            const n = counter +% 1;
-            defer self.counter = n;
-
-            const size = std.fmt.printInt(self.buffer[NUMERIC_START..], n, 10, .lower, .{});
-            return self.buffer[0 .. NUMERIC_START + size];
-        }
-
-        // extracts the numeric portion from an ID
-        pub fn parse(str: []const u8) !T {
-            if (str.len <= NUMERIC_START) {
-                return error.InvalidId;
-            }
-
-            if (@as(PrefixIntType, @bitCast(str[0..NUMERIC_START].*)) != PREFIX_INT_CODE) {
-                return error.InvalidId;
-            }
-
-            return std.fmt.parseInt(T, str[NUMERIC_START..], 10) catch {
-                return error.InvalidId;
-            };
-        }
-    };
-}
-
 pub fn uuidv4(hex: []u8) void {
     lp.assert(hex.len == 36, "uuidv4.len", .{ .len = hex.len });
 
@@ -108,36 +42,6 @@ pub fn uuidv4(hex: []u8) void {
 }
 
 const testing = std.testing;
-test "id: Incrementing.next" {
-    var id = Incrementing(u16, "IDX"){};
-    try testing.expectEqualStrings("IDX-1", id.next());
-    try testing.expectEqualStrings("IDX-2", id.next());
-    try testing.expectEqualStrings("IDX-3", id.next());
-
-    // force a wrap
-    id.counter = 65533;
-    try testing.expectEqualStrings("IDX-65534", id.next());
-    try testing.expectEqualStrings("IDX-65535", id.next());
-    try testing.expectEqualStrings("IDX-0", id.next());
-}
-
-test "id: Incrementing.parse" {
-    const ReqId = Incrementing(u32, "REQ");
-    try testing.expectError(error.InvalidId, ReqId.parse(""));
-    try testing.expectError(error.InvalidId, ReqId.parse("R"));
-    try testing.expectError(error.InvalidId, ReqId.parse("RE"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ-"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ--1"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ--"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ-Nope"));
-    try testing.expectError(error.InvalidId, ReqId.parse("REQ-4294967296"));
-
-    try testing.expectEqual(0, try ReqId.parse("REQ-0"));
-    try testing.expectEqual(99, try ReqId.parse("REQ-99"));
-    try testing.expectEqual(4294967295, try ReqId.parse("REQ-4294967295"));
-}
-
 test "id: uuiv4" {
     const expectUUID = struct {
         fn expect(uuid: [36]u8) !void {


### PR DESCRIPTION
Our BrowsingContext currently supports 1 target. So we have a per-BC target_id. Previously, our target had 1 "frame" - our page. So we often treated the targetId as the frameId. But to work with frames, we need page-specific frameIds and loaderIds.

This tries to clean up our ids (a little). frameIds are now ids derived from a new incrementing page.id. This page.id has to be passed around (via http Requests and through notifications) in order to properly generate messages with a frameId.