### PR TITLE
Remove unused imports

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -30,7 +30,6 @@ const EventTarget = @import("webapi/EventTarget.zig");
 const Element = @import("webapi/Element.zig");
 
 const log = lp.log;
-const String = lp.String;
 const Allocator = std.mem.Allocator;
 
 // Re-export types from EventManagerBase for API compatibility

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -21,10 +21,8 @@ const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
 const URL = @import("URL.zig");
-const Config = @import("../Config.zig");
 const Notification = @import("../Notification.zig");
 const CookieJar = @import("webapi/storage/Cookie.zig").Jar;
-const WebSocket = @import("webapi/net/WebSocket.zig");
 
 const http = @import("../network/http.zig");
 const Network = @import("../network/Network.zig");

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -25,7 +25,6 @@ const MouseEvent = @import("webapi/event/MouseEvent.zig");
 const KeyboardEvent = @import("webapi/event/KeyboardEvent.zig");
 const Frame = @import("Frame.zig");
 const Session = @import("Session.zig");
-const Selector = @import("webapi/selector/Selector.zig");
 
 fn dispatchInputAndChangeEvents(el: *Element, frame: *Frame) !void {
     const input_evt: *Event = try .initTrusted(comptime .wrap("input"), .{ .bubbles = true }, frame._page);

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -23,7 +23,6 @@ const string = @import("../../string.zig");
 const Frame = @import("../Frame.zig");
 const Page = @import("../Page.zig");
 const Session = @import("../Session.zig");
-const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
 
 const js = @import("js.zig");
 const Local = @import("Local.zig");

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("js.zig");
-const bridge = @import("bridge.zig");
 const Env = @import("Env.zig");
 const Origin = @import("Origin.zig");
 const Scheduler = @import("Scheduler.zig");

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -25,7 +25,6 @@ const bridge = @import("bridge.zig");
 const Context = @import("Context.zig");
 const Isolate = @import("Isolate.zig");
 const Platform = @import("Platform.zig");
-const Snapshot = @import("Snapshot.zig");
 const Inspector = @import("Inspector.zig");
 
 const App = @import("../../App.zig");

--- a/src/browser/js/Identity.zig
+++ b/src/browser/js/Identity.zig
@@ -29,8 +29,6 @@
 const std = @import("std");
 const js = @import("js.zig");
 
-const Session = @import("../Session.zig");
-
 const v8 = js.v8;
 
 const Identity = @This();

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -33,7 +33,6 @@ const TaggedOpaque = @import("TaggedOpaque.zig");
 const v8 = js.v8;
 const log = lp.log;
 const CallOpts = Caller.CallOpts;
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 // Where js.Context has a lifetime tied to the frame, and holds the
 // v8::Global<v8::Context>, this has a much shorter lifetime and holds a

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -21,7 +21,6 @@ const lp = @import("lightpanda");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
-const WebDriver = @import("../webapi/WebDriver.zig");
 
 const v8 = js.v8;
 const log = lp.log;

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -21,7 +21,6 @@ const lp = @import("lightpanda");
 
 const js = @import("js.zig");
 const Frame = @import("../Frame.zig");
-const Session = @import("../Session.zig");
 
 const v8 = js.v8;
 

--- a/src/browser/webapi/AbstractRange.zig
+++ b/src/browser/webapi/AbstractRange.zig
@@ -26,7 +26,6 @@ const Node = @import("Node.zig");
 const Range = @import("Range.zig");
 
 const Allocator = std.mem.Allocator;
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const AbstractRange = @This();
 

--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -28,7 +28,6 @@ const EventTarget = @import("EventTarget.zig");
 
 const String = lp.String;
 const Allocator = std.mem.Allocator;
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub const Event = @This();
 

--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -23,7 +23,6 @@ const Page = @import("../Page.zig");
 const EventManager = @import("../EventManager.zig");
 
 const Event = @import("Event.zig");
-const WorkerGlobalScope = @import("WorkerGlobalScope.zig");
 
 const RegisterOptions = EventManager.RegisterOptions;
 

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -29,7 +29,6 @@ const DOMRect = @import("DOMRect.zig");
 
 const log = lp.log;
 const Allocator = std.mem.Allocator;
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub fn registerTypes() []const type {
     return &.{

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const Frame = @import("../Frame.zig");
 const h5e = @import("../parser/html5ever.zig");
 
 const String = lp.String;

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -29,7 +29,6 @@ const Element = @import("Element.zig");
 const log = lp.log;
 const String = lp.String;
 const Allocator = std.mem.Allocator;
-const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub fn registerTypes() []const type {
     return &.{

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -21,7 +21,6 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
-const Session = @import("../Session.zig");
 
 const Node = @import("Node.zig");
 const DocumentFragment = @import("DocumentFragment.zig");

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const http = @import("../../network/http.zig");
 
 const URL = @import("../URL.zig");
 const Frame = @import("../Frame.zig");

--- a/src/browser/webapi/collections/ChildNodes.zig
+++ b/src/browser/webapi/collections/ChildNodes.zig
@@ -23,6 +23,7 @@ const Page = @import("../../Page.zig");
 const Frame = @import("../../Frame.zig");
 
 const Node = @import("../Node.zig");
+
 const GenericIterator = @import("iterator.zig").Entry;
 
 // Optimized for node.childNodes, which has to be a live list.

--- a/src/browser/webapi/collections/iterator.zig
+++ b/src/browser/webapi/collections/iterator.zig
@@ -21,9 +21,6 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
-const Frame = @import("../../Frame.zig");
-
-const Execution = js.Execution;
 
 pub fn Entry(comptime Inner: type, comptime field: ?[]const u8) type {
     const R = reflect(Inner, field);

--- a/src/browser/webapi/element/html/Canvas.zig
+++ b/src/browser/webapi/element/html/Canvas.zig
@@ -31,8 +31,6 @@ const Canvas = @This();
 _proto: *HtmlElement,
 _cached: ?DrawingContext = null,
 
-const ContextType = enum { none, @"2d", webgl };
-
 pub fn asElement(self: *Canvas) *Element {
     return self._proto._proto;
 }

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -18,7 +18,6 @@
 
 const std = @import("std");
 const js = @import("../../../js/js.zig");
-const URL = @import("../../../URL.zig");
 const Frame = @import("../../../Frame.zig");
 
 const Node = @import("../../Node.zig");

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -23,7 +23,6 @@ const Document = @import("../../Document.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
-const URL = @import("../../URL.zig");
 
 const IFrame = @This();
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
-const URL = @import("../../../URL.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
 
-const URL = @import("../../URL.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -23,7 +23,6 @@ const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
-const URL = @import("../../URL.zig");
 
 const Script = @This();
 

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -22,10 +22,10 @@ const js = @import("../../js/js.zig");
 const http = @import("../../../network/http.zig");
 
 const URL = @import("../URL.zig");
-const Frame = @import("../../Frame.zig");
 const Headers = @import("Headers.zig");
 const Blob = @import("../Blob.zig");
 const AbortSignal = @import("../AbortSignal.zig");
+
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 

--- a/src/browser/webapi/selector/Parser.zig
+++ b/src/browser/webapi/selector/Parser.zig
@@ -18,8 +18,6 @@
 
 const std = @import("std");
 
-const Frame = @import("../../Frame.zig");
-
 const Node = @import("../Node.zig");
 const Attribute = @import("../element/Attribute.zig");
 

--- a/src/cookies.zig
+++ b/src/cookies.zig
@@ -20,7 +20,6 @@ const Session = @import("browser/Session.zig");
 const Cookie = @import("browser/webapi/storage/Cookie.zig");
 
 const log = lp.log;
-const Allocator = std.mem.Allocator;
 
 /// Load cookies from a JSON file into the cookie jar.
 /// The file format is an array of objects with: name, value, domain, path,

--- a/src/network/cache/FsCache.zig
+++ b/src/network/cache/FsCache.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Cache = @import("Cache.zig");
-const Http = @import("../http.zig");
 
 const log = lp.log;
 const CacheRequest = Cache.CacheRequest;
@@ -89,7 +88,7 @@ pub fn deinit(self: *FsCache) void {
     self.dir.close();
 }
 
-pub fn get(self: *FsCache, arena: std.mem.Allocator, req: CacheRequest) ?Cache.CachedResponse {
+pub fn get(self: *FsCache, arena: std.mem.Allocator, req: CacheRequest) ?CachedResponse {
     const hashed_key = hashKey(req.url);
     const cache_p = cachePath(&hashed_key);
 


### PR DESCRIPTION
As a general rule, I keep `std` if its there and unused, mostly for debug.print debugging.