### PR TITLE
feat(console): implement group, groupCollapsed, and groupEnd

### DIFF
--- a/src/browser/tests/console/console.html
+++ b/src/browser/tests/console/console.html
@@ -26,3 +26,24 @@
 
     testing.expectEqual(true, true);
 </script>
+
+<script id="group">
+    // should not crash
+    console.group();
+    console.groupEnd();
+
+    console.group("outer");
+    console.group("inner");
+    console.log("nested");
+    console.groupEnd();
+    console.groupEnd();
+
+    console.groupCollapsed("collapsed");
+    console.log("inside collapsed");
+    console.groupEnd();
+
+    // groupEnd beyond depth 0 should not crash
+    console.groupEnd();
+
+    testing.expectEqual(true, true);
+</script>

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -26,7 +26,6 @@ const Console = @This();
 
 _timers: std.StringHashMapUnmanaged(u64) = .{},
 _counts: std.StringHashMapUnmanaged(u64) = .{},
-_group_depth: u32 = 0,
 
 pub const init: Console = .{};
 
@@ -129,21 +128,15 @@ pub fn timeEnd(self: *Console, label_: ?[]const u8) void {
     logger.info(.js, "console.timeEnd", .{ .label = label, .elapsed = elapsed - kv.value });
 }
 
-pub fn group(self: *Console, values: []js.Value, page: *Page) void {
+pub fn group(_: *const Console, values: []js.Value, page: *Page) void {
     logger.info(.js, "console.group", .{ValueWriter{ .page = page, .values = values }});
-    self._group_depth +|= 1;
 }
 
-pub fn groupCollapsed(self: *Console, values: []js.Value, page: *Page) void {
+pub fn groupCollapsed(_: *const Console, values: []js.Value, page: *Page) void {
     logger.info(.js, "console.groupCollapsed", .{ValueWriter{ .page = page, .values = values }});
-    self._group_depth +|= 1;
 }
 
-pub fn groupEnd(self: *Console) void {
-    if (self._group_depth > 0) {
-        self._group_depth -= 1;
-    }
-}
+pub fn groupEnd(_: *const Console) void {}
 
 fn timestamp() u64 {
     return @import("../../datetime.zig").timestamp(.monotonic);

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -26,6 +26,7 @@ const Console = @This();
 
 _timers: std.StringHashMapUnmanaged(u64) = .{},
 _counts: std.StringHashMapUnmanaged(u64) = .{},
+_group_depth: u32 = 0,
 
 pub const init: Console = .{};
 
@@ -128,6 +129,22 @@ pub fn timeEnd(self: *Console, label_: ?[]const u8) void {
     logger.info(.js, "console.timeEnd", .{ .label = label, .elapsed = elapsed - kv.value });
 }
 
+pub fn group(self: *Console, values: []js.Value, page: *Page) void {
+    logger.info(.js, "console.group", .{ValueWriter{ .page = page, .values = values }});
+    self._group_depth +|= 1;
+}
+
+pub fn groupCollapsed(self: *Console, values: []js.Value, page: *Page) void {
+    logger.info(.js, "console.groupCollapsed", .{ValueWriter{ .page = page, .values = values }});
+    self._group_depth +|= 1;
+}
+
+pub fn groupEnd(self: *Console) void {
+    if (self._group_depth > 0) {
+        self._group_depth -= 1;
+    }
+}
+
 fn timestamp() u64 {
     return @import("../../datetime.zig").timestamp(.monotonic);
 }
@@ -188,6 +205,9 @@ pub const JsApi = struct {
     pub const time = bridge.function(Console.time, .{});
     pub const timeLog = bridge.function(Console.timeLog, .{});
     pub const timeEnd = bridge.function(Console.timeEnd, .{});
+    pub const group = bridge.function(Console.group, .{});
+    pub const groupCollapsed = bridge.function(Console.groupCollapsed, .{});
+    pub const groupEnd = bridge.function(Console.groupEnd, .{});
 };
 
 const testing = @import("../../testing.zig");


### PR DESCRIPTION
Add missing console grouping APIs per the WHATWG Console spec:
- console.group(...data): logs label and increments group depth
- console.groupCollapsed(...data): same as group (headless mode has no visual collapsing, so behavior is identical to group)
- console.groupEnd(): decrements group depth, clamped at 0

Depth is tracked via _group_depth (u32) on the Console struct. Saturation arithmetic (+|=) prevents overflow on runaway group() calls.

Fixes TypeError crashes on sites that use console.group* APIs (e.g. React/Vite dev builds).