### PR TITLE
fix: only increment TrackingAllocator reallocation_count on successful resizes

### DIFF
--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -501,7 +501,7 @@ pub const TrackingAllocator = struct {
         defer self.mutex.unlock();
 
         const result = self.parent_allocator.rawResize(old_mem, alignment, new_len, ra);
-        self.reallocation_count += 1; // TODO: only if result is not null?
+        if (result) self.reallocation_count += 1;
         return result;
     }
 
@@ -531,7 +531,7 @@ pub const TrackingAllocator = struct {
         defer self.mutex.unlock();
 
         const result = self.parent_allocator.rawRemap(memory, alignment, new_len, ret_addr);
-        self.reallocation_count += 1; // TODO: only if result is not null?
+        if (result != null) self.reallocation_count += 1;
         return result;
     }
 };


### PR DESCRIPTION
Fixes #1820 

This small commit resolves the `// TODO: only if result is not null?` note in `TrackingAllocator` (`src/test_runner.zig`). 

Previously, `self.reallocation_count += 1` was incremented unconditionally after attempting to resize/remap, causing failed allocations to still count towards successful reallocations. This guards the increment behind a success check (`if (result)` for `rawResize` and `if (result != null)` for `rawRemap`).