### PR TITLE
Define v8 functions directly on console instance.

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -721,7 +721,6 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     if (!opts.force and URL.eqlDocument(target.url, resolved_url)) {
         target.url = try target.arena.dupeZ(u8, resolved_url);
         target.window._location = try Location.init(target.url, target);
-        target.document._location = target.window._location;
         if (target.parent == null) {
             try session.navigation.updateEntries(target.url, opts.kind, target, true);
         }

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -588,6 +588,12 @@ fn attachClass(comptime JsApi: type, isolate: *v8.Isolate, template: *const v8.F
     const prototype = v8.v8__FunctionTemplate__PrototypeTemplate(template);
     const signature = v8.v8__Signature__New(isolate, template);
 
+    // Namespace objects (e.g. console) expose their members as own properties
+    // of each instance rather than via the prototype, so Object.entries(...)
+    // returns them. See https://console.spec.whatwg.org/#console-namespace.
+    const own_properties = @hasDecl(JsApi.Meta, "own_properties") and JsApi.Meta.own_properties;
+    const member_template = if (own_properties) instance else prototype;
+
     const declarations = @typeInfo(JsApi).@"struct".decls;
     var has_named_index_getter = false;
 
@@ -653,7 +659,7 @@ fn attachClass(comptime JsApi: type, isolate: *v8.Isolate, template: *const v8.F
                 if (value.static) {
                     v8.v8__Template__Set(@ptrCast(template), js_name, @ptrCast(function_template), v8.None);
                 } else {
-                    v8.v8__Template__Set(@ptrCast(prototype), js_name, @ptrCast(function_template), v8.None);
+                    v8.v8__Template__Set(@ptrCast(member_template), js_name, @ptrCast(function_template), v8.None);
                 }
             },
             bridge.Indexed => {

--- a/src/browser/tests/console/console.html
+++ b/src/browser/tests/console/console.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
+<script id=entries>
+    {
+        const entries = Object.entries(console);
+        testing.expectEqual(true, entries.length > 10);
+
+        const log_entry = entries.find((e) => e[0] == 'log');
+        testing.expectEqual(true, log_entry[1] === console.log);
+    }
+</script>
+
 <script id="time">
     // should not crash
     console.time();

--- a/src/browser/tests/css.html
+++ b/src/browser/tests/css.html
@@ -7,6 +7,11 @@
   testing.expectEqual('function', typeof CSS.supports);
 </script>
 
+<script id="entries">
+  const entries = Object.entries(CSS);
+  testing.expectEqual(true, entries.length >= 2);
+</script>
+
 <script id="escape_basic">
   {
     testing.expectEqual('hello', CSS.escape('hello'));

--- a/src/browser/webapi/CSS.zig
+++ b/src/browser/webapi/CSS.zig
@@ -165,6 +165,11 @@ pub const JsApi = struct {
 
     pub const Meta = struct {
         pub const name = "Css";
+
+        // Per the CSSOM spec, CSS is a namespace object — members are own
+        // properties so Object.entries(CSS) returns them.
+        pub const own_properties = true;
+
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
         pub const empty_with_no_proto = true;

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -178,6 +178,10 @@ pub const JsApi = struct {
     pub const Meta = struct {
         pub const name = "Console";
 
+        // Per the console spec, members are own properties of the namespace
+        // object, so Object.entries(console) returns them.
+        pub const own_properties = true;
+
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -197,7 +197,8 @@ pub fn getCurrentScript(self: *const HTMLDocument) ?*Element.Html.Script {
 }
 
 pub fn getLocation(self: *const HTMLDocument) ?*@import("Location.zig") {
-    return self._proto._location;
+    const frame = self._proto._frame orelse return null;
+    return frame.window._location;
 }
 
 pub fn setLocation(self: *HTMLDocument, url: [:0]const u8, frame: *Frame) !void {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -170,12 +170,12 @@ pub fn getOrigin(self: *const Window) []const u8 {
     return self._frame.origin orelse "null";
 }
 
-pub fn getLocation(self: *const Window) *Location {
-    return self._location;
-}
-
 pub fn getSelection(self: *const Window) *Selection {
     return &self._document._selection;
+}
+
+pub fn getLocation(self: *const Window) *Location {
+    return self._location;
 }
 
 pub fn setLocation(self: *Window, url: [:0]const u8, frame: *Frame) !void {


### PR DESCRIPTION
functions should be defined directly on the window.console (and window.CSS) instances. This is necessary for being able to iterate their "own" properties. businessinsider.com has code that proxies console via such an iterator (through Object.entries(console)). This commit allows types to declare that they own their properties (as opposed to the prototype).

Also fixed HTMLDocument.location. This was using Document._location, but that field wasn't always set. The new code removes the _location field and changes the getter to get window._location. (Also an issue on businessinsider.com)