### PR TITLE
feat(mcp): add ping request handling

### DIFF
--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -116,3 +116,24 @@ test "MCP.Server - Integration: synchronous smoke test" {
 
     try testing.expectJson(.{ .id = 1 }, out_alloc.writer.buffered());
 }
+
+test "MCP.Server - Integration: ping request returns an empty result" {
+    defer testing.reset();
+    const allocator = testing.allocator;
+    const app = testing.test_app;
+
+    const input =
+        \\{"jsonrpc":"2.0","id":"ping-1","method":"ping"}
+    ;
+
+    var in_reader: std.io.Reader = .fixed(input);
+    var out_alloc: std.io.Writer.Allocating = .init(testing.arena_allocator);
+    defer out_alloc.deinit();
+
+    var server = try Self.init(allocator, app, &out_alloc.writer);
+    defer server.deinit();
+
+    try router.processRequests(server, &in_reader);
+
+    try testing.expectJson(.{ .id = "ping-1", .result = .{} }, out_alloc.writer.buffered());
+}

--- a/src/mcp/protocol.zig
+++ b/src/mcp/protocol.zig
@@ -238,6 +238,27 @@ test "MCP.protocol - request parsing" {
     try testing.expectString("1.0.0", init_params.value.clientInfo.version);
 }
 
+test "MCP.protocol - ping request parsing" {
+    defer testing.reset();
+    const raw_json =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "id": "123",
+        \\  "method": "ping"
+        \\}
+    ;
+
+    const parsed = try std.json.parseFromSlice(Request, testing.arena_allocator, raw_json, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    const req = parsed.value;
+    try testing.expectString("2.0", req.jsonrpc);
+    try testing.expectString("ping", req.method);
+    try testing.expect(req.id.? == .string);
+    try testing.expectString("123", req.id.?.string);
+    try testing.expectEqual(null, req.params);
+}
+
 test "MCP.protocol - response formatting" {
     defer testing.reset();
     const response = Response{

--- a/src/mcp/router.zig
+++ b/src/mcp/router.zig
@@ -34,6 +34,7 @@ const log = @import("../log.zig");
 
 const Method = enum {
     initialize,
+    ping,
     @"notifications/initialized",
     @"tools/list",
     @"tools/call",
@@ -43,6 +44,7 @@ const Method = enum {
 
 const method_map = std.StaticStringMap(Method).initComptime(.{
     .{ "initialize", .initialize },
+    .{ "ping", .ping },
     .{ "notifications/initialized", .@"notifications/initialized" },
     .{ "tools/list", .@"tools/list" },
     .{ "tools/call", .@"tools/call" },
@@ -68,6 +70,7 @@ pub fn handleMessage(server: *Server, arena: std.mem.Allocator, msg: []const u8)
 
     switch (method) {
         .initialize => try handleInitialize(server, req),
+        .ping => try handlePing(server, req),
         .@"notifications/initialized" => {},
         .@"tools/list" => try tools.handleList(server, arena, req),
         .@"tools/call" => try tools.handleCall(server, arena, req),
@@ -90,6 +93,11 @@ fn handleInitialize(server: *Server, req: protocol.Request) !void {
     };
 
     try server.sendResult(req.id.?, result);
+}
+
+fn handlePing(server: *Server, req: protocol.Request) !void {
+    const id = req.id orelse return;
+    try server.sendResult(id, .{});
 }
 
 const testing = @import("../testing.zig");
@@ -116,22 +124,29 @@ test "MCP.router - handleMessage - synchronous unit tests" {
     , out_alloc.writer.buffered());
     out_alloc.writer.end = 0;
 
-    // 2. Tools list
+    // 2. Ping
     try handleMessage(server, aa,
-        \\{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+        \\{"jsonrpc":"2.0","id":2,"method":"ping"}
     );
-    try testing.expectJson(.{ .id = 2 }, out_alloc.writer.buffered());
+    try testing.expectJson(.{ .id = 2, .result = .{} }, out_alloc.writer.buffered());
+    out_alloc.writer.end = 0;
+
+    // 3. Tools list
+    try handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":3,"method":"tools/list"}
+    );
+    try testing.expectJson(.{ .id = 3 }, out_alloc.writer.buffered());
     try testing.expect(std.mem.indexOf(u8, out_alloc.writer.buffered(), "\"name\":\"goto\"") != null);
     out_alloc.writer.end = 0;
 
-    // 3. Method not found
+    // 4. Method not found
     try handleMessage(server, aa,
-        \\{"jsonrpc":"2.0","id":3,"method":"unknown_method"}
+        \\{"jsonrpc":"2.0","id":4,"method":"unknown_method"}
     );
-    try testing.expectJson(.{ .id = 3, .@"error" = .{ .code = -32601 } }, out_alloc.writer.buffered());
+    try testing.expectJson(.{ .id = 4, .@"error" = .{ .code = -32601 } }, out_alloc.writer.buffered());
     out_alloc.writer.end = 0;
 
-    // 4. Parse error
+    // 5. Parse error
     {
         const filter: testing.LogFilter = .init(.mcp);
         defer filter.deinit();


### PR DESCRIPTION
This PR adds Model Context Protocol `ping` support to the inbuilt MCP Server. This is commonly used by Clients to detect server health. 

Specification: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping 
