### PR TITLE
docs(readme): clarify browser vs npm package versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Due to the nature of Playwright, a script that works with the current version of
 
 ## Quick start
 
+### Package naming note
+
+The browser binary in this repository is versioned independently from npm packages under the
+`@lightpanda/*` scope.
+
+- `lightpanda-io/browser` releases track the browser binary/runtime.
+- npm packages are SDK/integration packages and may use a different version sequence.
+
 ### Install
 **Install from the nightly builds**
 


### PR DESCRIPTION
## Summary
- add a short README note clarifying that browser binary releases are versioned independently from `@lightpanda/*` npm packages
- make the relationship explicit in Quick Start to reduce version comparison confusion

## Context
Issue #1986 reports confusion between `@lightpanda/browser` npm versions and browser binary releases in this repository.

Closes #1986
