### PR TITLE
Remove unnecessary flag clear

### DIFF
--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -242,7 +242,6 @@ fn httpErrorCallback(ctx: *anyopaque, _: anyerror) void {
 
     defer if (self._owns_response) {
         response.deinit(self._page._session);
-        self._owns_response = false;
     };
 
     var ls: js.Local.Scope = undefined;


### PR DESCRIPTION
Fetch is owned by response.arena (a) we need to clear the flag before freeing the arena and (b) there's no point in clearing the flag at all, since the memory is freed.