### PR TITLE
Bucket stylesheet rules

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -100,15 +100,25 @@ fn rebuildIfDirty(self: *StyleManager) !void {
 
     self.dirty = false;
     errdefer self.dirty = true;
+    const id_rules_count = self.id_rules.count();
+    const class_rules_count = self.class_rules.count();
+    const tag_rules_count = self.tag_rules.count();
+    const other_rules_count = self.other_rules.items.len;
 
     self.page._session.arena_pool.resetRetain(self.arena);
 
-    // Clear all buckets and reset document order
-    self.id_rules = .empty;
-    self.class_rules = .empty;
-    self.tag_rules = .empty;
-    self.other_rules = .empty;
     self.next_doc_order = 0;
+
+    self.id_rules = .empty;
+    try self.id_rules.ensureUnusedCapacity(self.arena, id_rules_count);
+
+    self.class_rules = .empty;
+    try self.class_rules.ensureUnusedCapacity(self.arena, class_rules_count);
+
+    self.tag_rules = .empty;
+    try self.tag_rules.ensureUnusedCapacity(self.arena, tag_rules_count);
+
+    self.other_rules = try .initCapacity(self.arena, other_rules_count);
 
     const sheets = self.page.document._style_sheets orelse return;
     for (sheets._sheets.items) |sheet| {


### PR DESCRIPTION
In the first iteration of this, we kept an ArrayList of all rules with visibility properties. Why bother evaluating if a rule's selector matches an element if that rule doesn't have any meanignful (i.e. visibility) properties?

This commit enhances that approach by bucketing the rules. Given the following selectors:
```
.hidden {....}
.footer > .small {...}
```

We can store the rules based on their right-most selector. So, given an element we can do:

```
if (getId(el)) |id| {
   const rules = id_lookup.get(id) orelse continue;
   // check rules
}

if (getClasses(el)) |classes| {
   for (classes) |c| {
     const rules = class_lookup(c) orelse continue;
     // chck rules
   }
}
...
```

On an amazon product page, the total list of visibility-related rules was ~230. Now, scanning 230 rules for a match isn't _aweful_, but remember that this has to be done up the ancestor tree AND, for Amazon, this is called over 20K times.

This change requires that the StyleManager becomes more matching/parsing-aware but a typical visibility check on that same Amazon product page only has to check 2 rules (down from 230) and often has to check 0 rules.

Also, we now filter out a few more interactive-related pseudo-elements, e.g. :hover. These aren't supported by the browser as a whole (i.e. they can _never_ match), so they can be filtered out early, when building the rules lookup.