### PR TITLE
implement Node.lookupNamespaceURI() and isDefaultNamespace()

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -111,6 +111,7 @@ _element_shadow_roots: Element.ShadowRootLookup = .empty,
 _node_owner_documents: Node.OwnerDocumentLookup = .empty,
 _element_assigned_slots: Element.AssignedSlotLookup = .empty,
 _element_scroll_positions: Element.ScrollPositionLookup = .empty,
+_element_namespace_uris: Element.NamespaceUriLookup = .empty,
 
 /// Lazily-created inline event listeners (or listeners provided as attributes).
 /// Avoids bloating all elements with extra function fields for rare usage.

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -160,6 +160,14 @@ pub fn createElementNS(self: *Document, namespace: ?[]const u8, name: []const u8
     const normalized_name = if (ns == .html) std.ascii.lowerString(&page.buf, name) else name;
     const node = try page.createElementNS(ns, normalized_name, null);
 
+    // Store original URI for unknown namespaces so lookupNamespaceURI can return it
+    if (ns == .unknown) {
+        if (namespace) |uri| {
+            const duped = try page.dupeString(uri);
+            try page._element_namespace_uris.put(page.arena, node.as(Element), duped);
+        }
+    }
+
     // Track owner document if it's not the main document
     if (self != page.document) {
         try page.setNodeOwnerDocument(node, self);


### PR DESCRIPTION
## Summary

- Implement `Node.lookupNamespaceURI()` and `Node.isDefaultNamespace()` per DOM spec
- Store custom namespace URIs in a page lookup for elements created via `createElementNS` with unknown namespaces
- Fix `setAttributeNS` to preserve qualified names for xmlns namespace declarations (e.g. `xmlns:bar` instead of just `bar`)
- Move `_prefix()` helper from JsApi to Element level for reuse by lookup algorithm

## Test plan

- [x] `make test` — 280/280 pass
- [x] WPT `dom/nodes/Node-lookupNamespaceURI.html` — 75/75 pass (was 0/75)
- [x] Broader `dom/nodes/` WPT suite — no regressions