### PR TITLE
On Client.stop, terminate the isolate

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -296,6 +296,10 @@ pub const Client = struct {
     }
 
     fn stop(self: *Client) void {
+        switch (self.mode) {
+            .http => {},
+            .cdp => |*cdp| cdp.browser.env.terminate(),
+        }
         self.ws.shutdown();
     }
 

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -470,6 +470,10 @@ pub fn dumpMemoryStats(self: *Env) void {
     , .{ stats.total_heap_size, stats.total_heap_size_executable, stats.total_physical_size, stats.total_available_size, stats.used_heap_size, stats.heap_size_limit, stats.malloced_memory, stats.external_memory, stats.peak_malloced_memory, stats.number_of_native_contexts, stats.number_of_detached_contexts, stats.total_global_handles_size, stats.used_global_handles_size, stats.does_zap_garbage });
 }
 
+pub fn terminate(self: *const Env) void {
+    v8.v8__Isolate__TerminateExecution(self.isolate.handle);
+}
+
 fn promiseRejectCallback(message_handle: v8.PromiseRejectMessage) callconv(.c) void {
     const promise_handle = v8.v8__PromiseRejectMessage__GetPromise(&message_handle).?;
     const v8_isolate = v8.v8__Object__GetIsolate(@ptrCast(promise_handle)).?;


### PR DESCRIPTION
Shutdown on MacOS doesn't work properly. The process appears to shutdown, but will continue to run in the background. It can run infinitely if it's stuck in a JS loop. To help it along, Client.stop now force-terminates the isolate.

I also don't think shutdown is working as intended on Linux, but the problem seems less serious there. On Linux, it appears to properly kill the process (which is the important thing), but I don't think it necessarily does a clean shutdown.