### PR TITLE
Add a "wpt" dump mode

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -185,6 +185,7 @@ pub const Serve = struct {
 pub const DumpFormat = enum {
     html,
     markdown,
+    wpt,
 };
 
 pub const Fetch = struct {


### PR DESCRIPTION
Adds a not-documented "wpt" mode to --dump which outputs a formatted report.cases.

This is meant to make working on a single WPT test case easier, particularly with some coding tool. Claude recommended this output for its own use.

Instead of telling claude to start the browser in serve mode, then run the wptrunner, and merge the two outputs (and then stop the server), you can do:

zig build run -- fetch --dump wpt "http://localhost:8000/dom/nodes/CharacterData-appendChild.html"

(you still need the wpt server up)