### PR TITLE
Add a --with_frames argument to fetch

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -191,7 +191,8 @@ pub const Fetch = struct {
     url: [:0]const u8,
     dump_mode: ?DumpFormat = null,
     common: Common = .{},
-    withbase: bool = false,
+    with_base: bool = false,
+    with_frames: bool = false,
     strip: dump.Opts.Strip = .{},
 };
 
@@ -342,6 +343,8 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\
         \\--with_base     Add a <base> tag in dump. Defaults to false.
         \\
+        \\--with_frames   Includes the contents of iframes. Defaults to false.
+        \\
     ++ common_options ++
         \\
         \\serve command
@@ -437,6 +440,10 @@ fn inferMode(opt: []const u8) ?RunMode {
     }
 
     if (std.mem.eql(u8, opt, "--with_base")) {
+        return .fetch;
+    }
+
+    if (std.mem.eql(u8, opt, "--with_frames")) {
         return .fetch;
     }
 
@@ -539,7 +546,8 @@ fn parseFetchArgs(
     args: *std.process.ArgIterator,
 ) !Fetch {
     var dump_mode: ?DumpFormat = null;
-    var withbase: bool = false;
+    var with_base: bool = false;
+    var with_frames: bool = false;
     var url: ?[:0]const u8 = null;
     var common: Common = .{};
     var strip: dump.Opts.Strip = .{};
@@ -570,7 +578,12 @@ fn parseFetchArgs(
         }
 
         if (std.mem.eql(u8, "--with_base", opt)) {
-            withbase = true;
+            with_base = true;
+            continue;
+        }
+
+        if (std.mem.eql(u8, "--with_frames", opt)) {
+            with_frames = true;
             continue;
         }
 
@@ -626,7 +639,8 @@ fn parseFetchArgs(
         .dump_mode = dump_mode,
         .strip = strip,
         .common = common,
-        .withbase = withbase,
+        .with_base = with_base,
+        .with_frames = with_frames,
     };
 }
 

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -309,6 +309,8 @@ pub fn init(self: *Page, id: u32, session: *Session, parent: ?*Page) !void {
     self.js = try browser.env.createContext(self);
     errdefer self.js.deinit();
 
+    document._page = self;
+
     if (comptime builtin.is_test == false) {
         // HTML test runner manually calls these as necessary
         try self.js.scheduler.add(session.browser, struct {

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -44,6 +44,7 @@ const Document = @This();
 
 _type: Type,
 _proto: *Node,
+_page: ?*Page = null,
 _location: ?*Location = null,
 _url: ?[:0]const u8 = null, // URL for documents created via DOMImplementation (about:blank)
 _ready_state: ReadyState = .loading,

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -36,7 +36,7 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub const FetchOpts = struct {
     wait_ms: u32 = 5000,
-    dump: dump.RootOpts,
+    dump: dump.Opts,
     dump_mode: ?Config.DumpFormat = null,
     writer: ?*std.Io.Writer = null,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -115,7 +115,8 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
                 .dump_mode = opts.dump_mode,
                 .dump = .{
                     .strip = opts.strip,
-                    .with_base = opts.withbase,
+                    .with_base = opts.with_base,
+                    .with_frames = opts.with_frames,
                 },
             };
 


### PR DESCRIPTION
When set (defaults to not set/false), --dump will include iframe contents.

I was hoping I could add a mode to strip_mode to this, but since dump is used extensively (e.g. innerHTML), this is something that has to be off by default (for correctness).