### PR TITLE
fix(cdp): stub Emulation.setUserAgentOverride to unblock Playwright

### DIFF
--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -24,6 +24,7 @@ pub fn processMessage(cmd: anytype) !void {
         setFocusEmulationEnabled,
         setDeviceMetricsOverride,
         setTouchEmulationEnabled,
+        setUserAgentOverride,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
@@ -31,6 +32,7 @@ pub fn processMessage(cmd: anytype) !void {
         .setFocusEmulationEnabled => return setFocusEmulationEnabled(cmd),
         .setDeviceMetricsOverride => return setDeviceMetricsOverride(cmd),
         .setTouchEmulationEnabled => return setTouchEmulationEnabled(cmd),
+        .setUserAgentOverride => return setUserAgentOverride(cmd),
     }
 }
 
@@ -62,5 +64,10 @@ fn setDeviceMetricsOverride(cmd: anytype) !void {
 
 // TODO: noop method
 fn setTouchEmulationEnabled(cmd: anytype) !void {
+    return cmd.sendResult(null, .{});
+}
+
+// TODO: noop method
+fn setUserAgentOverride(cmd: anytype) !void {
     return cmd.sendResult(null, .{});
 }


### PR DESCRIPTION
Fixes #1436

## Problem

Playwright calls `Emulation.setUserAgentOverride` when creating a browser context with device emulation or a custom user agent. Lightpanda returns `UnknownMethod`, which crashes the Playwright driver:

```
playwright: Protocol error (Emulation.setUserAgentOverride): UnknownMethod
```

## Solution

Add a noop handler for `setUserAgentOverride`, matching the existing pattern for all other Emulation methods (`setDeviceMetricsOverride`, `setEmulatedMedia`, `setFocusEmulationEnabled`, `setTouchEmulationEnabled`) which are all stubs marked `// TODO: noop method`.

This doesn't implement actual user agent override — it just prevents the CDP handshake from failing so Playwright sessions can proceed.

### Note

Actual user agent override support is a separate discussion (see #1436 thread). This PR only prevents the crash so Playwright can be used with Lightpanda without error.