### PR TITLE
Add RC support to NodeList

### DIFF
--- a/src/browser/tests/document/query_selector_all.html
+++ b/src/browser/tests/document/query_selector_all.html
@@ -442,3 +442,29 @@
 }
 </script>
 
+<script id=iterator_list_lifetime>
+  // This test is intended to ensure that a list remains alive as long as it
+  // must, i.e. as long as any iterator referencing the list is alive.
+  // This test depends on being able to force the v8 GC to cleanup, which
+  // we have no way of controlling. At worst, the test will pass without
+  // actually testing correct lifetime. But it was at least manually verified
+  // for me that this triggers plenty of GCs.
+  const expected = Array.from(document.querySelectorAll('*')).length;
+  {
+    let keys = [];
+
+    // Phase 1: Create many lists+iterators to fill up the arena pool
+    for (let i = 0; i < 1000; i++) {
+      let list = document.querySelectorAll('*');
+      keys.push(list.keys());
+
+      // Create an Event every iteration to compete for arenas
+      new Event('arena_compete');
+    }
+
+    for (let k of keys) {
+      const result = Array.from(k);
+      testing.expectEqual(expected, result.length);
+    }
+  }
+</script>

--- a/src/browser/webapi/collections/HTMLFormControlsCollection.zig
+++ b/src/browser/webapi/collections/HTMLFormControlsCollection.zig
@@ -85,7 +85,7 @@ pub fn namedItem(self: *HTMLFormControlsCollection, name: []const u8, page: *Pag
                     ._name = try page.dupeString(name),
                 });
 
-                radio_node_list._proto = try page._factory.create(NodeList{ .data = .{ .radio_node_list = radio_node_list } });
+                radio_node_list._proto = try page._factory.create(NodeList{ ._data = .{ .radio_node_list = radio_node_list } });
 
                 return .{ .radio_node_list = radio_node_list };
             }

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -349,7 +349,7 @@ pub fn NodeLive(comptime mode: Mode) type {
 
         pub fn runtimeGenericWrap(self: Self, page: *Page) !if (mode == .name) *NodeList else *HTMLCollection {
             const collection = switch (mode) {
-                .name => return page._factory.create(NodeList{ .data = .{ .name = self } }),
+                .name => return page._factory.create(NodeList{ ._data = .{ .name = self } }),
                 .tag => HTMLCollection{ ._data = .{ .tag = self } },
                 .tag_name => HTMLCollection{ ._data = .{ .tag_name = self } },
                 .tag_name_ns => HTMLCollection{ ._data = .{ .tag_name_ns = self } },

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -40,6 +40,10 @@ pub const EntryIterator = GenericIterator(Iterator, null);
 pub const KeyIterator = GenericIterator(Iterator, "0");
 pub const ValueIterator = GenericIterator(Iterator, "1");
 
+pub fn deinit(self: *const List, page: *Page) void {
+    page.releaseArena(self._arena);
+}
+
 pub fn collect(
     allocator: std.mem.Allocator,
     root: *Node,
@@ -207,8 +211,12 @@ pub fn getAtIndex(self: *const List, index: usize) !?*Node {
 }
 
 const NodeList = @import("../collections/NodeList.zig");
-pub fn runtimeGenericWrap(self: *List, page: *Page) !*NodeList {
-    return page._factory.create(NodeList{ .data = .{ .selector_list = self } });
+pub fn runtimeGenericWrap(self: *List, _: *const Page) !*NodeList {
+    const nl = try self._arena.create(NodeList);
+    nl.* = .{
+        ._data = .{ .selector_list = self },
+    };
+    return nl;
 }
 
 const IdAnchor = struct {

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -400,20 +400,32 @@ test "cdp Node: search list" {
         defer page._session.removePage();
         var doc = page.window._document;
 
-        const s1 = try search_list.create((try doc.querySelectorAll(.wrap("a"), page))._nodes);
-        try testing.expectEqual("1", s1.name);
-        try testing.expectEqualSlices(u32, &.{ 1, 2 }, s1.node_ids);
+        {
+            const l1 = try doc.querySelectorAll(.wrap("a"), page);
+            defer l1.deinit(page);
+            const s1 = try search_list.create(l1._nodes);
+            try testing.expectEqual("1", s1.name);
+            try testing.expectEqualSlices(u32, &.{ 1, 2 }, s1.node_ids);
+        }
 
         try testing.expectEqual(2, registry.lookup_by_id.count());
         try testing.expectEqual(2, registry.lookup_by_node.count());
 
-        const s2 = try search_list.create((try doc.querySelectorAll(.wrap("#a1"), page))._nodes);
-        try testing.expectEqual("2", s2.name);
-        try testing.expectEqualSlices(u32, &.{1}, s2.node_ids);
+        {
+            const l2 = try doc.querySelectorAll(.wrap("#a1"), page);
+            defer l2.deinit(page);
+            const s2 = try search_list.create(l2._nodes);
+            try testing.expectEqual("2", s2.name);
+            try testing.expectEqualSlices(u32, &.{1}, s2.node_ids);
+        }
 
-        const s3 = try search_list.create((try doc.querySelectorAll(.wrap("#a2"), page))._nodes);
-        try testing.expectEqual("3", s3.name);
-        try testing.expectEqualSlices(u32, &.{2}, s3.node_ids);
+        {
+            const l3 = try doc.querySelectorAll(.wrap("#a2"), page);
+            defer l3.deinit(page);
+            const s3 = try search_list.create(l3._nodes);
+            try testing.expectEqual("3", s3.name);
+            try testing.expectEqualSlices(u32, &.{2}, s3.node_ids);
+        }
 
         try testing.expectEqual(2, registry.lookup_by_id.count());
         try testing.expectEqual(2, registry.lookup_by_node.count());

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -98,6 +98,8 @@ fn performSearch(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
     const list = try Selector.querySelectorAll(page.window._document.asNode(), params.query, page);
+    defer list.deinit(page);
+
     const search = try bc.node_search_list.create(list._nodes);
 
     // dispatch setChildNodesEvents to inform the client of the subpart of node
@@ -247,6 +249,8 @@ fn querySelectorAll(cmd: anytype) !void {
     };
 
     const selected_nodes = try Selector.querySelectorAll(node.dom, params.selector, page);
+    defer selected_nodes.deinit(page);
+
     const nodes = selected_nodes._nodes;
 
     const node_ids = try cmd.arena.alloc(Node.Id, nodes.len);


### PR DESCRIPTION
Most importantly, this allows the Selector.List to be self-contained with an arena from the ArenaPool. Selector.List can be both relatively large and relatively common, so moving it off the page.arena is a nice win.

Also applied this to ChildNodes, which is much smaller but could also be called often.

I was initially going to hook into the v8::Object's internal fields to store the referencing v8::Object. So the v8::Object representing the Iterator would store the v8::Object representing the NodeList inside of its internal field - which the GC would trace/detect/respect. And that is probably the fastest and most v8-ish solution, but I couldn't come up with an elegant solution. The best I had was having a "afterCreate" callback which passed the v8 object (this is similar to the old postAttach callback we had, but used for a different purpose). However, since "acquireRef" was recently added to events, re-using that was much simpler and worked well.