### PR TITLE
Dump Attribute to empty string

### DIFF
--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -172,7 +172,11 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
             try writer.writeAll(">\n");
         },
         .document_fragment => try children(node, opts, writer, page),
-        .attribute => unreachable,
+        .attribute => {
+            // Not called normally, but can be called via XMLSerializer.serializeToString
+            // in which case it should return an empty string
+            try writer.writeAll("");
+        },
     }
 }
 

--- a/src/browser/tests/xmlserializer.html
+++ b/src/browser/tests/xmlserializer.html
@@ -129,3 +129,14 @@
   testing.expectEqual(original, serialized);
 }
 </script>
+
+<script id=serializeAttribute>
+{
+  const div = document.createElement('div');
+  div.setAttribute('over', '9000');
+
+  const serializer = new XMLSerializer();
+  const serialized = serializer.serializeToString(div.getAttributeNode('over'));
+  testing.expectEqual('', serialized);
+}
+</script>


### PR DESCRIPTION
This is normally not called in "normal" dump-usage, but with XMLSerializer.serializeToString an Attr node _can_ be provided. The spec says, and FF agrees, this should return an empty string.