### PR TITLE
ci: fix wba flaky test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -194,8 +194,6 @@ jobs:
           repository: 'lightpanda-io/demo'
           fetch-depth: 0
 
-      - run: echo "${{ secrets.WBA_PRIVATE_KEY_PEM }}" > private_key.pem
-
       - name: download artifact
         uses: actions/download-artifact@v4
         with:
@@ -204,17 +202,22 @@ jobs:
       - run: chmod a+x ./lightpanda
 
       - name: run wba test
+        shell: bash
         run: |
+
           node webbotauth/validator.js &
           VALIDATOR_PID=$!
           sleep 2
 
-          ./lightpanda fetch http://127.0.0.1:8989/ \
-            --web_bot_auth_key_file private_key.pem \
+          exec 3<<< "${{ secrets.WBA_PRIVATE_KEY_PEM }}"
+
+          ./lightpanda fetch --dump http://127.0.0.1:8989/ \
+            --web_bot_auth_key_file /proc/self/fd/3 \
             --web_bot_auth_keyid ${{ vars.WBA_KEY_ID }} \
             --web_bot_auth_domain ${{ vars.WBA_DOMAIN }}
 
           wait $VALIDATOR_PID
+          exec 3>&-
 
   cdp-and-hyperfine-bench:
     name: cdp-and-hyperfine-bench


### PR DESCRIPTION
Sometimes the GHA secret isn't dump in file correctly. So this commit inject the value directly to the command line