### PR TITLE
Improve network naming consistency

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -26,7 +26,7 @@ const Snapshot = @import("browser/js/Snapshot.zig");
 const Platform = @import("browser/js/Platform.zig");
 const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 
-const Network = @import("network/Runtime.zig");
+const Network = @import("network/Network.zig");
 pub const ArenaPool = @import("ArenaPool.zig");
 
 const App = @This();

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -34,7 +34,6 @@ pub const RunMode = enum {
     mcp,
 };
 
-pub const MAX_LISTENERS = 16;
 pub const CDP_MAX_HTTP_REQUEST_SIZE = 4096;
 
 // max message size

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -30,7 +30,7 @@ const Notification = @import("../Notification.zig");
 const CookieJar = @import("webapi/storage/Cookie.zig").Jar;
 
 const http = @import("../network/http.zig");
-const Runtime = @import("../network/Runtime.zig");
+const Network = @import("../network/Network.zig");
 const Robots = @import("../network/Robots.zig");
 
 const IS_DEBUG = builtin.mode == .Debug;
@@ -86,7 +86,7 @@ queue: std.DoublyLinkedList = .{},
 // The main app allocator
 allocator: Allocator,
 
-network: *Runtime,
+network: *Network,
 
 // Queue of requests that depend on a robots.txt.
 // Allows us to fetch the robots.txt just once.
@@ -131,7 +131,7 @@ pub const CDPClient = struct {
     blocking_read_end: *const fn (*anyopaque) bool,
 };
 
-pub fn init(allocator: Allocator, network: *Runtime) !*Client {
+pub fn init(allocator: Allocator, network: *Network) !*Client {
     var transfer_pool = std.heap.MemoryPool(Transfer).init(allocator);
     errdefer transfer_pool.deinit();
 
@@ -695,7 +695,7 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!PerformStatus {
         break :blk try self.handles.perform();
     };
 
-    // Process dirty connections — return them to Runtime pool.
+    // Process dirty connections — return them to Network pool.
     while (self.dirty.popFirst()) |node| {
         const conn: *http.Connection = @fieldParentPtr("node", node);
         self.handles.remove(conn) catch |err| {

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -22,7 +22,7 @@ const builtin = @import("builtin");
 
 const log = @import("../log.zig");
 const HttpClient = @import("HttpClient.zig");
-const net_http = @import("../network/http.zig");
+const http = @import("../network/http.zig");
 const String = @import("../string.zig").String;
 
 const js = @import("js/js.zig");
@@ -136,7 +136,7 @@ fn clearList(list: *std.DoublyLinkedList) void {
     }
 }
 
-fn getHeaders(self: *ScriptManager) !net_http.Headers {
+fn getHeaders(self: *ScriptManager) !http.Headers {
     var headers = try self.client.newHeaders();
     try self.page.headersForRequest(&headers);
     return headers;

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -86,8 +86,8 @@ pub fn forEach(self: *Headers, cb_: js.Function, js_this_: ?js.Object) !void {
 }
 
 // TODO: do we really need 2 different header structs??
-const net_http = @import("../../../network/http.zig");
-pub fn populateHttpHeader(self: *Headers, allocator: Allocator, http_headers: *net_http.Headers) !void {
+const http = @import("../../../network/http.zig");
+pub fn populateHttpHeader(self: *Headers, allocator: Allocator, http_headers: *http.Headers) !void {
     for (self._list._entries.items) |entry| {
         const merged = try std.mem.concatWithSentinel(allocator, u8, &.{ entry.name.str(), ": ", entry.value.str() }, 0);
         try http_headers.add(merged);

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -19,7 +19,7 @@
 const std = @import("std");
 
 const js = @import("../../js/js.zig");
-const net_http = @import("../../../network/http.zig");
+const http = @import("../../../network/http.zig");
 
 const URL = @import("../URL.zig");
 const Page = @import("../../Page.zig");
@@ -31,7 +31,7 @@ const Allocator = std.mem.Allocator;
 const Request = @This();
 
 _url: [:0]const u8,
-_method: net_http.Method,
+_method: http.Method,
 _headers: ?*Headers,
 _body: ?[]const u8,
 _arena: Allocator,
@@ -119,14 +119,14 @@ pub fn init(input: Input, opts_: ?InitOpts, page: *Page) !*Request {
     });
 }
 
-fn parseMethod(method: []const u8, page: *Page) !net_http.Method {
+fn parseMethod(method: []const u8, page: *Page) !http.Method {
     if (method.len > "propfind".len) {
         return error.InvalidMethod;
     }
 
     const lower = std.ascii.lowerString(&page.buf, method);
 
-    const method_lookup = std.StaticStringMap(net_http.Method).initComptime(.{
+    const method_lookup = std.StaticStringMap(http.Method).initComptime(.{
         .{ "get", .GET },
         .{ "post", .POST },
         .{ "delete", .DELETE },

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -22,7 +22,7 @@ const js = @import("../../js/js.zig");
 
 const log = @import("../../../log.zig");
 const HttpClient = @import("../../HttpClient.zig");
-const net_http = @import("../../../network/http.zig");
+const http = @import("../../../network/http.zig");
 
 const URL = @import("../../URL.zig");
 const Mime = @import("../../Mime.zig");
@@ -47,7 +47,7 @@ _transfer: ?*HttpClient.Transfer = null,
 _active_request: bool = false,
 
 _url: [:0]const u8 = "",
-_method: net_http.Method = .GET,
+_method: http.Method = .GET,
 _request_headers: *Headers,
 _request_body: ?[]const u8 = null,
 
@@ -406,7 +406,7 @@ fn httpStartCallback(transfer: *HttpClient.Transfer) !void {
     self._transfer = transfer;
 }
 
-fn httpHeaderCallback(transfer: *HttpClient.Transfer, header: net_http.Header) !void {
+fn httpHeaderCallback(transfer: *HttpClient.Transfer, header: http.Header) !void {
     const self: *XMLHttpRequest = @ptrCast(@alignCast(transfer.ctx));
     const joined = try std.fmt.allocPrint(self._arena, "{s}: {s}", .{ header.name, header.value });
     try self._response_headers.append(self._arena, joined);
@@ -574,7 +574,7 @@ fn stateChanged(self: *XMLHttpRequest, state: ReadyState, page: *Page) !void {
     }
 }
 
-fn parseMethod(method: []const u8) !net_http.Method {
+fn parseMethod(method: []const u8) !http.Method {
     if (std.ascii.eqlIgnoreCase(method, "get")) {
         return .GET;
     }

--- a/src/cdp/domains/fetch.zig
+++ b/src/cdp/domains/fetch.zig
@@ -23,7 +23,7 @@ const CDP = @import("../CDP.zig");
 const log = @import("../../log.zig");
 
 const HttpClient = @import("../../browser/HttpClient.zig");
-const net_http = @import("../../network/http.zig");
+const http = @import("../../network/http.zig");
 const Notification = @import("../../Notification.zig");
 
 const network = @import("network.zig");
@@ -224,7 +224,7 @@ fn continueRequest(cmd: *CDP.Command) !void {
         url: ?[]const u8 = null,
         method: ?[]const u8 = null,
         postData: ?[]const u8 = null,
-        headers: ?[]const net_http.Header = null,
+        headers: ?[]const http.Header = null,
         interceptResponse: bool = false,
     })) orelse return error.InvalidParams;
 
@@ -249,7 +249,7 @@ fn continueRequest(cmd: *CDP.Command) !void {
         try transfer.updateURL(try arena.dupeZ(u8, url));
     }
     if (params.method) |method| {
-        transfer.req.method = std.meta.stringToEnum(net_http.Method, method) orelse return error.InvalidParams;
+        transfer.req.method = std.meta.stringToEnum(http.Method, method) orelse return error.InvalidParams;
     }
 
     if (params.headers) |headers| {
@@ -326,7 +326,7 @@ fn fulfillRequest(cmd: *CDP.Command) !void {
     const params = (try cmd.params(struct {
         requestId: []const u8, // "INT-{d}"
         responseCode: u16,
-        responseHeaders: ?[]const net_http.Header = null,
+        responseHeaders: ?[]const http.Header = null,
         binaryResponseHeaders: ?[]const u8 = null,
         body: ?[]const u8 = null,
         responsePhrase: ?[]const u8 = null,

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -18,7 +18,7 @@
 
 const std = @import("std");
 pub const App = @import("App.zig");
-pub const Network = @import("network/Runtime.zig");
+pub const Network = @import("network/Network.zig");
 pub const Server = @import("Server.zig");
 pub const Config = @import("Config.zig");
 pub const URL = @import("browser/URL.zig");

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -26,11 +26,11 @@ const lp = @import("lightpanda");
 const Config = @import("../Config.zig");
 const libcurl = @import("../sys/libcurl.zig");
 
-const net_http = @import("http.zig");
+const http = @import("http.zig");
 const RobotStore = @import("Robots.zig").RobotStore;
 const WebBotAuth = @import("WebBotAuth.zig");
 
-const Runtime = @This();
+const Network = @This();
 
 const Listener = struct {
     socket: posix.socket_t,
@@ -46,11 +46,11 @@ const MAX_TICK_CALLBACKS = 16;
 allocator: Allocator,
 
 config: *const Config,
-ca_blob: ?net_http.Blob,
+ca_blob: ?http.Blob,
 robot_store: RobotStore,
 web_bot_auth: ?WebBotAuth,
 
-connections: []net_http.Connection,
+connections: []http.Connection,
 available: std.DoublyLinkedList = .{},
 conn_mutex: std.Thread.Mutex = .{},
 
@@ -63,8 +63,8 @@ wakeup_pipe: [2]posix.fd_t = .{ -1, -1 },
 shutdown: std.atomic.Value(bool) = .init(false),
 
 // Multi is a heavy structure that can consume up to 2MB of RAM.
-// Currently, Runtime is used sparingly, and we only create it on demand.
-// When Runtime becomes truly shared, it should become a regular field.
+// Currently, Network is used sparingly, and we only create it on demand.
+// When Network becomes truly shared, it should become a regular field.
 multi: ?*libcurl.CurlM = null,
 submission_mutex: std.Thread.Mutex = .{},
 submission_queue: std.DoublyLinkedList = .{},
@@ -200,7 +200,7 @@ fn globalDeinit() void {
     libcurl.curl_global_cleanup();
 }
 
-pub fn init(allocator: Allocator, config: *const Config) !Runtime {
+pub fn init(allocator: Allocator, config: *const Config) !Network {
     globalInit(allocator);
     errdefer globalDeinit();
 
@@ -213,18 +213,18 @@ pub fn init(allocator: Allocator, config: *const Config) !Runtime {
     @memset(pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
     pollfds[0] = .{ .fd = pipe[0], .events = posix.POLL.IN, .revents = 0 };
 
-    var ca_blob: ?net_http.Blob = null;
+    var ca_blob: ?http.Blob = null;
     if (config.tlsVerifyHost()) {
         ca_blob = try loadCerts(allocator);
     }
 
     const count: usize = config.httpMaxConcurrent();
-    const connections = try allocator.alloc(net_http.Connection, count);
+    const connections = try allocator.alloc(http.Connection, count);
     errdefer allocator.free(connections);
 
     var available: std.DoublyLinkedList = .{};
     for (0..count) |i| {
-        connections[i] = try net_http.Connection.init(ca_blob, config);
+        connections[i] = try http.Connection.init(ca_blob, config);
         available.append(&connections[i].node);
     }
 
@@ -249,7 +249,7 @@ pub fn init(allocator: Allocator, config: *const Config) !Runtime {
     };
 }
 
-pub fn deinit(self: *Runtime) void {
+pub fn deinit(self: *Network) void {
     if (self.multi) |multi| {
         libcurl.curl_multi_cleanup(multi) catch {};
     }
@@ -282,7 +282,7 @@ pub fn deinit(self: *Runtime) void {
 }
 
 pub fn bind(
-    self: *Runtime,
+    self: *Network,
     address: net.Address,
     ctx: *anyopaque,
     on_accept: *const fn (ctx: *anyopaque, socket: posix.socket_t) void,
@@ -313,7 +313,7 @@ pub fn bind(
     };
 }
 
-pub fn onTick(self: *Runtime, ctx: *anyopaque, callback: *const fn (*anyopaque) void) void {
+pub fn onTick(self: *Network, ctx: *anyopaque, callback: *const fn (*anyopaque) void) void {
     self.callbacks_mutex.lock();
     defer self.callbacks_mutex.unlock();
 
@@ -328,7 +328,7 @@ pub fn onTick(self: *Runtime, ctx: *anyopaque, callback: *const fn (*anyopaque) 
     self.wakeupPoll();
 }
 
-pub fn fireTicks(self: *Runtime) void {
+pub fn fireTicks(self: *Network) void {
     self.callbacks_mutex.lock();
     defer self.callbacks_mutex.unlock();
 
@@ -337,7 +337,7 @@ pub fn fireTicks(self: *Runtime) void {
     }
 }
 
-pub fn run(self: *Runtime) void {
+pub fn run(self: *Network) void {
     var drain_buf: [64]u8 = undefined;
     var running_handles: c_int = 0;
 
@@ -428,18 +428,18 @@ pub fn run(self: *Runtime) void {
     }
 }
 
-pub fn submitRequest(self: *Runtime, conn: *net_http.Connection) void {
+pub fn submitRequest(self: *Network, conn: *http.Connection) void {
     self.submission_mutex.lock();
     self.submission_queue.append(&conn.node);
     self.submission_mutex.unlock();
     self.wakeupPoll();
 }
 
-fn wakeupPoll(self: *Runtime) void {
+fn wakeupPoll(self: *Network) void {
     _ = posix.write(self.wakeup_pipe[1], &.{1}) catch {};
 }
 
-fn drainQueue(self: *Runtime) void {
+fn drainQueue(self: *Network) void {
     self.submission_mutex.lock();
     defer self.submission_mutex.unlock();
 
@@ -455,7 +455,7 @@ fn drainQueue(self: *Runtime) void {
     };
 
     while (self.submission_queue.popFirst()) |node| {
-        const conn: *net_http.Connection = @fieldParentPtr("node", node);
+        const conn: *http.Connection = @fieldParentPtr("node", node);
         conn.setPrivate(conn) catch |err| {
             lp.log.err(.app, "curl set private", .{ .err = err });
             self.releaseConnection(conn);
@@ -468,12 +468,12 @@ fn drainQueue(self: *Runtime) void {
     }
 }
 
-pub fn stop(self: *Runtime) void {
+pub fn stop(self: *Network) void {
     self.shutdown.store(true, .release);
     self.wakeupPoll();
 }
 
-fn acceptConnections(self: *Runtime) void {
+fn acceptConnections(self: *Network) void {
     if (self.shutdown.load(.acquire)) {
         return;
     }
@@ -503,7 +503,7 @@ fn acceptConnections(self: *Runtime) void {
     }
 }
 
-fn preparePollFds(self: *Runtime, multi: *libcurl.CurlM) void {
+fn preparePollFds(self: *Network, multi: *libcurl.CurlM) void {
     const curl_fds = self.pollfds[PSEUDO_POLLFDS..];
     @memset(curl_fds, .{ .fd = -1, .events = 0, .revents = 0 });
 
@@ -514,14 +514,14 @@ fn preparePollFds(self: *Runtime, multi: *libcurl.CurlM) void {
     };
 }
 
-fn getCurlTimeout(self: *Runtime) i32 {
+fn getCurlTimeout(self: *Network) i32 {
     const multi = self.multi orelse return -1;
     var timeout_ms: c_long = -1;
     libcurl.curl_multi_timeout(multi, &timeout_ms) catch return -1;
     return @intCast(@min(timeout_ms, std.math.maxInt(i32)));
 }
 
-fn processCompletions(self: *Runtime, multi: *libcurl.CurlM) void {
+fn processCompletions(self: *Network, multi: *libcurl.CurlM) void {
     var msgs_in_queue: c_int = 0;
     while (libcurl.curl_multi_info_read(multi, &msgs_in_queue)) |msg| {
         switch (msg.data) {
@@ -537,7 +537,7 @@ fn processCompletions(self: *Runtime, multi: *libcurl.CurlM) void {
         var ptr: *anyopaque = undefined;
         libcurl.curl_easy_getinfo(easy, .private, &ptr) catch
             lp.assert(false, "curl getinfo private", .{});
-        const conn: *net_http.Connection = @ptrCast(@alignCast(ptr));
+        const conn: *http.Connection = @ptrCast(@alignCast(ptr));
 
         libcurl.curl_multi_remove_handle(multi, easy) catch {};
         self.releaseConnection(conn);
@@ -556,7 +556,7 @@ comptime {
     }
 }
 
-pub fn getConnection(self: *Runtime) ?*net_http.Connection {
+pub fn getConnection(self: *Network) ?*http.Connection {
     self.conn_mutex.lock();
     defer self.conn_mutex.unlock();
 
@@ -564,7 +564,7 @@ pub fn getConnection(self: *Runtime) ?*net_http.Connection {
     return @fieldParentPtr("node", node);
 }
 
-pub fn releaseConnection(self: *Runtime, conn: *net_http.Connection) void {
+pub fn releaseConnection(self: *Network, conn: *http.Connection) void {
     conn.reset(self.config, self.ca_blob) catch |err| {
         lp.assert(false, "couldn't reset curl easy", .{ .err = err });
     };
@@ -575,8 +575,8 @@ pub fn releaseConnection(self: *Runtime, conn: *net_http.Connection) void {
     self.available.append(&conn.node);
 }
 
-pub fn newConnection(self: *Runtime) !net_http.Connection {
-    return net_http.Connection.init(self.ca_blob, self.config);
+pub fn newConnection(self: *Network) !http.Connection {
+    return http.Connection.init(self.ca_blob, self.config);
 }
 
 // Wraps lines @ 64 columns. A PEM is basically a base64 encoded DER (which is

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -8,7 +8,7 @@ const log = @import("../log.zig");
 const App = @import("../App.zig");
 const Config = @import("../Config.zig");
 const telemetry = @import("telemetry.zig");
-const Runtime = @import("../network/Runtime.zig");
+const Network = @import("../network/Network.zig");
 
 const URL = "https://telemetry.lightpanda.io";
 const BUFFER_SIZE = 1024;
@@ -17,7 +17,7 @@ const MAX_BODY_SIZE = 500 * 1024; // 500KB server limit
 const LightPanda = @This();
 
 allocator: Allocator,
-runtime: *Runtime,
+network: *Network,
 writer: std.Io.Writer.Allocating,
 
 /// Protects concurrent producers in send().
@@ -36,11 +36,11 @@ pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode
         .iid = iid,
         .run_mode = run_mode,
         .allocator = app.allocator,
-        .runtime = &app.network,
+        .network = &app.network,
         .writer = std.Io.Writer.Allocating.init(app.allocator),
     };
 
-    self.runtime.onTick(@ptrCast(self), flushCallback);
+    self.network.onTick(@ptrCast(self), flushCallback);
 }
 
 pub fn deinit(self: *LightPanda) void {
@@ -70,17 +70,17 @@ fn flushCallback(ctx: *anyopaque) void {
 }
 
 fn postEvent(self: *LightPanda) !void {
-    const conn = self.runtime.getConnection() orelse {
+    const conn = self.network.getConnection() orelse {
         return;
     };
-    errdefer self.runtime.releaseConnection(conn);
+    errdefer self.network.releaseConnection(conn);
 
     const h = self.head.load(.monotonic);
     const t = self.tail.load(.acquire);
     const dropped = self.dropped.swap(0, .monotonic);
 
     if (h == t and dropped == 0) {
-        self.runtime.releaseConnection(conn);
+        self.network.releaseConnection(conn);
         return;
     }
     errdefer _ = self.dropped.fetchAdd(dropped, .monotonic);
@@ -104,7 +104,7 @@ fn postEvent(self: *LightPanda) !void {
     try conn.setBody(self.writer.written());
 
     self.head.store(h + sent, .release);
-    self.runtime.submitRequest(conn);
+    self.network.submitRequest(conn);
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {


### PR DESCRIPTION
1.
Runtime.zig -> Network.zig (especially since most places imported it as `const Network = @import("Runtime.zig")`

2.
const net_http = @import(...) -> const http = @import(...)