### PR TITLE
Update WebDriver to use Page

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -36,13 +36,8 @@ jobs:
           os: ${{env.OS}}
           arch: ${{env.ARCH}}
 
-      - uses: ./.github/actions/v8-snapshot
-        with:
-          os: ${{env.OS}}
-          arch: ${{env.ARCH}}
-
       - name: zig build release
-        run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast -Dcpu=generic
+        run: zig build -Dwpt_extensions -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast -Dcpu=generic
 
       - name: upload artifact
         uses: actions/upload-artifact@v7

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -19,15 +19,15 @@
 const std = @import("std");
 
 const js = @import("../js/js.zig");
-const Session = @import("../Session.zig");
+const Page = @import("../Page.zig");
 
 // This type is only included when the binary is built with the -Dwpt_extensions flag
 const WebDriver = @This();
 
 _pad: bool = false,
 
-pub fn deleteAllCookies(_: *const WebDriver, session: *Session) void {
-    session.cookie_jar.clearRetainingCapacity();
+pub fn deleteAllCookies(_: *const WebDriver, page: *Page) void {
+    page.session.cookie_jar.clearRetainingCapacity();
 }
 
 pub const JsApi = struct {


### PR DESCRIPTION
Don't use pre-built snapshot for wpt action (the snapshot needs the WebDriver added, which is not normally added). Instead, rely on runtime snapshot creation (this just adds a bit of startup time and peak memory, neither or which should be an issue for WPT runs).