### PR TITLE
fix module re-import when previous compilation failed

### DIFF
--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -535,6 +535,14 @@ fn postCompileModule(self: *Context, mod: js.Module, url: [:0]const u8, local: *
             nested_gop.key_ptr.* = owned_specifier;
             nested_gop.value_ptr.* = .{};
             try script_manager.preloadImport(owned_specifier, url);
+        } else if (nested_gop.value_ptr.module == null) {
+            // Entry exists but module failed to compile previously.
+            // The imported_modules entry may have been consumed, so
+            // re-preload to ensure waitForImport can find it.
+            // Key was stored via dupeZ so it has a sentinel in memory.
+            const key = nested_gop.key_ptr.*;
+            const key_z: [:0]const u8 = key.ptr[0..key.len :0];
+            try script_manager.preloadImport(key_z, url);
         }
     }
 }
@@ -683,7 +691,15 @@ fn _resolveModuleCallback(self: *Context, referrer: js.Module, specifier: [:0]co
         return local.toLocal(m).handle;
     }
 
-    var source = try self.script_manager.?.waitForImport(normalized_specifier);
+    var source = self.script_manager.?.waitForImport(normalized_specifier) catch |err| switch (err) {
+        error.UnknownModule => blk: {
+            // Module is in cache but was consumed from imported_modules
+            // (e.g., by a previous failed resolution). Re-preload and retry.
+            try self.script_manager.?.preloadImport(normalized_specifier, referrer_path);
+            break :blk try self.script_manager.?.waitForImport(normalized_specifier);
+        },
+        else => return err,
+    };
     defer source.deinit();
 
     var try_catch: js.TryCatch = undefined;


### PR DESCRIPTION
## Summary

- When a module's compilation fails after its `imported_modules` entry has been consumed by `waitForImport`, sibling modules that share the same dependency get `UnknownModule` errors, causing cascading failures
- Fix: in `postCompileModule`, re-preload when `module_cache` entry exists but `module == null` (consumed entry)  
- Defensive fallback: in `_resolveModuleCallback`, catch `UnknownModule` from `waitForImport` and re-preload

## Context

On lequipe.fr, a single failing relative import (e.g. `./services-CMaH5mR6.js`) cascades into dozens of `UnknownModule` errors for unrelated modules (`useRoute`, `useShell`, etc.), breaking Vue/Nuxt hydration. After this fix, zero module resolution errors on lequipe.fr.

## Spec note

The HTML spec's module map caches failures permanently (`null`) — subsequent imports of a failed module should return the cached failure without re-fetching. Our fix may re-fetch a module that previously failed with a syntax error (HTTP 404s are handled separately via `error.Failed` and are unaffected). This is a minor spec deviation: the re-fetch produces an identical failure, but prevents cascading `UnknownModule` errors that would otherwise break sibling modules that could have succeeded.

## Test plan

- [x] All 316 unit tests pass
- [x] `zig fmt` clean
- [x] Integration: lequipe.fr fetch produces zero `UnknownModule` errors (was dozens before)