### PR TITLE
Add missing InvalidAccessError DOMException mapping

### DIFF
--- a/src/browser/webapi/DOMException.zig
+++ b/src/browser/webapi/DOMException.zig
@@ -59,6 +59,7 @@ pub fn fromError(err: anyerror) ?DOMException {
         error.TimeoutError => .{ ._code = .timeout_error },
         error.InvalidNodeType => .{ ._code = .invalid_node_type_error },
         error.DataClone => .{ ._code = .data_clone_error },
+        error.InvalidAccessError => .{ ._code = .invalid_access_error },
         else => null,
     };
 }


### PR DESCRIPTION
Fixes WPT crash /WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.html