### PR TITLE
fix(cdp): add ignore-level log to setUserAgentOverride stub

### DIFF
--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -69,6 +69,6 @@ fn setTouchEmulationEnabled(cmd: anytype) !void {
 }
 
 fn setUserAgentOverride(cmd: anytype) !void {
-    log.info(.app, "setUserAgentOverride ignored", .{});
+    log.warn(.ignore, "setUserAgentOverride", .{});
     return cmd.sendResult(null, .{});
 }

--- a/src/log.zig
+++ b/src/log.zig
@@ -31,6 +31,7 @@ pub const Scope = enum {
     cdp,
     console,
     http,
+    ignore,
     page,
     js,
     event,


### PR DESCRIPTION
## Summary
- Adds an `.ignore`-level log message to the `setUserAgentOverride` noop stub
- Follow-up to #1860 per discussion with @karlseguin and @krichprollsch
- Uses `.ignore` rather than `.not_implemented` since this is an explicit design choice not to implement
- Adds new `.ignore` variant to `log.Scope` enum to distinguish deliberately ignored features

## Test plan
- Verify log output appears when Playwright calls setUserAgentOverride
- Verify the `.ignore` scope is properly filtered/displayed in log output