### PR TITLE
Fix flaky window.scrollTo test

### DIFF
--- a/src/browser/tests/window/scroll.html
+++ b/src/browser/tests/window/scroll.html
@@ -37,6 +37,12 @@
 
     restore();
     testing.expectEqual(2, scrollevt);
-    testing.expectEqual(1, scrollendevt);
+    // This test used to assert that scrollendevt == 1. The idea being that
+    // the above resolve() would stop the test running after "scroll" fires but
+    // before "scrollend" fires. That timing is pretty sensitive/fragile. If
+    // the browser gets delayed and doesn't figure the scroll event exactly when
+    // schedule, it could easily execute in the same sheduler.run call as the
+    // scrollend.
+    testing.expectEqual(true, scrollendevt === 1 || scrollendevt === 2);
   });
 </script>


### PR DESCRIPTION
The test is sensitive to any delay in running the schedule task exactly when it's scheduled. Testing this feature isn't worth making the build flaky.