### PR TITLE
add missing dom_exception flags to bridge declarations

### DIFF
--- a/src/browser/tests/window/window.html
+++ b/src/browser/tests/window/window.html
@@ -82,7 +82,7 @@
   testing.expectEqual('ceil', atob('Y2VpbA'));  // 6 chars, len%4==2, needs '=='
 
   // length % 4 == 1 must still throw
-  testing.expectError('Error: InvalidCharacterError', () => {
+  testing.expectError('InvalidCharacterError: Invalid Character', () => {
     atob('Y');
   });
 </script>

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -268,7 +268,7 @@ pub const JsApi = struct {
 
     pub const now = bridge.function(Performance.now, .{});
     pub const mark = bridge.function(Performance.mark, .{});
-    pub const measure = bridge.function(Performance.measure, .{});
+    pub const measure = bridge.function(Performance.measure, .{ .dom_exception = true });
     pub const clearMarks = bridge.function(Performance.clearMarks, .{});
     pub const clearMeasures = bridge.function(Performance.clearMeasures, .{});
     pub const getEntries = bridge.function(Performance.getEntries, .{});

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -798,7 +798,7 @@ pub const JsApi = struct {
     pub const matchMedia = bridge.function(Window.matchMedia, .{});
     pub const postMessage = bridge.function(Window.postMessage, .{});
     pub const btoa = bridge.function(Window.btoa, .{});
-    pub const atob = bridge.function(Window.atob, .{});
+    pub const atob = bridge.function(Window.atob, .{ .dom_exception = true });
     pub const reportError = bridge.function(Window.reportError, .{});
     pub const getComputedStyle = bridge.function(Window.getComputedStyle, .{});
     pub const getSelection = bridge.function(Window.getSelection, .{});

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -474,12 +474,12 @@ pub const JsApi = struct {
     pub const canGoForward = bridge.accessor(Navigation.getCanGoForward, null, .{});
     pub const currentEntry = bridge.accessor(Navigation.getCurrentEntry, null, .{});
     pub const transition = bridge.accessor(Navigation.getTransition, null, .{});
-    pub const back = bridge.function(Navigation.back, .{});
+    pub const back = bridge.function(Navigation.back, .{ .dom_exception = true });
     pub const entries = bridge.function(Navigation.entries, .{});
-    pub const forward = bridge.function(Navigation.forward, .{});
-    pub const navigate = bridge.function(Navigation.navigate, .{});
-    pub const traverseTo = bridge.function(Navigation.traverseTo, .{});
-    pub const updateCurrentEntry = bridge.function(Navigation.updateCurrentEntry, .{});
+    pub const forward = bridge.function(Navigation.forward, .{ .dom_exception = true });
+    pub const navigate = bridge.function(Navigation.navigate, .{ .dom_exception = true });
+    pub const traverseTo = bridge.function(Navigation.traverseTo, .{ .dom_exception = true });
+    pub const updateCurrentEntry = bridge.function(Navigation.updateCurrentEntry, .{ .dom_exception = true });
 
     pub const oncurrententrychange = bridge.accessor(
         Navigation.getOnCurrentEntryChange,


### PR DESCRIPTION
## Summary

- `Window.atob`, `Performance.measure`, and 5 Navigation methods (`back`, `forward`, `navigate`, `traverseTo`, `updateCurrentEntry`) return DOMException errors but were missing the `dom_exception` bridge flag
- Without the flag, these functions throw generic `Error` objects instead of proper `DOMException` instances in JavaScript (e.g. `atob("!!!")` threw `Error: InvalidCharacterError` instead of `DOMException` with `.name = "InvalidCharacterError"` and `.code = 5`)
- Updated unit test expectation to match the new DOMException string format

## Test plan

- [x] `make test` — 316/316 pass
- [x] CDP integration: `atob("!!!")` → `DOMException:InvalidCharacterError:5`
- [x] MDN spec verified for all 7 functions