### PR TITLE
Add placeholder handlers for Audit enable/disable CDP methods

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -223,6 +223,7 @@ fn dispatchCommand(command: *Command, method: []const u8) !void {
         5 => switch (@as(u40, @bitCast(domain[0..5].*))) {
             asUint(u40, "Fetch") => return @import("domains/fetch.zig").processMessage(command),
             asUint(u40, "Input") => return @import("domains/input.zig").processMessage(command),
+            asUint(u40, "Audit") => return @import("domains/audit.zig").processMessage(command),
             else => {},
         },
         6 => switch (@as(u48, @bitCast(domain[0..6].*))) {

--- a/src/cdp/domains/audit.zig
+++ b/src/cdp/domains/audit.zig
@@ -1,0 +1,39 @@
+// Copyright (C) 2023-2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const CDP = @import("../CDP.zig");
+
+pub fn processMessage(cmd: *CDP.Command) !void {
+    const action = std.meta.stringToEnum(enum {
+        enable,
+        disable,
+    }, cmd.input.action) orelse return error.UnknownMethod;
+
+    switch (action) {
+        .enable => return enable(cmd),
+        .disable => return disable(cmd),
+    }
+}
+fn enable(cmd: *CDP.Command) !void {
+    return cmd.sendResult(null, .{});
+}
+
+fn disable(cmd: *CDP.Command) !void {
+    return cmd.sendResult(null, .{});
+}


### PR DESCRIPTION
Might help with: https://github.com/lightpanda-io/browser/issues/2177

I say "might" because there are a 2 more methods in Audit which I haven't implemented. This is just the most basic placeholder for now.