### PR TITLE
fix: preserve re-entrantly scheduled navigations in processQueuedNavigation

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -514,9 +514,12 @@ fn processQueuedNavigation(self: *Session) !void {
     const about_blank_queue = &self.queued_queued_navigation;
     defer about_blank_queue.clearRetainingCapacity();
 
-    // First pass: process async navigations (non-about:blank)
-    // These cannot cause re-entrant navigation scheduling
-    for (navigations.items) |page| {
+    // First pass: process non-about:blank navigations.
+    // Note: processFrameNavigation can cause re-entrant navigation scheduling
+    // when navigations complete synchronously (e.g. blob URLs), triggering
+    // cascading load events that schedule new navigations into the queue.
+    const original_count = navigations.items.len;
+    for (navigations.items[0..original_count]) |page| {
         const qn = page._queued_navigation.?;
 
         if (qn.is_about_blank) {
@@ -530,8 +533,13 @@ fn processQueuedNavigation(self: *Session) !void {
         };
     }
 
-    // Clear the queue after first pass
-    navigations.clearRetainingCapacity();
+    // Remove the processed items, preserving any navigations that were
+    // added to the queue during the first pass (re-entrant scheduling).
+    const new_count = navigations.items.len - original_count;
+    if (new_count > 0) {
+        std.mem.copyForwards(*Page, navigations.items[0..new_count], navigations.items[original_count..navigations.items.len]);
+    }
+    navigations.items.len = new_count;
 
     // Second pass: process synchronous navigations (about:blank)
     // These may trigger new navigations which go into queued_navigation


### PR DESCRIPTION
`processQueuedNavigation` in `Session.zig` cleared the entire navigation queue after its first-pass loop, discarding any navigations that were added to the queue *during* that loop. This fix preserves those re-entrantly added navigations by only removing the items that were actually processed.

## Why

The `WebApi: Frames` test (`link_click` section) fails intermittently with `script id: 'link_click' failed: no assertions` -- roughly 1 in 5-10 runs.

The flakiness comes from a timing-dependent race in `processQueuedNavigation`:

1. `_wait` detects queued navigations (e.g. `page.html` + `about:blank`, count=2) and calls `processQueuedNavigation`.
2. First-pass processes `page.html` via `processFrameNavigation`. This can complete **synchronously** (blob URLs, etc.), which triggers cascading `iframeCompletedLoading` -> `load` event dispatch -> JS runs `click()` -> `scheduleNavigation(after_link.html)` appends to the **same queue**.
3. `navigations.clearRetainingCapacity()` wipes the entire queue, including the just-added `after_link.html`.
4. Navigation is lost. `_wait` sees no pending work and returns `.done`. `assertOk` finds no observation.

The original code had a comment: "These cannot cause re-entrant navigation scheduling" -- this is incorrect. Non-about:blank navigations can complete synchronously, triggering load event cascades that schedule new navigations.

## Change

In `processQueuedNavigation`, instead of iterating over `navigations.items` and then calling `clearRetainingCapacity()`:

- Capture `original_count` before the loop.
- Iterate over `navigations.items[0..original_count]` (only the items that existed at loop start).
- After the loop, shift any newly-appended items (indices `original_count..len`) to the front and update the length.

This ensures the outer `wait()` loop picks up the preserved navigations on its next iteration.

## Verification

Without the fix (on `main`), the failure reproduces quickly (~1 in 5-10 runs):

```
Run 1: 391 of 391 tests passed
...
Run 13: 390 of 391 tests passed

src/browser/tests/frames/frames.html: test failure
        exception: script id: 'link_click' failed: no assertions
        stack: Error: script id: 'link_click' failed: no assertions
"WebApi: Frames" - JsException

390 of 391 tests passed
- WebApi: Frames
```

With the fix, all 391 tests pass across 30 consecutive runs.