### PR TITLE
Improve tests when running outside of our test runner

### DIFF
--- a/src/browser/tests/document/document.html
+++ b/src/browser/tests/document/document.html
@@ -12,7 +12,7 @@
   testing.expectEqual(10, document.childNodes[0].nodeType);
   testing.expectEqual(null, document.parentNode);
   testing.expectEqual(undefined, document.getCurrentScript);
-  testing.expectEqual("http://127.0.0.1:9582/src/browser/tests/document/document.html", document.URL);
+  testing.expectEqual(testing.BASE_URL + 'document/document.html', document.URL);
   testing.expectEqual(window, document.defaultView);
   testing.expectEqual(false, document.hidden);
   testing.expectEqual("visible", document.visibilityState);
@@ -57,7 +57,7 @@
   testing.expectEqual('CSS1Compat', document.compatMode);
   testing.expectEqual(document.URL, document.documentURI);
   testing.expectEqual('', document.referrer);
-  testing.expectEqual('127.0.0.1', document.domain);
+  testing.expectEqual(testing.HOST, document.domain);
 </script>
 
 <script id=programmatic_document_metadata>
@@ -70,7 +70,7 @@
   testing.expectEqual('CSS1Compat', doc.compatMode);
   testing.expectEqual('', doc.referrer);
   // Programmatic document should have empty domain (no URL/origin)
-  testing.expectEqual('127.0.0.1', doc.domain);
+  testing.expectEqual(testing.HOST, doc.domain);
 </script>
 
 <!-- Test anchors and links -->

--- a/src/browser/tests/element/html/anchor.html
+++ b/src/browser/tests/element/html/anchor.html
@@ -11,11 +11,11 @@
 <script id=empty_href>
   testing.expectEqual('', $('#a0').href);
 
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/anchor1.html', $('#a1').href);
-  testing.expectEqual('http://127.0.0.1:9582/hello/world/anchor2.html', $('#a2').href);
+  testing.expectEqual(testing.BASE_URL + 'element/anchor1.html', $('#a1').href);
+  testing.expectEqual(testing.ORIGIN + 'hello/world/anchor2.html', $('#a2').href);
   testing.expectEqual('https://www.openmymind.net/Elixirs-With-Statement/', $('#a3').href);
 
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/foo', $('#link').href);
+  testing.expectEqual(testing.BASE_URL + 'element/html/foo', $('#link').href);
 </script>
 
 <script id=dynamic_anchor_defaults>
@@ -129,7 +129,7 @@
   testing.expectEqual('https://foo.bar/?q=bar#frag', link.href);
 
   link.href = 'foo';
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/foo', link.href);
+  testing.expectEqual(testing.BASE_URL + 'element/html/foo', link.href);
 
   testing.expectEqual('', link.type);
   link.type = 'text/html';

--- a/src/browser/tests/element/html/image.html
+++ b/src/browser/tests/element/html/image.html
@@ -32,12 +32,12 @@
 
     img.src = 'test.png';
     // src property returns resolved absolute URL
-    testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/test.png', img.src);
+    testing.expectEqual(testing.BASE_URL + 'element/html/test.png', img.src);
     // getAttribute returns the raw attribute value
     testing.expectEqual('test.png', img.getAttribute('src'));
 
     img.src = '/absolute/path.png';
-    testing.expectEqual('http://127.0.0.1:9582/absolute/path.png', img.src);
+    testing.expectEqual(testing.ORIGIN + 'absolute/path.png', img.src);
     testing.expectEqual('/absolute/path.png', img.getAttribute('src'));
 
     img.src = 'https://example.com/image.png';

--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -57,9 +57,9 @@
 
     testing.expectEqual('', input.src);
     input.src = 'foo'
-    testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/foo', input.src);
+    testing.expectEqual(testing.BASE_URL + 'element/html/foo', input.src);
     input.src = '-3'
-    testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/-3', input.src);
+    testing.expectEqual(testing.BASE_URL + 'element/html/-3', input.src);
     input.src = ''
   }
 </script>

--- a/src/browser/tests/element/html/link.html
+++ b/src/browser/tests/element/html/link.html
@@ -8,7 +8,7 @@
   testing.expectEqual('https://lightpanda.io/opensource-browser/15', l2.href);
 
   l2.href = '/over/9000';
-  testing.expectEqual('http://127.0.0.1:9582/over/9000', l2.href);
+  testing.expectEqual(testing.ORIGIN + 'over/9000', l2.href);
 
   l2.crossOrigin = 'nope';
   testing.expectEqual('anonymous', l2.crossOrigin);

--- a/src/browser/tests/element/html/media.html
+++ b/src/browser/tests/element/html/media.html
@@ -238,7 +238,7 @@
     testing.expectEqual('', audio.src);
 
     audio.src = 'test.mp3';
-    testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/test.mp3', audio.src);
+    testing.expectEqual(testing.BASE_URL + 'element/html/test.mp3', audio.src);
   }
 </script>
 
@@ -248,7 +248,7 @@
     testing.expectEqual('', video.poster);
 
     video.poster = 'poster.jpg';
-    testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/element/html/poster.jpg', video.poster);
+    testing.expectEqual(testing.BASE_URL + 'element/html/poster.jpg', video.poster);
   }
 </script>
 

--- a/src/browser/tests/element/html/script/script.html
+++ b/src/browser/tests/element/html/script/script.html
@@ -6,7 +6,7 @@
     let s = document.createElement('script');
     testing.expectEqual('', s.src);
 
-    s.src = '/over.9000.js';
-    testing.expectEqual('http://127.0.0.1:9582/over.9000.js', s.src);
+    s.src = 'over.9000.js';
+    testing.expectEqual(testing.BASE_URL + 'element/html/script/over.9000.js', s.src);
    }
 </script>

--- a/src/browser/tests/element/inner.html
+++ b/src/browser/tests/element/inner.html
@@ -45,7 +45,6 @@
   testing.expectEqual('hi', $('#link').innerText);
 
   d1.innerHTML = '';
-  testing.todo(null, $('#link'));
 </script>
 
 <script id=attributeSerialization>

--- a/src/browser/tests/net/request.html
+++ b/src/browser/tests/net/request.html
@@ -111,7 +111,7 @@
 <script id=legacy>
   {
     let request = new Request("flower.png");
-    testing.expectEqual("http://127.0.0.1:9582/src/browser/tests/net/flower.png", request.url);
+    testing.expectEqual(testing.BASE_URL + 'net/flower.png', request.url);
     testing.expectEqual("GET", request.method);
 
     let request2 = new Request("https://google.com", {

--- a/src/browser/tests/node/base_uri.html
+++ b/src/browser/tests/node/base_uri.html
@@ -5,7 +5,7 @@
 <a href="foo" id="foo">foo</a>
 
 <script id=baseURI>
-  testing.expectEqual("http://127.0.0.1:9582/src/browser/tests/node/base_uri.html", document.URL);
+  testing.expectEqual(testing.BASE_URL + 'node/base_uri.html', document.URL);
   testing.expectEqual("https://example.com/", document.baseURI);
 
   const link = $('#foo');

--- a/src/browser/tests/testing.js
+++ b/src/browser/tests/testing.js
@@ -99,6 +99,9 @@
     }
   }
 
+  // our test runner sets this to true
+  const IS_TEST_RUNNER = window._lightpanda_skip_auto_assert === true;
+
   window.testing = {
     fail: fail,
     async: async,
@@ -109,8 +112,23 @@
     expectError: expectError,
     withError: withError,
     eventually: eventually,
-    todo: function(){},
+    IS_TEST_RUNNER: IS_TEST_RUNNER,
+    HOST: '127.0.0.1',
+    ORIGIN: 'http://127.0.0.1:9582/',
+    BASE_URL: 'http://127.0.0.1:9582/src/browser/tests/',
   };
+
+  if (!IS_TEST_RUNNER) {
+    // The page is running in a different browser. Probably a developer making sure
+    // a test is correct. There are a few tweaks we need to do to make this a
+    // seemless, namely around adapting paths/urls.
+    console.warn(`The page is not being executed in the test runner, certain behavior has been adjusted`);
+    window.testing.HOST = location.hostname;
+    window.testing.ORIGIN = location.origin + '/';
+    window.testing.BASE_URL = location.origin + '/src/browser/tests/';
+    window.addEventListener('load', testing.assertOk);
+  }
+
 
   window.$ = function(sel) {
     return document.querySelector(sel);
@@ -220,8 +238,4 @@
       return val;
     });
   }
-
-  if (window._lightpanda_skip_auto_assert !== true) {
-	  window.addEventListener('load', testing.assertOk);
-	}
 })();

--- a/src/browser/tests/window/location.html
+++ b/src/browser/tests/window/location.html
@@ -2,24 +2,24 @@
 <script src="../testing.js"></script>
 
 <script id=location>
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/window/location.html', window.location.href);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html', window.location.href);
   testing.expectEqual(document.location, window.location);
 </script>
 
 <script id=location_hash>
   location.hash = "";
   testing.expectEqual("", location.hash);
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/window/location.html', location.href);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html', location.href);
 
   location.hash = "#abcdef";
   testing.expectEqual("#abcdef", location.hash);
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/window/location.html#abcdef', location.href);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html#abcdef', location.href);
 
   location.hash = "xyzxyz";
   testing.expectEqual("#xyzxyz", location.hash);
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/window/location.html#xyzxyz', location.href);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html#xyzxyz', location.href);
 
   location.hash = "";
   testing.expectEqual("", location.hash);
-  testing.expectEqual('http://127.0.0.1:9582/src/browser/tests/window/location.html', location.href);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html', location.href);
 </script>

--- a/src/browser/tests/window/screen.html
+++ b/src/browser/tests/window/screen.html
@@ -3,8 +3,10 @@
 
 <script id=screen>
   let screen = window.screen;
-  testing.expectEqual(1920, screen.width);
-  testing.expectEqual(1080, screen.height);
+  if (testing.IS_TEST_RUNNER) {
+    testing.expectEqual(1920, screen.width);
+    testing.expectEqual(1080, screen.height);
+  }
 
   let orientation = screen.orientation;
   testing.expectEqual(0, orientation.angle);


### PR DESCRIPTION
We often verify the correctness of tests by loading them in an external browser, but some tests just don't run the same/correctly. For example, we used to hard- code the http://127.0.0.1:9582/ origin, but that would cause tests to fail if running from a different origin.

This commit _begins_ the work of improving this. It introduces a testing.ORIGIN, testing.BASE_URL and testing.HOST which will work correctly in both our runner and an external browser.

It also introduces `testing.IS_TEST_RUNNER` boolean flag so that tests which have no chance of working in an external browser (e.g. screen.width) can be skipped.

The goal is to reduce/remove tests which fail in external browsers so that such failures aren't quickly written off as "just how it is".