### PR TITLE
fix: serialize AXValue integer as string per CDP spec

### DIFF
--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -230,6 +230,7 @@ pub const Writer = struct {
         switch (value) {
             .integer => |v| {
                 // CDP spec requires integer values to be serialized as strings.
+                // 20 bytes is enough for the decimal representation of a 64-bit integer.
                 var buf: [20]u8 = undefined;
                 const s = try std.fmt.bufPrint(&buf, "{d}", .{v});
                 try w.write(s);


### PR DESCRIPTION
## Summary

Serialize `AXValue.value` as a JSON string when the type is `"integer"`, matching Chrome's behavior per the [CDP Accessibility spec](https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#type-AXValue).

## Why this matters

[#1822](https://github.com/lightpanda-io/browser/issues/1822) - CDP clients with strict deserialization (e.g., Rust serde) fail because `AXValue.value` is returned as a JSON integer (`1`) instead of a string (`"1"`) when `type` is `"integer"`.

**Before:** `{"name": "level", "value": {"type": "integer", "value": 1}}`
**After:** `{"name": "level", "value": {"type": "integer", "value": "1"}}`

## Changes

In `writeAXValue` (`src/cdp/AXNode.zig`), the `integer` variant now uses `std.fmt.bufPrint` to convert the `usize` to a string before writing, instead of relying on the `inline else` catch-all which writes it as a JSON number.

Also adds a test case verifying the h1 heading's `level` property is serialized as a string.

## Testing

- Extended the existing "AXNode: writer" test to find the h1 heading node and verify its level property value is the string `"1"` (not the integer `1`)
- `zig fmt --check` passes

Fixes #1822

This contribution was developed with AI assistance (Claude Code).