### PR TITLE
fix: handle trailing slash on /json/version CDP endpoint

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -521,7 +521,7 @@ pub const Client = struct {
             return true;
         }
 
-        if (std.mem.eql(u8, url, "/json/version")) {
+        if (std.mem.eql(u8, url, "/json/version") or std.mem.eql(u8, url, "/json/version/")) {
             try self.send(self.json_version_response);
             // Chromedp (a Go driver) does an http request to /json/version
             // then to / (websocket upgrade) using a different connection.


### PR DESCRIPTION
# Summary

Some CDP clients (e.g. `playwright-go`) request `/json/version` with a trailing slash. The server previously only matched `/json/version` exactly, causing these clients to receive no response.
This fix adds handling for the trailing slash variant using the same logic and response as the existing `/json/version` handler.