### PR TITLE
Encode form data based on the form (or documents) encoding.

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -3562,6 +3562,7 @@ pub fn submitForm(self: *Page, submitter_: ?*Element, form_: ?*Element.Html.Form
     }
 
     const FormData = @import("webapi/net/FormData.zig");
+
     // The submitter can be an input box (if enter was entered on the box)
     // I don't think this is technically correct, but FormData handles it ok
     const form_data = try FormData.init(form, submitter_, self);
@@ -3569,10 +3570,22 @@ pub fn submitForm(self: *Page, submitter_: ?*Element, form_: ?*Element.Html.Form
     const arena = try self._session.getArena(.medium, "submitForm");
     errdefer self._session.releaseArena(arena);
 
-    const encoding = form_element.getAttributeSafe(comptime .wrap("enctype"));
+    const enctype = form_element.getAttributeSafe(comptime .wrap("enctype"));
+
+    // Get charset from accept-charset attribute or fall back to document charset
+    const charset: []const u8 = blk: {
+        if (form_element.getAttributeSafe(.wrap("accept-charset"))) |ac| {
+            // Normalize to canonical encoding name
+            const info = h5e.encoding_for_label(ac.ptr, ac.len);
+            if (info.isValid()) {
+                break :blk info.name();
+            }
+        }
+        break :blk self.charset;
+    };
 
     var buf = std.Io.Writer.Allocating.init(arena);
-    try form_data.write(encoding, &buf.writer);
+    try form_data.write(.{ .enctype = enctype, .charset = charset, .allocator = arena }, &buf.writer);
 
     const method = form_element.getAttributeSafe(comptime .wrap("method")) orelse "";
     var action = form_element.getAttributeSafe(comptime .wrap("action")) orelse self.url;

--- a/src/browser/tests/element/html/form.html
+++ b/src/browser/tests/element/html/form.html
@@ -504,3 +504,14 @@
   testing.expectEqual(form, capturedSubmitter);
 }
 </script>
+
+<script id="acceptCharset_property">
+{
+  const form = document.createElement('form');
+  testing.expectEqual('', form.acceptCharset);
+
+  form.acceptCharset = 'big5';
+  testing.expectEqual('big5', form.acceptCharset);
+  testing.expectEqual('big5', form.getAttribute('accept-charset'));
+}
+</script>

--- a/src/browser/tests/net/url_search_params.html
+++ b/src/browser/tests/net/url_search_params.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="UTF-8">
 <script src="../testing.js"></script>
 
 <script>
@@ -85,7 +86,8 @@
   usp2.append('spaces', 'hello world');
   usp2.append('special', '!@#$%^&*()');
   usp2.append('utf8', 'café');
-  testing.expectEqual('spaces=hello+world&special=%21%40%23%24%25%5E%26*%28%29&utf8=caf%C3%83%C2%A9', usp2.toString());
+  // UTF-8 encoding of 'é' (U+00E9) is C3 A9, percent-encoded as %C3%A9
+  testing.expectEqual('spaces=hello+world&special=%21%40%23%24%25%5E%26*%28%29&utf8=caf%C3%A9', usp2.toString());
 }
 </script>
 
@@ -411,5 +413,50 @@
   testing.expectEqual(2, usp.size);
   testing.expectEqual('42', usp.get('count'));
   testing.expectEqual('3.14', usp.get('pi'));
+}
+</script>
+
+<script id=utf8Encoding>
+{
+  // Test that UTF-8 characters are properly percent-encoded (not double-encoded)
+
+  // 2-byte UTF-8: é (U+00E9) -> C3 A9 -> %C3%A9
+  const usp1 = new URLSearchParams();
+  usp1.set('cafe', 'café');
+  testing.expectEqual('cafe=caf%C3%A9', usp1.toString());
+
+  // 3-byte UTF-8: 中 (U+4E2D) -> E4 B8 AD -> %E4%B8%AD
+  const usp2 = new URLSearchParams();
+  usp2.set('chinese', '中文');
+  testing.expectEqual('chinese=%E4%B8%AD%E6%96%87', usp2.toString());
+
+  // 3-byte UTF-8: 日 (U+65E5) -> E6 97 A5 -> %E6%97%A5
+  const usp3 = new URLSearchParams();
+  usp3.set('japanese', '日本語');
+  testing.expectEqual('japanese=%E6%97%A5%E6%9C%AC%E8%AA%9E', usp3.toString());
+
+  // Mixed ASCII and UTF-8
+  const usp4 = new URLSearchParams();
+  usp4.set('mixed', 'hello世界');
+  testing.expectEqual('mixed=hello%E4%B8%96%E7%95%8C', usp4.toString());
+
+  // 4-byte UTF-8: 😀 (U+1F600) -> F0 9F 98 80 -> %F0%9F%98%80
+  const usp5 = new URLSearchParams();
+  usp5.set('emoji', '😀');
+  testing.expectEqual('emoji=%F0%9F%98%80', usp5.toString());
+}
+</script>
+
+<script id=utf8EncodingRoundtrip>
+{
+  // Test that UTF-8 encoding round-trips correctly
+  const original = '日本語テスト café 中文 😀';
+  const usp = new URLSearchParams();
+  usp.set('test', original);
+
+  // Parse the encoded string back
+  const encoded = usp.toString();
+  const usp2 = new URLSearchParams(encoded);
+  testing.expectEqual(original, usp2.get('test'));
 }
 </script>

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
 //
 // Francis Bouvier <francis@lightpanda.io>
 // Pierre Tachoire <pierre@lightpanda.io>
@@ -22,6 +22,7 @@ const String = @import("../../string.zig").String;
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const h5e = @import("../parser/html5ever.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -177,21 +178,24 @@ const URLEncodeMode = enum {
     query,
 };
 
-pub fn urlEncode(self: *const KeyValueList, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
+// URL-encode the key-value pairs.
+// For UTF-8 charset, does standard percent encoding.
+// For legacy charsets, converts to that encoding with NCR fallback for unmappable chars.
+pub fn urlEncode(self: *const KeyValueList, comptime mode: URLEncodeMode, allocator_: ?Allocator, charset: []const u8, writer: *std.Io.Writer) !void {
     const entries = self._entries.items;
     if (entries.len == 0) {
         return;
     }
 
-    try urlEncodeEntry(entries[0], mode, writer);
+    try urlEncodeEntry(entries[0], mode, allocator_, charset, writer);
     for (entries[1..]) |entry| {
         try writer.writeByte('&');
-        try urlEncodeEntry(entry, mode, writer);
+        try urlEncodeEntry(entry, mode, allocator_, charset, writer);
     }
 }
 
-fn urlEncodeEntry(entry: Entry, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
-    try urlEncodeValue(entry.name.str(), mode, writer);
+fn urlEncodeEntry(entry: Entry, comptime mode: URLEncodeMode, allocator_: ?Allocator, charset: []const u8, writer: *std.Io.Writer) !void {
+    try urlEncodeValue(entry.name.str(), mode, allocator_, charset, writer);
 
     // for a form, for an empty value, we'll do "spice="
     // but for a query, we do "spice"
@@ -200,10 +204,53 @@ fn urlEncodeEntry(entry: Entry, comptime mode: URLEncodeMode, writer: *std.Io.Wr
     }
 
     try writer.writeByte('=');
-    try urlEncodeValue(entry.value.str(), mode, writer);
+    try urlEncodeValue(entry.value.str(), mode, allocator_, charset, writer);
 }
 
-fn urlEncodeValue(value: []const u8, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
+fn urlEncodeValue(value: []const u8, comptime mode: URLEncodeMode, allocator_: ?Allocator, charset: []const u8, writer: *std.Io.Writer) !void {
+    // For UTF-8, do standard percent encoding
+    if (std.mem.eql(u8, charset, "UTF-8")) {
+        return urlEncodeValueUtf8(value, mode, writer);
+    }
+
+    const allocator = allocator_ orelse return urlEncodeValueUtf8(value, mode, writer);
+
+    const enc_info = h5e.encoding_for_label(charset.ptr, charset.len);
+    if (!enc_info.isValid()) {
+        // Unknown encoding, fall back to UTF-8
+        return urlEncodeValueUtf8(value, mode, writer);
+    }
+
+    // Calculate max buffer size for encoded output
+    const max_encoded_len = h5e.encoding_max_encode_buffer_length(enc_info.handle.?, value.len);
+    if (max_encoded_len == 0) {
+        return urlEncodeValueUtf8(value, mode, writer);
+    }
+
+    const encode_buf = try allocator.alloc(u8, max_encoded_len);
+    defer allocator.free(encode_buf);
+
+    // Encode UTF-8 to legacy encoding with NCR fallback
+    const result = h5e.encoding_encode_with_ncr(
+        enc_info.handle.?,
+        value.ptr,
+        value.len,
+        encode_buf.ptr,
+        encode_buf.len,
+    );
+
+    if (!result.isSuccess()) {
+        // Encoding failed, fall back to UTF-8
+        return urlEncodeValueUtf8(value, mode, writer);
+    }
+
+    // Percent-encode the result, preserving NCRs (& and ; must be encoded)
+    const encoded_bytes = encode_buf[0..result.bytes_written];
+    return urlEncodeValueLegacy(encoded_bytes, mode, writer);
+}
+
+/// Percent-encode a UTF-8 value - bytes >= 0x80 are percent-encoded directly.
+fn urlEncodeValueUtf8(value: []const u8, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
     if (!urlEncodeShouldEscape(value, mode)) {
         return writer.writeAll(value);
     }
@@ -213,13 +260,22 @@ fn urlEncodeValue(value: []const u8, comptime mode: URLEncodeMode, writer: *std.
             try writer.writeByte(b);
         } else if (b == ' ') {
             try writer.writeByte('+');
-        } else if (b >= 0x80) {
-            // Double-encode: treat byte as Latin-1 code point, encode to UTF-8, then percent-encode
-            // For bytes 0x80-0xFF (U+0080 to U+00FF), UTF-8 encoding is 2 bytes:
-            // [0xC0 | (b >> 6), 0x80 | (b & 0x3F)]
-            const byte1 = 0xC0 | (b >> 6);
-            const byte2 = 0x80 | (b & 0x3F);
-            try writer.print("%{X:0>2}%{X:0>2}", .{ byte1, byte2 });
+        } else {
+            try writer.print("%{X:0>2}", .{b});
+        }
+    }
+}
+
+/// Percent-encode a legacy-encoded value - must also encode & and ; to preserve NCRs.
+fn urlEncodeValueLegacy(value: []const u8, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
+    for (value) |b| {
+        if (urlEncodeUnreserved(b, mode)) {
+            try writer.writeByte(b);
+        } else if (b == ' ') {
+            try writer.writeByte('+');
+        } else if (b == '&' or b == ';') {
+            // Must encode & and ; to preserve NCRs like &#12345;
+            try writer.print("%{X:0>2}", .{b});
         } else {
             try writer.print("%{X:0>2}", .{b});
         }
@@ -281,3 +337,58 @@ const GenericIterator = @import("collections/iterator.zig").Entry;
 pub const KeyIterator = GenericIterator(Iterator, "0");
 pub const ValueIterator = GenericIterator(Iterator, "1");
 pub const EntryIterator = GenericIterator(Iterator, null);
+
+const testing = @import("../../testing.zig");
+
+test "KeyValueList: urlEncode UTF-8" {
+    // Test that UTF-8 characters are properly percent-encoded (not double-encoded)
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "cafe", "café"); // é = C3 A9 in UTF-8
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    // é (U+00E9) in UTF-8 is C3 A9, percent-encoded as %C3%A9
+    try testing.expectString("cafe=caf%C3%A9", buf.written());
+}
+
+test "KeyValueList: urlEncode UTF-8 CJK" {
+    // Test 3-byte UTF-8 characters (Chinese/Japanese)
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "text", "中文"); // 中 = E4 B8 AD, 文 = E6 96 87
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("text=%E4%B8%AD%E6%96%87", buf.written());
+}
+
+test "KeyValueList: urlEncode GBK with NCR fallback" {
+    // Test legacy encoding with NCR fallback for unmappable characters
+    // U+3D34 (㴴) is NOT in GBK, should become &#15668;
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "q", "\u{3D34}");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, allocator, "GBK", &buf.writer);
+
+    // &#15668; percent-encoded is %26%2315668%3B
+    try testing.expectString("q=%26%2315668%3B", buf.written());
+}
+
+test "KeyValueList: urlEncode GBK mappable character" {
+    // Test legacy encoding with a character that IS in GBK
+    // U+4E2D (中) IS in GBK, should encode to GBK bytes D6 D0
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "q", "中");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, allocator, "GBK", &buf.writer);
+
+    // GBK encoding of 中 is D6 D0, percent-encoded as %D6%D0
+    try testing.expectString("q=%D6%D0", buf.written());
+}

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -222,10 +222,15 @@ fn urlEncodeValue(value: []const u8, comptime mode: URLEncodeMode, allocator_: ?
     }
 
     // Calculate max buffer size for encoded output
-    const max_encoded_len = h5e.encoding_max_encode_buffer_length(enc_info.handle.?, value.len);
-    if (max_encoded_len == 0) {
+    // encoding_max_encode_buffer_length doesn't account for NCR expansion,
+    // so we need extra space. Each UTF-8 char (1-4 bytes) can become &#NNNNNNN; (10 bytes)
+    const base_len = h5e.encoding_max_encode_buffer_length(enc_info.handle.?, value.len);
+    if (base_len == 0) {
         return urlEncodeValueUtf8(value, mode, writer);
     }
+    // For NCR encoding, each character could expand significantly
+    // Use 4x the base buffer to be safe (NCRs are ~10 bytes for a 3-byte UTF-8 char)
+    const max_encoded_len = base_len * 4;
 
     const encode_buf = try allocator.alloc(u8, max_encoded_len);
     defer allocator.free(encode_buf);
@@ -391,4 +396,17 @@ test "KeyValueList: urlEncode GBK mappable character" {
 
     // GBK encoding of 中 is D6 D0, percent-encoded as %D6%D0
     try testing.expectString("q=%D6%D0", buf.written());
+}
+
+test "KeyValueList: urlEncode Big5 unmappable character" {
+    // U+70A3 (炣) is NOT in Big5, should become &#28835;
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "q", "\u{70A3}");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, allocator, "Big5", &buf.writer);
+
+    // &#28835; percent-encoded is %26%2328835%3B
+    try testing.expectString("q=%26%2328835%3B", buf.written());
 }

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -112,6 +112,14 @@ pub fn setTarget(self: *Form, value: []const u8, page: *Page) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), page);
 }
 
+pub fn getAcceptCharset(self: *Form) []const u8 {
+    return self.asElement().getAttributeSafe(.wrap("accept-charset")) orelse "";
+}
+
+pub fn setAcceptCharset(self: *Form, value: []const u8, page: *Page) !void {
+    try self.asElement().setAttributeSafe(.wrap("accept-charset"), .wrap(value), page);
+}
+
 pub fn getLength(self: *Form, page: *Page) !u32 {
     const elements = try self.getElements(page);
     return elements.length(page);
@@ -174,6 +182,7 @@ pub const JsApi = struct {
     pub const method = bridge.accessor(Form.getMethod, Form.setMethod, .{});
     pub const action = bridge.accessor(Form.getAction, Form.setAction, .{});
     pub const target = bridge.accessor(Form.getTarget, Form.setTarget, .{});
+    pub const acceptCharset = bridge.accessor(Form.getAcceptCharset, Form.setAcceptCharset, .{});
     pub const elements = bridge.accessor(Form.getElements, null, .{});
     pub const length = bridge.accessor(Form.getLength, null, .{});
     pub const submit = bridge.function(Form.submit, .{});

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -99,17 +99,23 @@ pub fn forEach(self: *FormData, cb_: js.Function, js_this_: ?js.Object) !void {
     }
 }
 
-pub fn write(self: *const FormData, encoding_: ?[]const u8, writer: *std.Io.Writer) !void {
-    const encoding = encoding_ orelse {
-        return self._list.urlEncode(.form, writer);
+pub const WriteOpts = struct {
+    enctype: ?[]const u8 = null,
+    charset: []const u8 = "UTF-8",
+    allocator: ?std.mem.Allocator = null,
+};
+
+pub fn write(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !void {
+    const enctype = opts.enctype orelse {
+        return self._list.urlEncode(.form, opts.allocator, opts.charset, writer);
     };
 
-    if (std.ascii.eqlIgnoreCase(encoding, "application/x-www-form-urlencoded")) {
-        return self._list.urlEncode(.form, writer);
+    if (std.ascii.eqlIgnoreCase(enctype, "application/x-www-form-urlencoded")) {
+        return self._list.urlEncode(.form, opts.allocator, opts.charset, writer);
     }
 
     log.warn(.not_implemented, "FormData.encoding", .{
-        .encoding = encoding,
+        .encoding = enctype,
     });
 }
 

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -112,7 +112,8 @@ pub fn entries(self: *URLSearchParams, page: *Page) !*KeyValueList.EntryIterator
 }
 
 pub fn toString(self: *const URLSearchParams, writer: *std.Io.Writer) !void {
-    return self._params.urlEncode(.query, writer);
+    // URLSearchParams always uses UTF-8 per the URL Standard
+    return self._params.urlEncode(.query, null, "UTF-8", writer);
 }
 
 pub fn format(self: *const URLSearchParams, writer: *std.Io.Writer) !void {
@@ -278,34 +279,6 @@ const HEX_DECODE_ARRAY = blk: {
 
 inline fn decodeHex(char: u8) u8 {
     return @as([*]const u8, @ptrFromInt((@intFromPtr(&HEX_DECODE_ARRAY) - @as(usize, '0'))))[char];
-}
-
-fn escape(input: []const u8, writer: *std.Io.Writer) !void {
-    for (input) |c| {
-        if (isUnreserved(c)) {
-            try writer.writeByte(c);
-        } else if (c == ' ') {
-            try writer.writeByte('+');
-        } else if (c == '*') {
-            try writer.writeByte('*');
-        } else if (c >= 0x80) {
-            // Double-encode: treat byte as Latin-1 code point, encode to UTF-8, then percent-encode
-            // For bytes 0x80-0xFF (U+0080 to U+00FF), UTF-8 encoding is 2 bytes:
-            // [0xC0 | (c >> 6), 0x80 | (c & 0x3F)]
-            const byte1 = 0xC0 | (c >> 6);
-            const byte2 = 0x80 | (c & 0x3F);
-            try writer.print("%{X:0>2}%{X:0>2}", .{ byte1, byte2 });
-        } else {
-            try writer.print("%{X:0>2}", .{c});
-        }
-    }
-}
-
-fn isUnreserved(c: u8) bool {
-    return switch (c) {
-        'A'...'Z', 'a'...'z', '0'...'9', '-', '.', '_' => true,
-        else => false,
-    };
 }
 
 pub const Iterator = struct {


### PR DESCRIPTION
Does something similar to https://github.com/lightpanda-io/browser/pull/2126 but for form submission. It uses the form's accept-charset attribute, or fallsback to the document's charset.