### PR TITLE
browser: bound per-tick memory growth on JS-heavy pages

### DIFF
--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -72,7 +72,21 @@ fn _wait(self: *Runner, comptime is_cdp: bool, opts: WaitOpts) !CDPWaitResult {
         .ms = 200,
         .until = opts.until,
     };
+
+    // Periodic V8 GC hint during long waits. V8 is otherwise only nudged on
+    // session/page teardown (Browser.zig, Page.zig), so a page that stays
+    // alive for seconds while running heavy JS accumulates wrappers and
+    // external-ref'd Zig allocations V8 has no reason to drop. `.moderate`
+    // speeds up incremental GC without stalling the tick.
+    const gc_hint_period_ns: u64 = std.time.ns_per_s;
+    var gc_hint_timer = std.time.Timer.start() catch unreachable;
+
     while (true) {
+        if (gc_hint_timer.read() >= gc_hint_period_ns) {
+            gc_hint_timer.reset();
+            self.session.browser.env.memoryPressureNotification(.moderate);
+        }
+
         const tick_result = self._tick(is_cdp, tick_opts) catch |err| {
             switch (err) {
                 error.JsError => {}, // already logged (with hopefully more context)


### PR DESCRIPTION
Two related changes that stop Runner._wait from freezing inside a single tick on JS-heavy pages (github.com/features/copilot and similar React marketing sites reproduce deterministically), and nudge V8 to release wrappers during long waits.

1. HttpClient.processMessages drains every ready HTTP completion in one call, and each completion synchronously runs the transfer's done_callback — which for a main-page HTML response kicks the parser, allocating DOM nodes / strings and invoking JS. A burst of many simultaneous completions runs parser / JS work for seconds inside a single Runner._tick, allocating GBs before control returns to the wait loop. During that stall the wait loop can't hint GC, check bounds, or yield.

   Cap at 16 completions per tick. Remaining messages stay in curl's queue and are picked up on the next tick.

2. Runner._wait can iterate for the full opts.ms budget (up to 30s in fetch, longer in agent tool-use loops). V8 was only nudged to GC on session/page teardown (Browser.deinit, Page.deinit), so a page that stays alive while running heavy JS accumulates wrappers and external-ref'd Zig allocations V8 has no reason to drop. Fire memoryPressureNotification(.moderate) once per second from the wait loop.

Repro:

    lightpanda fetch --dump html --wait-ms 30000 \
        https://github.com/features/copilot

Before: wait loop iterates ~1s, then stalls inside one http_client.tick for 10+ seconds while RSS grows ~190 MB/s. Process OOMs the host (or cgroup) without returning from that tick.

After: wait loop iterates continuously through the full --wait-ms budget. Growth is still ~100 MB/s (the native-side DOM allocator leak is a separate, architectural fix — Node/Element need to participate in the V8 finalizer system so Frame.removeNode can _factory.destroy the removed node) but the process exits cleanly at the deadline instead of freezing inside curl.