### PR TITLE
fix: resolve memory leak in Option.getText() by using page arena

### DIFF
--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -231,7 +231,7 @@ fn extractSelectOptions(node: *Node, page: *Page, arena: std.mem.Allocator) ![]O
         if (child.is(Element)) |el| {
             if (el.getTag() == .option) {
                 if (el.is(Element.Html.Option)) |opt| {
-                    const text = opt.getText();
+                    const text = opt.getText(page);
                     const value = opt.getValue(page);
                     const selected = opt.getSelected();
                     try options.append(arena, .{ .text = text, .value = value, .selected = selected });
@@ -240,7 +240,7 @@ fn extractSelectOptions(node: *Node, page: *Page, arena: std.mem.Allocator) ![]O
                 var group_it = child.childrenIterator();
                 while (group_it.next()) |group_child| {
                     if (group_child.is(Element.Html.Option)) |opt| {
-                        const text = opt.getText();
+                        const text = opt.getText(page);
                         const value = opt.getValue(page);
                         const selected = opt.getSelected();
                         try options.append(arena, .{ .text = text, .value = value, .selected = selected });

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -61,10 +61,9 @@ pub fn setValue(self: *Option, value: []const u8, page: *Page) !void {
     self._value = owned;
 }
 
-pub fn getText(self: *const Option) []const u8 {
+pub fn getText(self: *const Option, page: *Page) []const u8 {
     const node: *Node = @constCast(self.asConstElement().asConstNode());
-    const allocator = std.heap.page_allocator; // TODO: use proper allocator
-    return node.getTextContentAlloc(allocator) catch "";
+    return node.getTextContentAlloc(page.call_arena) catch "";
 }
 
 pub fn setText(self: *Option, value: []const u8, page: *Page) !void {


### PR DESCRIPTION
This PR fixes a minor memory leak when calling `getText()` on `<option>` elements and resolves an existing `TODO: use proper allocator` in `src/browser/webapi/element/html/Option.zig`.

Previously, `std.heap.page_allocator` was used and never freed (e.g. when called inside `SemanticTree.zig`). By introducing `page: *Page` to the signature of `getText` and using `page.call_arena`, the memory lifecycle is safely scoped and collected, keeping headless usage slim.

- Fixes memory leak on Option text extraction
- Eliminates the TODO in `Option.zig`
- Auto-injected parameter in JS bridge logic means no JS engine wiring needs updating