### PR TITLE
Ensure valid cookie isn't interpreted as null

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -933,7 +933,7 @@ pub const RequestCookie = struct {
 
         if (arr.items.len > 0) {
             try arr.append(temp, 0); //null terminate
-            headers.cookies = @ptrCast(arr.items.ptr);
+            headers.cookies = @as([*c]const u8, @ptrCast(arr.items.ptr));
         }
     }
 };


### PR DESCRIPTION
Use an explicit type when @ptrCast() is assigned to an optional to ensure the value isn't interpreted as null.