### PR TITLE
Use github repo for curl source

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
             .hash = "boringssl-0.1.0-VtJeWehMAAA4RNnwRnzEvKcS9rjsR1QVRw1uJrwXxmVK",
         },
         .curl = .{
-            .url = "https://curl.se/download/curl-8.18.0.tar.gz",
+            .url = "https://github.com/curl/curl/releases/download/curl-8_18_0/curl-8.18.0.tar.gz",
             .hash = "N-V-__8AALp9QAGn6CCHZ6fK_FfMyGtG824LSHYHHasM3w-y",
         },
     },


### PR DESCRIPTION
Since we already rely on github for builds, this removes a point of failure. Also curl.se consistently fails from a VPS machine for me - not sure if they're blocking IP ranges, but it works fine on github.