### PR TITLE
fix textarea text insertion to respect selection range

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -3113,9 +3113,7 @@ pub fn handleKeydown(self: *Page, target: *Node, event: *Event) !void {
             else return
         ;
         // zig fmt: on
-        const current_value = textarea.getValue();
-        const new_value = try std.mem.concat(self.arena, u8, &.{ current_value, append });
-        return textarea.setValue(new_value, self);
+        return textarea.innerInsert(append, self);
     }
 }
 
@@ -3200,13 +3198,11 @@ pub fn insertText(self: *Page, v: []const u8) !void {
             return;
         }
 
-        try input.innerInsert(v, self);
+        return input.innerInsert(v, self);
     }
 
     if (html_element.is(Element.Html.TextArea)) |textarea| {
-        const current_value = textarea.getValue();
-        const new_value = try std.mem.concat(self.arena, u8, &.{ current_value, v });
-        return textarea.setValue(new_value, self);
+        return textarea.innerInsert(v, self);
     }
 }
 


### PR DESCRIPTION
## Summary

- `Page.insertText()` and `Page.handleKeydown()` were manually concatenating text to the textarea value, completely ignoring the current selection range
- Both now use the existing `TextArea.innerInsert()` method which correctly handles full selection replacement, partial selection replacement, and cursor-position insertion — matching how the `Input` element already works
- Also fixes a missing `return` after `input.innerInsert()` in `insertText()` that could cause unintended fall-through

Relates to #1161

## Test plan

- [x] Unit tests pass (246/246)
- [x] CDP integration test: create textarea, set value + selection, `Input.insertText` replaces selected range correctly (6/6 assertions pass)