### PR TITLE
Fix same-url navigate

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -720,7 +720,10 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     };
 
     const session = target._session;
-    if (!opts.force and URL.eqlDocument(target.url, resolved_url)) {
+    // Short-circuit only true fragment-only navigations (same path/query, different
+    // fragment). Identical URLs fall through and trigger a real reload.
+    const is_fragment_navigation = !std.mem.eql(u8, target.url, resolved_url) and URL.eqlDocument(target.url, resolved_url);
+    if (!opts.force and is_fragment_navigation) {
         target.url = try target.arena.dupeZ(u8, resolved_url);
         target.window._location = try Location.init(target.url, target);
         if (target.parent == null) {

--- a/src/browser/tests/frames/frames.html
+++ b/src/browser/tests/frames/frames.html
@@ -151,8 +151,20 @@
   }
 </script>
 
+<iframe id=f7></iframe>
+<script id=onloadorder type=module>
+  {
+    const state = await testing.async();
+    $('#f7').onload = state.resolve;
+    $('#f7').src = "about:blank";
+    await state.done(() => {
+      testing.expectEqual(true, true);
+    });
+  }
+</script>
+
 <script id=count>
   testing.onload(() => {
-    testing.expectEqual(9, window.length);
+    testing.expectEqual(10, window.length);
   });
 </script>

--- a/src/browser/tests/window/location.html
+++ b/src/browser/tests/window/location.html
@@ -7,13 +7,13 @@
 </script>
 
 <script id=location_hash>
-  location.hash = "";
-  testing.expectEqual("", location.hash);
-  testing.expectEqual(testing.BASE_URL + 'window/location.html', location.href);
-
   location.hash = "#abcdef";
   testing.expectEqual("#abcdef", location.hash);
   testing.expectEqual(testing.BASE_URL + 'window/location.html#abcdef', location.href);
+
+  location.hash = "";
+  testing.expectEqual("", location.hash);
+  testing.expectEqual(testing.BASE_URL + 'window/location.html', location.href);
 
   location.hash = "xyzxyz";
   testing.expectEqual("#xyzxyz", location.hash);


### PR DESCRIPTION
Same-URL navigate should always cause a reload. The code that currently prevents a navigate on fragment change is too loose and treats identical URLs as being a fragment change..but for it to be considered a fragment change, the fragment actually has to change.

This improves some WPT compat where tests do:

```
<iframe></iframe>  <--- loads "about:blank"

<script>
document.querySelector('iframe').src = "about:blank"; <--- should load it again 
</script>
```