### PR TITLE
handle Connection: close without TLS close_notify

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -858,7 +858,6 @@ fn processMessages(self: *Client) !bool {
         const is_conn_close_recv = blk: {
             const err = msg.err orelse break :blk false;
             if (err != error.RecvError) break :blk false;
-            if (!transfer._header_done_called) break :blk false;
             const hdr = msg.conn.getResponseHeader("connection", 0) orelse break :blk false;
             break :blk std.ascii.eqlIgnoreCase(hdr.value, "close");
         };


### PR DESCRIPTION
Some servers (e.g. ec.europa.eu) close the TCP connection without sending a TLS close_notify alert after responding with Connection: close. BoringSSL treats this as a fatal error, which libcurl surfaces as CURLE_RECV_ERROR. If we already received valid HTTP headers and the response included Connection: close, the connection closure is the expected end-of-body signal per HTTP/1.1 — treat it as success.

You can reproduce with
```
lightpanda fetch https://ec.europa.eu/commission/presscorner/detail/en/ip_26_614
```