### PR TITLE
docs: add SECURITY.md for responsible disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Lightpanda Browser, please report
+it responsibly through [GitHub Security Advisories](https://github.com/lightpanda-io/browser/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.
+
+## What to Include
+
+- A description of the vulnerability
+- Steps to reproduce
+- Affected versions or commits, if known
+
+## Response
+
+We will acknowledge receipt and provide an initial assessment as soon as
+possible. We aim to release a fix promptly after confirming the issue.


### PR DESCRIPTION
Adds a SECURITY.md that directs vulnerability reports to GitHub Security Advisories instead of public issues.

Includes guidance on what to include in a report and a note on response expectations. Matches the tone of the existing CONTRIBUTING.md and LICENSING.md.

This contribution was developed with AI assistance (Claude Code).

Fixes #2018