### PR TITLE
new: allow CDP change useragent

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -1193,3 +1193,100 @@ fn parseCommonArg(
 
     return false;
 }
+
+test "HttpHeaders: default user agent" {
+    const allocator = std.testing.allocator;
+    var config = Config{
+        .mode = .{ .serve = .{} },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+
+    try std.testing.expectEqualStrings("Lightpanda/1.0", config.http_headers.user_agent);
+    try std.testing.expectEqualStrings("User-Agent: Lightpanda/1.0", config.http_headers.user_agent_header);
+    try std.testing.expect(config.http_headers.proxy_bearer_header == null);
+}
+
+test "HttpHeaders: custom user agent override" {
+    const allocator = std.testing.allocator;
+    const ua = try allocator.dupe(u8, "MyBot/2.0");
+    var config = Config{
+        .mode = .{ .serve = .{ .common = .{ .user_agent = ua } } },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+    defer allocator.free(ua);
+
+    try std.testing.expectEqualStrings("MyBot/2.0", config.http_headers.user_agent);
+    try std.testing.expectEqualStrings("User-Agent: MyBot/2.0", config.http_headers.user_agent_header);
+}
+
+test "HttpHeaders: user agent suffix" {
+    const allocator = std.testing.allocator;
+    const suffix = try allocator.dupe(u8, "CustomSuffix/3.0");
+    var config = Config{
+        .mode = .{ .serve = .{ .common = .{ .user_agent_suffix = suffix } } },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+    defer allocator.free(suffix);
+
+    try std.testing.expectEqualStrings("Lightpanda/1.0 CustomSuffix/3.0", config.http_headers.user_agent);
+    try std.testing.expectEqualStrings("User-Agent: Lightpanda/1.0 CustomSuffix/3.0", config.http_headers.user_agent_header);
+}
+
+test "HttpHeaders: fetch mode default user agent" {
+    const allocator = std.testing.allocator;
+    const url = try allocator.dupeZ(u8, "https://example.com");
+    defer allocator.free(url);
+    var config = Config{
+        .mode = .{ .fetch = .{ .url = url } },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+
+    try std.testing.expectEqualStrings("Lightpanda/1.0", config.http_headers.user_agent);
+}
+
+test "HttpHeaders: fetch mode custom user agent" {
+    const allocator = std.testing.allocator;
+    const url = try allocator.dupeZ(u8, "https://example.com");
+    defer allocator.free(url);
+    const ua = try allocator.dupe(u8, "FetchBot/1.0");
+    var config = Config{
+        .mode = .{ .fetch = .{ .url = url, .common = .{ .user_agent = ua } } },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+    defer allocator.free(ua);
+
+    try std.testing.expectEqualStrings("FetchBot/1.0", config.http_headers.user_agent);
+    try std.testing.expectEqualStrings("User-Agent: FetchBot/1.0", config.http_headers.user_agent_header);
+}
+
+test "HttpHeaders: proxy bearer header" {
+    const allocator = std.testing.allocator;
+    const token: [:0]const u8 = try allocator.dupeZ(u8, "secret-token");
+    var config = Config{
+        .mode = .{ .serve = .{ .common = .{ .proxy_bearer_token = token } } },
+        .exec_name = "test",
+        .http_headers = undefined,
+    };
+    config.http_headers = try HttpHeaders.init(allocator, &config);
+    defer config.http_headers.deinit(allocator);
+    defer allocator.free(token);
+
+    try std.testing.expectEqualStrings("Lightpanda/1.0", config.http_headers.user_agent);
+    try std.testing.expectEqualStrings("Proxy-Authorization: Bearer secret-token", config.http_headers.proxy_bearer_header.?);
+}
+

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -115,6 +115,12 @@ tls_verify: bool = true,
 
 obey_robots: bool,
 
+// User agent override set via CDP Emulation.setUserAgentOverride.
+// When set, takes precedence over the config's http_headers values.
+// Both fields are allocated from self.allocator when set, null otherwise.
+user_agent_override: ?[:0]const u8 = null,
+user_agent_header_override: ?[:0]const u8 = null,
+
 cdp_client: ?CDPClient = null,
 
 max_response_size: usize,
@@ -177,7 +183,31 @@ pub fn deinit(self: *Client) void {
     }
     self.pending_robots_queue.deinit(self.allocator);
 
+    self.clearUserAgentOverride();
     self.allocator.destroy(self);
+}
+
+// Set a user agent override. Both the raw UA string and the pre-formatted
+// "User-Agent: <ua>" header string are allocated from self.allocator.
+pub fn setUserAgentOverride(self: *Client, ua: []const u8) !void {
+    self.clearUserAgentOverride();
+    const override = try self.allocator.dupeZ(u8, ua);
+    errdefer self.allocator.free(override);
+    const header = try std.fmt.allocPrintSentinel(self.allocator, "User-Agent: {s}", .{ua}, 0);
+    self.user_agent_override = override;
+    self.user_agent_header_override = header;
+}
+
+// Clear any user agent override, restoring the default from config.
+pub fn clearUserAgentOverride(self: *Client) void {
+    if (self.user_agent_override) |ua| {
+        self.allocator.free(ua);
+        self.user_agent_override = null;
+    }
+    if (self.user_agent_header_override) |uah| {
+        self.allocator.free(uah);
+        self.user_agent_header_override = null;
+    }
 }
 
 // Enable TLS verification on all connections.
@@ -209,7 +239,12 @@ pub fn changeProxy(self: *Client, proxy: ?[:0]const u8) !void {
 }
 
 pub fn newHeaders(self: *const Client) !http.Headers {
-    return http.Headers.init(self.network.config.http_headers.user_agent_header);
+    const ua_header = self.user_agent_header_override orelse self.network.config.http_headers.user_agent_header;
+    return http.Headers.init(ua_header);
+}
+
+pub fn getUserAgent(self: *const Client) [:0]const u8 {
+    return self.user_agent_override orelse self.network.config.http_headers.user_agent;
 }
 
 pub fn abort(self: *Client) void {
@@ -511,7 +546,7 @@ fn robotsDoneCallback(ctx_ptr: *anyopaque) !void {
         200 => {
             if (ctx.buffer.items.len > 0) {
                 const robots: ?Robots = ctx.client.network.robot_store.robotsFromBytes(
-                    ctx.client.network.config.http_headers.user_agent,
+                    ctx.client.getUserAgent(),
                     ctx.buffer.items,
                 ) catch blk: {
                     log.warn(.browser, "failed to parse robots", .{ .robots_url = ctx.robots_url });

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -37,7 +37,7 @@ _storage: StorageManager = .{},
 pub const init: Navigator = .{};
 
 pub fn getUserAgent(_: *const Navigator, page: *Page) []const u8 {
-    return page._session.browser.app.config.http_headers.user_agent;
+    return page._session.browser.http_client.getUserAgent();
 }
 
 pub fn getLanguages(_: *const Navigator) [2][]const u8 {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -368,6 +368,7 @@ pub const BrowserContext = struct {
     next_script_id: u32 = 1,
 
     http_proxy_changed: bool = false,
+    user_agent_changed: bool = false,
 
     // Extra headers to add to all requests.
     extra_headers: std.ArrayList([*c]const u8) = .empty,
@@ -476,6 +477,9 @@ pub const BrowserContext = struct {
             browser.http_client.changeProxy(null) catch |err| {
                 log.warn(.http, "changeProxy", .{ .err = err });
             };
+        }
+        if (self.user_agent_changed) {
+            browser.http_client.clearUserAgentOverride();
         }
         self.intercept_state.deinit();
     }

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -70,6 +70,30 @@ fn setTouchEmulationEnabled(cmd: *CDP.Command) !void {
 }
 
 fn setUserAgentOverride(cmd: *CDP.Command) !void {
-    log.info(.app, "setUserAgentOverride ignored", .{});
+    const params = (try cmd.params(struct {
+        userAgent: []const u8,
+        acceptLanguage: ?[]const u8 = null,
+        platform: ?[]const u8 = null,
+    })) orelse return error.InvalidParams;
+
+    const ua = params.userAgent;
+
+    // Validate: all characters must be printable ASCII
+    for (ua) |c| {
+        if (!std.ascii.isPrint(c)) {
+            return cmd.sendError(-32602, "User agent contains non-printable characters", .{});
+        }
+    }
+
+    // Reject user agents containing "mozilla" (case-insensitive)
+    if (std.ascii.indexOfIgnoreCase(ua, "mozilla") != null) {
+        return cmd.sendError(-32602, "User agent must not contain Mozilla", .{});
+    }
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const http_client = cmd.cdp.browser.http_client;
+    try http_client.setUserAgentOverride(ua);
+    bc.user_agent_changed = true;
+
     return cmd.sendResult(null, .{});
 }

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -97,3 +97,102 @@ fn setUserAgentOverride(cmd: *CDP.Command) !void {
 
     return cmd.sendResult(null, .{});
 }
+
+const testing = @import("../testing.zig");
+
+test "cdp.Emulation: setUserAgentOverride with valid user agent" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "CustomBot/1.0" },
+    });
+
+    try ctx.expectSentResult(null, .{ .id = 1 });
+}
+
+test "cdp.Emulation: setUserAgentOverride rejects mozilla" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA2" });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "Mozilla/5.0 (Windows NT 10.0)" },
+    });
+
+    try ctx.expectSentError(-32602, "User agent must not contain Mozilla", .{ .id = 2 });
+}
+
+test "cdp.Emulation: setUserAgentOverride rejects mozilla case insensitive" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA3" });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "MOZILLA/5.0 test" },
+    });
+
+    try ctx.expectSentError(-32602, "User agent must not contain Mozilla", .{ .id = 3 });
+}
+
+test "cdp.Emulation: setUserAgentOverride rejects non-printable characters" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA4" });
+
+    try ctx.processMessage(.{
+        .id = 4,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "Bot/1.0\x01hidden" },
+    });
+
+    try ctx.expectSentError(-32602, "User agent contains non-printable characters", .{ .id = 4 });
+}
+
+test "cdp.Emulation: setUserAgentOverride with optional params" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA5" });
+
+    try ctx.processMessage(.{
+        .id = 5,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{
+            .userAgent = "CustomBot/2.0",
+            .acceptLanguage = "en-US",
+            .platform = "Linux",
+        },
+    });
+
+    try ctx.expectSentResult(null, .{ .id = 5 });
+}
+
+test "cdp.Emulation: setUserAgentOverride can be called multiple times" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-UA6" });
+
+    try ctx.processMessage(.{
+        .id = 6,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "FirstBot/1.0" },
+    });
+
+    try ctx.expectSentResult(null, .{ .id = 6 });
+
+    try ctx.processMessage(.{
+        .id = 7,
+        .method = "Emulation.setUserAgentOverride",
+        .params = .{ .userAgent = "SecondBot/2.0" },
+    });
+
+    try ctx.expectSentResult(null, .{ .id = 7 });
+}
+


### PR DESCRIPTION
Uses `Network.setUserAgentOverride` to override agent according to the same rules that `serve` uses.

[Auto generated with Claude]