### PR TITLE
Fix a flaky frame test

### DIFF
--- a/src/browser/tests/frames/frames.html
+++ b/src/browser/tests/frames/frames.html
@@ -108,7 +108,7 @@
   {
     let f5 = document.createElement('iframe');
     f5.id = 'f5';
-    f5.src = "support/sub 1.html";
+    f5.src = "support/page.html";
     document.documentElement.appendChild(f5);
     f5.src = "about:blank";
 


### PR DESCRIPTION
Loading `sub 1.html` has a side effect - it increments window.top..sub1_count). So it should be used careful. It was being used in `about_blank_renavigate` as a placeholder which _should_ not get navigated, but there's no strict guarantee about when it gets canceled.