### PR TITLE
Websocket fixes.

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -57,8 +57,11 @@ pub const HeaderIterator = http.HeaderIterator;
 // those other http requests.
 pub const Client = @This();
 
-// Count of active requests
-active: usize = 0,
+// Count of active ws requests
+ws_active: usize = 0,
+
+// Count of active http requests
+http_active: usize = 0,
 
 // Count of intercepted requests. This is to help deal with intercepted requests.
 // The client doesn't track intercepted transfers. If a request is intercepted,
@@ -86,6 +89,13 @@ next_request_id: u32 = 0,
 
 // When handles has no more available easys, requests get queued.
 queue: std.DoublyLinkedList = .{},
+
+// Queue is for Transfers that have no connection. ready_queue is for connections
+// that were initiated when performing == true and thus need to wait until
+// performing == false before being added. I'm hoping this is temporary and that
+// we can unify the two queues. But HTTP is being changed a lot right now, and
+// I'm trying to minimize the surface area.
+ready_queue: std.DoublyLinkedList = .{},
 
 // The main app allocator
 allocator: Allocator,
@@ -220,6 +230,13 @@ pub fn setTlsVerify(self: *Client, verify: bool) !void {
         const conn: *http.Connection = @fieldParentPtr("node", node);
         try conn.setTlsVerify(verify, self.use_proxy);
     }
+
+    it = self.ready_queue.first;
+    while (it) |node| : (it = node.next) {
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        try conn.setTlsVerify(verify, self.use_proxy);
+    }
+
     self.tls_verify = verify;
 }
 
@@ -258,26 +275,8 @@ pub fn abortFrame(self: *Client, frame_id: u32) void {
 // Written this way so that both abort and abortFrame can share the same code
 // but abort can avoid the frame_id check at comptime.
 fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
-    {
-        var n = self.in_use.first;
-        while (n) |node| {
-            n = node.next;
-            const conn: *http.Connection = @fieldParentPtr("node", node);
-            switch (conn.transport) {
-                .http => |transfer| {
-                    if ((comptime abort_all) or transfer.req.frame_id == frame_id) {
-                        transfer.kill();
-                    }
-                },
-                .websocket => |ws| {
-                    if ((comptime abort_all) or ws._page._frame_id == frame_id) {
-                        ws.kill();
-                    }
-                },
-                .none => unreachable,
-            }
-        }
-    }
+    abortConnections(self.in_use, abort_all, frame_id);
+    abortConnections(self.ready_queue, abort_all, frame_id);
 
     {
         var q = &self.queue;
@@ -296,6 +295,7 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
 
     if (comptime abort_all) {
         self.queue = .{};
+        self.ready_queue = .{};
     }
 
     if (comptime IS_DEBUG and abort_all) {
@@ -312,7 +312,28 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
             }
             leftover += 1;
         }
-        std.debug.assert(self.active == leftover);
+        std.debug.assert(self.http_active == leftover);
+    }
+}
+
+fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_id: u32) void {
+    var n = list.first;
+    while (n) |node| {
+        n = node.next;
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        switch (conn.transport) {
+            .http => |transfer| {
+                if ((comptime abort_all) or transfer.req.frame_id == frame_id) {
+                    transfer.kill();
+                }
+            },
+            .websocket => |ws| {
+                if ((comptime abort_all) or ws._page._frame_id == frame_id) {
+                    ws.kill();
+                }
+            },
+            .none => unreachable,
+        }
     }
 }
 
@@ -848,6 +869,11 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!PerformStatus {
         self.releaseConn(conn);
     }
 
+    while (self.ready_queue.popFirst()) |node| {
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        try self.trackConn(conn);
+    }
+
     // We're potentially going to block for a while until we get data. Process
     // whatever messages we have waiting ahead of time.
     if (try self.processMessages()) {
@@ -1034,7 +1060,7 @@ fn processMessages(self: *Client) !bool {
                         // Conn was removed from handles during redirect reconfiguration
                         // but not re-added. Release it directly to avoid double-remove.
                         self.in_use.remove(&c.node);
-                        self.active -= 1;
+                        self.http_active -= 1;
                         self.releaseConn(c);
                         transfer._detached_conn = null;
                     }
@@ -1046,6 +1072,7 @@ fn processMessages(self: *Client) !bool {
                 }
             },
             .websocket => |ws| {
+                // ws_active will be decremented through the call to disconnected
                 if (msg.err) |err| switch (err) {
                     error.GotNothing => ws.disconnected(null),
                     else => ws.disconnected(err),
@@ -1063,26 +1090,51 @@ fn processMessages(self: *Client) !bool {
 }
 
 pub fn trackConn(self: *Client, conn: *http.Connection) !void {
+    if (self.performing) {
+        conn.in_use = false;
+        self.ready_queue.append(&conn.node);
+        return;
+    }
+
     self.in_use.append(&conn.node);
+    conn.in_use = true;
     // Set private pointer so readMessage can find the Connection.
     // Must be done each time since curl_easy_reset clears it when
     // connections are returned to pool.
     conn.setPrivate(conn) catch |err| {
         self.in_use.remove(&conn.node);
+        conn.in_use = false;
         self.releaseConn(conn);
         return err;
     };
     self.handles.add(conn) catch |err| {
         self.in_use.remove(&conn.node);
+        conn.in_use = false;
         self.releaseConn(conn);
         return err;
     };
-    self.active += 1;
+
+    switch (conn.transport) {
+        .http => self.http_active += 1,
+        .websocket => self.ws_active += 1,
+        else => unreachable,
+    }
 }
 
 pub fn removeConn(self: *Client, conn: *http.Connection) void {
+    if (conn.in_use == false) {
+        self.ready_queue.remove(&conn.node);
+        self.releaseConn(conn);
+        return;
+    }
+
     self.in_use.remove(&conn.node);
-    self.active -= 1;
+    conn.in_use = false;
+    switch (conn.transport) {
+        .http => self.http_active -= 1,
+        .websocket => self.ws_active -= 1,
+        else => unreachable,
+    }
     if (self.handles.remove(conn)) {
         self.releaseConn(conn);
     } else |_| {
@@ -1097,7 +1149,7 @@ fn releaseConn(self: *Client, conn: *http.Connection) void {
 }
 
 fn ensureNoActiveConnection(self: *const Client) !void {
-    if (self.active > 0) {
+    if (self.http_active > 0 or self.ws_active > 0) {
         return error.InflightConnection;
     }
 }

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -135,7 +135,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
         .pre, .raw, .text, .image => {
             // The main page hasn't started/finished navigating.
             // There's no JS to run, and no reason to run the scheduler.
-            if (http_client.active == 0 and (comptime is_cdp) == false) {
+            if (http_client.http_active == 0 and (comptime is_cdp) == false) {
                 // haven't started navigating, I guess.
                 return .done;
             }
@@ -162,14 +162,14 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
             // download, or scheduled tasks to execute, or both.
 
             // scheduler.run could trigger new http transfers, so do not
-            // store http_client.active BEFORE this call and then use
+            // store http_client.http_active BEFORE this call and then use
             // it AFTER.
             try browser.runMacrotasks();
 
             // Each call to this runs scheduled load events.
             try page.dispatchLoad();
 
-            const http_active = http_client.active;
+            const http_active = http_client.http_active;
             const total_network_activity = http_active + http_client.intercepted;
             if (page._notified_network_almost_idle.check(total_network_activity <= 2)) {
                 page.notifyNetworkAlmostIdle();
@@ -178,9 +178,22 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
                 page.notifyNetworkIdle();
             }
 
-            if (http_active == 0 and (comptime is_cdp == false)) {
+            switch (opts.until) {
+                .done => {},
+                .domcontentloaded => if (page._load_state == .load or page._load_state == .complete) {
+                    return .done;
+                },
+                .load => if (page._load_state == .complete) {
+                    return .done;
+                },
+                .networkidle => if (page._notified_network_idle == .done) {
+                    return .done;
+                },
+            }
+
+            if (http_active == 0 and http_client.ws_active == 0 and (comptime is_cdp == false)) {
                 // we don't need to consider http_client.intercepted here
-                // because is_cdp is true, and that can only be
+                // because is_cdp is false, and that can only be
                 // the case when interception isn't possible.
                 if (comptime IS_DEBUG) {
                     std.debug.assert(http_client.intercepted == 0);
@@ -190,19 +203,6 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
                     // _we_ have nothing to run, but v8 is working on
                     // background tasks. We'll wait for them.
                     browser.waitForBackgroundTasks();
-                }
-
-                switch (opts.until) {
-                    .done => {},
-                    .domcontentloaded => if (page._load_state == .load or page._load_state == .complete) {
-                        return .done;
-                    },
-                    .load => if (page._load_state == .complete) {
-                        return .done;
-                    },
-                    .networkidle => if (page._notified_network_idle == .done) {
-                        return .done;
-                    },
                 }
 
                 // We never advertise a wait time of more than 20, there can

--- a/src/browser/tests/animation/animation.html
+++ b/src/browser/tests/animation/animation.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
-<script id=animation>
+<script id=animation type=module>
+  const state = await testing.async();
+
   let a1 = document.createElement('div').animate(null, null);
   testing.expectEqual('idle', a1.playState);
 
@@ -9,13 +11,18 @@
   a1.finished.then((x) => {
     cb.push(a1.playState);
     cb.push(x == a1);
+    state.resolve();
   });
+
   a1.ready.then(() => {
     cb.push(a1.playState);
     a1.play();
     cb.push(a1.playState);
   });
-  testing.onload(() => testing.expectEqual(['idle', 'running', 'finished', true], cb));
+
+  await state.done(() => {
+    testing.expectEqual(['idle', 'running', 'finished', true], cb);
+  });
 </script>
 
 <!-- <script id=startTime>

--- a/src/browser/tests/document/write.html
+++ b/src/browser/tests/document/write.html
@@ -121,7 +121,9 @@
 
 <div id="will_be_removed">This will be removed by document.open()</div>
 
-<script id=test_open_close_async>
+<script id=test_open_close_async type=module>
+  const state = await testing.async();
+
   // Mark that we saw the element before
   const sawBefore = document.getElementById('will_be_removed') !== null;
   testing.expectEqual(true, sawBefore);
@@ -131,7 +133,15 @@
     document.open();
   }, 5);
 
-  testing.onload(() => {
+  // doing this after test_open_close_async used to crash, so we keep it
+  // to make sure it doesn't
+  setTimeout(() => {
+    document.open();
+    document.close();
+    state.resolve();
+  }, 20);
+
+  await state.done(() => {
     // The element should be gone now
     const afterOpen = document.getElementById('will_be_removed');
     testing.expectEqual(null, afterOpen);
@@ -148,14 +158,5 @@
     const newContent = document.getElementById('new_content');
     testing.expectEqual('Replaced', newContent.textContent);
   })
-</script>
-
-<script>
-  // doing this after test_open_close_async used to crash, so we keep it
-  // to make sure it doesn't
-  setTimeout(() => {
-    document.open();
-    document.close();
-  }, 20);
 </script>
 </body>

--- a/src/browser/tests/event/abort_controller.html
+++ b/src/browser/tests/event/abort_controller.html
@@ -240,13 +240,20 @@
   testing.expectEqual('AbortError', AbortSignal.abort().reason);
 </script>
 
-<script id=abortsignal_timeout>
-  var s3 = AbortSignal.timeout(10);
-  testing.onload(() => {
-    testing.expectEqual(true, s3.aborted);
-    testing.expectEqual('TimeoutError', s3.reason);
-    testing.expectError('Error: TimeoutError', () => {
-      s3.throwIfAborted()
+<script id=abortsignal_timeout type=module>
+  {
+    const state = await testing.async();
+    var s3 = AbortSignal.timeout(10);
+    window.setTimeout(() => {
+      state.resolve()
+    }, 11);
+
+    await state.done(() => {
+      testing.expectEqual(true, s3.aborted);
+      testing.expectEqual('TimeoutError', s3.reason);
+      testing.expectError('Error: TimeoutError', () => {
+        s3.throwIfAborted()
+      });
     });
-  });
+  }
 </script>

--- a/src/browser/tests/frames/post_message.html
+++ b/src/browser/tests/frames/post_message.html
@@ -3,11 +3,13 @@
 
 <iframe id="receiver"></iframe>
 
-<script id="messages">
+<script id="messages" type=module>
 {
+  const state = await testing.async();
   let reply = null;
   window.addEventListener('message', (e) => {
     reply = e.data;
+    state.resolve();
   });
 
   const iframe = $('#receiver');
@@ -16,7 +18,7 @@
     iframe.contentWindow.postMessage('ping', '*');
   });
 
-  testing.onload(() => {
+  await state.done(() => {
     testing.expectEqual('pong', reply.data);
     testing.expectEqual(testing.ORIGIN, reply.origin);
   });

--- a/src/browser/tests/frames/target.html
+++ b/src/browser/tests/frames/target.html
@@ -3,9 +3,13 @@
 
 <iframe name=f1 id=frame1></iframe>
 <a id=l1 target=f1 href=support/page.html></a>
-<script id=anchor>
+<script id=anchor type=module>
+  const state = await testing.async();
   $('#l1').click();
-  testing.onload(() => {
+
+  $('#frame1').onload = () => { state.resolve(); }
+
+  state.done(() => {
     testing.expectEqual('<html><head></head><body>a-page\n</body></html>', $('#frame1').contentDocument.documentElement.outerHTML);
   });
 </script>

--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -1,105 +1,124 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
-<script id=fetch_basic>
-  testing.async(async (restore) => {
+<script id=fetch_basic type=module>
+  {
+    const state = await testing.async()
     const response = await fetch('http://127.0.0.1:9582/xhr');
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-    testing.expectEqual('basic', response.type);
-    testing.expectEqual('http://127.0.0.1:9582/xhr', response.url);
-    testing.expectEqual(false, response.redirected);
-
-    // Check headers
-    const headers = response.headers;
-    testing.expectEqual('text/html; charset=utf-8', headers.get('Content-Type'));
-    testing.expectEqual('100', headers.get('content-length'));
-
-    // Check text response
     const text = await response.text();
-    testing.expectEqual(100, text.length);
-  });
+
+    state.resolve();
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual('basic', response.type);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', response.url);
+      testing.expectEqual(false, response.redirected);
+
+      // Check headers
+      const headers = response.headers;
+      testing.expectEqual('text/html; charset=utf-8', headers.get('Content-Type'));
+      testing.expectEqual('100', headers.get('content-length'));
+
+      // Check text response
+
+      testing.expectEqual(100, text.length);
+    });
+  }
 </script>
 
-<script id=fetch_json>
-  testing.async(async (restore) => {
+<script id=fetch_json type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr/json');
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-    testing.expectEqual('basic', response.type);
-    testing.expectEqual(false, response.redirected);
-
     const json = await response.json();
-    testing.expectEqual('9000!!!', json.over);
-    testing.expectEqual("number", typeof json.updated_at);
-    testing.expectEqual(1765867200000, json.updated_at);
-    testing.expectEqual({over: '9000!!!',updated_at:1765867200000}, json);
-  });
+    state.resolve();
+
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual('basic', response.type);
+      testing.expectEqual(false, response.redirected);
+
+      testing.expectEqual('9000!!!', json.over);
+      testing.expectEqual("number", typeof json.updated_at);
+      testing.expectEqual(1765867200000, json.updated_at);
+      testing.expectEqual({over: '9000!!!',updated_at:1765867200000}, json);
+    });
+  }
 </script>
 
-<script id=fetch_post>
-  testing.async(async (restore) => {
+<script id=fetch_post type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr', {
       method: 'POST',
       body: 'foo'
     });
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-
     const text = await response.text();
-    testing.expectEqual(true, text.length > 64);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual(true, text.length > 64);
+    });
+  }
 </script>
 
-<script id=fetch_redirect>
-  testing.async(async (restore) => {
+<script id=fetch_redirect type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr/redirect');
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-    testing.expectEqual('http://127.0.0.1:9582/xhr', response.url);
-    testing.expectEqual(true, response.redirected);
-
     const text = await response.text();
-    testing.expectEqual(100, text.length);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', response.url);
+      testing.expectEqual(true, response.redirected);
+
+      testing.expectEqual(100, text.length);
+    });
+  }
 </script>
 
-<script id=fetch_404>
-  testing.async(async (restore) => {
+<script id=fetch_404 type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr/404');
-    restore();
-
-    testing.expectEqual(404, response.status);
-    testing.expectEqual(false, response.ok);
-
     const text = await response.text();
-    testing.expectEqual('Not Found', text);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(404, response.status);
+      testing.expectEqual(false, response.ok);
+
+      testing.expectEqual('Not Found', text);
+    });
+  }
 </script>
 
-<script id=fetch_500>
-  testing.async(async (restore) => {
+<script id=fetch_500 type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr/500');
-    restore();
-
-    testing.expectEqual(500, response.status);
-    testing.expectEqual(false, response.ok);
-
     const text = await response.text();
-    testing.expectEqual('Internal Server Error', text);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(500, response.status);
+      testing.expectEqual(false, response.ok);
+      testing.expectEqual('Internal Server Error', text);
+    });
+  }
 </script>
 
-<script id=fetch_request_object>
-  testing.async(async (restore) => {
+<script id=fetch_request_object type=module>
+  {
+    const state = await testing.async();
     const request = new Request('http://127.0.0.1:9582/xhr', {
       method: 'GET'
     });
@@ -108,29 +127,33 @@
     testing.expectEqual('GET', request.method);
 
     const response = await fetch(request);
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-
     const text = await response.text();
-    testing.expectEqual(100, text.length);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual(100, text.length);
+    });
+  }
 </script>
 
-<script id=fetch_request_with_headers>
-  testing.async(async (restore) => {
+<script id=fetch_request_with_headers type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr', {
       method: 'GET',
       headers: {
         'X-Custom-Header': 'test-value'
       }
     });
-    restore();
+    state.resolve();
 
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-  });
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+    });
+  }
 </script>
 
 <script id=fetch_request_with_method_variations>
@@ -154,8 +177,8 @@
   }
 </script>
 
-<script id=response_constructor>
-  testing.async(async (restore) => {
+<script id=response_constructor type=module>
+  {
     const response1 = new Response(null);
     testing.expectEqual(200, response1.status);
     testing.expectEqual(true, response1.ok);
@@ -163,79 +186,97 @@
     const response2 = new Response('Hello', {
       status: 201,
     });
-    testing.expectEqual(201, response2.status);
-    testing.expectEqual(true, response2.ok);
 
+    const state = await testing.async();
     const text = await response2.text();
-    restore();
+    state.resolve();
 
-    testing.expectEqual('Hello', text);
-  });
+    await state.done(() => {
+      testing.expectEqual(201, response2.status);
+      testing.expectEqual(true, response2.ok);
+      testing.expectEqual('Hello', text);
+    });
+  }
 </script>
 
-<script id=response_body_stream>
-  testing.async(async (restore) => {
+<script id=response_body_stream type=module>
+  {
+    const state = await testing.async();
     const response = await fetch('http://127.0.0.1:9582/xhr');
-    restore();
-
-    testing.expectEqual(true, response.body !== null);
-    testing.expectEqual(true, response.body instanceof ReadableStream);
+    state.resolve();
 
     const buf = await response.arrayBuffer()
-    restore();
 
-    const uint8array = new Uint8Array(buf);
-    const decoder = new TextDecoder('utf-8');
-    testing.expectEqual('1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890', decoder.decode(uint8array));
-  });
+    await state.done(() => {
+      testing.expectEqual(true, response.body !== null);
+      testing.expectEqual(true, response.body instanceof ReadableStream);
+
+
+      const uint8array = new Uint8Array(buf);
+      const decoder = new TextDecoder('utf-8');
+      testing.expectEqual('1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890', decoder.decode(uint8array));
+    })
+  };
 </script>
 
-<script id=response_empty_body>
-  testing.async(async (restore) => {
+<script id=response_empty_body type=module>
+  {
+    const state = await testing.async();
     const response = new Response('');
-    testing.expectEqual(200, response.status);
-
     const text = await response.text();
-    restore();
+    state.resolve();
 
-    testing.expectEqual('', text);
-    // Empty body should still create a valid stream
-    testing.expectEqual(true, response.body !== null);
-  });
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+
+      testing.expectEqual('', text);
+      // Empty body should still create a valid stream
+      testing.expectEqual(true, response.body !== null);
+    });
+  }
 </script>
 
-<script id=fetch_blob_url>
-  testing.async(async (restore) => {
+<script id=fetch_blob_url type=module>
+  {
+    const state = await testing.async();
     // Create a blob and get its URL
     const blob = new Blob(['Hello from blob!'], { type: 'text/plain' });
     const blobUrl = URL.createObjectURL(blob);
-
     const response = await fetch(blobUrl);
-    restore();
-
-    testing.expectEqual(200, response.status);
-    testing.expectEqual(true, response.ok);
-    testing.expectEqual(blobUrl, response.url);
-    testing.expectEqual('text/plain', response.headers.get('Content-Type'));
-
     const text = await response.text();
-    testing.expectEqual('Hello from blob!', text);
 
-    // Clean up
-    URL.revokeObjectURL(blobUrl);
-  });
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(true, response.ok);
+      testing.expectEqual(blobUrl, response.url);
+      testing.expectEqual('text/plain', response.headers.get('Content-Type'));
+
+      testing.expectEqual('Hello from blob!', text);
+
+      // Clean up
+      URL.revokeObjectURL(blobUrl);
+    });
+  }
 </script>
 
-<script id=abort>
-  testing.async(async (restore) => {
+<script id=abort type=module>
+  {
+    const state = await testing.async();
     const controller = new AbortController();
     controller.abort();
     try {
       await fetch('http://127.0.0.1:9582/xhr', { signal: controller.signal });
-      testain.fail('fetch should have been aborted');
+      state.resolve();
+      await state.done(() => {
+        testing.fail('fetch should have been aborted');
+      });
     } catch (e) {
-      restore();
-      testing.expectEqual("AbortError", e.name);
+      state.resolve();
+      await state.done(() => {
+        testing.expectEqual("AbortError", e.name);
+      });
     }
-  });
+  }
 </script>

--- a/src/browser/tests/net/websocket.html
+++ b/src/browser/tests/net/websocket.html
@@ -561,3 +561,21 @@
   });
 }
 </script>
+
+<script id=ws_within_callback type=module>
+{
+  const state = await testing.async();
+  let nested = false;
+  let ws1 = new WebSocket('ws://127.0.0.1:9584/');
+
+  ws1.addEventListener('open', () => {
+    let ws2 = new WebSocket('ws://127.0.0.1:9584/');
+    ws2.addEventListener('open', state.resolve);
+  });
+
+  await state.done(() => {
+    // this case used to fail, so just reaching here is a success!
+    testing.expectTrue(true);
+  });
+}
+</script>

--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -1,332 +1,335 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
-<script id=xhr>
+<script id=xhr type=module>
   testing.expectEqual(0, XMLHttpRequest.UNSENT);
   testing.expectEqual(1, XMLHttpRequest.OPENED);
   testing.expectEqual(2, XMLHttpRequest.HEADERS_RECEIVED);
   testing.expectEqual(3, XMLHttpRequest.LOADING);
   testing.expectEqual(4, XMLHttpRequest.DONE);
-
-  testing.async(async (restore) => {
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
-    const event = await new Promise((resolve) => {
-      function cbk(event) {
-        resolve(event)
-      }
 
-      req.onload = cbk;
-      testing.expectEqual(cbk, req.onload);
-      req.onload = cbk;
+    function cbk(event) {
+      state.resolve(event)
+    }
 
-      req.open('GET', 'http://127.0.0.1:9582/xhr');
-      testing.expectEqual(0, req.status);
-      testing.expectEqual('', req.statusText);
-      testing.expectEqual('', req.getAllResponseHeaders());
-      testing.expectEqual(null, req.getResponseHeader('Content-Type'));
-      testing.expectEqual('', req.responseText);
-      testing.expectEqual('', req.responseURL);
-      req.send();
+    req.onload = cbk;
+    testing.expectEqual(cbk, req.onload);
+    req.onload = cbk;
+
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    testing.expectEqual(0, req.status);
+    testing.expectEqual('', req.statusText);
+    testing.expectEqual('', req.getAllResponseHeaders());
+    testing.expectEqual(null, req.getResponseHeader('Content-Type'));
+    testing.expectEqual('', req.responseText);
+    testing.expectEqual('', req.responseURL);
+    req.send();
+
+
+    await state.done((event) => {
+      testing.expectEqual('load', event.type);
+      testing.expectEqual(true, event.loaded > 0);
+      testing.expectEqual(true, event instanceof ProgressEvent);
+      testing.expectEqual(200, req.status);
+      testing.expectEqual('OK', req.statusText);
+      testing.expectEqual('text/html; charset=utf-8', req.getResponseHeader('Content-Type'));
+      testing.expectEqual('content-length: 100\r\nContent-Type: text/html; charset=utf-8\r\n', req.getAllResponseHeaders());
+      testing.expectEqual(100, req.responseText.length);
+      testing.expectEqual(req.responseText.length, req.response.length);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', req.responseURL);
     });
-
-    restore();
-    testing.expectEqual('load', event.type);
-    testing.expectEqual(true, event.loaded > 0);
-    testing.expectEqual(true, event instanceof ProgressEvent);
-    testing.expectEqual(200, req.status);
-    testing.expectEqual('OK', req.statusText);
-    testing.expectEqual('text/html; charset=utf-8', req.getResponseHeader('Content-Type'));
-    testing.expectEqual('content-length: 100\r\nContent-Type: text/html; charset=utf-8\r\n', req.getAllResponseHeaders());
-    testing.expectEqual(100, req.responseText.length);
-    testing.expectEqual(req.responseText.length, req.response.length);
-    testing.expectEqual('http://127.0.0.1:9582/xhr', req.responseURL);
-  });
+  }
 </script>
 
-<script id=xhr2>
-  const req2 = new XMLHttpRequest()
-  testing.async(async (restore) => {
-    await new Promise((resolve) => {
-      req2.onload = resolve;
-      req2.open('GET', 'http://127.0.0.1:9582/xhr')
-      req2.responseType = 'document';
-      req2.send()
-    });
+<script id=xhr2 type=module type=module>
+  {
+    const state = await testing.async();
 
-    restore();
-    testing.expectEqual(200, req2.status);
-    testing.expectEqual('OK', req2.statusText);
-    testing.expectEqual(true, req2.response instanceof Document);
-    testing.expectEqual(true, req2.responseXML instanceof Document);
-  });
+    const req2 = new XMLHttpRequest()
+    req2.onload = () => { state.resolve() };
+    req2.open('GET', 'http://127.0.0.1:9582/xhr')
+    req2.responseType = 'document';
+    req2.send()
+
+    await state.done(() => {
+      testing.expectEqual(200, req2.status);
+      testing.expectEqual('OK', req2.statusText);
+      testing.expectEqual(true, req2.response instanceof Document);
+      testing.expectEqual(true, req2.responseXML instanceof Document);
+    });
+  }
 </script>
 
-<script id=xhr3>
-  const req3 = new XMLHttpRequest()
-  testing.async(async (restore) => {
-    await new Promise((resolve) => {
-      req3.onload = resolve;
-      req3.open('GET', 'http://127.0.0.1:9582/xhr/json')
-      req3.responseType = 'json';
-      req3.send()
-    });
+<script id=xhr3 type=module type=module>
+  {
+    const state = await testing.async();
 
-    restore();
-    testing.expectEqual(200, req3.status);
-    testing.expectEqual('OK', req3.statusText);
-    testing.expectEqual('9000!!!', req3.response.over);
-    testing.expectEqual("number", typeof json.updated_at);
-    testing.expectEqual(1765867200000, json.updated_at);
-    testing.expectEqual({over: '9000!!!',updated_at:1765867200000}, json);
-  });
+    const req3 = new XMLHttpRequest()
+    req3.onload = () => { state.resolve() };
+    req3.open('GET', 'http://127.0.0.1:9582/xhr/json')
+    req3.responseType = 'json';
+    req3.send();
+
+    await state.done(() => {
+      testing.expectEqual(200, req3.status);
+      testing.expectEqual('OK', req3.statusText);
+      testing.expectEqual('9000!!!', req3.response.over);
+      testing.expectEqual("number", typeof json.updated_at);
+      testing.expectEqual(1765867200000, json.updated_at);
+      testing.expectEqual({over: '9000!!!',updated_at:1765867200000}, json);
+    });
+  }
 </script>
 
-<script id=xhr4>
-  const req4 = new XMLHttpRequest()
-  testing.async(async (restore) => {
-    await new Promise((resolve) => {
-      req4.onload = resolve;
-      req4.open('POST', 'http://127.0.0.1:9582/xhr')
-      req4.send('foo')
-    });
+<script id=xhr4 type=module>
+  {
+    const state = await testing.async();
 
-    restore();
-    testing.expectEqual(200, req4.status);
-    testing.expectEqual('OK', req4.statusText);
-    testing.expectEqual(true, req4.responseText.length > 64);
-  });
+    const req4 = new XMLHttpRequest();
+    req4.onload = () => { state.resolve() };
+    req4.open('POST', 'http://127.0.0.1:9582/xhr')
+    req4.send('foo');
+
+
+    await state.done(() => {
+      testing.expectEqual(200, req4.status);
+      testing.expectEqual('OK', req4.statusText);
+      testing.expectEqual(true, req4.responseText.length > 64);
+    });
+  }
 </script>
 
-<script id=xhr5>
-  testing.async(async (restore) => {
-    let state = [];
+<script id=xhr5 type=module>
+  {
+    const state = await testing.async();
+    let records = [];
     const req5 = new XMLHttpRequest();
-
-    const result = await new Promise((resolve) => {
-      req5.onreadystatechange = (e) => {
-        state.push(req5.readyState);
-        if (req5.readyState === XMLHttpRequest.DONE) {
-          resolve({states: state, target: e.currentTarget});
-        }
+    req5.onreadystatechange = (e) => {
+      records.push(req5.readyState);
+      if (req5.readyState === XMLHttpRequest.DONE) {
+        state.resolve({records: records, target: e.currentTarget});
       }
+    }
+    req5.open('GET', 'http://127.0.0.1:9582/xhr');
+    req5.send();
 
-      req5.open('GET', 'http://127.0.0.1:9582/xhr');
-      req5.send();
+    await state.done((result) => {
+      const {records: records, target: target} = result;
+      testing.expectEqual(4, records.length)
+      testing.expectEqual(XMLHttpRequest.OPENED, records[0]);
+      testing.expectEqual(XMLHttpRequest.HEADERS_RECEIVED, records[1]);
+      testing.expectEqual(XMLHttpRequest.LOADING, records[2]);
+      testing.expectEqual(XMLHttpRequest.DONE, records[3]);
+      testing.expectEqual(req5, target);
     });
-
-    restore();
-    const {states: states, target: target} = result;
-    testing.expectEqual(4, states.length)
-    testing.expectEqual(XMLHttpRequest.OPENED, states[0]);
-    testing.expectEqual(XMLHttpRequest.HEADERS_RECEIVED, states[1]);
-    testing.expectEqual(XMLHttpRequest.LOADING, states[2]);
-    testing.expectEqual(XMLHttpRequest.DONE, states[3]);
-    testing.expectEqual(req5, target);
-  })
+  }
 </script>
 
-<script id=xhr6>
-  const req6 = new XMLHttpRequest()
-  testing.async(async (restore) => {
-    await new Promise((resolve) => {
-      req6.onload = resolve;
-      req6.open('GET', 'http://127.0.0.1:9582/xhr/binary')
-      req6.responseType ='arraybuffer'
-      req6.send()
-    });
+<script id=xhr6 type=module>
+  {
+    const state = await testing.async();
 
-    restore();
-    testing.expectEqual(200, req6.status);
-    testing.expectEqual('OK', req6.statusText);
-    testing.expectEqual(7, req6.response.byteLength);
-    testing.expectEqual([0, 0, 1, 2, 0, 0, 9], new Int32Array(req6.response));
-    testing.expectEqual('', typeof req6.response);
-    testing.expectEqual('arraybuffer', req6.responseType);
-  });
+    const req6 = new XMLHttpRequest();
+    req6.onload = () => { state.resolve() };
+    req6.open('GET', 'http://127.0.0.1:9582/xhr/binary')
+    req6.responseType ='arraybuffer';
+    req6.send();
+
+    await state.done(() => {
+      testing.expectEqual(200, req6.status);
+      testing.expectEqual('OK', req6.statusText);
+      testing.expectEqual(7, req6.response.byteLength);
+      testing.expectEqual([0, 0, 1, 2, 0, 0, 9], new Int32Array(req6.response));
+      testing.expectEqual('', typeof req6.response);
+      testing.expectEqual('arraybuffer', req6.responseType);
+    });
+  }
 </script>
 
-<script id=xhr_redirect>
-  testing.async(async (restore) => {
+<script id=xhr_redirect type=module>
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
-    await new Promise((resolve) => {
-      req.onload = resolve;
-      req.open('GET', 'http://127.0.0.1:9582/xhr/redirect');
-      req.send();
-    });
+    req.onload = () => { state.resolve() };
+    req.open('GET', 'http://127.0.0.1:9582/xhr/redirect');
+    req.send();
 
-    restore();
-    testing.expectEqual(200, req.status);
-    testing.expectEqual('OK', req.statusText);
-    testing.expectEqual('http://127.0.0.1:9582/xhr', req.responseURL);
-    testing.expectEqual(100, req.responseText.length);
-  });
+    await state.done(() => {
+      testing.expectEqual(200, req.status);
+      testing.expectEqual('OK', req.statusText);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', req.responseURL);
+      testing.expectEqual(100, req.responseText.length);
+    });
+  }
 </script>
 
-<script id=xhr_404>
-  testing.async(async (restore) => {
-
+<script id=xhr_404 type=module>
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
-    await new Promise((resolve) => {
-      req.onload = resolve;
-      req.open('GET', 'http://127.0.0.1:9582/xhr/404');
-      req.send();
-    });
+    req.onload = () => { state.resolve() };
+    req.open('GET', 'http://127.0.0.1:9582/xhr/404');
+    req.send();
 
-    restore();
-    testing.expectEqual(404, req.status);
-    testing.expectEqual('Not Found', req.statusText);
-    testing.expectEqual('Not Found', req.responseText);
-  });
+    await state.done(() => {
+      testing.expectEqual(404, req.status);
+      testing.expectEqual('Not Found', req.statusText);
+      testing.expectEqual('Not Found', req.responseText);
+    });
+  }
 </script>
 
-<script id=xhr_500>
-  testing.async(async (restore) => {
+<script id=xhr_500 type=module>
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
-    await new Promise((resolve) => {
-      req.onload = resolve;
-      req.open('GET', 'http://127.0.0.1:9582/xhr/500');
-      req.send();
-    });
+    req.onload = () => { state.resolve() };
+    req.open('GET', 'http://127.0.0.1:9582/xhr/500');
+    req.send();
 
-    restore();
-    testing.expectEqual(500, req.status);
-    testing.expectEqual('Internal Server Error', req.statusText);
-    testing.expectEqual('Internal Server Error', req.responseText);
-  });
+    await state.done(() => {
+      testing.expectEqual(500, req.status);
+      testing.expectEqual('Internal Server Error', req.statusText);
+      testing.expectEqual('Internal Server Error', req.responseText);
+    });
+  }
 </script>
 
-<script id=xhr_abort>
-  testing.async(async (restore) => {
+<script id=xhr_abort type=module>
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
     let abortFired = false;
     let errorFired = false;
     let loadEndFired = false;
 
-    await new Promise((resolve) => {
-      req.onabort = () => { abortFired = true; };
-      req.onerror = () => { errorFired = true; };
-      req.onloadend = () => {
-        loadEndFired = true;
-        resolve();
-      };
+    req.onabort = () => { abortFired = true; };
+    req.onerror = () => { errorFired = true; };
+    req.onloadend = () => {
+      loadEndFired = true;
+      state.resolve();
+    };
 
-      req.open('GET', 'http://127.0.0.1:9582/xhr');
-      req.send();
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    req.send();
+    req.abort();
+
+    await state.done(() => {
+      testing.expectEqual(true, abortFired);
+      testing.expectEqual(true, errorFired);
+      testing.expectEqual(true, loadEndFired);
+      testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
+    });
+  }
+</script>
+
+<script id=xhr_abort_callback type=module>
+  {
+    const state = await testing.async();
+    const req = new XMLHttpRequest();
+    let abortFired = false;
+    let errorFired = false;
+    let loadEndFired = false;
+
+    req.onabort = () => { abortFired = true; };
+    req.onerror = () => { errorFired = true; };
+    req.onloadend = () => {
+      loadEndFired = true;
+      state.resolve();
+    };
+
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    req.onreadystatechange = (e) => {
       req.abort();
-    });
+    }
+    req.send();
 
-    restore();
-    testing.expectEqual(true, abortFired);
-    testing.expectEqual(true, errorFired);
-    testing.expectEqual(true, loadEndFired);
-    testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
-  });
+    await state.done(() => {
+      testing.expectEqual(true, abortFired);
+      testing.expectEqual(true, errorFired);
+      testing.expectEqual(true, loadEndFired);
+      testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
+    });
+  }
 </script>
 
-<script id=xhr_abort_callback>
-  testing.async(async (restore) => {
+<script id=xhr_abort_callback_nobody type=module>
+  {
+    const state = await testing.async();
     const req = new XMLHttpRequest();
     let abortFired = false;
     let errorFired = false;
     let loadEndFired = false;
 
-    await new Promise((resolve) => {
-      req.onabort = () => { abortFired = true; };
-      req.onerror = () => { errorFired = true; };
-      req.onloadend = () => {
-        loadEndFired = true;
-        resolve();
-      };
+    req.onabort = () => { abortFired = true; };
+    req.onerror = () => { errorFired = true; };
+    req.onloadend = () => {
+      loadEndFired = true;
+      state.resolve();
+    };
 
-      req.open('GET', 'http://127.0.0.1:9582/xhr');
-      req.onreadystatechange = (e) => {
-        req.abort();
-      }
-      req.send();
+    req.open('GET', 'http://127.0.0.1:9582/xhr_empty');
+    req.onreadystatechange = (e) => {
+      req.abort();
+    }
+    req.send();
+
+    await state.done(() => {
+      testing.expectEqual(true, abortFired);
+      testing.expectEqual(true, errorFired);
+      testing.expectEqual(true, loadEndFired);
+      testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
     });
-
-    restore();
-    testing.expectEqual(true, abortFired);
-    testing.expectEqual(true, errorFired);
-    testing.expectEqual(true, loadEndFired);
-    testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
-  });
+  }
 </script>
 
+<script id=xhr_blob_url type=module>
+  {
+    const state = await testing.async();
 
-<script id=xhr_abort_callback_nobody>
-  testing.async(async (restore) => {
-    const req = new XMLHttpRequest();
-    let abortFired = false;
-    let errorFired = false;
-    let loadEndFired = false;
-
-    await new Promise((resolve) => {
-      req.onabort = () => { abortFired = true; };
-      req.onerror = () => { errorFired = true; };
-      req.onloadend = () => {
-        loadEndFired = true;
-        resolve();
-      };
-
-      req.open('GET', 'http://127.0.0.1:9582/xhr_empty');
-      req.onreadystatechange = (e) => {
-        req.abort();
-      }
-      req.send();
-    });
-
-    restore();
-    testing.expectEqual(true, abortFired);
-    testing.expectEqual(true, errorFired);
-    testing.expectEqual(true, loadEndFired);
-    testing.expectEqual(XMLHttpRequest.UNSENT, req.readyState);
-  });
-</script>
-
-<script id=xhr_blob_url>
-  testing.async(async (restore) => {
     // Create a blob and get its URL
     const blob = new Blob(['Hello from blob!'], { type: 'text/plain' });
     const blobUrl = URL.createObjectURL(blob);
 
     const req = new XMLHttpRequest();
-    await new Promise((resolve) => {
-      req.onload = resolve;
-      req.open('GET', blobUrl);
-      req.send();
+    req.onload = () => { state.resolve() };
+    req.open('GET', blobUrl);
+    req.send();
+
+    await state.done(() => {
+      testing.expectEqual(200, req.status);
+      testing.expectEqual('Hello from blob!', req.responseText);
+      testing.expectEqual(blobUrl, req.responseURL);
+
+      // Clean up
+      URL.revokeObjectURL(blobUrl);
     });
-
-    restore();
-    testing.expectEqual(200, req.status);
-    testing.expectEqual('Hello from blob!', req.responseText);
-    testing.expectEqual(blobUrl, req.responseURL);
-
-    // Clean up
-    URL.revokeObjectURL(blobUrl);
-  });
+  }
 </script>
 
-<script id=xhr_timeout>
-  // timeout property: default is 0
-  const req = new XMLHttpRequest();
-  testing.expectEqual(0, req.timeout);
+<script id=xhr_timeout type=module>
+  {
+    // timeout property: default is 0
+    const req = new XMLHttpRequest();
+    testing.expectEqual(0, req.timeout);
 
-  // timeout can be set and read back
-  req.timeout = 5000;
-  testing.expectEqual(5000, req.timeout);
-
-  // request with timeout set succeeds normally when server responds in time
-  testing.async(async (restore) => {
-    const event = await new Promise((resolve) => {
-      req.onload = resolve;
-      req.open('GET', 'http://127.0.0.1:9582/xhr');
-      req.send();
-    });
-
-    restore();
-    testing.expectEqual('load', event.type);
-    testing.expectEqual(200, req.status);
+    // timeout can be set and read back
+    req.timeout = 5000;
     testing.expectEqual(5000, req.timeout);
-  });
+
+    // request with timeout set succeeds normally when server responds in time
+    const state = await testing.async();
+    req.onload = (e) => { state.resolve(e) };
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    req.send();
+
+    await state.done((event) => {
+      testing.expectEqual('load', event.type);
+      testing.expectEqual(200, req.status);
+      testing.expectEqual(5000, req.timeout);
+    });
+  }
 </script>

--- a/src/browser/tests/page/encoding.html
+++ b/src/browser/tests/page/encoding.html
@@ -2,13 +2,15 @@
 <body></body>
 <script src="../testing.js"></script>
 
-<script id="gbk_encoding">
+<script id="gbk_encoding" type=module>
   {
+    const state = await testing.async();
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = 'encoding/gbk.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       // GBK-encoded "中文" should be decoded to UTF-8
       testing.expectEqual('中文', iframe.contentDocument.getElementById('test').textContent);
       // document.characterSet should return canonical encoding name
@@ -19,57 +21,67 @@
   }
 </script>
 
-<script id="shift_jis_encoding">
+<script id="shift_jis_encoding" type=module>
   {
+    const state = await testing.async();
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = 'encoding/shift_jis.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       // Shift_JIS-encoded "日本語" should be decoded to UTF-8
       testing.expectEqual('日本語', iframe.contentDocument.getElementById('test').textContent);
     });
   }
 </script>
 
-<script id="latin1_encoding">
+<script id="latin1_encoding" type=module>
   {
+    const state = await testing.async();
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = 'encoding/latin1.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       // ISO-8859-1-encoded "Café" should be decoded to UTF-8
       testing.expectEqual('Café', iframe.contentDocument.getElementById('test').textContent);
     });
   }
 </script>
 
-<script id="content_type_header_charset">
+<script id="content_type_header_charset" type=module>
   {
+    const state = await testing.async();
+
     // Test charset from Content-Type HTTP header (no meta charset in file)
     // TestHTTPServer returns "text/html; charset=GB2312" for *.GB2312.html files
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = testing.BASE_URL + 'page/encoding/content_type.GB2312.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       // GB2312-encoded "中文" should be decoded to UTF-8 via Content-Type header charset
       testing.expectEqual('中文', iframe.contentDocument.getElementById('test').textContent);
     });
   }
 </script>
 
-<script id="no_charset_fallback">
+<script id="no_charset_fallback" type=module>
   {
+    const state = await testing.async();
+
     // Test file with non-UTF-8 bytes but NO charset declaration anywhere.
     // Without charset info, the bytes are parsed as UTF-8, producing replacement characters.
     // This documents the "broken" behavior for files without proper encoding declaration.
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = 'encoding/no_charset.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       // The GBK bytes D6 D0 CE C4 are invalid UTF-8, each becomes U+FFFD
       const text = iframe.contentDocument.getElementById('test').textContent;
       // Should contain replacement characters (the exact count depends on how invalid bytes are handled)
@@ -78,16 +90,19 @@
   }
 </script>
 
-<script id="anchor_href_encoding_with_ncr">
+<script id="anchor_href_encoding_with_ncr" type=module>
   {
+    const state = await testing.async();
+
     // Test that anchor.href encodes unmappable characters as NCRs in non-UTF-8 documents.
     // When a character can't be represented in the document's encoding, it should become &#nnnnn;
     // Per WHATWG URL Standard, query strings use document encoding with NCR fallback.
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.src = 'encoding/gbk.html';
+    iframe.onload = () => { state.resolve(); }
 
-    testing.onload(() => {
+    await state.done(() => {
       testing.expectEqual('GBK', iframe.contentDocument.characterSet);
 
       // Test 1: U+3D34 (㴴) - a Han character NOT in GBK, should become NCR &#15668;

--- a/src/browser/tests/testing.js
+++ b/src/browser/tests/testing.js
@@ -81,10 +81,10 @@
         resolve: resolve,
         capture: {script_id: document.currentScript.id, stack: new Error().stack},
         done: async function(cb) {
-          await this.promise;
+          const res = await this.promise;
           async_pending -= 1;
           async_capture = this.capture;
-          cb();
+          cb(res);
           async_capture = false;
         }
       };

--- a/src/browser/tests/testing.js
+++ b/src/browser/tests/testing.js
@@ -4,7 +4,7 @@
   let eventuallies = [];
   let async_capture = null;
   let current_script_id = null;
-  let async_pending = 0;
+  let async_pending = new Set();
 
   function expectTrue(actual) {
      expectEqual(true, actual);
@@ -71,18 +71,21 @@
   }
 
   async function async(cb) {
+    const script_id = document.currentScript.id;
+
     if (cb == undefined) {
       let resolve = null
       const promise = new Promise((r) => { resolve = r});
-      async_pending += 1;
+      async_pending.add(script_id);
+
 
       return {
         promise: promise,
         resolve: resolve,
-        capture: {script_id: document.currentScript.id, stack: new Error().stack},
+        capture: {script_id: script_id, stack: new Error().stack},
         done: async function(cb) {
           const res = await this.promise;
-          async_pending -= 1;
+          async_pending.delete(script_id);
           async_capture = this.capture;
           cb(res);
           async_capture = false;
@@ -90,7 +93,7 @@
       };
     }
 
-    let capture = {script_id: document.currentScript.id, stack: new Error().stack};
+    let capture = {script_id: script_id, stack: new Error().stack};
     await cb(() => { async_capture = capture; });
     async_capture = null;
   }
@@ -100,7 +103,7 @@
       throw new Error('Failed');
     }
 
-    if (async_pending > 0) {
+    if (async_pending.size > 0) {
       return false;
     }
 
@@ -131,6 +134,10 @@
     return true;
   }
 
+  function printTimeoutState() {
+  	console.warn('Pending count:', Array.from(async_pending));
+  }
+
   const IS_TEST_RUNNER = window.navigator.userAgent.startsWith("Lightpanda/");
 
   window.testing = {
@@ -142,6 +149,7 @@
     expectEqual: expectEqual,
     expectError: expectError,
     withError: withError,
+    printTimeoutState: printTimeoutState,
     onload: onload,
     IS_TEST_RUNNER: IS_TEST_RUNNER,
     HOST: '127.0.0.1',

--- a/src/browser/tests/window/timers.html
+++ b/src/browser/tests/window/timers.html
@@ -1,35 +1,47 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
-<script id=setInterval>
-  let set_interval1 = false
-  let timer1 = window.setInterval(function() {
-    set_interval1 = true;
-    testing.expectEqual(window, this);
-  }, 1);
+<script id=setInterval type=module>
+  {
+    const state = await testing.async();
 
-  let set_interval2 = false
-  let timer2 = window.setInterval(function() {
-    set_interval2 = true;
-  }, 1)
-  window.clearInterval(timer2);
+    let set_interval1 = false
+    let timer1 = window.setInterval(function() {
+      set_interval1 = true;
+      testing.expectEqual(window, this);
+    }, 1);
 
-  testing.expectEqual(true, timer1 != timer2);
+    let set_interval2 = false
+    let timer2 = window.setInterval(function() {
+      set_interval2 = true;
+    }, 1)
+    window.clearInterval(timer2);
 
+    testing.expectEqual(true, timer1 != timer2);
 
-  testing.onload(() => {
-    testing.expectEqual(true, set_interval1);
-    testing.expectEqual(false, set_interval2);
-  });
+    window.setTimeout(() => {
+      state.resolve()
+    }, 5);
+
+    await state.done(() => {
+      testing.expectEqual(true, set_interval1);
+      testing.expectEqual(false, set_interval2);
+    });
+  }
 </script>
 
-<script id=setTimeout>
+<script id=setTimeout type=module>
+  const state = await testing.async();
+
   testing.expectEqual(1, window.setTimeout.length);
   let wst2 = 1;
+
   window.setTimeout((a, b) => {
     wst2 = a + b;
+    state.resolve();
   }, 1, 2, 3);
-  testing.onload(() => testing.expectEqual(5, wst2));
+
+  await state.done(() => testing.expectEqual(5, wst2));
 </script>
 
 <script id=invalid-timer-clear>

--- a/src/browser/tests/worker/worker.html
+++ b/src/browser/tests/worker/worker.html
@@ -11,48 +11,51 @@
   }
 </script>
 
-<script id="worker_message">
-  testing.async(async (capture) => {
+<script id="worker_message" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      // Give the script time to load before posting
-      setTimeout(() => {
-        worker.postMessage({ greeting: 'hello' });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
 
-    capture();
-    testing.expectEqual('hello', response.echo.greeting);
-    testing.expectEqual('worker', response.from);
-  });
+      // Give the script time to load before posting
+    setTimeout(() => {
+      worker.postMessage({ greeting: 'hello' });
+    }, 10);
+
+    await state.done((response) => {
+      testing.expectEqual('hello', response.echo.greeting);
+      testing.expectEqual('worker', response.from);
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_date">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_date" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const testDate = new Date('2024-06-15T12:30:00Z');
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ date: testDate });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
 
-    capture();
-    testing.expectTrue(response.echo.date instanceof Date);
-    testing.expectEqual(testDate.getTime(), response.echo.date.getTime());
-  });
+    setTimeout(() => {
+      worker.postMessage({ date: testDate });
+    }, 10);
+
+    await state.done((response) => {
+      testing.expectTrue(response.echo.date instanceof Date);
+      testing.expectEqual(testDate.getTime(), response.echo.date.getTime());
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_arraybuffer">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_arraybuffer" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const buffer = new ArrayBuffer(8);
@@ -60,118 +63,118 @@
     view[0] = 1; view[1] = 2; view[2] = 3; view[3] = 4;
     view[4] = 5; view[5] = 6; view[6] = 7; view[7] = 8;
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ buffer: buffer });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage({ buffer: buffer });
+    }, 10);
 
-    capture();
-    testing.expectTrue(response.echo.buffer instanceof ArrayBuffer);
-    testing.expectEqual(8, response.echo.buffer.byteLength);
-    const resultView = new Uint8Array(response.echo.buffer);
-    testing.expectEqual(1, resultView[0]);
-    testing.expectEqual(8, resultView[7]);
-  });
+    await state.done((response) => {
+      testing.expectTrue(response.echo.buffer instanceof ArrayBuffer);
+      testing.expectEqual(8, response.echo.buffer.byteLength);
+      const resultView = new Uint8Array(response.echo.buffer);
+      testing.expectEqual(1, resultView[0]);
+      testing.expectEqual(8, resultView[7]);
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_typedarray">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_typedarray" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const arr = new Float64Array([1.5, 2.5, 3.5, 4.5]);
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ arr: arr });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage({ arr: arr });
+    }, 10);
 
-    capture();
-    testing.expectTrue(response.echo.arr instanceof Float64Array);
-    testing.expectEqual(4, response.echo.arr.length);
-    testing.expectEqual(1.5, response.echo.arr[0]);
-    testing.expectEqual(4.5, response.echo.arr[3]);
-  });
+    await state.done((response) => {
+      testing.expectTrue(response.echo.arr instanceof Float64Array);
+      testing.expectEqual(4, response.echo.arr.length);
+      testing.expectEqual(1.5, response.echo.arr[0]);
+      testing.expectEqual(4.5, response.echo.arr[3]);
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_map">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_map" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const map = new Map([['a', 1], ['b', 2], ['c', 3]]);
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ map: map });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage({ map: map });
+    }, 10);
 
-    capture();
-    testing.expectTrue(response.echo.map instanceof Map);
-    testing.expectEqual(3, response.echo.map.size);
-    testing.expectEqual(1, response.echo.map.get('a'));
-    testing.expectEqual(3, response.echo.map.get('c'));
-  });
+    await state.done((response) => {
+      testing.expectTrue(response.echo.map instanceof Map);
+      testing.expectEqual(3, response.echo.map.size);
+      testing.expectEqual(1, response.echo.map.get('a'));
+      testing.expectEqual(3, response.echo.map.get('c'));
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_set">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_set" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const set = new Set([1, 2, 3, 'four', 'five']);
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ set: set });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage({ set: set });
+    }, 100);
 
-    capture();
-    testing.expectTrue(response.echo.set instanceof Set);
-    testing.expectEqual(5, response.echo.set.size);
-    testing.expectTrue(response.echo.set.has(1));
-    testing.expectTrue(response.echo.set.has('four'));
-  });
+    await state.done((response) => {
+      testing.expectTrue(response.echo.set instanceof Set);
+      testing.expectEqual(5, response.echo.set.size);
+      testing.expectTrue(response.echo.set.has(1));
+      testing.expectTrue(response.echo.set.has('four'));
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_regexp">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_regexp" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const regex = /hello.*world/gi;
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage({ regex: regex });
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage({ regex: regex });
+    }, 10);
 
-    capture();
-    testing.expectTrue(response.echo.regex instanceof RegExp);
-    testing.expectEqual('hello.*world', response.echo.regex.source);
-    testing.expectTrue(response.echo.regex.global);
-    testing.expectTrue(response.echo.regex.ignoreCase);
-  });
+    await state.done((response) => {
+      testing.expectTrue(response.echo.regex instanceof RegExp);
+      testing.expectEqual('hello.*world', response.echo.regex.source);
+      testing.expectTrue(response.echo.regex.global);
+      testing.expectTrue(response.echo.regex.ignoreCase);
+    });
+  }
 </script>
 
-<script id="worker_structured_clone_nested">
-  testing.async(async (capture) => {
+<script id="worker_structured_clone_nested" type=module>
+  {
+    const state = await testing.async();
     const worker = new Worker('./echo-worker.js');
 
     const complex = {
@@ -184,23 +187,22 @@
       buffer: new Uint8Array([10, 20, 30]).buffer
     };
 
-    const response = await new Promise((resolve) => {
-      worker.onmessage = function(event) {
-        resolve(event.data);
-      };
-      setTimeout(() => {
-        worker.postMessage(complex);
-      }, 100);
-    });
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+    setTimeout(() => {
+      worker.postMessage(complex);
+    }, 10);
 
-    capture();
-    testing.expectEqual('hello', response.echo.string);
-    testing.expectEqual(42, response.echo.number);
-    testing.expectEqual(true, response.echo.boolean);
-    testing.expectEqual(null, response.echo.null);
-    testing.expectEqual(3, response.echo.array.length);
-    testing.expectEqual('value', response.echo.array[2].nested);
-    testing.expectTrue(response.echo.date instanceof Date);
-    testing.expectTrue(response.echo.buffer instanceof ArrayBuffer);
-  });
+    await state.done((response) => {
+      testing.expectEqual('hello', response.echo.string);
+      testing.expectEqual(42, response.echo.number);
+      testing.expectEqual(true, response.echo.boolean);
+      testing.expectEqual(null, response.echo.null);
+      testing.expectEqual(3, response.echo.array.length);
+      testing.expectEqual('value', response.echo.array[2].nested);
+      testing.expectTrue(response.echo.date instanceof Date);
+      testing.expectTrue(response.echo.buffer instanceof ArrayBuffer);
+    });
+  }
 </script>

--- a/src/browser/tests/worker/worker.html
+++ b/src/browser/tests/worker/worker.html
@@ -23,7 +23,7 @@
       // Give the script time to load before posting
     setTimeout(() => {
       worker.postMessage({ greeting: 'hello' });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectEqual('hello', response.echo.greeting);
@@ -44,7 +44,7 @@
 
     setTimeout(() => {
       worker.postMessage({ date: testDate });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectTrue(response.echo.date instanceof Date);
@@ -68,7 +68,7 @@
     };
     setTimeout(() => {
       worker.postMessage({ buffer: buffer });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectTrue(response.echo.buffer instanceof ArrayBuffer);
@@ -92,7 +92,7 @@
     };
     setTimeout(() => {
       worker.postMessage({ arr: arr });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectTrue(response.echo.arr instanceof Float64Array);
@@ -115,7 +115,7 @@
     };
     setTimeout(() => {
       worker.postMessage({ map: map });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectTrue(response.echo.map instanceof Map);
@@ -161,7 +161,7 @@
     };
     setTimeout(() => {
       worker.postMessage({ regex: regex });
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectTrue(response.echo.regex instanceof RegExp);
@@ -192,7 +192,7 @@
     };
     setTimeout(() => {
       worker.postMessage(complex);
-    }, 10);
+    }, 100);
 
     await state.done((response) => {
       testing.expectEqual('hello', response.echo.string);

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -141,7 +141,7 @@ fn setLifecycleEventsEnabled(cmd: *CDP.Command) !void {
         try sendPageLifecycle(bc, "load", now, frame_id, loader_id);
 
         const http_client = page._session.browser.http_client;
-        const http_active = http_client.active;
+        const http_active = http_client.http_active;
         const total_network_activity = http_active + http_client.intercepted;
         if (page._notified_network_almost_idle.check(total_network_activity <= 2)) {
             try sendPageLifecycle(bc, "networkAlmostIdle", now, frame_id, loader_id);

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -262,6 +262,7 @@ fn opensocketCallback(
 
 pub const Connection = struct {
     _easy: *libcurl.Curl,
+    in_use: bool,
     transport: Transport,
     node: std.DoublyLinkedList.Node = .{},
 
@@ -278,7 +279,7 @@ pub const Connection = struct {
     ) !Connection {
         const easy = libcurl.curl_easy_init() orelse return error.FailedToInitializeEasy;
 
-        var self = Connection{ ._easy = easy, .transport = .none };
+        var self = Connection{ ._easy = easy, .in_use = false, .transport = .none };
         errdefer self.deinit();
 
         try self.reset(config, ca_blob, ip_filter);

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -419,7 +419,7 @@ fn runWebApiTest(test_file: [:0]const u8) !void {
     }
 
     var runner = try test_session.runner(.{});
-    try runner.wait(.{ .ms = 2000 });
+    try runner.wait(.{ .ms = 2000, .until = .load });
 
     var wait_ms: u32 = 2000;
     var timer = try std.time.Timer.start();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -443,6 +443,7 @@ fn runWebApiTest(test_file: [:0]const u8) !void {
 
         const ms_elapsed = timer.lap() / 1_000_000;
         if (ms_elapsed >= wait_ms) {
+            ls.local.eval("testing.printTimeoutState()", "testing.printTimeoutState()") catch {};
             return error.TestTimedOut;
         }
         wait_ms -= @intCast(ms_elapsed);


### PR DESCRIPTION
This commit fixes a few serious issues with the Websocket implementation.

1 - libcurl recursive api calls
Creating a Websocket instance from within a libcurl callback results in libcurl failing with a RecursiveApiCall error. I fixed this more generally by adding a `ready_queue` which connections can use when the `HttpClient` is performing actions. Once `perform` ends, this new `ready_queue` is processed. There might be a more holistic solution to this (we seem to run into RecursiveApiCall everywhere), but since HttpClient is going through heavy changes, this seemed like the smallest possible change to fix it.

2 - "load" blocking
Load and IdleNetwork notifications should not block on Websocket connections. To solve this, `HttpClient` now ha `http_active` and `ws_active` to replace `active`. Only `http_active` is used for things like "load" triggering.

3 - The above change made the Runner's job more complicated. It used to be binary: you either have active connections or not. Now there are different types of active connections. To keep it simple, and I think probably more correct, the "done-ness" (based on the `wait` parameter) is now independent of active (or not) network activity. If the page's `load_state == .complete`, then the `wait == .done` is considered successful, whether or not we have active connections.

4 - As a consequence of the above, and seemingly unrelated to all of these changes, a number of html tests now use the "new" robust async framework. Most of these tests were using the `testing.onload` (aka `testing.eventually`) which had somewhat...unclear semantics. These tests passed more of a consequence of how we processed a page and being very simple (e.g. just needing 1 micro or macrotask tick). But `eventually` never worked for more complicated cases, and the previous `testing.async` didn't work well. Now, the test runner waits for .load (which, as per #3, can fire more aggressively), which caused many `eventually` tests to fail. Moving these tests to the new `async` is more robust and works with the new aggressive "load".