### PR TITLE
Keyboard events are bubbling, cancelable and composed

### DIFF
--- a/src/browser/webapi/event/KeyboardEvent.zig
+++ b/src/browser/webapi/event/KeyboardEvent.zig
@@ -219,6 +219,13 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     );
 
     Event.populatePrototypes(event, opts, trusted);
+
+    // https://w3c.github.io/uievents/#event-type-keyup
+    const rootevt = event._proto._proto;
+    rootevt._bubbles = true;
+    rootevt._cancelable = true;
+    rootevt._composed = true;
+
     return event;
 }
 


### PR DESCRIPTION
According to the specs: https://w3c.github.io/uievents/#event-type-keyup

fix for ddg integration test 2/2