### PR TITLE
Callers to page.navigate ensure URL is properly encoded.

### DIFF
--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -22,6 +22,7 @@ const lp = @import("lightpanda");
 const id = @import("../id.zig");
 const log = @import("../../log.zig");
 const js = @import("../../browser/js/js.zig");
+const URL = @import("../../browser/URL.zig");
 const Page = @import("../../browser/Page.zig");
 const timestampF = @import("../../datetime.zig").timestamp;
 const Notification = @import("../../Notification.zig");
@@ -224,7 +225,8 @@ fn navigate(cmd: anytype) !void {
         page = try session.replacePage();
     }
 
-    try page.navigate(params.url, .{
+    const encoded_url = try URL.ensureEncoded(page.call_arena, params.url);
+    try page.navigate(encoded_url, .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
         .kind = .{ .push = null },

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const id = @import("../id.zig");
 const log = @import("../../log.zig");
+const URL = @import("../../browser/URL.zig");
 const js = @import("../../browser/js/js.zig");
 
 // TODO: hard coded IDs
@@ -218,8 +219,9 @@ fn createTarget(cmd: anytype) !void {
     }
 
     if (!std.mem.eql(u8, "about:blank", params.url)) {
+        const encoded_url = try URL.ensureEncoded(page.call_arena, params.url);
         try page.navigate(
-            params.url,
+            encoded_url,
             .{ .reason = .address_bar, .kind = .{ .push = null } },
         );
     }

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 pub const App = @import("App.zig");
 pub const Server = @import("Server.zig");
 pub const Config = @import("Config.zig");
+pub const URL = @import("browser/URL.zig");
 pub const Page = @import("browser/Page.zig");
 pub const Browser = @import("browser/Browser.zig");
 pub const Session = @import("browser/Session.zig");
@@ -92,7 +93,8 @@ pub fn fetch(app: *App, url: [:0]const u8, opts: FetchOpts) !void {
     //     }
     // }
 
-    _ = try page.navigate(url, .{
+    const encoded_url = try URL.ensureEncoded(page.call_arena, url);
+    _ = try page.navigate(encoded_url, .{
         .reason = .address_bar,
         .kind = .{ .push = null },
     });


### PR DESCRIPTION
Follow up to https://github.com/lightpanda-io/browser/pull/1646

The encodeURL (renamed to ensureEncoded and exposed in this commit) already handled already-encoded URLs, so this was largely a matter of exposing the functionality.

The reason this isn't baked directly into Page.navigate is that, in some places e.g. internal navigation, the URL is already know to be encoded. So it's up to every caller to make sure they are passing a valid URL to navigate.