### PR TITLE
CDP: implement Page.reload

### DIFF
--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -269,12 +269,8 @@ fn doReload(cmd: anytype) !void {
     const session = bc.session;
     var page = session.currentPage() orelse return error.PageNotLoaded;
 
-    // Copy URL to stack before replacePage() frees the old page's arena.
-    var url_buf: [8192:0]u8 = undefined;
-    const len = @min(page.url.len, url_buf.len);
-    @memcpy(url_buf[0..len], page.url[0..len]);
-    url_buf[len] = 0;
-    const reload_url: [:0]const u8 = url_buf[0..len :0];
+    // Dupe URL before replacePage() frees the old page's arena.
+    const reload_url = try cmd.arena.dupeZ(u8, page.url);
 
     if (page._load_state != .waiting) {
         page = try session.replacePage();
@@ -822,7 +818,7 @@ test "cdp.page: getLayoutMetrics" {
 }
 
 test "cdp.page: reload" {
-    var ctx = testing.context();
+    var ctx = try testing.context();
     defer ctx.deinit();
 
     {


### PR DESCRIPTION
## Summary

- Add `Page.reload` to the CDP Page domain dispatch enum
- Reuse the existing `page.navigate()` path with `NavigationKind.reload`, matching what `Location.reload` already does for the JS `location.reload()` API
- Accept standard CDP params (`ignoreCache`, `scriptToEvaluateOnLoad`) per the [Chrome DevTools Protocol spec](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-reload)
- Copy the current page URL to the stack before `replacePage()` to avoid a use-after-free when the old page's arena is freed

## Motivation

CDP clients (Puppeteer, capybara-lightpanda, Selenium, etc.) that call `Page.reload` currently get `UnknownMethod`. This forces workarounds like navigating to `location.href` (which creates a new history entry instead of a proper reload, and doesn't send `Cache-Control` headers).

The implementation is minimal (~30 lines) since all the infrastructure already exists: `NavigationKind.reload` is defined, `Location.reload` uses it via `scheduleNavigation`, and the `navigate` CDP handler provides the exact pattern to follow.

## Test plan

- [x] `Page.reload` dispatches correctly (enum + switch added)
- [ ] Existing CDP tests still pass (CI)
- [ ] Manual test: `Page.navigate` to a URL, then `Page.reload` triggers a reload navigation with the same URL

🤖 Generated with [Claude Code](https://claude.ai/code)