### PR TITLE
Optimizes properties and noop functions

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -463,6 +463,7 @@ const ReturnValue = struct {
 
 pub const Function = struct {
     pub const Opts = struct {
+        noop: bool = false,
         static: bool = false,
         dom_exception: bool = false,
         as_typed_array: bool = false,

--- a/src/browser/tests/canvas/canvas_rendering_context_2d.html
+++ b/src/browser/tests/canvas/canvas_rendering_context_2d.html
@@ -88,3 +88,15 @@
   ctx.putImageData(imageData, 0, 0, 0, 0, 5, 5);
 }
 </script>
+
+
+<script id="getter">
+{
+  const element = document.createElement("canvas");
+  const ctx = element.getContext("2d");
+  testing.expectEqual('10px sans-serif', ctx.font);
+  ctx.font = 'bold 48px serif'
+  testing.expectEqual('bold 48px serif', ctx.font);
+
+}
+</script>

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -178,7 +178,7 @@ pub const JsApi = struct {
     pub const info = bridge.function(Console.info, .{});
     pub const log = bridge.function(Console.log, .{});
     pub const warn = bridge.function(Console.warn, .{});
-    pub const clear = bridge.function(Console.clear, .{});
+    pub const clear = bridge.function(Console.clear, .{ .noop = true });
     pub const assert = bridge.function(Console.assert, .{});
     pub const @"error" = bridge.function(Console.@"error", .{});
     pub const exception = bridge.function(Console.@"error", .{});

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -821,17 +821,6 @@ pub fn setAdoptedStyleSheets(self: *Document, sheets: js.Object) !void {
     self._adopted_style_sheets = try sheets.persist();
 }
 
-pub fn getHidden(_: *const Document) bool {
-    // it's hidden when, for example, the decive is locked, or user is on a
-    // a different tab.
-    return false;
-}
-
-pub fn getVisibilityState(_: *const Document) []const u8 {
-    // See getHidden above, possible options are "visible" or "hidden"
-    return "visible";
-}
-
 // Validates that nodes can be inserted into a Document, respecting Document constraints:
 // - At most one Element child
 // - At most one DocumentType child
@@ -1028,8 +1017,8 @@ pub const JsApi = struct {
     pub const lastElementChild = bridge.accessor(Document.getLastElementChild, null, .{});
     pub const childElementCount = bridge.accessor(Document.getChildElementCount, null, .{});
     pub const adoptedStyleSheets = bridge.accessor(Document.getAdoptedStyleSheets, Document.setAdoptedStyleSheets, .{});
-    pub const hidden = bridge.accessor(Document.getHidden, null, .{});
-    pub const visibilityState = bridge.accessor(Document.getVisibilityState, null, .{});
+    pub const hidden = bridge.property(false, .{ .template = false, .readonly = true });
+    pub const visibilityState = bridge.property("visible", .{ .template = false, .readonly = true });
     pub const defaultView = bridge.accessor(struct {
         fn defaultView(_: *const Document, page: *Page) *@import("Window.zig") {
             return page.window;

--- a/src/browser/webapi/ImageData.zig
+++ b/src/browser/webapi/ImageData.zig
@@ -93,14 +93,6 @@ pub fn getHeight(self: *const ImageData) u32 {
     return self._height;
 }
 
-pub fn getPixelFormat(_: *const ImageData) String {
-    return comptime .wrap("rgba-unorm8");
-}
-
-pub fn getColorSpace(_: *const ImageData) String {
-    return comptime .wrap("srgb");
-}
-
 pub fn getData(self: *const ImageData) js.ArrayBufferRef(.uint8_clamped).Global {
     return self._data;
 }
@@ -116,11 +108,12 @@ pub const JsApi = struct {
 
     pub const constructor = bridge.constructor(ImageData.constructor, .{ .dom_exception = true });
 
+    pub const colorSpace = bridge.property("srgb", .{ .template = false, .readonly = true });
+    pub const pixelFormat = bridge.property("rgba-unorm8", .{ .template = false, .readonly = true });
+
+    pub const data = bridge.accessor(ImageData.getData, null, .{});
     pub const width = bridge.accessor(ImageData.getWidth, null, .{});
     pub const height = bridge.accessor(ImageData.getHeight, null, .{});
-    pub const pixelFormat = bridge.accessor(ImageData.getPixelFormat, null, .{});
-    pub const colorSpace = bridge.accessor(ImageData.getColorSpace, null, .{});
-    pub const data = bridge.accessor(ImageData.getData, null, .{});
 };
 
 const testing = @import("../../testing.zig");

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -807,7 +807,7 @@ pub const JsApi = struct {
 
     pub const alert = bridge.function(struct {
         fn alert(_: *const Window, _: ?[]const u8) void {}
-    }.alert, .{});
+    }.alert, .{ .noop = true });
     pub const confirm = bridge.function(struct {
         fn confirm(_: *const Window, _: ?[]const u8) bool {
             return false;

--- a/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
@@ -47,46 +47,6 @@ pub fn setFillStyle(
     self._fill_style = color.RGBA.parse(value) catch self._fill_style;
 }
 
-pub fn getGlobalAlpha(_: *const CanvasRenderingContext2D) f64 {
-    return 1.0;
-}
-
-pub fn getGlobalCompositeOperation(_: *const CanvasRenderingContext2D) []const u8 {
-    return "source-over";
-}
-
-pub fn getStrokeStyle(_: *const CanvasRenderingContext2D) []const u8 {
-    return "#000000";
-}
-
-pub fn getLineWidth(_: *const CanvasRenderingContext2D) f64 {
-    return 1.0;
-}
-
-pub fn getLineCap(_: *const CanvasRenderingContext2D) []const u8 {
-    return "butt";
-}
-
-pub fn getLineJoin(_: *const CanvasRenderingContext2D) []const u8 {
-    return "miter";
-}
-
-pub fn getMiterLimit(_: *const CanvasRenderingContext2D) f64 {
-    return 10.0;
-}
-
-pub fn getFont(_: *const CanvasRenderingContext2D) []const u8 {
-    return "10px sans-serif";
-}
-
-pub fn getTextAlign(_: *const CanvasRenderingContext2D) []const u8 {
-    return "start";
-}
-
-pub fn getTextBaseline(_: *const CanvasRenderingContext2D) []const u8 {
-    return "alphabetic";
-}
-
 const WidthOrImageData = union(enum) {
     width: u32,
     image_data: *ImageData,
@@ -113,7 +73,6 @@ pub fn createImageData(
 }
 
 pub fn putImageData(_: *const CanvasRenderingContext2D, _: *ImageData, _: f64, _: f64, _: ?f64, _: ?f64, _: ?f64, _: ?f64) void {}
-
 pub fn save(_: *CanvasRenderingContext2D) void {}
 pub fn restore(_: *CanvasRenderingContext2D) void {}
 pub fn scale(_: *CanvasRenderingContext2D, _: f64, _: f64) void {}
@@ -122,13 +81,7 @@ pub fn translate(_: *CanvasRenderingContext2D, _: f64, _: f64) void {}
 pub fn transform(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn setTransform(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn resetTransform(_: *CanvasRenderingContext2D) void {}
-pub fn setGlobalAlpha(_: *CanvasRenderingContext2D, _: f64) void {}
-pub fn setGlobalCompositeOperation(_: *CanvasRenderingContext2D, _: []const u8) void {}
 pub fn setStrokeStyle(_: *CanvasRenderingContext2D, _: []const u8) void {}
-pub fn setLineWidth(_: *CanvasRenderingContext2D, _: f64) void {}
-pub fn setLineCap(_: *CanvasRenderingContext2D, _: []const u8) void {}
-pub fn setLineJoin(_: *CanvasRenderingContext2D, _: []const u8) void {}
-pub fn setMiterLimit(_: *CanvasRenderingContext2D, _: f64) void {}
 pub fn clearRect(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn fillRect(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn strokeRect(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
@@ -144,9 +97,6 @@ pub fn rect(_: *CanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {
 pub fn fill(_: *CanvasRenderingContext2D) void {}
 pub fn stroke(_: *CanvasRenderingContext2D) void {}
 pub fn clip(_: *CanvasRenderingContext2D) void {}
-pub fn setFont(_: *CanvasRenderingContext2D, _: []const u8) void {}
-pub fn setTextAlign(_: *CanvasRenderingContext2D, _: []const u8) void {}
-pub fn setTextBaseline(_: *CanvasRenderingContext2D, _: []const u8) void {}
 pub fn fillText(_: *CanvasRenderingContext2D, _: []const u8, _: f64, _: f64, _: ?f64) void {}
 pub fn strokeText(_: *CanvasRenderingContext2D, _: []const u8, _: f64, _: f64, _: ?f64) void {}
 
@@ -160,53 +110,46 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const createImageData = bridge.function(CanvasRenderingContext2D.createImageData, .{ .dom_exception = true });
-    pub const putImageData = bridge.function(CanvasRenderingContext2D.putImageData, .{});
-
-    pub const save = bridge.function(CanvasRenderingContext2D.save, .{});
-    pub const restore = bridge.function(CanvasRenderingContext2D.restore, .{});
-
-    pub const scale = bridge.function(CanvasRenderingContext2D.scale, .{});
-    pub const rotate = bridge.function(CanvasRenderingContext2D.rotate, .{});
-    pub const translate = bridge.function(CanvasRenderingContext2D.translate, .{});
-    pub const transform = bridge.function(CanvasRenderingContext2D.transform, .{});
-    pub const setTransform = bridge.function(CanvasRenderingContext2D.setTransform, .{});
-    pub const resetTransform = bridge.function(CanvasRenderingContext2D.resetTransform, .{});
-
-    pub const globalAlpha = bridge.accessor(CanvasRenderingContext2D.getGlobalAlpha, CanvasRenderingContext2D.setGlobalAlpha, .{});
-    pub const globalCompositeOperation = bridge.accessor(CanvasRenderingContext2D.getGlobalCompositeOperation, CanvasRenderingContext2D.setGlobalCompositeOperation, .{});
+    pub const font = bridge.property("10px sans-serif", .{ .template = false, .readonly = false });
+    pub const globalAlpha = bridge.property(1.0, .{ .template = false, .readonly = false });
+    pub const globalCompositeOperation = bridge.property("source-over", .{ .template = false, .readonly = false });
+    pub const strokeStyle = bridge.property("#000000", .{ .template = false, .readonly = false });
+    pub const lineWidth = bridge.property(1.0, .{ .template = false, .readonly = false });
+    pub const lineCap = bridge.property("butt", .{ .template = false, .readonly = false });
+    pub const lineJoin = bridge.property("miter", .{ .template = false, .readonly = false });
+    pub const miterLimit = bridge.property(10.0, .{ .template = false, .readonly = false });
+    pub const textAlign = bridge.property("start", .{ .template = false, .readonly = false });
+    pub const textBaseline = bridge.property("alphabetic", .{ .template = false, .readonly = false });
 
     pub const fillStyle = bridge.accessor(CanvasRenderingContext2D.getFillStyle, CanvasRenderingContext2D.setFillStyle, .{});
-    pub const strokeStyle = bridge.accessor(CanvasRenderingContext2D.getStrokeStyle, CanvasRenderingContext2D.setStrokeStyle, .{});
+    pub const createImageData = bridge.function(CanvasRenderingContext2D.createImageData, .{ .dom_exception = true });
 
-    pub const lineWidth = bridge.accessor(CanvasRenderingContext2D.getLineWidth, CanvasRenderingContext2D.setLineWidth, .{});
-    pub const lineCap = bridge.accessor(CanvasRenderingContext2D.getLineCap, CanvasRenderingContext2D.setLineCap, .{});
-    pub const lineJoin = bridge.accessor(CanvasRenderingContext2D.getLineJoin, CanvasRenderingContext2D.setLineJoin, .{});
-    pub const miterLimit = bridge.accessor(CanvasRenderingContext2D.getMiterLimit, CanvasRenderingContext2D.setMiterLimit, .{});
-
-    pub const clearRect = bridge.function(CanvasRenderingContext2D.clearRect, .{});
-    pub const fillRect = bridge.function(CanvasRenderingContext2D.fillRect, .{});
-    pub const strokeRect = bridge.function(CanvasRenderingContext2D.strokeRect, .{});
-
-    pub const beginPath = bridge.function(CanvasRenderingContext2D.beginPath, .{});
-    pub const closePath = bridge.function(CanvasRenderingContext2D.closePath, .{});
-    pub const moveTo = bridge.function(CanvasRenderingContext2D.moveTo, .{});
-    pub const lineTo = bridge.function(CanvasRenderingContext2D.lineTo, .{});
-    pub const quadraticCurveTo = bridge.function(CanvasRenderingContext2D.quadraticCurveTo, .{});
-    pub const bezierCurveTo = bridge.function(CanvasRenderingContext2D.bezierCurveTo, .{});
-    pub const arc = bridge.function(CanvasRenderingContext2D.arc, .{});
-    pub const arcTo = bridge.function(CanvasRenderingContext2D.arcTo, .{});
-    pub const rect = bridge.function(CanvasRenderingContext2D.rect, .{});
-
-    pub const fill = bridge.function(CanvasRenderingContext2D.fill, .{});
-    pub const stroke = bridge.function(CanvasRenderingContext2D.stroke, .{});
-    pub const clip = bridge.function(CanvasRenderingContext2D.clip, .{});
-
-    pub const font = bridge.accessor(CanvasRenderingContext2D.getFont, CanvasRenderingContext2D.setFont, .{});
-    pub const textAlign = bridge.accessor(CanvasRenderingContext2D.getTextAlign, CanvasRenderingContext2D.setTextAlign, .{});
-    pub const textBaseline = bridge.accessor(CanvasRenderingContext2D.getTextBaseline, CanvasRenderingContext2D.setTextBaseline, .{});
-    pub const fillText = bridge.function(CanvasRenderingContext2D.fillText, .{});
-    pub const strokeText = bridge.function(CanvasRenderingContext2D.strokeText, .{});
+    pub const putImageData = bridge.function(CanvasRenderingContext2D.putImageData, .{ .noop = true });
+    pub const save = bridge.function(CanvasRenderingContext2D.save, .{ .noop = true });
+    pub const restore = bridge.function(CanvasRenderingContext2D.restore, .{ .noop = true });
+    pub const scale = bridge.function(CanvasRenderingContext2D.scale, .{ .noop = true });
+    pub const rotate = bridge.function(CanvasRenderingContext2D.rotate, .{ .noop = true });
+    pub const translate = bridge.function(CanvasRenderingContext2D.translate, .{ .noop = true });
+    pub const transform = bridge.function(CanvasRenderingContext2D.transform, .{ .noop = true });
+    pub const setTransform = bridge.function(CanvasRenderingContext2D.setTransform, .{ .noop = true });
+    pub const resetTransform = bridge.function(CanvasRenderingContext2D.resetTransform, .{ .noop = true });
+    pub const clearRect = bridge.function(CanvasRenderingContext2D.clearRect, .{ .noop = true });
+    pub const fillRect = bridge.function(CanvasRenderingContext2D.fillRect, .{ .noop = true });
+    pub const strokeRect = bridge.function(CanvasRenderingContext2D.strokeRect, .{ .noop = true });
+    pub const beginPath = bridge.function(CanvasRenderingContext2D.beginPath, .{ .noop = true });
+    pub const closePath = bridge.function(CanvasRenderingContext2D.closePath, .{ .noop = true });
+    pub const moveTo = bridge.function(CanvasRenderingContext2D.moveTo, .{ .noop = true });
+    pub const lineTo = bridge.function(CanvasRenderingContext2D.lineTo, .{ .noop = true });
+    pub const quadraticCurveTo = bridge.function(CanvasRenderingContext2D.quadraticCurveTo, .{ .noop = true });
+    pub const bezierCurveTo = bridge.function(CanvasRenderingContext2D.bezierCurveTo, .{ .noop = true });
+    pub const arc = bridge.function(CanvasRenderingContext2D.arc, .{ .noop = true });
+    pub const arcTo = bridge.function(CanvasRenderingContext2D.arcTo, .{ .noop = true });
+    pub const rect = bridge.function(CanvasRenderingContext2D.rect, .{ .noop = true });
+    pub const fill = bridge.function(CanvasRenderingContext2D.fill, .{ .noop = true });
+    pub const stroke = bridge.function(CanvasRenderingContext2D.stroke, .{ .noop = true });
+    pub const clip = bridge.function(CanvasRenderingContext2D.clip, .{ .noop = true });
+    pub const fillText = bridge.function(CanvasRenderingContext2D.fillText, .{ .noop = true });
+    pub const strokeText = bridge.function(CanvasRenderingContext2D.strokeText, .{ .noop = true });
 };
 
 const testing = @import("../../../testing.zig");

--- a/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
@@ -46,46 +46,6 @@ pub fn setFillStyle(
     self._fill_style = color.RGBA.parse(value) catch self._fill_style;
 }
 
-pub fn getGlobalAlpha(_: *const OffscreenCanvasRenderingContext2D) f64 {
-    return 1.0;
-}
-
-pub fn getGlobalCompositeOperation(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "source-over";
-}
-
-pub fn getStrokeStyle(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "#000000";
-}
-
-pub fn getLineWidth(_: *const OffscreenCanvasRenderingContext2D) f64 {
-    return 1.0;
-}
-
-pub fn getLineCap(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "butt";
-}
-
-pub fn getLineJoin(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "miter";
-}
-
-pub fn getMiterLimit(_: *const OffscreenCanvasRenderingContext2D) f64 {
-    return 10.0;
-}
-
-pub fn getFont(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "10px sans-serif";
-}
-
-pub fn getTextAlign(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "start";
-}
-
-pub fn getTextBaseline(_: *const OffscreenCanvasRenderingContext2D) []const u8 {
-    return "alphabetic";
-}
-
 const WidthOrImageData = union(enum) {
     width: u32,
     image_data: *ImageData,
@@ -112,7 +72,6 @@ pub fn createImageData(
 }
 
 pub fn putImageData(_: *const OffscreenCanvasRenderingContext2D, _: *ImageData, _: f64, _: f64, _: ?f64, _: ?f64, _: ?f64, _: ?f64) void {}
-
 pub fn save(_: *OffscreenCanvasRenderingContext2D) void {}
 pub fn restore(_: *OffscreenCanvasRenderingContext2D) void {}
 pub fn scale(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64) void {}
@@ -121,13 +80,7 @@ pub fn translate(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64) void {}
 pub fn transform(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn setTransform(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn resetTransform(_: *OffscreenCanvasRenderingContext2D) void {}
-pub fn setGlobalAlpha(_: *OffscreenCanvasRenderingContext2D, _: f64) void {}
-pub fn setGlobalCompositeOperation(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
 pub fn setStrokeStyle(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
-pub fn setLineWidth(_: *OffscreenCanvasRenderingContext2D, _: f64) void {}
-pub fn setLineCap(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
-pub fn setLineJoin(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
-pub fn setMiterLimit(_: *OffscreenCanvasRenderingContext2D, _: f64) void {}
 pub fn clearRect(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn fillRect(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
 pub fn strokeRect(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f64) void {}
@@ -143,9 +96,6 @@ pub fn rect(_: *OffscreenCanvasRenderingContext2D, _: f64, _: f64, _: f64, _: f6
 pub fn fill(_: *OffscreenCanvasRenderingContext2D) void {}
 pub fn stroke(_: *OffscreenCanvasRenderingContext2D) void {}
 pub fn clip(_: *OffscreenCanvasRenderingContext2D) void {}
-pub fn setFont(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
-pub fn setTextAlign(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
-pub fn setTextBaseline(_: *OffscreenCanvasRenderingContext2D, _: []const u8) void {}
 pub fn fillText(_: *OffscreenCanvasRenderingContext2D, _: []const u8, _: f64, _: f64, _: ?f64) void {}
 pub fn strokeText(_: *OffscreenCanvasRenderingContext2D, _: []const u8, _: f64, _: f64, _: ?f64) void {}
 
@@ -159,51 +109,44 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const createImageData = bridge.function(OffscreenCanvasRenderingContext2D.createImageData, .{ .dom_exception = true });
-    pub const putImageData = bridge.function(OffscreenCanvasRenderingContext2D.putImageData, .{});
-
-    pub const save = bridge.function(OffscreenCanvasRenderingContext2D.save, .{});
-    pub const restore = bridge.function(OffscreenCanvasRenderingContext2D.restore, .{});
-
-    pub const scale = bridge.function(OffscreenCanvasRenderingContext2D.scale, .{});
-    pub const rotate = bridge.function(OffscreenCanvasRenderingContext2D.rotate, .{});
-    pub const translate = bridge.function(OffscreenCanvasRenderingContext2D.translate, .{});
-    pub const transform = bridge.function(OffscreenCanvasRenderingContext2D.transform, .{});
-    pub const setTransform = bridge.function(OffscreenCanvasRenderingContext2D.setTransform, .{});
-    pub const resetTransform = bridge.function(OffscreenCanvasRenderingContext2D.resetTransform, .{});
-
-    pub const globalAlpha = bridge.accessor(OffscreenCanvasRenderingContext2D.getGlobalAlpha, OffscreenCanvasRenderingContext2D.setGlobalAlpha, .{});
-    pub const globalCompositeOperation = bridge.accessor(OffscreenCanvasRenderingContext2D.getGlobalCompositeOperation, OffscreenCanvasRenderingContext2D.setGlobalCompositeOperation, .{});
+    pub const font = bridge.property("10px sans-serif", .{ .template = false, .readonly = false });
+    pub const globalAlpha = bridge.property(1.0, .{ .template = false, .readonly = false });
+    pub const globalCompositeOperation = bridge.property("source-over", .{ .template = false, .readonly = false });
+    pub const strokeStyle = bridge.property("#000000", .{ .template = false, .readonly = false });
+    pub const lineWidth = bridge.property(1.0, .{ .template = false, .readonly = false });
+    pub const lineCap = bridge.property("butt", .{ .template = false, .readonly = false });
+    pub const lineJoin = bridge.property("miter", .{ .template = false, .readonly = false });
+    pub const miterLimit = bridge.property(10.0, .{ .template = false, .readonly = false });
+    pub const textAlign = bridge.property("start", .{ .template = false, .readonly = false });
+    pub const textBaseline = bridge.property("alphabetic", .{ .template = false, .readonly = false });
 
     pub const fillStyle = bridge.accessor(OffscreenCanvasRenderingContext2D.getFillStyle, OffscreenCanvasRenderingContext2D.setFillStyle, .{});
-    pub const strokeStyle = bridge.accessor(OffscreenCanvasRenderingContext2D.getStrokeStyle, OffscreenCanvasRenderingContext2D.setStrokeStyle, .{});
+    pub const createImageData = bridge.function(OffscreenCanvasRenderingContext2D.createImageData, .{ .dom_exception = true });
 
-    pub const lineWidth = bridge.accessor(OffscreenCanvasRenderingContext2D.getLineWidth, OffscreenCanvasRenderingContext2D.setLineWidth, .{});
-    pub const lineCap = bridge.accessor(OffscreenCanvasRenderingContext2D.getLineCap, OffscreenCanvasRenderingContext2D.setLineCap, .{});
-    pub const lineJoin = bridge.accessor(OffscreenCanvasRenderingContext2D.getLineJoin, OffscreenCanvasRenderingContext2D.setLineJoin, .{});
-    pub const miterLimit = bridge.accessor(OffscreenCanvasRenderingContext2D.getMiterLimit, OffscreenCanvasRenderingContext2D.setMiterLimit, .{});
-
-    pub const clearRect = bridge.function(OffscreenCanvasRenderingContext2D.clearRect, .{});
-    pub const fillRect = bridge.function(OffscreenCanvasRenderingContext2D.fillRect, .{});
-    pub const strokeRect = bridge.function(OffscreenCanvasRenderingContext2D.strokeRect, .{});
-
-    pub const beginPath = bridge.function(OffscreenCanvasRenderingContext2D.beginPath, .{});
-    pub const closePath = bridge.function(OffscreenCanvasRenderingContext2D.closePath, .{});
-    pub const moveTo = bridge.function(OffscreenCanvasRenderingContext2D.moveTo, .{});
-    pub const lineTo = bridge.function(OffscreenCanvasRenderingContext2D.lineTo, .{});
-    pub const quadraticCurveTo = bridge.function(OffscreenCanvasRenderingContext2D.quadraticCurveTo, .{});
-    pub const bezierCurveTo = bridge.function(OffscreenCanvasRenderingContext2D.bezierCurveTo, .{});
-    pub const arc = bridge.function(OffscreenCanvasRenderingContext2D.arc, .{});
-    pub const arcTo = bridge.function(OffscreenCanvasRenderingContext2D.arcTo, .{});
-    pub const rect = bridge.function(OffscreenCanvasRenderingContext2D.rect, .{});
-
-    pub const fill = bridge.function(OffscreenCanvasRenderingContext2D.fill, .{});
-    pub const stroke = bridge.function(OffscreenCanvasRenderingContext2D.stroke, .{});
-    pub const clip = bridge.function(OffscreenCanvasRenderingContext2D.clip, .{});
-
-    pub const font = bridge.accessor(OffscreenCanvasRenderingContext2D.getFont, OffscreenCanvasRenderingContext2D.setFont, .{});
-    pub const textAlign = bridge.accessor(OffscreenCanvasRenderingContext2D.getTextAlign, OffscreenCanvasRenderingContext2D.setTextAlign, .{});
-    pub const textBaseline = bridge.accessor(OffscreenCanvasRenderingContext2D.getTextBaseline, OffscreenCanvasRenderingContext2D.setTextBaseline, .{});
-    pub const fillText = bridge.function(OffscreenCanvasRenderingContext2D.fillText, .{});
-    pub const strokeText = bridge.function(OffscreenCanvasRenderingContext2D.strokeText, .{});
+    pub const putImageData = bridge.function(OffscreenCanvasRenderingContext2D.putImageData, .{ .noop = true });
+    pub const save = bridge.function(OffscreenCanvasRenderingContext2D.save, .{ .noop = true });
+    pub const restore = bridge.function(OffscreenCanvasRenderingContext2D.restore, .{ .noop = true });
+    pub const scale = bridge.function(OffscreenCanvasRenderingContext2D.scale, .{ .noop = true });
+    pub const rotate = bridge.function(OffscreenCanvasRenderingContext2D.rotate, .{ .noop = true });
+    pub const translate = bridge.function(OffscreenCanvasRenderingContext2D.translate, .{ .noop = true });
+    pub const transform = bridge.function(OffscreenCanvasRenderingContext2D.transform, .{ .noop = true });
+    pub const setTransform = bridge.function(OffscreenCanvasRenderingContext2D.setTransform, .{ .noop = true });
+    pub const resetTransform = bridge.function(OffscreenCanvasRenderingContext2D.resetTransform, .{ .noop = true });
+    pub const clearRect = bridge.function(OffscreenCanvasRenderingContext2D.clearRect, .{ .noop = true });
+    pub const fillRect = bridge.function(OffscreenCanvasRenderingContext2D.fillRect, .{ .noop = true });
+    pub const strokeRect = bridge.function(OffscreenCanvasRenderingContext2D.strokeRect, .{ .noop = true });
+    pub const beginPath = bridge.function(OffscreenCanvasRenderingContext2D.beginPath, .{ .noop = true });
+    pub const closePath = bridge.function(OffscreenCanvasRenderingContext2D.closePath, .{ .noop = true });
+    pub const moveTo = bridge.function(OffscreenCanvasRenderingContext2D.moveTo, .{ .noop = true });
+    pub const lineTo = bridge.function(OffscreenCanvasRenderingContext2D.lineTo, .{ .noop = true });
+    pub const quadraticCurveTo = bridge.function(OffscreenCanvasRenderingContext2D.quadraticCurveTo, .{ .noop = true });
+    pub const bezierCurveTo = bridge.function(OffscreenCanvasRenderingContext2D.bezierCurveTo, .{ .noop = true });
+    pub const arc = bridge.function(OffscreenCanvasRenderingContext2D.arc, .{ .noop = true });
+    pub const arcTo = bridge.function(OffscreenCanvasRenderingContext2D.arcTo, .{ .noop = true });
+    pub const rect = bridge.function(OffscreenCanvasRenderingContext2D.rect, .{ .noop = true });
+    pub const fill = bridge.function(OffscreenCanvasRenderingContext2D.fill, .{ .noop = true });
+    pub const stroke = bridge.function(OffscreenCanvasRenderingContext2D.stroke, .{ .noop = true });
+    pub const clip = bridge.function(OffscreenCanvasRenderingContext2D.clip, .{ .noop = true });
+    pub const fillText = bridge.function(OffscreenCanvasRenderingContext2D.fillText, .{ .noop = true });
+    pub const strokeText = bridge.function(OffscreenCanvasRenderingContext2D.strokeText, .{ .noop = true });
 };

--- a/src/browser/webapi/canvas/WebGLRenderingContext.zig
+++ b/src/browser/webapi/canvas/WebGLRenderingContext.zig
@@ -122,14 +122,6 @@ pub const Extension = union(enum) {
             pub const UNMASKED_VENDOR_WEBGL: u64 = 0x9245;
             pub const UNMASKED_RENDERER_WEBGL: u64 = 0x9246;
 
-            pub fn getUnmaskedVendorWebGL(_: *const WEBGL_debug_renderer_info) u64 {
-                return UNMASKED_VENDOR_WEBGL;
-            }
-
-            pub fn getUnmaskedRendererWebGL(_: *const WEBGL_debug_renderer_info) u64 {
-                return UNMASKED_RENDERER_WEBGL;
-            }
-
             pub const JsApi = struct {
                 pub const bridge = js.Bridge(WEBGL_debug_renderer_info);
 
@@ -140,8 +132,8 @@ pub const Extension = union(enum) {
                     pub var class_id: bridge.ClassId = undefined;
                 };
 
-                pub const UNMASKED_VENDOR_WEBGL = bridge.accessor(WEBGL_debug_renderer_info.getUnmaskedVendorWebGL, null, .{});
-                pub const UNMASKED_RENDERER_WEBGL = bridge.accessor(WEBGL_debug_renderer_info.getUnmaskedRendererWebGL, null, .{});
+                pub const UNMASKED_VENDOR_WEBGL = bridge.property(WEBGL_debug_renderer_info.UNMASKED_VENDOR_WEBGL, .{ .template = false, .readonly = true });
+                pub const UNMASKED_RENDERER_WEBGL = bridge.property(WEBGL_debug_renderer_info.UNMASKED_RENDERER_WEBGL, .{ .template = false, .readonly = true });
             };
         };
 
@@ -160,8 +152,8 @@ pub const Extension = union(enum) {
                     pub var class_id: bridge.ClassId = undefined;
                 };
 
-                pub const loseContext = bridge.function(WEBGL_lose_context.loseContext, .{});
-                pub const restoreContext = bridge.function(WEBGL_lose_context.restoreContext, .{});
+                pub const loseContext = bridge.function(WEBGL_lose_context.loseContext, .{ .noop = true });
+                pub const restoreContext = bridge.function(WEBGL_lose_context.restoreContext, .{ .noop = true });
             };
         };
     };

--- a/src/browser/webapi/css/FontFaceSet.zig
+++ b/src/browser/webapi/css/FontFaceSet.zig
@@ -17,14 +17,6 @@ pub fn getReady(_: *FontFaceSet, page: *Page) !js.Promise {
     return page.js.local.?.resolvePromise({});
 }
 
-pub fn getStatus(_: *const FontFaceSet) []const u8 {
-    return "loaded";
-}
-
-pub fn getSize(_: *const FontFaceSet) u32 {
-    return 0;
-}
-
 // check(font, text?) - always true; headless has no real fonts to check.
 pub fn check(_: *const FontFaceSet, font: []const u8) bool {
     _ = font;
@@ -46,9 +38,9 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    pub const size = bridge.property(0, .{ .template = false, .readonly = true });
+    pub const status = bridge.property("loaded", .{ .template = false, .readonly = true });
     pub const ready = bridge.accessor(FontFaceSet.getReady, null, .{});
-    pub const status = bridge.accessor(FontFaceSet.getStatus, null, .{});
-    pub const size = bridge.accessor(FontFaceSet.getSize, null, .{});
     pub const check = bridge.function(FontFaceSet.check, .{});
     pub const load = bridge.function(FontFaceSet.load, .{});
 };

--- a/src/browser/webapi/css/MediaQueryList.zig
+++ b/src/browser/webapi/css/MediaQueryList.zig
@@ -38,11 +38,6 @@ pub fn getMedia(self: *const MediaQueryList) []const u8 {
     return self._media;
 }
 
-/// Always returns false for dummy implementation
-pub fn getMatches(_: *const MediaQueryList) bool {
-    return false;
-}
-
 pub fn addListener(_: *const MediaQueryList, _: js.Function) void {}
 pub fn removeListener(_: *const MediaQueryList, _: js.Function) void {}
 
@@ -56,9 +51,9 @@ pub const JsApi = struct {
     };
 
     pub const media = bridge.accessor(MediaQueryList.getMedia, null, .{});
-    pub const matches = bridge.accessor(MediaQueryList.getMatches, null, .{});
-    pub const addListener = bridge.function(MediaQueryList.addListener, .{});
-    pub const removeListener = bridge.function(MediaQueryList.removeListener, .{});
+    pub const matches = bridge.property(false, .{ .template = false, .readonly = true });
+    pub const addListener = bridge.function(MediaQueryList.addListener, .{ .noop = true });
+    pub const removeListener = bridge.function(MediaQueryList.removeListener, .{ .noop = true });
 };
 
 const testing = @import("../../../testing.zig");


### PR DESCRIPTION
Define properties directly on the PrototypeTemplate, removing the need for 1 FunctionTemplate per instance-property. Also, properties were previously all readonly. There is now a readonly flag...thus, properties which we don't care about, but have a default value, can be defined this way.

Added a 'noop' flag to functions which skips the zig callback and does nothing.

I was initially hoping these would noticeably reduce the size of our snapshot due to requiring fewer FunctionTemplates. While it shaves a few ~3KB, it's far less than I was hoping. The issue is that noop function templates still need to be unique so that `type_a.noopFunc !== type_b.noopFunc` remains true.

Still, as we add more dummy implementation, these little tweaks might add up.