### PR TITLE
Add safety check around cache get

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -660,6 +660,17 @@ pub const Function = struct {
 
         switch (cache) {
             .internal => |idx| {
+                // Defensive check: verify object has enough internal fields.
+                // This guards against edge cases where signature check passes but
+                // the receiver doesn't have expected internal fields (e.g., global
+                // proxy vs global object, cross-context scenarios).
+                if (v8.v8__Object__InternalFieldCount(js_this) <= idx) {
+                    if (comptime IS_DEBUG) {
+                        std.debug.assert(false);
+                    }
+                    return false;
+                }
+
                 if (v8.v8__Object__GetInternalField(js_this, idx)) |cached| {
                     // means we can't cache undefined, since we can't tell the
                     // difference between "it isn't in the cache" and  "it's


### PR DESCRIPTION
It should be impossible for a internal cache get to have an incorrect # of internal fields. But we're seeing this exact scenario in production. https://github.com/lightpanda-io/browser/pull/1991 was meant to help with this, but you can do some pretty weird things in JavaScript and it's possible there's some combination of JavaScript which still allows calling these methods on a different receiver.