### PR TITLE
ci: use cache for snapshots

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,5 +1,5 @@
-name: "Browsercore install"
-description: "Install deps for the project browsercore"
+name: "Deps install"
+description: "Install deps for the browser"
 
 inputs:
   arch:

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -1,0 +1,32 @@
+name: "V8 snaphsot"
+description: "Generate v8 snapshot"
+
+runs:
+  using: "composite"
+
+  steps:
+      # Use the commit hash of bridge.zig and Snapshot.zig as cache key for
+      # snapshot.
+    - name: V8 snapshot cache key
+      id: snapshot_cache_key
+      run: echo "hash=v8-snapshot-$(git log -n 1 --pretty=format:%H --
+                 src/browser/js/bridge.zig
+                 src/browser/js/Snapshot.zig
+                 )" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    # Fetch the cache for snapshot
+    - name: Cache V8 snapshot
+      id: cache-v8-snapshot
+      uses: actions/cache@v5
+      env:
+        cache-name: cache-v8-snapshot
+      with:
+        path: src/snapshot.bin
+        key: ${{ steps.snapshot_cache_key.outputs.hash }}
+
+    # Generate snapshot on cache miss.
+    - name: v8 snapshot
+      shell: bash
+      if: hashFiles('src/snapshot.bin') == ''
+      run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,7 +51,24 @@ jobs:
 
       - uses: ./.github/actions/install
 
+      # Use the commit hash of src/browser/js/bridge.zig as cache key for
+      # snapshot.
+      - run: echo "hash=v8-snapshot-$(git log -n 1 --pretty=format:%H -- src/browser/js/bridge.zig)" >> "$GITHUB_OUTPUT"
+        id: snapshot_cache_key
+
+      # Fetch the cache for snapshot
+      - name: Cache V8 snapshot
+        id: cache-v8-snapshot
+        uses: actions/cache@v5
+        env:
+          cache-name: cache-v8-snapshot
+        with:
+          path: src/snapshot.bin
+          key: ${{ steps.snapshot_cache_key.outputs.hash }}
+
+      # Generate snapshot on cache miss.
       - name: v8 snapshot
+        if: ${{ steps.cache-v8-snapshot.outputs.cache-hit != 'true' }}
         run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin
 
       - name: zig build release

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,9 +51,12 @@ jobs:
 
       - uses: ./.github/actions/install
 
-      # Use the commit hash of src/browser/js/bridge.zig as cache key for
+      # Use the commit hash of bridge.zig and Snapshot.zig as cache key for
       # snapshot.
-      - run: echo "hash=v8-snapshot-$(git log -n 1 --pretty=format:%H -- src/browser/js/bridge.zig)" >> "$GITHUB_OUTPUT"
+      - run: echo "hash=v8-snapshot-$(git log -n 1 --pretty=format:%H -- \
+                   src/browser/js/bridge.zig \
+                   src/browser/js/Snapshot.zig \
+                   )" >> "$GITHUB_OUTPUT"
         id: snapshot_cache_key
 
       # Fetch the cache for snapshot

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,29 +50,7 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/install
-
-      # Use the commit hash of bridge.zig and Snapshot.zig as cache key for
-      # snapshot.
-      - run: echo "hash=v8-snapshot-$(git log -n 1 --pretty=format:%H -- \
-                   src/browser/js/bridge.zig \
-                   src/browser/js/Snapshot.zig \
-                   )" >> "$GITHUB_OUTPUT"
-        id: snapshot_cache_key
-
-      # Fetch the cache for snapshot
-      - name: Cache V8 snapshot
-        id: cache-v8-snapshot
-        uses: actions/cache@v5
-        env:
-          cache-name: cache-v8-snapshot
-        with:
-          path: src/snapshot.bin
-          key: ${{ steps.snapshot_cache_key.outputs.hash }}
-
-      # Generate snapshot on cache miss.
-      - name: v8 snapshot
-        if: ${{ steps.cache-v8-snapshot.outputs.cache-hit != 'true' }}
-        run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin
+      - uses: ./.github/actions/v8-snapshot
 
       - name: zig build release
         run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast -Dcpu=x86_64


### PR DESCRIPTION
Add a cache for v8 snapshot file.
Use a cache key for v8 snapshot with the last hash changing `src/browser/js/bridge.zig` and `src/browser/js/Snapshot.zig`
eg. `v8-snapshot-4dcb2c997e01e4367ca6118629fb4ac712f9692c`