### PR TITLE
cdp: add waitForNetworkIdle to LP domain

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -597,6 +597,7 @@ pub fn BrowserContext(comptime CDP_T: type) type {
 
         pub fn onPageNavigated(ctx: *anyopaque, msg: *const Notification.PageNavigated) !void {
             const self: *Self = @ptrCast(@alignCast(ctx));
+            try @import("domains/lp.zig").onPageNavigated(self, msg);
             defer self.resetNotificationArena();
             return @import("domains/page.zig").pageNavigated(self.notification_arena, self, msg);
         }

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -26,6 +26,7 @@ const Allocator = std.mem.Allocator;
 
 pub const LpState = struct {
     pending_wait_for_network_idle: ?i64 = null,
+    pending_wait_for_load: ?i64 = null,
 };
 
 pub fn processMessage(cmd: anytype) !void {
@@ -71,23 +72,41 @@ fn waitFor(cmd: anytype) !void {
     };
     const params = (try cmd.params(Params)) orelse return error.InvalidParams;
 
-    if (std.mem.eql(u8, params.condition, "networkIdle")) {
-        // If network is already idle, we can return immediately
-        const http_client = bc.cdp.browser.http_client;
-        if (http_client.active == 0 and http_client.intercepted == 0) {
-            return cmd.sendResult(null, .{});
-        }
+    const Condition = enum { networkIdle, load };
+    const cond = std.meta.stringToEnum(Condition, params.condition) orelse return error.InvalidParams;
 
-        // Otherwise, we store the ID and wait for the notification.
-        bc.lp_state.pending_wait_for_network_idle = cmd.input.id;
-    } else {
-        return error.InvalidParams;
+    switch (cond) {
+        .networkIdle => {
+            const http_client = bc.cdp.browser.http_client;
+            if (http_client.active == 0 and http_client.intercepted == 0) {
+                return cmd.sendResult(null, .{});
+            }
+            bc.lp_state.pending_wait_for_network_idle = cmd.input.id;
+        },
+        .load => {
+            const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+            if (page._load_state == .complete) {
+                return cmd.sendResult(null, .{});
+            }
+            bc.lp_state.pending_wait_for_load = cmd.input.id;
+        },
     }
 }
 
 pub fn onPageNetworkIdle(bc: anytype, _: *const Notification.PageNetworkIdle) !void {
     const id = bc.lp_state.pending_wait_for_network_idle orelse return;
     bc.lp_state.pending_wait_for_network_idle = null;
+
+    try bc.cdp.client.sendJSON(.{
+        .id = id,
+        .result = struct {}{},
+        .sessionId = bc.session_id,
+    }, .{ .emit_null_optional_fields = false });
+}
+
+pub fn onPageNavigated(bc: anytype, _: *const Notification.PageNavigated) !void {
+    const id = bc.lp_state.pending_wait_for_load orelse return;
+    bc.lp_state.pending_wait_for_load = null;
 
     try bc.cdp.client.sendJSON(.{
         .id = id,
@@ -133,4 +152,21 @@ test "cdp.lp: waitFor" {
 
     try onPageNetworkIdle(bc, &.{ .req_id = 0, .frame_id = 0, .timestamp = 0 });
     try ctx.expectSentResult(null, .{ .id = 2 });
+
+    // 3. Test waiting for load
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "LP.waitFor",
+        .params = .{ .condition = "load" },
+    });
+    try testing.expectEqual(@as(?i64, 3), bc.lp_state.pending_wait_for_load);
+
+    try onPageNavigated(bc, &.{
+        .req_id = 0,
+        .frame_id = 0,
+        .timestamp = 0,
+        .url = "",
+        .opts = .{},
+    });
+    try ctx.expectSentResult(null, .{ .id = 3 });
 }


### PR DESCRIPTION
Goal: Move Network Idle synchronization from the "Driver" to the "Engine."

Standard browsers implement networkidle using client-side heuristics (Puppeteer/Playwright).
The driver watches events and guesses when the page is quiet, which can be flaky and adds complexity to automation scripts.

This PR introduces `LP.waitForNetworkIdle`, exposing Lightpanda’s internal idle state (a 500ms quiet window) as a direct CDP command.                                                                                                                                                         

Advantages:                                                                                                                                                                                 
   * Engine-Level Reliability: Hooks directly into Lightpanda’s internal execution ticks and libcurl queues, ensuring tighter synchronization than external event-watching.
   * Action-Based Syncing: Unlike standard goto idle checks, this can be called after any action (clicks, form submissions) to wait for the fallout to settle.
   * Simplified Agent Logic: Turns a complex stream of "lifecycle events" into a single, clean command—ideal for AI agents and MCP-based tools.
                                                                                                                                                                                                
Result: A more robust synchronization primitive that simplifies high-speed automation.  

Tested with this script

```js
const puppeteer = require("puppeteer");

(async () => {
  try {
    const browser = await puppeteer.connect({
      browserURL: "http://127.0.0.1:9222",
    });

    const page = await browser.newPage();

    console.log("Navigating to archlinux.org...");
    // 1. Navigate without waiting for idle
    await page.goto("https://www.archlinux.org", {
      waitUntil: "domcontentloaded",
      timeout: 60000,
    });

    const client = await page.target().createCDPSession();

    // 2. Use the new Lightpanda native idle detection
    console.log("Waiting for TRUE network idle via Lightpanda...");
    await client.send("LP.waitForNetworkIdle");
    console.log("Network is completely idle!");

    // 3. Get the markdown
    const response = await client.send("LP.getMarkdown");

    console.log("--- ROBOT NOTES ---");
    // console.log(response.markdown);
    console.log("-------------------");

    await browser.disconnect();
  } catch (err) {
    console.error(err);
    process.exit(1);
  }
})();
```


