### PR TITLE
update page URL and location on pushState/replaceState

### DIFF
--- a/src/browser/tests/history_url_update.html
+++ b/src/browser/tests/history_url_update.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="testing.js"></script>
+
+<script id=url_updates>
+  {
+    const originalUrl = location.href;
+
+    // pushState updates the URL
+    history.pushState(null, '', '/test-push-path');
+    testing.expectEqual('/test-push-path', location.pathname);
+
+    // replaceState updates the URL
+    history.replaceState(null, '', '/test-replace-path');
+    testing.expectEqual('/test-replace-path', location.pathname);
+
+    // Restore original URL so other tests aren't affected
+    history.replaceState(null, '', originalUrl);
+  }
+</script>

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const js = @import("../js/js.zig");
 
 const Page = @import("../Page.zig");
+const Location = @import("Location.zig");
 const PopStateEvent = @import("event/PopStateEvent.zig");
 
 const History = @This();
@@ -55,6 +56,10 @@ pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.pushEntry(url, .{ .source = .history, .value = json }, page, true);
+
+    // Update page URL and location so that location.pathname reflects the pushed state
+    page.url = url;
+    page.window._location = try Location.init(url, page);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, page: *Page) !void {
@@ -63,6 +68,10 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, page, true);
+
+    // Update page URL and location so that location.pathname reflects the replaced state
+    page.url = url;
+    page.window._location = try Location.init(url, page);
 }
 
 fn goInner(delta: i32, page: *Page) !void {

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -138,4 +138,5 @@ pub const JsApi = struct {
 const testing = @import("../../testing.zig");
 test "WebApi: History" {
     try testing.htmlRunner("history.html", .{});
+    try testing.htmlRunner("history_url_update.html", .{});
 }

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -22,6 +22,7 @@ const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const Location = @import("Location.zig");
 const PopStateEvent = @import("event/PopStateEvent.zig");
+const URL = @import("URL.zig");
 
 const History = @This();
 
@@ -52,24 +53,28 @@ pub fn setScrollRestoration(self: *History, str: []const u8) void {
 
 pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, page: *Page) !void {
     const arena = page._session.arena;
-    const url = if (_url) |u| try arena.dupeZ(u8, u) else try arena.dupeZ(u8, page.url);
+    const url = if (_url) |u|
+        try @import("../URL.zig").resolve(arena, page.url, u, .{ .always_dupe = true })
+    else
+        try arena.dupeZ(u8, page.url);
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.pushEntry(url, .{ .source = .history, .value = json }, page, true);
 
-    // Update page URL and location so that location.pathname reflects the pushed state
     page.url = url;
-    page.window._location = try Location.init(url, page);
+    page.window._location._url = try URL.init(url, null, page);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, page: *Page) !void {
     const arena = page._session.arena;
-    const url = if (_url) |u| try arena.dupeZ(u8, u) else try arena.dupeZ(u8, page.url);
+    const url = if (_url) |u|
+        try @import("../URL.zig").resolve(arena, page.url, u, .{ .always_dupe = true })
+    else
+        try arena.dupeZ(u8, page.url);
 
     const json = state.toJson(arena) catch return error.DataClone;
     _ = try page._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, page, true);
 
-    // Update page URL and location so that location.pathname reflects the replaced state
     page.url = url;
     page.window._location = try Location.init(url, page);
 }


### PR DESCRIPTION
Adapted from https://github.com/lightpanda-io/browser/pull/2084.

Original Description:
`history.pushState()` and `replaceState()` added entries to the navigation history but didn't update `page.url` or reinitialize `window._location`. This meant `location.pathname` still returned the old path after pushState, breaking SPA routing detection in automation scripts.

The fix adds two lines to both `pushState` and `replaceState` in `History.zig`:
1. `page.url = url` to update the page's active URL
2. `page.window._location = try Location.init(url, page)` to reinitialize the Location object

This follows the same pattern used during actual navigation (Page.zig lines 477, 560, 895).

`replaceState` gets the same fix since it had the same gap.

This adds on by fixing the `pushState` and `replaceState` by properly resolving the URL before initializing the `Location`. It also adds a test that ensures the proper behavior and prevents regressions.