### PR TITLE
feat(document): implement document.writeln

### DIFF
--- a/src/browser/tests/document/write.html
+++ b/src/browser/tests/document/write.html
@@ -115,7 +115,41 @@
   testing.expectEqual('function', typeof document.open);
   testing.expectEqual('function', typeof document.close);
   testing.expectEqual('function', typeof document.write);
+  testing.expectEqual('function', typeof document.writeln);
 </script>
+
+<!-- Phase 4 Tests: document.writeln -->
+
+<script id=basic_writeln>
+  document.writeln('<p id="writeln_basic">Line</p>');
+  testing.expectEqual(true, true);
+</script>
+
+<script id=verify_writeln_basic>
+  const el = document.getElementById('writeln_basic');
+  testing.expectEqual('Line', el.textContent);
+  // writeln should append a newline after the written text; that newline
+  // becomes a text node sibling of the element.
+  const next = el.nextSibling;
+  testing.expectEqual(true, next !== null);
+  testing.expectEqual('#text', next.nodeName);
+  testing.expectEqual('\n', next.nodeValue);
+</script>
+
+<script id=writeln_multiple_args>
+  // writeln joins all arguments, then appends a single U+000A.
+  document.writeln('<span id="wln_a">A</span>', '<span id="wln_b">B</span>');
+  testing.expectEqual(true, true);
+</script>
+
+<script id=verify_writeln_multiple_args>
+  const a = document.getElementById('wln_a');
+  const b = document.getElementById('wln_b');
+  testing.expectEqual('A', a.textContent);
+  testing.expectEqual('B', b.textContent);
+  testing.expectEqual(b, a.nextElementSibling);
+</script>
+
 
 <!-- Phase 3 Tests: document.open/close (post-parsing with setTimeout) -->
 

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -621,6 +621,17 @@ fn looksLikeNewDocument(html: []const u8) bool {
 }
 
 pub fn write(self: *Document, text: []const []const u8, page: *Page) !void {
+    return self.writeInternal(text, false, page);
+}
+
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln
+// `writeln(...text)` runs the document write steps with `text` followed by a
+// U+000A LINE FEED character.
+pub fn writeln(self: *Document, text: []const []const u8, page: *Page) !void {
+    return self.writeInternal(text, true, page);
+}
+
+fn writeInternal(self: *Document, text: []const []const u8, append_newline: bool, page: *Page) !void {
     if (self._type == .xml) {
         return error.InvalidStateError;
     }
@@ -633,6 +644,9 @@ pub fn write(self: *Document, text: []const []const u8, page: *Page) !void {
         var joined: std.ArrayList(u8) = .empty;
         for (text) |str| {
             try joined.appendSlice(page.call_arena, str);
+        }
+        if (append_newline) {
+            try joined.append(page.call_arena, '\n');
         }
         break :blk joined.items;
     };
@@ -1052,6 +1066,7 @@ pub const JsApi = struct {
     pub const elementFromPoint = bridge.function(Document.elementFromPoint, .{});
     pub const elementsFromPoint = bridge.function(Document.elementsFromPoint, .{});
     pub const write = bridge.function(Document.write, .{ .dom_exception = true });
+    pub const writeln = bridge.function(Document.writeln, .{ .dom_exception = true });
     pub const open = bridge.function(Document.open, .{ .dom_exception = true });
     pub const close = bridge.function(Document.close, .{ .dom_exception = true });
     pub const doctype = bridge.accessor(Document.getDocType, null, .{});


### PR DESCRIPTION
## Summary

Implements `document.writeln` on the Document prototype. Previously the method was not registered at all, so any page calling it hit `TypeError: document.writeln is not a function` and stopped executing.

## Why it matters

`document.writeln` is still used in the wild by legacy script-loaders and server-rendered pages. One real-world example I hit: `https://www.shqp.gov.cn/` (a Chinese government portal) uses an inline bootstrap that does

```js
document.writeln('<scr' + 'ipt src="/jquery.min.js"></scr' + 'ipt>');
```

to inject jQuery. Because `writeln` was missing, the whole page never ran jQuery and rendered blank in Lightpanda.

## Implementation

Per [HTML spec §dynamic-markup-insertion](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln), `writeln(...text)` is `write(...text)` followed by a U+000A LINE FEED character.

I factored `Document.write` into a shared `writeInternal` that takes an `append_newline` flag. That keeps all the existing `InvalidStateError` / script-created-parser / inline-during-parsing behavior identical between `write` and `writeln`, which is exactly what the spec calls for ("run the document write steps").

## Tests

Added three new `<script id=…>` blocks to `src/browser/tests/document/write.html`:

- Basic `writeln('<p>…</p>')` — asserts the written element exists and that the trailing `#text` sibling is `"\n"`.
- Multi-arg form — `writeln(a, b)` concatenates then appends one newline.
- Extended the existing `final_assertion` to check `typeof document.writeln === 'function'`.

`zig build test -- "WebApi: Document"` → 487/487 passing.

## Notes

Signed the CLA on a previous PR (#2141).
