### PR TITLE
mcp: initialize server in mcpThread to avoid V8 isolate crashes

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -168,7 +168,7 @@ fn fetchThread(app: *App, url: [:0]const u8, fetch_opts: lp.FetchOpts) void {
 
 fn mcpThread(allocator: std.mem.Allocator, app: *App) void {
     defer app.network.stop();
-    
+
     var stdout = std.fs.File.stdout().writer(&.{});
     var mcp_server: *lp.mcp.Server = lp.mcp.Server.init(allocator, app, &stdout.interface) catch |err| {
         log.fatal(.mcp, "mcp init error", .{ .err = err });


### PR DESCRIPTION
When running mcp server, it initialized lp.mcp.Server in the main thread which also implicitly created the V8 isolate in the main thread. When processing requests (like calling the goto tool) inside mcpThread, V8 would assert that the isolate doesn't match the current thread.

Fixes #1938