### PR TITLE
Escape XHR URL, Lax MIME parameter parsing

### DIFF
--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -415,7 +415,7 @@ fn setAttributeListener(
 ) !void {
     if (comptime IS_DEBUG) {
         log.debug(.event, "Html.setAttributeListener", .{
-            .type = self._type,
+            .type = std.meta.activeTag(self._type),
             .listener_type = listener_type,
         });
     }

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -183,7 +183,7 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8) !void
 
     const page = self._page;
     self._method = try parseMethod(method_);
-    self._url = try URL.resolve(self._arena, page.base(), url, .{ .always_dupe = true });
+    self._url = try URL.resolve(self._arena, page.base(), url, .{ .always_dupe = true, .encode = true });
     try self.stateChanged(.opened, page.js.local.?, page);
 }
 


### PR DESCRIPTION
Follow up to https://github.com/lightpanda-io/browser/pull/1646 applies the same change to XHR URLs.

Following specs, ignores unknown/invalid parameters of the Content-Type when parsing the MIME (rather than rejecting the entire header).