### PR TITLE
Don't release pending MutationObserver records

### DIFF
--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -179,7 +179,7 @@ pub fn observe(self: *MutationObserver, target: *Node, options: ObserveOptions, 
 
 pub fn disconnect(self: *MutationObserver, page: *Page) void {
     for (self._pending_records.items) |record| {
-        _ = record.releaseRef(page._session);
+        record.deinit(page._session);
     }
     self._pending_records.clearRetainingCapacity();
 


### PR DESCRIPTION
These have not been handed to v8 yet (hence the pending) and can be freed directly. This is correctly handled in IntersectionObserver.