### PR TITLE
ci: refacto release workflow and add Arch linux package build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,13 @@ jobs:
           tag: ${{ env.RELEASE }}
           makeLatest: true
 
+      - name: Share binary with packaging jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          path: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          retention-days: 1
+
   build-linux-aarch64:
     env:
       ARCH: aarch64
@@ -102,6 +109,13 @@ jobs:
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           tag: ${{ env.RELEASE }}
           makeLatest: true
+
+      - name: Share binary with packaging jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          path: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          retention-days: 1
 
   build-macos-aarch64:
     env:
@@ -182,5 +196,77 @@ jobs:
         with:
           allowUpdates: true
           artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          tag: ${{ env.RELEASE }}
+          makeLatest: true
+
+  package-archlinux:
+    if: github.ref_type == 'tag'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+
+    env:
+      ARCH: ${{ matrix.arch }}
+      OS: linux
+
+    needs:
+      - build-linux-x86_64
+      - build-linux-aarch64
+    runs-on: ubuntu-22.04
+    container: archlinux:latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install packaging deps
+        run: pacman -Syu --noconfirm --needed base-devel sudo
+
+      - name: Download linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: lightpanda-${{ env.ARCH }}-${{ env.OS }}
+          path: .
+
+      - name: Build Arch package
+        run: |
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+          RAW_VERSION="${{ env.RELEASE }}"
+          PKGVER="${RAW_VERSION#v}"
+          PKGREL="1"
+          echo "PKGVER=${PKGVER}" >> "$GITHUB_ENV"
+          echo "PKGREL=${PKGREL}" >> "$GITHUB_ENV"
+
+          mkdir -p pkg
+          cp lightpanda-${{ env.ARCH }}-${{ env.OS }} pkg/
+          cp LICENSE pkg/
+
+          cat > pkg/PKGBUILD <<EOF
+          pkgname=lightpanda
+          pkgver=${PKGVER}
+          pkgrel=${PKGREL}
+          pkgdesc="Lightpanda, headless browser built for AI and automation"
+          arch=('x86_64' 'aarch64')
+          url="https://lightpanda.io"
+          license=('AGPL-3.0-or-later')
+          options=(!strip !debug)
+          package() {
+              install -Dm755 "\$startdir/lightpanda-\$CARCH-linux" "\$pkgdir/usr/bin/lightpanda"
+              install -Dm644 "\$startdir/LICENSE" "\$pkgdir/usr/share/licenses/\$pkgname/LICENSE"
+          }
+          EOF
+
+          chown -R builder:builder pkg
+          cd pkg
+          sudo -u builder env CARCH=${{ env.ARCH }} makepkg -f --noconfirm -A
+
+      - name: Upload Arch package to release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: pkg/lightpanda-${{ env.PKGVER }}-${{ env.PKGREL }}-${{ env.ARCH }}.pkg.tar.zst
           tag: ${{ env.RELEASE }}
           makeLatest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: nightly build
+name: release build
 
 env:
   AWS_ACCESS_KEY_ID: ${{ vars.NIGHTLY_BUILD_AWS_ACCESS_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,23 @@ permissions:
   contents: write
 
 jobs:
-  build-linux-x86_64:
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            cpu_flag: -Dcpu=x86_64
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            cpu_flag: -Dcpu=generic
+
     env:
-      ARCH: x86_64
+      ARCH: ${{ matrix.arch }}
       OS: linux
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
 
     steps:
@@ -45,7 +56,7 @@ jobs:
         run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin
 
       - name: zig build
-        run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast -Dcpu=x86_64 ${{ env.VERSION_FLAG }}
+        run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast ${{ matrix.cpu_flag }} ${{ env.VERSION_FLAG }}
 
       - name: Rename binary
         run: mv zig-out/bin/lightpanda lightpanda-${{ env.ARCH }}-${{ env.OS }}
@@ -70,101 +81,23 @@ jobs:
           path: lightpanda-${{ env.ARCH }}-${{ env.OS }}
           retention-days: 1
 
-  build-linux-aarch64:
+  build-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-14 runs on arm CPU. see
+          # https://github.com/actions/runner-images?tab=readme-ov-file
+          - arch: aarch64
+            runner: macos-14
+          - arch: x86_64
+            runner: macos-14-large
+
     env:
-      ARCH: aarch64
-      OS: linux
-
-    runs-on: ubuntu-22.04-arm
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/install
-        with:
-          os: ${{env.OS}}
-          arch: ${{env.ARCH}}
-
-      - name: v8 snapshot
-        run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin
-
-      - name: zig build
-        run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast -Dcpu=generic ${{ env.VERSION_FLAG }}
-
-      - name: Rename binary
-        run: mv zig-out/bin/lightpanda lightpanda-${{ env.ARCH }}-${{ env.OS }}
-
-      - name: upload on s3
-        run: |
-          export DIR=`git show --no-patch --no-notes --pretty='%cs_%h'`
-          aws s3 cp --storage-class=GLACIER_IR lightpanda-${{ env.ARCH }}-${{ env.OS }} s3://lpd-nightly-build/${DIR}/lightpanda-${{ env.ARCH }}-${{ env.OS }}
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
-          tag: ${{ env.RELEASE }}
-          makeLatest: true
-
-      - name: Share binary with packaging jobs
-        uses: actions/upload-artifact@v4
-        with:
-          name: lightpanda-${{ env.ARCH }}-${{ env.OS }}
-          path: lightpanda-${{ env.ARCH }}-${{ env.OS }}
-          retention-days: 1
-
-  build-macos-aarch64:
-    env:
-      ARCH: aarch64
+      ARCH: ${{ matrix.arch }}
       OS: macos
 
-    # macos-14 runs on arm CPU. see
-    # https://github.com/actions/runner-images?tab=readme-ov-file
-    runs-on: macos-14
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/install
-        with:
-          os: ${{env.OS}}
-          arch: ${{env.ARCH}}
-
-      - name: v8 snapshot
-        run: zig build -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast snapshot_creator -- src/snapshot.bin
-
-      - name: zig build
-        run: zig build -Dsnapshot_path=../../snapshot.bin -Dprebuilt_v8_path=v8/libc_v8.a -Doptimize=ReleaseFast ${{ env.VERSION_FLAG }}
-
-      - name: Rename binary
-        run: mv zig-out/bin/lightpanda lightpanda-${{ env.ARCH }}-${{ env.OS }}
-
-      - name: upload on s3
-        run: |
-          export DIR=`git show --no-patch --no-notes --pretty='%cs_%h'`
-          aws s3 cp --storage-class=GLACIER_IR lightpanda-${{ env.ARCH }}-${{ env.OS }} s3://lpd-nightly-build/${DIR}/lightpanda-${{ env.ARCH }}-${{ env.OS }}
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: lightpanda-${{ env.ARCH }}-${{ env.OS }}
-          tag: ${{ env.RELEASE }}
-          makeLatest: true
-
-  build-macos-x86_64:
-    env:
-      ARCH: x86_64
-      OS: macos
-
-    runs-on: macos-14-large
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
 
     steps:
@@ -210,9 +143,7 @@ jobs:
       ARCH: ${{ matrix.arch }}
       OS: linux
 
-    needs:
-      - build-linux-x86_64
-      - build-linux-aarch64
+    needs: build-linux
     runs-on: ubuntu-22.04
     container: archlinux:latest
     timeout-minutes: 10


### PR DESCRIPTION
* [x] rename workflow `nightly.yml` into `release.yml`
* [x] refacto build steps into 1 job per OS + cpu arch matrix
* [x] add arch linux package build only for tag version (not for nightly)