### PR TITLE
testing: add LogFilter utility for scoped log suppression

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -3457,6 +3457,9 @@ fn asUint(comptime string: anytype) std.meta.Int(
 
 const testing = @import("../testing.zig");
 test "WebApi: Page" {
+    const filter: testing.LogFilter = .init(.http);
+    defer filter.deinit();
+
     try testing.htmlRunner("page", .{});
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -662,6 +662,10 @@ test "cdp.page: getFrameTree" {
 }
 
 test "cdp.page: captureScreenshot" {
+    const LogFilter = @import("../../testing.zig").LogFilter;
+    const filter: LogFilter = .init(.not_implemented);
+    defer filter.deinit();
+
     var ctx = testing.context();
     defer ctx.deinit();
     {

--- a/src/mcp/router.zig
+++ b/src/mcp/router.zig
@@ -133,9 +133,8 @@ test "MCP.router - handleMessage - synchronous unit tests" {
 
     // 4. Parse error
     {
-        const old_filter = log.opts.filter_scopes;
-        log.opts.filter_scopes = &.{.mcp};
-        defer log.opts.filter_scopes = old_filter;
+        const filter: testing.LogFilter = .init(.mcp);
+        defer filter.deinit();
 
         try handleMessage(server, aa, "invalid json");
         try testing.expectJson("{\"id\": null, \"error\": {\"code\": -32700}}", out_alloc.writer.buffered());

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -610,3 +610,23 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
 
     unreachable;
 }
+
+/// LogFilter provides a scoped way to suppress specific log categories during tests.
+/// This is useful for tests that trigger expected errors or warnings.
+pub const LogFilter = struct {
+    old_filter: []const log.Scope,
+
+    /// Sets the log filter to only include the specified scope.
+    /// Returns a LogFilter that should be deinitialized to restore previous filters.
+    pub fn init(comptime scope: log.Scope) LogFilter {
+        const old_filter = log.opts.filter_scopes;
+        const new_filter = comptime &[_]log.Scope{scope};
+        log.opts.filter_scopes = new_filter;
+        return .{ .old_filter = old_filter };
+    }
+
+    /// Restores the log filters to their previous state.
+    pub fn deinit(self: LogFilter) void {
+        log.opts.filter_scopes = self.old_filter;
+    }
+};


### PR DESCRIPTION
This PR adds a custom `LogFilter` that allows filtering out some logs based on their `log.Scope`.
Useful to have a clean output when running the tests.