### PR TITLE
fix: use proper link text in markdown dump for block-content anchors

### DIFF
--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -589,7 +589,7 @@ test "browser.markdown: block link" {
         \\### Title
         \\
         \\Description
-        \\([](https://example.com))
+        \\[https://example.com](https://example.com)
         \\
     );
 }

--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -594,6 +594,38 @@ test "browser.markdown: block link" {
     );
 }
 
+test "browser.markdown: block link with aria-label" {
+    try testMarkdownHTML(
+        \\<a href="https://example.com" aria-label="Docs">
+        \\  <h3>Title</h3>
+        \\  <p>Description</p>
+        \\</a>
+    ,
+        \\
+        \\### Title
+        \\
+        \\Description
+        \\[Docs](https://example.com)
+        \\
+    );
+}
+
+test "browser.markdown: block link with title" {
+    try testMarkdownHTML(
+        \\<a href="https://example.com" title="Docs">
+        \\  <h3>Title</h3>
+        \\  <p>Description</p>
+        \\</a>
+    ,
+        \\
+        \\### Title
+        \\
+        \\Description
+        \\[Docs](https://example.com)
+        \\
+    );
+}
+
 test "browser.markdown: inline link" {
     try testMarkdownHTML(
         \\<p>Visit <a href="https://example.com">Example</a>.</p>

--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -298,9 +298,11 @@ const Context = struct {
                     try self.renderChildren(el.asNode());
                     if (href) |h| {
                         if (!self.state.last_char_was_newline) try self.writer.writeByte('\n');
-                        try self.writer.writeAll("([](");
+                        try self.writer.writeByte('[');
+                        try self.writer.writeAll(label orelse h);
+                        try self.writer.writeAll("](");
                         try self.writer.writeAll(h);
-                        try self.writer.writeAll("))\n");
+                        try self.writer.writeAll(")\n");
                         self.state.last_char_was_newline = true;
                     }
                     return;


### PR DESCRIPTION
## Summary

When an anchor wraps block content (divs, images, buttons), the markdown dump produced `([](url))` with empty display text. Now produces `[label](url)` using the anchor's aria-label, title, or the href as fallback.

## Why this matters

Lightpanda's `--dump markdown` is the primary way AI agents consume web content. The `([](url))` syntax provides zero context to LLMs about what the link points to. Since Lightpanda positions as "the browser for AI," markdown quality directly affects downstream LLM performance.

Crawl4AI (63K stars) has built its value specifically on LLM-optimized extraction. This fix closes a gap where Lightpanda's markdown output was less useful than what Crawl4AI produces.

## Demo

![Demo](https://files.catbox.moe/kfypk0.gif)

Before: `([](https://lightpanda.io/docs/open-source/installation))`
After: `[Docs](https://lightpanda.io/docs/open-source/installation)`

## Changes

In `src/browser/markdown.zig`, the block-content anchor rendering path (line ~298) now:
1. Uses `aria-label` or `title` attribute as display text when available
2. Falls back to the raw href as display text
3. Produces standard `[text](url)` markdown instead of `([](url))`

The change is 4 lines in the `has_block` branch of the anchor rendering logic. The non-block anchor path (standalone and inline links) already rendered correctly.

## Testing

The existing `markdown.zig` test suite covers anchor rendering. This change modifies only the block-content branch, which is exercised when anchors wrap divs, images, or other block elements.

This contribution was developed with AI assistance (Claude Code).