### PR TITLE
fix: correct target window and sender origin in Window.postMessage

### DIFF
--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -373,10 +373,11 @@ pub fn postMessage(self: *Window, message: js.Value.Temp, target_origin: ?[]cons
     const arena = try page.getArena(.{ .debug = "Window.schedule" });
     errdefer page.releaseArena(arena);
 
-    const origin = try self._location.getOrigin(page);
+    const origin = try page.window._location.getOrigin(page);
     const callback = try arena.create(PostMessageCallback);
     callback.* = .{
         .page = page,
+        .target = self,
         .arena = arena,
         .message = message,
         .origin = try arena.dupe(u8, origin),
@@ -702,6 +703,7 @@ const ScheduleCallback = struct {
 
 const PostMessageCallback = struct {
     page: *Page,
+    target: *Window,
     arena: Allocator,
     origin: []const u8,
     message: js.Value.Temp,
@@ -720,16 +722,17 @@ const PostMessageCallback = struct {
         defer self.deinit();
 
         const page = self.page;
-        const window = page.window;
+        const target = self.target;
+        const source = page.window;
 
         const event = (try MessageEvent.initTrusted(comptime .wrap("message"), .{
             .data = self.message,
             .origin = self.origin,
-            .source = window,
+            .source = source,
             .bubbles = false,
             .cancelable = false,
         }, page)).asEvent();
-        try page._event_manager.dispatch(window.asEventTarget(), event);
+        try page._event_manager.dispatch(target.asEventTarget(), event);
 
         return null;
     }


### PR DESCRIPTION
Fixes #1817 (window.postMessage across frames)

### Issue Analysis
The previous implementation of `Window.postMessage` had a few context-related bugs that broke cross-frame messaging:
1. **Target Window Loss:** `postMessage` saved the global `page.window` instead of the actual receiver (target `Window` on which `postMessage` was called).
2. **Origin Mismatch:** It used the receiver's origin (`self._location.getOrigin()`) instead of the sender's origin.
3. **Event Dispatch Target:** The `MessageEvent` was being unconditionally dispatched to the global `page.window` instead of the intended target window.

### Fix
This PR fixes the cross-frame messaging deadlock/loss by:
- Adding a explicit `target: *Window` property to `PostMessageCallback` to store the intended receiver.
- Changing the origin extraction to use the sender's origin (`page.window._location.getOrigin(page)`).
- Changing the target of `_event_manager.dispatch()` to the saved `target.asEventTarget()`.
- Setting the `event.source` properly to the sender (`page.window`).