### PR TITLE
Fix canada.ca problem

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -411,6 +411,12 @@ pub const HttpHeaders = struct {
         break :blk out;
     };
 
+    // Some bot-protection frontends (e.g. Akamai on canada.ca) RST the HTTP/2
+    // stream when a client sends Accept-Encoding without Accept-Language,
+    // treating it as a bot signal. Ship a neutral default so we look like a
+    // normal client.
+    pub const accept_language: [:0]const u8 = "Accept-Language: en-US,en;q=0.9";
+
     user_agent: [:0]const u8, // User agent value (e.g. "Lightpanda/1.0")
     user_agent_header: [:0]const u8,
 

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -66,7 +66,14 @@ pub const Headers = struct {
         }
 
         // Always add sec-CH-UA header
-        const updated_headers = libcurl.curl_slist_append(header_list, Config.HttpHeaders.sec_ch_ua);
+        const with_sec_ch_ua = libcurl.curl_slist_append(header_list, Config.HttpHeaders.sec_ch_ua);
+        if (with_sec_ch_ua == null) {
+            return error.OutOfMemory;
+        }
+
+        // Always add Accept-Language. Omitting it triggers bot-protection on
+        // some CDNs (Akamai) when Accept-Encoding is present.
+        const updated_headers = libcurl.curl_slist_append(with_sec_ch_ua, Config.HttpHeaders.accept_language);
         if (updated_headers == null) {
             return error.OutOfMemory;
         }


### PR DESCRIPTION
The problem is not related to redirects or HTTP 2, it is related to bot protection on the CDN.