### PR TITLE
docs: note glibc requirement in Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Verify the binary before running anything:
 
 [Linux aarch64 is also available](https://github.com/lightpanda-io/browser/releases/tag/nightly)
 
+> **Note:** The Linux release binaries are linked against glibc. On musl-based distros (Alpine, etc.) the binary fails with `cannot execute: required file not found` because the glibc dynamic linker is missing. Use a glibc-based base image (e.g., `FROM debian:bookworm-slim` or `FROM ubuntu:24.04`) or [build from sources](#build-from-sources).
+
 *For MacOS*
 ```console
 curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/nightly/lightpanda-aarch64-macos && \


### PR DESCRIPTION
Closes #2166

## What

Adds a one-line note in the README install section warning that the Linux release binary is linked against glibc, and pointing Alpine / musl users to either a glibc-based base image or the build-from-sources path.

## Why

The error message Alpine users see (`cannot execute: required file not found`) is opaque - it looks like a missing file but actually means bash found the binary and the kernel refused to load it because `/lib/ld-musl-*` is not the glibc dynamic linker the binary was built against. The reporter of #2166 described exactly this flow and noted "I did not find anything documented regarding any system dependencies."

## Scope

Docs-only. No code or binary behavior change. Out of scope for this PR:
- Shipping a musl-tagged release binary. That's a real option but a bigger change (CI matrix + tests). The docs change lands standalone and a musl build can be a follow-up if the maintainers want it.
- Adding an install.sh that refuses to run on musl. There's no install.sh today, so nothing to gate.

## Verified

- `grep -n "Build from sources" README.md` matches the anchor I link to (`#build-from-sources`).
- Rendered the diff locally; the blockquote renders as a callout under the Linux install snippet.

This contribution was developed with AI assistance (Claude Code).
