### PR TITLE
fix(dom): return parsererror document on XML parse failure

### DIFF
--- a/src/browser/webapi/DOMParser.zig
+++ b/src/browser/webapi/DOMParser.zig
@@ -86,15 +86,15 @@ pub fn parseFromString(
             var parser = Parser.init(arena, doc_node, page);
             parser.parseXML(html);
 
-            if (parser.err) |pe| {
-                return pe.err;
+            if (parser.err != null or doc_node.firstChild() == null) {
+                // Return a document with a <parsererror> element per spec.
+                const err_doc = try page._factory.document(XMLDocument{ ._proto = undefined });
+                var err_parser = Parser.init(arena, err_doc.asNode(), page);
+                err_parser.parseXML("<parsererror xmlns=\"http://www.mozilla.org/newlayout/xml/parsererror.xml\">error</parsererror>");
+                return err_doc.asDocument();
             }
 
-            const first_child = doc_node.firstChild() orelse {
-                // Empty XML or no root element - this is a parse error.
-                // TODO: Return a document with a <parsererror> element per spec.
-                return error.JsException;
-            };
+            const first_child = doc_node.firstChild().?;
 
             // If first node is a `ProcessingInstruction`, skip it.
             if (first_child.getNodeType() == 7) {


### PR DESCRIPTION
This PR resolves a `TODO` in `src/browser/webapi/DOMParser.zig` regarding XML parsing behavior.

According to the [DOMParser spec](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring), when `parseFromString` is called with an XML mime type and the parsing fails (or returns an empty document without a root element), it should not throw an exception. Instead, it must return an `XMLDocument` containing a `<parsererror>` element.

### Changes
- When `parser.err != null` or `doc_node.firstChild() == null` during XML parsing, we now generate and return a fallback `XMLDocument` containing the proper `<parsererror xmlns="http://www.mozilla.org/newlayout/xml/parsererror.xml">error</parsererror>` markup rather than throwing `error.JsException`.