### PR TITLE
fix ChildNode after() and replaceWith() sibling ordering

### DIFF
--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -227,24 +227,30 @@ pub fn before(self: *CData, nodes: []const Node.NodeOrText, page: *Page) !void {
 pub fn after(self: *CData, nodes: []const Node.NodeOrText, page: *Page) !void {
     const node = self.asNode();
     const parent = node.parentNode() orelse return;
-    const next = node.nextSibling();
+    const viable_next = Node.NodeOrText.viableNextSibling(node, nodes);
 
     for (nodes) |node_or_text| {
         const child = try node_or_text.toNode(page);
-        _ = try parent.insertBefore(child, next, page);
+        _ = try parent.insertBefore(child, viable_next, page);
     }
 }
 
 pub fn replaceWith(self: *CData, nodes: []const Node.NodeOrText, page: *Page) !void {
-    const node = self.asNode();
-    const parent = node.parentNode() orelse return;
-    const next = node.nextSibling();
+    const ref_node = self.asNode();
+    const parent = ref_node.parentNode() orelse return;
 
-    _ = try parent.removeChild(node, page);
-
+    var rm_ref_node = true;
     for (nodes) |node_or_text| {
         const child = try node_or_text.toNode(page);
-        _ = try parent.insertBefore(child, next, page);
+        if (child == ref_node) {
+            rm_ref_node = false;
+            continue;
+        }
+        _ = try parent.insertBefore(child, ref_node, page);
+    }
+
+    if (rm_ref_node) {
+        _ = try parent.removeChild(ref_node, page);
     }
 }
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -870,11 +870,11 @@ pub fn before(self: *Element, nodes: []const Node.NodeOrText, page: *Page) !void
 pub fn after(self: *Element, nodes: []const Node.NodeOrText, page: *Page) !void {
     const node = self.asNode();
     const parent = node.parentNode() orelse return;
-    const next = node.nextSibling();
+    const viable_next = Node.NodeOrText.viableNextSibling(node, nodes);
 
     for (nodes) |node_or_text| {
         const child = try node_or_text.toNode(page);
-        _ = try parent.insertBefore(child, next, page);
+        _ = try parent.insertBefore(child, viable_next, page);
     }
 }
 

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1069,6 +1069,25 @@ pub const NodeOrText = union(enum) {
             .text => |txt| page.createTextNode(txt),
         };
     }
+
+    /// DOM spec: first following sibling of `node` that is not in `nodes`.
+    pub fn viableNextSibling(node: *Node, nodes: []const NodeOrText) ?*Node {
+        var sibling = node.nextSibling() orelse return null;
+        blk: while (true) {
+            for (nodes) |n| {
+                switch (n) {
+                    .node => |nn| if (sibling == nn) {
+                        sibling = sibling.nextSibling() orelse return null;
+                        continue :blk;
+                    },
+                    .text => {},
+                }
+            } else {
+                return sibling;
+            }
+        }
+        return null;
+    }
 };
 
 const testing = @import("../../testing.zig");


### PR DESCRIPTION
## Summary

- `after()` captured `node.nextSibling()` once, which went stale when that sibling was in the insertion list. Now uses `viableNextSibling()` per DOM spec to find the first following sibling not in the nodes list.
- `replaceWith()` in CData had the same stale-reference bug and also removed self before inserting (unlike Element.replaceWith). Now uses self as the insertion anchor: insert before self, remove self at end.
- Added `NodeOrText.viableNextSibling()` helper to Node.zig.

## WPT results

| Test file | Before | After |
|---|---|---|
| ChildNode-after.html | 33/45 | **45/45** |
| ChildNode-replaceWith.html | 27/33 | **33/33** |
| ChildNode-before.html | 45/45 | 45/45 (no regression) |

## Test plan

- [x] `make test` — 260/260 pass
- [x] WPT ChildNode-after: 45/45
- [x] WPT ChildNode-replaceWith: 33/33
- [x] WPT ChildNode-before: 45/45 (regression check)