### PR TITLE
Add [basic] reference counting to events

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -204,7 +204,8 @@ pub fn dispatch(self: *EventManager, target: *EventTarget, event: *Event) Dispat
 }
 
 pub fn dispatchOpts(self: *EventManager, target: *EventTarget, event: *Event, comptime opts: DispatchOpts) DispatchError!void {
-    defer if (!event._v8_handoff) event.deinit(false, self.page);
+    event.acquireRef();
+    defer event.deinit(false, self.page);
 
     if (comptime IS_DEBUG) {
         log.debug(.event, "eventManager.dispatch", .{ .type = event._type_string.str(), .bubbles = event._bubbles });
@@ -254,7 +255,8 @@ const DispatchWithFunctionOptions = struct {
     inject_target: bool = true,
 };
 pub fn dispatchWithFunction(self: *EventManager, target: *EventTarget, event: *Event, function_: ?js.Function, comptime opts: DispatchWithFunctionOptions) !void {
-    defer if (!event._v8_handoff) event.deinit(false, self.page);
+    event.acquireRef();
+    defer event.deinit(false, self.page);
 
     if (comptime IS_DEBUG) {
         log.debug(.event, "dispatchWithFunction", .{ .type = event._type_string.str(), .context = opts.context, .has_function = function_ != null });

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -237,6 +237,7 @@ fn eventInit(arena: Allocator, typ: String, value: anytype) !Event {
     const time_stamp = (raw_timestamp / 2) * 2;
 
     return .{
+        ._rc = 0,
         ._arena = arena,
         ._type = unionInit(Event.Type, value),
         ._type_string = typ,

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -217,7 +217,7 @@ pub fn mapZigInstanceToJs(self: *const Local, js_obj_handle: ?*const v8.Object, 
                     try ctx.finalizer_callbacks.put(ctx.arena, @intFromPtr(resolved.ptr), fc);
                 }
 
-                conditionallyFlagHandoff(value);
+                conditionallyReference(value);
                 if (@hasDecl(JsApi.Meta, "weak")) {
                     if (comptime IS_DEBUG) {
                         std.debug.assert(JsApi.Meta.weak == true);
@@ -1101,14 +1101,14 @@ fn resolveT(comptime T: type, value: *anyopaque) Resolved {
     };
 }
 
-fn conditionallyFlagHandoff(value: anytype) void {
+fn conditionallyReference(value: anytype) void {
     const T = bridge.Struct(@TypeOf(value));
-    if (@hasField(T, "_v8_handoff")) {
-        value._v8_handoff = true;
+    if (@hasDecl(T, "acquireRef")) {
+        value.acquireRef();
         return;
     }
     if (@hasField(T, "_proto")) {
-        conditionallyFlagHandoff(value._proto);
+        conditionallyReference(value._proto);
     }
 }
 

--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -55,7 +55,8 @@ pub fn dispatchEvent(self: *EventTarget, event: *Event, page: *Page) !bool {
     if (event._event_phase != .none) {
         return error.InvalidStateError;
     }
-    event._isTrusted = false;
+    event._is_trusted = false;
+    event.acquireRef();
     try page._event_manager.dispatch(self, event);
     return !event._cancelable or !event._prevent_default;
 }


### PR DESCRIPTION
Previously, we used a boolean, `_v8_handoff` to detect whether or not an event was handed off to v8. When it _was_ handed off, then we relied on the Global finalizer (or context shutdown) to cleanup the instance. When it wasn't handed off, we could immediately free the instance.

The issue is that, under pressure, v8 might finalize the event _before_ we've checked the handoff flag. This was the old code:

```zig
    const event = try Event.initTrusted(.wrap("DOMContentLoaded"), .{ .bubbles = true }, self);
    defer if (!event._v8_handoff) event.deinit(false);
    try self._event_manager.dispatch(
        self.document.asEventTarget(),
        event,
    );
```

But what happens if, during the call to dispatch, v8 finalizes the event? The defer statement will access event after its been freed.

Rather than a boolean, we now track a basic reference count. deinit decreases the reference count, and only frees the object when it reaches 0. Any handoff to v8 automatically increases the reference count by 1. The above code becomes a simpler:

```zig
    const event = try Event.initTrusted(.wrap("DOMContentLoaded"), .{ .bubbles = true }, self);
    defer event.deinit(false);
    try self._event_manager.dispatch(
        self.document.asEventTarget(),
        event,
    );
```

The deinit is un-conditional. The dispatch function itself increases the RC by 1, and then the v8 handoff  increases it to 2. On v8 finalization the RC is decreased to 1. The defer deinit decreases it to 0, at which point it is freed.

Fixes WPT /css/css-transitions/properties-value-003.html