### PR TITLE
Introduce NodeType enum for Node.getNodeType()

### DIFF
--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -75,15 +75,16 @@ pub fn dump(node: *Node, opts: Opts, writer: *std.Io.Writer, page: *Page) !void 
 }
 
 fn render(node: *Node, state: *State, writer: *std.Io.Writer, page: *Page) error{WriteFailed}!void {
-    switch (node._type) {
+    switch (node.getNodeType()) {
         .document, .document_fragment => {
             try renderChildren(node, state, writer, page);
         },
-        .element => |el| {
-            try renderElement(el, state, writer, page);
+        .element => {
+            try renderElement(node.as(Element), state, writer, page);
         },
-        .cdata => |cd| {
+        .text, .cdata_section => {
             if (node.is(Node.CData.Text)) |_| {
+                const cd = node.as(Node.CData);
                 var text = cd.getData();
                 if (state.in_pre) {
                     if (state.pre_node) |pre| {

--- a/src/browser/webapi/DOMParser.zig
+++ b/src/browser/webapi/DOMParser.zig
@@ -93,7 +93,7 @@ pub fn parseFromString(
                 unreachable;
             };
 
-            if (first_child.getNodeType() == 7) {
+            if (first_child.getNodeType() == .processing_instruction) {
                 // We're sure that firstChild exist, this cannot fail.
                 _ = doc_node.removeChild(first_child, page) catch unreachable;
             }

--- a/src/browser/webapi/NodeFilter.zig
+++ b/src/browser/webapi/NodeFilter.zig
@@ -75,7 +75,7 @@ pub fn shouldShow(node: *const Node, what_to_show: u32) bool {
     // nodeType values (1=ELEMENT, 3=TEXT, 9=DOCUMENT, etc.) need to map to
     // SHOW_* bitmask positions (0x1, 0x4, 0x100, etc.)
     const node_type_value = node.getNodeType();
-    const bit_position = node_type_value - 1;
+    const bit_position = @intFromEnum(node_type_value) - 1;
     const node_type_bit: u32 = @as(u32, 1) << @intCast(bit_position);
     return (what_to_show & node_type_bit) != 0;
 }

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -300,7 +300,7 @@ pub const Writer = struct {
         }
 
         try w.objectField("nodeType");
-        try w.write(dom_node.getNodeType());
+        try w.write(@intFromEnum(dom_node.getNodeType()));
 
         try w.objectField("nodeName");
         var name_buf: [Page.BUF_SIZE]u8 = undefined;


### PR DESCRIPTION
I thought I'd introduce an enum for the node type instead of just having numbers.
It clutters the code base a bit with casts, so feel free to reject.