### PR TITLE
fix: navigator.languages should include base language per spec

### DIFF
--- a/src/browser/tests/navigator/navigator.html
+++ b/src/browser/tests/navigator/navigator.html
@@ -15,8 +15,9 @@
   testing.expectEqual(true, validPlatforms.includes(navigator.platform));
   testing.expectEqual('en-US', navigator.language);
   testing.expectEqual(true, Array.isArray(navigator.languages));
-  testing.expectEqual(1, navigator.languages.length);
+  testing.expectEqual(2, navigator.languages.length);
   testing.expectEqual('en-US', navigator.languages[0]);
+  testing.expectEqual('en', navigator.languages[1]);
   testing.expectEqual(true, navigator.onLine);
   testing.expectEqual(true, navigator.cookieEnabled);
   testing.expectEqual(true, navigator.hardwareConcurrency > 0);

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -40,8 +40,8 @@ pub fn getUserAgent(_: *const Navigator, page: *Page) []const u8 {
     return page._session.browser.app.config.http_headers.user_agent;
 }
 
-pub fn getLanguages(_: *const Navigator) [1][]const u8 {
-    return .{"en-US"};
+pub fn getLanguages(_: *const Navigator) [2][]const u8 {
+    return .{ "en-US", "en" };
 }
 
 pub fn getPlatform(_: *const Navigator) []const u8 {


### PR DESCRIPTION
## Summary

`navigator.languages` currently returns `["en-US"]` (1 element). Per the [HTML spec](https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-languages) and real browser behavior (Chrome, Firefox, Safari), the preferred languages list should include the base language tag alongside the regional variant — i.e. `["en-US", "en"]`.

This improves compatibility with sites that perform language negotiation and expect the base language to be present.

## Changes

- `Navigator.getLanguages()` — return `["en-US", "en"]` instead of `["en-US"]`
- Updated navigator test to expect 2 languages

## Test plan

- [x] `zig fmt --check` passes
- [x] Navigator test updated to match new behavior
- [ ] `zig build test` (CI will verify)