### PR TITLE
feat(window): accept DOMString handler in setTimeout/setInterval

### DIFF
--- a/src/browser/tests/window/timers.html
+++ b/src/browser/tests/window/timers.html
@@ -39,3 +39,33 @@
   clearImmediate(-3);
   testing.expectEqual(true, true);
 </script>
+
+<script id=setTimeout-string-handler>
+  // Per HTML spec, TimerHandler = Function or DOMString. The string form
+  // is legacy but still required by the spec, and many sites (especially
+  // legacy or server-rendered pages) rely on it.
+  window.__st_string_ran = 0;
+  const st_id = window.setTimeout("window.__st_string_ran = 42;", 1);
+  testing.expectEqual('number', typeof st_id);
+  testing.onload(() => testing.expectEqual(42, window.__st_string_ran));
+</script>
+
+<script id=setInterval-string-handler>
+  window.__si_string_ran = 0;
+  const si_id = window.setInterval("window.__si_string_ran += 1;", 1);
+  testing.expectEqual('number', typeof si_id);
+  window.setTimeout(() => window.clearInterval(si_id), 5);
+  testing.onload(() => testing.expectEqual(true, window.__si_string_ran >= 1));
+</script>
+
+<script id=setTimeout-invalid-handler>
+  // Non-function, non-string handlers must throw a TypeError.
+  let threw = false;
+  try {
+    window.setTimeout(123, 1);
+  } catch (e) {
+    threw = true;
+  }
+  testing.expectEqual(true, threw);
+</script>
+

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -249,7 +249,8 @@ pub fn fetch(_: *const Window, input: Fetch.Input, options: ?Fetch.InitOpts, pag
     return Fetch.init(input, options, page);
 }
 
-pub fn setTimeout(self: *Window, cb: js.Function.Temp, delay_ms: ?u32, params: []js.Value.Temp, page: *Page) !u32 {
+pub fn setTimeout(self: *Window, handler: js.Value.Temp, delay_ms: ?u32, params: []js.Value.Temp, page: *Page) !u32 {
+    const cb = try resolveTimerHandler(handler, page);
     return self.scheduleCallback(cb, delay_ms orelse 0, .{
         .repeat = false,
         .params = params,
@@ -258,13 +259,37 @@ pub fn setTimeout(self: *Window, cb: js.Function.Temp, delay_ms: ?u32, params: [
     }, page);
 }
 
-pub fn setInterval(self: *Window, cb: js.Function.Temp, delay_ms: ?u32, params: []js.Value.Temp, page: *Page) !u32 {
+pub fn setInterval(self: *Window, handler: js.Value.Temp, delay_ms: ?u32, params: []js.Value.Temp, page: *Page) !u32 {
+    const cb = try resolveTimerHandler(handler, page);
     return self.scheduleCallback(cb, delay_ms orelse 0, .{
         .repeat = true,
         .params = params,
         .low_priority = false,
         .name = "window.setInterval",
     }, page);
+}
+
+// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout
+// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timerhandler
+// TimerHandler = Function or DOMString. When a string is passed, it is
+// compiled into an anonymous function body, matching how legacy browsers
+// (and all current UAs) interpret `setTimeout("foo()", 100)`.
+fn resolveTimerHandler(handler: js.Value.Temp, page: *Page) !js.Function.Temp {
+    var ls: js.Local.Scope = undefined;
+    page.js.localScope(&ls);
+    defer ls.deinit();
+
+    const value = handler.local(&ls.local);
+    if (value.isFunction()) {
+        const js_func = js.Function{ .local = &ls.local, .handle = @ptrCast(value.handle) };
+        return try js_func.temp();
+    }
+    if (value.isString()) |js_str| {
+        const body = try js_str.toSliceWithAlloc(page.call_arena);
+        const fun = try ls.local.compileFunction(body, &.{}, &.{});
+        return try fun.temp();
+    }
+    return error.InvalidArgument;
 }
 
 pub fn setImmediate(self: *Window, cb: js.Function.Temp, params: []js.Value.Temp, page: *Page) !u32 {


### PR DESCRIPTION
## Summary

Accept `DOMString` as a valid `TimerHandler` in `window.setTimeout` and `window.setInterval`, per [HTML spec §timers](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers):

```webidl
typedef (DOMString or Function) TimerHandler;
long setTimeout(TimerHandler handler, optional long timeout = 0, any... arguments);
long setInterval(TimerHandler handler, optional long timeout = 0, any... arguments);
```

## Why it matters

Previously the binding signature was `cb: js.Function.Temp`, so passing a string threw `TypeError: invalid argument` from the argument-coercion layer and aborted the page's script.

Hit in the wild on `https://sh.cma.gov.cn/` (Shanghai weather bureau):

```js
// Top.js
setInterval("TimeInfo()", 1000);
```

The IIFE that defines `TimeInfo` wraps the whole Top-bar script, and when the setInterval call blew up the entire page navigation bar disappeared and the weather widget never mounted.

Every current browser (Chromium, Firefox, Safari) accepts string handlers; refusing them is a pure spec-conformance gap.

## Implementation

Changed the binding-facing type of the handler parameter from `js.Function.Temp` to `js.Value.Temp`, and added a `resolveTimerHandler` helper that dispatches:

| value.isFunction() | action |
|---|---|
| `true` | cast `Value → Function` (same pattern as `Local.jsValueToStruct` uses for `Function.Temp` args) and `.temp()` it |
| `isString()` returns a `js.String` | `toSliceWithAlloc(page.call_arena)` then `Local.compileFunction(body, &.{}, &.{}).temp()` |
| anything else | `error.InvalidArgument` → TypeError (same as before) |

The string → function path reuses `Local.compileFunction`, which is what `Context.stringToPersistedFunction` already uses for inline HTML event handlers (`<body onload="…">`), so the compilation semantics are consistent across the codebase.

`scheduleCallback` and the downstream timer machinery are untouched; they still see a `js.Function.Temp`.

`setImmediate` is non-standard and not part of `TimerHandler`, so it intentionally keeps the function-only signature.

## Tests

Added three new `<script id=…>` blocks to `src/browser/tests/window/timers.html`:

- `setTimeout("…", 1)` executes the compiled body (asserted via a global sentinel inside `testing.onload`).
- `setInterval("…", 1)` fires at least once and is cancellable via `clearInterval`.
- Non-function, non-string handler (`setTimeout(123, 1)`) still throws — regression guard for the `InvalidArgument` path.

`zig build test -- "WebApi: Window"` → 487/487 passing.

## Notes

Signed the CLA on a previous PR (#2141).
