### PR TITLE
mcp: extract parseOptionalAndGetPage helper

### DIFF
--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -827,12 +827,3 @@ fn testLoadPage(url: [:0]const u8, writer: *std.Io.Writer) !*Server {
     try runner.wait(.{ .ms = 2000 });
     return server;
 }
-    errdefer server.deinit();
-
-    const page = try server.session.createPage();
-    try page.navigate(url, .{});
-
-    var runner = try server.session.runner(.{});
-    try runner.wait(.{ .ms = 2000 });
-    return server;
-}


### PR DESCRIPTION
Deduplicate the repeated "parse optional URL, maybe navigate, get page" pattern across 6 MCP tool handlers (markdown, links, semantic_tree, interactiveElements, structuredData, detectForms).