### PR TITLE
`fetch`: add support for `--inject-script` and `--inject-script-file` options

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -130,6 +130,24 @@ fn waitScriptFileValidator(allocator: Allocator, args: *std.process.ArgIterator)
     };
 }
 
+fn injectScriptFileValidator(
+    allocator: Allocator,
+    args: *std.process.ArgIterator,
+    list: *std.ArrayList([:0]const u8),
+) !void {
+    const path = args.next() orelse {
+        log.fatal(.app, "missing argument value", .{ .arg = "--inject-script-file" });
+        return error.InvalidArgument;
+    };
+
+    const bytes = std.fs.cwd().readFileAllocOptions(allocator, path, 1024 * 1024, null, .of(u8), 0) catch |err| {
+        log.fatal(.app, "failed to read file", .{ .arg = "--inject-script-file", .path = path, .err = err });
+        return error.InvalidArgument;
+    };
+
+    return list.append(allocator, bytes);
+}
+
 /// Definition for all the commands and its arguments. See @cli.zig for further.
 const Commands = cli.Builder(.{
     .{
@@ -163,7 +181,14 @@ const Commands = cli.Builder(.{
                 },
             },
             .{ .name = "wait_selector", .type = ?[:0]const u8 },
-            .{ .name = "script", .type = ?[:0]const u8 },
+            .{
+                .name = "inject_script",
+                .type = [:0]const u8,
+                .multiple = true,
+                .variants = .{
+                    .{ .name = "inject_script_file", .validator = injectScriptFileValidator },
+                },
+            },
             .{ .name = "terminate_ms", .type = ?u32 },
         },
         .shared_options = CommonOptions,
@@ -642,8 +667,15 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\--wait-script-file
         \\                Like --wait-script, but reads the script from a file.
         \\
-        \\--script        Path to a JavaScript file to execute in the page context
-        \\                once the --wait- conditions have been met, before the dump.
+        \\--inject-script JavaScript to inject as an inline <script> element in
+        \\                <head> once the --wait-* conditions have been met,
+        \\                before the dump.
+        \\                Can be passed multiple times; scripts run in order.
+        \\
+        \\--inject-script-file
+        \\                Like --inject-script, but reads the script from a file.
+        \\                Can be passed multiple times; can be mixed with
+        \\                --inject-script and runs in CLI order.
         \\
         \\--terminate-ms  Hard deadline in milliseconds. After this time elapses,
         \\                JavaScript execution is forcibly terminated (e.g. for

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -163,6 +163,7 @@ const Commands = cli.Builder(.{
                 },
             },
             .{ .name = "wait_selector", .type = ?[:0]const u8 },
+            .{ .name = "script", .type = ?[:0]const u8 },
             .{ .name = "terminate_ms", .type = ?u32 },
         },
         .shared_options = CommonOptions,
@@ -640,6 +641,9 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\
         \\--wait-script-file
         \\                Like --wait-script, but reads the script from a file.
+        \\
+        \\--script        Path to a JavaScript file to execute in the page context
+        \\                once the --wait- conditions have been met, before the dump.
         \\
         \\--terminate-ms  Hard deadline in milliseconds. After this time elapses,
         \\                JavaScript execution is forcibly terminated (e.g. for

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -667,9 +667,8 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\--wait-script-file
         \\                Like --wait-script, but reads the script from a file.
         \\
-        \\--inject-script JavaScript to inject as an inline <script> element in
-        \\                <head> once the --wait-* conditions have been met,
-        \\                before the dump.
+        \\--inject-script JavaScript to execute as the document's <head> is
+        \\                parsed, before any other scripts in the page run.
         \\                Can be passed multiple times; scripts run in order.
         \\
         \\--inject-script-file

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -140,7 +140,7 @@ fn injectScriptFileValidator(
         return error.InvalidArgument;
     };
 
-    const bytes = std.fs.cwd().readFileAllocOptions(allocator, path, 1024 * 1024, null, .of(u8), 0) catch |err| {
+    const bytes = std.fs.cwd().readFileAllocOptions(allocator, path, std.math.maxInt(usize), null, .of(u8), null) catch |err| {
         log.fatal(.app, "failed to read file", .{ .arg = "--inject-script-file", .path = path, .err = err });
         return error.InvalidArgument;
     };

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -133,7 +133,7 @@ fn waitScriptFileValidator(allocator: Allocator, args: *std.process.ArgIterator)
 fn injectScriptFileValidator(
     allocator: Allocator,
     args: *std.process.ArgIterator,
-    list: *std.ArrayList([:0]const u8),
+    list: *std.ArrayList([]const u8),
 ) !void {
     const path = args.next() orelse {
         log.fatal(.app, "missing argument value", .{ .arg = "--inject-script-file" });
@@ -183,7 +183,7 @@ const Commands = cli.Builder(.{
             .{ .name = "wait_selector", .type = ?[:0]const u8 },
             .{
                 .name = "inject_script",
-                .type = [:0]const u8,
+                .type = []const u8,
                 .multiple = true,
                 .variants = .{
                     .{ .name = "inject_script_file", .validator = injectScriptFileValidator },

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2147,15 +2147,14 @@ pub fn createElementNS(self: *Frame, namespace: Element.Namespace, name: []const
                             self.js.localScope(&ls);
                             defer ls.deinit();
 
-                            var try_catch: JS.TryCatch = undefined;
-                            try_catch.init(&ls.local);
-                            defer try_catch.deinit();
-
                             for (inject_scripts) |inject_script| {
+                                var try_catch: JS.TryCatch = undefined;
+                                try_catch.init(&ls.local);
+                                defer try_catch.deinit();
+
                                 ls.local.eval(inject_script, "inject_script") catch |err| {
                                     const caught = try_catch.caughtOrError(self.call_arena, err);
                                     log.err(.app, "inject script error", .{ .err = caught });
-                                    return error.InjectScriptError;
                                 };
                             }
                         }
@@ -4110,6 +4109,12 @@ test "WebApi: Frames" {
 
 test "WebApi: Integration" {
     try testing.htmlRunner("integration", .{});
+}
+
+test "WebApi: inject_script" {
+    try testing.htmlRunner("inject_script.html", .{
+        .inject_script = "window.__injected = true; window.__injectValue = 42;",
+    });
 }
 
 test "Page: isSameOrigin" {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1152,7 +1152,58 @@ fn frameDoneCallback(ctx: *anyopaque) !void {
                     self._parse_state = .complete;
                 }
 
-                const raw_html = html.buffer.items;
+                const raw_html = blk: {
+                    const inject_scripts = self._session.inject_scripts;
+                    if (inject_scripts.len > 0) {
+                        // Find where <head> is.
+                        // Doing it as such since head can appear like <head>,
+                        // <HEAD>, <head lang="en">, <head class="..."> etc.
+                        // We must also skip false matches like <header>, so
+                        // require the byte after "<head" to be a tag terminator.
+                        const head_partial_end_index = scan: {
+                            var from: usize = 0;
+                            while (std.ascii.indexOfIgnoreCasePos(html.buffer.items, from, "<head")) |i| {
+                                const after = i + "<head".len;
+                                if (after >= html.buffer.items.len) break;
+                                switch (html.buffer.items[after]) {
+                                    '>', '/', ' ', '\t', '\n', '\r' => break :scan after,
+                                    else => from = i + 1,
+                                }
+                            }
+                            break :blk html.buffer.items;
+                        };
+                        // Look for closing caret.
+                        const head_end_index = (std.mem.indexOfScalarPos(u8, html.buffer.items, head_partial_end_index, '>') orelse {
+                            return error.InvalidHtml;
+                        }) + 1;
+
+                        // Allocate inject chunk in one go.
+                        const inject_chunk_size = calc: {
+                            var total: usize = "<script></script>".len * inject_scripts.len;
+                            for (inject_scripts) |script| total += script.len;
+                            break :calc total;
+                        };
+
+                        const inject_chunk = try html.arena.alloc(u8, inject_chunk_size);
+                        defer html.arena.free(inject_chunk);
+
+                        // Fill `inject_chunk`.
+                        var from: usize = 0;
+                        for (inject_scripts) |script| {
+                            @memcpy(inject_chunk[from..][0..8], "<script>");
+                            from += "<script>".len;
+                            @memcpy(inject_chunk[from..][0..script.len], script);
+                            from += script.len;
+                            @memcpy(inject_chunk[from..][0..9], "</script>");
+                            from += "</script>".len;
+                        }
+
+                        // Insert at the beginning of the <head>.
+                        try html.buffer.insertSlice(html.arena, head_end_index, inject_chunk);
+                    }
+
+                    break :blk html.buffer.items;
+                };
 
                 if (std.mem.eql(u8, self.charset, "UTF-8")) {
                     parser.parse(raw_html);

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1152,58 +1152,7 @@ fn frameDoneCallback(ctx: *anyopaque) !void {
                     self._parse_state = .complete;
                 }
 
-                const raw_html = blk: {
-                    const inject_scripts = self._session.inject_scripts;
-                    if (inject_scripts.len > 0) {
-                        // Find where <head> is.
-                        // Doing it as such since head can appear like <head>,
-                        // <HEAD>, <head lang="en">, <head class="..."> etc.
-                        // We must also skip false matches like <header>, so
-                        // require the byte after "<head" to be a tag terminator.
-                        const head_partial_end_index = scan: {
-                            var from: usize = 0;
-                            while (std.ascii.indexOfIgnoreCasePos(html.buffer.items, from, "<head")) |i| {
-                                const after = i + "<head".len;
-                                if (after >= html.buffer.items.len) break;
-                                switch (html.buffer.items[after]) {
-                                    '>', '/', ' ', '\t', '\n', '\r' => break :scan after,
-                                    else => from = i + 1,
-                                }
-                            }
-                            break :blk html.buffer.items;
-                        };
-                        // Look for closing caret.
-                        const head_end_index = (std.mem.indexOfScalarPos(u8, html.buffer.items, head_partial_end_index, '>') orelse {
-                            return error.InvalidHtml;
-                        }) + 1;
-
-                        // Allocate inject chunk in one go.
-                        const inject_chunk_size = calc: {
-                            var total: usize = "<script></script>".len * inject_scripts.len;
-                            for (inject_scripts) |script| total += script.len;
-                            break :calc total;
-                        };
-
-                        const inject_chunk = try html.arena.alloc(u8, inject_chunk_size);
-                        defer html.arena.free(inject_chunk);
-
-                        // Fill `inject_chunk`.
-                        var from: usize = 0;
-                        for (inject_scripts) |script| {
-                            @memcpy(inject_chunk[from..][0..8], "<script>");
-                            from += "<script>".len;
-                            @memcpy(inject_chunk[from..][0..script.len], script);
-                            from += script.len;
-                            @memcpy(inject_chunk[from..][0..9], "</script>");
-                            from += "</script>".len;
-                        }
-
-                        // Insert at the beginning of the <head>.
-                        try html.buffer.insertSlice(html.arena, head_end_index, inject_chunk);
-                    }
-
-                    break :blk html.buffer.items;
-                };
+                const raw_html = html.buffer.items;
 
                 if (std.mem.eql(u8, self.charset, "UTF-8")) {
                     parser.parse(raw_html);
@@ -2188,12 +2137,36 @@ pub fn createElementNS(self: *Frame, namespace: Element.Namespace, name: []const
                         attribute_iterator,
                         .{ ._proto = undefined },
                     ),
-                    asUint("head") => return self.createHtmlElementT(
-                        Element.Html.Head,
-                        namespace,
-                        attribute_iterator,
-                        .{ ._proto = undefined },
-                    ),
+                    asUint("head") => {
+                        // Inject user-provided scripts.
+                        const inject_scripts = self._session.inject_scripts;
+                        const should_inject_scripts = from_parser and self._parse_mode == .document and inject_scripts.len > 0;
+
+                        if (should_inject_scripts) {
+                            var ls: JS.Local.Scope = undefined;
+                            self.js.localScope(&ls);
+                            defer ls.deinit();
+
+                            var try_catch: JS.TryCatch = undefined;
+                            try_catch.init(&ls.local);
+                            defer try_catch.deinit();
+
+                            for (inject_scripts) |inject_script| {
+                                ls.local.eval(inject_script, "inject_script") catch |err| {
+                                    const caught = try_catch.caughtOrError(self.call_arena, err);
+                                    log.err(.app, "inject script error", .{ .err = caught });
+                                    return error.InjectScriptError;
+                                };
+                            }
+                        }
+
+                        return self.createHtmlElementT(
+                            Element.Html.Head,
+                            namespace,
+                            attribute_iterator,
+                            .{ ._proto = undefined },
+                        );
+                    },
                     asUint("body") => return self.createHtmlElementT(
                         Element.Html.Body,
                         namespace,

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -294,31 +294,20 @@ pub fn waitForSelector(self: *Runner, selector: [:0]const u8, timeout_ms: u32) !
     }
 }
 
-pub fn runScriptFile(runner: *Runner, allocator: std.mem.Allocator, file_path: [:0]const u8) !void {
+pub fn injectScripts(runner: *Runner, scripts: std.ArrayList([:0]const u8)) !void {
     const frame = runner.frame;
 
-    const bytes = std.fs.cwd().readFileAlloc(allocator, file_path, 64 * 1024 * 1024) catch |err| {
-        switch (err) {
-            error.FileNotFound => log.err(.app, "Runner.runScriptFile", .{ .path = file_path, .note = "file not found" }),
-            else => log.err(.app, "Runner.runScriptFile", .{ .path = file_path, .err = err }),
-        }
-        return;
-    };
-    defer allocator.free(bytes);
+    for (scripts.items) |source| {
+        // Create <script> element.
+        const script_node = try frame.createElementNS(.html, "script", null);
+        const script_element = script_node.as(@import("webapi/element/html/Script.zig"));
+        try script_element.setInnerText(source, frame);
 
-    var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
-    defer ls.deinit();
-
-    var try_catch: js.TryCatch = undefined;
-    try_catch.init(&ls.local);
-    defer try_catch.deinit();
-
-    return ls.local.eval(bytes, "script") catch |err| {
-        const caught = try_catch.caughtOrError(frame.call_arena, err);
-        log.err(.app, "run script file error", .{ .err = caught });
-        return error.ScriptError;
-    };
+        // Insert to <head>.
+        const doc = frame.document.as(@import("webapi/HTMLDocument.zig"));
+        const head = doc.getHead() orelse return error.NoHead;
+        _ = try head.asNode().appendChild(script_node, frame);
+    }
 }
 
 pub fn waitForScript(runner: *Runner, script: [:0]const u8, timeout_ms: u32) !void {

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -294,6 +294,33 @@ pub fn waitForSelector(self: *Runner, selector: [:0]const u8, timeout_ms: u32) !
     }
 }
 
+pub fn runScriptFile(runner: *Runner, allocator: std.mem.Allocator, file_path: [:0]const u8) !void {
+    const frame = runner.frame;
+
+    const bytes = std.fs.cwd().readFileAlloc(allocator, file_path, 64 * 1024 * 1024) catch |err| {
+        switch (err) {
+            error.FileNotFound => log.err(.app, "Runner.runScriptFile", .{ .path = file_path, .note = "file not found" }),
+            else => log.err(.app, "Runner.runScriptFile", .{ .path = file_path, .err = err }),
+        }
+        return;
+    };
+    defer allocator.free(bytes);
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    var try_catch: js.TryCatch = undefined;
+    try_catch.init(&ls.local);
+    defer try_catch.deinit();
+
+    return ls.local.eval(bytes, "script") catch |err| {
+        const caught = try_catch.caughtOrError(frame.call_arena, err);
+        log.err(.app, "run script file error", .{ .err = caught });
+        return error.ScriptError;
+    };
+}
+
 pub fn waitForScript(runner: *Runner, script: [:0]const u8, timeout_ms: u32) !void {
     var timer = try std.time.Timer.start();
 

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -294,22 +294,6 @@ pub fn waitForSelector(self: *Runner, selector: [:0]const u8, timeout_ms: u32) !
     }
 }
 
-pub fn injectScripts(runner: *Runner, scripts: std.ArrayList([:0]const u8)) !void {
-    const frame = runner.frame;
-
-    for (scripts.items) |source| {
-        // Create <script> element.
-        const script_node = try frame.createElementNS(.html, "script", null);
-        const script_element = script_node.as(@import("webapi/element/html/Script.zig"));
-        try script_element.setInnerText(source, frame);
-
-        // Insert to <head>.
-        const doc = frame.document.as(@import("webapi/HTMLDocument.zig"));
-        const head = doc.getHead() orelse return error.NoHead;
-        _ = try head.asNode().appendChild(script_node, frame);
-    }
-}
-
 pub fn waitForScript(runner: *Runner, script: [:0]const u8, timeout_ms: u32) !void {
     var timer = try std.time.Timer.start();
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -57,6 +57,8 @@ navigation: Navigation,
 storage_shed: storage.Shed,
 notification: *Notification,
 cookie_jar: storage.Cookie.Jar,
+/// User-provided scripts to inject into header.
+inject_scripts: []const []const u8 = &.{},
 
 // Shared allocator. Used by Session itself and borrowed by Pages.
 arena_pool: *ArenaPool,

--- a/src/browser/tests/inject_script.html
+++ b/src/browser/tests/inject_script.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="./testing.js"></script>
+</head>
+<body>
+  <script id=inject-script-runs>
+    testing.expectEqual(true, window.__injected);
+    testing.expectEqual(42, window.__injectValue);
+  </script>
+</body>
+</html>

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -55,7 +55,7 @@ pub const FetchOpts = struct {
     wait_ms: u32 = 5000,
     wait_until: ?Config.WaitUntil = null,
     wait_script: ?[:0]const u8 = null,
-    script: ?[:0]const u8 = null,
+    inject_script: std.ArrayList([:0]const u8) = .{},
     wait_selector: ?[:0]const u8 = null,
     dump: dump.Opts,
     dump_mode: ?Config.DumpFormat = null,
@@ -150,8 +150,9 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
         try runner.waitForScript(script, remaining);
     }
 
-    if (opts.script) |script| {
-        try runner.runScriptFile(app.allocator, script);
+    // Inject scripts to DOM if any.
+    if (opts.inject_script.items.len > 0) {
+        try runner.injectScripts(opts.inject_script);
     }
 
     const writer = opts.writer orelse return;

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -55,6 +55,7 @@ pub const FetchOpts = struct {
     wait_ms: u32 = 5000,
     wait_until: ?Config.WaitUntil = null,
     wait_script: ?[:0]const u8 = null,
+    script: ?[:0]const u8 = null,
     wait_selector: ?[:0]const u8 = null,
     dump: dump.Opts,
     dump_mode: ?Config.DumpFormat = null,
@@ -147,6 +148,10 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
         const remaining = opts.wait_ms -| elapsed;
         if (remaining == 0) return error.Timeout;
         try runner.waitForScript(script, remaining);
+    }
+
+    if (opts.script) |script| {
+        try runner.runScriptFile(app.allocator, script);
     }
 
     const writer = opts.writer orelse return;

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -55,7 +55,7 @@ pub const FetchOpts = struct {
     wait_ms: u32 = 5000,
     wait_until: ?Config.WaitUntil = null,
     wait_script: ?[:0]const u8 = null,
-    inject_script: std.ArrayList([:0]const u8) = .{},
+    inject_script: std.ArrayList([]const u8) = .{},
     wait_selector: ?[:0]const u8 = null,
     dump: dump.Opts,
     dump_mode: ?Config.DumpFormat = null,
@@ -76,6 +76,9 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
             cookies.saveToFile(&session.cookie_jar, cookie_jar_path);
         }
     }
+
+    // Stash scripts user want to inject.
+    session.inject_scripts = opts.inject_script.items;
 
     const frame = try session.createPage();
 
@@ -148,11 +151,6 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
         const remaining = opts.wait_ms -| elapsed;
         if (remaining == 0) return error.Timeout;
         try runner.waitForScript(script, remaining);
-    }
-
-    // Inject scripts to DOM if any.
-    if (opts.inject_script.items.len > 0) {
-        try runner.injectScripts(opts.inject_script);
     }
 
     const writer = opts.writer orelse return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,7 +124,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
                 .wait_ms = opts.wait_ms,
                 .wait_until = opts.wait_until,
                 .wait_script = opts.wait_script,
-                .script = opts.script,
+                .inject_script = opts.inject_script,
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
                 .dump = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,6 +124,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
                 .wait_ms = opts.wait_ms,
                 .wait_until = opts.wait_until,
                 .wait_script = opts.wait_script,
+                .script = opts.script,
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
                 .dump = .{

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -338,11 +338,19 @@ pub var test_notification: *Notification = undefined;
 pub var test_session: *Session = undefined;
 
 const WEB_API_TEST_ROOT = "src/browser/tests/";
-const HtmlRunnerOpts = struct {};
+const HtmlRunnerOpts = struct {
+    inject_script: ?[]const u8 = null,
+};
 
 pub fn htmlRunner(comptime path: []const u8, opts: HtmlRunnerOpts) !void {
-    _ = opts;
     defer reset();
+
+    var inject_scripts: [1][]const u8 = undefined;
+    if (opts.inject_script) |script| {
+        inject_scripts[0] = script;
+        test_session.inject_scripts = inject_scripts[0..1];
+    }
+    defer test_session.inject_scripts = &.{};
 
     const root = try std.fs.path.joinZ(arena_allocator, &.{ WEB_API_TEST_ROOT, path });
     const stat = std.fs.cwd().statFile(root) catch |err| {


### PR DESCRIPTION
Allows passing inline JS codes or files as an arg to be inserted into `<head>` tag. Addressing #2056.