### PR TITLE
Improve Context shutdown

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.2.9'
+    default: 'v0.3.0'
   v8:
     description: 'v8 version to install'
     required: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.0.365.4
-ARG ZIG_V8=v0.2.9
+ARG ZIG_V8=v0.3.0
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.2.9.tar.gz",
-            .hash = "v8-0.0.0-xddH689vBACgpqFVEhT2wxRin-qQQSOcKJoM37MVo0rU",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.3.0.tar.gz",
+            .hash = "v8-0.0.0-xddH69R6BADRXsnhjA8wNnfKfLQACF1I7CSTZvsMAvp8",
         },
         //.v8 = .{ .path = "../zig-v8-fork" },
         .@"boringssl-zig" = .{

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -96,10 +96,6 @@ pub fn runMacrotasks(self: *Browser) !?u64 {
 }
 
 pub fn runMessageLoop(self: *const Browser) void {
-    while (self.env.pumpMessageLoop()) {
-        if (comptime IS_DEBUG) {
-            log.debug(.browser, "pumpMessageLoop", .{});
-        }
-    }
+    self.env.pumpMessageLoop();
     self.env.runIdleTasks();
 }

--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -241,8 +241,6 @@ pub const Session = struct {
             msg.ptr,
             msg.len,
         );
-
-        v8.v8__Isolate__PerformMicrotaskCheckpoint(isolate);
     }
 
     // Gets a value by object ID regardless of which context it is in.

--- a/src/browser/js/Isolate.zig
+++ b/src/browser/js/Isolate.zig
@@ -41,18 +41,6 @@ pub fn exit(self: Isolate) void {
     v8.v8__Isolate__Exit(self.handle);
 }
 
-pub fn performMicrotasksCheckpoint(self: Isolate) void {
-    v8.v8__Isolate__PerformMicrotaskCheckpoint(self.handle);
-}
-
-pub fn enqueueMicrotask(self: Isolate, callback: anytype, data: anytype) void {
-    v8.v8__Isolate__EnqueueMicrotask(self.handle, callback, data);
-}
-
-pub fn enqueueMicrotaskFunc(self: Isolate, function: js.Function) void {
-    v8.v8__Isolate__EnqueueMicrotaskFunc(self.handle, function.handle);
-}
-
 pub fn lowMemoryNotification(self: Isolate) void {
     v8.v8__Isolate__LowMemoryNotification(self.handle);
 }

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -82,7 +82,7 @@ pub fn createTypedArray(self: *const Local, comptime array_type: js.ArrayType, s
 }
 
 pub fn runMicrotasks(self: *const Local) void {
-    self.isolate.performMicrotasksCheckpoint();
+    self.ctx.env.runMicrotasks();
 }
 
 // == Executors ==

--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -662,6 +662,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         pub fn callInspector(self: *const Self, msg: []const u8) void {
             self.inspector_session.send(msg);
+            self.session.browser.env.runMicrotasks();
         }
 
         pub fn onInspectorResponse(ctx: *anyopaque, _: u32, msg: []const u8) void {


### PR DESCRIPTION
Under some conditions, a microtask would be executed for a context that was already deinit'd, resulting in various use-after-free.

The culprit appears to be WASM compilation being placed in the microtask queue (by a user-script) and then resolved at some point in the future. We guard the microtask queue by a context.shutting_down boolean, but v8 doesn't know anything about this flag. The fact is that, microtasks are tied to an isolate, not a context.

This commit introduces a number of changes:

1 - It follows https://github.com/lightpanda-io/browser/commit/309f254c2c8c590a2655972aa1b31d020777634c and stores the zig Context inside of an embedder field. This
    ensures v8 doesn't consider this when GC'ing, which _could_ extend the
    lifetime of the v8::Context beyond what we expect

2 - Most significantly, it introduces per-context microtasks queues. Each
    context gets its own queue. This makes cleanup much simpler and reduces the
    chance of microtasks outliving the context

3 - pumpMessageLoop is called on context.deinit, this helps to ensure that any
    tasks v8 has for our context are processed (e.g. wasm compilation) before
    shtudown

4 - The order of context shutdown is important, we notify the isolate of the
    context destruction first, then pump the message loop and finally destroy
    the context's message loop.

Depends on https://github.com/lightpanda-io/zig-v8-fork/pull/151