### PR TITLE
fix: handle null pointer from GetAlignedPointerFromInternalField to prevent SIGSEGV

### DIFF
--- a/src/browser/js/Inspector.zig
+++ b/src/browser/js/Inspector.zig
@@ -368,7 +368,9 @@ pub fn getTaggedOpaque(value: *const v8.Value) ?*TaggedOpaque {
         return null;
     }
 
-    const tao_ptr = v8.v8__Object__GetAlignedPointerFromInternalField(value, 0).?;
+    const tao_ptr = v8.v8__Object__GetAlignedPointerFromInternalField(value, 0) orelse {
+        return null;
+    };
     return @ptrCast(@alignCast(tao_ptr));
 }
 

--- a/src/browser/js/TaggedOpaque.zig
+++ b/src/browser/js/TaggedOpaque.zig
@@ -106,7 +106,9 @@ pub fn fromJS(comptime R: type, js_obj_handle: *const v8.Object) !R {
         @compileError("unknown Zig type: " ++ @typeName(R));
     }
 
-    const tao_ptr = v8.v8__Object__GetAlignedPointerFromInternalField(js_obj_handle, 0).?;
+    const tao_ptr = v8.v8__Object__GetAlignedPointerFromInternalField(js_obj_handle, 0) orelse {
+        return error.InvalidArgument;
+    };
     const tao: *TaggedOpaque = @ptrCast(@alignCast(tao_ptr));
     const expected_type_index = bridge.JsApiLookup.getId(JsApi);
 


### PR DESCRIPTION
`v8__Object__GetAlignedPointerFromInternalField` can return null even when `InternalFieldCount > 0` — for example when a JS library passes objects whose internal fields are allocated but not yet initialized.

The previous code used `.?` (unsafe unwrap) on the return value, which panics on null and causes SIGSEGV. This replaces `.?` with `orelse` to gracefully handle null:

- **TaggedOpaque.zig**: returns `error.InvalidArgument` (same pattern as the `internal_field_count == 0` check above)
- **Inspector.zig**: returns `null` (matches the function's `?*TaggedOpaque` return type and existing null returns)

## Use case

I'm building a browser automation tool for [wishket.com](https://www.wishket.com/) (a Korean freelancing platform) using Lightpanda's CDP server with Playwright. Lightpanda crashes with SIGSEGV every time it loads the site because wishket.com includes Sentry's `bundle.tracing.min.js`, which extensively probes DOM APIs and passes objects that trigger the null pointer path.

## Minimal reproduction

```javascript
// test-sigsegv.mjs — requires: playwright-core
import { spawn } from 'child_process';
import { chromium } from 'playwright-core';

const proc = spawn('lightpanda', [
  'serve', '--host', '127.0.0.1', '--port', '9222',
  '--log-level', 'warn', '--timeout', '30',
], { stdio: ['ignore', 'pipe', 'pipe'] });

proc.stderr.on('data', d => process.stderr.write(d));
proc.on('exit', (code, signal) => console.log(`EXIT code=${code} signal=${signal}`));
await new Promise(r => setTimeout(r, 2000));

const browser = await chromium.connectOverCDP('ws://127.0.0.1:9222');
const ctx = await browser.newContext({});
const page = await ctx.newPage();

// Crashes with SIGSEGV
await page.goto('https://www.wishket.com/', { timeout: 15000, waitUntil: 'domcontentloaded' });

await page.close();
await ctx.close();
await browser.close();
proc.kill();
```

## Workaround

Blocking tracking scripts via `page.route()` prevents the crash:

```javascript
const BLOCK = ['sentry-cdn.com', 'clarity.ms', 'googletagmanager.com',
  'googleoptimize.com', 'doubleclick.net', 'channel.io'];
await page.route(u => BLOCK.some(d => u.toString().includes(d)), r => r.abort());
await page.goto('https://www.wishket.com/', { timeout: 15000, waitUntil: 'domcontentloaded' });
// Works — title: "대한민국 대표 IT 프로젝트 플랫폼 · 위시켓(Wishket)", body: 11032 chars
```

## Debug log (last lines before crash)

```
INFO  browser : executing script  src = https://www.wishket.com/static/renewal/js/moment.min.js
DEBUG http : script fetch start   req = GET https://browser.sentry-cdn.com/7.8.0/bundle.tracing.min.js
[LP EXIT] code=null signal=SIGSEGV
```

## Tested sites

| Site | Result | Tracking JS |
|------|--------|------------|
| wishket.com | SIGSEGV | Sentry + Clarity + GTM |
| naver.com | SIGSEGV | Naver analytics + CDN |
| wikipedia.org | OK | No Sentry |
| github.com | OK | Lightweight JS |

## Environment

- Version: `1.0.0-nightly.5301+a6a87527`
- OS: macOS Darwin 25.4.0 arm64 (Apple Silicon)

Related: #1738
