### PR TITLE
Handle http response with closed socket

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -917,17 +917,15 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     // Transfer is done (success or error). Caller (processMessages) owns deinit.
     // Return true = done (caller will deinit), false = continues (redirect/auth).
 
-    // When the server sends "Connection: close" and closes the TLS
-    // connection without a close_notify alert, BoringSSL reports
-    // RecvError. If we already received valid HTTP headers, this is
-    // a normal end-of-body (the connection closure signals the end
+    // When the server closes the TLS onnection without a close_notify alert,
+    // BoringSSL reports RecvError. If we already received valid HTTP headers,
+    // this is a normal end-of-body (the connection closure signals the end
     // of the response per HTTP/1.1 when there is no Content-Length).
-    // We must check this before endTransfer, which may reset the
-    // easy handle.
+    // We must check this before endTransfer, which may reset the easy handle.
     const is_conn_close_recv = blk: {
         const err = msg.err orelse break :blk false;
         if (err != error.RecvError) break :blk false;
-        const hdr = msg.conn.getResponseHeader("connection", 0) orelse break :blk false;
+        const hdr = msg.conn.getResponseHeader("connection", 0) orelse break :blk true;
         break :blk std.ascii.eqlIgnoreCase(hdr.value, "close");
     };
 


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/1987 added support for a connection that was close with a valid response. This commit goes a step further and removes the requirement for a "connection: close" header.

We see a lot of these in WPT tests, e.g.
/referrer-policy/gen/iframe.http-rp/unset/iframe-tag.http.html