### PR TITLE
build: add code formatting check

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -52,6 +52,17 @@ pub fn build(b: *Build) !void {
         mod.addImport("lightpanda", mod); // allow circular "lightpanda" import
         mod.addImport("build_config", opts.createModule());
 
+        // Format check
+        const fmt_step = b.step("fmt", "Check code formatting");
+        const fmt = b.addFmt(.{
+            .paths = &.{ "src", "build.zig", "build.zig.zon" },
+            .check = true,
+        });
+        fmt_step.dependOn(&fmt.step);
+
+        // Set default behavior
+        b.default_step.dependOn(fmt_step);
+
         try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path);
         try linkCurl(b, mod);
         try linkHtml5Ever(b, mod);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,6 @@
         .v8 = .{
             .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.3.1.tar.gz",
             .hash = "v8-0.0.0-xddH64J7BAC81mkf6G9RbEJxS-W3TIRl5iFnShwbqCqy",
-
         },
         //.v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{


### PR DESCRIPTION
Not sure this is something we want, but I add it to all my projects, so compilation fails early if the code is not properly formatted.

Since #1751 has not been merged, checks should fail here (to test the feature is working)