### PR TITLE
Fix TrackingAllocator reallocation_count being incremented on failed operations

### DIFF
--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -501,7 +501,7 @@ pub const TrackingAllocator = struct {
         defer self.mutex.unlock();
 
         const result = self.parent_allocator.rawResize(old_mem, alignment, new_len, ra);
-        self.reallocation_count += 1; // TODO: only if result is not null?
+        if (result) self.reallocation_count += 1;
         return result;
     }
 
@@ -531,7 +531,7 @@ pub const TrackingAllocator = struct {
         defer self.mutex.unlock();
 
         const result = self.parent_allocator.rawRemap(memory, alignment, new_len, ret_addr);
-        self.reallocation_count += 1; // TODO: only if result is not null?
+        if (result != null) self.reallocation_count += 1;
         return result;
     }
 };


### PR DESCRIPTION
## Summary
- Fixed `TrackingAllocator.reallocation_count` being incremented regardless of whether `resize()`/`remap()` operations succeeded
- Only increment the counter when the operation actually succeeds

## Problem
The `reallocation_count` counter was being incremented unconditionally in both:
- `resize()`: even when `rawResize()` returns `false` (failure)
- `remap()`: even when `rawRemap()` returns `null` (failure)

This led to inaccurate memory allocation statistics being reported.

## Fix
- `resize()`: Only increment `reallocation_count` when `rawResize()` returns `true`
- `remap()`: Only increment `reallocation_count` when `rawRemap()` returns non-null

This also resolves the TODO comments that were present in the code.

## Test plan
- The fix is straightforward - only changes the condition for incrementing the counter
- No existing tests need to be modified as this was a silent bug affecting statistics accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)