### PR TITLE
Comptime CLI builder and parser

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -39,25 +39,41 @@ const Config = @This();
 
 /// Common CLI args.
 const CommonOptions = .{
-    .{ .name = "obey_robots", .type = bool, .default = false },
-    .{ .name = "proxy_bearer_token", .type = ?[:0]const u8, .default = null },
-    .{ .name = "http_proxy", .type = ?[:0]const u8, .default = null },
-    .{ .name = "http_max_concurrent", .type = ?u8, .default = null },
-    .{ .name = "http_max_host_open", .type = ?u8, .default = null },
-    .{ .name = "http_timeout", .type = ?u31, .default = null },
-    .{ .name = "http_connect_timeout", .type = ?u31, .default = null },
-    .{ .name = "http_max_response_size", .type = ?usize, .default = null },
-    .{ .name = "ws_max_concurrent", .type = ?u8, .default = null },
-    .{ .name = "insecure_disable_tls_host_verification", .type = bool, .default = false },
-    .{ .name = "log_level", .type = ?log.Level, .default = null },
-    .{ .name = "log_format", .type = ?log.Format, .default = null },
+    .{ .name = "obey_robots", .type = bool },
+    .{ .name = "proxy_bearer_token", .type = ?[:0]const u8 },
+    .{ .name = "http_proxy", .type = ?[:0]const u8 },
+    .{ .name = "http_max_concurrent", .type = ?u8 },
+    .{ .name = "http_max_host_open", .type = ?u8 },
+    .{ .name = "http_timeout", .type = ?u31 },
+    .{ .name = "http_connect_timeout", .type = ?u31 },
+    .{ .name = "http_max_response_size", .type = ?usize },
+    .{ .name = "ws_max_concurrent", .type = ?u8 },
+    .{ .name = "insecure_disable_tls_host_verification", .type = bool },
+    .{ .name = "log_level", .type = ?log.Level },
+    .{ .name = "log_format", .type = ?log.Format },
     // TODO: log_filter_scopes (?[]log.Scope) — parser doesn't yet support `multiple` for enums.
-    .{ .name = "user_agent_suffix", .type = ?[]const u8, .default = null },
-    .{ .name = "http_cache_dir", .type = ?[]const u8, .default = null },
-    .{ .name = "web_bot_auth_key_file", .type = ?[]const u8, .default = null },
-    .{ .name = "web_bot_auth_keyid", .type = ?[]const u8, .default = null },
-    .{ .name = "web_bot_auth_domain", .type = ?[]const u8, .default = null },
+    .{ .name = "user_agent_suffix", .type = ?[]const u8 },
+    .{ .name = "http_cache_dir", .type = ?[]const u8 },
+    .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
+    .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
+    .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
 };
+
+fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
+    // Peek next argument.
+    var peek_args = args.*;
+    if (peek_args.next()) |next_arg| {
+        // Skip the argument we peek if successful.
+        defer _ = args.next();
+        return std.meta.stringToEnum(DumpFormat, next_arg) orelse {
+            return error.UnknownDumpOption;
+        };
+    }
+
+    // Means we couldn't get something like `--dump html` but we do have
+    // `--dump`; which should fall to `html` by default.
+    return .html;
+}
 
 /// Definition for all the commands and its arguments. See @cli.zig for further.
 const Commands = cli.Builder(.{
@@ -66,7 +82,7 @@ const Commands = cli.Builder(.{
         .options = .{
             .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
             .{ .name = "port", .type = u16, .default = 9222 },
-            .{ .name = "advertise_host", .type = ?[]const u8, .default = null },
+            .{ .name = "advertise_host", .type = ?[]const u8 },
             .{ .name = "timeout", .type = u31, .default = 10 },
             .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
             .{ .name = "cdp_max_pending_connections", .type = u16, .default = 128 },
@@ -76,24 +92,30 @@ const Commands = cli.Builder(.{
     .{
         .name = "fetch",
         .aliases = .{ "f", "get" },
-        // Fetch only; this argument can be given anywhere.
+        // This argument can be given out of order.
         .positional = .{ .name = "url", .type = ?[:0]const u8 },
         .options = .{
-            .{ .name = "dump", .type = ?DumpFormat, .default = null },
-            .{ .name = "with_base", .type = bool, .default = false },
-            .{ .name = "with_frames", .type = bool, .default = false },
+            .{
+                .name = "dump",
+                // Prefixed by `-` (single dash).
+                .shortcuts = .{"d"},
+                .type = ?DumpFormat,
+                .validator = dumpValidator,
+            },
+            .{ .name = "with_base", .type = bool },
+            .{ .name = "with_frames", .type = bool },
             .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
             .{ .name = "wait_ms", .type = u32, .default = 5_000 },
-            .{ .name = "wait_until", .type = ?WaitUntil, .default = null },
-            .{ .name = "wait_script", .type = ?[:0]const u8, .default = null },
-            .{ .name = "wait_selector", .type = ?[:0]const u8, .default = null },
+            .{ .name = "wait_until", .type = ?WaitUntil },
+            .{ .name = "wait_script", .type = ?[:0]const u8 },
+            .{ .name = "wait_selector", .type = ?[:0]const u8 },
         },
         .shared_options = CommonOptions,
     },
     .{
         .name = "mcp",
         .options = .{
-            .{ .name = "cdp_port", .type = ?u16, .default = null },
+            .{ .name = "cdp_port", .type = ?u16 },
         },
         .shared_options = CommonOptions,
     },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -653,3 +653,15 @@ pub fn parseArgs(allocator: Allocator) !Config {
     const exec_name, const command = try Commands.parse(allocator);
     return .init(allocator, exec_name, command);
 }
+
+pub fn validateUserAgent(ua: []const u8) !void {
+    for (ua) |c| {
+        if (!std.ascii.isPrint(c)) {
+            return error.NonPrintable;
+        }
+    }
+
+    if (std.ascii.indexOfIgnoreCase(ua, "mozilla") != null) {
+        return error.Reserved;
+    }
+}

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -74,6 +74,8 @@ const CommonOptions = .{
     .{ .name = "user_agent", .type = ?[]const u8 },
     .{ .name = "block_private_networks", .type = bool },
     .{ .name = "block_cidrs", .type = ?[]const u8 },
+    .{ .name = "cookie", .type = ?[]const u8 },
+    .{ .name = "cookie_jar", .type = ?[]const u8 },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -275,14 +277,14 @@ pub fn httpCacheDir(self: *const Config) ?[]const u8 {
 
 pub fn cookieFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.cookie,
+        inline .serve, .fetch, .mcp => |opts| opts.cookie,
         else => null,
     };
 }
 
 pub fn cookieJarFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .fetch, .mcp => |opts| opts.common.cookie_jar,
+        inline .fetch, .mcp => |opts| opts.cookie_jar,
         else => null,
     };
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
+const cli = @import("cli.zig");
 const dump = @import("browser/dump.zig");
 
 const mcp = @import("mcp.zig");
@@ -27,16 +28,6 @@ const Storage = @import("storage/Storage.zig");
 const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
 
 const log = lp.log;
-const Allocator = std.mem.Allocator;
-
-pub const RunMode = enum {
-    help,
-    fetch,
-    serve,
-    version,
-    mcp,
-};
-
 pub const CDP_MAX_HTTP_REQUEST_SIZE = 4096;
 
 // max message size
@@ -44,11 +35,78 @@ pub const CDP_MAX_HTTP_REQUEST_SIZE = 4096;
 // +140 for the max control packet that might be interleaved in a message
 pub const CDP_MAX_MESSAGE_SIZE = 512 * 1024 + 14 + 140;
 
+const Config = @This();
+
+/// Common CLI args.
+const CommonOptions = .{
+    .{ .name = "obey_robots", .type = bool, .default = false },
+    .{ .name = "proxy_bearer_token", .type = ?[:0]const u8, .default = null },
+    .{ .name = "http_proxy", .type = ?[:0]const u8, .default = null },
+    .{ .name = "http_max_concurrent", .type = ?u8, .default = null },
+    .{ .name = "http_max_host_open", .type = ?u8, .default = null },
+    .{ .name = "http_timeout", .type = ?u31, .default = null },
+    .{ .name = "http_connect_timeout", .type = ?u31, .default = null },
+    .{ .name = "http_max_response_size", .type = ?usize, .default = null },
+    .{ .name = "ws_max_concurrent", .type = ?u8, .default = null },
+    .{ .name = "insecure_disable_tls_host_verification", .type = bool, .default = false },
+    .{ .name = "log_level", .type = ?log.Level, .default = null },
+    .{ .name = "log_format", .type = ?log.Format, .default = null },
+    // TODO: log_filter_scopes (?[]log.Scope) — parser doesn't yet support `multiple` for enums.
+    .{ .name = "user_agent_suffix", .type = ?[]const u8, .default = null },
+    .{ .name = "http_cache_dir", .type = ?[]const u8, .default = null },
+    .{ .name = "web_bot_auth_key_file", .type = ?[]const u8, .default = null },
+    .{ .name = "web_bot_auth_keyid", .type = ?[]const u8, .default = null },
+    .{ .name = "web_bot_auth_domain", .type = ?[]const u8, .default = null },
+};
+
+/// Definition for all the commands and its arguments. See @cli.zig for further.
+const Commands = cli.Builder(.{
+    .{
+        .name = "serve",
+        .options = .{
+            .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .type = u16, .default = 9222 },
+            .{ .name = "advertise_host", .type = ?[]const u8, .default = null },
+            .{ .name = "timeout", .type = u31, .default = 10 },
+            .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
+            .{ .name = "cdp_max_pending_connections", .type = u16, .default = 128 },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{
+        .name = "fetch",
+        .aliases = .{ "f", "get" },
+        // Fetch only; this argument can be given anywhere.
+        .positional = .{ .name = "url", .type = ?[:0]const u8 },
+        .options = .{
+            .{ .name = "dump", .type = ?DumpFormat, .default = null },
+            .{ .name = "with_base", .type = bool, .default = false },
+            .{ .name = "with_frames", .type = bool, .default = false },
+            .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
+            .{ .name = "wait_ms", .type = u32, .default = 5_000 },
+            .{ .name = "wait_until", .type = ?WaitUntil, .default = null },
+            .{ .name = "wait_script", .type = ?[:0]const u8, .default = null },
+            .{ .name = "wait_selector", .type = ?[:0]const u8, .default = null },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{
+        .name = "mcp",
+        .options = .{
+            .{ .name = "cdp_port", .type = ?u16, .default = null },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{ .name = "version", .options = .{} },
+    .{ .name = "help", .options = .{} },
+});
+
+pub const RunMode = Commands.Enum;
+pub const Mode = Commands.Union;
+
 mode: Mode,
 exec_name: []const u8,
 http_headers: HttpHeaders,
-
-const Config = @This();
 
 pub fn init(allocator: Allocator, exec_name: []const u8, mode: Mode) !Config {
     var config = Config{
@@ -66,56 +124,56 @@ pub fn deinit(self: *const Config, allocator: Allocator) void {
 
 pub fn tlsVerifyHost(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.tls_verify_host,
+        inline .serve, .fetch, .mcp => |opts| !opts.insecure_disable_tls_host_verification,
         else => unreachable,
     };
 }
 
 pub fn obeyRobots(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.obey_robots,
+        inline .serve, .fetch, .mcp => |opts| opts.obey_robots,
         else => unreachable,
     };
 }
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_proxy,
+        inline .serve, .fetch, .mcp => |opts| opts.http_proxy,
         else => unreachable,
     };
 }
 
 pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.proxy_bearer_token,
+        inline .serve, .fetch, .mcp => |opts| opts.proxy_bearer_token,
         .help, .version => null,
     };
 }
 
 pub fn httpMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_max_concurrent orelse 10,
+        inline .serve, .fetch, .mcp => |opts| opts.http_max_concurrent orelse 10,
         else => unreachable,
     };
 }
 
 pub fn httpMaxHostOpen(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_max_host_open orelse 4,
+        inline .serve, .fetch, .mcp => |opts| opts.http_max_host_open orelse 4,
         else => unreachable,
     };
 }
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .mcp => |opts| opts.http_connect_timeout orelse 0,
         else => unreachable,
     };
 }
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_timeout orelse 5000,
+        inline .serve, .fetch, .mcp => |opts| opts.http_timeout orelse 5000,
         else => unreachable,
     };
 }
@@ -126,42 +184,42 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_max_response_size,
+        inline .serve, .fetch, .mcp => |opts| opts.http_max_response_size,
         else => unreachable,
     };
 }
 
 pub fn wsMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.ws_max_concurrent orelse 64,
+        inline .serve, .fetch, .mcp => |opts| opts.ws_max_concurrent orelse 8,
         else => unreachable,
     };
 }
 
 pub fn logLevel(self: *const Config) ?log.Level {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.log_level,
+        inline .serve, .fetch, .mcp => |opts| opts.log_level,
         else => unreachable,
     };
 }
 
 pub fn logFormat(self: *const Config) ?log.Format {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.log_format,
+        inline .serve, .fetch, .mcp => |opts| opts.log_format,
         else => unreachable,
     };
 }
 
-pub fn logFilterScopes(self: *const Config) ?[]const log.Scope {
-    return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.log_filter_scopes,
-        else => unreachable,
-    };
-}
+//pub fn logFilterScopes(self: *const Config) ?[]const log.Scope {
+//    return switch (self.mode) {
+//        inline .serve, .fetch, .mcp => |opts| opts.log_filter_scopes,
+//        else => unreachable,
+//    };
+//}
 
 pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.user_agent_suffix,
+        inline .serve, .fetch, .mcp => |opts| opts.user_agent_suffix,
         .help, .version => null,
     };
 }
@@ -175,7 +233,7 @@ pub fn userAgent(self: *const Config) ?[]const u8 {
 
 pub fn httpCacheDir(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.http_cache_dir,
+        inline .serve, .fetch, .mcp => |opts| opts.http_cache_dir,
         else => null,
     };
 }
@@ -196,8 +254,8 @@ pub fn cookieJarFile(self: *const Config) ?[]const u8 {
 
 pub fn cdpTimeout(self: *const Config) usize {
     return switch (self.mode) {
-        .serve => |opts| if (opts.timeout > 604_800) 604_800_000 else @as(usize, opts.timeout) * 1000,
-        .mcp => 10000, // Default timeout for MCP-CDP
+        .serve => |opts| if (opts.timeout > 604_800) 604_800_000 else @as(usize, opts.timeout) * 1_000,
+        .mcp => 10_000, // Default timeout for MCP-CDP
         else => unreachable,
     };
 }
@@ -221,9 +279,9 @@ pub fn advertiseHost(self: *const Config) []const u8 {
 pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| WebBotAuthConfig{
-            .key_file = opts.common.web_bot_auth_key_file orelse return null,
-            .keyid = opts.common.web_bot_auth_keyid orelse return null,
-            .domain = opts.common.web_bot_auth_domain orelse return null,
+            .key_file = opts.web_bot_auth_key_file orelse return null,
+            .keyid = opts.web_bot_auth_keyid orelse return null,
+            .domain = opts.web_bot_auth_domain orelse return null,
         },
         .help, .version => null,
     };
@@ -263,8 +321,8 @@ pub fn storageEngine(self: *const Config) ?Storage.EngineType {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| opts.common.storage_engine,
         else => unreachable,
-    };
 }
+    };
 
 pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
@@ -273,28 +331,10 @@ pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
     };
 }
 
-pub const Mode = union(RunMode) {
-    help: bool, // false when being printed because of an error
-    fetch: Fetch,
-    serve: Serve,
-    version: void,
-    mcp: Mcp,
-};
-
-pub const Serve = struct {
-    host: []const u8 = "127.0.0.1",
-    port: u16 = 9222,
-    advertise_host: ?[]const u8 = null,
-    timeout: u31 = 10,
-    cdp_max_connections: u16 = 16,
-    cdp_max_pending_connections: u16 = 128,
-    common: Common = .{},
-};
-
-pub const Mcp = struct {
-    common: Common = .{},
-    cdp_port: ?u16 = null,
-};
+//pub const Mcp = struct {
+//    common: Common = .{},
+//    cdp_port: ?u16 = null,
+//};
 
 pub const DumpFormat = enum {
     html,
@@ -309,49 +349,6 @@ pub const WaitUntil = enum {
     domcontentloaded,
     networkidle,
     done,
-};
-
-pub const Fetch = struct {
-    url: [:0]const u8,
-    dump_mode: ?DumpFormat = null,
-    common: Common = .{},
-    with_base: bool = false,
-    with_frames: bool = false,
-    strip: dump.Opts.Strip = .{},
-    wait_ms: u32 = 5000,
-    wait_until: ?WaitUntil = null,
-    wait_script: ?[:0]const u8 = null,
-    wait_selector: ?[:0]const u8 = null,
-};
-
-pub const Common = struct {
-    obey_robots: bool = false,
-    proxy_bearer_token: ?[:0]const u8 = null,
-    http_proxy: ?[:0]const u8 = null,
-    http_max_concurrent: ?u8 = null,
-    http_max_host_open: ?u8 = null,
-    http_timeout: ?u31 = null,
-    http_connect_timeout: ?u31 = null,
-    http_max_response_size: ?usize = null,
-    ws_max_concurrent: ?u8 = null,
-    tls_verify_host: bool = true,
-    log_level: ?log.Level = null,
-    log_format: ?log.Format = null,
-    log_filter_scopes: ?[]log.Scope = null,
-    user_agent_suffix: ?[]const u8 = null,
-    user_agent: ?[]const u8 = null,
-    http_cache_dir: ?[]const u8 = null,
-    cookie: ?[]const u8 = null,
-    cookie_jar: ?[]const u8 = null,
-    storage_engine: ?Storage.EngineType = null,
-    storage_sqlite_path: ?[:0]const u8 = null,
-
-    web_bot_auth_key_file: ?[]const u8 = null,
-    web_bot_auth_keyid: ?[]const u8 = null,
-    web_bot_auth_domain: ?[]const u8 = null,
-
-    block_private_networks: bool = false,
-    block_cidrs: ?[]const u8 = null,
 };
 
 /// Pre-formatted HTTP headers for reuse across Http and Client.
@@ -525,12 +522,12 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\                Argument must be 'html', 'markdown', 'semantic_tree', or 'semantic_tree_text'.
         \\                Defaults to no dump.
         \\
-        \\--strip-mode    Comma separated list of tag groups to remove from dump
-        \\                the dump. e.g. --strip-mode js,css
+        \\--strip         Comma separated list of tag groups to remove from dump
+        \\                the dump. e.g. --strip js,css
         \\                  - "js" script and link[as=script, rel=preload]
         \\                  - "ui" includes img, picture, video, css and svg
         \\                  - "css" includes style and link[rel=stylesheet]
-        \\                  - "full" includes js, ui and css
+        \\                  - "all" includes js, ui and css
         \\
         \\--with-base     Add a <base> tag in dump. Defaults to false.
         \\
@@ -623,732 +620,8 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
     std.process.exit(1);
 }
 
+// TODO: Fix mode sniff regression.
 pub fn parseArgs(allocator: Allocator) !Config {
-    var args = try std.process.argsWithAllocator(allocator);
-    defer args.deinit();
-
-    const exec_name = try allocator.dupe(u8, std.fs.path.basename(args.next().?));
-
-    const mode_string = args.next() orelse "";
-    const run_mode = std.meta.stringToEnum(RunMode, mode_string) orelse blk: {
-        const inferred_mode = inferMode(mode_string) orelse
-            return init(allocator, exec_name, .{ .help = false });
-        // "command" wasn't a command but an option. We can't reset args, but
-        // we can create a new one. Not great, but this fallback is temporary
-        // as we transition to this command mode approach.
-        args.deinit();
-
-        args = try std.process.argsWithAllocator(allocator);
-        // skip the exec_name
-        _ = args.skip();
-
-        break :blk inferred_mode;
-    };
-
-    const mode: Mode = switch (run_mode) {
-        .help => .{ .help = true },
-        .serve => .{ .serve = parseServeArgs(allocator, &args) catch
-            return init(allocator, exec_name, .{ .help = false }) },
-        .fetch => .{ .fetch = parseFetchArgs(allocator, &args) catch
-            return init(allocator, exec_name, .{ .help = false }) },
-        .mcp => .{ .mcp = parseMcpArgs(allocator, &args) catch
-            return init(allocator, exec_name, .{ .help = false }) },
-        .version => .{ .version = {} },
-    };
-    return init(allocator, exec_name, mode);
-}
-
-fn inferMode(opt: []const u8) ?RunMode {
-    if (opt.len == 0) {
-        return .serve;
-    }
-
-    if (std.mem.startsWith(u8, opt, "--") == false) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--dump")) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--noscript")) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--strip-mode") or std.mem.eql(u8, opt, "--strip_mode")) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--with-base") or std.mem.eql(u8, opt, "--with_base")) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--with-frames") or std.mem.eql(u8, opt, "--with_frames")) {
-        return .fetch;
-    }
-
-    if (std.mem.eql(u8, opt, "--host")) {
-        return .serve;
-    }
-
-    if (std.mem.eql(u8, opt, "--port")) {
-        return .serve;
-    }
-
-    if (std.mem.eql(u8, opt, "--timeout")) {
-        return .serve;
-    }
-
-    return null;
-}
-
-fn parseServeArgs(
-    allocator: Allocator,
-    args: *std.process.ArgIterator,
-) !Serve {
-    var serve: Serve = .{};
-
-    while (args.next()) |opt| {
-        if (std.mem.eql(u8, "--host", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = "--host" });
-                return error.InvalidArgument;
-            };
-            serve.host = try allocator.dupe(u8, str);
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--port", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = "--port" });
-                return error.InvalidArgument;
-            };
-
-            serve.port = std.fmt.parseInt(u16, str, 10) catch |err| {
-                log.fatal(.app, "invalid argument value", .{ .arg = "--port", .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--advertise-host", opt) or std.mem.eql(u8, "--advertise_host", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            serve.advertise_host = try allocator.dupe(u8, str);
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--timeout", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = "--timeout" });
-                return error.InvalidArgument;
-            };
-
-            serve.timeout = std.fmt.parseInt(u31, str, 10) catch |err| {
-                log.fatal(.app, "invalid argument value", .{ .arg = "--timeout", .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--cdp-max-connections", opt) or std.mem.eql(u8, "--cdp_max_connections", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-
-            serve.cdp_max_connections = std.fmt.parseInt(u16, str, 10) catch |err| {
-                log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--cdp-max-pending-connections", opt) or std.mem.eql(u8, "--cdp_max_pending_connections", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-
-            serve.cdp_max_pending_connections = std.fmt.parseInt(u16, str, 10) catch |err| {
-                log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--cookie-jar", opt)) {
-            log.fatal(.app, "invalid argument value", .{
-                .arg = opt,
-                .detail = "--cookie-jar is only available for fetch and mcp",
-            });
-            return error.InvalidArgument;
-        }
-
-        if (try parseCommonArg(allocator, opt, args, &serve.common)) {
-            continue;
-        }
-
-        log.fatal(.app, "unknown argument", .{ .mode = "serve", .arg = opt });
-        return error.UnknownOption;
-    }
-
-    return serve;
-}
-
-fn parseMcpArgs(
-    allocator: Allocator,
-    args: *std.process.ArgIterator,
-) !Mcp {
-    var result: Mcp = .{};
-
-    while (args.next()) |opt| {
-        if (std.mem.eql(u8, "--cdp-port", opt) or std.mem.eql(u8, "--cdp_port", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.mcp, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-
-            result.cdp_port = std.fmt.parseInt(u16, str, 10) catch |err| {
-                log.fatal(.mcp, "invalid argument value", .{ .arg = opt, .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (try parseCommonArg(allocator, opt, args, &result.common)) {
-            continue;
-        }
-
-        log.fatal(.mcp, "unknown argument", .{ .mode = "mcp", .arg = opt });
-        return error.UnknownOption;
-    }
-
-    return result;
-}
-
-fn parseFetchArgs(
-    allocator: Allocator,
-    args: *std.process.ArgIterator,
-) !Fetch {
-    var dump_mode: ?DumpFormat = null;
-    var with_base: bool = false;
-    var with_frames: bool = false;
-    var url: ?[:0]const u8 = null;
-    var common: Common = .{};
-    var strip: dump.Opts.Strip = .{};
-    var wait_ms: u32 = 5000;
-    var wait_until: ?WaitUntil = null;
-    var wait_script: ?[:0]const u8 = null;
-    var wait_selector: ?[:0]const u8 = null;
-
-    while (args.next()) |opt| {
-        if (std.mem.eql(u8, "--wait-ms", opt) or std.mem.eql(u8, "--wait_ms", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            wait_ms = std.fmt.parseInt(u32, str, 10) catch |err| {
-                log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--wait-until", opt) or std.mem.eql(u8, "--wait_until", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            wait_until = std.meta.stringToEnum(WaitUntil, str) orelse {
-                log.fatal(.app, "invalid argument value", .{ .arg = opt, .val = str });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--wait-selector", opt) or std.mem.eql(u8, "--wait_selector", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            wait_selector = try allocator.dupeZ(u8, str);
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--wait-script", opt) or std.mem.eql(u8, "--wait_script", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            wait_script = try allocator.dupeZ(u8, str);
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--wait-script-file", opt) or std.mem.eql(u8, "--wait_script_file", opt)) {
-            const path = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-            wait_script = std.fs.cwd().readFileAllocOptions(allocator, path, 1024 * 1024, null, .of(u8), 0) catch |err| {
-                log.fatal(.app, "failed to read file", .{ .arg = opt, .path = path, .err = err });
-                return error.InvalidArgument;
-            };
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--dump", opt)) {
-            var peek_args = args.*;
-            if (peek_args.next()) |next_arg| {
-                if (std.meta.stringToEnum(DumpFormat, next_arg)) |mode| {
-                    dump_mode = mode;
-                    _ = args.next();
-                } else {
-                    dump_mode = .html;
-                }
-            } else {
-                dump_mode = .html;
-            }
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--noscript", opt)) {
-            log.warn(.app, "deprecation warning", .{
-                .feature = "--noscript argument",
-                .hint = "use '--strip-mode js' instead",
-            });
-            strip.js = true;
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--with-base", opt) or std.mem.eql(u8, "--with_base", opt)) {
-            with_base = true;
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--with-frames", opt) or std.mem.eql(u8, "--with_frames", opt)) {
-            with_frames = true;
-            continue;
-        }
-
-        if (std.mem.eql(u8, "--strip-mode", opt) or std.mem.eql(u8, "--strip_mode", opt)) {
-            const str = args.next() orelse {
-                log.fatal(.app, "missing argument value", .{ .arg = opt });
-                return error.InvalidArgument;
-            };
-
-            var it = std.mem.splitScalar(u8, str, ',');
-            while (it.next()) |part| {
-                const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
-                if (std.mem.eql(u8, trimmed, "js")) {
-                    strip.js = true;
-                } else if (std.mem.eql(u8, trimmed, "ui")) {
-                    strip.ui = true;
-                } else if (std.mem.eql(u8, trimmed, "css")) {
-                    strip.css = true;
-                } else if (std.mem.eql(u8, trimmed, "full")) {
-                    strip.js = true;
-                    strip.ui = true;
-                    strip.css = true;
-                } else {
-                    log.fatal(.app, "invalid option choice", .{ .arg = opt, .value = trimmed });
-                }
-            }
-            continue;
-        }
-
-        if (try parseCommonArg(allocator, opt, args, &common)) {
-            continue;
-        }
-
-        if (std.mem.startsWith(u8, opt, "--")) {
-            log.fatal(.app, "unknown argument", .{ .mode = "fetch", .arg = opt });
-            return error.UnknownOption;
-        }
-
-        if (url != null) {
-            log.fatal(.app, "duplicate fetch url", .{ .help = "only 1 URL can be specified" });
-            return error.TooManyURLs;
-        }
-        url = try allocator.dupeZ(u8, opt);
-    }
-
-    if (url == null) {
-        log.fatal(.app, "missing fetch url", .{ .help = "URL to fetch must be provided" });
-        return error.MissingURL;
-    }
-
-    return .{
-        .url = url.?,
-        .dump_mode = dump_mode,
-        .strip = strip,
-        .common = common,
-        .with_base = with_base,
-        .with_frames = with_frames,
-        .wait_ms = wait_ms,
-        .wait_until = wait_until,
-        .wait_selector = wait_selector,
-        .wait_script = wait_script,
-    };
-}
-
-fn parseCommonArg(
-    allocator: Allocator,
-    opt: []const u8,
-    args: *std.process.ArgIterator,
-    common: *Common,
-) !bool {
-    if (std.mem.eql(u8, "--insecure-disable-tls-host-verification", opt) or std.mem.eql(u8, "--insecure_disable_tls_host_verification", opt)) {
-        common.tls_verify_host = false;
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--obey-robots", opt) or std.mem.eql(u8, "--obey_robots", opt)) {
-        common.obey_robots = true;
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-proxy", opt) or std.mem.eql(u8, "--http_proxy", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-        common.http_proxy = try allocator.dupeZ(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--proxy-bearer-token", opt) or std.mem.eql(u8, "--proxy_bearer_token", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-        common.proxy_bearer_token = try allocator.dupeZ(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-max-concurrent", opt) or std.mem.eql(u8, "--http_max_concurrent", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.http_max_concurrent = std.fmt.parseInt(u8, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-max-host-open", opt) or std.mem.eql(u8, "--http_max_host_open", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.http_max_host_open = std.fmt.parseInt(u8, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-connect-timeout", opt) or std.mem.eql(u8, "--http_connect_timeout", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.http_connect_timeout = std.fmt.parseInt(u31, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-timeout", opt) or std.mem.eql(u8, "--http_timeout", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.http_timeout = std.fmt.parseInt(u31, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-max-response-size", opt) or std.mem.eql(u8, "--http_max_response_size", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.http_max_response_size = std.fmt.parseInt(usize, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--ws-max-concurrent", opt) or std.mem.eql(u8, "--ws_max_concurrent", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.ws_max_concurrent = std.fmt.parseInt(u8, str, 10) catch |err| {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .err = err });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--log-level", opt) or std.mem.eql(u8, "--log_level", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.log_level = std.meta.stringToEnum(log.Level, str) orelse blk: {
-            if (std.mem.eql(u8, str, "error")) {
-                break :blk .err;
-            }
-            log.fatal(.app, "invalid option choice", .{ .arg = opt, .value = str });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--log-format", opt) or std.mem.eql(u8, "--log_format", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        common.log_format = std.meta.stringToEnum(log.Format, str) orelse {
-            log.fatal(.app, "invalid option choice", .{ .arg = opt, .value = str });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--log-filter-scopes", opt) or std.mem.eql(u8, "--log_filter_scopes", opt)) {
-        if (builtin.mode != .Debug) {
-            log.fatal(.app, "experimental", .{ .help = "log scope filtering is only available in debug builds" });
-            return false;
-        }
-
-        const str = args.next() orelse {
-            // disables the default filters
-            common.log_filter_scopes = &.{};
-            return true;
-        };
-
-        var arr: std.ArrayList(log.Scope) = .empty;
-
-        var it = std.mem.splitScalar(u8, str, ',');
-        while (it.next()) |part| {
-            try arr.append(allocator, std.meta.stringToEnum(log.Scope, part) orelse {
-                log.fatal(.app, "invalid option choice", .{ .arg = opt, .value = part });
-                return false;
-            });
-        }
-        common.log_filter_scopes = arr.items;
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--user-agent", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        validateUserAgent(str) catch |err| {
-            log.fatal(.app, "invalid value", .{
-                .detail = "invalid user agent",
-                .arg = opt,
-                .err = err,
-            });
-            return error.InvalidArgument;
-        };
-
-        common.user_agent = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--user-agent-suffix", opt) or std.mem.eql(u8, "--user_agent_suffix", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-
-        if (common.user_agent != null) {
-            log.fatal(.app, "exclusive options", .{
-                .arg = opt,
-                .detail = "--user-agent and --user-agent-suffix are exclusive",
-            });
-            return error.InvalidArgument;
-        }
-
-        for (str) |c| {
-            if (!std.ascii.isPrint(c)) {
-                log.fatal(.app, "not printable character", .{ .arg = opt });
-                return error.InvalidArgument;
-            }
-        }
-        common.user_agent_suffix = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--web-bot-auth-key-file", opt) or std.mem.eql(u8, "--web_bot_auth_key_file", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-        common.web_bot_auth_key_file = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--web-bot-auth-keyid", opt) or std.mem.eql(u8, "--web_bot_auth_keyid", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-        common.web_bot_auth_keyid = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--web-bot-auth-domain", opt) or std.mem.eql(u8, "--web_bot_auth_domain", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = opt });
-            return error.InvalidArgument;
-        };
-        common.web_bot_auth_domain = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--http-cache-dir", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--http-cache-dir" });
-            return error.InvalidArgument;
-        };
-        common.http_cache_dir = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--storage-engine", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--storage-engine" });
-            return error.InvalidArgument;
-        };
-        common.storage_engine = std.meta.stringToEnum(Storage.EngineType, str) orelse {
-            log.fatal(.app, "invalid argument value", .{ .arg = opt, .val = str });
-            return error.InvalidArgument;
-        };
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--storage-sqlite-path", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--storage-sqlite-path" });
-            return error.InvalidArgument;
-        };
-        common.storage_sqlite_path = try allocator.dupeZ(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--block-private-networks", opt)) {
-        common.block_private_networks = true;
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--block-cidrs", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--block-cidrs" });
-            return error.InvalidArgument;
-        };
-        common.block_cidrs = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--cookie", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--cookie" });
-            return error.InvalidArgument;
-        };
-        common.cookie = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    if (std.mem.eql(u8, "--cookie-jar", opt)) {
-        const str = args.next() orelse {
-            log.fatal(.app, "missing argument value", .{ .arg = "--cookie-jar" });
-            return error.InvalidArgument;
-        };
-        common.cookie_jar = try allocator.dupe(u8, str);
-        return true;
-    }
-
-    return false;
-}
-
-pub fn validateUserAgent(ua: []const u8) !void {
-    for (ua) |c| {
-        if (!std.ascii.isPrint(c)) {
-            return error.NonPrintable;
-        }
-    }
-
-    if (std.ascii.indexOfIgnoreCase(ua, "mozilla") != null) {
-        return error.Reserved;
-    }
-}
-
-const testing = @import("testing.zig");
-test "Config: HttpHeaders - default user agent" {
-    var config = try Config.init(testing.allocator, "", .{ .serve = .{} });
-    defer config.deinit(testing.allocator);
-
-    try testing.expectEqual("Lightpanda/1.0", config.http_headers.user_agent);
-    try testing.expectEqual("User-Agent: Lightpanda/1.0", config.http_headers.user_agent_header);
-    try testing.expect(config.http_headers.proxy_bearer_header == null);
-}
-
-test "Config: HttpHeaders - custom user agent override" {
-    var config = try Config.init(testing.allocator, "", .{ .serve = .{ .common = .{ .user_agent = "MyBot/2.0" } } });
-    defer config.deinit(testing.allocator);
-
-    try testing.expectEqual("MyBot/2.0", config.http_headers.user_agent);
-    try testing.expectEqual("User-Agent: MyBot/2.0", config.http_headers.user_agent_header);
-}
-
-test "Config: HttpHeaders - user agent suffix" {
-    var config = try Config.init(testing.allocator, "", .{ .serve = .{ .common = .{ .user_agent_suffix = "CustomSuffix/3.0" } } });
-    defer config.deinit(testing.allocator);
-
-    try testing.expectEqual("Lightpanda/1.0 CustomSuffix/3.0", config.http_headers.user_agent);
-    try testing.expectEqual("User-Agent: Lightpanda/1.0 CustomSuffix/3.0", config.http_headers.user_agent_header);
-}
-
-test "Config: HttpHeaders - fetch mode default user agent" {
-    var config = try Config.init(testing.allocator, "", .{ .fetch = .{ .url = "https://example.com" } });
-    defer config.deinit(testing.allocator);
-    try testing.expectEqual("Lightpanda/1.0", config.http_headers.user_agent);
-}
-
-test "Config: HttpHeaders - fetch mode custom user agent" {
-    var config = try Config.init(testing.allocator, "", .{ .fetch = .{ .url = "https://example.com", .common = .{ .user_agent = "FetchBot/1.0" } } });
-    defer config.deinit(testing.allocator);
-    try testing.expectEqual("FetchBot/1.0", config.http_headers.user_agent);
-    try testing.expectEqual("User-Agent: FetchBot/1.0", config.http_headers.user_agent_header);
-}
-
-test "Config: HttpHeaders - proxy bearer header" {
-    var config = try Config.init(testing.allocator, "", .{ .serve = .{ .common = .{ .proxy_bearer_token = "secret-token" } } });
-    defer config.deinit(testing.allocator);
-    try testing.expectEqual("Lightpanda/1.0", config.http_headers.user_agent);
-    try testing.expectEqual("Proxy-Authorization: Bearer secret-token", config.http_headers.proxy_bearer_header.?);
+    const exec_name, const command = try Commands.parse(allocator);
+    return .init(allocator, exec_name, command);
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -80,11 +80,13 @@ fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
     // Peek next argument.
     var peek_args = args.*;
     if (peek_args.next()) |next_arg| {
-        // Skip the argument we peek if successful.
-        defer _ = args.next();
-        return std.meta.stringToEnum(DumpFormat, next_arg) orelse {
-            return error.UnknownDumpOption;
+        const mode = std.meta.stringToEnum(DumpFormat, next_arg) orelse {
+            return .html;
         };
+
+        // Skip the argument we peek if successful.
+        _ = args.next();
+        return mode;
     }
 
     // Means we couldn't get something like `--dump html` but we do have

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -78,6 +78,8 @@ const CommonOptions = .{
     .{ .name = "block_cidrs", .type = ?[]const u8 },
     .{ .name = "cookie", .type = ?[]const u8 },
     .{ .name = "cookie_jar", .type = ?[]const u8 },
+    .{ .name = "storage_engine", .type = ?Storage.EngineType },
+    .{ .name = "storage_sqlite_path", .type = ?[:0]const u8 },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -357,14 +359,14 @@ pub fn maxPendingConnections(self: *const Config) u31 {
 
 pub fn storageEngine(self: *const Config) ?Storage.EngineType {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.storage_engine,
+        inline .serve, .fetch, .mcp => |opts| opts.storage_engine,
         else => unreachable,
-}
     };
+}
 
 pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.storage_sqlite_path,
+        inline .serve, .fetch, .mcp => |opts| opts.storage_sqlite_path,
         else => unreachable,
     };
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -71,6 +71,9 @@ const CommonOptions = .{
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
+    .{ .name = "user_agent", .type = ?[]const u8 },
+    .{ .name = "block_private_networks", .type = bool },
+    .{ .name = "block_cidrs", .type = ?[]const u8 },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -256,7 +259,7 @@ pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
 
 pub fn userAgent(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.user_agent,
+        inline .serve, .fetch, .mcp => |opts| opts.user_agent,
         .help, .version => null,
     };
 }
@@ -319,14 +322,14 @@ pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
 
 pub fn blockPrivateNetworks(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.block_private_networks,
+        inline .serve, .fetch, .mcp => |opts| opts.block_private_networks,
         else => unreachable,
     };
 }
 
 pub fn blockCidrs(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp => |opts| opts.common.block_cidrs,
+        inline .serve, .fetch, .mcp => |opts| opts.block_cidrs,
         else => unreachable,
     };
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -94,8 +94,8 @@ const Commands = cli.Builder(.{
     .{
         .name = "serve",
         .options = .{
-            .{ .name = "host", .shortcuts = .{"h"}, .type = []const u8, .default = "127.0.0.1" },
-            .{ .name = "port", .shortcuts = .{"p"}, .type = u16, .default = 9222 },
+            .{ .name = "host", .shortcuts = .{ "h", "H" }, .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .shortcuts = .{ "p", "P" }, .type = u16, .default = 9222 },
             .{ .name = "advertise_host", .type = ?[]const u8 },
             .{ .name = "timeout", .type = u31, .default = 10 },
             .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
@@ -109,7 +109,7 @@ const Commands = cli.Builder(.{
         // This argument can be given out of order.
         .positional = .{ .name = "url", .type = ?[:0]const u8 },
         .options = .{
-            .{ .name = "dump", .shortcuts = .{"d"}, .type = ?DumpFormat, .validator = dumpValidator },
+            .{ .name = "dump", .shortcuts = .{ "d", "D" }, .type = ?DumpFormat, .validator = dumpValidator },
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
             .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
@@ -127,8 +127,8 @@ const Commands = cli.Builder(.{
         },
         .shared_options = CommonOptions,
     },
-    .{ .name = "version", .options = .{} },
-    .{ .name = "help", .options = .{} },
+    .{ .name = "version", .aliases = .{"v"}, .options = .{} },
+    .{ .name = "help", .aliases = .{ "h", "?" }, .options = .{} },
 });
 
 pub const RunMode = Commands.Enum;

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -37,6 +37,20 @@ pub const CDP_MAX_MESSAGE_SIZE = 512 * 1024 + 14 + 140;
 
 const Config = @This();
 
+fn logFilterScopesValidator(allocator: Allocator, args: *std.process.ArgIterator, list: *std.ArrayList(log.Scope)) !void {
+    const str = args.next() orelse return error.InvalidOption;
+
+    var it = std.mem.splitScalar(u8, str, ',');
+    while (it.next()) |part| {
+        const v = std.meta.stringToEnum(log.Scope, part) orelse {
+            log.fatal(.app, "invalid option choice", .{ .arg = "log-filter-scopes", .value = part });
+            return error.InvalidOption;
+        };
+
+        try list.append(allocator, v);
+    }
+}
+
 /// Common CLI args.
 const CommonOptions = .{
     .{ .name = "obey_robots", .type = bool },
@@ -51,7 +65,7 @@ const CommonOptions = .{
     .{ .name = "insecure_disable_tls_host_verification", .type = bool },
     .{ .name = "log_level", .type = ?log.Level },
     .{ .name = "log_format", .type = ?log.Format },
-    // TODO: log_filter_scopes (?[]log.Scope) — parser doesn't yet support `multiple` for enums.
+    .{ .name = "log_filter_scopes", .type = log.Scope, .multiple = true, .validator = logFilterScopesValidator },
     .{ .name = "user_agent_suffix", .type = ?[]const u8 },
     .{ .name = "http_cache_dir", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
@@ -232,12 +246,12 @@ pub fn logFormat(self: *const Config) ?log.Format {
     };
 }
 
-//pub fn logFilterScopes(self: *const Config) ?[]const log.Scope {
-//    return switch (self.mode) {
-//        inline .serve, .fetch, .mcp => |opts| opts.log_filter_scopes,
-//        else => unreachable,
-//    };
-//}
+pub fn logFilterScopes(self: *const Config) std.ArrayList(log.Scope) {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp => |opts| opts.log_filter_scopes,
+        else => unreachable,
+    };
+}
 
 pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
     return switch (self.mode) {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -94,8 +94,8 @@ const Commands = cli.Builder(.{
     .{
         .name = "serve",
         .options = .{
-            .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
-            .{ .name = "port", .type = u16, .default = 9222 },
+            .{ .name = "host", .shortcuts = .{"h"}, .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .shortcuts = .{"p"}, .type = u16, .default = 9222 },
             .{ .name = "advertise_host", .type = ?[]const u8 },
             .{ .name = "timeout", .type = u31, .default = 10 },
             .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
@@ -109,13 +109,7 @@ const Commands = cli.Builder(.{
         // This argument can be given out of order.
         .positional = .{ .name = "url", .type = ?[:0]const u8 },
         .options = .{
-            .{
-                .name = "dump",
-                // Prefixed by `-` (single dash).
-                .shortcuts = .{"d"},
-                .type = ?DumpFormat,
-                .validator = dumpValidator,
-            },
+            .{ .name = "dump", .shortcuts = .{"d"}, .type = ?DumpFormat, .validator = dumpValidator },
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
             .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -118,7 +118,7 @@ const Commands = cli.Builder(.{
             .{ .name = "dump", .type = ?DumpFormat, .validator = dumpValidator },
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
-            .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
+            .{ .name = "strip_mode", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
             .{ .name = "wait_ms", .type = u32, .default = 5_000 },
             .{ .name = "wait_until", .type = ?WaitUntil },
             .{ .name = "wait_script", .type = ?[:0]const u8 },
@@ -552,12 +552,12 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\                Argument must be 'html', 'markdown', 'semantic_tree', or 'semantic_tree_text'.
         \\                Defaults to no dump.
         \\
-        \\--strip         Comma separated list of tag groups to remove from dump
-        \\                the dump. e.g. --strip js,css
+        \\--strip-mode    Comma separated list of tag groups to remove from dump
+        \\                the dump. e.g. --strip-mode js,css
         \\                  - "js" script and link[as=script, rel=preload]
         \\                  - "ui" includes img, picture, video, css and svg
         \\                  - "css" includes style and link[rel=stylesheet]
-        \\                  - "all" includes js, ui and css
+        \\                  - "full" includes js, ui and css
         \\
         \\--with-base     Add a <base> tag in dump. Defaults to false.
         \\

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -101,8 +101,8 @@ const Commands = cli.Builder(.{
     .{
         .name = "serve",
         .options = .{
-            .{ .name = "host", .shortcuts = .{ "h", "H" }, .type = []const u8, .default = "127.0.0.1" },
-            .{ .name = "port", .shortcuts = .{ "p", "P" }, .type = u16, .default = 9222 },
+            .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .type = u16, .default = 9222 },
             .{ .name = "advertise_host", .type = ?[]const u8 },
             .{ .name = "timeout", .type = u31, .default = 10 },
             .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
@@ -112,11 +112,10 @@ const Commands = cli.Builder(.{
     },
     .{
         .name = "fetch",
-        .aliases = .{ "f", "get" },
         // This argument can be given out of order.
         .positional = .{ .name = "url", .type = ?[:0]const u8 },
         .options = .{
-            .{ .name = "dump", .shortcuts = .{ "d", "D" }, .type = ?DumpFormat, .validator = dumpValidator },
+            .{ .name = "dump", .type = ?DumpFormat, .validator = dumpValidator },
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
             .{ .name = "strip", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
@@ -134,8 +133,8 @@ const Commands = cli.Builder(.{
         },
         .shared_options = CommonOptions,
     },
-    .{ .name = "version", .aliases = .{"v"}, .options = .{} },
-    .{ .name = "help", .aliases = .{ "h", "?" }, .options = .{} },
+    .{ .name = "version", .options = .{} },
+    .{ .name = "help", .options = .{} },
 });
 
 pub const RunMode = Commands.Enum;

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -365,12 +365,6 @@ pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
         else => unreachable,
     };
 }
-
-//pub const Mcp = struct {
-//    common: Common = .{},
-//    cdp_port: ?u16 = null,
-//};
-
 pub const DumpFormat = enum {
     html,
     markdown,

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const log = lp.log;
 const builtin = @import("builtin");
 
 const cli = @import("cli.zig");
@@ -27,7 +28,8 @@ const mcp = @import("mcp.zig");
 const Storage = @import("storage/Storage.zig");
 const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
 
-const log = lp.log;
+const Allocator = std.mem.Allocator;
+
 pub const CDP_MAX_HTTP_REQUEST_SIZE = 4096;
 
 // max message size

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -653,7 +653,6 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
     std.process.exit(1);
 }
 
-// TODO: Fix mode sniff regression.
 pub fn parseArgs(allocator: Allocator) !Config {
     const exec_name, const command = try Commands.parse(allocator);
     return .init(allocator, exec_name, command);

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -30,7 +30,7 @@ pub const Opts = struct {
     strip: Opts.Strip = .{},
     shadow: Opts.Shadow = .rendered,
 
-    pub const Strip = struct {
+    pub const Strip = packed struct(u3) {
         js: bool = false,
         ui: bool = false,
         css: bool = false,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,13 +26,14 @@ const Allocator = std.mem.Allocator;
 /// ## Command descriptor fields
 ///
 ///   - `name: []const u8` — canonical command name on the command line.
-///   - `options: tuple` — tuple of option descriptors (see below). Use `.{}` for none.
-///   - `aliases: tuple` (optional) — alternative names for the command.
+///   - `options: tuple` — tuple of option descriptors (see below). Use `.{}`
+///     for none.
 ///   - `shared_options: tuple` (optional) — extra options merged into this
 ///     command. Useful for common flags shared across commands.
 ///   - `positional: struct` (optional) — a single positional argument with
 ///     `.name` and `.type`. Type must be an optional pointer-to-u8 slice
-///     (e.g. `?[:0]const u8`). Positionals can appear anywhere in argv.
+///     (e.g. `?[:0]const u8`). Positionals can appear anywhere in argv and
+///     must be provided; a missing positional returns `error.MissingArgument`.
 ///
 /// ## Option descriptor fields
 ///
@@ -41,38 +42,41 @@ const Allocator = std.mem.Allocator;
 ///   - `type` — the Zig type of the parsed value (see supported types below).
 ///   - `default` (optional) — compile-time default when the flag is absent.
 ///     Rules vary by type; see the defaults section below.
-///   - `shortcuts: tuple` (optional) — single-character short flags. Each
-///     shortcut is matched as `-X` on the command line.
 ///   - `multiple: bool` (optional) — when `true`, the field becomes a
-///     `std.ArrayList(type)` and each occurrence appends.
+///     `std.ArrayList(type)` and each occurrence appends. Not supported for
+///     `bool` or packed-struct options.
 ///   - `validator: fn` (optional) — custom parse function that replaces the
 ///     built-in type switch. See the validator section below.
 ///
 /// ## Supported types and their defaults
 ///
-///   - `bool` — presence sets `true`; always defaults to `false`.
-///     Specifying `default` is a compile error. `?bool` is not allowed.
+///   - `bool` — presence flips the field to the opposite of its `default`
+///     (so a flag with `default = true` acts as a disable switch). Defaults
+///     to `false` when no `default` is given. `?bool` is not allowed.
 ///   - Integers (`u8`, `u16`, `u31`, `usize`, etc.) — parsed with
 ///     `std.fmt.parseInt`. Requires `default` unless wrapped in `?`.
-///   - `[]const u8`, `[:0]const u8` (and mutable variants) — string slices,
+///   - `[]const u8`, `[:0]const u8` (and mutable variants) — string slices
 ///     duped from argv. Sentinel is preserved. Requires `default` unless `?`.
-///   - Enums — parsed via `std.meta.stringToEnum`. Requires `default` unless `?`.
+///   - Enums — parsed via `std.meta.stringToEnum`. Returns
+///     `error.UnknownArgument` on a bad value. Requires `default` unless `?`.
 ///   - Packed structs of `bool` fields — parsed from a comma-separated list
-///     (e.g. `--strip js,css`). The literal `"all"` sets every field.
-///     Requires `default`.
+///     (e.g. `--strip js,css`). The literal `"full"` sets every field.
+///     Unknown names return `error.UnknownArgument`. Requires `default`.
+///     `multiple` is not supported.
 ///   - Optional types default to `null` when `default` is omitted.
 ///
 /// ## Validators
 ///
 /// A `validator` is a custom parse function that takes over argument
-/// consumption for an option. The expected signature depends on whether
-/// `multiple` is set:
+/// consumption for an option. Its signature depends on whether `multiple`
+/// is set:
 ///
 ///   - Single: `fn (Allocator, *ArgIterator) !T` — returns the parsed value.
 ///   - Multiple: `fn (Allocator, *ArgIterator, *std.ArrayList(T)) !void` —
 ///     appends directly into the list.
 ///
 /// When a validator is present, the built-in type switch is skipped entirely.
+/// The validator owns advancing the iterator and is free to peek ahead.
 ///
 /// ## Example
 ///
@@ -93,10 +97,9 @@ const Allocator = std.mem.Allocator;
 /// const Cli = cli.Builder(.{
 ///     .{
 ///         .name = "serve",
-///         .aliases = .{"s"},
 ///         .options = .{
-///             .{ .name = "host", .shortcuts = .{"h"}, .type = []const u8, .default = "127.0.0.1" },
-///             .{ .name = "port", .shortcuts = .{"p"}, .type = u16, .default = 9222 },
+///             .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
+///             .{ .name = "port", .type = u16, .default = 9222 },
 ///         },
 ///         .shared_options = CommonOptions,
 ///     },
@@ -105,14 +108,14 @@ const Allocator = std.mem.Allocator;
 ///         .positional = .{ .name = "url", .type = ?[:0]const u8 },
 ///         .options = .{
 ///             .{ .name = "dump", .type = ?DumpFormat, .validator = dumpValidator },
-///             .{ .name = "strip", .type = StripMode, .default = .{} },
+///             .{ .name = "strip_mode", .type = StripMode, .default = .{} },
 ///             .{ .name = "wait_until", .type = ?WaitUntil },
 ///             .{ .name = "extra_header", .type = []const u8, .multiple = true },
 ///         },
 ///         .shared_options = CommonOptions,
 ///     },
 ///     .{ .name = "version", .options = .{} },
-///     .{ .name = "help", .aliases = .{ "h", "?" }, .options = .{} },
+///     .{ .name = "help", .options = .{} },
 /// });
 ///
 /// const _, const cmd = try Cli.parse(arena);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -19,6 +19,110 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+/// Comptime CLI builder that generates a tagged union parser from a
+/// declarative command recipe. Each command becomes a union variant whose
+/// payload is a struct with one field per option.
+///
+/// ## Command descriptor fields
+///
+///   - `name: []const u8` — canonical command name on the command line.
+///   - `options: tuple` — tuple of option descriptors (see below). Use `.{}` for none.
+///   - `aliases: tuple` (optional) — alternative names for the command.
+///   - `shared_options: tuple` (optional) — extra options merged into this
+///     command. Useful for common flags shared across commands.
+///   - `positional: struct` (optional) — a single positional argument with
+///     `.name` and `.type`. Type must be an optional pointer-to-u8 slice
+///     (e.g. `?[:0]const u8`). Positionals can appear anywhere in argv.
+///
+/// ## Option descriptor fields
+///
+///   - `name: []const u8` — snake_case field name. Both `--snake_case` and
+///     `--kebab-case` are accepted on the command line.
+///   - `type` — the Zig type of the parsed value (see supported types below).
+///   - `default` (optional) — compile-time default when the flag is absent.
+///     Rules vary by type; see the defaults section below.
+///   - `shortcuts: tuple` (optional) — single-character short flags. Each
+///     shortcut is matched as `-X` on the command line.
+///   - `multiple: bool` (optional) — when `true`, the field becomes a
+///     `std.ArrayList(type)` and each occurrence appends.
+///   - `validator: fn` (optional) — custom parse function that replaces the
+///     built-in type switch. See the validator section below.
+///
+/// ## Supported types and their defaults
+///
+///   - `bool` — presence sets `true`; always defaults to `false`.
+///     Specifying `default` is a compile error. `?bool` is not allowed.
+///   - Integers (`u8`, `u16`, `u31`, `usize`, etc.) — parsed with
+///     `std.fmt.parseInt`. Requires `default` unless wrapped in `?`.
+///   - `[]const u8`, `[:0]const u8` (and mutable variants) — string slices,
+///     duped from argv. Sentinel is preserved. Requires `default` unless `?`.
+///   - Enums — parsed via `std.meta.stringToEnum`. Requires `default` unless `?`.
+///   - Packed structs of `bool` fields — parsed from a comma-separated list
+///     (e.g. `--strip js,css`). The literal `"all"` sets every field.
+///     Requires `default`.
+///   - Optional types default to `null` when `default` is omitted.
+///
+/// ## Validators
+///
+/// A `validator` is a custom parse function that takes over argument
+/// consumption for an option. The expected signature depends on whether
+/// `multiple` is set:
+///
+///   - Single: `fn (Allocator, *ArgIterator) !T` — returns the parsed value.
+///   - Multiple: `fn (Allocator, *ArgIterator, *std.ArrayList(T)) !void` —
+///     appends directly into the list.
+///
+/// When a validator is present, the built-in type switch is skipped entirely.
+///
+/// ## Example
+///
+/// ```zig
+/// const StripMode = packed struct(u2) {
+///     js: bool = false,
+///     css: bool = false,
+/// };
+///
+/// const WaitUntil = enum { load, domcontentloaded, networkidle };
+///
+/// const CommonOptions = .{
+///     .{ .name = "verbose", .type = bool },
+///     .{ .name = "log_level", .type = ?log.Level },
+///     .{ .name = "timeout", .type = u31, .default = 30 },
+/// };
+///
+/// const Cli = cli.Builder(.{
+///     .{
+///         .name = "serve",
+///         .aliases = .{"s"},
+///         .options = .{
+///             .{ .name = "host", .shortcuts = .{"h"}, .type = []const u8, .default = "127.0.0.1" },
+///             .{ .name = "port", .shortcuts = .{"p"}, .type = u16, .default = 9222 },
+///         },
+///         .shared_options = CommonOptions,
+///     },
+///     .{
+///         .name = "fetch",
+///         .positional = .{ .name = "url", .type = ?[:0]const u8 },
+///         .options = .{
+///             .{ .name = "dump", .type = ?DumpFormat, .validator = dumpValidator },
+///             .{ .name = "strip", .type = StripMode, .default = .{} },
+///             .{ .name = "wait_until", .type = ?WaitUntil },
+///             .{ .name = "extra_header", .type = []const u8, .multiple = true },
+///         },
+///         .shared_options = CommonOptions,
+///     },
+///     .{ .name = "version", .options = .{} },
+///     .{ .name = "help", .aliases = .{ "h", "?" }, .options = .{} },
+/// });
+///
+/// const _, const cmd = try Cli.parse(arena);
+/// switch (cmd) {
+///     .serve => |opts| listen(opts.host, opts.port),
+///     .fetch => |opts| fetch(opts.url.?, opts.dump),
+///     .version => printVersion(),
+///     .help => printHelp(),
+/// }
+/// ```
 pub fn Builder(comptime commands: anytype) type {
     return struct {
         const Self = @This();

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -404,6 +404,12 @@ pub fn Builder(comptime commands: anytype) type {
                 }
             }
 
+            // Parsing is complete and positional is null.
+            const positional_is_null = @hasField(@TypeOf(command), "positional") and @field(c, command.positional.name) == null;
+            if (positional_is_null) {
+                return error.MissingArgument;
+            }
+
             return @unionInit(Union, command.name, c);
         }
     };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -329,25 +329,19 @@ pub fn Builder(comptime commands: anytype) type {
                                     }
                                 },
                                 .@"enum" => {
-                                    if (is_multiple) {
-                                        @compileError("multiple option is not supported for enums");
-                                    }
-
                                     const E = switch (@typeInfo(T)) {
                                         .optional => |optional| optional.child,
                                         inline else => T,
                                     };
 
-                                    // This type only, we peek ahead to check if there's a following arg.
-                                    // If there isn't, the default is set already.
-                                    var peek_args = args.*;
-                                    if (peek_args.next()) |next_arg| {
-                                        const v = std.meta.stringToEnum(E, next_arg) orelse {
-                                            return error.UnknownArgument;
-                                        };
-                                        // Discard.
-                                        _ = args.next();
+                                    // TODO: Return errors.
+                                    const v = std.meta.stringToEnum(E, args.next().?) orelse {
+                                        return error.UnknownArgument;
+                                    };
 
+                                    if (is_multiple) {
+                                        try @field(c, option.name).append(allocator, v);
+                                    } else {
                                         @field(c, option.name) = v;
                                     }
                                 },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -310,11 +310,7 @@ pub fn Builder(comptime commands: anytype) type {
             // Serve heuristics.
             inline for (.{
                 "--host",
-                "-h",
-                "-H",
                 "--port",
-                "-p",
-                "-P",
                 "--timeout",
             }) |heuristic| {
                 if (std.mem.eql(u8, cmd_str, heuristic)) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -242,11 +242,13 @@ pub fn Builder(comptime commands: anytype) type {
 
                         // Prefer custom validator logic instead.
                         if (has_validator) {
-                            const v = try @call(.auto, option.validator, .{ allocator, args });
-
+                            const validator = option.validator;
                             if (is_multiple) {
-                                try @field(c, option.name).append(allocator, v);
+                                // Pass the list.
+                                try @call(.auto, validator, .{ allocator, args, &@field(c, option.name) });
                             } else {
+                                // Receive the value from return.
+                                const v = try @call(.auto, validator, .{ allocator, args });
                                 @field(c, option.name) = v;
                             }
                         } else {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -279,6 +279,61 @@ pub fn Builder(comptime commands: anytype) type {
                 }
             }
 
+            // Last resort, try sniffing.
+            const command_enum = try sniffCommand(cmd_str);
+            // "cmd_str" wasn't a command but an option. We can't reset args, but
+            // we can create a new one. Not great, but this fallback is temporary
+            // as we transition to this command mode approach.
+            args.deinit();
+            args = try std.process.argsWithAllocator(allocator);
+            // Skip the `exec_name`.
+            _ = args.skip();
+
+            inline for (commands) |command| {
+                if (std.mem.eql(u8, @tagName(command_enum), command.name)) {
+                    return .{ exec_name, try parseCommand(allocator, command, &args) };
+                }
+            }
+
+            unreachable;
+        }
+
+        /// Try to sniff the command out of given option.
+        /// Only exists for legacy reasons; hence hardcoded.
+        fn sniffCommand(cmd_str: []const u8) error{UnknownCommand}!Enum {
+            if (std.mem.startsWith(u8, cmd_str, "--") == false) {
+                return .fetch;
+            }
+
+            // Fetch heuristics.
+            inline for (.{
+                "--dump",
+                "--strip",
+                "--with-base",
+                "--with_base",
+                "--with-frames",
+                "--with_frames",
+            }) |heuristic| {
+                if (std.mem.eql(u8, cmd_str, heuristic)) {
+                    return .fetch;
+                }
+            }
+
+            // Serve heuristics.
+            inline for (.{
+                "--host",
+                "-h",
+                "-H",
+                "--port",
+                "-p",
+                "-P",
+                "--timeout",
+            }) |heuristic| {
+                if (std.mem.eql(u8, cmd_str, heuristic)) {
+                    return .serve;
+                }
+            }
+
             return error.UnknownCommand;
         }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -574,6 +574,9 @@ pub fn Builder(comptime commands: anytype) type {
                         },
                         inline else => @compileError("not supported"),
                     }
+                } else {
+                    log.fatal(.app, "unknown argument", .{ .mode = command.name, .arg = option_name });
+                    return error.UnknownOption;
                 }
             }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -440,7 +440,7 @@ pub fn Builder(comptime commands: anytype) type {
                                         @field(c, option.name) = @bitCast(@as(Int, std.math.maxInt(Int)));
                                     } else {
                                         // Parse given args.
-                                        var it = std.mem.splitScalar(u8, str, ',');
+                                        var it = std.mem.tokenizeScalar(u8, str, ',');
                                         outer: while (it.next()) |part| {
                                             const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -263,19 +263,9 @@ pub fn Builder(comptime commands: anytype) type {
 
             const cmd_str: []const u8 = args.next() orelse return error.MissingCommand;
             inline for (commands) |command| {
-                // Command name together with it's aliases.
-                const with_aliases = blk: {
-                    if (@hasField(@TypeOf(command), "aliases")) {
-                        break :blk command.aliases ++ .{command.name};
-                    }
-
-                    break :blk .{command.name};
-                };
-
-                inline for (with_aliases) |name| {
-                    if (std.mem.eql(u8, cmd_str, name)) {
-                        return .{ exec_name, try parseCommand(allocator, command, &args) };
-                    }
+                // Match a command.
+                if (std.mem.eql(u8, cmd_str, command.name)) {
+                    return .{ exec_name, try parseCommand(allocator, command, &args) };
                 }
             }
 
@@ -369,18 +359,6 @@ pub fn Builder(comptime commands: anytype) type {
                         const match =
                             std.mem.eql(u8, option_name, "--" ++ option.name) or
                             std.mem.eql(u8, option_name, "--" ++ kebab_cased);
-
-                        // Name not matched; try shortcuts if provided.
-                        if (!match) {
-                            if (@hasField(@TypeOf(option), "shortcuts")) {
-                                inline for (option.shortcuts) |shortcut| {
-                                    if (std.mem.eql(u8, option_name, "-" ++ shortcut)) {
-                                        break :blk true;
-                                    }
-                                }
-                            }
-                        }
-
                         break :blk match;
                     };
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -60,7 +60,7 @@ const Allocator = std.mem.Allocator;
 ///   - Enums — parsed via `std.meta.stringToEnum`. Returns
 ///     `error.UnknownArgument` on a bad value. Requires `default` unless `?`.
 ///   - Packed structs of `bool` fields — parsed from a comma-separated list
-///     (e.g. `--strip js,css`). The literal `"full"` sets every field.
+///     (e.g. `--strip-mode js,css`). The literal `"full"` sets every field.
 ///     Unknown names return `error.UnknownArgument`. Requires `default`.
 ///     `multiple` is not supported.
 ///   - Optional types default to `null` when `default` is omitted.
@@ -306,7 +306,8 @@ pub fn Builder(comptime commands: anytype) type {
             // Fetch heuristics.
             inline for (.{
                 "--dump",
-                "--strip",
+                "--strip-mode",
+                "--strip_mode",
                 "--with-base",
                 "--with_base",
                 "--with-frames",

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -157,8 +157,7 @@ pub fn Builder(comptime commands: anytype) type {
 
             const exec_name = std.fs.path.basename(args.next().?);
 
-            // TODO: Return error.
-            const cmd_str: []const u8 = args.next().?;
+            const cmd_str: []const u8 = args.next() orelse return error.MissingCommand;
             inline for (commands) |command| {
                 // Command name together with it's aliases.
                 const with_aliases = blk: {
@@ -176,8 +175,7 @@ pub fn Builder(comptime commands: anytype) type {
                 }
             }
 
-            // TODO: Unknown command.
-            @panic("unknown command");
+            return error.UnknownCommand;
         }
 
         /// Parses the command with its options.
@@ -236,7 +234,6 @@ pub fn Builder(comptime commands: anytype) type {
                             break :blk info;
                         };
 
-                        // TODO: Support multiples.
                         const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
                         const has_validator = @hasField(@TypeOf(option), "validator");
 
@@ -255,8 +252,7 @@ pub fn Builder(comptime commands: anytype) type {
                             switch (option_info) {
                                 .int => |int| {
                                     const Int = std.meta.Int(int.signedness, int.bits);
-                                    // TODO: Return correct errors.
-                                    const v = try std.fmt.parseInt(Int, args.next().?, 10);
+                                    const v = try std.fmt.parseInt(Int, args.next() orelse return error.MissingArgument, 10);
 
                                     if (is_multiple) {
                                         // Push to ArrayList.
@@ -271,10 +267,9 @@ pub fn Builder(comptime commands: anytype) type {
                                         @compileError("Only []u8, []const u8, [:sentinel]u8 and [:sentinel]const u8 pointers are supported");
                                     }
 
-                                    // TODO: Return error.
-                                    const str = args.next().?;
-
                                     const v = blk: {
+                                        const str = args.next() orelse return error.MissingArgument;
+
                                         // DupeZ branch.
                                         if (comptime pointer.sentinel()) |sentinel| {
                                             const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len + 1);
@@ -306,8 +301,7 @@ pub fn Builder(comptime commands: anytype) type {
                                         @compileError("only packed structs are allowed");
                                     }
 
-                                    // TODO: Return error.
-                                    const str = args.next().?;
+                                    const str = args.next() orelse return error.MissingArgument;
 
                                     if (std.mem.eql(u8, str, "all")) {
                                         // "all" sets all the fields of packed struct.
@@ -336,8 +330,7 @@ pub fn Builder(comptime commands: anytype) type {
                                         inline else => T,
                                     };
 
-                                    // TODO: Return errors.
-                                    const v = std.meta.stringToEnum(E, args.next().?) orelse {
+                                    const v = std.meta.stringToEnum(E, args.next() orelse return error.MissingArgument) orelse {
                                         return error.UnknownArgument;
                                     };
 
@@ -372,7 +365,7 @@ pub fn Builder(comptime commands: anytype) type {
 
                     // Already given one.
                     if (@field(c, positional.name) != null) {
-                        return error.TooManyPositionalArgs;
+                        return error.TooManyPositionalArguments;
                     }
 
                     // The positional must be an optional type.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -363,11 +363,6 @@ pub fn Builder(comptime commands: anytype) type {
                     }
                 }
 
-                // An option we don't know of.
-                if (std.mem.startsWith(u8, option_name, "--")) {
-                    return error.UnkownOption;
-                }
-
                 // Parse positional arg if provided; can be given out of order:
                 //
                 // lightpanda fetch --wait-ms 2_000 "https://lightpanda.io" --dump "html"
@@ -410,6 +405,9 @@ pub fn Builder(comptime commands: anytype) type {
                         },
                         inline else => @compileError("not supported"),
                     }
+                } else {
+                    // An option we don't know of.
+                    return error.UnknownOption;
                 }
             }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -19,8 +19,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-/// Creates a new CLI parser from given commands recipe.
-pub fn Commands(comptime commands: anytype) type {
+pub fn Builder(comptime commands: anytype) type {
     return struct {
         const Self = @This();
 
@@ -41,59 +40,64 @@ pub fn Commands(comptime commands: anytype) type {
             });
         };
 
+        /// Creates an array of `StructField` out of given options.
+        fn optionsToStructFields(comptime options: anytype) [options.len]std.builtin.Type.StructField {
+            var fields: [options.len]std.builtin.Type.StructField = undefined;
+
+            inline for (options, 0..) |option, j| {
+                const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
+                const T, const default = type_and_default: {
+                    if (is_multiple) {
+                        // We currently don't allow default values for lists.
+                        if (@hasField(@TypeOf(option), "default")) unreachable;
+                        // If `multiple` provided, prefer `ArrayList`.
+                        const T = std.ArrayList(option.type);
+                        break :type_and_default .{ T, &@as(T, .{}) };
+                    }
+
+                    const T = option.type;
+                    break :type_and_default .{ T, &@as(T, option.default) };
+                };
+
+                fields[j] = .{
+                    .name = option.name,
+                    .type = T,
+                    .default_value_ptr = @ptrCast(default),
+                    .is_comptime = false,
+                    .alignment = @alignOf(T),
+                };
+            }
+
+            return fields;
+        }
+
         /// Union type for provided commands.
         pub const Union = blk: {
             var union_fields: [commands.len]std.builtin.Type.UnionField = undefined;
-            // Populate both `enum_fields` and `union_fields`.
             for (commands, 0..) |command, i| {
+                const Command = @TypeOf(command);
                 const options = command.options;
-
-                // Whether this command has `positional` argument.
-                const has_positional = @hasField(@TypeOf(command), "positional");
-                const fields_len = if (has_positional) options.len + 1 else options.len;
-
-                var struct_fields: [fields_len]std.builtin.Type.StructField = undefined;
-                for (options, 0..) |option, j| {
-                    const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
-                    const T, const default = type_and_default: {
-                        if (is_multiple) {
-                            // We currently don't allow default values for lists.
-                            if (@hasField(@TypeOf(option), "default")) unreachable;
-                            // If `multiple` provided, prefer `ArrayList`.
-                            const T = std.ArrayList(option.type);
-                            break :type_and_default .{ T, &@as(T, .{}) };
-                        }
-
-                        const T = option.type;
-                        break :type_and_default .{ T, &@as(T, option.default) };
-                    };
-
-                    struct_fields[j] = .{
-                        .name = option.name,
-                        .type = T,
-                        .default_value_ptr = default,
-                        .is_comptime = false,
-                        .alignment = @alignOf(T),
-                    };
-                }
-
-                // Add a field for `positional`.
-                if (has_positional) {
-                    const positional = command.positional;
-                    const T = positional.type;
-                    struct_fields[fields_len - 1] = .{
-                        .name = positional.name,
-                        .type = T,
-                        .default_value_ptr = &@as(T, null),
-                        .is_comptime = false,
-                        .alignment = @alignOf(T),
-                    };
-                }
 
                 const T = @Type(.{
                     .@"struct" = .{
                         .decls = &.{},
-                        .fields = &struct_fields,
+                        .fields = &(optionsToStructFields(options) ++
+                            (if (@hasField(Command, "shared_options"))
+                                optionsToStructFields(command.shared_options)
+                            else
+                                .{}) ++
+                            (if (@hasField(Command, "positional"))
+                                [1]std.builtin.Type.StructField{
+                                    .{
+                                        .name = command.positional.name,
+                                        .type = command.positional.type,
+                                        .default_value_ptr = @ptrCast(&@as(command.positional.type, null)),
+                                        .is_comptime = false,
+                                        .alignment = @alignOf(command.positional.type),
+                                    },
+                                }
+                            else
+                                .{})),
                         .is_tuple = false,
                         .layout = .auto,
                     },
@@ -112,19 +116,29 @@ pub fn Commands(comptime commands: anytype) type {
             });
         };
 
-        pub fn parse(allocator: Allocator) !Union {
+        /// Parses executable name, command and options via single call.
+        pub fn parse(allocator: Allocator) !struct { []const u8, Union } {
             var args = try std.process.argsWithAllocator(allocator);
             defer args.deinit();
 
-            // Skip program name.
             const exec_name = std.fs.path.basename(args.next().?);
-            _ = exec_name;
 
+            // TODO: Return error.
             const cmd_str: []const u8 = args.next().?;
-
             inline for (commands) |command| {
-                if (std.mem.eql(u8, cmd_str, command.name)) {
-                    return parseCommand(allocator, command, &args);
+                // Command name together with it's aliases.
+                const with_aliases = blk: {
+                    if (@hasField(@TypeOf(command), "aliases")) {
+                        break :blk command.aliases ++ .{command.name};
+                    }
+
+                    break :blk .{command.name};
+                };
+
+                inline for (with_aliases) |name| {
+                    if (std.mem.eql(u8, cmd_str, name)) {
+                        return .{ exec_name, try parseCommand(allocator, command, &args) };
+                    }
                 }
             }
 
@@ -141,7 +155,13 @@ pub fn Commands(comptime commands: anytype) type {
             const Command = @FieldType(Union, command.name);
             var c = Command{};
 
-            const options = command.options;
+            const options = blk: {
+                if (@hasField(@TypeOf(command), "shared_options")) {
+                    break :blk command.options ++ command.shared_options;
+                }
+
+                break :blk command.options;
+            };
             iter_args: while (args.next()) |option_name| {
                 inline for (options) |option| {
                     // We allow both `--my-option` and `--my_option` variants;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -464,6 +464,9 @@ pub fn Builder(comptime commands: anytype) type {
                                                     continue :outer;
                                                 }
                                             }
+
+                                            // Not equal to any of the fields.
+                                            return error.UnknownArgument;
                                         }
                                     }
                                 },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -180,11 +180,9 @@ pub fn Builder(comptime commands: anytype) type {
                             break :blk @as(*const anyopaque, @ptrCast(&@as(T, option.default)));
                         },
                         .bool => {
-                            if (has_default) {
-                                @compileError("booleans are always `false` by default");
-                            }
-                            // Booleans are always initalized false.
-                            break :blk @as(*const anyopaque, @ptrCast(&@as(T, false)));
+                            // Prefer `false` if no default.
+                            const default = if (has_default) option.default else false;
+                            break :blk @as(*const anyopaque, @ptrCast(&@as(T, default)));
                         },
                         inline else => {
                             if (!has_default) {
@@ -482,7 +480,15 @@ pub fn Builder(comptime commands: anytype) type {
                                         @compileError("multiple option is not supported for booleans");
                                     }
 
-                                    @field(c, option.name) = true;
+                                    const default = blk: {
+                                        if (@hasField(@TypeOf(option), "default")) {
+                                            break :blk option.default;
+                                        }
+                                        break :blk false;
+                                    };
+
+                                    // Set opposite of the default.
+                                    @field(c, option.name) = !default;
                                 },
 
                                 else => {},

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -269,6 +269,13 @@ pub fn Builder(comptime commands: anytype) type {
 
             // Last resort, try sniffing.
             const command_enum = try sniffCommand(cmd_str);
+
+            // `help` takes no arguments; short-circuit so the sniffed flag
+            // isn't re-parsed as an unknown option.
+            if (command_enum == .help) {
+                return .{ exec_name, .{ .help = .{} } };
+            }
+
             // "cmd_str" wasn't a command but an option. We can't reset args, but
             // we can create a new one. Not great, but this fallback is temporary
             // as we transition to this command mode approach.
@@ -316,6 +323,11 @@ pub fn Builder(comptime commands: anytype) type {
                 if (std.mem.eql(u8, cmd_str, heuristic)) {
                     return .serve;
                 }
+            }
+
+            // Legacy `--help` flag maps to the `help` command.
+            if (std.mem.eql(u8, cmd_str, "--help")) {
+                return .help;
             }
 
             return error.UnknownCommand;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -18,6 +18,8 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const lp = @import("lightpanda");
+const log = lp.log;
 
 /// Comptime CLI builder that generates a tagged union parser from a
 /// declarative command recipe. Each command becomes a union variant whose
@@ -355,22 +357,19 @@ pub fn Builder(comptime commands: anytype) type {
             };
             iter_args: while (args.next()) |option_name| {
                 inline for (options) |option| {
-                    // Match an option.
-                    const match = blk: {
-                        // We allow both `--my-option` and `--my_option` variants;
-                        // assuming given `option` struct prefer snake_case for `name`.
-                        const kebab_cased = comptime casing: {
-                            var output: [option.name.len]u8 = undefined;
-                            @memcpy(&output, option.name);
-                            std.mem.replaceScalar(u8, &output, '_', '-');
-                            break :casing output;
-                        };
-
-                        const match =
-                            std.mem.eql(u8, option_name, "--" ++ option.name) or
-                            std.mem.eql(u8, option_name, "--" ++ kebab_cased);
-                        break :blk match;
+                    // We allow both `--my-option` and `--my_option` variants;
+                    // assuming given `option` struct prefer snake_case for `name`.
+                    const kebab_cased = comptime casing: {
+                        var output: [option.name.len]u8 = undefined;
+                        @memcpy(&output, option.name);
+                        std.mem.replaceScalar(u8, &output, '_', '-');
+                        break :casing "--" ++ output;
                     };
+
+                    // Match an option.
+                    const match =
+                        std.mem.eql(u8, option_name, "--" ++ option.name) or
+                        std.mem.eql(u8, option_name, kebab_cased);
 
                     if (match) {
                         const T = option.type;
@@ -399,7 +398,15 @@ pub fn Builder(comptime commands: anytype) type {
                             switch (option_info) {
                                 .int => |int| {
                                     const Int = std.meta.Int(int.signedness, int.bits);
-                                    const v = try std.fmt.parseInt(Int, args.next() orelse return error.MissingArgument, 10);
+
+                                    const str = args.next() orelse return error.MissingArgument;
+                                    const v = std.fmt.parseInt(Int, str, 10) catch |err| {
+                                        switch (err) {
+                                            error.Overflow => log.fatal(.app, "range overflow", .{ .arg = kebab_cased, .value = str }),
+                                            error.InvalidCharacter => log.fatal(.app, "invalid character", .{ .arg = kebab_cased, .value = str }),
+                                        }
+                                        continue :iter_args;
+                                    };
 
                                     if (is_multiple) {
                                         // Push to ArrayList.
@@ -461,7 +468,10 @@ pub fn Builder(comptime commands: anytype) type {
                                             const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
 
                                             inline for (_struct.fields) |f| {
-                                                std.debug.assert(f.type == bool);
+                                                lp.assert(f.type == bool, "all fields of packed struct must be boolean", .{
+                                                    .option = option.name,
+                                                    .field = f.name,
+                                                });
 
                                                 if (std.mem.eql(u8, trimmed, @as([]const u8, f.name))) {
                                                     @field(@field(c, option.name), f.name) = true;
@@ -469,8 +479,8 @@ pub fn Builder(comptime commands: anytype) type {
                                                 }
                                             }
 
-                                            // Not equal to any of the fields.
-                                            return error.UnknownArgument;
+                                            // Invalid option choice.
+                                            log.fatal(.app, "invalid option choice", .{ .arg = kebab_cased, .value = trimmed });
                                         }
                                     }
                                 },
@@ -480,8 +490,10 @@ pub fn Builder(comptime commands: anytype) type {
                                         inline else => T,
                                     };
 
-                                    const v = std.meta.stringToEnum(E, args.next() orelse return error.MissingArgument) orelse {
-                                        return error.UnknownArgument;
+                                    const str = args.next() orelse return error.MissingArgument;
+                                    const v = std.meta.stringToEnum(E, str) orelse {
+                                        log.fatal(.app, "invalid option choice", .{ .arg = kebab_cased, .value = str });
+                                        continue :iter_args;
                                     };
 
                                     if (is_multiple) {
@@ -512,6 +524,12 @@ pub fn Builder(comptime commands: anytype) type {
 
                         continue :iter_args;
                     }
+                }
+
+                // Encountered an option we don't know of.
+                if (std.mem.startsWith(u8, option_name, "--")) {
+                    log.fatal(.app, "unknown argument", .{ .mode = command.name, .arg = option_name });
+                    return error.UnknownOption;
                 }
 
                 // Parse positional arg if provided; can be given out of order:
@@ -556,9 +574,6 @@ pub fn Builder(comptime commands: anytype) type {
                         },
                         inline else => @compileError("not supported"),
                     }
-                } else {
-                    // An option we don't know of.
-                    return error.UnknownOption;
                 }
             }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -45,24 +45,56 @@ pub fn Builder(comptime commands: anytype) type {
             var fields: [options.len]std.builtin.Type.StructField = undefined;
 
             inline for (options, 0..) |option, j| {
+                // Whether prefer `ArrayList` for the option.
                 const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
-                const T, const default = type_and_default: {
+                // Whether option has a default value.
+                const has_default = @hasField(@TypeOf(option), "default");
+
+                const T = if (is_multiple) std.ArrayList(option.type) else option.type;
+
+                const default = blk: {
                     if (is_multiple) {
                         // We currently don't allow default values for lists.
-                        if (@hasField(@TypeOf(option), "default")) unreachable;
-                        // If `multiple` provided, prefer `ArrayList`.
-                        const T = std.ArrayList(option.type);
-                        break :type_and_default .{ T, &@as(T, .{}) };
+                        if (has_default) {
+                            @compileError("`default` is not allowed for lists");
+                        }
+                        // Multiples are always initialized the same.
+                        break :blk @as(*const anyopaque, @ptrCast(&@as(T, .{})));
                     }
 
-                    const T = option.type;
-                    break :type_and_default .{ T, &@as(T, option.default) };
+                    switch (@typeInfo(option.type)) {
+                        .optional => |optional| {
+                            if (optional.child == bool) {
+                                @compileError("?bool is not supported, prefer enum");
+                            }
+
+                            // If type is an optional type without default value, prefer null.
+                            if (!has_default) {
+                                break :blk @as(*const anyopaque, @ptrCast(&@as(T, null)));
+                            }
+                            // We have default value for an optional.
+                            break :blk @as(*const anyopaque, @ptrCast(&@as(T, option.default)));
+                        },
+                        .bool => {
+                            if (has_default) {
+                                @compileError("booleans are always `false` by default");
+                            }
+                            // Booleans are always initalized false.
+                            break :blk @as(*const anyopaque, @ptrCast(&@as(T, false)));
+                        },
+                        inline else => {
+                            if (!has_default) {
+                                @compileError("option `" ++ option.name ++ "` is not optional type and has no default value");
+                            }
+                            break :blk @as(*const anyopaque, @ptrCast(&@as(T, option.default)));
+                        },
+                    }
                 };
 
                 fields[j] = .{
                     .name = option.name,
                     .type = T,
-                    .default_value_ptr = @ptrCast(default),
+                    .default_value_ptr = default,
                     .is_comptime = false,
                     .alignment = @alignOf(T),
                 };
@@ -78,26 +110,28 @@ pub fn Builder(comptime commands: anytype) type {
                 const Command = @TypeOf(command);
                 const options = command.options;
 
+                const fields = optionsToStructFields(options) ++
+                    (if (@hasField(Command, "shared_options"))
+                        optionsToStructFields(command.shared_options)
+                    else
+                        .{}) ++
+                    (if (@hasField(Command, "positional"))
+                        [1]std.builtin.Type.StructField{
+                            .{
+                                .name = command.positional.name,
+                                .type = command.positional.type,
+                                .default_value_ptr = @ptrCast(&@as(command.positional.type, null)),
+                                .is_comptime = false,
+                                .alignment = @alignOf(command.positional.type),
+                            },
+                        }
+                    else
+                        .{});
+
                 const T = @Type(.{
                     .@"struct" = .{
                         .decls = &.{},
-                        .fields = &(optionsToStructFields(options) ++
-                            (if (@hasField(Command, "shared_options"))
-                                optionsToStructFields(command.shared_options)
-                            else
-                                .{}) ++
-                            (if (@hasField(Command, "positional"))
-                                [1]std.builtin.Type.StructField{
-                                    .{
-                                        .name = command.positional.name,
-                                        .type = command.positional.type,
-                                        .default_value_ptr = @ptrCast(&@as(command.positional.type, null)),
-                                        .is_comptime = false,
-                                        .alignment = @alignOf(command.positional.type),
-                                    },
-                                }
-                            else
-                                .{})),
+                        .fields = &fields,
                         .is_tuple = false,
                         .layout = .auto,
                     },
@@ -164,19 +198,36 @@ pub fn Builder(comptime commands: anytype) type {
             };
             iter_args: while (args.next()) |option_name| {
                 inline for (options) |option| {
-                    // We allow both `--my-option` and `--my_option` variants;
-                    // assuming given `option` struct prefer snake_case for name.
-                    const kebab_cased = comptime blk: {
-                        var output: [option.name.len]u8 = undefined;
-                        @memcpy(&output, option.name);
-                        std.mem.replaceScalar(u8, &output, '_', '-');
-                        break :blk output;
+                    // Match an option.
+                    const match = blk: {
+                        // We allow both `--my-option` and `--my_option` variants;
+                        // assuming given `option` struct prefer snake_case for `name`.
+                        const kebab_cased = comptime casing: {
+                            var output: [option.name.len]u8 = undefined;
+                            @memcpy(&output, option.name);
+                            std.mem.replaceScalar(u8, &output, '_', '-');
+                            break :casing output;
+                        };
+
+                        const match =
+                            std.mem.eql(u8, option_name, "--" ++ option.name) or
+                            std.mem.eql(u8, option_name, "--" ++ kebab_cased);
+
+                        // Name not matched; try shortcuts if provided.
+                        if (!match) {
+                            if (@hasField(@TypeOf(option), "shortcuts")) {
+                                inline for (option.shortcuts) |shortcut| {
+                                    if (std.mem.eql(u8, option_name, "-" ++ shortcut)) {
+                                        break :blk true;
+                                    }
+                                }
+                            }
+                        }
+
+                        break :blk match;
                     };
 
-                    // Match an option.
-                    if (std.mem.eql(u8, option_name, "--" ++ option.name) or
-                        std.mem.eql(u8, option_name, "--" ++ kebab_cased))
-                    {
+                    if (match) {
                         const T = option.type;
                         const option_info = blk: {
                             const info = @typeInfo(T);
@@ -187,117 +238,129 @@ pub fn Builder(comptime commands: anytype) type {
 
                         // TODO: Support multiples.
                         const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
+                        const has_validator = @hasField(@TypeOf(option), "validator");
 
-                        switch (option_info) {
-                            .int => |int| {
-                                const Int = std.meta.Int(int.signedness, int.bits);
-                                // TODO: Return correct errors.
-                                const v = try std.fmt.parseInt(Int, args.next().?, 10);
+                        // Prefer custom validator logic instead.
+                        if (has_validator) {
+                            const v = try @call(.auto, option.validator, .{ allocator, args });
 
-                                if (is_multiple) {
-                                    // Push to ArrayList.
-                                    try @field(c, option.name).append(allocator, v);
-                                } else {
-                                    @field(c, option.name) = v;
-                                }
-                            },
-                            .pointer => |pointer| {
-                                const not_u8_slice = pointer.child != u8 or pointer.size != .slice;
-                                if (not_u8_slice) {
-                                    @compileError("Only []u8, []const u8, [:sentinel]u8 and [:sentinel]const u8 pointers are supported");
-                                }
+                            if (is_multiple) {
+                                try @field(c, option.name).append(allocator, v);
+                            } else {
+                                @field(c, option.name) = v;
+                            }
+                        } else {
+                            switch (option_info) {
+                                .int => |int| {
+                                    const Int = std.meta.Int(int.signedness, int.bits);
+                                    // TODO: Return correct errors.
+                                    const v = try std.fmt.parseInt(Int, args.next().?, 10);
 
-                                // TODO: Return error.
-                                const str = args.next().?;
-
-                                const v = blk: {
-                                    // DupeZ branch.
-                                    if (comptime pointer.sentinel()) |sentinel| {
-                                        const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len + 1);
-                                        @memcpy(buf[0..str.len], str);
-                                        buf[str.len] = sentinel;
-                                        break :blk buf[0..str.len :sentinel];
+                                    if (is_multiple) {
+                                        // Push to ArrayList.
+                                        try @field(c, option.name).append(allocator, v);
+                                    } else {
+                                        @field(c, option.name) = v;
+                                    }
+                                },
+                                .pointer => |pointer| {
+                                    const not_u8_slice = pointer.child != u8 or pointer.size != .slice;
+                                    if (not_u8_slice) {
+                                        @compileError("Only []u8, []const u8, [:sentinel]u8 and [:sentinel]const u8 pointers are supported");
                                     }
 
-                                    // Dupe branch.
-                                    const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len);
-                                    @memcpy(buf, str);
-                                    break :blk buf;
-                                };
+                                    // TODO: Return error.
+                                    const str = args.next().?;
 
-                                if (is_multiple) {
-                                    try @field(c, option.name).append(allocator, v);
-                                } else {
-                                    @field(c, option.name) = v;
-                                }
-                            },
-                            .@"struct" => |_struct| {
-                                // Don't support multiple for structs for now.
-                                if (is_multiple) {
-                                    @compileError("multiple option is not supported for structs");
-                                }
+                                    const v = blk: {
+                                        // DupeZ branch.
+                                        if (comptime pointer.sentinel()) |sentinel| {
+                                            const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len + 1);
+                                            @memcpy(buf[0..str.len], str);
+                                            buf[str.len] = sentinel;
+                                            break :blk buf[0..str.len :sentinel];
+                                        }
 
-                                const not_packed = _struct.layout != .@"packed";
-                                if (not_packed) {
-                                    @compileError("only packed structs are allowed");
-                                }
+                                        // Dupe branch.
+                                        const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len);
+                                        @memcpy(buf, str);
+                                        break :blk buf;
+                                    };
 
-                                // TODO: Return error.
-                                const str = args.next().?;
+                                    if (is_multiple) {
+                                        try @field(c, option.name).append(allocator, v);
+                                    } else {
+                                        @field(c, option.name) = v;
+                                    }
+                                },
+                                .@"struct" => |_struct| {
+                                    // Don't support multiple for structs for now.
+                                    if (is_multiple) {
+                                        @compileError("multiple option is not supported for structs");
+                                    }
 
-                                if (std.mem.eql(u8, str, "all")) {
-                                    // "all" sets all the fields of packed struct.
-                                    const Int = _struct.backing_integer.?;
-                                    @field(c, option.name) = @bitCast(@as(Int, std.math.maxInt(Int)));
-                                } else {
-                                    // Parse given args.
-                                    var it = std.mem.splitScalar(u8, str, ',');
-                                    outer: while (it.next()) |part| {
-                                        const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
+                                    const not_packed = _struct.layout != .@"packed";
+                                    if (not_packed) {
+                                        @compileError("only packed structs are allowed");
+                                    }
 
-                                        inline for (_struct.fields) |f| {
-                                            std.debug.assert(f.type == bool);
+                                    // TODO: Return error.
+                                    const str = args.next().?;
 
-                                            if (std.mem.eql(u8, trimmed, @as([]const u8, f.name))) {
-                                                @field(@field(c, option.name), f.name) = true;
-                                                continue :outer;
+                                    if (std.mem.eql(u8, str, "all")) {
+                                        // "all" sets all the fields of packed struct.
+                                        const Int = _struct.backing_integer.?;
+                                        @field(c, option.name) = @bitCast(@as(Int, std.math.maxInt(Int)));
+                                    } else {
+                                        // Parse given args.
+                                        var it = std.mem.splitScalar(u8, str, ',');
+                                        outer: while (it.next()) |part| {
+                                            const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
+
+                                            inline for (_struct.fields) |f| {
+                                                std.debug.assert(f.type == bool);
+
+                                                if (std.mem.eql(u8, trimmed, @as([]const u8, f.name))) {
+                                                    @field(@field(c, option.name), f.name) = true;
+                                                    continue :outer;
+                                                }
                                             }
                                         }
                                     }
-                                }
-                            },
-                            .@"enum" => {
-                                if (is_multiple) {
-                                    @compileError("multiple option is not supported for enums");
-                                }
+                                },
+                                .@"enum" => {
+                                    if (is_multiple) {
+                                        @compileError("multiple option is not supported for enums");
+                                    }
 
-                                const E = switch (@typeInfo(T)) {
-                                    .optional => |optional| optional.child,
-                                    inline else => T,
-                                };
-
-                                // This type only, we peek ahead to check if there's a following arg.
-                                // If there isn't, the default is set already.
-                                var peek_args = args.*;
-                                if (peek_args.next()) |next_arg| {
-                                    const v = std.meta.stringToEnum(E, next_arg) orelse {
-                                        return error.UnknownArgument;
+                                    const E = switch (@typeInfo(T)) {
+                                        .optional => |optional| optional.child,
+                                        inline else => T,
                                     };
-                                    // Discard.
-                                    _ = args.next();
 
-                                    @field(c, option.name) = v;
-                                }
-                            },
-                            .bool => {
-                                if (is_multiple) {
-                                    @compileError("multiple option is not supported for booleans");
-                                }
+                                    // This type only, we peek ahead to check if there's a following arg.
+                                    // If there isn't, the default is set already.
+                                    var peek_args = args.*;
+                                    if (peek_args.next()) |next_arg| {
+                                        const v = std.meta.stringToEnum(E, next_arg) orelse {
+                                            return error.UnknownArgument;
+                                        };
+                                        // Discard.
+                                        _ = args.next();
 
-                                @field(c, option.name) = true;
-                            },
+                                        @field(c, option.name) = v;
+                                    }
+                                },
+                                .bool => {
+                                    if (is_multiple) {
+                                        @compileError("multiple option is not supported for booleans");
+                                    }
 
-                            else => {},
+                                    @field(c, option.name) = true;
+                                },
+
+                                else => {},
+                            }
                         }
 
                         continue :iter_args;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -440,8 +440,8 @@ pub fn Builder(comptime commands: anytype) type {
 
                                     const str = args.next() orelse return error.MissingArgument;
 
-                                    if (std.mem.eql(u8, str, "all")) {
-                                        // "all" sets all the fields of packed struct.
+                                    if (std.mem.eql(u8, str, "full")) {
+                                        // "full" sets all the fields of packed struct.
                                         const Int = _struct.backing_integer.?;
                                         @field(c, option.name) = @bitCast(@as(Int, std.math.maxInt(Int)));
                                     } else {

--- a/src/cli_parser.zig
+++ b/src/cli_parser.zig
@@ -1,0 +1,340 @@
+// Copyright (C) 2023-2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// Creates a new CLI parser from given commands recipe.
+pub fn Commands(comptime commands: anytype) type {
+    return struct {
+        const Self = @This();
+
+        /// Enum type for provided commands.
+        pub const Enum = blk: {
+            var enum_fields: [commands.len]std.builtin.Type.EnumField = undefined;
+            for (commands, 0..) |command, i| {
+                enum_fields[i] = .{ .name = command.name, .value = i };
+            }
+
+            break :blk @Type(.{
+                .@"enum" = .{
+                    .decls = &.{},
+                    .fields = &enum_fields,
+                    .is_exhaustive = true,
+                    .tag_type = std.math.IntFittingRange(0, commands.len),
+                },
+            });
+        };
+
+        /// Union type for provided commands.
+        pub const Union = blk: {
+            var union_fields: [commands.len]std.builtin.Type.UnionField = undefined;
+            // Populate both `enum_fields` and `union_fields`.
+            for (commands, 0..) |command, i| {
+                const options = command.options;
+
+                // Whether this command has `positional` argument.
+                const has_positional = @hasField(@TypeOf(command), "positional");
+                const fields_len = if (has_positional) options.len + 1 else options.len;
+
+                var struct_fields: [fields_len]std.builtin.Type.StructField = undefined;
+                for (options, 0..) |option, j| {
+                    const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
+                    const T, const default = type_and_default: {
+                        if (is_multiple) {
+                            // We currently don't allow default values for lists.
+                            if (@hasField(@TypeOf(option), "default")) unreachable;
+                            // If `multiple` provided, prefer `ArrayList`.
+                            const T = std.ArrayList(option.type);
+                            break :type_and_default .{ T, &@as(T, .{}) };
+                        }
+
+                        const T = option.type;
+                        break :type_and_default .{ T, &@as(T, option.default) };
+                    };
+
+                    struct_fields[j] = .{
+                        .name = option.name,
+                        .type = T,
+                        .default_value_ptr = default,
+                        .is_comptime = false,
+                        .alignment = @alignOf(T),
+                    };
+                }
+
+                // Add a field for `positional`.
+                if (has_positional) {
+                    const positional = command.positional;
+                    const T = positional.type;
+                    struct_fields[fields_len - 1] = .{
+                        .name = positional.name,
+                        .type = T,
+                        .default_value_ptr = &@as(T, null),
+                        .is_comptime = false,
+                        .alignment = @alignOf(T),
+                    };
+                }
+
+                const T = @Type(.{
+                    .@"struct" = .{
+                        .decls = &.{},
+                        .fields = &struct_fields,
+                        .is_tuple = false,
+                        .layout = .auto,
+                    },
+                });
+
+                union_fields[i] = .{ .name = command.name, .type = T, .alignment = @alignOf(T) };
+            }
+
+            break :blk @Type(.{
+                .@"union" = .{
+                    .decls = &.{},
+                    .fields = &union_fields,
+                    .layout = .auto,
+                    .tag_type = Enum,
+                },
+            });
+        };
+
+        pub fn parse(allocator: Allocator) !Union {
+            var args = try std.process.argsWithAllocator(allocator);
+            defer args.deinit();
+
+            // Skip program name.
+            const exec_name = std.fs.path.basename(args.next().?);
+            _ = exec_name;
+
+            const cmd_str: []const u8 = args.next().?;
+
+            inline for (commands) |command| {
+                if (std.mem.eql(u8, cmd_str, command.name)) {
+                    return parseCommand(allocator, command, &args);
+                }
+            }
+
+            // TODO: Unknown command.
+            @panic("unknown command");
+        }
+
+        /// Parses the command with its options.
+        fn parseCommand(
+            allocator: Allocator,
+            command: anytype,
+            args: *std.process.ArgIterator,
+        ) !Union {
+            const Command = @FieldType(Union, command.name);
+            var c = Command{};
+
+            const options = command.options;
+            iter_args: while (args.next()) |option_name| {
+                inline for (options) |option| {
+                    // We allow both `--my-option` and `--my_option` variants;
+                    // assuming given `option` struct prefer snake_case for name.
+                    const kebab_cased = comptime blk: {
+                        var output: [option.name.len]u8 = undefined;
+                        @memcpy(&output, option.name);
+                        std.mem.replaceScalar(u8, &output, '_', '-');
+                        break :blk output;
+                    };
+
+                    // Match an option.
+                    if (std.mem.eql(u8, option_name, "--" ++ option.name) or
+                        std.mem.eql(u8, option_name, "--" ++ kebab_cased))
+                    {
+                        const T = option.type;
+                        const option_info = blk: {
+                            const info = @typeInfo(T);
+                            // If wrapped in optional, prefer the child type.
+                            if (info == .optional) break :blk @typeInfo(info.optional.child);
+                            break :blk info;
+                        };
+
+                        // TODO: Support multiples.
+                        const is_multiple = @hasField(@TypeOf(option), "multiple") and option.multiple;
+
+                        switch (option_info) {
+                            .int => |int| {
+                                const Int = std.meta.Int(int.signedness, int.bits);
+                                // TODO: Return correct errors.
+                                const v = try std.fmt.parseInt(Int, args.next().?, 10);
+
+                                if (is_multiple) {
+                                    // Push to ArrayList.
+                                    try @field(c, option.name).append(allocator, v);
+                                } else {
+                                    @field(c, option.name) = v;
+                                }
+                            },
+                            .pointer => |pointer| {
+                                const not_u8_slice = pointer.child != u8 or pointer.size != .slice;
+                                if (not_u8_slice) {
+                                    @compileError("Only []u8, []const u8, [:sentinel]u8 and [:sentinel]const u8 pointers are supported");
+                                }
+
+                                // TODO: Return error.
+                                const str = args.next().?;
+
+                                const v = blk: {
+                                    // DupeZ branch.
+                                    if (comptime pointer.sentinel()) |sentinel| {
+                                        const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len + 1);
+                                        @memcpy(buf[0..str.len], str);
+                                        buf[str.len] = sentinel;
+                                        break :blk buf[0..str.len :sentinel];
+                                    }
+
+                                    // Dupe branch.
+                                    const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len);
+                                    @memcpy(buf, str);
+                                    break :blk buf;
+                                };
+
+                                if (is_multiple) {
+                                    try @field(c, option.name).append(allocator, v);
+                                } else {
+                                    @field(c, option.name) = v;
+                                }
+                            },
+                            .@"struct" => |_struct| {
+                                // Don't support multiple for structs for now.
+                                if (is_multiple) {
+                                    @compileError("multiple option is not supported for structs");
+                                }
+
+                                const not_packed = _struct.layout != .@"packed";
+                                if (not_packed) {
+                                    @compileError("only packed structs are allowed");
+                                }
+
+                                // TODO: Return error.
+                                const str = args.next().?;
+
+                                if (std.mem.eql(u8, str, "all")) {
+                                    // "all" sets all the fields of packed struct.
+                                    const Int = _struct.backing_integer.?;
+                                    @field(c, option.name) = @bitCast(@as(Int, std.math.maxInt(Int)));
+                                } else {
+                                    // Parse given args.
+                                    var it = std.mem.splitScalar(u8, str, ',');
+                                    outer: while (it.next()) |part| {
+                                        const trimmed = std.mem.trim(u8, part, &std.ascii.whitespace);
+
+                                        inline for (_struct.fields) |f| {
+                                            std.debug.assert(f.type == bool);
+
+                                            if (std.mem.eql(u8, trimmed, @as([]const u8, f.name))) {
+                                                @field(@field(c, option.name), f.name) = true;
+                                                continue :outer;
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            .@"enum" => {
+                                if (is_multiple) {
+                                    @compileError("multiple option is not supported for enums");
+                                }
+
+                                const E = switch (@typeInfo(T)) {
+                                    .optional => |optional| optional.child,
+                                    inline else => T,
+                                };
+
+                                // This type only, we peek ahead to check if there's a following arg.
+                                // If there isn't, the default is set already.
+                                var peek_args = args.*;
+                                if (peek_args.next()) |next_arg| {
+                                    const v = std.meta.stringToEnum(E, next_arg) orelse {
+                                        return error.UnknownArgument;
+                                    };
+                                    // Discard.
+                                    _ = args.next();
+
+                                    @field(c, option.name) = v;
+                                }
+                            },
+                            .bool => {
+                                if (is_multiple) {
+                                    @compileError("multiple option is not supported for booleans");
+                                }
+
+                                @field(c, option.name) = true;
+                            },
+
+                            else => {},
+                        }
+
+                        continue :iter_args;
+                    }
+                }
+
+                // An option we don't know of.
+                if (std.mem.startsWith(u8, option_name, "--")) {
+                    return error.UnkownOption;
+                }
+
+                // Parse positional arg if provided; can be given out of order:
+                //
+                // lightpanda fetch --wait-ms 2_000 "https://lightpanda.io" --dump "html"
+                // ---------------------------------^
+                if (comptime @hasField(@TypeOf(command), "positional")) {
+                    const positional = command.positional;
+
+                    // Already given one.
+                    if (@field(c, positional.name) != null) {
+                        return error.TooManyPositionalArgs;
+                    }
+
+                    // The positional must be an optional type.
+                    const info = @typeInfo(@typeInfo(positional.type).optional.child);
+
+                    const str = @as([]const u8, option_name);
+                    switch (info) {
+                        .pointer => |pointer| {
+                            const not_u8_slice = pointer.child != u8 or pointer.size != .slice;
+                            if (not_u8_slice) {
+                                @compileError("Only []u8, []const u8, [:sentinel]u8 and [:sentinel]const u8 pointers are supported");
+                            }
+
+                            const v = blk: {
+                                // DupeZ branch.
+                                if (comptime pointer.sentinel()) |sentinel| {
+                                    const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len + 1);
+                                    @memcpy(buf[0..str.len], str);
+                                    buf[str.len] = sentinel;
+                                    break :blk buf[0..str.len :sentinel];
+                                }
+
+                                // Dupe branch.
+                                const buf = try allocator.alignedAlloc(u8, .fromByteUnits(pointer.alignment), str.len);
+                                @memcpy(buf, str);
+                                break :blk buf;
+                            };
+
+                            @field(c, positional.name) = v;
+                        },
+                        inline else => @compileError("not supported"),
+                    }
+                }
+            }
+
+            return @unionInit(Union, command.name, c);
+        }
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,7 +55,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
 
     switch (args.mode) {
         .help => {
-            args.printUsageAndExit(args.mode.help);
+            args.printUsageAndExit(true);
             return std.process.cleanExit();
         },
         .version => {
@@ -72,9 +72,10 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     if (args.logFormat()) |lf| {
         log.opts.format = lf;
     }
-    if (args.logFilterScopes()) |lfs| {
-        log.opts.filter_scopes = lfs;
-    }
+    // TODO: Fix regression.
+    //if (args.logFilterScopes()) |lfs| {
+    //    log.opts.filter_scopes = lfs;
+    //}
 
     // must be installed before any other threads
     const sighandler = try main_arena.create(SigHandler);
@@ -118,14 +119,14 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
         },
         .fetch => |opts| {
             const url = opts.url;
-            log.debug(.app, "startup", .{ .mode = "fetch", .dump_mode = opts.dump_mode, .url = url, .snapshot = app.snapshot.fromEmbedded() });
+            log.debug(.app, "startup", .{ .mode = "fetch", .dump_mode = opts.dump, .url = url, .snapshot = app.snapshot.fromEmbedded() });
 
             var fetch_opts = lp.FetchOpts{
                 .wait_ms = opts.wait_ms,
                 .wait_until = opts.wait_until,
                 .wait_script = opts.wait_script,
                 .wait_selector = opts.wait_selector,
-                .dump_mode = opts.dump_mode,
+                .dump_mode = opts.dump,
                 .dump = .{
                     .strip = opts.strip,
                     .with_base = opts.with_base,
@@ -135,11 +136,11 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
 
             var stdout = std.fs.File.stdout();
             var writer = stdout.writer(&.{});
-            if (opts.dump_mode != null) {
+            if (opts.dump != null) {
                 fetch_opts.writer = &writer.interface;
             }
 
-            var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, url, fetch_opts });
+            var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, url.?, fetch_opts });
             defer worker_thread.join();
 
             app.network.run();

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,10 +72,9 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     if (args.logFormat()) |lf| {
         log.opts.format = lf;
     }
-    // TODO: Fix regression.
-    //if (args.logFilterScopes()) |lfs| {
-    //    log.opts.filter_scopes = lfs;
-    //}
+
+    // Set log filter scopes.
+    log.opts.filter_scopes = args.logFilterScopes().items;
 
     // must be installed before any other threads
     const sighandler = try main_arena.create(SigHandler);

--- a/src/main.zig
+++ b/src/main.zig
@@ -127,7 +127,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
                 .dump = .{
-                    .strip = opts.strip,
+                    .strip = opts.strip_mode,
                     .with_base = opts.with_base,
                     .with_frames = opts.with_frames,
                 },

--- a/src/main_legacy_test.zig
+++ b/src/main_legacy_test.zig
@@ -33,10 +33,8 @@ pub fn main() !void {
     }
     lp.log.opts.level = .warn;
     const config = try lp.Config.init(allocator, "legacy-test", .{ .serve = .{
-        .common = .{
-            .tls_verify_host = false,
-            .user_agent_suffix = "internal-tester",
-        },
+        .insecure_disable_tls_host_verification = true,
+        .user_agent_suffix = "internal-tester",
     } });
     defer config.deinit(allocator);
 

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -491,11 +491,9 @@ test "tests:beforeAll" {
     const test_allocator = @import("root").tracking_allocator;
 
     test_config = try Config.init(test_allocator, "test", .{ .serve = .{
-        .common = .{
-            .tls_verify_host = false,
-            .user_agent_suffix = "internal-tester",
-            .ws_max_concurrent = 50,
-        },
+        .insecure_disable_tls_host_verification = true,
+        .user_agent_suffix = "internal-tester",
+        .ws_max_concurrent = 50,
     } });
 
     test_app = try App.init(test_allocator, &test_config);


### PR DESCRIPTION
This PR adds a comptime CLI builder that generates a tagged union parser from a
declarative command recipe. Each command becomes a union variant whose
payload is a struct with one field per option.

## Command descriptor fields

  - `name: []const u8` — canonical command name on the command line.
  - `options: tuple` — tuple of option descriptors (see below). Use `.{}` for none.
  - `aliases: tuple` (optional) — alternative names for the command.
  - `shared_options: tuple` (optional) — extra options merged into this
    command. Useful for common flags shared across commands.
  - `positional: struct` (optional) — a single positional argument with
    `.name` and `.type`. Type must be an optional pointer-to-u8 slice
    (e.g. `?[:0]const u8`). Positionals can appear anywhere in argv.

## Option descriptor fields

  - `name: []const u8` — snake_case field name. Both `--snake_case` and
    `--kebab-case` are accepted on the command line.
  - `type` — the Zig type of the parsed value (see supported types below).
  - `default` (optional) — compile-time default when the flag is absent.
    Rules vary by type; see the defaults section below.
  - `shortcuts: tuple` (optional) — single-character short flags. Each
    shortcut is matched as `-X` on the command line.
  - `multiple: bool` (optional) — when `true`, the field becomes a
    `std.ArrayList(type)` and each occurrence appends.
  - `validator: fn` (optional) — custom parse function that replaces the
    built-in type switch. See the validator section below.

## Supported types and their defaults

  - `bool` — presence sets `true`; always defaults to `false`.
    Specifying `default` is a compile error. `?bool` is not allowed.
  - Integers (`u8`, `u16`, `u31`, `usize`, etc.) — parsed with
    `std.fmt.parseInt`. Requires `default` unless wrapped in `?`.
  - `[]const u8`, `[:0]const u8` (and mutable variants) — string slices,
    duped from argv. Sentinel is preserved. Requires `default` unless `?`.
  - Enums — parsed via `std.meta.stringToEnum`. Requires `default` unless `?`.
  - Packed structs of `bool` fields — parsed from a comma-separated list
    (e.g. `--strip js,css`). The literal `"all"` sets every field.
    Requires `default`.
  - Optional types default to `null` when `default` is omitted.

## Validators

A `validator` is a custom parse function that takes over argument
consumption for an option. The expected signature depends on whether
`multiple` is set:

  - Single: `fn (Allocator, *ArgIterator) !T` — returns the parsed value.
  - Multiple: `fn (Allocator, *ArgIterator, *std.ArrayList(T)) !void` —
    appends directly into the list.

When a validator is present, the built-in type switch is skipped entirely.

## Example

```zig
const StripMode = packed struct(u2) {
    js: bool = false,
    css: bool = false,
};

const WaitUntil = enum { load, domcontentloaded, networkidle };

const CommonOptions = .{
    .{ .name = "verbose", .type = bool },
    .{ .name = "log_level", .type = ?log.Level },
    .{ .name = "timeout", .type = u31, .default = 30 },
};

const Cli = cli.Builder(.{
    .{
        .name = "serve",
        .aliases = .{"s"},
        .options = .{
            .{ .name = "host", .shortcuts = .{"h"}, .type = []const u8, .default = "127.0.0.1" },
            .{ .name = "port", .shortcuts = .{"p"}, .type = u16, .default = 9222 },
        },
        .shared_options = CommonOptions,
    },
    .{
        .name = "fetch",
        .positional = .{ .name = "url", .type = ?[:0]const u8 },
        .options = .{
            .{ .name = "dump", .type = ?DumpFormat, .validator = dumpValidator },
            .{ .name = "strip", .type = StripMode, .default = .{} },
            .{ .name = "wait_until", .type = ?WaitUntil },
            .{ .name = "extra_header", .type = []const u8, .multiple = true },
        },
        .shared_options = CommonOptions,
    },
    .{ .name = "version", .options = .{} },
    .{ .name = "help", .aliases = .{ "h", "?" }, .options = .{} },
});

const _, const cmd = try Cli.parse(arena);
switch (cmd) {
    .serve => |opts| listen(opts.host, opts.port),
    .fetch => |opts| fetch(opts.url.?, opts.dump),
    .version => printVersion(),
    .help => printHelp(),
}
```