### PR TITLE
On Page cleanup, capture next linked list node _before_ releasing MO

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -365,9 +365,10 @@ pub fn deinit(self: *Page, abort_http: bool) void {
         }
 
         {
-            var it: ?*std.DoublyLinkedList.Node = self._mutation_observers.first;
-            while (it) |node| : (it = node.next) {
-                const observer: *MutationObserver = @fieldParentPtr("node", node);
+            var node: ?*std.DoublyLinkedList.Node = self._mutation_observers.first;
+            while (node) |n| {
+                node = n.next; // capture before we potentially delete observer
+                const observer: *MutationObserver = @fieldParentPtr("node", n);
                 observer.releaseRef(session);
             }
         }

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -71,7 +71,7 @@ pub const ObserverInit = struct {
 };
 
 pub fn init(callback: js.Function.Temp, options: ?ObserverInit, page: *Page) !*IntersectionObserver {
-    const arena = try page.getArena(.medium, "IntersectionObserver");
+    const arena = try page.getArena(.small, "IntersectionObserver");
     errdefer page.releaseArena(arena);
 
     const opts = options orelse ObserverInit{};

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -76,9 +76,8 @@ pub const ObserveOptions = struct {
 };
 
 pub fn init(callback: js.Function.Temp, page: *Page) !*MutationObserver {
-    const arena = try page.getArena(.medium, "MutationObserver");
+    const arena = try page.getArena(.small, "MutationObserver");
     errdefer page.releaseArena(arena);
-
     const self = try arena.create(MutationObserver);
     self.* = .{
         ._arena = arena,


### PR DESCRIPTION
Also, switch MO and IO to use a "small" arena, as they probably don't require too many allocations in most normal cases (just observing 1 or 2 things).