### PR TITLE
fix: url resolve path scheme

### DIFF
--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -58,12 +58,12 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, c
                                 while (rest_start < path.len and (path[rest_start] == '/' or path[rest_start] == '\\')) {
                                     rest_start += 1;
                                 }
-                                //special scheme need to any symbols after "://"
-                                if (rest_start >= path.len) {
-                                    return error.InvalidURL;
+                                // A special scheme (exclude "file") must contain at least anu chars after "://"
+                                if (rest_start == path.len and !std.ascii.eqlIgnoreCase(scheme_path, "file")) {
+                                    return error.TypeError;
                                 }
                                 //File scheme allow empty host
-                                const separator: []const u8 = if (std.ascii.eqlIgnoreCase(scheme_path, "file") and !has_double_slashas) ":///" else "://";
+                                const separator: []const u8 = if (!has_double_slashas and std.ascii.eqlIgnoreCase(scheme_path, "file")) ":///" else "://";
 
                                 path = try std.mem.joinZ(allocator, "", &.{ scheme_path, separator, path[rest_start..] });
                                 return processResolved(allocator, path, opts);
@@ -1694,6 +1694,12 @@ test "URL: resolve path scheme" {
             .path = "file:/path/to/file",
             .expected = "file:///path/to/file",
         },
+        //different schemes and path as absolute (path scheme=file, host is empty)
+        .{
+            .base = "https://www.example.com/example",
+            .path = "file:/",
+            .expected = "file:///",
+        },
         //different schemes without :// and normalize "file" scheme, absolute path
         .{
             .base = "https://www.example.com/example",
@@ -1712,13 +1718,13 @@ test "URL: resolve path scheme" {
             .path = "https:/http://relative/path/",
             .expected = "https://www.example.com/http://relative/path/",
         },
-         //same schemes without :// in path , relative state
+        //same schemes without :// in path , relative state
         .{
             .base = "http://www.example.com/example",
             .path = "http:relative:path",
             .expected = "http://www.example.com/relative:path",
         },
-         //repeat different schemes in path
+        //repeat different schemes in path
         .{
             .base = "http://www.example.com/example",
             .path = "http:http:/relative/path/",
@@ -1770,15 +1776,12 @@ test "URL: resolve path scheme" {
     };
 
     for (cases) |case| {
-        const result = resolve(testing.arena_allocator, case.base, case.path, .{}) catch |err| {
-            if (err == error.InvalidURL) {
-                try testing.expect(case.expected_error);
-                continue;
-            }
-
-            return err;
-        };
-
-        try testing.expectString(case.expected, result);
+        if (case.expected_error) {
+            const result = resolve(testing.arena_allocator, case.base, case.path, .{});
+            try testing.expectError(error.TypeError, result);
+        } else {
+            const result = try resolve(testing.arena_allocator, case.base, case.path, .{});
+            try testing.expectString(case.expected, result);
+        }
     }
 }

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -750,7 +750,6 @@ const CloneError = error{
     TypeError,
     CompilationError,
     JsException,
-    InvalidURL,
 };
 pub fn cloneNode(self: *Node, deep_: ?bool, page: *Page) CloneError!*Node {
     const deep = deep_ orelse false;


### PR DESCRIPTION
Fix related to issue: https://github.com/lightpanda-io/browser/issues/1994
Path url with a scheme can be resolve as absolute URLs or as relative paths, depending on the context.
General example:
1. base = https://host/a | path = https:/b | url = https://host/b (same schemes and resolve path as relative)
2. base = https://host/a | path = http:/b | url = http://b (different schemes and resolve path as absolute)

See more examples in test cases.

Changes based on [https://url.spec.whatwg.org/](Spec) .
**Relevant sections:**
- https://url.spec.whatwg.org/#special-scheme
- https://url.spec.whatwg.org/#scheme-state (section 5 and 6)
- https://url.spec.whatwg.org/#special-relative-or-authority-state