### PR TITLE
Remove outdated git submodule documentation and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,13 +102,8 @@ end2end:
 # ------------
 .PHONY: install
 
-## Install and build dependencies for release
-install: install-submodule
+install: build
 
 data:
 	cd src/data && go run public_suffix_list_gen.go > public_suffix_list.zig
 
-## Init and update git submodule
-install-submodule:
-	@git submodule init && \
-	git submodule update

--- a/README.md
+++ b/README.md
@@ -220,18 +220,6 @@ For **MacOS**, you need cmake and [Rust](https://rust-lang.org/tools/install/).
 brew install cmake
 ```
 
-### Install Git submodules
-
-The project uses git submodules for dependencies.
-
-To init or update the submodules in the `vendor/` directory:
-
-```
-make install-submodule
-```
-
-This is an alias for `git submodule init && git submodule update`.
-
 ### Build and run
 
 You an build the entire browser with `make build` or `make build-dev` for debug


### PR DESCRIPTION
# Summary
The project migrated from git submodules to the Zig package manager in commit `a8164f6` and removed the `vendor` folder. However, the `README.md` and `Makefile` were not updated to reflect this change. This PR removes the now-obsolete references in both files. I kept the `install` target in case anyone's workflow depends on it but we can probably remove it entirely. 
