### PR TITLE
Gracefull close ws socket

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -242,7 +242,10 @@ pub const Client = struct {
     fn stop(self: *Client) void {
         switch (self.mode) {
             .http => {},
-            .cdp => |*cdp| cdp.browser.env.terminate(),
+            .cdp => |*cdp| {
+                cdp.browser.env.terminate();
+                self.ws.sendClose();
+            },
         }
         self.ws.shutdown();
     }

--- a/src/network/Runtime.zig
+++ b/src/network/Runtime.zig
@@ -308,9 +308,12 @@ pub fn run(self: *Runtime) void {
 
         const socket = posix.accept(listener.socket, null, null, posix.SOCK.NONBLOCK) catch |err| {
             switch (err) {
-                error.SocketNotListening, error.ConnectionAborted => {
+                error.SocketNotListening => {
                     self.pollfds[1] = .{ .fd = -1, .events = 0, .revents = 0 };
                     self.listener = null;
+                },
+                error.ConnectionAborted => {
+                    lp.log.warn(.app, "accept connection aborted", .{});
                 },
                 error.WouldBlock => {},
                 else => {

--- a/src/network/websocket.zig
+++ b/src/network/websocket.zig
@@ -308,6 +308,7 @@ pub fn Reader(comptime EXPECT_MASK: bool) type {
 pub const WsConnection = struct {
     // CLOSE, 2 length, code
     const CLOSE_NORMAL = [_]u8{ 136, 2, 3, 232 }; // code: 1000
+    const CLOSE_GOING_AWAY = [_]u8{ 136, 2, 3, 233 }; // code: 1001
     const CLOSE_TOO_BIG = [_]u8{ 136, 2, 3, 241 }; // 1009
     const CLOSE_PROTOCOL_ERROR = [_]u8{ 136, 2, 3, 234 }; //code: 1002
     // "private-use" close codes must be from 4000-49999
@@ -581,6 +582,10 @@ pub const WsConnection = struct {
         var socklen: posix.socklen_t = @sizeOf(std.net.Address);
         try posix.getpeername(self.socket, &address.any, &socklen);
         return address;
+    }
+
+    pub fn sendClose(self: *WsConnection) void {
+        self.send(&CLOSE_GOING_AWAY) catch {};
     }
 
     pub fn shutdown(self: *WsConnection) void {


### PR DESCRIPTION
Fixes two bugs in WS connection handling:
- if a connection fails to be accepted, we should continue trying new connections; this is normal.
- when closing a WS socket at the browser's initiative, send a CLOSE message.