### PR TITLE
Tweak Finalizer callbacks

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -170,6 +170,8 @@ const DispatchError = error{
     JsException,
 };
 pub fn dispatch(self: *EventManager, target: *EventTarget, event: *Event) DispatchError!void {
+    defer if (!event._v8_handoff) event.deinit(false, self.page);
+
     if (comptime IS_DEBUG) {
         log.debug(.event, "eventManager.dispatch", .{ .type = event._type_string.str(), .bubbles = event._bubbles });
     }
@@ -218,6 +220,8 @@ const DispatchWithFunctionOptions = struct {
     inject_target: bool = true,
 };
 pub fn dispatchWithFunction(self: *EventManager, target: *EventTarget, event: *Event, function_: ?js.Function, comptime opts: DispatchWithFunctionOptions) !void {
+    defer if (!event._v8_handoff) event.deinit(false, self.page);
+
     if (comptime IS_DEBUG) {
         log.debug(.event, "dispatchWithFunction", .{ .type = event._type_string.str(), .context = opts.context, .has_function = function_ != null });
     }
@@ -757,7 +761,6 @@ const ActivationState = struct {
             .bubbles = true,
             .cancelable = false,
         }, page);
-        defer if (!event._v8_handoff) event.deinit(false);
 
         const target = input.asElement().asEventTarget();
         try page._event_manager.dispatch(target, event);

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -893,7 +893,7 @@ pub const Script = struct {
             });
             return;
         };
-        defer if (!event._v8_handoff) event.deinit(false);
+        defer if (!event._v8_handoff) event.deinit(false, self.manager.page);
 
         var caught: js.TryCatch.Caught = undefined;
         cb.tryCall(void, .{event}, &caught) catch {

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -1011,7 +1011,7 @@ pub fn queueMicrotaskFunc(self: *Context, cb: js.Function) void {
     self.isolate.enqueueMicrotaskFunc(cb);
 }
 
-pub fn createFinalizerCallback(self: *Context, global: v8.Global, ptr: *anyopaque, finalizerFn: *const fn (ptr: *anyopaque) void) !*FinalizerCallback {
+pub fn createFinalizerCallback(self: *Context, global: v8.Global, ptr: *anyopaque, finalizerFn: *const fn (ptr: *anyopaque, page: *Page) void) !*FinalizerCallback {
     const fc = try self.finalizer_callback_pool.create();
     fc.* = .{
         .ctx = self,
@@ -1031,10 +1031,10 @@ pub const FinalizerCallback = struct {
     ctx: *Context,
     ptr: *anyopaque,
     global: v8.Global,
-    finalizerFn: *const fn (ptr: *anyopaque) void,
+    finalizerFn: *const fn (ptr: *anyopaque, page: *Page) void,
 
     pub fn deinit(self: *FinalizerCallback) void {
-        self.finalizerFn(self.ptr);
+        self.finalizerFn(self.ptr, self.ctx.page);
         self.ctx.finalizer_callback_pool.destroy(self);
     }
 };

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const Page = @import("../Page.zig");
 const log = @import("../../log.zig");
 const string = @import("../../string.zig");
 
@@ -1061,7 +1062,7 @@ const Resolved = struct {
     class_id: u16,
     prototype_chain: []const @import("TaggedOpaque.zig").PrototypeChainEntry,
     finalizer_from_v8: ?*const fn (handle: ?*const v8.WeakCallbackInfo) callconv(.c) void = null,
-    finalizer_from_zig: ?*const fn (ptr: *anyopaque) void = null,
+    finalizer_from_zig: ?*const fn (ptr: *anyopaque, page: *Page) void = null,
 };
 pub fn resolveValue(value: anytype) Resolved {
     const T = bridge.Struct(@TypeOf(value));

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -77,8 +77,6 @@ pub fn abort(self: *AbortSignal, reason_: ?Reason, local: *const js.Local, page:
 
     // Dispatch abort event
     const event = try Event.initTrusted(comptime .wrap("abort"), .{}, page);
-    defer if (!event._v8_handoff) event.deinit(false);
-
     try page._event_manager.dispatchWithFunction(
         self.asEventTarget(),
         event,

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -868,12 +868,10 @@ pub fn focus(self: *Element, page: *Page) !void {
 
         // Dispatch blur on old element (no bubble, composed)
         const blur_event = try FocusEvent.initTrusted(comptime .wrap("blur"), .{ .composed = true, .relatedTarget = new_target }, page);
-        defer if (!blur_event.asEvent()._v8_handoff) blur_event.deinit(false);
         try page._event_manager.dispatch(old_target, blur_event.asEvent());
 
         // Dispatch focusout on old element (bubbles, composed)
         const focusout_event = try FocusEvent.initTrusted(comptime .wrap("focusout"), .{ .bubbles = true, .composed = true, .relatedTarget = new_target }, page);
-        defer if (!focusout_event.asEvent()._v8_handoff) focusout_event.deinit(false);
         try page._event_manager.dispatch(old_target, focusout_event.asEvent());
     }
 
@@ -881,12 +879,10 @@ pub fn focus(self: *Element, page: *Page) !void {
 
     // Dispatch focus on new element (no bubble, composed)
     const focus_event = try FocusEvent.initTrusted(comptime .wrap("focus"), .{ .composed = true, .relatedTarget = old_related }, page);
-    defer if (!focus_event.asEvent()._v8_handoff) focus_event.deinit(false);
     try page._event_manager.dispatch(new_target, focus_event.asEvent());
 
     // Dispatch focusin on new element (bubbles, composed)
     const focusin_event = try FocusEvent.initTrusted(comptime .wrap("focusin"), .{ .bubbles = true, .composed = true, .relatedTarget = old_related }, page);
-    defer if (!focusin_event.asEvent()._v8_handoff) focusin_event.deinit(false);
     try page._event_manager.dispatch(new_target, focusin_event.asEvent());
 }
 
@@ -900,12 +896,10 @@ pub fn blur(self: *Element, page: *Page) !void {
 
     // Dispatch blur (no bubble, composed)
     const blur_event = try FocusEvent.initTrusted(comptime .wrap("blur"), .{ .composed = true }, page);
-    defer if (!blur_event.asEvent()._v8_handoff) blur_event.deinit(false);
     try page._event_manager.dispatch(old_target, blur_event.asEvent());
 
     // Dispatch focusout (bubbles, composed)
     const focusout_event = try FocusEvent.initTrusted(comptime .wrap("focusout"), .{ .bubbles = true, .composed = true }, page);
-    defer if (!focusout_event.asEvent()._v8_handoff) focusout_event.deinit(false);
     try page._event_manager.dispatch(old_target, focusout_event.asEvent());
 }
 

--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -30,7 +30,6 @@ pub const Event = @This();
 
 pub const _prototype_root = true;
 _type: Type,
-_page: *Page,
 _arena: Allocator,
 _bubbles: bool = false,
 _cancelable: bool = false,
@@ -84,16 +83,16 @@ pub fn init(typ: []const u8, opts_: ?Options, page: *Page) !*Event {
     const arena = try page.getArena(.{ .debug = "Event" });
     errdefer page.releaseArena(arena);
     const str = try String.init(arena, typ, .{});
-    return initWithTrusted(arena, str, opts_, false, page);
+    return initWithTrusted(arena, str, opts_, false);
 }
 
 pub fn initTrusted(typ: String, opts_: ?Options, page: *Page) !*Event {
     const arena = try page.getArena(.{ .debug = "Event.trusted" });
     errdefer page.releaseArena(arena);
-    return initWithTrusted(arena, typ, opts_, true, page);
+    return initWithTrusted(arena, typ, opts_, true);
 }
 
-fn initWithTrusted(arena: Allocator, typ: String, opts_: ?Options, trusted: bool, page: *Page) !*Event {
+fn initWithTrusted(arena: Allocator, typ: String, opts_: ?Options, trusted: bool) !*Event {
     const opts = opts_ orelse Options{};
 
     // Round to 2ms for privacy (browsers do this)
@@ -102,7 +101,6 @@ fn initWithTrusted(arena: Allocator, typ: String, opts_: ?Options, trusted: bool
 
     const event = try arena.create(Event);
     event.* = .{
-        ._page = page,
         ._arena = arena,
         ._type = .generic,
         ._bubbles = opts.bubbles,
@@ -133,9 +131,9 @@ pub fn initEvent(
     self._prevent_default = false;
 }
 
-pub fn deinit(self: *Event, shutdown: bool) void {
+pub fn deinit(self: *Event, shutdown: bool, page: *Page) void {
     _ = shutdown;
-    self._page.releaseArena(self._arena);
+    page.releaseArena(self._arena);
 }
 
 pub fn as(self: *Event, comptime T: type) *T {

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -80,8 +80,6 @@ fn goInner(delta: i32, page: *Page) !void {
     if (entry._url) |url| {
         if (try page.isSameOrigin(url)) {
             const event = (try PopStateEvent.initTrusted(comptime .wrap("popstate"), .{ .state = entry._state.value }, page)).asEvent();
-            defer if (!event._v8_handoff) event.deinit(false);
-
             try page._event_manager.dispatchWithFunction(
                 page.window.asEventTarget(),
                 event,

--- a/src/browser/webapi/MessagePort.zig
+++ b/src/browser/webapi/MessagePort.zig
@@ -130,7 +130,6 @@ const PostMessageCallback = struct {
             log.err(.dom, "MessagePort.postMessage", .{ .err = err });
             return null;
         }).asEvent();
-        defer if (!event._v8_handoff) event.deinit(false);
 
         var ls: js.Local.Scope = undefined;
         page.js.localScope(&ls);

--- a/src/browser/webapi/Selection.zig
+++ b/src/browser/webapi/Selection.zig
@@ -39,7 +39,6 @@ pub const init: Selection = .{};
 
 fn dispatchSelectionChangeEvent(page: *Page) !void {
     const event = try Event.init("selectionchange", .{}, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(page.document.asEventTarget(), event);
 }
 

--- a/src/browser/webapi/animation/Animation.zig
+++ b/src/browser/webapi/animation/Animation.zig
@@ -61,8 +61,8 @@ pub fn init(page: *Page) !*Animation {
     return self;
 }
 
-pub fn deinit(self: *Animation, _: bool) void {
-    self._page.releaseArena(self._arena);
+pub fn deinit(self: *Animation, _: bool, page: *Page) void {
+    page.releaseArena(self._arena);
 }
 
 pub fn play(self: *Animation, page: *Page) !void {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -338,7 +338,6 @@ pub fn click(self: *HtmlElement, page: *Page) !void {
         .clientX = 0,
         .clientY = 0,
     }, page)).asEvent();
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asEventTarget(), event);
 }
 

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -100,7 +100,6 @@ pub fn setOnSelectionChange(self: *Input, listener: ?js.Function) !void {
 
 fn dispatchSelectionChangeEvent(self: *Input, page: *Page) !void {
     const event = try Event.init("selectionchange", .{ .bubbles = true }, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
@@ -344,7 +343,6 @@ pub fn select(self: *Input, page: *Page) !void {
     const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
     try self.setSelectionRange(0, len, null, page);
     const event = try Event.init("select", .{ .bubbles = true }, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 

--- a/src/browser/webapi/element/html/Media.zig
+++ b/src/browser/webapi/element/html/Media.zig
@@ -166,7 +166,6 @@ pub fn load(self: *Media, page: *Page) !void {
 
 fn dispatchEvent(self: *Media, name: []const u8, page: *Page) !void {
     const event = try Event.init(name, .{ .bubbles = false, .cancelable = false }, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -52,7 +52,6 @@ pub fn setOnSelectionChange(self: *TextArea, listener: ?js.Function) !void {
 
 fn dispatchSelectionChangeEvent(self: *TextArea, page: *Page) !void {
     const event = try Event.init("selectionchange", .{ .bubbles = true }, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
@@ -140,7 +139,6 @@ pub fn select(self: *TextArea, page: *Page) !void {
     const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
     try self.setSelectionRange(0, len, null, page);
     const event = try Event.init("select", .{ .bubbles = true }, page);
-    defer if (!event._v8_handoff) event.deinit(false);
     try page._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 

--- a/src/browser/webapi/encoding/TextDecoder.zig
+++ b/src/browser/webapi/encoding/TextDecoder.zig
@@ -25,7 +25,6 @@ const Allocator = std.mem.Allocator;
 const TextDecoder = @This();
 
 _fatal: bool,
-_page: *Page,
 _arena: Allocator,
 _ignore_bom: bool,
 _stream: std.ArrayList(u8),
@@ -52,7 +51,6 @@ pub fn init(label_: ?[]const u8, opts_: ?InitOpts, page: *Page) !*TextDecoder {
     const opts = opts_ orelse InitOpts{};
     const self = try arena.create(TextDecoder);
     self.* = .{
-        ._page = page,
         ._arena = arena,
         ._stream = .empty,
         ._fatal = opts.fatal,
@@ -61,8 +59,8 @@ pub fn init(label_: ?[]const u8, opts_: ?InitOpts, page: *Page) !*TextDecoder {
     return self;
 }
 
-pub fn deinit(self: *TextDecoder, _: bool) void {
-    self._page.releaseArena(self._arena);
+pub fn deinit(self: *TextDecoder, _: bool, page: *Page) void {
+    page.releaseArena(self._arena);
 }
 
 pub fn getIgnoreBOM(self: *const TextDecoder) bool {

--- a/src/browser/webapi/event/CompositionEvent.zig
+++ b/src/browser/webapi/event/CompositionEvent.zig
@@ -53,8 +53,8 @@ pub fn init(typ: []const u8, opts_: ?Options, page: *Page) !*CompositionEvent {
     return event;
 }
 
-pub fn deinit(self: *CompositionEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *CompositionEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *CompositionEvent) *Event {

--- a/src/browser/webapi/event/CustomEvent.zig
+++ b/src/browser/webapi/event/CustomEvent.zig
@@ -72,12 +72,11 @@ pub fn initCustomEvent(
     self._detail = detail_;
 }
 
-pub fn deinit(self: *CustomEvent, shutdown: bool) void {
-    const proto = self._proto;
+pub fn deinit(self: *CustomEvent, shutdown: bool, page: *Page) void {
     if (self._detail) |d| {
-        proto._page.js.release(d);
+        page.js.release(d);
     }
-    proto.deinit(shutdown);
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *CustomEvent) *Event {

--- a/src/browser/webapi/event/ErrorEvent.zig
+++ b/src/browser/webapi/event/ErrorEvent.zig
@@ -79,12 +79,11 @@ fn initWithTrusted(arena: Allocator, typ: String, opts_: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *ErrorEvent, shutdown: bool) void {
-    const proto = self._proto;
+pub fn deinit(self: *ErrorEvent, shutdown: bool, page: *Page) void {
     if (self._error) |e| {
-        proto._page.js.release(e);
+        page.js.release(e);
     }
-    proto.deinit(shutdown);
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *ErrorEvent) *Event {

--- a/src/browser/webapi/event/FocusEvent.zig
+++ b/src/browser/webapi/event/FocusEvent.zig
@@ -69,8 +69,8 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *FocusEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *FocusEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *FocusEvent) *Event {

--- a/src/browser/webapi/event/KeyboardEvent.zig
+++ b/src/browser/webapi/event/KeyboardEvent.zig
@@ -221,8 +221,8 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *KeyboardEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *KeyboardEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *KeyboardEvent) *Event {

--- a/src/browser/webapi/event/MessageEvent.zig
+++ b/src/browser/webapi/event/MessageEvent.zig
@@ -72,12 +72,11 @@ fn initWithTrusted(arena: Allocator, typ: String, opts_: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *MessageEvent, shutdown: bool) void {
-    const proto = self._proto;
+pub fn deinit(self: *MessageEvent, shutdown: bool, page: *Page) void {
     if (self._data) |d| {
-        proto._page.js.release(d);
+        page.js.release(d);
     }
-    proto.deinit(shutdown);
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *MessageEvent) *Event {

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -109,8 +109,8 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*MouseEvent {
     return event;
 }
 
-pub fn deinit(self: *MouseEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *MouseEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *MouseEvent) *Event {

--- a/src/browser/webapi/event/NavigationCurrentEntryChangeEvent.zig
+++ b/src/browser/webapi/event/NavigationCurrentEntryChangeEvent.zig
@@ -82,8 +82,8 @@ fn initWithTrusted(
     return event;
 }
 
-pub fn deinit(self: *NavigationCurrentEntryChangeEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *NavigationCurrentEntryChangeEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *NavigationCurrentEntryChangeEvent) *Event {

--- a/src/browser/webapi/event/PageTransitionEvent.zig
+++ b/src/browser/webapi/event/PageTransitionEvent.zig
@@ -65,8 +65,8 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *PageTransitionEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *PageTransitionEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *PageTransitionEvent) *Event {

--- a/src/browser/webapi/event/PointerEvent.zig
+++ b/src/browser/webapi/event/PointerEvent.zig
@@ -127,8 +127,8 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*PointerEvent {
     return event;
 }
 
-pub fn deinit(self: *PointerEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *PointerEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *PointerEvent) *Event {

--- a/src/browser/webapi/event/PopStateEvent.zig
+++ b/src/browser/webapi/event/PopStateEvent.zig
@@ -66,8 +66,8 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *PopStateEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *PopStateEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *PopStateEvent) *Event {

--- a/src/browser/webapi/event/ProgressEvent.zig
+++ b/src/browser/webapi/event/ProgressEvent.zig
@@ -67,8 +67,8 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     return event;
 }
 
-pub fn deinit(self: *ProgressEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *ProgressEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *ProgressEvent) *Event {

--- a/src/browser/webapi/event/PromiseRejectionEvent.zig
+++ b/src/browser/webapi/event/PromiseRejectionEvent.zig
@@ -56,16 +56,14 @@ pub fn init(typ: []const u8, opts_: ?Options, page: *Page) !*PromiseRejectionEve
     return event;
 }
 
-pub fn deinit(self: *PromiseRejectionEvent, shutdown: bool) void {
-    const proto = self._proto;
-    const js_ctx = proto._page.js;
+pub fn deinit(self: *PromiseRejectionEvent, shutdown: bool, page: *Page) void {
     if (self._reason) |r| {
-        js_ctx.release(r);
+        page.js.release(r);
     }
     if (self._promise) |p| {
-        js_ctx.release(p);
+        page.js.release(p);
     }
-    proto.deinit(shutdown);
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *PromiseRejectionEvent) *Event {

--- a/src/browser/webapi/event/TextEvent.zig
+++ b/src/browser/webapi/event/TextEvent.zig
@@ -58,8 +58,8 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*TextEvent {
     return event;
 }
 
-pub fn deinit(self: *TextEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *TextEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *TextEvent) *Event {

--- a/src/browser/webapi/event/UIEvent.zig
+++ b/src/browser/webapi/event/UIEvent.zig
@@ -69,8 +69,8 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*UIEvent {
     return event;
 }
 
-pub fn deinit(self: *UIEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *UIEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn as(self: *UIEvent, comptime T: type) *T {

--- a/src/browser/webapi/event/WheelEvent.zig
+++ b/src/browser/webapi/event/WheelEvent.zig
@@ -86,8 +86,8 @@ pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*WheelEvent {
     return event;
 }
 
-pub fn deinit(self: *WheelEvent, shutdown: bool) void {
-    self._proto.deinit(shutdown);
+pub fn deinit(self: *WheelEvent, shutdown: bool, page: *Page) void {
+    self._proto.deinit(shutdown, page);
 }
 
 pub fn asEvent(self: *WheelEvent) *Event {

--- a/src/browser/webapi/net/Response.zig
+++ b/src/browser/webapi/net/Response.zig
@@ -36,7 +36,6 @@ pub const Type = enum {
     opaqueredirect,
 };
 
-_page: *Page,
 _status: u16,
 _arena: Allocator,
 _headers: *Headers,
@@ -65,7 +64,6 @@ pub fn init(body_: ?[]const u8, opts_: ?InitOpts, page: *Page) !*Response {
 
     const self = try arena.create(Response);
     self.* = .{
-        ._page = page,
         ._arena = arena,
         ._status = opts.status,
         ._status_text = status_text,
@@ -78,7 +76,7 @@ pub fn init(body_: ?[]const u8, opts_: ?InitOpts, page: *Page) !*Response {
     return self;
 }
 
-pub fn deinit(self: *Response, shutdown: bool) void {
+pub fn deinit(self: *Response, shutdown: bool, page: *Page) void {
     if (self._transfer) |transfer| {
         if (shutdown) {
             transfer.terminate();
@@ -87,7 +85,7 @@ pub fn deinit(self: *Response, shutdown: bool) void {
         }
         self._transfer = null;
     }
-    self._page.releaseArena(self._arena);
+    page.releaseArena(self._arena);
 }
 
 pub fn getStatus(self: *const Response) u16 {

--- a/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
+++ b/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
@@ -62,7 +62,6 @@ pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchT
         .{ .total = progress.total, .loaded = progress.loaded },
         page,
     )).asEvent();
-    defer if (!event._v8_handoff) event.deinit(false);
 
     return page._event_manager.dispatchWithFunction(
         self.asEventTarget(),

--- a/src/browser/webapi/storage/Cookie.zig
+++ b/src/browser/webapi/storage/Cookie.zig
@@ -435,7 +435,7 @@ pub const Jar = struct {
     pub fn removeExpired(self: *Jar, request_time: ?i64) void {
         if (self.cookies.items.len == 0) return;
         const time = request_time orelse std.time.timestamp();
-        var i: usize = self.cookies.items.len ;
+        var i: usize = self.cookies.items.len;
         while (i > 0) {
             i -= 1;
             const cookie = &self.cookies.items[i];


### PR DESCRIPTION
1 - Finalizer callbacks are now give a *Page parameter. Various types no longer
    need to maintain a reference to *Page just to finalize

2 - EventManager now handles v8_handoff == false cleanup. This is largely
    because of the above change, which would require every:

```
defer if (!event._v8_handoff) event.deinit(false);
```

to be turned into:

```
defer if (!event._v8_handoff) event.deinit(false, page);
```

But the caller might not have a page. Besides this, it makes most uses of Event simpler. But, in some cases, it could leave a window where the event doesn't reach the EventManager to be properly managed (though, we have no such cases as of now).