### PR TITLE
Remove frame double-free on navigate error

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -1091,7 +1091,6 @@ pub fn iframeAddedCallback(self: *Page, iframe: *IFrame) !void {
         log.warn(.page, "iframe navigate failure", .{ .url = url, .err = err });
         self._pending_loads -= 1;
         iframe._window = null;
-        page_frame.deinit(true);
         return error.IFrameLoadError;
     };
 


### PR DESCRIPTION
The explicit deinit isn't needed as here's already an errdefer in play.