### PR TITLE
Expand rel's that trigger a link's onload

### DIFF
--- a/src/browser/tests/element/html/link.html
+++ b/src/browser/tests/element/html/link.html
@@ -84,3 +84,24 @@
   testing.eventually(() => testing.expectEqual(true, result));
 }
 </script>
+
+<script id="refs">
+{
+  const rels = ['stylesheet', 'preload', 'modulepreload'];
+  const results = rels.map(() => false);
+  rels.forEach((rel, i) => {
+    let link = document.createElement('link')
+    link.rel = rel;
+    link.href = '/nope';
+    link.onload = () => results[i] = true;
+    document.documentElement.appendChild(link);
+  });
+
+
+  testing.eventually(() => {
+    results.forEach((r) => {
+      testing.expectEqual(true, r);
+    });
+  });
+}
+</script>

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -93,13 +93,21 @@ pub fn linkAddedCallback(self: *Link, page: *Page) !void {
     }
 
     const element = self.asElement();
-    // Exit if rel not set.
+
     const rel = element.getAttributeSafe(comptime .wrap("rel")) orelse return;
-    // Exit if rel is not stylesheet.
-    if (!std.mem.eql(u8, rel, "stylesheet")) return;
-    // Exit if href not set.
+    const loadable_rels = std.StaticStringMap(void).initComptime(.{
+        .{ "stylesheet", {} },
+        .{ "preload", {} },
+        .{ "modulepreload", {} },
+    });
+    if (loadable_rels.has(rel) == false) {
+        return;
+    }
+
     const href = element.getAttributeSafe(comptime .wrap("href")) orelse return;
-    if (href.len == 0) return;
+    if (href.len == 0) {
+        return;
+    }
 
     try page._to_load.append(page.arena, self._proto);
 }


### PR DESCRIPTION
Was only "stylesheet", not also includes "preload" and "modulepreload"