### PR TITLE
network: accept empty params on clearBrowserCookies, add getAllCookies

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -600,12 +600,11 @@ test "cdp.Network: clearBrowserCookies accepts empty params object" {
 
     // Most CDP clients (chrome-remote-interface, chromedp, etc.) always include
     // a `params` field on every command, even for methods that take none.
-    // Chrome ignores the empty object; we should too.
-    try ctx.processMessage(.{
-        .id = 2,
-        .method = "Network.clearBrowserCookies",
-        .params = .{},
-    });
+    // Chrome ignores the empty object; we should too. Sent as raw JSON because
+    // an empty Zig anonymous struct serializes as `[]`, not `{}`.
+    try ctx.processMessage(
+        \\{"id":2,"method":"Network.clearBrowserCookies","params":{}}
+    );
     try ctx.expectSentResult(null, .{ .id = 2 });
 
     try ctx.processMessage(.{
@@ -639,11 +638,11 @@ test "cdp.Network: getAllCookies returns whole jar regardless of current origin"
     });
     try ctx.expectSentResult(null, .{ .id = 1 });
 
-    try ctx.processMessage(.{
-        .id = 2,
-        .method = "Network.getAllCookies",
-        .params = .{},
-    });
+    // Empty params object — sent as raw JSON because an empty Zig anonymous
+    // struct serializes as `[]`, not `{}`.
+    try ctx.processMessage(
+        \\{"id":2,"method":"Network.getAllCookies","params":{}}
+    );
     try ctx.expectSentResult(.{
         .cookies = &[_]ResCookie{
             .{ .name = "a", .value = "1", .domain = "example.com", .path = "/", .size = 2, .secure = true },

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -45,6 +45,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         setCookie,
         setCookies,
         getCookies,
+        getAllCookies,
         getResponseBody,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
@@ -59,6 +60,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .setCookie => return setCookie(cmd),
         .setCookies => return setCookies(cmd),
         .getCookies => return getCookies(cmd),
+        .getAllCookies => return getAllCookies(cmd),
         .getResponseBody => return getResponseBody(cmd),
     }
 }
@@ -149,7 +151,10 @@ fn deleteCookies(cmd: *CDP.Command) !void {
 }
 
 fn clearBrowserCookies(cmd: *CDP.Command) !void {
-    if (try cmd.params(struct {}) != null) return error.InvalidParams;
+    // Network.clearBrowserCookies takes no parameters per the CDP spec, but most
+    // CDP clients (chrome-remote-interface, chromedp, custom websocket clients)
+    // include an empty `"params":{}` object on every command for ergonomics.
+    // Chrome accepts that and clears the jar; reject only on truly malformed JSON.
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     bc.session.cookie_jar.clearRetainingCapacity();
     return cmd.sendResult(null, .{});
@@ -202,6 +207,18 @@ fn getCookies(cmd: *CDP.Command) !void {
     var jar = &bc.session.cookie_jar;
     jar.removeExpired(null);
     const writer = CdpStorage.CookieWriter{ .cookies = jar.cookies.items, .urls = urls.items };
+    try cmd.sendResult(.{ .cookies = writer }, .{});
+}
+
+fn getAllCookies(cmd: *CDP.Command) !void {
+    // Returns every cookie in the jar regardless of the current frame's origin.
+    // Mirrors Chrome's Network.getAllCookies and Storage.getCookies (without
+    // the latter's browserContextId filter, since Network commands are scoped
+    // to the current browser context already).
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    var jar = &bc.session.cookie_jar;
+    jar.removeExpired(null);
+    const writer = CdpStorage.CookieWriter{ .cookies = jar.cookies.items };
     try cmd.sendResult(.{ .cookies = writer }, .{});
 }
 
@@ -564,4 +581,85 @@ test "cdp.Network: cookies" {
         .params = .{ .browserContextId = "BID-S" },
     });
     try ctx.expectSentResult(.{ .cookies = &[_]ResCookie{} }, .{ .id = 10 });
+}
+
+test "cdp.Network: clearBrowserCookies accepts empty params object" {
+    const CdpCookie = CdpStorage.CdpCookie;
+    const ResCookie = CdpStorage.ResCookie;
+
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-N1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCookie",
+        .params = CdpCookie{ .name = "foo", .value = "bar", .url = "https://example.com/" },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    // Most CDP clients (chrome-remote-interface, chromedp, etc.) always include
+    // a `params` field on every command, even for methods that take none.
+    // Chrome ignores the empty object; we should too.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Network.clearBrowserCookies",
+        .params = .{},
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Storage.getCookies",
+        .params = .{ .browserContextId = "BID-N1" },
+    });
+    try ctx.expectSentResult(.{ .cookies = &[_]ResCookie{} }, .{ .id = 3 });
+}
+
+test "cdp.Network: getAllCookies returns whole jar regardless of current origin" {
+    const CdpCookie = CdpStorage.CdpCookie;
+    const ResCookie = CdpStorage.ResCookie;
+
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-N2" });
+
+    // Two cookies on different origins. With no current frame URL,
+    // Network.getCookies (no `urls`) would return -32602 InvalidParams;
+    // Network.getAllCookies must still return both.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCookies",
+        .params = .{
+            .cookies = &[_]CdpCookie{
+                .{ .name = "a", .value = "1", .url = "https://example.com/" },
+                .{ .name = "b", .value = "2", .url = "https://other.test/" },
+            },
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Network.getAllCookies",
+        .params = .{},
+    });
+    try ctx.expectSentResult(.{
+        .cookies = &[_]ResCookie{
+            .{ .name = "a", .value = "1", .domain = "example.com", .path = "/", .size = 2, .secure = true },
+            .{ .name = "b", .value = "2", .domain = "other.test", .path = "/", .size = 2, .secure = true },
+        },
+    }, .{ .id = 2 });
+
+    // Also works without any params field at all (CDP-spec literal "no params").
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.getAllCookies",
+    });
+    try ctx.expectSentResult(.{
+        .cookies = &[_]ResCookie{
+            .{ .name = "a", .value = "1", .domain = "example.com", .path = "/", .size = 2, .secure = true },
+            .{ .name = "b", .value = "2", .domain = "other.test", .path = "/", .size = 2, .secure = true },
+        },
+    }, .{ .id = 3 });
 }


### PR DESCRIPTION
## What

Two small `Network.*` cookie-management fixes:

1. `Network.clearBrowserCookies` no longer rejects an empty `params: {}` object — most CDP clients (chrome-remote-interface, chromedp, raw websocket clients) include `"params":{}` on every command and Chrome silently accepts it.
2. `Network.getAllCookies` is now implemented. Previously it returned `UnknownMethod`, leaving clients no `Network.*` path to enumerate the in-memory jar across origins.

Closes #2254.

## Root cause

`src/cdp/domains/network.zig` `clearBrowserCookies` had an inverted-logic guard:

```zig
if (try cmd.params(struct {}) != null) return error.InvalidParams;
```

`cmd.params(T)` returns `null` only when the JSON message has no `params` field at all. With `"params":{}` present it parses successfully and returns `Some({})`, so the `!= null` branch fires and the jar is left untouched. Spec-conformant clients hit this on every call.

`getAllCookies` was simply absent from the `Network` dispatch enum, so `stringToEnum` returned `null` and the method dispatched to `error.UnknownMethod`.

```mermaid
flowchart LR
    A["Network.clearBrowserCookies<br/>(empty params object)"] --> B["guard: params != null fires"]
    B --> C["error -31998 InvalidParams"]
    D["Network.getAllCookies"] --> E["stringToEnum returns null"]
    E --> F["error -31998 UnknownMethod"]
    style B fill:#fdd
    style C fill:#fdd
    style E fill:#fdd
    style F fill:#fdd
```

## Fix

- `src/cdp/domains/network.zig` `clearBrowserCookies`: drop the inverted guard. Replaced with a comment explaining why an empty params object is accepted (CDP / JSON-RPC convention; matches sibling `Storage.clearCookies`).
- `src/cdp/domains/network.zig` `processMessage`: add `getAllCookies` to the action enum and switch.
- `src/cdp/domains/network.zig` new function `getAllCookies`: returns every cookie in the jar via the existing `CdpStorage.CookieWriter`, mirroring `Storage.getCookies` minus the `browserContextId` filter. No URL list, no origin scoping.

```mermaid
flowchart LR
    A["Network.clearBrowserCookies<br/>(empty params object)"] --> B["clear jar"]
    B --> C["empty result"]
    D["Network.getAllCookies"] --> E["CookieWriter, no urls filter"]
    E --> F["result.cookies = full list"]
    style B fill:#dfd
    style C fill:#dfd
    style E fill:#dfd
    style F fill:#dfd
```

## Test

Two new test blocks in `src/cdp/domains/network.zig`:

- `test "cdp.Network: clearBrowserCookies accepts empty params object"` — sends `params: .{}` (the spec-conformant call that fails today), asserts success and an empty jar afterward.
- `test "cdp.Network: getAllCookies returns whole jar regardless of current origin"` — sets cookies on two distinct origins (`example.com`, `other.test`), then asserts both shapes — with `params: .{}` and without any `params` field — return both cookies.

Both tests are added alongside the existing `test "cdp.Network: cookies"` block (kept untouched). Verified with the reproducer from the linked issue: exits 1 on `main`, exits 0 with this commit.

## Notes

`Network.clearBrowserCookies` previously also crashed the WebSocket on pre-`v0.2.6` (#1821 stopped the crash by adding the missing `clearRetainingCapacity()` call). This patch fixes a separate regression — the surviving handler then refused any spec-conformant call. The `Storage.clearCookies` and `Storage.getCookies` handlers already accept an empty params object via `(try cmd.params(T)) orelse T{}`; this brings `Network.clearBrowserCookies` in line.
