### PR TITLE
initialize all App fields after allocator.create

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -47,10 +47,17 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
     const app = try allocator.create(App);
     errdefer allocator.destroy(app);
 
-    app.config = config;
-    app.allocator = allocator;
-
-    app.robots = RobotStore.init(allocator);
+    app.* = .{
+        .config = config,
+        .allocator = allocator,
+        .robots = RobotStore.init(allocator),
+        .http = undefined,
+        .platform = undefined,
+        .snapshot = undefined,
+        .app_dir_path = undefined,
+        .telemetry = undefined,
+        .arena_pool = undefined,
+    };
 
     app.http = try Http.init(allocator, &app.robots, config);
     errdefer app.http.deinit();


### PR DESCRIPTION
## Summary

Same pattern as 3dea554e (mcp/Server.zig fix): `allocator.create(App)` returns undefined memory, and the struct field default `shutdown: bool = false` is not applied when fields are set individually — only struct literal syntax applies defaults.

Uses `app.* = .{...}` to ensure all fields are initialized, including `shutdown` which is read atomically in `deinit()`.

## Test plan

- [x] `make test` — 316/316 pass on aarch64 Docker Desktop
- [x] CI passes on x86_64