### PR TITLE
Send Target.detachedFromTarget event on detach

### DIFF
--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -394,15 +394,13 @@ fn sendMessageToTarget(cmd: anytype) !void {
 }
 
 fn detachFromTarget(cmd: anytype) !void {
-    // TODO check if sessionId/targetId match.
-    // const params = (try cmd.params(struct {
-    //     sessionId: ?[]const u8,
-    //     targetId: ?[]const u8,
-    // })) orelse return error.InvalidParams;
-
     if (cmd.browser_context) |bc| {
+        if (bc.session_id) |session_id| {
+            try cmd.sendEvent("Target.detachedFromTarget", .{
+                .sessionId = session_id,
+            }, .{});
+        }
         bc.session_id = null;
-        // TODO should we send a Target.detachedFromTarget event?
     }
 
     return cmd.sendResult(null, .{});
@@ -427,8 +425,12 @@ fn setAutoAttach(cmd: anytype) !void {
     if (cmd.cdp.target_auto_attach == false) {
         // detach from all currently attached targets.
         if (cmd.browser_context) |bc| {
+            if (bc.session_id) |session_id| {
+                try cmd.sendEvent("Target.detachedFromTarget", .{
+                    .sessionId = session_id,
+                }, .{});
+            }
             bc.session_id = null;
-            // TODO should we send a Target.detachedFromTarget event?
         }
         try cmd.sendResult(null, .{});
         return;
@@ -759,13 +761,48 @@ test "cdp.target: detachFromTarget" {
         try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 10 });
 
         try ctx.processMessage(.{ .id = 11, .method = "Target.attachToTarget", .params = .{ .targetId = bc.target_id.? } });
-        try ctx.expectSentResult(.{ .sessionId = bc.session_id.? }, .{ .id = 11 });
+        const session_id = bc.session_id.?;
+        try ctx.expectSentResult(.{ .sessionId = session_id }, .{ .id = 11 });
 
         try ctx.processMessage(.{ .id = 12, .method = "Target.detachFromTarget", .params = .{ .targetId = bc.target_id.? } });
+        try ctx.expectSentEvent("Target.detachedFromTarget", .{ .sessionId = session_id }, .{});
         try testing.expectEqual(null, bc.session_id);
         try ctx.expectSentResult(null, .{ .id = 12 });
 
         try ctx.processMessage(.{ .id = 13, .method = "Target.attachToTarget", .params = .{ .targetId = bc.target_id.? } });
         try ctx.expectSentResult(.{ .sessionId = bc.session_id.? }, .{ .id = 13 });
+    }
+}
+
+test "cdp.target: detachFromTarget without session" {
+    var ctx = testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-9" });
+    {
+        // detach when no session is attached should not send event
+        try ctx.processMessage(.{ .id = 10, .method = "Target.detachFromTarget" });
+        try ctx.expectSentResult(null, .{ .id = 10 });
+        try ctx.expectSentCount(0);
+    }
+}
+
+test "cdp.target: setAutoAttach false sends detachedFromTarget" {
+    var ctx = testing.context();
+    defer ctx.deinit();
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9" });
+    {
+        try ctx.processMessage(.{ .id = 10, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        try testing.expectEqual(true, bc.target_id != null);
+        try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 10 });
+
+        try ctx.processMessage(.{ .id = 11, .method = "Target.attachToTarget", .params = .{ .targetId = bc.target_id.? } });
+        const session_id = bc.session_id.?;
+        try ctx.expectSentResult(.{ .sessionId = session_id }, .{ .id = 11 });
+
+        // setAutoAttach false should fire detachedFromTarget event
+        try ctx.processMessage(.{ .id = 12, .method = "Target.setAutoAttach", .params = .{ .autoAttach = false, .waitForDebuggerOnStart = false } });
+        try ctx.expectSentEvent("Target.detachedFromTarget", .{ .sessionId = session_id }, .{});
+        try testing.expectEqual(null, bc.session_id);
+        try ctx.expectSentResult(null, .{ .id = 12 });
     }
 }


### PR DESCRIPTION
## Summary

- `detachFromTarget` and `setAutoAttach(autoAttach: false)` both null `bc.session_id` without notifying the client. Per the [CDP spec](https://chromedevtools.github.io/devtools-protocol/tot/Target/#event-detachedFromTarget), detaching a session must fire a `Target.detachedFromTarget` event so the driver stops sending messages on the stale session ID.
- Both code paths had TODO comments calling out this exact gap: `// TODO should we send a Target.detachedFromTarget event?`
- This captures the session_id before nulling it and fires the event in both paths.

## Changes

- `detachFromTarget`: emit `Target.detachedFromTarget` with the session ID before nulling it
- `setAutoAttach(false)`: same treatment
- New test: `detachFromTarget` emits the event after attach
- New test: `detachFromTarget` without a session does not emit an event
- New test: `setAutoAttach(false)` emits the event after attach

## Test plan

- [x] All 368 existing tests pass (`zig build test`)
- [x] New tests cover event emission in both detach paths
- [x] Edge case: detach with no active session does not crash or emit

Fixes #1819

This contribution was developed with AI assistance (Claude Code + Codex).