### PR TITLE
fix: update page URL and location on pushState/replaceState

### DIFF
--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const js = @import("../js/js.zig");
 
 const Page = @import("../Page.zig");
+const Location = @import("Location.zig");
 const PopStateEvent = @import("event/PopStateEvent.zig");
 
 const History = @This();
@@ -55,6 +56,10 @@ pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.pushEntry(url, .{ .source = .history, .value = json }, page, true);
+
+    // Update page URL and location so that location.pathname reflects the pushed state
+    page.url = url;
+    page.window._location = try Location.init(url, page);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, page: *Page) !void {
@@ -63,6 +68,10 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, page, true);
+
+    // Update page URL and location so that location.pathname reflects the replaced state
+    page.url = url;
+    page.window._location = try Location.init(url, page);
 }
 
 fn goInner(delta: i32, page: *Page) !void {


### PR DESCRIPTION
`history.pushState()` and `replaceState()` added entries to the navigation history but didn't update `page.url` or reinitialize `window._location`. This meant `location.pathname` still returned the old path after pushState, breaking SPA routing detection in automation scripts.

The fix adds two lines to both `pushState` and `replaceState` in `History.zig`:
1. `page.url = url` to update the page's active URL
2. `page.window._location = try Location.init(url, page)` to reinitialize the Location object

This follows the same pattern used during actual navigation (Page.zig lines 477, 560, 895).

`replaceState` gets the same fix since it had the same gap.

Fixes #2081
Ref #2043

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)