### PR TITLE
Tweak CDP startup messages.

### DIFF
--- a/src/cdp/cdp.zig
+++ b/src/cdp/cdp.zig
@@ -196,7 +196,7 @@ pub fn CDPT(comptime TypeProvider: type) type {
                 return command.sendResult(.{
                     .frameTree = .{
                         .frame = .{
-                            .id = "TID-STARTUP-B",
+                            .id = "TID-STARTUP",
                             .loaderId = "LOADERID24DD2FD56CF1EF33C965C79C",
                             .securityOrigin = URL_BASE,
                             .url = "about:blank",

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -340,7 +340,7 @@ fn getTargetInfo(cmd: anytype) !void {
 
     return cmd.sendResult(.{
         .targetInfo = TargetInfo{
-            .targetId = "TID-STARTUP-B",
+            .targetId = "TID-STARTUP",
             .type = "browser",
             .title = "",
             .url = "about:blank",
@@ -424,14 +424,13 @@ fn setAutoAttach(cmd: anytype) !void {
     // set a flag to send Target.attachedToTarget events
     cmd.cdp.target_auto_attach = params.autoAttach;
 
-    try cmd.sendResult(null, .{});
-
     if (cmd.cdp.target_auto_attach == false) {
         // detach from all currently attached targets.
         if (cmd.browser_context) |bc| {
             bc.session_id = null;
             // TODO should we send a Target.detachedFromTarget event?
         }
+        try cmd.sendResult(null, .{});
         return;
     }
 
@@ -444,7 +443,7 @@ fn setAutoAttach(cmd: anytype) !void {
                 try doAttachtoTarget(cmd, &bc.target_id.?);
             }
         }
-        // should we send something here?
+        try cmd.sendResult(null, .{});
         return;
     }
 
@@ -460,12 +459,14 @@ fn setAutoAttach(cmd: anytype) !void {
         .sessionId = "STARTUP",
         .targetInfo = TargetInfo{
             .type = "page",
-            .targetId = "TID-STARTUP-P",
+            .targetId = "TID-STARTUP",
             .title = "",
             .url = "about:blank",
             .browserContextId = "BID-STARTUP",
         },
     }, .{});
+
+    try cmd.sendResult(null, .{});
 }
 
 fn doAttachtoTarget(cmd: anytype, target_id: []const u8) !void {


### PR DESCRIPTION
1 - When Target.setAutoAttach is called, send the `Target.attachedToTarget`
    event before sending the response. This matches Chrome's behavior and
    it stops playwright from thinking there's no target and making extra calls,
    e.g. to Target.attachedToTarget.

2 - Use the same dummy frameId for all startup messages. I'm not sure why we
    have STARTUP-P and STARTUP-B. Using the same frame (a) makes more sense to
    me (b) doesn't break any existing integration tests, and (c) improves this
    scenario: https://github.com/lightpanda-io/browser/issues/1800