### PR TITLE
Change all @import("...../log.zig") to const log = lp.log;

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -17,10 +17,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
-const Allocator = std.mem.Allocator;
-
-const log = @import("log.zig");
 const Config = @import("Config.zig");
 const Snapshot = @import("browser/js/Snapshot.zig");
 const Platform = @import("browser/js/Platform.zig");
@@ -28,6 +26,9 @@ const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
 
 const Network = @import("network/Network.zig");
 pub const ArenaPool = @import("ArenaPool.zig");
+
+const log = lp.log;
+const Allocator = std.mem.Allocator;
 
 const App = @This();
 

--- a/src/ArenaPool.zig
+++ b/src/ArenaPool.zig
@@ -17,9 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
-const log = @import("log.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -17,14 +17,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
-const Allocator = std.mem.Allocator;
 
-const log = @import("log.zig");
 const dump = @import("browser/dump.zig");
 
-const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
 const mcp = @import("mcp.zig");
+const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
+
+const log = lp.log;
+const Allocator = std.mem.Allocator;
 
 pub const RunMode = enum {
     help,

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -19,13 +19,12 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const log = @import("log.zig");
 const Page = @import("browser/Page.zig");
 const Transfer = @import("browser/HttpClient.zig").Transfer;
 
-const Allocator = std.mem.Allocator;
-
+const log = lp.log;
 const List = std.DoublyLinkedList;
+const Allocator = std.mem.Allocator;
 
 // Allows code to register for and emit events.
 // Keeps two lists

--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -17,11 +17,9 @@
 // along with this program.  See <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-
 const lp = @import("lightpanda");
-const log = @import("log.zig");
+
 const isAllWhitespace = @import("string.zig").isAllWhitespace;
-const Page = lp.Page;
 const interactive = @import("browser/interactive.zig");
 
 const CData = @import("browser/webapi/CData.zig");
@@ -29,6 +27,9 @@ const Element = @import("browser/webapi/Element.zig");
 const Node = @import("browser/webapi/Node.zig");
 const AXNode = @import("cdp/AXNode.zig");
 const CDPNode = @import("cdp/Node.zig");
+
+const log = lp.log;
+const Page = lp.Page;
 
 const Self = @This();
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -18,17 +18,17 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const net = std.net;
-const posix = std.posix;
 
-const Allocator = std.mem.Allocator;
-
-const log = @import("log.zig");
 const App = @import("App.zig");
 const Config = @import("Config.zig");
 const CDP = @import("cdp/CDP.zig");
 const Net = @import("network/websocket.zig");
 const HttpClient = @import("browser/HttpClient.zig");
+
+const log = lp.log;
+const net = std.net;
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
 
 const Server = @This();
 

--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -17,9 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../log.zig");
 const String = @import("../string.zig").String;
 
 const js = @import("js/js.zig");
@@ -31,6 +31,7 @@ const Event = @import("webapi/Event.zig");
 const EventTarget = @import("webapi/EventTarget.zig");
 const Element = @import("webapi/Element.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 // Re-export types from EventManagerBase for API compatibility

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -17,9 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../log.zig");
 const String = @import("../string.zig").String;
 
 const js = @import("js/js.zig");
@@ -28,8 +28,8 @@ const Session = @import("Session.zig");
 const Event = @import("webapi/Event.zig");
 const EventTarget = @import("webapi/EventTarget.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
-
 const IS_DEBUG = builtin.mode == .Debug;
 
 const EventKey = struct {

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -17,10 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
-const reflect = @import("reflect.zig");
 
-const log = @import("../log.zig");
+const reflect = @import("reflect.zig");
 const String = @import("../string.zig").String;
 
 const SlabAllocator = @import("../slab.zig").SlabAllocator;
@@ -37,10 +37,10 @@ const XMLHttpRequestEventTarget = @import("webapi/net/XMLHttpRequestEventTarget.
 const Blob = @import("webapi/Blob.zig");
 const AbstractRange = @import("webapi/AbstractRange.zig");
 
-const Allocator = std.mem.Allocator;
-
-const IS_DEBUG = builtin.mode == .Debug;
+const log = lp.log;
 const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const IS_DEBUG = builtin.mode == .Debug;
 
 // Shared across all frames of a Page.
 const Factory = @This();

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -17,18 +17,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const JS = @import("js/js.zig");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const Allocator = std.mem.Allocator;
-
-const IS_DEBUG = builtin.mode == .Debug;
-
-const log = @import("../log.zig");
-
 const String = @import("../string.zig").String;
 
+const JS = @import("js/js.zig");
 const Mime = @import("Mime.zig");
 const Factory = @import("Factory.zig");
 const Session = @import("Session.zig");
@@ -70,9 +64,13 @@ const HttpClient = @import("HttpClient.zig");
 const timestamp = @import("../datetime.zig").timestamp;
 const milliTimestamp = @import("../datetime.zig").milliTimestamp;
 
-const IFrame = Element.Html.IFrame;
 const WebApiURL = @import("webapi/URL.zig");
 const GlobalEventHandlersLookup = @import("webapi/global_event_handlers.zig").Lookup;
+
+const log = lp.log;
+const IFrame = Element.Html.IFrame;
+const Allocator = std.mem.Allocator;
+const IS_DEBUG = builtin.mode == .Debug;
 
 var default_url = WebApiURL{ ._raw = "about:blank" };
 pub var default_location: Location = Location{ ._url = &default_url };

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -20,8 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../log.zig");
-
 const js = @import("js/js.zig");
 const Page = @import("Page.zig");
 const Session = @import("Session.zig");
@@ -30,6 +28,7 @@ const HttpClient = @import("HttpClient.zig");
 const Node = @import("webapi/Node.zig");
 const Selector = @import("webapi/selector/Selector.zig");
 
+const log = lp.log;
 const IS_DEBUG = builtin.mode == .Debug;
 
 const Runner = @This();

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../log.zig");
 const HttpClient = @import("HttpClient.zig");
 const http = @import("../network/http.zig");
 const String = @import("../string.zig").String;
@@ -31,8 +30,8 @@ const Page = @import("Page.zig");
 
 const Element = @import("webapi/Element.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
-
 const IS_DEBUG = builtin.mode == .Debug;
 
 const ScriptManager = @This();

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../log.zig");
 const App = @import("../App.zig");
 
 const js = @import("js/js.zig");
@@ -36,8 +35,9 @@ const Factory = @import("Factory.zig");
 const Notification = @import("../Notification.zig");
 const QueuedNavigation = Page.QueuedNavigation;
 
-const Allocator = std.mem.Allocator;
+const log = lp.log;
 const ArenaPool = App.ArenaPool;
+const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
 
 // You can create successively multiple pages for a session, but you must

--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -17,8 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-
-const log = @import("../log.zig");
+const lp = @import("lightpanda");
 const String = @import("../string.zig").String;
 
 const Page = @import("Page.zig");
@@ -35,6 +34,7 @@ const CSSStyleSheet = @import("webapi/css/CSSStyleSheet.zig");
 const CSSStyleProperties = @import("webapi/css/CSSStyleProperties.zig");
 const CSSStyleProperty = @import("webapi/css/CSSStyleDeclaration.zig").Property;
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub const VisibilityCache = std.AutoHashMapUnmanaged(*Element, bool);

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 const string = @import("../../string.zig");
 
 const Page = @import("../Page.zig");
@@ -30,12 +30,13 @@ const Context = @import("Context.zig");
 const TaggedOpaque = @import("TaggedOpaque.zig");
 
 const v8 = js.v8;
+const log = lp.log;
 const ArenaAllocator = std.heap.ArenaAllocator;
-
 const CALL_ARENA_RETAIN = 1024 * 16;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Caller = @This();
+
 local: Local,
 prev_local: ?*const js.Local,
 prev_context: *Context,

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -18,7 +18,6 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const log = @import("../../log.zig");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
@@ -33,10 +32,9 @@ const ScriptManager = @import("../ScriptManager.zig");
 const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
 
 const v8 = js.v8;
+const log = lp.log;
 const Caller = js.Caller;
-
 const Allocator = std.mem.Allocator;
-
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 // Loosely maps to a Browser Page or Worker.

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -17,14 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("js.zig");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const v8 = js.v8;
-
-const App = @import("../../App.zig");
-const log = @import("../../log.zig");
-
+const js = @import("js.zig");
 const bridge = @import("bridge.zig");
 const Context = @import("Context.zig");
 const Isolate = @import("Isolate.zig");
@@ -32,10 +28,13 @@ const Platform = @import("Platform.zig");
 const Snapshot = @import("Snapshot.zig");
 const Inspector = @import("Inspector.zig");
 
+const App = @import("../../App.zig");
 const Page = @import("../Page.zig");
 const Window = @import("../webapi/Window.zig");
 const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
 
+const v8 = js.v8;
+const log = lp.log;
 const JsApis = bridge.JsApis;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -17,10 +17,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("js.zig");
-const v8 = js.v8;
+const lp = @import("lightpanda");
 
-const log = @import("../../log.zig");
+const js = @import("js.zig");
+
+const v8 = js.v8;
+const log = lp.log;
 
 const Function = @This();
 

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 const string = @import("../../string.zig");
 
 const Session = @import("../Session.zig");
@@ -29,10 +29,10 @@ const Context = @import("Context.zig");
 const Isolate = @import("Isolate.zig");
 const TaggedOpaque = @import("TaggedOpaque.zig");
 
-const IS_DEBUG = @import("builtin").mode == .Debug;
-
 const v8 = js.v8;
+const log = lp.log;
 const CallOpts = Caller.CallOpts;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 // Where js.Context has a lifetime tied to the page, and holds the
 // v8::Global<v8::Context>, this has a much shorter lifetime and holds a

--- a/src/browser/js/PromiseResolver.zig
+++ b/src/browser/js/PromiseResolver.zig
@@ -16,12 +16,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const js = @import("js.zig");
-const v8 = js.v8;
+const lp = @import("lightpanda");
 
-const log = @import("../../log.zig");
+const js = @import("js.zig");
 
 const DOMException = @import("../webapi/DOMException.zig");
+
+const v8 = js.v8;
+const log = lp.log;
 
 const PromiseResolver = @This();
 

--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -17,11 +17,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
-
-const log = @import("../../log.zig");
 const milliTimestamp = @import("../../datetime.zig").milliTimestamp;
 
+const log = lp.log;
 const IS_DEBUG = builtin.mode == .Debug;
 
 const Queue = std.PriorityQueue(Task, void, struct {

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -23,7 +23,6 @@ const js = @import("js.zig");
 const bridge = @import("bridge.zig");
 const WebDriver = @import("../webapi/WebDriver.zig");
 
-
 const v8 = js.v8;
 const log = lp.log;
 const JsApis = bridge.JsApis;

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -21,15 +21,15 @@ const lp = @import("lightpanda");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
-const log = @import("../../log.zig");
 const WebDriver = @import("../webapi/WebDriver.zig");
 
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const v8 = js.v8;
+const log = lp.log;
 const JsApis = bridge.JsApis;
 const PageJsApis = bridge.PageJsApis;
 const WorkerJsApis = bridge.WorkerJsApis;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Snapshot = @This();
 

--- a/src/browser/js/TryCatch.zig
+++ b/src/browser/js/TryCatch.zig
@@ -17,12 +17,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const js = @import("js.zig");
+
 const v8 = js.v8;
-
-const IS_DEBUG = @import("builtin").mode == .Debug;
-
 const Allocator = std.mem.Allocator;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const TryCatch = @This();
 
@@ -121,7 +122,7 @@ pub const Caught = struct {
     exception: ?[]const u8 = null,
 
     pub fn format(self: Caught, writer: *std.Io.Writer) !void {
-        const separator = @import("../../log.zig").separator();
+        const separator = lp.log.separator();
         try writer.print("{s}exception: {?s}", .{ separator, self.exception });
         try writer.print("{s}stack: {?s}", .{ separator, self.stack });
         try writer.print("{s}line: {?d}", .{ separator, self.line });

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -17,12 +17,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("../js/js.zig");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 
+const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+
 const Event = @import("Event.zig");
 const EventTarget = @import("EventTarget.zig");
+
+const log = lp.log;
 
 const AbortSignal = @This();
 

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -17,9 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
-const logger = @import("../../log.zig");
+const logger = lp.log;
 
 const Console = @This();
 

--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
@@ -26,6 +26,8 @@ const Node = @import("Node.zig");
 const Element = @import("Element.zig");
 const Custom = @import("element/html/Custom.zig");
 const CustomElementDefinition = @import("CustomElementDefinition.zig");
+
+const log = lp.log;
 
 const CustomElementRegistry = @This();
 

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -17,9 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
-const String = @import("../../string.zig").String;
+const lp = @import("lightpanda");
 
+const String = @import("../../string.zig").String;
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const URL = @import("../URL.zig");
@@ -40,6 +40,7 @@ const Selection = @import("Selection.zig");
 pub const XMLDocument = @import("XMLDocument.zig");
 pub const HTMLDocument = @import("HTMLDocument.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Document = @This();

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -19,7 +19,6 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const log = @import("../../log.zig");
 const String = @import("../../string.zig").String;
 
 const js = @import("../js/js.zig");
@@ -41,6 +40,8 @@ pub const DOMRect = @import("DOMRect.zig");
 pub const Svg = @import("element/Svg.zig");
 pub const Html = @import("element/Html.zig");
 pub const Attribute = @import("element/Attribute.zig");
+
+const log = lp.log;
 
 const Element = @This();
 

--- a/src/browser/webapi/EventCounts.zig
+++ b/src/browser/webapi/EventCounts.zig
@@ -17,9 +17,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
-const log = @import("../../log.zig");
+
+const log = lp.log;
 
 pub fn registerTypes() []const type {
     return &.{

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -19,11 +19,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const log = @import("../../log.zig");
-
-const IS_DEBUG = @import("builtin").mode == .Debug;
-
-const Allocator = std.mem.Allocator;
 
 const Page = @import("../Page.zig");
 const Session = @import("../Session.zig");
@@ -31,6 +26,10 @@ const Session = @import("../Session.zig");
 const Node = @import("Node.zig");
 const Element = @import("Element.zig");
 const DOMRect = @import("DOMRect.zig");
+
+const log = lp.log;
+const Allocator = std.mem.Allocator;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub fn registerTypes() []const type {
     return &.{

--- a/src/browser/webapi/MessagePort.zig
+++ b/src/browser/webapi/MessagePort.zig
@@ -17,12 +17,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("../js/js.zig");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 
+const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+
 const EventTarget = @import("EventTarget.zig");
 const MessageEvent = @import("event/MessageEvent.zig");
+
+const log = lp.log;
 
 const MessagePort = @This();
 

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -23,10 +23,11 @@ const String = @import("../../string.zig").String;
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const Session = @import("../Session.zig");
+
 const Node = @import("Node.zig");
 const Element = @import("Element.zig");
-const log = @import("../../log.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Allocator = std.mem.Allocator;

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -17,9 +17,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
-
-const log = @import("../../log.zig");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
@@ -27,6 +26,8 @@ const Page = @import("../Page.zig");
 const PluginArray = @import("PluginArray.zig");
 const Permissions = @import("Permissions.zig");
 const StorageManager = @import("StorageManager.zig");
+
+const log = lp.log;
 
 const Navigator = @This();
 _pad: bool = false,

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 const String = @import("../../string.zig").String;
 
 const js = @import("../js/js.zig");
@@ -37,6 +37,7 @@ pub const DocumentFragment = @import("DocumentFragment.zig");
 pub const DocumentType = @import("DocumentType.zig");
 pub const ShadowRoot = @import("ShadowRoot.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 const LinkedList = std.DoublyLinkedList;
 

--- a/src/browser/webapi/PerformanceObserver.zig
+++ b/src/browser/webapi/PerformanceObserver.zig
@@ -20,8 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const Page = @import("../Page.zig")
-;
+const Page = @import("../Page.zig");
 const Performance = @import("Performance.zig");
 
 const log = lp.log;

--- a/src/browser/webapi/PerformanceObserver.zig
+++ b/src/browser/webapi/PerformanceObserver.zig
@@ -17,12 +17,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const log = @import("../../log.zig");
-
-const Page = @import("../Page.zig");
+const Page = @import("../Page.zig")
+;
 const Performance = @import("Performance.zig");
+
+const log = lp.log;
 
 pub fn registerTypes() []const type {
     return &.{ PerformanceObserver, EntryList };

--- a/src/browser/webapi/SubtleCrypto.zig
+++ b/src/browser/webapi/SubtleCrypto.zig
@@ -18,7 +18,6 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const log = @import("../../log.zig");
 const crypto = @import("../../sys/libcrypto.zig");
 
 const Page = @import("../Page.zig");
@@ -29,6 +28,8 @@ const CryptoKey = @import("CryptoKey.zig");
 const algorithm = @import("crypto/algorithm.zig");
 const HMAC = @import("crypto/HMAC.zig");
 const X25519 = @import("crypto/X25519.zig");
+
+const log = lp.log;
 
 /// The SubtleCrypto interface of the Web Crypto API provides a number of low-level
 /// cryptographic functions.

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -17,10 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("../js/js.zig");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const log = @import("../../log.zig");
+const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const Console = @import("Console.zig");
 const History = @import("History.zig");
@@ -45,6 +45,7 @@ const CSSStyleProperties = @import("css/CSSStyleProperties.zig");
 const CustomElementRegistry = @import("CustomElementRegistry.zig");
 const Selection = @import("Selection.zig");
 
+const log = lp.log;
 const IS_DEBUG = builtin.mode == .Debug;
 
 const Allocator = std.mem.Allocator;

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -17,9 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const log = @import("../../log.zig");
 const http = @import("../../network/http.zig");
 
 const URL = @import("../URL.zig");
@@ -33,6 +33,7 @@ const MessageEvent = @import("event/MessageEvent.zig");
 const ErrorEvent = @import("event/ErrorEvent.zig");
 const WorkerGlobalScope = @import("WorkerGlobalScope.zig");
 
+const log = lp.log;
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -21,8 +21,7 @@
 // what's what...e.g what is a WebAPI call and what it called internally.
 
 const std = @import("std");
-
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 
 const JS = @import("../js/js.zig");
 const Factory = @import("../Factory.zig");
@@ -39,6 +38,7 @@ const ErrorEvent = @import("event/ErrorEvent.zig");
 const builtin = @import("builtin");
 const IS_DEBUG = builtin.mode == .Debug;
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 const WorkerGlobalScope = @This();

--- a/src/browser/webapi/animation/Animation.zig
+++ b/src/browser/webapi/animation/Animation.zig
@@ -18,11 +18,11 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const log = @import("../../../log.zig");
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
 const Session = @import("../../Session.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 const Animation = @This();

--- a/src/browser/webapi/collections/DOMTokenList.zig
+++ b/src/browser/webapi/collections/DOMTokenList.zig
@@ -17,13 +17,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
 const String = @import("../../../string.zig").String;
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
 const Element = @import("../Element.zig");
 const GenericIterator = @import("iterator.zig").Entry;
+
+const log = lp.log;
 
 pub const DOMTokenList = @This();
 

--- a/src/browser/webapi/collections/NodeList.zig
+++ b/src/browser/webapi/collections/NodeList.zig
@@ -19,7 +19,6 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const log = @import("../../../log.zig");
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
 const Session = @import("../../Session.zig");
@@ -29,6 +28,8 @@ const ChildNodes = @import("ChildNodes.zig");
 const RadioNodeList = @import("RadioNodeList.zig");
 const SelectorList = @import("../selector/List.zig");
 const NodeLive = @import("node_live.zig").NodeLive;
+
+const log = lp.log;
 
 const NodeList = @This();
 

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -17,7 +17,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
+
 const String = @import("../../../string.zig").String;
 
 const CssParser = @import("../../css/Parser.zig");
@@ -26,6 +27,7 @@ const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
 const Element = @import("../Element.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 const CSSStyleDeclaration = @This();

--- a/src/browser/webapi/css/CSSStyleSheet.zig
+++ b/src/browser/webapi/css/CSSStyleSheet.zig
@@ -1,12 +1,17 @@
 const std = @import("std");
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
+
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Parser = @import("../../css/Parser.zig");
+
 const Element = @import("../Element.zig");
+
 const CSSRuleList = @import("CSSRuleList.zig");
 const CSSRule = @import("CSSRule.zig");
 const CSSStyleRule = @import("CSSStyleRule.zig");
-const Parser = @import("../../css/Parser.zig");
+
+const log = lp.log;
 
 const CSSStyleSheet = @This();
 

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -17,9 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const js = @import("../../js/js.zig");
 const reflect = @import("../../reflect.zig");
-const log = @import("../../../log.zig");
 
 const global_event_handlers = @import("../global_event_handlers.zig");
 const GlobalEventHandler = global_event_handlers.Handler;
@@ -95,6 +95,7 @@ pub const Track = @import("html/Track.zig");
 pub const UL = @import("html/UL.zig");
 pub const Unknown = @import("html/Unknown.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const HtmlElement = @This();

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -15,8 +15,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-const log = @import("../../../../log.zig");
+const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Page = @import("../../../Page.zig");
@@ -24,6 +23,8 @@ const Page = @import("../../../Page.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
+
+const log = lp.log;
 
 const Body = @This();
 

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -17,16 +17,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const String = @import("../../../../string.zig").String;
 
 const js = @import("../../../js/js.zig");
-const log = @import("../../../../log.zig");
 const Page = @import("../../../Page.zig");
 
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 const CustomElementDefinition = @import("../../CustomElementDefinition.zig");
+
+const log = lp.log;
 
 const Custom = @This();
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/Slot.zig
+++ b/src/browser/webapi/element/html/Slot.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
-
-const log = @import("../../../../log.zig");
+const lp = @import("lightpanda");
 const js = @import("../../../js/js.zig");
 const Page = @import("../../../Page.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 const ShadowRoot = @import("../../ShadowRoot.zig");
+
+const log = lp.log;
 
 const Slot = @This();
 

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -18,7 +18,6 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const log = @import("../../../log.zig");
 const URL = @import("../URL.zig");
 
 const js = @import("../../js/js.zig");
@@ -26,6 +25,8 @@ const Page = @import("../../Page.zig");
 
 const Event = @import("../Event.zig");
 const EventTarget = @import("../EventTarget.zig");
+
+const log = lp.log;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigation
 const Navigation = @This();

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -17,8 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
 const HttpClient = @import("../../HttpClient.zig");
 
 const js = @import("../../js/js.zig");
@@ -31,6 +30,7 @@ const Response = @import("Response.zig");
 const AbortSignal = @import("../AbortSignal.zig");
 const DOMException = @import("../DOMException.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Fetch = @This();

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -17,8 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
@@ -26,6 +25,7 @@ const Form = @import("../element/html/Form.zig");
 const Element = @import("../Element.zig");
 const KeyValueList = @import("../KeyValueList.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 const FormData = @This();

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -1,10 +1,13 @@
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const js = @import("../../js/js.zig");
-const log = @import("../../../log.zig");
 
 const Page = @import("../../Page.zig");
 const KeyValueList = @import("../KeyValueList.zig");
 
+
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 const Headers = @This();

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -6,7 +6,6 @@ const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
 const KeyValueList = @import("../KeyValueList.zig");
 
-
 const log = lp.log;
 const Allocator = std.mem.Allocator;
 

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -17,15 +17,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const js = @import("../../js/js.zig");
 
-const log = @import("../../../log.zig");
 const String = @import("../../../string.zig").String;
-const Allocator = std.mem.Allocator;
 
 const FormData = @import("FormData.zig");
 const KeyValueList = @import("../KeyValueList.zig");
+
+const log = lp.log;
 const Execution = js.Execution;
+const Allocator = std.mem.Allocator;
 
 const URLSearchParams = @This();
 

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -19,7 +19,6 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const log = @import("../../../log.zig");
 const http = @import("../../../network/http.zig");
 
 const js = @import("../../js/js.zig");
@@ -34,6 +33,7 @@ const EventTarget = @import("../EventTarget.zig");
 const MessageEvent = @import("../event/MessageEvent.zig");
 const CloseEvent = @import("../event/CloseEvent.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const js = @import("../../js/js.zig");
 
-const log = @import("../../../log.zig");
 const HttpClient = @import("../../HttpClient.zig");
 const http = @import("../../../network/http.zig");
 
@@ -35,6 +34,7 @@ const Headers = @import("Headers.zig");
 const EventTarget = @import("../EventTarget.zig");
 const XMLHttpRequestEventTarget = @import("XMLHttpRequestEventTarget.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 

--- a/src/browser/webapi/storage/Cookie.zig
+++ b/src/browser/webapi/storage/Cookie.zig
@@ -17,13 +17,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
-const ArenaAllocator = std.heap.ArenaAllocator;
+const lp = @import("lightpanda");
 
 const URL = @import("../../URL.zig");
-const log = @import("../../../log.zig");
 const DateTime = @import("../../../datetime.zig").DateTime;
 const public_suffix_list = @import("../../../data/public_suffix_list.zig").lookup;
+
+const log = lp.log;
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
 
 const Cookie = @This();
 

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
@@ -26,6 +26,7 @@ const ReadableStreamDefaultReader = @import("ReadableStreamDefaultReader.zig");
 const ReadableStreamDefaultController = @import("ReadableStreamDefaultController.zig");
 const WritableStream = @import("WritableStream.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub fn registerTypes() []const type {

--- a/src/browser/webapi/streams/ReadableStreamDefaultController.zig
+++ b/src/browser/webapi/streams/ReadableStreamDefaultController.zig
@@ -17,7 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../../log.zig");
+const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
@@ -25,6 +25,7 @@ const Page = @import("../../Page.zig");
 const ReadableStream = @import("ReadableStream.zig");
 const ReadableStreamDefaultReader = @import("ReadableStreamDefaultReader.zig");
 
+const log = lp.log;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const ReadableStreamDefaultController = @This();

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -17,14 +17,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const jsonStringify = std.json.Stringify;
+const lp = @import("lightpanda");
 
-const log = @import("../log.zig");
 const Page = @import("../browser/Page.zig");
 const DOMNode = @import("../browser/webapi/Node.zig");
 const Label = @import("../browser/webapi/element/html/Label.zig");
 
 const Node = @import("Node.zig");
+
+const log = lp.log;
+const jsonStringify = std.json.Stringify;
 
 const AXNode = @This();
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -19,16 +19,8 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const Allocator = std.mem.Allocator;
-const json = std.json;
-
-const Incrementing = @import("id.zig").Incrementing;
-
-const log = @import("../log.zig");
 const Notification = @import("../Notification.zig");
-
 const Client = @import("../Server.zig").Client;
-
 const js = @import("../browser/js/js.zig");
 const Browser = @import("../browser/Browser.zig");
 const Session = @import("../browser/Session.zig");
@@ -37,7 +29,12 @@ const Mime = @import("../browser/Mime.zig");
 const Element = @import("../browser/webapi/Element.zig");
 const Label = @import("../browser/webapi/element/html/Label.zig");
 
+const Incrementing = @import("id.zig").Incrementing;
 const InterceptState = @import("domains/fetch.zig").InterceptState;
+
+const log = lp.log;
+const json = std.json;
+const Allocator = std.mem.Allocator;
 
 pub const URL_BASE = "chrome://newtab/";
 

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -17,11 +17,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
+const lp = @import("lightpanda");
 
-const log = @import("../log.zig");
 const Page = @import("../browser/Page.zig");
 const DOMNode = @import("../browser/webapi/Node.zig");
+
+const log = lp.log;
+const Allocator = std.mem.Allocator;
 
 pub const Id = u32;
 

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -17,16 +17,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 const Node = @import("../Node.zig");
 
-const log = @import("../../log.zig");
 const dump = @import("../../browser/dump.zig");
 const js = @import("../../browser/js/js.zig");
 const DOMNode = @import("../../browser/webapi/Node.zig");
 const Selector = @import("../../browser/webapi/selector/Selector.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: *CDP.Command) !void {

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -17,9 +17,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const CDP = @import("../CDP.zig");
-const log = @import("../../log.zig");
 const Config = @import("../../Config.zig");
+
+const log = lp.log;
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {

--- a/src/cdp/domains/fetch.zig
+++ b/src/cdp/domains/fetch.zig
@@ -17,16 +17,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-
-const id = @import("../id.zig");
-const CDP = @import("../CDP.zig");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 
 const HttpClient = @import("../../browser/HttpClient.zig");
 const http = @import("../../network/http.zig");
 const Notification = @import("../../Notification.zig");
 
+const id = @import("../id.zig");
+const CDP = @import("../CDP.zig");
+
 const network = @import("network.zig");
+
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: *CDP.Command) !void {

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -19,8 +19,6 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const log = @import("../../log.zig");
-
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 
@@ -30,6 +28,8 @@ const Notification = @import("../../Notification.zig");
 const Mime = @import("../../browser/Mime.zig");
 
 const CdpStorage = @import("storage.zig");
+
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: *CDP.Command) !void {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -25,13 +25,13 @@ const screenshot_png = @embedFile("screenshot.png");
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 
-const log = @import("../../log.zig");
 const js = @import("../../browser/js/js.zig");
 const URL = @import("../../browser/URL.zig");
 const Page = @import("../../browser/Page.zig");
 const timestampF = @import("../../datetime.zig").timestamp;
 const Notification = @import("../../Notification.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub fn processMessage(cmd: *CDP.Command) !void {

--- a/src/cdp/domains/storage.zig
+++ b/src/cdp/domains/storage.zig
@@ -17,13 +17,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const CDP = @import("../CDP.zig");
-
-const log = @import("../../log.zig");
 const URL = @import("../../browser/URL.zig");
 const Cookie = @import("../../browser/webapi/storage/storage.zig").Cookie;
 
+const log = lp.log;
 const CookieJar = Cookie.Jar;
 pub const PreparedUri = Cookie.PreparedUri;
 

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -22,9 +22,10 @@ const lp = @import("lightpanda");
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 
-const log = @import("../../log.zig");
 const URL = @import("../../browser/URL.zig");
 const js = @import("../../browser/js/js.zig");
+
+const log = lp.log;
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {

--- a/src/cookies.zig
+++ b/src/cookies.zig
@@ -14,11 +14,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("log.zig");
+const lp = @import("lightpanda");
 
 const Session = @import("browser/Session.zig");
 const Cookie = @import("browser/webapi/storage/Cookie.zig");
 
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 /// Load cookies from a JSON file into the cookie jar.

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -50,7 +50,7 @@ pub noinline fn crash(
                 writer.print("version: {s}\n", .{lp.build_config.version}) catch abort();
                 inline for (@typeInfo(@TypeOf(args)).@"struct".fields) |f| {
                     writer.writeAll(f.name ++ ": ") catch break;
-                    @import("log.zig").writeValue(.pretty, @field(args, f.name), writer) catch abort();
+                    lp.log.writeValue(.pretty, @field(args, f.name), writer) catch abort();
                     writer.writeByte('\n') catch abort();
                 }
 
@@ -104,7 +104,7 @@ fn report(reason: []const u8, begin_addr: usize, args: anytype) !void {
         var writer: std.Io.Writer = .fixed(body_buffer[0..8191]); // reserve 1 space
         inline for (@typeInfo(@TypeOf(args)).@"struct".fields) |f| {
             writer.writeAll(f.name ++ ": ") catch break;
-            @import("log.zig").writeValue(.pretty, @field(args, f.name), &writer) catch {};
+            lp.log.writeValue(.pretty, @field(args, f.name), &writer) catch {};
             writer.writeByte('\n') catch {};
         }
 

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -17,6 +17,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+
+pub const log = @import("log.zig");
 pub const App = @import("App.zig");
 pub const Network = @import("network/Network.zig");
 pub const Server = @import("Server.zig");
@@ -28,7 +30,6 @@ pub const Browser = @import("browser/Browser.zig");
 pub const Session = @import("browser/Session.zig");
 pub const Notification = @import("Notification.zig");
 
-pub const log = @import("log.zig");
 pub const js = @import("browser/js/js.zig");
 pub const dump = @import("browser/dump.zig");
 pub const markdown = @import("browser/markdown.zig");
@@ -45,6 +46,7 @@ pub const build_config = @import("build_config");
 pub const crash_handler = @import("crash_handler.zig");
 
 pub const HttpClient = @import("browser/HttpClient.zig");
+
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub const FetchOpts = struct {

--- a/src/mcp/router.zig
+++ b/src/mcp/router.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const protocol = @import("protocol.zig");
 const resources = @import("resources.zig");
 const Server = @import("Server.zig");
 const tools = @import("tools.zig");
+
+const log = lp.log;
 
 pub fn processRequests(server: *Server, reader: *std.io.Reader) !void {
     var arena: std.heap.ArenaAllocator = .init(server.allocator);
@@ -29,8 +33,6 @@ pub fn processRequests(server: *Server, reader: *std.io.Reader) !void {
         }
     }
 }
-
-const log = @import("../log.zig");
 
 const Method = enum {
     initialize,

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -17,13 +17,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../log.zig");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
+
+const log = lp.log;
 const net = std.net;
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
 
-const lp = @import("lightpanda");
 const Config = @import("../Config.zig");
 const libcurl = @import("../sys/libcurl.zig");
 

--- a/src/network/Robots.zig
+++ b/src/network/Robots.zig
@@ -16,9 +16,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const builtin = @import("builtin");
 const std = @import("std");
-const log = @import("../log.zig");
+const lp = @import("lightpanda");
+const builtin = @import("builtin");
+
+const log = lp.log;
 
 pub const CompiledPattern = struct {
     pattern: []const u8,

--- a/src/network/cache/Cache.zig
+++ b/src/network/cache/Cache.zig
@@ -17,9 +17,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
 const Http = @import("../http.zig");
 const FsCache = @import("FsCache.zig");
+
+const log = lp.log;
 
 /// A browser-wide cache for resources across the network.
 /// This mostly conforms to RFC9111 with regards to caching behavior.

--- a/src/network/cache/FsCache.zig
+++ b/src/network/cache/FsCache.zig
@@ -17,9 +17,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const log = @import("../../log.zig");
+const lp = @import("lightpanda");
+
 const Cache = @import("Cache.zig");
 const Http = @import("../http.zig");
+
+const log = lp.log;
 const CacheRequest = Cache.CacheRequest;
 const CachedMetadata = Cache.CachedMetadata;
 const CachedResponse = Cache.CachedResponse;

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -1,18 +1,19 @@
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 const build_config = @import("build_config");
 
-const Allocator = std.mem.Allocator;
-
-const log = @import("../log.zig");
 const App = @import("../App.zig");
 const Config = @import("../Config.zig");
 const telemetry = @import("telemetry.zig");
 const Network = @import("../network/Network.zig");
 
-const URL = "https://telemetry.lightpanda.io";
+const log = lp.log;
+const Allocator = std.mem.Allocator;
+
 const BUFFER_SIZE = 1024;
 const MAX_BODY_SIZE = 500 * 1024; // 500KB server limit
+const URL = "https://telemetry.lightpanda.io";
 
 const LightPanda = @This();
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -1,14 +1,14 @@
 const std = @import("std");
+const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
-const Allocator = std.mem.Allocator;
-
-const log = @import("../log.zig");
 const App = @import("../App.zig");
 const Config = @import("../Config.zig");
-
 const uuidv4 = @import("../id.zig").uuidv4;
+
+const log = lp.log;
 const IID_FILE = "iid";
+const Allocator = std.mem.Allocator;
 
 pub fn isDisabled() bool {
     if (builtin.mode == .Debug or builtin.is_test) {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -17,6 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
+const log = lp.log;
 const Allocator = std.mem.Allocator;
 
 pub const allocator = std.testing.allocator;
@@ -473,7 +476,6 @@ pub fn pageTest(comptime test_file: []const u8, opts: PageTestOpts) !*Page {
     return page;
 }
 
-const log = @import("log.zig");
 const TestHTTPServer = @import("TestHTTPServer.zig");
 const TestWSServer = @import("TestWSServer.zig");
 


### PR DESCRIPTION
@import("lightpanda") where needed.

Would also like to do this for String, Page, Session and js which all stand out as types that are use across the codebase.

I know that a few devs are doing this in new work and I haven't heard anyone voice an objection.

I also tried to improve the import grouping..though I'm less fuss about that. 

````
1. external

2. internal (often sub-grouped by distance to the current file)

3. constants
```

This grouping is already mostly how things naturally end up.
