### PR TITLE
fix: handle scheme in path for resolving url with specific cases

### DIFF
--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -24,22 +24,6 @@ const ResolveOpts = struct {
     always_dupe: bool = false,
 };
 
-const scheme_full_separator = "://";
-const special_schemes = [_][]const u8{ "https", "http", "ws", "wss", "file", "ftp" };
-
-fn isSpecialScheme(scheme: []const u8) bool {
-    if (scheme.len == 0 or scheme.len > 5) {
-        return false;
-    }
-
-    inline for (special_schemes) |special_scheme| {
-        if (std.ascii.eqlIgnoreCase(scheme, special_scheme)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 // path is anytype, so that it can be used with both []const u8 and [:0]const u8
 pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, comptime opts: ResolveOpts) ![:0]const u8 {
     const PT = @TypeOf(source_path);
@@ -47,62 +31,43 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, c
     if (source_path.len == 0) {
         return processResolved(allocator, base, opts);
     }
-    const path_needs_duping = comptime isNullTerminated(PT) or !opts.always_dupe;
-    var path: [:0]const u8 = if (path_needs_duping) try allocator.dupeZ(u8, source_path) else source_path;
-    errdefer if (path_needs_duping) allocator.free(path);
+    var path: [:0]const u8 = if (comptime !isNullTerminated(PT) or opts.always_dupe) try allocator.dupeZ(u8, source_path) else source_path;
 
-    if (base.len == 0) {
+    if (base.len == 0 or isCompleteHTTPUrl(path)) {
         return processResolved(allocator, path, opts);
     }
 
-    // Minimum is "x://" and skip relative path
-    if (path.len > 3 and path[0] != '/') {
-        if (std.mem.startsWith(u8, path, "blob:") or std.mem.startsWith(u8, path, "data:")) {
-            return processResolved(allocator, path, opts);
-        }
+    scheme_check: {
+        // Minimum is "ws:x" and skip relative path (very common case)
+        if (path.len >= 4 and path[0] != '/') {
+            if (std.mem.indexOfScalar(u8, path[0..@min(path.len, 6)], ':')) |scheme_path_end| {
+                if (scheme_path_end <= 5) {
+                    const special_schemes = [_][]const u8{ "https", "http", "ws", "wss", "file", "ftp" };
 
-        var scheme_path: []const u8 = "";
-        var scheme_path_end: usize = 0;
+                    for (special_schemes) |special_scheme| {
+                        if (std.ascii.eqlIgnoreCase(path[0..scheme_path_end], special_scheme)) {
+                            const base_scheme_end = std.mem.indexOf(u8, base, "://") orelse 0;
 
-        if (std.mem.indexOf(u8, path, ":")) |scheme_end| {
-            scheme_path = path[0..scheme_end];
-            scheme_path_end = scheme_end;
-        }
+                            if (base_scheme_end > 0 and std.mem.eql(u8, base[0..base_scheme_end], path[0..scheme_path_end])) {
+                                //Skip ":" and exit as relative state
+                                path = path[scheme_path_end + 1 ..];
+                                break :scheme_check;
+                            } else {
+                                //Skip ":"
+                                var rest_start: usize = scheme_path_end + 1;
 
-        if (isSpecialScheme(scheme_path)) {
-            var scheme_base: []const u8 = "";
-
-            if (std.mem.indexOf(u8, base, scheme_full_separator)) |scheme_end| {
-                scheme_base = base[0..scheme_end];
-            }
-
-            const has_double_sleshes: bool = path[scheme_path_end + 1] == '/' and path[scheme_path_end + 2] == '/';
-
-            if (std.mem.eql(u8, scheme_base, scheme_path) and !has_double_sleshes) {
-                //Skip ":" and set relative state
-                path = path[scheme_path_end + 1 ..];
-            } else {
-                //Skip ":"
-                var path_start: usize = scheme_path_end + 1;
-                var host_file_separator: []const u8 = "";
-
-                //file scheme allow empty host
-                if (std.mem.eql(u8, scheme_path, "file") and !has_double_sleshes) {
-                    host_file_separator = "/";
-                }
-
-                //Skip any sleshes after "scheme:"
-                for (path[path_start..]) |char| {
-                    if (char == '/' or char == '\\') {
-                        path_start += 1;
-                    } else {
-                        break;
+                                //file scheme allow empty host
+                                const separator: []const u8 = if (std.ascii.eqlIgnoreCase(path[0..scheme_path_end], "file")) ":///" else "://";
+                                //Skip any sleshes after "scheme:"
+                                while (rest_start < path.len and (path[rest_start] == '/' or path[rest_start] == '\\')) {
+                                    rest_start += 1;
+                                }
+                                path = try std.mem.joinZ(allocator, "", &.{ path[0..scheme_path_end], separator, path[rest_start..] });
+                                return try processResolved(allocator, path, opts);
+                            }
+                        }
                     }
                 }
-                path = try std.mem.joinZ(allocator, "", &.{ scheme_path, scheme_full_separator, host_file_separator, path[path_start..] });
-                errdefer allocator.free(path);
-
-                return try processResolved(allocator, path, opts);
             }
         }
     }
@@ -110,16 +75,12 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, c
     if (path[0] == '?') {
         const base_path_end = std.mem.indexOfAny(u8, base, "?#") orelse base.len;
         const result = try std.mem.joinZ(allocator, "", &.{ base[0..base_path_end], path });
-        errdefer allocator.free(result);
-
-        return try processResolved(allocator, result, opts);
+        return processResolved(allocator, result, opts);
     }
     if (path[0] == '#') {
         const base_fragment_start = std.mem.indexOfScalar(u8, base, '#') orelse base.len;
         const result = try std.mem.joinZ(allocator, "", &.{ base[0..base_fragment_start], path });
-        errdefer allocator.free(result);
-        
-        return try processResolved(allocator, result, opts);
+        return processResolved(allocator, result, opts);
     }
 
     if (std.mem.startsWith(u8, path, "//")) {
@@ -129,20 +90,16 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, c
         };
         const protocol = base[0 .. index + 1];
         const result = try std.mem.joinZ(allocator, "", &.{ protocol, path });
-        errdefer allocator.free(result);
-
-        return try processResolved(allocator, result, opts);
+        return processResolved(allocator, result, opts);
     }
 
-    const scheme_end = std.mem.indexOf(u8, base, scheme_full_separator);
+    const scheme_end = std.mem.indexOf(u8, base, "://");
     const authority_start = if (scheme_end) |end| end + 3 else 0;
     const path_start = std.mem.indexOfScalarPos(u8, base, authority_start, '/') orelse base.len;
 
     if (path[0] == '/') {
         const result = try std.mem.joinZ(allocator, "", &.{ base[0..path_start], path });
-        errdefer allocator.free(result);
-
-        return try processResolved(allocator, result, opts);
+        return processResolved(allocator, result, opts);
     }
 
     var normalized_base: []const u8 = base[0..path_start];
@@ -155,8 +112,7 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, c
     // trailing space so that we always have space to append the null terminator
     // and so that we can compare the next two characters without needing to length check
     var out = try std.mem.join(allocator, "", &.{ normalized_base, "/", path, "  " });
-    errdefer allocator.free(out);
-    
+
     const end = out.len - 2;
 
     const path_marker = path_start + 1;
@@ -217,7 +173,7 @@ fn processResolved(allocator: Allocator, url: [:0]const u8, comptime opts: Resol
 }
 
 pub fn ensureEncoded(allocator: Allocator, url: [:0]const u8) ![:0]const u8 {
-    const scheme_end = std.mem.indexOf(u8, url, scheme_full_separator);
+    const scheme_end = std.mem.indexOf(u8, url, "://");
     const authority_start = if (scheme_end) |end| end + 3 else 0;
     const path_start = std.mem.indexOfScalarPos(u8, url, authority_start, '/') orelse return url;
 
@@ -386,7 +342,7 @@ pub fn getPassword(raw: [:0]const u8) []const u8 {
 }
 
 pub fn getPathname(raw: [:0]const u8) []const u8 {
-    const protocol_end = std.mem.indexOf(u8, raw, scheme_full_separator);
+    const protocol_end = std.mem.indexOf(u8, raw, "://");
 
     // Handle scheme:path URLs like about:blank (no "://")
     if (protocol_end == null) {
@@ -469,7 +425,7 @@ pub fn getHash(raw: [:0]const u8) []const u8 {
 }
 
 pub fn getOrigin(allocator: Allocator, raw: [:0]const u8) !?[]const u8 {
-    const scheme_end = std.mem.indexOf(u8, raw, scheme_full_separator) orelse return null;
+    const scheme_end = std.mem.indexOf(u8, raw, "://") orelse return null;
 
     // Only HTTP and HTTPS schemes have origins
     const protocol = raw[0 .. scheme_end + 1];
@@ -527,7 +483,7 @@ fn getUserInfo(raw: [:0]const u8) ?[]const u8 {
     if (!auth.has_user_info) return null;
 
     // User info is from authority_start to host_start - 1 (excluding the @)
-    const scheme_end = std.mem.indexOf(u8, raw, scheme_full_separator).?;
+    const scheme_end = std.mem.indexOf(u8, raw, "://").?;
     const authority_start = scheme_end + 3;
     return raw[authority_start .. auth.host_start - 1];
 }
@@ -828,7 +784,7 @@ const AuthorityInfo = struct {
 // SECURITY: Only looks for @ within the authority portion (before /?#)
 // to prevent path-based @ injection attacks.
 fn parseAuthority(raw: []const u8) ?AuthorityInfo {
-    const scheme_end = std.mem.indexOf(u8, raw, scheme_full_separator) orelse return null;
+    const scheme_end = std.mem.indexOf(u8, raw, "://") orelse return null;
     const authority_start = scheme_end + 3;
 
     // Find end of authority FIRST (start of path/query/fragment or end of string)
@@ -1024,100 +980,6 @@ test "URL: resolve" {
             .base = "https://www.example.com/hello/world/",
             .path = "../../../../example/about",
             .expected = "https://www.example.com/example/about",
-        },
-    };
-
-    for (cases) |case| {
-        const result = try resolve(testing.arena_allocator, case.base, case.path, .{});
-        try testing.expectString(case.expected, result);
-    }
-}
-
-test "URL: resolve path scheme" {
-    const Case = struct {
-        base: [:0]const u8,
-        path: [:0]const u8,
-        expected: [:0]const u8,
-    };
-
-    const cases = [_]Case{
-        //same schemes and path as relative path (one slash)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "https:/about",
-            .expected = "https://www.example.com/about",
-        },
-        //same schemes and path as relative path (without slash)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "https:about",
-            .expected = "https://www.example.com/about",
-        },
-        //same schemes and path as absolute path (two slashes)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "https://about",
-            .expected = "https://about",
-        },
-        //different schemes and path as absolute (without slash)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "http:about",
-            .expected = "http://about",
-        },
-        //different schemes and path as absolute (with one slash)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "http:/about",
-            .expected = "http://about",
-        },
-        //different schemes and path as absolute (with two slashes)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "http://about",
-            .expected = "http://about",
-        },
-        //same schemes and path as absolute (with more slashes)
-        .{
-            .base = "https://site/",
-            .path = "https://path",
-            .expected = "https://path",
-        },
-        //path scheme is not special and path as absolute (without additional slashes)
-        .{
-            .base = "http://localhost/",
-            .path = "data:test",
-            .expected = "data:test",
-        },
-        //different schemes and path as absolute (pathscheme=ws)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "ws://about",
-            .expected = "ws://about",
-        },
-        //different schemes and path as absolute (path scheme=wss)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "wss://about",
-            .expected = "wss://about",
-        },
-        //different schemes and path as absolute (path scheme=ftp)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "ftp://about",
-            .expected = "ftp://about",
-        },
-        //different schemes and path as absolute (path scheme=file)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "file://path/to/file",
-            .expected = "file://path/to/file",
-        },
-        //different schemes and path as absolute (path scheme=file, host is empty)
-        .{
-            .base = "https://www.example.com/example",
-            .path = "file:/path/to/file",
-            .expected = "file:///path/to/file",
         },
     };
 
@@ -1723,5 +1585,139 @@ test "URL: getOrigin" {
         } else {
             try testing.expectEqual(null, result);
         }
+    }
+}
+
+test "URL: resolve path scheme" {
+    const Case = struct {
+        base: [:0]const u8,
+        path: [:0]const u8,
+        expected: [:0]const u8,
+    };
+
+    const cases = [_]Case{
+        //same schemes and path as relative path (one slash)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https:/about",
+            .expected = "https://www.example.com/about",
+        },
+        //same schemes and path as relative path (without slash)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https:about",
+            .expected = "https://www.example.com/about",
+        },
+        //same schemes and path as absolute path (two slashes)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https://about",
+            .expected = "https://about",
+        },
+        //different schemes and path as absolute (without slash)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "http:about",
+            .expected = "http://about",
+        },
+        //different schemes and path as absolute (with one slash)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "http:/about",
+            .expected = "http://about",
+        },
+        //different schemes and path as absolute (with two slashes)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "http://about",
+            .expected = "http://about",
+        },
+        //same schemes and path as absolute (with more slashes)
+        .{
+            .base = "https://site/",
+            .path = "https://path",
+            .expected = "https://path",
+        },
+        //path scheme is not special and path as absolute (without additional slashes)
+        .{
+            .base = "http://localhost/",
+            .path = "data:test",
+            .expected = "data:test",
+        },
+        //different schemes and path as absolute (pathscheme=ws)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "ws://about",
+            .expected = "ws://about",
+        },
+        //different schemes and path as absolute (path scheme=wss)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "wss://about",
+            .expected = "wss://about",
+        },
+        //different schemes and path as absolute (path scheme=ftp)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "ftp://about",
+            .expected = "ftp://about",
+        },
+        //different schemes and path as absolute (path scheme=file)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "file://path/to/file",
+            .expected = "file://path/to/file",
+        },
+        //different schemes and path as absolute (path scheme=file, host is empty)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "file:/path/to/file",
+            .expected = "file:///path/to/file",
+        },
+        .{
+            .base = "https://www.example.com/example",
+            .path = "file:path/to/file",
+            .expected = "file:///path/to/file",
+        },
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https:/file:/relative/path/",
+            .expected = "https://www.example.com/file:/relative/path/",
+        },
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https:/http://relative/path/",
+            .expected = "https://www.example.com/http://relative/path/",
+        },
+        .{
+            .base = "http://www.example.com/example",
+            .path = "http:http:/relative/path/",
+            .expected = "http://www.example.com/http:/relative/path/",
+        },
+        .{
+            .base = "http://www.example.com/example",
+            .path = "http:relative:path",
+            .expected = "http://www.example.com/relative:path",
+        },
+        .{
+            .base = "https://www.example.com/example",
+            .path = "https:/http://relative/path/",
+            .expected = "https://www.example.com/http://relative/path/",
+        },
+        .{
+            .base = "http://www.example.com/example",
+            .path = "http:http:/relative/path/",
+            .expected = "http://www.example.com/http:/relative/path/",
+        },
+        .{
+            .base = "http://www.example.com/example",
+            .path = "http:https://relative:path",
+            .expected = "http://www.example.com/https://relative:path",
+        },
+    };
+
+    for (cases) |case| {
+        const result = try resolve(testing.arena_allocator, case.base, case.path, .{});
+        try testing.expectString(case.expected, result);
     }
 }

--- a/test.html
+++ b/test.html
@@ -1,0 +1,175 @@
+<div style="font-size: 13px; font-family: Arial, Helvetica, Verdana, sans-serif">
+    <div dir="ltr" class="es-wrapper-color" lang="en" style="background-color: rgb(246, 246, 246)">
+        <table width="100%" cellspacing="0" cellpadding="0" class="es-wrapper" role="none" style="border-spacing: 0px; padding: 0px; margin: 0px; width: 100%; height: 100%; background-color: rgb(246, 246, 246); max-width: 100%">
+            <tbody>
+                <tr>
+                    <td valign="top" style="padding: 0; Margin: 0">
+                        <table cellspacing="0" cellpadding="0" align="center" class="es-header" role="none" style="border-spacing: 0px; width: 100%; background-color: transparent; table-layout: fixed !important; max-width: 100%">
+                            <tbody>
+                                <tr>
+                                    <td align="center" style="padding: 0; Margin: 0">
+                                        <table cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center" class="es-header-body" role="none" style="border-spacing: 0px; background-color: rgb(255, 255, 255); width: 600px; max-width: 100%">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="left" bgcolor="#1376c8" style="Margin: 0; padding-top: 5px; padding-right: 20px; padding-bottom: 5px; padding-left: 20px; background-color: rgb(19, 118, 200)">
+                                                        <table cellspacing="0" cellpadding="0" align="right" class="es-right" role="none" style="border-spacing: 0px; float: right; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="left" style="padding: 0; Margin: 0; width: 560px">
+                                                                        <table width="100%" cellspacing="0" cellpadding="0" bgcolor="#3d85c6" style="border-spacing: 0px; background-color: rgb(19, 118, 200); max-width: 100%" role="presentation">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="center" style="padding: 0; Margin: 0">
+                                                                                        <h5 style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; letter-spacing: 0; font-size: 20px; font-style: normal; font-weight: normal; line-height: 24px; color: rgb(255, 255, 255)">A HEALTH FIRST COMPANY</h5>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table cellspacing="0" cellpadding="0" align="center" class="es-content" role="none" style="border-spacing: 0px; width: 100%; table-layout: fixed !important; max-width: 100%">
+                            <tbody>
+                                <tr>
+                                    <td align="center" style="padding: 0; Margin: 0">
+                                        <table cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center" class="es-content-body" role="none" style="border-spacing: 0px; background-color: rgb(255, 255, 255); width: 600px; max-width: 100%">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="left" style="padding: 0; Margin: 0; padding-right: 20px; padding-left: 20px; padding-top: 20px">
+                                                        <table width="100%" cellspacing="0" cellpadding="0" role="none" style="border-spacing: 0px; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td valign="top" align="center" style="padding: 0; Margin: 0; width: 560px">
+                                                                        <table width="100%" cellspacing="0" cellpadding="0" role="presentation" style="border-spacing: 0px; max-width: 100%">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="center" style="padding: 0; Margin: 0; font-size: 0"><img src="https://crm.zoho.com/crm/viewInLineImage?fileContent=b67f7f7680e79b32fd88dfd4c61f5f2d3eb2d531182efff8ff5cace6ef4c0a218e8147295566868eea836834273f6ee717a73358140f988584f25d0a2101513c4fd64f5acca10e1eaecf07c96ae392dd982a893120d9b62db27f72ff00c8efc3" alt="" width="158" style="display: block; font-size: 14px; border: 0px; outline: none; text-decoration: none; margin: 0px; max-width: 100%"></td>
+                                                                                </tr>
+                                                                                <tr>
+                                                                                    <td align="left" style="padding: 0; Margin: 0">
+                                                                                        <p style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 21px; letter-spacing: 0; color: rgb(51, 51, 51); font-size: 14px"><br></p>
+                                                                                        <p style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 21px; letter-spacing: 0; color: rgb(51, 51, 51); font-size: 14px">{YOUR CONTENT}<br></p>
+                                                                                        <div><br></div>
+                                                                                        <div style="overflow: hidden;">
+                                                                                            <p style="Margin: 0; margin-left: -40px; padding: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 21px; letter-spacing: 0; color: rgb(51, 51, 51); font-size: 14px; text-align: left"><a rel="noopener noreferrer" target="_blank" href="https://salesiq.zohopublic.com/signaturesupport.ls?widgetcode=siq4126af14cc7718d65ebca24d2529a6f9a119fdac18e32f3e5843947bb2401256e2ad576e927e5074dc940b09b8ce39de"><img style="max-width: 100%; display: block; margin: 0px; padding: 0px; border: 0px; height: auto;" src="https://salesiq.zohopublic.com/visitor/v2/channels/emailsignature/sticker?widgetcode=siq4126af14cc7718d65ebca24d2529a6f9a119fdac18e32f3e5843947bb2401256e2ad576e927e5074dc940b09b8ce39de" data-zdeskdocid="img_8188904808242549" class="docsimage" data-zdeskdocselectedclass="original"></a></p>
+                                                                                        </div>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table cellspacing="0" cellpadding="0" align="center" class="es-footer" role="none" style="border-spacing: 0px; width: 100%; background-color: transparent; table-layout: fixed !important; max-width: 100%">
+                            <tbody>
+                                <tr>
+                                    <td align="center" style="padding: 0; Margin: 0">
+                                        <table cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center" class="es-footer-body" role="none" style="border-spacing: 0px; background-color: rgb(255, 255, 255); width: 600px; max-width: 100%">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="left" bgcolor="#1376c8" style="padding: 0; Margin: 0; padding-right: 20px; padding-left: 20px; padding-top: 20px; background-color: rgb(19, 118, 200)">
+                                                        <table cellspacing="0" align="left" cellpadding="0" class="es-left" role="none" style="border-spacing: 0px; float: left; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="left" class="es-m-p20b" style="padding: 0; Margin: 0; width: 206px">
+                                                                        <table cellpadding="0" cellspacing="0" role="presentation" width="100%" style="border-spacing: 0px; max-width: 100%">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="left" class="es-text-1824" style="padding: 0; Margin: 0">
+                                                                                        <p class="es-text-mobile-size-16" style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 16px; letter-spacing: 0; color: rgb(255, 255, 255); font-size: 16px"><a rel="noopener noreferrer" href="https://vitaalhealth.com/terms-of-service" target="_blank" style="text-decoration: none; color: rgb(255, 255, 255); font-size: 16px; line-height: 16px">Terms of Service</a></p>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                    <td class="es-hidden" style="padding: 0; Margin: 0; width: 20px"></td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                        <table align="left" cellpadding="0" cellspacing="0" class="es-left" role="none" style="border-spacing: 0px; float: left; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="left" style="padding: 0; Margin: 0; width: 156px">
+                                                                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-spacing: 0px; max-width: 100%">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="left" class="es-text-9626 es-m-p20b" style="padding: 0; Margin: 0">
+                                                                                        <p class="es-text-mobile-size-16" style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 16px; letter-spacing: 0; color: rgb(255, 255, 255); font-size: 16px"><a rel="noopener noreferrer" href="https://vitaalhealth.com/safety-information" target="_blank" style="text-decoration: none; color: rgb(255, 255, 255); font-size: 16px; line-height: 16px">Safety Information</a></p>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                        <table cellpadding="0" cellspacing="0" align="right" class="es-right" role="none" style="border-spacing: 0px; float: right; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="left" class="es-m-p20b" style="padding: 0; Margin: 0; width: 158px">
+                                                                        <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-spacing: 0px; max-width: 100%">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="left" class="es-text-9209" style="padding: 0; Margin: 0">
+                                                                                        <p class="es-text-mobile-size-16" style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 16px; letter-spacing: 0; color: rgb(255, 255, 255); font-size: 16px"><a rel="noopener noreferrer" target="_blank" href="https://vitaalhealth.com/privacy-policy" style="text-decoration: none; color: rgb(255, 255, 255); font-size: 16px; line-height: 16px">Privacy Policy</a></p>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td align="left" bgcolor="#1376c8" style="Margin: 0; padding-top: 5px; padding-right: 20px; padding-bottom: 5px; padding-left: 20px; background-color: rgb(19, 118, 200)">
+                                                        <table width="100%" cellpadding="0" cellspacing="0" role="none" style="border-spacing: 0px; max-width: 100%">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="left" style="padding: 0; Margin: 0; width: 560px">
+                                                                        <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-spacing: 0px; max-width: 100%">
+                                                                            <tbody>
+                                                                                <tr>
+                                                                                    <td align="left" class="es-text-3652" style="padding: 0; Margin: 0">
+                                                                                        <p class="es-text-mobile-size-16" style="Margin: 0; font-family: arial, &quot;helvetica neue&quot;, helvetica, sans-serif; line-height: 24px; letter-spacing: 0; color: rgb(255, 255, 255); font-size: 16px">Copyright ©2026 Vitäal Health, LLC. All rights reserved.</p>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
Fix related to issue: https://github.com/lightpanda-io/browser/issues/1994
Changes based on [https://url.spec.whatwg.org/](Spec) .
**Relevant sections:**
- https://url.spec.whatwg.org/#special-scheme
- https://url.spec.whatwg.org/#scheme-state (section 5 and 6)
- https://url.spec.whatwg.org/#special-relative-or-authority-state
See examples in test cases.
**Important**:
The current algorithm working for special schemes and only specific non-special schemes ( blob: and data:). At the moment, I haven’t found any other commonly used **custom** schemes.