### PR TITLE
Fix SubmitEvent.submitter for requestSubmit() with no argument

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3701,7 +3701,15 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     };
 
     if (submit_opts.fire_event) {
-        const submitter_html: ?*HtmlElement = if (submitter_) |s| s.is(HtmlElement) else null;
+        // Per HTML spec "submit a form element" algorithm: SubmitEvent.submitter
+        // must be null when the submitter is the form itself, which is what
+        // Form.requestSubmit() passes when called with no submitter argument.
+        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit
+        const submitter_html: ?*HtmlElement = blk: {
+            const s = submitter_ orelse break :blk null;
+            if (s == form_element) break :blk null;
+            break :blk s.is(HtmlElement);
+        };
         const submit_event = (try SubmitEvent.initTrusted(comptime .wrap("submit"), .{ .bubbles = true, .cancelable = true, .submitter = submitter_html }, self)).asEvent();
 
         // so submit_event is still valid when we check _prevent_default

--- a/src/browser/tests/element/html/form.html
+++ b/src/browser/tests/element/html/form.html
@@ -485,12 +485,13 @@
 }
 </script>
 
-<!-- Test: requestSubmit() without submitter sets submitter to the form element -->
+<!-- Test: requestSubmit() without submitter sets SubmitEvent.submitter to null
+     per the HTML spec "submit a form element" algorithm step 4. -->
 <form id="test_form_submitter2" action="/should-not-navigate7" method="get">
   <input type="text" name="q" value="test">
 </form>
 
-<script id="requestSubmit_default_submitter_is_form">
+<script id="requestSubmit_default_submitter_is_null">
 {
   const form = $('#test_form_submitter2');
   let capturedSubmitter = undefined;
@@ -501,7 +502,7 @@
   });
 
   form.requestSubmit();
-  testing.expectEqual(form, capturedSubmitter);
+  testing.expectEqual(null, capturedSubmitter);
 }
 </script>
 


### PR DESCRIPTION
## What

`HTMLFormElement.prototype.requestSubmit()`, when called with no argument, fired a `SubmitEvent` whose `.submitter` was the form element instead of `null`. This commit aligns `Frame.submitForm` with the HTML spec's "submit a form element" algorithm, which collapses `submitter === form` back to `null` before constructing the event.

Closes #2252.

## Root cause

`Form.requestSubmit()` correctly follows spec step 2 by defaulting the internal `submitter` to the form element when no argument is passed, then calls `Frame.submitForm(form_element, form, ...)`. But `Frame.submitForm` was passing that `submitter_` straight through to `SubmitEvent.initTrusted` without applying the spec's "submit a form element" algorithm step 4:

> Let *submitterButton* be null.
> If *submitter* is not *form*, then set *submitterButton* to *submitter*.
> ... Fire an event named `submit` at *form*, using `SubmitEvent`, with the `submitter` attribute initialized to *submitterButton*, ...

The bug was introduced by my own #1984, which got `requestSubmit(button)` working but missed this null-collapse for the no-argument case.

```mermaid
flowchart LR
    A["Form.requestSubmit()<br/>(no argument)"] --> B["Frame.submitForm<br/>submitter_ = form_element"]
    B --> C["submitter_html = submitter_.is(HtmlElement)<br/>= form"]
    C --> D["SubmitEvent.submitter = form ❌"]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `submitForm`: coerce `submitter_` to `null` when it equals `form_element` before passing to `SubmitEvent.initTrusted`. Five-line change inside the existing `submit_opts.fire_event` block; behavior of explicit submitter buttons is unchanged.
- `src/browser/tests/element/html/form.html` — script `requestSubmit_default_submitter_is_null` (renamed from `_is_form`): the prior assertion was wrong and is replaced with `expectEqual(null, capturedSubmitter)`.

```mermaid
flowchart LR
    A["Form.requestSubmit()<br/>(no argument)"] --> B["Frame.submitForm<br/>submitter_ = form_element"]
    B --> C["if submitter_ == form_element:<br/>submitter_html = null"]
    C --> D["SubmitEvent.submitter = null ✅"]
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit test**: `src/browser/tests/element/html/form.html` script `requestSubmit_default_submitter_is_null` now asserts `e.submitter === null` for `form.requestSubmit()` with no argument. The existing `requestSubmit_sets_submitter` test (which passes a button explicitly) still asserts `e.submitter === btn`, confirming the no-argument fix doesn't regress the explicit-submitter path.
- **Reproducer**: `repro.sh` from #2252 exits `1` on `main` (`observed: {"submitterIsForm":true,"submitterIsNull":false,"submitterTagName":"FORM"}`) and exits `0` after this commit.

## Notes

- Behavior of `form.submit()` (the bare submit method) is unaffected — it's called with `.fire_event = false`, so the `SubmitEvent` block is skipped entirely.
- `FormData.init(form, submitter_, ...)` continues to receive the form element when called from `requestSubmit()` with no argument; this was already a no-op for FormData entry construction (the form fails the "is a submit button" check), so no FormData changes are needed.
