### PR TITLE
Node matching using tag name string comparison on non-HTML nodes

### DIFF
--- a/src/browser/tests/domparser.html
+++ b/src/browser/tests/domparser.html
@@ -397,3 +397,25 @@
   }
 }
 </script>
+
+<script id=getElementsByTagName-xml>
+{
+  const parser = new DOMParser();
+  const doc = parser.parseFromString('<layout><row><col>A</col><col>B</col></row></layout>', 'text/xml');
+
+  // Test getElementsByTagName on document
+  const rows = doc.getElementsByTagName('row');
+  testing.expectEqual(1, rows.length);
+
+  // Test getElementsByTagName on element
+  const row = rows[0];
+  const cols = row.getElementsByTagName('col');
+  testing.expectEqual(2, cols.length);
+  testing.expectEqual('A', cols[0].textContent);
+  testing.expectEqual('B', cols[1].textContent);
+
+  // Test getElementsByTagName('*') on element
+  const allElements = row.getElementsByTagName('*');
+  testing.expectEqual(2, allElements.length);
+}
+</script>

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -219,7 +219,14 @@ pub fn NodeLive(comptime mode: Mode) type {
             switch (mode) {
                 .tag => {
                     const el = node.is(Element) orelse return false;
-                    return el.getTag() == self._filter;
+                    // For HTML namespace elements, we can use the optimized tag comparison.
+                    // For other namespaces (XML, SVG custom elements, etc.), fall back to string comparison.
+                    if (el._namespace == .html) {
+                        return el.getTag() == self._filter;
+                    }
+                    // For non-HTML elements, compare by tag name string
+                    const element_tag = el.getTagNameLower();
+                    return std.mem.eql(u8, element_tag, @tagName(self._filter));
                 },
                 .tag_name => {
                     // If we're in `tag_name` mode, then the tag_name isn't


### PR DESCRIPTION
NodeLive (used by, e.g. getElementsByTagName) needs to revert to the non- optimized string-comparison for non-HTML tags.

This should help fix https://github.com/lightpanda-io/browser/issues/1214