### PR TITLE
Improve loaderId and requestId compatibility

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -111,6 +111,7 @@ pub const PageRemove = struct {};
 
 pub const PageNavigate = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
     url: [:0]const u8,
@@ -119,6 +120,7 @@ pub const PageNavigate = struct {
 
 pub const PageNavigated = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
     url: [:0]const u8,
@@ -127,17 +129,20 @@ pub const PageNavigated = struct {
 
 pub const PageNetworkIdle = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
 };
 
 pub const PageNetworkAlmostIdle = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
 };
 
 pub const PageFrameCreated = struct {
+    page_id: u32,
     frame_id: u32,
     parent_id: u32,
     timestamp: u64,
@@ -145,12 +150,14 @@ pub const PageFrameCreated = struct {
 
 pub const PageDOMContentLoaded = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
 };
 
 pub const PageLoaded = struct {
     req_id: u32,
+    page_id: u32,
     frame_id: u32,
     timestamp: u64,
 };
@@ -343,6 +350,7 @@ test "Notification" {
 
     // noop
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 39,
         .frame_id = 0,
         .req_id = 1,
         .timestamp = 4,
@@ -354,6 +362,7 @@ test "Notification" {
 
     try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 39,
         .frame_id = 0,
         .req_id = 1,
         .timestamp = 4,
@@ -364,6 +373,7 @@ test "Notification" {
 
     notifier.unregisterAll(&tc);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 39,
         .frame_id = 0,
         .req_id = 1,
         .timestamp = 10,
@@ -375,25 +385,27 @@ test "Notification" {
     try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
     try notifier.register(.page_navigated, &tc, TestClient.pageNavigated);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 39,
         .frame_id = 0,
         .req_id = 1,
         .timestamp = 10,
         .url = undefined,
         .opts = .{},
     });
-    notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 6, .url = undefined, .opts = .{} });
+    notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 6, .url = undefined, .opts = .{} });
     try testing.expectEqual(14, tc.page_navigate);
     try testing.expectEqual(6, tc.page_navigated);
 
     notifier.unregisterAll(&tc);
     notifier.dispatch(.page_navigate, &.{
+        .page_id = 39,
         .frame_id = 0,
         .req_id = 1,
         .timestamp = 100,
         .url = undefined,
         .opts = .{},
     });
-    notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+    notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
     try testing.expectEqual(14, tc.page_navigate);
     try testing.expectEqual(6, tc.page_navigated);
 
@@ -401,27 +413,27 @@ test "Notification" {
         // unregister
         try notifier.register(.page_navigate, &tc, TestClient.pageNavigate);
         try notifier.register(.page_navigated, &tc, TestClient.pageNavigated);
-        notifier.dispatch(.page_navigate, &.{ .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(1006, tc.page_navigated);
 
         notifier.unregister(.page_navigate, &tc);
-        notifier.dispatch(.page_navigate, &.{ .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
 
         notifier.unregister(.page_navigated, &tc);
-        notifier.dispatch(.page_navigate, &.{ .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
 
         // already unregistered, try anyways
         notifier.unregister(.page_navigated, &tc);
-        notifier.dispatch(.page_navigate, &.{ .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
-        notifier.dispatch(.page_navigated, &.{ .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigate, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 100, .url = undefined, .opts = .{} });
+        notifier.dispatch(.page_navigated, &.{ .page_id = 39, .frame_id = 0, .req_id = 1, .timestamp = 1000, .url = undefined, .opts = .{} });
         try testing.expectEqual(114, tc.page_navigate);
         try testing.expectEqual(2006, tc.page_navigated);
     }

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -460,6 +460,7 @@ fn fetchRobotsThenProcessRequest(self: *Client, robots_url: [:0]const u8, req: R
             .method = .GET,
             .headers = headers,
             .blocking = false,
+            .page_id = req.page_id,
             .frame_id = req.frame_id,
             .cookie_jar = req.cookie_jar,
             .cookie_origin = req.cookie_origin,
@@ -1069,6 +1070,7 @@ fn ensureNoActiveConnection(self: *const Client) !void {
 }
 
 pub const Request = struct {
+    page_id: u32,
     frame_id: u32,
     method: Method,
     url: [:0]const u8,

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -525,9 +525,10 @@ pub fn navigate(self: *Page, request_url: [:0]const u8, opts: NavigateOpts) !voi
         }
 
         session.notification.dispatch(.page_navigate, &.{
-            .frame_id = self._frame_id,
-            .req_id = req_id,
             .opts = opts,
+            .req_id = req_id,
+            .page_id = self.id,
+            .frame_id = self._frame_id,
             .url = request_url,
             .timestamp = timestamp(.monotonic),
         });
@@ -541,8 +542,9 @@ pub fn navigate(self: *Page, request_url: [:0]const u8, opts: NavigateOpts) !voi
         });
 
         session.notification.dispatch(.page_navigated, &.{
-            .frame_id = self._frame_id,
             .req_id = req_id,
+            .page_id = self.id,
+            .frame_id = self._frame_id,
             .opts = .{
                 .cdp_id = opts.cdp_id,
                 .reason = opts.reason,
@@ -578,10 +580,11 @@ pub fn navigate(self: *Page, request_url: [:0]const u8, opts: NavigateOpts) !voi
     // We dispatch page_navigate event before sending the request.
     // It ensures the event page_navigated is not dispatched before this one.
     session.notification.dispatch(.page_navigate, &.{
-        .frame_id = self._frame_id,
-        .req_id = req_id,
         .opts = opts,
         .url = self.url,
+        .req_id = req_id,
+        .page_id = self.id,
+        .frame_id = self._frame_id,
         .timestamp = timestamp(.monotonic),
     });
 
@@ -596,6 +599,7 @@ pub fn navigate(self: *Page, request_url: [:0]const u8, opts: NavigateOpts) !voi
     http_client.request(.{
         .ctx = self,
         .url = self.url,
+        .page_id = self.id,
         .frame_id = self._frame_id,
         .method = opts.method,
         .headers = headers,
@@ -777,8 +781,9 @@ pub fn _documentIsLoaded(self: *Page) !void {
     );
 
     self._session.notification.dispatch(.page_dom_content_loaded, &.{
-        .frame_id = self._frame_id,
+        .page_id = self.id,
         .req_id = self._req_id,
+        .frame_id = self._frame_id,
         .timestamp = timestamp(.monotonic),
     });
 }
@@ -858,8 +863,9 @@ fn _documentIsComplete(self: *Page) !void {
     }
 
     self._session.notification.dispatch(.page_loaded, &.{
-        .frame_id = self._frame_id,
+        .page_id = self.id,
         .req_id = self._req_id,
+        .frame_id = self._frame_id,
         .timestamp = timestamp(.monotonic),
     });
 
@@ -918,10 +924,11 @@ fn pageHeaderDoneCallback(response: HttpClient.Response) !bool {
         // "navigating" to about:blank, in which case this notification has
         // already been sent
         self._session.notification.dispatch(.page_navigated, &.{
-            .frame_id = self._frame_id,
-            .req_id = self._req_id,
             .opts = no,
             .url = self.url,
+            .page_id = self.id,
+            .req_id = self._req_id,
+            .frame_id = self._frame_id,
             .timestamp = timestamp(.monotonic),
         });
     }
@@ -1183,6 +1190,7 @@ pub fn iframeAddedCallback(self: *Page, iframe: *IFrame) !void {
 
     // on first load, dispatch frame_created event
     self._session.notification.dispatch(.page_frame_created, &.{
+        .page_id = self.id,
         .frame_id = frame_id,
         .parent_id = self._frame_id,
         .timestamp = timestamp(.monotonic),
@@ -1544,6 +1552,7 @@ pub fn deliverSlotchangeEvents(self: *Page) void {
 pub fn notifyNetworkIdle(self: *Page) void {
     lp.assert(self._notified_network_idle == .done, "Page.notifyNetworkIdle", .{});
     self._session.notification.dispatch(.page_network_idle, &.{
+        .page_id = self.id,
         .req_id = self._req_id,
         .frame_id = self._frame_id,
         .timestamp = timestamp(.monotonic),
@@ -1553,6 +1562,7 @@ pub fn notifyNetworkIdle(self: *Page) void {
 pub fn notifyNetworkAlmostIdle(self: *Page) void {
     lp.assert(self._notified_network_almost_idle == .done, "Page.notifyNetworkAlmostIdle", .{});
     self._session.notification.dispatch(.page_network_almost_idle, &.{
+        .page_id = self.id,
         .req_id = self._req_id,
         .frame_id = self._frame_id,
         .timestamp = timestamp(.monotonic),

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -295,6 +295,7 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
                 .url = url,
                 .ctx = script,
                 .method = .GET,
+                .page_id = page.id,
                 .frame_id = page._frame_id,
                 .headers = try self.getHeaders(),
                 .blocking = is_blocking,
@@ -410,6 +411,7 @@ pub fn preloadImport(self: *ScriptManager, url: [:0]const u8, referrer: []const 
         .url = url,
         .ctx = script,
         .method = .GET,
+        .page_id = page.id,
         .frame_id = page._frame_id,
         .headers = try self.getHeaders(),
         .cookie_jar = &page._session.cookie_jar,
@@ -514,6 +516,7 @@ pub fn getAsyncImport(self: *ScriptManager, url: [:0]const u8, cb: ImportAsync.C
     self.client.request(.{
         .url = url,
         .method = .GET,
+        .page_id = page.id,
         .frame_id = page._frame_id,
         .headers = try self.getHeaders(),
         .ctx = script,

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -90,6 +90,7 @@ pub fn init(input: Input, options: ?InitOpts, page: *Page) !js.Promise {
         .ctx = fetch,
         .url = request._url,
         .method = request._method,
+        .page_id = page.id,
         .frame_id = page._frame_id,
         .body = request._body,
         .headers = headers,

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -260,6 +260,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
         .url = self._url,
         .method = self._method,
         .headers = headers,
+        .page_id = page.id,
         .frame_id = page._frame_id,
         .body = self._request_body,
         .cookie_jar = if (cookie_support) &page._session.cookie_jar else null,

--- a/src/cdp/domains/fetch.zig
+++ b/src/cdp/domains/fetch.zig
@@ -204,7 +204,7 @@ pub fn requestIntercept(bc: *CDP.BrowserContext, intercept: *const Notification.
             .document => "Document",
             .fetch => "Fetch",
         },
-        .networkId = &id.toRequestId(transfer.id), // matches the Network REQ-ID
+        .networkId = &id.toRequestId(transfer), // matches the Network REQ-ID
     }, .{ .session_id = session_id });
 
     log.debug(.cdp, "request intercept", .{
@@ -414,7 +414,7 @@ pub fn requestAuthRequired(bc: *CDP.BrowserContext, intercept: *const Notificati
             .scheme = if (challenge.scheme) |s| (if (s == .digest) "digest" else "basic") else "",
             .realm = challenge.realm orelse "",
         },
-        .networkId = &id.toRequestId(transfer.id),
+        .networkId = &id.toRequestId(transfer),
     }, .{ .session_id = session_id });
 
     log.debug(.cdp, "request auth required", .{

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -242,7 +242,7 @@ pub fn httpRequestFail(bc: *CDP.BrowserContext, msg: *const Notification.Request
 
     // We're missing a bunch of fields, but, for now, this seems like enough
     try bc.cdp.sendEvent("Network.loadingFailed", .{
-        .requestId = &id.toRequestId(msg.transfer.id),
+        .requestId = &id.toRequestId(msg.transfer),
         // Seems to be what chrome answers with. I assume it depends on the type of error?
         .type = "Ping",
         .errorText = msg.err,
@@ -265,10 +265,10 @@ pub fn httpRequestStart(bc: *CDP.BrowserContext, msg: *const Notification.Reques
         try req.headers.add(extra);
     }
 
-    // We're missing a bunch of fields, but, for now, this seems like enough
+    // We're missing a bunch of fields, but, for now, this eems like enough
     try bc.cdp.sendEvent("Network.requestWillBeSent", .{
-        .loaderId = &id.toLoaderId(transfer.id),
-        .requestId = &id.toRequestId(transfer.id),
+        .loaderId = &id.toLoaderId(req.page_id),
+        .requestId = &id.toRequestId(transfer),
         .frameId = &id.toFrameId(frame_id),
         .type = req.resource_type.string(),
         .documentURL = page.url,
@@ -285,13 +285,14 @@ pub fn httpResponseHeaderDone(arena: Allocator, bc: *CDP.BrowserContext, msg: *c
     const session_id = bc.session_id orelse return;
 
     const transfer = msg.transfer;
+    const req = &transfer.req;
 
     // We're missing a bunch of fields, but, for now, this seems like enough
     try bc.cdp.sendEvent("Network.responseReceived", .{
-        .loaderId = &id.toLoaderId(transfer.id),
-        .requestId = &id.toRequestId(transfer.id),
-        .frameId = &id.toFrameId(transfer.req.frame_id),
-        .response = TransferAsResponseWriter.init(arena, msg.transfer),
+        .loaderId = &id.toLoaderId(req.page_id),
+        .requestId = &id.toRequestId(transfer),
+        .frameId = &id.toFrameId(req.frame_id),
+        .response = TransferAsResponseWriter.init(arena, transfer),
         .hasExtraInfo = false, // TODO change after adding Network.responseReceivedExtraInfo
     }, .{ .session_id = session_id });
 }
@@ -302,7 +303,7 @@ pub fn httpRequestDone(bc: *CDP.BrowserContext, msg: *const Notification.Request
     const session_id = bc.session_id orelse return;
     const transfer = msg.transfer;
     try bc.cdp.sendEvent("Network.loadingFinished", .{
-        .requestId = &id.toRequestId(transfer.id),
+        .requestId = &id.toRequestId(transfer),
         .encodedDataLength = transfer.bytes_received,
     }, .{ .session_id = session_id });
 }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -134,7 +134,7 @@ fn setLifecycleEventsEnabled(cmd: *CDP.Command) !void {
 
     if (page._load_state == .complete) {
         const frame_id = &id.toFrameId(page._frame_id);
-        const loader_id = &id.toLoaderId(page._req_id);
+        const loader_id = &id.toLoaderId(page.id);
 
         const now = timestampF(.monotonic);
         try sendPageLifecycle(bc, "DOMContentLoaded", now, frame_id, loader_id);
@@ -331,7 +331,7 @@ pub fn pageNavigate(bc: *CDP.BrowserContext, event: *const Notification.PageNavi
     bc.reset();
 
     const frame_id = &id.toFrameId(event.frame_id);
-    const loader_id = &id.toLoaderId(event.req_id);
+    const loader_id = &id.toLoaderId(event.page_id);
 
     var cdp = bc.cdp;
     const reason_: ?[]const u8 = switch (event.opts.reason) {
@@ -414,7 +414,7 @@ pub fn pageFrameCreated(bc: *CDP.BrowserContext, event: *const Notification.Page
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
             .name = "init",
             .frameId = frame_id,
-            .loaderId = &id.toLoaderId(event.frame_id),
+            .loaderId = &id.toLoaderId(event.page_id),
             .timestamp = event.timestamp,
         }, .{ .session_id = session_id });
     }
@@ -426,7 +426,7 @@ pub fn pageNavigated(arena: Allocator, bc: *CDP.BrowserContext, event: *const No
     const session_id = bc.session_id orelse return;
 
     const frame_id = &id.toFrameId(event.frame_id);
-    const loader_id = &id.toLoaderId(event.req_id);
+    const loader_id = &id.toLoaderId(event.page_id);
 
     var cdp = bc.cdp;
 
@@ -585,7 +585,7 @@ pub fn pageDOMContentLoaded(bc: anytype, event: *const Notification.PageDOMConte
 
     if (bc.page_life_cycle_events) {
         const frame_id = &id.toFrameId(event.frame_id);
-        const loader_id = &id.toLoaderId(event.req_id);
+        const loader_id = &id.toLoaderId(event.page_id);
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
             .timestamp = timestamp,
             .name = "DOMContentLoaded",
@@ -609,7 +609,7 @@ pub fn pageLoaded(bc: anytype, event: *const Notification.PageLoaded) !void {
     );
 
     if (bc.page_life_cycle_events) {
-        const loader_id = &id.toLoaderId(event.req_id);
+        const loader_id = &id.toLoaderId(event.page_id);
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
             .timestamp = timestamp,
             .name = "load",
@@ -624,11 +624,11 @@ pub fn pageLoaded(bc: anytype, event: *const Notification.PageLoaded) !void {
 }
 
 pub fn pageNetworkIdle(bc: *CDP.BrowserContext, event: *const Notification.PageNetworkIdle) !void {
-    return sendPageLifecycle(bc, "networkIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.req_id));
+    return sendPageLifecycle(bc, "networkIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.page_id));
 }
 
 pub fn pageNetworkAlmostIdle(bc: *CDP.BrowserContext, event: *const Notification.PageNetworkAlmostIdle) !void {
-    return sendPageLifecycle(bc, "networkAlmostIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.req_id));
+    return sendPageLifecycle(bc, "networkAlmostIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.page_id));
 }
 
 fn sendPageLifecycle(bc: *CDP.BrowserContext, name: []const u8, timestamp: u64, frame_id: []const u8, loader_id: []const u8) !void {

--- a/src/cdp/id.zig
+++ b/src/cdp/id.zig
@@ -180,11 +180,6 @@ test "id: toLoaderId" {
     try testing.expectEqual("LID-4294967295", toLoaderId(4294967295));
 }
 
-test "id: toRequestId" {
-    try testing.expectEqual("REQ-0000000000", toRequestId(0));
-    try testing.expectEqual("REQ-4294967295", toRequestId(4294967295));
-}
-
 test "id: toInterceptId" {
     try testing.expectEqual("INT-0000000000", toInterceptId(0));
     try testing.expectEqual("INT-4294967295", toInterceptId(4294967295));

--- a/src/cdp/id.zig
+++ b/src/cdp/id.zig
@@ -31,27 +31,35 @@ pub fn toPageId(comptime id_type: enum { frame_id, loader_id }, input: []const u
     return std.fmt.parseInt(u32, input[4..], 10) catch err;
 }
 
-pub fn toFrameId(page_id: u32) [14]u8 {
+pub fn toFrameId(id: u32) [14]u8 {
     var buf: [14]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "FID-{d:0>10}", .{page_id}) catch unreachable;
+    _ = std.fmt.bufPrint(&buf, "FID-{d:0>10}", .{id}) catch unreachable;
     return buf;
 }
 
-pub fn toLoaderId(page_id: u32) [14]u8 {
+pub fn toLoaderId(id: u32) [14]u8 {
     var buf: [14]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "LID-{d:0>10}", .{page_id}) catch unreachable;
+    _ = std.fmt.bufPrint(&buf, "LID-{d:0>10}", .{id}) catch unreachable;
     return buf;
 }
 
-pub fn toRequestId(page_id: u32) [14]u8 {
+// requestId has special requirements. If it's the main document navigation,
+// then it should match the loader id.
+const Transfer = @import("../browser/HttpClient.zig").Transfer;
+pub fn toRequestId(transfer: *const Transfer) [14]u8 {
+    const req = transfer.req;
+    if (req.resource_type == .document) {
+        return toLoaderId(req.page_id);
+    }
+
     var buf: [14]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "REQ-{d:0>10}", .{page_id}) catch unreachable;
+    _ = std.fmt.bufPrint(&buf, "REQ-{d:0>10}", .{transfer.id}) catch unreachable;
     return buf;
 }
 
-pub fn toInterceptId(page_id: u32) [14]u8 {
+pub fn toInterceptId(id: u32) [14]u8 {
     var buf: [14]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "INT-{d:0>10}", .{page_id}) catch unreachable;
+    _ = std.fmt.bufPrint(&buf, "INT-{d:0>10}", .{id}) catch unreachable;
     return buf;
 }
 


### PR DESCRIPTION
This introduces two slightly related changes.

My understanding is:

- frameId represents the page. Even if the page navigates, it's the same frameId. We capture this in Page._frame_id. Nothing here changes.

- loaderId is essentially for a specific document of the page. If the page navigates, it should be a different loaderId. We were using a distinct loaderId per request. Not sure what problems that caused. But it was wrong. This was achieved by exposing Page.id to CDP.

- requestId was mostly correct: unique per request. HOWEVER, for the original document, apparently, requestId == loaderId. This change is particularly important for various puppeteer and playwrightb behavior. This is a bit hacked. CDP will look at the resource_type, if it's .document, it'll return the loaderId, else it returns the requestId it always id.