### PR TITLE
Try to improve stability of history test

### DIFF
--- a/src/browser/tests/history.html
+++ b/src/browser/tests/history.html
@@ -2,37 +2,17 @@
 <script src="testing.js"></script>
 
 <script id=history>
-  testing.expectEqual('auto', history.scrollRestoration);
-
-  history.scrollRestoration = 'manual';
-  testing.expectEqual('manual', history.scrollRestoration);
-
-  history.scrollRestoration = 'auto';
-  testing.expectEqual('auto', history.scrollRestoration);
-  testing.expectEqual(null, history.state)
-
-  history.pushState({ testInProgress: true }, null, 'http://127.0.0.1:9582/src/browser/tests/history_after_nav.skip.html');
-  testing.expectEqual({ testInProgress: true }, history.state);
-
-  history.pushState({ testInProgress: false }, null, 'http://127.0.0.1:9582/xhr/json');
-  history.replaceState({ "new": "field", testComplete: true }, null);
-
-  let state = { "new": "field", testComplete: true };
-  testing.expectEqual(state, history.state);
-
-  let popstateEventFired = false;
-  let popstateEventState = null;
-
-  window.addEventListener('popstate', (event) => {
-      popstateEventFired = true;
-      popstateEventState = event.state;
-  });
-
+  // This test is a bit wonky. But it's trying to test navigation, which is
+  // something we can't do in the main page (we can't navigate away from this
+  // page and still assertOk in the test runner).
+  // If support/history.html has a failed assertion, it'll log the error and
+  // stop the script. If it succeeds, it'll set support_history_completed
+  // which we can use here to assume everything passed.
   testing.eventually(() => {
-    testing.expectEqual(true, popstateEventFired);
-    testing.expectEqual({testInProgress: true }, popstateEventState);
-  })
-
-  history.back();
+    testing.expectEqual(true, window.support_history_completed);
+    testing.expectEqual(true, window.support_history_popstateEventFired);
+    testing.expectEqual({testInProgress: true }, window.support_history_popstateEventState);
+  });
 </script>
 
+<iframe id=frame src="support/history.html"></iframe>

--- a/src/browser/tests/support/history.html
+++ b/src/browser/tests/support/history.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+<script id=history>
+  testing.expectEqual('auto', history.scrollRestoration);
+
+  history.scrollRestoration = 'manual';
+  testing.expectEqual('manual', history.scrollRestoration);
+
+  history.scrollRestoration = 'auto';
+  testing.expectEqual('auto', history.scrollRestoration);
+  testing.expectEqual(null, history.state)
+
+  history.pushState({ testInProgress: true }, null, testing.BASE_URL + 'history_after_nav.skip.html');
+  testing.expectEqual({ testInProgress: true }, history.state);
+
+  history.pushState({ testInProgress: false }, null, testing.ORIGIN + '/xhr/json');
+  history.replaceState({ "new": "field", testComplete: true }, null);
+
+  let state = { "new": "field", testComplete: true };
+  testing.expectEqual(state, history.state);
+
+  let popstateEventFired = false;
+  let popstateEventState = null;
+
+  window.top.support_history_completed = true;
+  window.addEventListener('popstate', (event) => {
+    window.top.window.support_history_popstateEventFired = true;
+    window.top.window.support_history_popstateEventState = event.state;
+  });
+
+  history.back();
+</script>
+

--- a/src/browser/tests/testing.js
+++ b/src/browser/tests/testing.js
@@ -99,8 +99,7 @@
     }
   }
 
-  // our test runner sets this to true
-  const IS_TEST_RUNNER = window._lightpanda_skip_auto_assert === true;
+  const IS_TEST_RUNNER = window.navigator.userAgent.startsWith("Lightpanda/");
 
   window.testing = {
     fail: fail,
@@ -118,7 +117,7 @@
     BASE_URL: 'http://127.0.0.1:9582/src/browser/tests/',
   };
 
-  if (window.navigator.userAgent.startsWith("Lightpanda/") == false) {
+  if (IS_TEST_RUNNER === false) {
     // The page is running in a different browser. Probably a developer making sure
     // a test is correct. There are a few tweaks we need to do to make this a
     // seemless, namely around adapting paths/urls.


### PR DESCRIPTION
Tests cannot navigate away from the page page. If they do, the testRunner will crash, as it tries to access `assertOk` on a page that no longer exists. This commit hacks the history test, using an iframe, to try to test the history API without navigating off the main page.