### PR TITLE
Noop when document.open is called during iframe parsing

### DIFF
--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -653,11 +653,13 @@ pub fn write(self: *Document, text: []const []const u8, page: *Page) !void {
         }
 
         if (html.len > 0) {
-            self._script_created_parser.?.read(html) catch |err| {
-                log.warn(.dom, "document.write parser error", .{ .err = err });
-                // was alrady closed
-                self._script_created_parser = null;
-            };
+            if (self._script_created_parser) |*parser| {
+                parser.read(html) catch |err| {
+                    log.warn(.dom, "document.write parser error", .{ .err = err });
+                    // was alrady closed
+                    self._script_created_parser = null;
+                };
+            }
         }
         return;
     }


### PR DESCRIPTION
I'm not sure what the correct behavior is, but this fixes a WPT crash: /html/browsers/sandboxing/sandbox-inherited-from-required-csp.html

The issue is iframe-specific as, with an iframe, you document.write can be called during parsing when there's no document._current_script (because it's being executed from the parent).