### PR TITLE
ci: don't run wba test on PR

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -179,6 +179,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    # Don't execute on PR
+    if: github.event_name != 'pull_request'
+
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
wba test requires secrets read to run.
But we don't want to exposes secrets on external contributions. So it's easier to run it only after PR merged.