### PR TITLE
dispatch select event from input/textarea select()

### DIFF
--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -221,6 +221,44 @@
   }
 </script>
 
+<script id="select_event">
+  {
+    const input = document.createElement('input');
+    input.value = 'Hello World';
+    document.body.appendChild(input);
+
+    let eventCount = 0;
+    let lastEvent = null;
+
+    input.addEventListener('select', (e) => {
+      eventCount++;
+      lastEvent = e;
+    });
+
+    let onselectFired = false;
+    input.onselect = () => { onselectFired = true; };
+
+    let bubbledToBody = false;
+    document.body.addEventListener('select', () => {
+      bubbledToBody = true;
+    });
+
+    testing.expectEqual(0, eventCount);
+
+    input.select();
+
+    testing.eventually(() => {
+      testing.expectEqual(1, eventCount);
+      testing.expectEqual('select', lastEvent.type);
+      testing.expectEqual(input, lastEvent.target);
+      testing.expectEqual(true, lastEvent.bubbles);
+      testing.expectEqual(false, lastEvent.cancelable);
+      testing.expectEqual(true, bubbledToBody);
+      testing.expectEqual(true, onselectFired);
+    });
+  }
+</script>
+
 <!-- <script id="defaultChecked">
   testing.expectEqual(true, $('#check1').defaultChecked)
   testing.expectEqual(false, $('#check2').defaultChecked)

--- a/src/browser/tests/element/html/textarea.html
+++ b/src/browser/tests/element/html/textarea.html
@@ -230,6 +230,44 @@
   }
 </script>
 
+<script id="select_event">
+  {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'Hello World';
+    document.body.appendChild(textarea);
+
+    let eventCount = 0;
+    let lastEvent = null;
+
+    textarea.addEventListener('select', (e) => {
+      eventCount++;
+      lastEvent = e;
+    });
+
+    let onselectFired = false;
+    textarea.onselect = () => { onselectFired = true; };
+
+    let bubbledToBody = false;
+    document.body.addEventListener('select', () => {
+      bubbledToBody = true;
+    });
+
+    testing.expectEqual(0, eventCount);
+
+    textarea.select();
+
+    testing.eventually(() => {
+      testing.expectEqual(1, eventCount);
+      testing.expectEqual('select', lastEvent.type);
+      testing.expectEqual(textarea, lastEvent.target);
+      testing.expectEqual(true, lastEvent.bubbles);
+      testing.expectEqual(false, lastEvent.cancelable);
+      testing.expectEqual(true, bubbledToBody);
+      testing.expectEqual(true, onselectFired);
+    });
+  }
+</script>
+
 <script id="selectionchange_event">
   {
     const textarea = document.createElement('textarea');

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -290,6 +290,9 @@ pub fn setRequired(self: *Input, required: bool, page: *Page) !void {
 pub fn select(self: *Input, page: *Page) !void {
     const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
     try self.setSelectionRange(0, len, null, page);
+    const event = try Event.init("select", .{ .bubbles = true }, page);
+    defer if (!event._v8_handoff) event.deinit(false);
+    try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
 fn selectionAvailable(self: *const Input) bool {

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -139,6 +139,9 @@ pub fn setRequired(self: *TextArea, required: bool, page: *Page) !void {
 pub fn select(self: *TextArea, page: *Page) !void {
     const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
     try self.setSelectionRange(0, len, null, page);
+    const event = try Event.init("select", .{ .bubbles = true }, page);
+    defer if (!event._v8_handoff) event.deinit(false);
+    try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
 const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };


### PR DESCRIPTION
## Summary

Fixes part of #1161.

- `input.select()` and `textarea.select()` now dispatch a `select` event after selecting all text
- Per MDN spec: `bubbles: true`, `cancelable: false`, plain `Event`
- Follows the existing `dispatchSelectionChangeEvent` pattern

## Test plan

- [x] Unit tests for both input and textarea (event fires, correct properties, bubbles, onselect handler)
- [x] All 246 unit tests pass
- [x] CDP integration test confirms events fire correctly on dev build
- [x] CDP integration test confirms nightly does not yet have this feature