### PR TITLE
Fix leak introduced in inner navigation refactoring

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -652,6 +652,10 @@ fn scheduleNavigationWithArena(originator: *Page, arena: Allocator, request_url:
         .navigation_type = std.meta.activeTag(nt),
     };
 
+    if (target._queued_navigation) |existing| {
+        target.arena_pool.release(existing.arena);
+    }
+
     target._queued_navigation = qn;
     return session.scheduleNavigation(target);
 }


### PR DESCRIPTION
A inner-navigate event can override an existing pending queued navigation. When it does, the previously queued navigation has to be cleaned up. We were doing this, but it must have been stripped out when navigation was refactored to work with frames.