### PR TITLE
Add timing fields to a few CDP messages

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -17,13 +17,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const builtin = @import("builtin");
-const posix = std.posix;
-const Allocator = std.mem.Allocator;
-const ArenaAllocator = std.heap.ArenaAllocator;
-
 const lp = @import("lightpanda");
-const log = lp.log;
+const builtin = @import("builtin");
+
 const URL = @import("URL.zig");
 const Config = @import("../Config.zig");
 const Notification = @import("../Notification.zig");
@@ -34,15 +30,20 @@ const http = @import("../network/http.zig");
 const Network = @import("../network/Network.zig");
 const Robots = @import("../network/Robots.zig");
 const Cache = @import("../network/cache/Cache.zig");
-const CacheMetadata = Cache.CachedMetadata;
-const CachedResponse = Cache.CachedResponse;
+const timestamp = @import("../datetime.zig").timestamp;
 
+const log = lp.log;
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+const ArenaAllocator = std.heap.ArenaAllocator;
 const IS_DEBUG = builtin.mode == .Debug;
 
 pub const Method = http.Method;
 pub const Headers = http.Headers;
 pub const ResponseHead = http.ResponseHead;
 pub const HeaderIterator = http.HeaderIterator;
+const CacheMetadata = Cache.CachedMetadata;
+const CachedResponse = Cache.CachedResponse;
 
 // This is loosely tied to a browser Page. Loading all the <scripts>, doing
 // XHR requests, and loading imports all happens through here. Sine the app
@@ -769,6 +770,7 @@ fn makeTransfer(self: *Client, req: Request) !*Transfer {
 
     const id = self.incrReqId();
     transfer.* = .{
+        .start_time = timestamp(.monotonic),
         .arena = ArenaAllocator.init(self.allocator),
         .id = id,
         .url = req.url,
@@ -1292,6 +1294,7 @@ pub const Transfer = struct {
     bytes_received: usize = 0,
     _pending_cache_metadata: ?*CacheMetadata = null,
 
+    start_time: u64,
     aborted: bool = false,
 
     // We'll store the response header here

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -277,8 +277,8 @@ pub fn httpRequestStart(bc: *CDP.BrowserContext, msg: *const Notification.Reques
         .initiator = .{ .type = "other" },
         .redirectHasExtraInfo = false, // TODO change after adding Network.requestWillBeSentExtraInfo
         .hasUserGesture = false,
-        .timestamp = datetime(.monotonic),
-        .wallTime = datetime(.clock),
+        .timestamp = timestamp(.monotonic),
+        .wallTime = timestamp(.clock),
     }, .{ .session_id = session_id });
 }
 

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -23,9 +23,10 @@ const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 
 const URL = @import("../../browser/URL.zig");
-const Transfer = @import("../../browser/HttpClient.zig").Transfer;
-const Notification = @import("../../Notification.zig");
 const Mime = @import("../../browser/Mime.zig");
+const Notification = @import("../../Notification.zig");
+const timestamp = @import("../../datetime.zig").timestamp;
+const Transfer = @import("../../browser/HttpClient.zig").Transfer;
 
 const CdpStorage = @import("storage.zig");
 
@@ -276,6 +277,8 @@ pub fn httpRequestStart(bc: *CDP.BrowserContext, msg: *const Notification.Reques
         .initiator = .{ .type = "other" },
         .redirectHasExtraInfo = false, // TODO change after adding Network.requestWillBeSentExtraInfo
         .hasUserGesture = false,
+        .timestamp = datetime(.monotonic),
+        .wallTime = datetime(.clock),
     }, .{ .session_id = session_id });
 }
 
@@ -412,6 +415,25 @@ const TransferAsResponseWriter = struct {
             try jws.write(mime.contentTypeString());
             try jws.objectField("charset");
             try jws.write(mime.charsetString());
+        }
+
+        {
+            try jws.objectField("timing");
+            try jws.write(.{
+                .requestTime = transfer.start_time,
+                .connectEnd = -1,
+                .connectStart = -1,
+                .dnsEnd = -1,
+                .dnsStart = -1,
+                .proxyEnd = -1,
+                .proxyStart = -1,
+                .receiveHeadersEnd = -1,
+                .receiveHeadersStart = -1,
+                .sendEnd = -1,
+                .sendStart = -1,
+                .sslEnd = -1,
+                .sslStart = -1,
+            });
         }
 
         {


### PR DESCRIPTION
Hopefully fixes https://github.com/lightpanda-io/browser/issues/2199

Adds requestTime to responseReceived and, for completeness, adds timestamp and wallTime to requestWillBeSent.