### PR TITLE
Add FileList Web API stub

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -885,6 +885,7 @@ pub const JsApis = flattenTypes(&.{
     @import("../webapi/IdleDeadline.zig"),
     @import("../webapi/Blob.zig"),
     @import("../webapi/File.zig"),
+    @import("../webapi/FileList.zig"),
     @import("../webapi/FileReader.zig"),
     @import("../webapi/Screen.zig"),
     @import("../webapi/VisualViewport.zig"),

--- a/src/browser/webapi/FileList.zig
+++ b/src/browser/webapi/FileList.zig
@@ -1,0 +1,28 @@
+const js = @import("../js/js.zig");
+
+const FileList = @This();
+
+/// Padding to avoid zero-size struct, which causes identity_map pointer collisions.
+_pad: bool = false,
+
+pub fn getLength(_: *const FileList) u32 {
+    return 0;
+}
+
+pub fn item(_: *const FileList, _: u32) ?*@import("File.zig") {
+    return null;
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(FileList);
+
+    pub const Meta = struct {
+        pub const name = "FileList";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+        pub const empty_with_no_proto = true;
+    };
+
+    pub const length = bridge.accessor(FileList.getLength, null, .{});
+    pub const item = bridge.function(FileList.item, .{});
+};


### PR DESCRIPTION
Next.js hydration references FileList as a global for feature detection. Register a minimal stub (length=0, item()→null) so the type exists in the global scope and the reference check doesn't throw.