### PR TITLE
fix(cookie): reject Set-Cookie domains that are public suffixes

### DIFF
--- a/src/browser/webapi/storage/Cookie.zig
+++ b/src/browser/webapi/storage/Cookie.zig
@@ -273,6 +273,12 @@ pub fn parseDomain(arena: Allocator, url_: ?[:0]const u8, explicit_domain: ?[]co
                 // can't set a cookie for a TLD
                 return error.InvalidDomain;
             }
+
+            // Can't set a cookie for a public suffix (e.g. co.uk, com.au).
+            if (public_suffix_list(owned_domain[1..])) {
+                return error.InvalidDomain;
+            }
+
             if (encoded_host) |host| {
                 if (std.mem.endsWith(u8, host, owned_domain[1..]) == false) {
                     return error.InvalidDomain;
@@ -1027,6 +1033,15 @@ test "Cookie: parse domain" {
     try expectError(error.InvalidDomain, "http://lightpanda.io/", "b;domain=other.lightpanda.io");
     try expectError(error.InvalidDomain, "http://lightpanda.io/", "b;domain=other.lightpanda.com");
     try expectError(error.InvalidDomain, "http://lightpanda.io/", "b;domain=other.example.com");
+
+    // Public suffixes should be rejected (test PSL entries: "gov.uk", "api.gov.uk")
+    try expectError(error.InvalidDomain, "http://example.gov.uk/", "b;domain=gov.uk");
+    try expectError(error.InvalidDomain, "http://example.gov.uk/", "b;domain=.gov.uk");
+    try expectError(error.InvalidDomain, "http://test.api.gov.uk/", "b;domain=api.gov.uk");
+
+    // Subdomains of public suffixes should still be accepted
+    try expectAttribute(.{ .domain = ".example.gov.uk" }, "http://example.gov.uk/", "b;domain=example.gov.uk");
+    try expectAttribute(.{ .domain = ".example.gov.uk" }, "http://sub.example.gov.uk/", "b;domain=example.gov.uk");
 }
 
 test "Cookie: parse limit" {


### PR DESCRIPTION
`parseDomain()` rejects bare TLDs (e.g. `Domain=.io`) but accepts multi-level public suffixes like `.co.uk`, `.com.au`, `.co.jp`.

Per [RFC 6265bis §5.7.3.10](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-storage-model), user agents should reject cookies whose domain attribute is a public suffix. Chrome, Firefox, and Safari all enforce this using the [Public Suffix List](https://publicsuffix.org/).

The PSL data is already imported (`Cookie.zig:26`) and used in `findSecondLevelDomain()` (line 559), but `parseDomain()` does not consult it.

### What this fixes

When automating `.co.uk` / `.com.au` / `.co.jp` sites via CDP, cookies that Chrome silently drops are accepted by Lightpanda. This causes cookie jar pollution across unrelated sites in the same session, and behavior differences vs Chrome.

For example, if a site sets `Set-Cookie: x=1; Domain=.co.uk`, Chrome rejects it, but Lightpanda accepts it and sends that cookie to every `.co.uk` site visited afterward.

### Change

Two lines added after the existing TLD check (line 274):

```zig
// Can't set a cookie for a public suffix (e.g. co.uk, com.au).
if (public_suffix_list(owned_domain[1..])) {
    return error.InvalidDomain;
}
```

### Tests added

- `Domain=gov.uk` / `.gov.uk` / `api.gov.uk` → rejected (using test-mode PSL entries)
- `Domain=example.gov.uk` from `example.gov.uk` and `sub.example.gov.uk` → accepted (legitimate subdomain cookies still work)

Related: #2088 (also improves `parseDomain`, different issue — empty domain handling)