### PR TITLE
Fix CDP WebSocket connection dying during complex page navigation

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -295,7 +295,7 @@ pub const Client = struct {
         }
 
         var cdp = &self.mode.cdp;
-        var last_message = timestamp(.monotonic);
+        var last_message = milliTimestamp(.monotonic);
         var ms_remaining = self.ws.timeout_ms;
 
         while (true) {
@@ -304,7 +304,7 @@ pub const Client = struct {
                     if (self.readSocket() == false) {
                         return;
                     }
-                    last_message = timestamp(.monotonic);
+                    last_message = milliTimestamp(.monotonic);
                     ms_remaining = self.ws.timeout_ms;
                 },
                 .no_page => {
@@ -319,16 +319,18 @@ pub const Client = struct {
                     if (self.readSocket() == false) {
                         return;
                     }
-                    last_message = timestamp(.monotonic);
+                    last_message = milliTimestamp(.monotonic);
                     ms_remaining = self.ws.timeout_ms;
                 },
                 .done => {
-                    const elapsed = timestamp(.monotonic) - last_message;
-                    if (elapsed > ms_remaining) {
+                    const now = milliTimestamp(.monotonic);
+                    const elapsed = now - last_message;
+                    if (elapsed >= ms_remaining) {
                         log.info(.app, "CDP timeout", .{});
                         return;
                     }
                     ms_remaining -= @intCast(elapsed);
+                    last_message = now;
                 },
             }
         }
@@ -501,6 +503,7 @@ fn buildJSONVersionResponse(
 }
 
 pub const timestamp = @import("datetime.zig").timestamp;
+pub const milliTimestamp = @import("datetime.zig").milliTimestamp;
 
 const testing = std.testing;
 test "server: buildJSONVersionResponse" {


### PR DESCRIPTION
## Summary

- Fix unit mismatch in CDP timeout handler: `timestamp(.monotonic)` returns **seconds** but `ms_remaining` is in **milliseconds**, causing incorrect timeout arithmetic
- Fix double-counting: `last_message` was never updated in the `.done` branch, so `elapsed` grew as absolute time rather than incremental, draining `ms_remaining` quadratically
- During complex page loads (large HTML + JS bundles), `Session._wait()` returns `.done` rapidly, triggering the bug and killing the WebSocket in ~2 seconds instead of the configured 10s timeout

Fixes #1849

## Test plan

- [ ] `Page.navigate` to complex pages with sub-resource fetches should not kill the CDP WebSocket
- [ ] Full navigation lifecycle completes: `frameStartedNavigating` → `frameNavigated` → `domContentEventFired` → `loadEventFired`
- [ ] Simple pages continue to work as before
- [ ] `lightpanda fetch <url>` mode unaffected (code path not exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)