### PR TITLE
feat: add git_version build option for release version detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,12 +27,14 @@ pub fn build(b: *Build) !void {
     const manifest = Manifest.init(b);
 
     const git_commit = b.option([]const u8, "git_commit", "Current git commit");
+    const git_version = b.option([]const u8, "git_version", "Current git version (from tag)");
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
     const snapshot_path = b.option([]const u8, "snapshot_path", "Path to v8 snapshot");
 
     var opts = b.addOptions();
     opts.addOption([]const u8, "version", manifest.version);
     opts.addOption([]const u8, "git_commit", git_commit orelse "dev");
+    opts.addOption([]const u8, "git_version", git_version orelse "dev");
     opts.addOption(?[]const u8, "snapshot_path", snapshot_path);
 
     const enable_tsan = b.option(bool, "tsan", "Enable Thread Sanitizer") orelse false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -59,7 +59,11 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             return std.process.cleanExit();
         },
         .version => {
-            std.debug.print("{s}\n", .{lp.build_config.git_commit});
+            const version = if (std.mem.eql(u8, lp.build_config.git_version, "dev"))
+                lp.build_config.git_commit
+            else
+                lp.build_config.git_version;
+            std.debug.print("{s}\n", .{version});
             return std.process.cleanExit();
         },
         else => {},


### PR DESCRIPTION
Fixes #1867

Addresses feedback from @mrdimidium:
- Added `git_version` build option (similar to existing `git_commit`)
- CI can pass `-Dgit_version=$(git describe --tags --exact-match)` for releases
- Falls back to `git_commit` when not on a tagged release

This avoids running external commands during build and improves reproducibility.