### PR TITLE
Ignore partitionKey in cookie operations to fix Puppeteer page.setCookie()

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 const Allocator = std.mem.Allocator;
+const log = @import("../../log.zig");
 
 const CdpStorage = @import("storage.zig");
 

--- a/src/cdp/domains/storage.zig
+++ b/src/cdp/domains/storage.zig
@@ -132,7 +132,6 @@ pub fn setCdpCookie(cookie_jar: *CookieJar, param: CdpCookie) !void {
     // This allows Puppeteer's page.setCookie() to work, which may send cookies with
     // partitionKey as part of its cookie-setting workflow.
     if (param.partitionKey != null) {
-        const log = @import("../../log.zig");
         log.debug(.storage, "partitionKey ignored in setCdpCookie", .{});
     }
     // Still reject unsupported features


### PR DESCRIPTION
## Summary
- Fix `Network.deleteCookies` and `Network.setCookie` to ignore `partitionKey` parameter instead of returning `NotImplemented`
- This enables Puppeteer's `page.setCookie()` to work correctly

## Problem
Puppeteer's `page.setCookie()` internally calls `Network.deleteCookies` twice before setting a cookie. The second call includes a `partitionKey` field for CHIPS (Chrome's partitioned cookies):

```json
{ "name": "test", "domain": ".example.com", "url": "https://example.com/", "partitionKey": { "topLevelSite": "https//example.com", "hasCrossSiteAncestor": false } }
```

This caused Lightpanda to return `NotImplemented`, making `page.setCookie()` fail even though the actual cookie deletion/setting logic works fine.

## Solution
Since Lightpanda doesn't support partitioned cookies (CHIPS), we now silently ignore the `partitionKey` parameter and proceed with cookie operations based on name/domain/path matching.

## Changes
- `src/cdp/domains/network.zig`: Log debug message when partitionKey is present in deleteCookies, but don't return error
- `src/cdp/domains/storage.zig`: Log debug message when partitionKey is present in setCdpCookie, but don't return error

## Test plan
Reproduction from issue #1818:
```javascript
import puppeteer from 'puppeteer-core';
const browser = await puppeteer.connect({ browserWSEndpoint: 'ws://127.0.0.1:9222' });
const page = await browser.newPage();
await page.goto('https://example.com', { waitUntil: 'domcontentloaded' });
// This now works instead of throwing NotImplemented
await page.setCookie({ name: 'test', value: 'hello', domain: 'example.com' });
```

Fixes #1818

🤖 Generated with [Claude Code](https://claude.com/claude-code)