### PR TITLE
Fix load event for page with no external scripts but with iframes

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -866,11 +866,6 @@ fn pageDoneCallback(ctx: *anyopaque) !void {
         .html => |buf| {
             parser.parse(buf.items);
             self._script_manager.staticScriptsDone();
-            if (self._script_manager.isDone()) {
-                // No scripts, or just inline scripts that were already processed
-                // we need to trigger this ourselves
-                self.documentIsComplete();
-            }
             self._parse_state = .complete;
         },
         .text => |*buf| {

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -582,12 +582,6 @@ fn evaluate(self: *ScriptManager) void {
     }
 }
 
-pub fn isDone(self: *const ScriptManager) bool {
-    return self.static_scripts_done and // page is done processing initial html
-        self.defer_scripts.first == null and // no deferred scripts
-        self.async_scripts.first == null; // no async scripts
-}
-
 fn parseImportmap(self: *ScriptManager, script: *const Script) !void {
     const content = script.source.content();
 


### PR DESCRIPTION
Previously the "load" event happened when all external scripts were done. In the case that there was no external script, the "load" event would fire immediately after parsing.

With iframes, it now waits for external script AND iframes to complete but the no-external-script code was never updated to consider iframes and would thus fire load events prematurely.