### PR TITLE
fix(cdp): auto-close existing target on createTarget

### DIFF
--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -471,6 +471,10 @@ fn doCloseTarget(cmd: anytype, bc: anytype) !void {
         bc.session_id = null;
     }
 
+    try cmd.sendEvent("Target.targetDestroyed", .{
+        .targetId = &bc.target_id.?,
+    }, .{});
+
     bc.session.removePage();
     for (bc.isolated_worlds.items) |world| {
         world.deinit();
@@ -657,6 +661,7 @@ test "cdp.target: closeTarget" {
     {
         try ctx.processMessage(.{ .id = 11, .method = "Target.closeTarget", .params = .{ .targetId = "TID-000000000A" } });
         try ctx.expectSentResult(.{ .success = true }, .{ .id = 11 });
+        try ctx.expectSentEvent("Target.targetDestroyed", .{ .targetId = "TID-000000000A" }, .{});
         try testing.expectEqual(null, bc.session.page);
         try testing.expectEqual(null, bc.target_id);
     }
@@ -794,6 +799,7 @@ test "cdp.target: createTarget closes existing target (issue #1962)" {
 
         // Create second target — should succeed by auto-closing the first
         try ctx.processMessage(.{ .id = 11, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        try ctx.expectSentEvent("Target.targetDestroyed", .{ .targetId = "FID-0000000001" }, .{});
         try testing.expectEqual(true, bc.target_id != null);
         try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 11 });
 
@@ -821,6 +827,7 @@ test "cdp.target: createTarget closes existing attached target (issue #1962)" {
         // Should have sent detach events for the old session
         try ctx.expectSentEvent("Inspector.detached", .{ .reason = "Render process gone." }, .{ .session_id = session_id });
         try ctx.expectSentEvent("Target.detachedFromTarget", .{ .sessionId = session_id, .reason = "Render process gone." }, .{});
+        try ctx.expectSentEvent("Target.targetDestroyed", .{ .targetId = "FID-0000000001" }, .{});
         // New target should be created
         try testing.expectEqual(true, bc.target_id != null);
         try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 12 });

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -158,13 +158,18 @@ fn createTarget(cmd: anytype) !void {
         else => return err,
     };
 
-    if (bc.target_id != null) {
-        return error.TargetAlreadyLoaded;
-    }
     if (params.browserContextId) |param_browser_context_id| {
         if (std.mem.eql(u8, param_browser_context_id, bc.id) == false) {
             return error.UnknownBrowserContextId;
         }
+    }
+
+    // If a target already exists, close it first. Lightpanda only supports
+    // one page at a time, so we replace the existing target rather than
+    // rejecting the request. This unblocks automation frameworks (e.g.
+    // Stagehand) that call createTarget multiple times.
+    if (bc.target_id != null) {
+        try doCloseTarget(cmd, bc);
     }
 
     // if target_id is null, we should never have a page
@@ -280,34 +285,9 @@ fn closeTarget(cmd: anytype) !void {
         return error.UnknownTargetId;
     }
 
-    // can't be null if we have a target_id
-    lp.assert(bc.session.page != null, "CDP.target.closeTarget null page", .{});
-
     try cmd.sendResult(.{ .success = true }, .{ .include_session_id = false });
 
-    // could be null, created but never attached
-    if (bc.session_id) |session_id| {
-        // Inspector.detached event
-        try cmd.sendEvent("Inspector.detached", .{
-            .reason = "Render process gone.",
-        }, .{ .session_id = session_id });
-
-        // detachedFromTarget event
-        try cmd.sendEvent("Target.detachedFromTarget", .{
-            .targetId = target_id,
-            .sessionId = session_id,
-            .reason = "Render process gone.",
-        }, .{});
-
-        bc.session_id = null;
-    }
-
-    bc.session.removePage();
-    for (bc.isolated_worlds.items) |world| {
-        world.deinit();
-    }
-    bc.isolated_worlds.clearRetainingCapacity();
-    bc.target_id = null;
+    try doCloseTarget(cmd, bc);
 }
 
 fn getTargetInfo(cmd: anytype) !void {
@@ -466,6 +446,37 @@ fn setAutoAttach(cmd: anytype) !void {
     }, .{});
 
     try cmd.sendResult(null, .{});
+}
+
+/// Close the current target in a browser context: send detach events,
+/// remove the page, clean up isolated worlds, and clear the target_id.
+/// Shared by closeTarget and createTarget (which auto-closes before
+/// creating a replacement).
+fn doCloseTarget(cmd: anytype, bc: anytype) !void {
+    // can't be null if we have a target_id
+    lp.assert(bc.session.page != null, "CDP.target.doCloseTarget null page", .{});
+
+    // could be null, created but never attached
+    if (bc.session_id) |session_id| {
+        try cmd.sendEvent("Inspector.detached", .{
+            .reason = "Render process gone.",
+        }, .{ .session_id = session_id });
+
+        try cmd.sendEvent("Target.detachedFromTarget", .{
+            .targetId = &bc.target_id.?,
+            .sessionId = session_id,
+            .reason = "Render process gone.",
+        }, .{});
+
+        bc.session_id = null;
+    }
+
+    bc.session.removePage();
+    for (bc.isolated_worlds.items) |world| {
+        world.deinit();
+    }
+    bc.isolated_worlds.clearRetainingCapacity();
+    bc.target_id = null;
 }
 
 fn doAttachtoTarget(cmd: anytype, target_id: []const u8) !void {
@@ -768,6 +779,51 @@ test "cdp.target: detachFromTarget" {
 
         try ctx.processMessage(.{ .id = 13, .method = "Target.attachToTarget", .params = .{ .targetId = bc.target_id.? } });
         try ctx.expectSentResult(.{ .sessionId = bc.session_id.? }, .{ .id = 13 });
+    }
+}
+
+test "cdp.target: createTarget closes existing target (issue #1962)" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9" });
+    {
+        // Create first target
+        try ctx.processMessage(.{ .id = 10, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        try testing.expectEqual(true, bc.target_id != null);
+        try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 10 });
+
+        // Create second target — should succeed by auto-closing the first
+        try ctx.processMessage(.{ .id = 11, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        try testing.expectEqual(true, bc.target_id != null);
+        try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 11 });
+
+        // Page should exist (new target is active)
+        try testing.expectEqual(true, bc.session.page != null);
+    }
+}
+
+test "cdp.target: createTarget closes existing attached target (issue #1962)" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9" });
+    {
+        // Create and attach first target
+        try ctx.processMessage(.{ .id = 10, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        try testing.expectEqual(true, bc.target_id != null);
+        try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 10 });
+
+        try ctx.processMessage(.{ .id = 11, .method = "Target.attachToTarget", .params = .{ .targetId = bc.target_id.? } });
+        const session_id = bc.session_id.?;
+        try ctx.expectSentResult(.{ .sessionId = session_id }, .{ .id = 11 });
+
+        // Create second target — should close and detach the first
+        try ctx.processMessage(.{ .id = 12, .method = "Target.createTarget", .params = .{ .browserContextId = "BID-9" } });
+        // Should have sent detach events for the old session
+        try ctx.expectSentEvent("Inspector.detached", .{ .reason = "Render process gone." }, .{ .session_id = session_id });
+        try ctx.expectSentEvent("Target.detachedFromTarget", .{ .sessionId = session_id, .reason = "Render process gone." }, .{});
+        // New target should be created
+        try testing.expectEqual(true, bc.target_id != null);
+        try ctx.expectSentResult(.{ .targetId = bc.target_id.? }, .{ .id = 12 });
     }
 }
 


### PR DESCRIPTION
When `Target.createTarget` is called and a target already exists in the browser context, the existing target is now automatically closed and detached instead of returning a `TargetAlreadyLoaded` error. This unblocks automation frameworks (like Stagehand) that call `createTarget` multiple times sequentially.

Note: this does not add concurrent multi-tab support; Lightpanda still supports one page per connection. The existing target is replaced, not kept alongside the new one.

Addresses #1962
