### PR TITLE
Improve finalizer code

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -75,6 +75,10 @@ identity: js.Identity = .{},
 // This ensures objects are only freed when ALL v8 wrappers are gone.
 finalizer_callbacks: std.AutoHashMapUnmanaged(usize, *FinalizerCallback) = .empty,
 
+// Pool for FinalizerCallback.Identity structs. These must survive page resets
+// so V8 weak callbacks can validate the FC before dereferencing it.
+fc_identity_pool: std.heap.MemoryPool(FinalizerCallback.Identity),
+
 // Tracked global v8 objects that need to be released on cleanup.
 // Lives at Session level so objects can outlive individual Identities.
 globals: std.ArrayList(v8.Global) = .empty,
@@ -133,6 +137,7 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         .queued_queued_navigation = .{},
         .notification = notification,
         .cookie_jar = storage.Cookie.Jar.init(allocator),
+        .fc_identity_pool = .init(allocator),
     };
     self.queued_navigation = &self.queued_navigation_1;
 }
@@ -142,6 +147,7 @@ pub fn deinit(self: *Session) void {
         self.removePage();
     }
     self.cookie_jar.deinit();
+    self.fc_identity_pool.deinit();
 
     self.storage_shed.deinit(self.browser.app.allocator);
     self.arena_pool.release(self.page_arena);
@@ -506,9 +512,13 @@ pub const FinalizerCallback = struct {
 
     // For every FinalizerCallback we'll have 1+ FinalizerCallback.Identity: one
     // for every identity that gets the instance. In most cases, that'l be 1.
+    // Allocated from Session.fc_identity_pool so it survives page resets and
+    // allows the weak callback to validate the FC before dereferencing it.
     pub const Identity = struct {
+        session: *Session,
         identity: *js.Identity,
-        fc: *Session.FinalizerCallback,
+        finalizer_ptr_id: usize,
+        resolved_ptr_id: usize,
     };
 
     // Called during page reset to force cleanup regardless of identity_count.

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -506,23 +506,33 @@ pub const FinalizerCallback = struct {
     finalizer_ptr_id: usize,
     release_ref: *const fn (ptr_id: usize, session: *Session) void,
 
-    // Track how many identities (JS worlds) reference this FC.
-    // Only cleanup when all identities have finalized.
+    // Linked list of Identities referencing this FC.
+    identities: ?*Identity = null,
+    // Count of active identities (for knowing when to clean up FC).
     identity_count: u8 = 0,
 
     // For every FinalizerCallback we'll have 1+ FinalizerCallback.Identity: one
-    // for every identity that gets the instance. In most cases, that'l be 1.
+    // for every identity that gets the instance. In most cases, that'll be 1.
     // Allocated from Session.fc_identity_pool so it survives page resets and
-    // allows the weak callback to validate the FC before dereferencing it.
+    // allows the weak callback to safely check the done flag.
     pub const Identity = struct {
         session: *Session,
         identity: *js.Identity,
         finalizer_ptr_id: usize,
         resolved_ptr_id: usize,
+        next: ?*Identity = null,
+        done: bool = false,
     };
 
-    // Called during page reset to force cleanup regardless of identity_count.
+    // Called during page reset to force cleanup regardless of identities.
     fn deinit(self: *FinalizerCallback, session: *Session) void {
+        // Mark all identities as done so stale V8 weak callbacks
+        // won't find the wrong FC if resolved_ptr_id is reused.
+        var id = self.identities;
+        while (id) |identity| {
+            identity.done = true;
+            id = identity.next;
+        }
         self.release_ref(self.finalizer_ptr_id, session);
         session.releaseArena(self.arena);
     }

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -287,7 +287,9 @@ pub fn mapZigInstanceToJs(self: *const Local, js_obj_handle: ?*const v8.Object, 
                     .identity = ctx.identity,
                     .finalizer_ptr_id = finalizer_ptr_id,
                     .resolved_ptr_id = resolved_ptr_id,
+                    .next = fc.identities,
                 };
+                fc.identities = identity_finalizer;
                 fc.identity_count += 1;
 
                 v8.v8__Global__SetWeakFinalizer(gop.value_ptr, identity_finalizer, finalizer.release_ref, v8.kParameter);
@@ -1222,7 +1224,6 @@ fn resolveT(comptime T: type, value: *T) Resolved {
 
                     // Identity is allocated from pool, so it's valid even after page reset.
                     const session = identity_finalizer.session;
-                    const finalizer_ptr_id = identity_finalizer.finalizer_ptr_id;
                     const resolved_ptr_id = identity_finalizer.resolved_ptr_id;
                     defer session.fc_identity_pool.destroy(identity_finalizer);
 
@@ -1232,17 +1233,18 @@ fn resolveT(comptime T: type, value: *T) Resolved {
                         v8.v8__Global__Reset(&global);
                     }
 
-                    // Validate FC before dereferencing - it may have been cleaned up during page reset
+                    // If done, FC was already cleaned up during page reset. The
+                    // finalizer_ptr_id may have been reused for a new object, so
+                    // we must not look it up in the map.
+                    if (identity_finalizer.done) return;
+
+                    const finalizer_ptr_id = identity_finalizer.finalizer_ptr_id;
                     const fc = session.finalizer_callbacks.get(finalizer_ptr_id) orelse return;
 
                     const identity_count = fc.identity_count;
                     if (identity_count == 1) {
-                        // All IsolatedWorlds that reference this object have
-                        // released it. Release the instance ref, remove the
-                        // FinalizerCallback and free it.
-                        //
-                        // Remove from finalizer_callbacks before releaseRef. releaseRef
-                        // could cause a new object at the same address.
+                        // Last identity - clean up the FC.
+                        // Remove from map before releaseRef to prevent address reuse issues.
                         _ = session.finalizer_callbacks.remove(finalizer_ptr_id);
                         FT.releaseRef(@ptrFromInt(finalizer_ptr_id), session);
                         session.releaseArena(fc.arena);

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -281,10 +281,12 @@ pub fn mapZigInstanceToJs(self: *const Local, js_obj_handle: ?*const v8.Object, 
                     finalizer_gop.value_ptr.* = try self.createFinalizerCallback(resolved_ptr_id, finalizer_ptr_id, finalizer.release_ref_from_zig);
                 }
                 const fc = finalizer_gop.value_ptr.*;
-                const identity_finalizer = try fc.arena.create(Session.FinalizerCallback.Identity);
+                const identity_finalizer = try session.fc_identity_pool.create();
                 identity_finalizer.* = .{
-                    .fc = fc,
+                    .session = session,
                     .identity = ctx.identity,
+                    .finalizer_ptr_id = finalizer_ptr_id,
+                    .resolved_ptr_id = resolved_ptr_id,
                 };
                 fc.identity_count += 1;
 
@@ -1218,26 +1220,31 @@ fn resolveT(comptime T: type, value: *T) Resolved {
                     const ptr = v8.v8__WeakCallbackInfo__GetParameter(handle.?).?;
                     const identity_finalizer: *Session.FinalizerCallback.Identity = @ptrCast(@alignCast(ptr));
 
-                    const fc = identity_finalizer.fc;
-                    const session = fc.session;
-                    const finalizer_ptr_id = fc.finalizer_ptr_id;
+                    // Identity is allocated from pool, so it's valid even after page reset.
+                    const session = identity_finalizer.session;
+                    const finalizer_ptr_id = identity_finalizer.finalizer_ptr_id;
+                    const resolved_ptr_id = identity_finalizer.resolved_ptr_id;
+                    defer session.fc_identity_pool.destroy(identity_finalizer);
 
-                    // Remove from this identity's map
-                    if (identity_finalizer.identity.identity_map.fetchRemove(fc.resolved_ptr_id)) |kv| {
+                    // Always clean up the identity map entry
+                    if (identity_finalizer.identity.identity_map.fetchRemove(resolved_ptr_id)) |kv| {
                         var global = kv.value;
                         v8.v8__Global__Reset(&global);
                     }
+
+                    // Validate FC before dereferencing - it may have been cleaned up during page reset
+                    const fc = session.finalizer_callbacks.get(finalizer_ptr_id) orelse return;
 
                     const identity_count = fc.identity_count;
                     if (identity_count == 1) {
                         // All IsolatedWorlds that reference this object have
                         // released it. Release the instance ref, remove the
                         // FinalizerCallback and free it.
+                        //
+                        // Remove from finalizer_callbacks before releaseRef. releaseRef
+                        // could cause a new object at the same address.
+                        _ = session.finalizer_callbacks.remove(finalizer_ptr_id);
                         FT.releaseRef(@ptrFromInt(finalizer_ptr_id), session);
-                        const removed = session.finalizer_callbacks.remove(finalizer_ptr_id);
-                        if (comptime IS_DEBUG) {
-                            std.debug.assert(removed);
-                        }
                         session.releaseArena(fc.arena);
                     } else {
                         fc.identity_count = identity_count - 1;

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -38,6 +38,7 @@ const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const WebSocket = @This();
+
 _rc: lp.RC(u8) = .{},
 _page: *Page,
 _proto: *EventTarget,

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -587,7 +587,7 @@ pub const BrowserContext = struct {
 
     pub fn onPageRemove(ctx: *anyopaque, _: Notification.PageRemove) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
-        try @import("domains/page.zig").pageRemove(self);
+        @import("domains/page.zig").pageRemove(self);
     }
 
     pub fn onPageCreated(ctx: *anyopaque, page: *Page) !void {
@@ -808,16 +808,18 @@ const IsolatedWorld = struct {
     identity: js.Identity = .{},
 
     pub fn deinit(self: *IsolatedWorld) void {
-        self.removeContext() catch {};
-        self.identity.deinit();
+        self.removeContext();
         self.browser.arena_pool.release(self.call_arena);
         self.browser.arena_pool.release(self.arena);
     }
 
-    pub fn removeContext(self: *IsolatedWorld) !void {
-        const ctx = self.context orelse return error.NoIsolatedContextToRemove;
-        self.browser.env.destroyContext(ctx);
-        self.context = null;
+    pub fn removeContext(self: *IsolatedWorld) void {
+        if (self.context) |ctx| {
+            self.browser.env.destroyContext(ctx);
+            self.context = null;
+        }
+        // I don't think it's possible to have any identity without a context,
+        // but there's no harm in being safe.
         self.identity.deinit();
         self.identity = .{};
     }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -376,14 +376,14 @@ pub fn pageNavigate(bc: *CDP.BrowserContext, event: *const Notification.PageNavi
     }, .{ .session_id = session_id });
 }
 
-pub fn pageRemove(bc: *CDP.BrowserContext) !void {
+pub fn pageRemove(bc: *CDP.BrowserContext) void {
     // Clear all remote object mappings to prevent stale objectIds from being used
     // after the context is destroy
     bc.inspector_session.inspector.resetContextGroup();
 
     // The main page is going to be removed, we need to remove contexts from other worlds first.
     for (bc.isolated_worlds.items) |isolated_world| {
-        try isolated_world.removeContext();
+        isolated_world.removeContext();
     }
 }
 


### PR DESCRIPTION
2 small changes:
1 - Ensure that isolated world identity is always reset. Not clear how we can have identity without a context, but very little harm in doing it this way.

2 - Clear finalizer_callback map _before_ finalizing an instance. Finalizing an instance could (a) release an arena (they almost all do) and (b) create an object with the newly released arena. I don't think anything does that now, but they could. That object could even be passed into v8 during finalization. In which case, we'd temporarily have 2 "live" instances (one being finalized, one jsut created) at the same address. Don't think we have any code that does this, but switching the order (remove from map, then finalize) protects against this address re-use.

1 big change:
Not really big, but more likely to actually fix things. A finalizer can still be called _after_ we've cleared the finalizer callback. This can happen if v8 has queued the finalizer prior to us clearing it. We do see some evidence that this might be an issue, as many extra releaseRefs are happening in the message loop or microtasks. This makes that scenario safer. First, it moves the finalizer identity to a dedicated MemoryPool that can outlive the page. Second, it uses the finalizer_callback map itself to tell whether or not anything has to happen.