### PR TITLE
Implement window.event property

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -233,6 +233,12 @@ const DispatchDirectOptions = struct {
 pub fn dispatchDirect(self: *EventManager, target: *EventTarget, event: *Event, handler: anytype, comptime opts: DispatchDirectOptions) !void {
     const page = self.page;
 
+    // Set window.event to the currently dispatching event (WHATWG spec)
+    const window = page.window;
+    const prev_event = window._current_event;
+    window._current_event = event;
+    defer window._current_event = prev_event;
+
     event.acquireRef();
     defer event.deinit(false, page._session);
 
@@ -398,6 +404,13 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
     }
 
     const page = self.page;
+
+    // Set window.event to the currently dispatching event (WHATWG spec)
+    const window = page.window;
+    const prev_event = window._current_event;
+    window._current_event = event;
+    defer window._current_event = prev_event;
+
     var was_handled = false;
 
     // Create a single scope for all event handlers in this dispatch.

--- a/src/browser/tests/window/window_event.html
+++ b/src/browser/tests/window/window_event.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=windowEventUndefinedOutsideHandler>
+testing.expectEqual(undefined, window.event);
+</script>
+
+<script id=windowEventSetDuringWindowHandler>
+var capturedEvent = null;
+
+window.addEventListener('test-event', function(e) {
+  capturedEvent = window.event;
+});
+
+var ev = new Event('test-event');
+window.dispatchEvent(ev);
+
+testing.expectEqual(ev, capturedEvent);
+testing.expectEqual(undefined, window.event);
+</script>
+
+<script id=windowEventRestoredAfterHandler>
+var captured2 = null;
+
+window.addEventListener('test-event-2', function(e) {
+  captured2 = window.event;
+});
+
+var ev2 = new Event('test-event-2');
+window.dispatchEvent(ev2);
+
+testing.expectEqual(ev2, captured2);
+testing.expectEqual(undefined, window.event);
+</script>

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -68,6 +68,7 @@ _on_popstate: ?js.Function.Global = null,
 _on_error: ?js.Function.Global = null,
 _on_message: ?js.Function.Global = null,
 _on_unhandled_rejection: ?js.Function.Global = null, // TODO: invoke on error
+_current_event: ?*Event = null,
 _location: *Location,
 _timer_id: u30 = 0,
 _timers: std.AutoHashMapUnmanaged(u32, *ScheduleCallback) = .{},
@@ -88,6 +89,10 @@ _scroll_pos: struct {
 
 pub fn asEventTarget(self: *Window) *EventTarget {
     return self._proto;
+}
+
+pub fn getEvent(self: *const Window) ?*Event {
+    return self._current_event;
 }
 
 pub fn getSelf(self: *Window) *Window {
@@ -805,6 +810,7 @@ pub const JsApi = struct {
     pub const onerror = bridge.accessor(Window.getOnError, Window.setOnError, .{});
     pub const onmessage = bridge.accessor(Window.getOnMessage, Window.setOnMessage, .{});
     pub const onunhandledrejection = bridge.accessor(Window.getOnUnhandledRejection, Window.setOnUnhandledRejection, .{});
+    pub const event = bridge.accessor(Window.getEvent, null, .{ .null_as_undefined = true });
     pub const fetch = bridge.function(Window.fetch, .{});
     pub const queueMicrotask = bridge.function(Window.queueMicrotask, .{});
     pub const setTimeout = bridge.function(Window.setTimeout, .{});


### PR DESCRIPTION
## Summary

Implements the `window.event` property per the [WHATWG spec](https://html.spec.whatwg.org/multipage/window-object.html#dom-window-event). Returns the Event currently being handled by an event handler, or `undefined` when no event is being dispatched.

## Why this matters

Many legacy scripts and libraries (jQuery, analytics snippets) depend on `window.event` to access the current event object. Without it, these scripts fail silently or throw. [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Window/event).

## Changes

- **Window.zig**: Add `_current_event` field and `getEvent` accessor exposed via JsApi
- **EventManager.zig**: Save/restore `window._current_event` around handler invocation in both `dispatchDirect` and `dispatchNode`, supporting nested event dispatch
- **window_event.html**: Tests for undefined-outside-handler, set-during-handler, and restored-after-handler

## Testing

- `zig build test` - 360/360 tests pass
- New test covers: property is undefined outside handlers, equals the dispatched Event inside handlers, restored to undefined after handler completes

Fixes #1770

This contribution was developed with AI assistance (Claude Code).