### PR TITLE
Improve markdown links

### DIFF
--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -298,7 +298,7 @@ fn renderElement(el: *Element, state: *State, writer: *std.Io.Writer, page: *Pag
             }
             try writer.writeAll("](");
             if (el.getAttributeSafe(comptime .wrap("src"))) |src| {
-                const absolute_src = URL.resolve(page.call_arena, page.base(), src, .{}) catch src;
+                const absolute_src = URL.resolve(page.call_arena, page.base(), src, .{ .encode = true }) catch src;
                 try writer.writeAll(absolute_src);
             }
             try writer.writeAll(")");
@@ -313,7 +313,7 @@ fn renderElement(el: *Element, state: *State, writer: *std.Io.Writer, page: *Pag
             if (!has_content and label == null and href_raw == null) return;
 
             const has_block = hasBlockDescendant(el.asNode());
-            const href = if (href_raw) |h| URL.resolve(page.call_arena, page.base(), h, .{}) catch h else null;
+            const href = if (href_raw) |h| URL.resolve(page.call_arena, page.base(), h, .{ .encode = true }) catch h else null;
 
             if (has_block) {
                 try renderChildren(el.asNode(), state, writer, page);
@@ -667,6 +667,7 @@ test "browser.markdown: resolve links" {
     try page.parseHtmlAsChildren(div.asNode(),
         \\<a href="b">Link</a>
         \\<img src="../c.png" alt="Img">
+        \\<a href="/my page">Space</a>
     );
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
@@ -675,7 +676,8 @@ test "browser.markdown: resolve links" {
 
     try testing.expectString(
         \\[Link](https://example.com/a/b)
-        \\![Img](https://example.com/c.png)
+        \\![Img](https://example.com/c.png) 
+        \\[Space](https://example.com/my%20page)
         \\
     , aw.written());
 }


### PR DESCRIPTION
Since the article is coming soon, let's polish this a bit more.

- The Markdown link text (`[text]`) is determined using the following priority:

1.  **Visible Content**: Uses inner text or nested `<img>` tags if present.
2.  **Semantic Fallback**: If no content is found (e.g., icon-only links), it falls back to the `aria-label` or `title` attributes.
3.  **Empty Placeholder**: If both are missing but an `href` exists, it renders as `[]`. This preserves the link for LLMs to follow without introducing "hallucinated" filler text like `[Link]`, while saving on tokens.

- Additionally, all links are now resolved to **absolute URLs** using the page's base URI.

My intuition tells me that the proposed approach uses more input tokens, which are the cheapest ones, but less thinking/output tokens, which are more expensive. So we make the task more straightforward for the LLM.

```console
lightpanda fetch --dump markdown https://lightpanda.io/
```

```diff
< [](/)
< - [Cloud offer](/#cloud-offer)
< - [Docs](/docs)
< - [Blog](/blog)
< - [Jobs](/jobs)
---
> [](https://lightpanda.io/)
> - [Cloud offer](https://lightpanda.io/#cloud-offer)
> - [Docs](https://lightpanda.io/docs)
> - [Blog](https://lightpanda.io/blog)
> - [Jobs](https://lightpanda.io/jobs)
```