### PR TITLE
build: move snapshot_creator and legacy_test to an `extras` step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -102,6 +102,11 @@ pub fn build(b: *Build) !void {
     });
     check.dependOn(&check_lib.step);
 
+    // Extras (snapshot_creator, legacy_test) are off the default install to
+    // avoid paying for three exe compiles on every edit. Build explicitly
+    // with `zig build extras`.
+    const extras_step = b.step("extras", "Build snapshot_creator and legacy_test");
+
     {
         // browser
         const exe = b.addExecutable(.{
@@ -153,7 +158,7 @@ pub fn build(b: *Build) !void {
                 },
             }),
         });
-        b.installArtifact(exe);
+        extras_step.dependOn(&b.addInstallArtifact(exe, .{}).step);
 
         const exe_check = b.addLibrary(.{
             .name = "snapshot_creator_check",
@@ -197,7 +202,7 @@ pub fn build(b: *Build) !void {
                 },
             }),
         });
-        b.installArtifact(exe);
+        extras_step.dependOn(&b.addInstallArtifact(exe, .{}).step);
 
         const exe_check = b.addLibrary(.{
             .name = "legacy_test_check",


### PR DESCRIPTION
Profiling `zig build --release=fast` after a one-file edit showed the cost was three parallel exe compiles of the same module: each re-runs LLVM codegen when anything in `lightpanda_module` changes. All C/C++ deps (v8, sqlite, curl, brotli, nghttp2, boringssl) already cache across builds and are not the bottleneck.

Default install now builds only the main `lightpanda` exe. `lightpanda-snapshot-creator` and `legacy_test` move to a new named step and can be built explicitly via `zig build extras`. CI is unaffected: nightly.yml already invokes `snapshot_creator` as an explicit step, and no job consumes the legacy_test artifact.

Measured (release=fast, one source file modified, 36/36 steps):
  before: real 3m32s, compile exe lightpanda ~3m, others ~2m each
  after:  real 2m43s, only compile exe lightpanda

Also tried and rejected:
  - self-hosted Zig backend for Debug: fatal linker error, unhandled relocation type R_X86_64_PC64 in V8 objects.
  - mold via `mold -run`: ~4s delta, within noise — Zig invokes LLD as a library, so no external `ld` process exists to intercept.