### PR TITLE
Bound per-tick memory growth on JS-heavy pages

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1048,8 +1048,18 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     return true;
 }
 
+// Cap on HTTP completions processed per `perform()` call. Without this bound,
+// a burst of many simultaneous response completions can run parser / JS work
+// synchronously for seconds inside a single `Runner._tick` — allocating GBs
+// before control returns to the wait loop, blocking GC hints and memory
+// checks. 16 leaves throughput high for typical pages while keeping per-tick
+// work bounded. Messages over the cap stay in curl's queue and are picked up
+// on the next tick.
+const max_messages_per_tick: u32 = 16;
+
 fn processMessages(self: *Client) !bool {
     var processed = false;
+    var count: u32 = 0;
     while (try self.handles.readMessage()) |msg| {
         switch (msg.conn.transport) {
             .http => |transfer| {
@@ -1085,6 +1095,8 @@ fn processMessages(self: *Client) !bool {
             },
             .none => unreachable,
         }
+        count += 1;
+        if (count >= max_messages_per_tick) break;
     }
     return processed;
 }

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -72,7 +72,21 @@ fn _wait(self: *Runner, comptime is_cdp: bool, opts: WaitOpts) !CDPWaitResult {
         .ms = 200,
         .until = opts.until,
     };
+
+    // Periodic V8 GC hint during long waits. V8 is otherwise only nudged on
+    // session/page teardown (Browser.zig, Page.zig), so a page that stays
+    // alive for seconds while running heavy JS accumulates wrappers and
+    // external-ref'd Zig allocations V8 has no reason to drop. `.moderate`
+    // speeds up incremental GC without stalling the tick.
+    const gc_hint_period_ns: u64 = std.time.ns_per_s;
+    var gc_hint_timer = std.time.Timer.start() catch unreachable;
+
     while (true) {
+        if (gc_hint_timer.read() >= gc_hint_period_ns) {
+            gc_hint_timer.reset();
+            self.session.browser.env.memoryPressureNotification(.moderate);
+        }
+
         const tick_result = self._tick(is_cdp, tick_opts) catch |err| {
             switch (err) {
                 error.JsError => {}, // already logged (with hopefully more context)


### PR DESCRIPTION
## Summary

Two small changes that stop `Runner._wait` from freezing inside a single tick on JS-heavy pages, and nudge V8 to release wrappers during long waits:

- **`http: cap processMessages completions per tick`** (`bda07f08`) — `HttpClient.processMessages` drains every ready HTTP completion in one call, running each transfer's `done_callback` synchronously. A burst of simultaneous completions runs parser / JS work for seconds inside one `Runner._tick`, allocating gigabytes before control returns to the wait loop. Capped at 16 completions per tick; remaining messages stay in curl's queue and are picked up on the next tick.
- **`browser: hint v8 gc during long waits`** (`3d6f7674`) — V8 is only nudged on session/page teardown (`Browser.deinit`, `Page.deinit`). For a page that stays alive while running heavy JS, wrappers and external-ref'd Zig allocations accumulate unbounded. Fire `memoryPressureNotification(.moderate)` once per second from `Runner._wait`.

## Reproducer

```
zig build -Doptimize=ReleaseFast
lightpanda fetch --dump html --wait-ms 30000 https://github.com/features/copilot
```

Other URLs that reproduce: `github.com/pricing`, the GitHub signup page, and (anecdotally) most React-heavy marketing sites.

**Before these commits**: the wait loop iterates for ~1s, then stalls inside a single `http_client.tick` call for 10+ seconds while RSS grows ~190 MB/s. Process OOMs the host (or cgroup) without ever returning from that tick.

**After these commits**: wait loop iterates continuously through the full `--wait-ms` budget. Growth still happens (~100 MB/s steady) but is paced and predictable — the process exits cleanly at the deadline instead of freezing inside curl.

## Measurement

Instrumented `Runner._wait` (reverted before commit) to sample every 100 ms:

| t (ms) | VmRSS  | frame_arena | V8 total | malloc | "other"  |
|-------:|-------:|------------:|---------:|-------:|---------:|
|    333 |  27 MB |       3 KB  |   1 MB   |  56 KB |  26 MB   |
|    584 |  28 MB |       3 KB  |   1 MB   |  56 KB |  27 MB   |
|   1116 | 117 MB |      28 MB  |  37 MB   | 504 KB |  52 MB   |

All three allocator pools (`frame_arena`, V8 heap, "other") grow in parallel. V8's `used_heap_size` stays small even at 6 GiB process RSS — a V8 heap snapshot alone won't show this; you need `frame_arena.queryCapacity` + `VmRSS - V8 total` to see the native-side portion.

## Benchmark impact

Tested via the WebVoyager GitHub subset (41 tasks) in `../benchmarks`. Before these changes, 4 tasks consistently OOM'd the subprocess (`returncode=-9`): `GitHub--10`, `GitHub--20`, `GitHub--37`, `GitHub--40`. With these changes, `GitHub--40` recovers and completes cleanly. The other three still fail, but now reach the `--timeout` deadline and exit predictably rather than hanging inside curl.

## What's left (not in this PR)

Full closure of the leak needs two more pieces that are architecturally bigger and deserve their own PRs:

### 1. Enroll `Node`/`Element` in the V8 finalizer system

`Factory` already allocates DOM nodes through `SlabAllocator` (`src/browser/Factory.zig:49,290,310`), which supports individual `rawFree`. But `Frame.removeNode` (`src/browser/Frame.zig:2658-2763`) never calls `_factory.destroy(child)` on the removed node — it only destroys the `children` wrapper. Every removed node leaks its slab slot until `Page.deinit()`. React-style marketing pages that create/discard nodes every render leak steadily.

Safety wrinkle: `Node`/`Element` are not currently in the V8 finalizer system (`release_ref_from_zig` is set up for `Blob`, `Event`, `Observer`, `Selection`, `MessagePort` — not `Node`). Just destroying in `removeNode` is a use-after-free if JS has a live wrapper or if a `TreeWalker`/`Range`/`NodeIterator` holds a raw pointer. A proper fix enrolls DOM nodes in the finalizer system, and transitions a node to "finalizable" only once it's detached from the tree AND V8 confirms the wrapper is unreferenced.

### 2. Bound the main thread's `curl_multi_perform` (or pause it during dump)

`Network.run()` on the main thread calls `curl_multi_perform`, which drives `Transfer.dataCallback` → `_stream_buffer.appendSlice`. When the worker thread is busy (e.g. in `dump.root`), the main thread keeps filling Transfer buffers with no consumer. Observed on the copilot page: `fetch --dump html --wait-ms 3000` fills 3+ GB of buffered response data during the ~7s dump phase before cgroup-kill.

Options for a fix:
- Pause-flag the main thread during dump (simple; needs careful handshake).
- Cap total buffered bytes across all `Transfer._stream_buffer`s (more general; requires deciding what to do when capped — drop vs. set `error.ResponseTooLarge`).

## Notes

- A diagnostic doc with the full investigation (measurements, instrumentation notes, suspected code sites) is in `MEMORY_LEAK_NOTES.md` — left untracked so it can be adopted into wiki / dropped / committed separately as preferred.
- The benchmark harness (`../benchmarks`) uses a `systemd-run --scope -p MemoryMax=6G` cgroup wrapper around each subprocess to contain runaways as `returncode=-9`. After this PR the harness still needs that wrapper for pages that hit the remaining leak points above, but with less aggressive pathology.

## Test plan

- [ ] Build: `zig build -Doptimize=ReleaseFast` passes.
- [ ] Smoke: `lightpanda fetch --dump html --wait-ms 2000 https://example.com` still produces valid HTML output.
- [ ] Repro: `lightpanda fetch --dump html --wait-ms 30000 https://github.com/features/copilot` — wait loop iterates throughout (watch `htop` or `while true; do grep VmRSS /proc/$PID/status; sleep 1; done`), process exits at cgroup cap instead of stalling.
- [ ] Benchmarks: `webvoyager-run --site GitHub` — `GitHub--40` now completes (was previously an EMPTY / returncode=-9 crash).
- [ ] No regression on `assistantbench-run --limit 3` / `gaia-run --limit 3` / similar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)