### PR TITLE
Clarify Windows WSL installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ chmod a+x ./lightpanda
 
 *For Windows + WSL2*
 
-Lightpanda runs inside WSL when invoked from a WSL shell; follow the Linux install steps above in that environment.
-Install automation clients such as Puppeteer or Playwright on the Windows host so they can drive Lightpanda through CDP over the mapped ports.
+Lightpanda has no native Windows binary. Install it inside WSL following the Linux steps above.
+
+WSL not installed? Run `wsl --install` from an administrator shell, restart, then open `wsl`.
+See [Microsoft's WSL install guide](https://learn.microsoft.com/en-us/windows/wsl/install) for details.
+
+Your automation client (Puppeteer, Playwright, etc.) can run either inside WSL or on the Windows host. WSL forwards `localhost:9222` automatically.
 
 **Install from Docker**
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download
 chmod a+x ./lightpanda
 ```
 
-### Windows (via WSL2)
+*For Windows + WSL2*
 
 Lightpanda runs inside WSL when invoked from a WSL shell; follow the Linux install steps above in that environment.
 Install automation clients such as Puppeteer or Playwright on the Windows host so they can drive Lightpanda through CDP over the mapped ports.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download
 chmod a+x ./lightpanda
 ```
 
-*For Windows + WSL2*
+### Windows (via WSL2)
 
-The Lightpanda browser is compatible to run on windows inside WSL. Follow the Linux instruction for installation from a WSL terminal.
-It is recommended to install clients like Puppeteer on the Windows host.
+Lightpanda runs inside WSL when invoked from a WSL shell; follow the Linux install steps above in that environment.
+Install automation clients such as Puppeteer or Playwright on the Windows host so they can drive Lightpanda through CDP over the mapped ports.
 
 **Install from Docker**
 


### PR DESCRIPTION
## Summary
- explain how to install Lightpanda via WSL using the Linux steps
- recommend installing automation clients like Puppeteer on the Windows host for CDP control

## Testing
- not run (docs only)