### PR TITLE
fix: propagate keyUp and char keyboard events to JS listeners

### DIFF
--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -52,17 +52,19 @@ fn dispatchKeyEvent(cmd: *CDP.Command) !void {
 
     try cmd.sendResult(null, .{});
 
-    // quickly ignore types we know we don't handle
-    switch (params.type) {
-        .keyUp, .rawKeyDown, .char => return,
-        .keyDown => {},
-    }
+    // rawKeyDown is a Chrome-internal event type not used for JS dispatch
+    if (params.type == .rawKeyDown) return;
 
     const bc = cmd.browser_context orelse return;
     const page = bc.session.currentPage() orelse return;
 
     const KeyboardEvent = @import("../../browser/webapi/event/KeyboardEvent.zig");
-    const keyboard_event = try KeyboardEvent.initTrusted(comptime .wrap("keydown"), .{
+    const keyboard_event = try KeyboardEvent.initTrusted(switch (params.type) {
+        .keyDown => comptime .wrap("keydown"),
+        .keyUp => comptime .wrap("keyup"),
+        .char => comptime .wrap("keypress"),
+        .rawKeyDown => unreachable,
+    }, .{
         .key = params.key,
         .code = params.code,
         .altKey = params.modifiers & 1 == 1,


### PR DESCRIPTION
`Input.dispatchKeyEvent` only dispatched `keyDown` events to the page's keyboard handler. The `keyUp`, `rawKeyDown`, and `char` types were returned early at `input.zig:57` without reaching JS listeners.

This meant Puppeteer's `keyboard.press()` would fire `keydown` but never `keyup` or `keypress`, so any JS code listening for those events would never trigger.

The fix maps CDP event types to their DOM equivalents:
- `keyDown` -> `"keydown"` (unchanged)
- `keyUp` -> `"keyup"` (new)
- `char` -> `"keypress"` (new)
- `rawKeyDown` -> no-op (Chrome-internal, not used for JS dispatch)

All three dispatched types use the same `KeyboardEvent.initTrusted` + `page.triggerKeyboard()` path that `keyDown` already uses. The only difference is the event type string passed to `initTrusted`.

Fixes #2080
Ref #2043

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)