### PR TITLE
Fix Frame.getElementByIdFromNode to recover from removed_ids

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1364,8 +1364,22 @@ pub fn removeElementIdWithMaps(self: *Frame, id_maps: ElementIdMaps, id: []const
 
 pub fn getElementByIdFromNode(self: *Frame, node: *Node, id: []const u8) ?*Element {
     if (node.isConnected() or node.isInShadowTree()) {
-        const lookup = self.getElementIdMap(node).lookup;
-        return lookup.get(id);
+        var current = node;
+        while (true) {
+            if (current.is(ShadowRoot)) |shadow_root| {
+                return shadow_root.getElementById(id, self);
+            }
+            const parent = current._parent orelse {
+                if (current._type == .document) {
+                    return current._type.document.getElementById(id, self);
+                }
+                if (IS_DEBUG) {
+                    std.debug.assert(false);
+                }
+                return null;
+            };
+            current = parent;
+        }
     }
     var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(node, .{});
     while (tw.next()) |el| {

--- a/src/browser/tests/element/duplicate_ids.html
+++ b/src/browser/tests/element/duplicate_ids.html
@@ -17,3 +17,24 @@
 
   // testing.expectEqual(null, document.getElementById('test'));
 </script>
+
+<div id="qs-test">first</div>
+<div id="qs-test">second</div>
+
+<script id=duplicateIdsQuerySelector>
+{
+  // Regression test: querySelector('#id') must agree with getElementById('id')
+  // when the first duplicate is removed. Selector engine fast path goes through
+  // Frame.getElementByIdFromNode, which previously only checked the lookup map
+  // and missed the _removed_ids recovery, so it returned null.
+  const first = document.querySelector('#qs-test');
+  testing.expectEqual('first', first.textContent);
+
+  first.remove();
+
+  testing.expectEqual('second', document.querySelector('#qs-test').textContent);
+  testing.expectEqual('second', document.body.querySelector('#qs-test').textContent);
+  testing.expectEqual(1, document.querySelectorAll('#qs-test').length);
+  testing.expectEqual('second', document.getElementById('qs-test').textContent);
+}
+</script>


### PR DESCRIPTION
## TL;DR

`querySelector('#id')` returned `null` when `getElementById('id')` returned the element. This fix makes them agree by construction.

## The bug

Given this HTML after some DOM manipulation:

```js
const id = 'page-title';
document.body.innerHTML = '<h1 id="' + id + '">a</h1>';
const newBody = document.createElement('body');
newBody.innerHTML = '<h1 id="' + id + '">b</h1>';
document.body.replaceWith(newBody);
```

The two lookups disagreed:

| Call | Before | After |
| --- | --- | --- |
| `document.querySelector('#page-title')` | `null` | `<h1>b</h1>` |
| `document.getElementById('page-title')` | `<h1>b</h1>` | `<h1>b</h1>` |

## How I hit it

I was using Lightpanda as the headless-browser backend for an automated test that runs CSS-selector assertions — effectively `await page.$('#page-title')` — against a live site.

The site uses [Turbo Drive](https://turbo.hotwired.dev/), a small client-side JS library that intercepts link clicks and swaps the current `<body>` for the new page's `<body>` to avoid a full reload. Its `PageRenderer.replaceBody` does the `innerHTML` + `replaceWith` sequence shown above, which is how the code path reached the bug.

## Root cause

Three functions look up an element by ID:

- `Document.getElementById` — checks `_elements_by_id`, falls back to `_removed_ids` + `TreeWalker` recovery
- `ShadowRoot.getElementById` — same fallback
- `Frame.getElementByIdFromNode` — **only checked `_elements_by_id`, no fallback** ← the bug

`Frame.getElementByIdFromNode` is the fast path for the selector engine's `#id` selector. After the first body was removed, the original `<h1>` ended up in `_removed_ids`. The new body's `<h1>` was never registered in the new map, so the `lookup` miss returned `null`. `Document.getElementById` recovered via `TreeWalker`; `getElementByIdFromNode` did not.

## The fix

Rather than duplicate the recovery logic a third time, dispatch to the existing canonical implementations:

1. Walk up ancestors from the node, the same way `getElementIdMap` already does.
2. When we reach a `ShadowRoot`, call `ShadowRoot.getElementById`.
3. When we reach the `Document` root, call `Document.getElementById`.

The selector `#id` fast path now goes through the same code path as `document.getElementById` / `shadowRoot.getElementById`, so they cannot drift apart again.

## Test

`src/browser/tests/element/duplicate_ids.html` gets a new script block asserting that `querySelector('#id')`, `querySelectorAll('#id')`, and `getElementById('id')` all return the same element after the first duplicate is removed.

## Test plan

- [x] `zig fmt --check src/browser/Frame.zig`
- [x] CI: `zig build test`

I have read the CLA Document and I hereby sign the CLA.