### PR TITLE
ax: route AXNode.Writer scratch allocations through a dedicated arena

### DIFF
--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -28,6 +28,10 @@ const Node = @import("Node.zig");
 
 const AXNode = @This();
 
+// Max bytes retained in the name-resolution scratch arena across resets.
+// Anything beyond is freed back to the backing allocator.
+const scratch_retain_limit = 64 * 1024;
+
 // Need a custom writer, because we can't just serialize the node as-is.
 // Sometimes we want to serializ the node without children, sometimes with just
 // its direct children, and sometimes the entire tree.
@@ -829,6 +833,8 @@ fn writeName(
     label_index: ?*Label.LabelByForIndex,
     temp_arena: ?*std.heap.ArenaAllocator,
 ) !?AXSource {
+    defer resetScratch(temp_arena);
+
     const node = axnode.dom;
 
     return switch (node._type) {
@@ -856,9 +862,6 @@ fn writeName(
                 var it = std.mem.splitScalar(u8, labelledby, ' ');
                 var has_content = false;
 
-                defer if (temp_arena) |a| {
-                    _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
-                };
                 var buf = std.Io.Writer.Allocating.init(scratchAllocator(temp_arena, page));
                 while (it.next()) |id| {
                     const trimmed_id = std.mem.trim(u8, id, &std.ascii.whitespace);
@@ -927,9 +930,6 @@ fn writeName(
                 => {},
                 else => {
                     // write text content if exists.
-                    defer if (temp_arena) |a| {
-                        _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
-                    };
                     var buf: std.Io.Writer.Allocating = .init(scratchAllocator(temp_arena, page));
                     try writeAccessibleNameFallback(node, &buf.writer, page);
                     if (buf.written().len > 0) {
@@ -1050,9 +1050,6 @@ fn writeLabelInnerText(
     temp_arena: ?*std.heap.ArenaAllocator,
     w: anytype,
 ) !bool {
-    defer if (temp_arena) |a| {
-        _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
-    };
     var buf: std.Io.Writer.Allocating = .init(scratchAllocator(temp_arena, page));
     try label_el.getInnerText(&buf.writer);
     const text = std.mem.trim(u8, buf.written(), &std.ascii.whitespace);
@@ -1061,8 +1058,17 @@ fn writeLabelInnerText(
     return true;
 }
 
+/// Allocator for throwaway name-resolution buffers: prefers the writer's
+/// temp arena so multiple calls reuse its retained page; falls back to
+/// `page.call_arena` on the non-Writer `getName` path.
 fn scratchAllocator(temp_arena: ?*std.heap.ArenaAllocator, page: *Page) std.mem.Allocator {
     return if (temp_arena) |a| a.allocator() else page.call_arena;
+}
+
+fn resetScratch(temp_arena: ?*std.heap.ArenaAllocator) void {
+    if (temp_arena) |a| {
+        _ = a.reset(.{ .retain_with_limit = scratch_retain_limit });
+    }
 }
 
 fn isHidden(elt: *DOMNode.Element, page: *Page, cache: *DOMNode.Element.VisibilityCache) bool {

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -38,6 +38,7 @@ pub const Writer = struct {
     page: *Page,
     visibility_cache: *DOMNode.Element.VisibilityCache,
     label_index: *Label.LabelByForIndex,
+    temp_arena: *std.heap.ArenaAllocator,
 
     pub const Opts = struct {};
 
@@ -494,7 +495,7 @@ pub const Writer = struct {
             try w.objectField("type");
             try w.write(@tagName(.computedString));
             try w.objectField("value");
-            const source = try axn.writeName(w, self.page, self.label_index);
+            const source = try axn.writeName(w, self.page, self.label_index, self.temp_arena);
             if (source) |s| {
                 try self.writeAXSource(s, w);
             }
@@ -810,7 +811,7 @@ pub fn getName(self: AXNode, page: *Page, allocator: std.mem.Allocator) !?[]cons
 
     const w: TextCaptureWriter = .{ .aw = &aw, .writer = &aw.writer };
 
-    const source = try self.writeName(w, page, null);
+    const source = try self.writeName(w, page, null, null);
     if (source != null) {
         // Remove literal quotes inserted by writeString.
         var raw_text = std.mem.trim(u8, aw.written(), "\"");
@@ -821,7 +822,13 @@ pub fn getName(self: AXNode, page: *Page, allocator: std.mem.Allocator) !?[]cons
     return null;
 }
 
-fn writeName(axnode: AXNode, w: anytype, page: *Page, label_index: ?*Label.LabelByForIndex) !?AXSource {
+fn writeName(
+    axnode: AXNode,
+    w: anytype,
+    page: *Page,
+    label_index: ?*Label.LabelByForIndex,
+    temp_arena: ?*std.heap.ArenaAllocator,
+) !?AXSource {
     const node = axnode.dom;
 
     return switch (node._type) {
@@ -849,7 +856,10 @@ fn writeName(axnode: AXNode, w: anytype, page: *Page, label_index: ?*Label.Label
                 var it = std.mem.splitScalar(u8, labelledby, ' ');
                 var has_content = false;
 
-                var buf = std.Io.Writer.Allocating.init(page.call_arena);
+                defer if (temp_arena) |a| {
+                    _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
+                };
+                var buf = std.Io.Writer.Allocating.init(scratchAllocator(temp_arena, page));
                 while (it.next()) |id| {
                     const trimmed_id = std.mem.trim(u8, id, &std.ascii.whitespace);
                     if (trimmed_id.len == 0) continue;
@@ -874,7 +884,7 @@ fn writeName(axnode: AXNode, w: anytype, page: *Page, label_index: ?*Label.Label
             }
 
             if (isLabellableTag(el.getTag())) {
-                if (try writeLabelName(node, el, page, label_index, w)) |source| {
+                if (try writeLabelName(node, el, page, label_index, temp_arena, w)) |source| {
                     return source;
                 }
             }
@@ -917,7 +927,10 @@ fn writeName(axnode: AXNode, w: anytype, page: *Page, label_index: ?*Label.Label
                 => {},
                 else => {
                     // write text content if exists.
-                    var buf: std.Io.Writer.Allocating = .init(page.call_arena);
+                    defer if (temp_arena) |a| {
+                        _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
+                    };
+                    var buf: std.Io.Writer.Allocating = .init(scratchAllocator(temp_arena, page));
                     try writeAccessibleNameFallback(node, &buf.writer, page);
                     if (buf.written().len > 0) {
                         try writeString(buf.written(), w);
@@ -1007,6 +1020,7 @@ fn writeLabelName(
     el: *DOMNode.Element,
     page: *Page,
     label_index: ?*Label.LabelByForIndex,
+    temp_arena: ?*std.heap.ArenaAllocator,
     w: anytype,
 ) !?AXSource {
     if (el.getAttributeSafe(comptime .wrap("id"))) |id_value| {
@@ -1017,26 +1031,38 @@ fn writeLabelName(
                 else
                     Label.findLabelByFor(doc.asNode(), id_value);
                 if (match) |label_el| {
-                    if (try writeLabelInnerText(label_el, page, w)) return .label_element;
+                    if (try writeLabelInnerText(label_el, page, temp_arena, w)) return .label_element;
                 }
             }
         }
     }
 
     if (Label.findWrappingLabel(el)) |wrap_label| {
-        if (try writeLabelInnerText(wrap_label, page, w)) return .label_wrap;
+        if (try writeLabelInnerText(wrap_label, page, temp_arena, w)) return .label_wrap;
     }
 
     return null;
 }
 
-fn writeLabelInnerText(label_el: *DOMNode.Element, page: *Page, w: anytype) !bool {
-    var buf: std.Io.Writer.Allocating = .init(page.call_arena);
+fn writeLabelInnerText(
+    label_el: *DOMNode.Element,
+    page: *Page,
+    temp_arena: ?*std.heap.ArenaAllocator,
+    w: anytype,
+) !bool {
+    defer if (temp_arena) |a| {
+        _ = a.reset(.{ .retain_with_limit = 64 * 1024 });
+    };
+    var buf: std.Io.Writer.Allocating = .init(scratchAllocator(temp_arena, page));
     try label_el.getInnerText(&buf.writer);
     const text = std.mem.trim(u8, buf.written(), &std.ascii.whitespace);
     if (text.len == 0) return false;
     try writeString(text, w);
     return true;
+}
+
+fn scratchAllocator(temp_arena: ?*std.heap.ArenaAllocator, page: *Page) std.mem.Allocator {
+    return if (temp_arena) |a| a.allocator() else page.call_arena;
 }
 
 fn isHidden(elt: *DOMNode.Element, page: *Page, cache: *DOMNode.Element.VisibilityCache) bool {
@@ -1286,12 +1312,15 @@ test "AXNode: writer" {
     // allocator and let the page arena clean them up.
     var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
+    var temp_arena = std.heap.ArenaAllocator.init(page.call_arena);
+    defer temp_arena.deinit();
     const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .page = page,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
+        .temp_arena = &temp_arena,
     }, .{});
     defer testing.allocator.free(json);
 
@@ -1357,12 +1386,15 @@ test "AXNode: writer prunes hidden and resolves labels" {
     const node = try registry.register(doc.asNode());
     var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
+    var temp_arena = std.heap.ArenaAllocator.init(page.call_arena);
+    defer temp_arena.deinit();
     const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .page = page,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
+        .temp_arena = &temp_arena,
     }, .{});
     defer testing.allocator.free(json);
 

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -42,7 +42,7 @@ pub const Writer = struct {
     page: *Page,
     visibility_cache: *DOMNode.Element.VisibilityCache,
     label_index: *Label.LabelByForIndex,
-    temp_arena: *std.heap.ArenaAllocator,
+    temp_arena: std.mem.Allocator,
 
     pub const Opts = struct {};
 
@@ -499,7 +499,7 @@ pub const Writer = struct {
             try w.objectField("type");
             try w.write(@tagName(.computedString));
             try w.objectField("value");
-            const source = try axn.writeName(w, self.page, self.label_index, self.temp_arena);
+            const source = try axn.writeName(self.temp_arena, w, self.page, self.label_index);
             if (source) |s| {
                 try self.writeAXSource(s, w);
             }
@@ -815,7 +815,7 @@ pub fn getName(self: AXNode, page: *Page, allocator: std.mem.Allocator) !?[]cons
 
     const w: TextCaptureWriter = .{ .aw = &aw, .writer = &aw.writer };
 
-    const source = try self.writeName(w, page, null, null);
+    const source = try self.writeName(null, w, page, null);
     if (source != null) {
         // Remove literal quotes inserted by writeString.
         var raw_text = std.mem.trim(u8, aw.written(), "\"");
@@ -828,12 +828,12 @@ pub fn getName(self: AXNode, page: *Page, allocator: std.mem.Allocator) !?[]cons
 
 fn writeName(
     axnode: AXNode,
+    temp_arena: ?std.mem.Allocator,
     w: anytype,
     page: *Page,
     label_index: ?*Label.LabelByForIndex,
-    temp_arena: ?*std.heap.ArenaAllocator,
 ) !?AXSource {
-    defer resetScratch(temp_arena);
+    defer if (temp_arena) |a| page._session.arena_pool.reset(a, scratch_retain_limit);
 
     const node = axnode.dom;
 
@@ -887,7 +887,7 @@ fn writeName(
             }
 
             if (isLabellableTag(el.getTag())) {
-                if (try writeLabelName(node, el, page, label_index, temp_arena, w)) |source| {
+                if (try writeLabelName(temp_arena, node, el, page, label_index, w)) |source| {
                     return source;
                 }
             }
@@ -1016,11 +1016,11 @@ fn isLabellableTag(tag: DOMNode.Element.Tag) bool {
 }
 
 fn writeLabelName(
+    temp_arena: ?std.mem.Allocator,
     node: *DOMNode,
     el: *DOMNode.Element,
     page: *Page,
     label_index: ?*Label.LabelByForIndex,
-    temp_arena: ?*std.heap.ArenaAllocator,
     w: anytype,
 ) !?AXSource {
     if (el.getAttributeSafe(comptime .wrap("id"))) |id_value| {
@@ -1031,23 +1031,23 @@ fn writeLabelName(
                 else
                     Label.findLabelByFor(doc.asNode(), id_value);
                 if (match) |label_el| {
-                    if (try writeLabelInnerText(label_el, page, temp_arena, w)) return .label_element;
+                    if (try writeLabelInnerText(temp_arena, label_el, page, w)) return .label_element;
                 }
             }
         }
     }
 
     if (Label.findWrappingLabel(el)) |wrap_label| {
-        if (try writeLabelInnerText(wrap_label, page, temp_arena, w)) return .label_wrap;
+        if (try writeLabelInnerText(temp_arena, wrap_label, page, w)) return .label_wrap;
     }
 
     return null;
 }
 
 fn writeLabelInnerText(
+    temp_arena: ?std.mem.Allocator,
     label_el: *DOMNode.Element,
     page: *Page,
-    temp_arena: ?*std.heap.ArenaAllocator,
     w: anytype,
 ) !bool {
     var buf: std.Io.Writer.Allocating = .init(scratchAllocator(temp_arena, page));
@@ -1061,14 +1061,8 @@ fn writeLabelInnerText(
 /// Allocator for throwaway name-resolution buffers: prefers the writer's
 /// temp arena so multiple calls reuse its retained page; falls back to
 /// `page.call_arena` on the non-Writer `getName` path.
-fn scratchAllocator(temp_arena: ?*std.heap.ArenaAllocator, page: *Page) std.mem.Allocator {
-    return if (temp_arena) |a| a.allocator() else page.call_arena;
-}
-
-fn resetScratch(temp_arena: ?*std.heap.ArenaAllocator) void {
-    if (temp_arena) |a| {
-        _ = a.reset(.{ .retain_with_limit = scratch_retain_limit });
-    }
+fn scratchAllocator(temp_arena: ?std.mem.Allocator, page: *Page) std.mem.Allocator {
+    return temp_arena orelse page.call_arena;
 }
 
 fn isHidden(elt: *DOMNode.Element, page: *Page, cache: *DOMNode.Element.VisibilityCache) bool {
@@ -1314,19 +1308,17 @@ test "AXNode: writer" {
     var doc = page.window._document;
 
     const node = try registry.register(doc.asNode());
-    // Cache inserts go through page.call_arena, so give the caches the same
-    // allocator and let the page arena clean them up.
     var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
-    var temp_arena = std.heap.ArenaAllocator.init(page.call_arena);
-    defer temp_arena.deinit();
+    const temp_arena = try page.getArena(.medium, "AXNode");
+    defer page.releaseArena(temp_arena);
     const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .page = page,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
-        .temp_arena = &temp_arena,
+        .temp_arena = temp_arena,
     }, .{});
     defer testing.allocator.free(json);
 
@@ -1392,15 +1384,15 @@ test "AXNode: writer prunes hidden and resolves labels" {
     const node = try registry.register(doc.asNode());
     var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
-    var temp_arena = std.heap.ArenaAllocator.init(page.call_arena);
-    defer temp_arena.deinit();
+    const temp_arena = try page.getArena(.medium, "AXNode");
+    defer page.releaseArena(temp_arena);
     const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .page = page,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
-        .temp_arena = &temp_arena,
+        .temp_arena = temp_arena,
     }, .{});
     defer testing.allocator.free(json);
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -533,12 +533,15 @@ pub const BrowserContext = struct {
         cache.* = .empty;
         const label_index = try page.call_arena.create(Label.LabelByForIndex);
         label_index.* = .{};
+        const temp_arena = try page.call_arena.create(std.heap.ArenaAllocator);
+        temp_arena.* = std.heap.ArenaAllocator.init(page.call_arena);
         return .{
             .page = page,
             .root = root,
             .registry = &self.node_registry,
             .visibility_cache = cache,
             .label_index = label_index,
+            .temp_arena = temp_arena,
         };
     }
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -526,15 +526,13 @@ pub const BrowserContext = struct {
         };
     }
 
-    pub fn axnodeWriter(self: *BrowserContext, root: *const Node, opts: AXNode.Writer.Opts) !AXNode.Writer {
+    pub fn axnodeWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.Writer.Opts) !AXNode.Writer {
         const page = self.session.currentPage() orelse return error.PageNotLoaded;
         _ = opts;
         const cache = try page.call_arena.create(Element.VisibilityCache);
         cache.* = .empty;
         const label_index = try page.call_arena.create(Label.LabelByForIndex);
         label_index.* = .{};
-        const temp_arena = try page.call_arena.create(std.heap.ArenaAllocator);
-        temp_arena.* = std.heap.ArenaAllocator.init(page.call_arena);
         return .{
             .page = page,
             .root = root,

--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -63,5 +63,8 @@ fn getFullAXTree(cmd: *CDP.Command) !void {
     const doc = page.window._document.asNode();
     const node = try bc.node_registry.register(doc);
 
-    return cmd.sendResult(.{ .nodes = try bc.axnodeWriter(node, .{}) }, .{});
+    const temp_arena = try page.getArena(.medium, "AXNode");
+    defer page.releaseArena(temp_arena);
+
+    return cmd.sendResult(.{ .nodes = try bc.axnodeWriter(temp_arena, node, .{}) }, .{});
 }


### PR DESCRIPTION
Depends on #2182 