### PR TITLE
fix: version command should print version number

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -59,7 +59,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             return std.process.cleanExit();
         },
         .version => {
-            std.debug.print("{s}\n", .{lp.build_config.git_commit});
+            std.debug.print("{s} ({s})\n", .{ lp.build_config.version, lp.build_config.git_commit });
             return std.process.cleanExit();
         },
         else => {},


### PR DESCRIPTION
## Problem
`lightpanda version` only prints the git commit hash:
```
fe3faa0a
```

Instead of the version number on stable releases.

## Solution
Print both version number and git commit:
```
v0.2.6 (fe3faa0a)
```

## Changes
- Modified `src/main.zig` to print `version` field from `build_config`
- Kept git commit for debugging purposes

Fixes #1835