### PR TITLE
browser: trigger navigation when Location.pathname or .search is assigned

### DIFF
--- a/src/browser/tests/window/location.html
+++ b/src/browser/tests/window/location.html
@@ -23,3 +23,11 @@
   testing.expectEqual("", location.hash);
   testing.expectEqual(testing.BASE_URL + 'window/location.html', location.href);
 </script>
+
+<script id=location_pathname_setter>
+  testing.expectEqual('function', typeof Object.getOwnPropertyDescriptor(Location.prototype, 'pathname').set);
+</script>
+
+<script id=location_search_setter>
+  testing.expectEqual('function', typeof Object.getOwnPropertyDescriptor(Location.prototype, 'search').set);
+</script>

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const js = @import("../js/js.zig");
 
 const URL = @import("URL.zig");
+const U = @import("../URL.zig");
 const Frame = @import("../Frame.zig");
 
 const Location = @This();
@@ -63,6 +64,22 @@ pub fn getSearch(self: *const Location, exec: *const js.Execution) ![]const u8 {
 
 pub fn getHash(self: *const Location) []const u8 {
     return self._url.getHash();
+}
+
+pub fn setPathname(_: *const Location, pathname: []const u8, frame: *Frame) !void {
+    const new_url = try U.setPathname(frame.url, pathname, frame.call_arena);
+    return frame.scheduleNavigation(new_url, .{
+        .reason = .script,
+        .kind = .{ .push = null },
+    }, .{ .script = frame });
+}
+
+pub fn setSearch(_: *const Location, search: []const u8, frame: *Frame) !void {
+    const new_url = try U.setSearch(frame.url, search, frame.call_arena);
+    return frame.scheduleNavigation(new_url, .{
+        .reason = .script,
+        .kind = .{ .push = null },
+    }, .{ .script = frame });
 }
 
 pub fn setHash(_: *const Location, hash: []const u8, frame: *Frame) !void {
@@ -117,9 +134,9 @@ pub const JsApi = struct {
         return self.assign(url, frame);
     }
 
-    pub const search = bridge.accessor(Location.getSearch, null, .{});
+    pub const search = bridge.accessor(Location.getSearch, Location.setSearch, .{});
     pub const hash = bridge.accessor(Location.getHash, Location.setHash, .{});
-    pub const pathname = bridge.accessor(Location.getPathname, null, .{});
+    pub const pathname = bridge.accessor(Location.getPathname, Location.setPathname, .{});
     pub const hostname = bridge.accessor(Location.getHostname, null, .{});
     pub const host = bridge.accessor(Location.getHost, null, .{});
     pub const port = bridge.accessor(Location.getPort, null, .{});


### PR DESCRIPTION
## What

Per [HTML Living Standard §7.4.4.5.5](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-pathname) (and §7.4.4.5.6 for `search`), assigning to `Location.pathname` or `Location.search` must run the URL parser against a copy of the current URL and then "Location-object navigate" to the result. The current `JsApi` binding in `src/browser/webapi/Location.zig` registers both as read-only accessors (`null` setter), so assignments are silently no-ops — V8 returns the right-hand-side but Lightpanda neither updates the URL nor queues a navigation. `Location.hash` (and `Location.href`) already work; only these two are missing.

Closes #2256.

## Root cause

The `pathname` and `search` accessors in the `JsApi` block bind only the getter:

```zig
pub const search   = bridge.accessor(Location.getSearch,   null, .{});
pub const pathname = bridge.accessor(Location.getPathname, null, .{});
```

There is no `setPathname` / `setSearch` member function on `Location`, so V8 has nothing to invoke when JavaScript assigns to `location.pathname = ...`. The `setHash` member a few lines above shows the expected shape: compute the new URL via a helper in `src/browser/URL.zig`, then call `Frame.scheduleNavigation`.

```mermaid
flowchart LR
    A["JS: location.pathname = '/dest'"] --> B["V8 invokes pathname setter"]
    B --> C["JsApi accessor setter = null"]
    C --> D["No-op; URL unchanged"]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

Mirror the existing `setHash` implementation. Both setters use the matching helper from `src/browser/URL.zig` to compute the new full URL from `frame.url` and forward to `Frame.scheduleNavigation` with `kind = .push`, which matches Chrome's history-handling for these setters (a new entry is pushed onto the session history).

- `src/browser/webapi/Location.zig` — add `setPathname` and `setSearch` member functions; wire them into the `pathname` / `search` `JsApi` accessors in place of the `null` setters.
- `src/browser/tests/window/location.html` — add regression test blocks asserting that `Location.prototype.pathname` and `Location.prototype.search` expose a setter (`Object.getOwnPropertyDescriptor(...).set` is a function).

```mermaid
flowchart LR
    A["JS: location.pathname = '/dest'"] --> B["Location.setPathname"]
    B --> C["URL.setPathname(frame.url, '/dest')"]
    C --> D["Frame.scheduleNavigation(new_url, push)"]
    D --> E["Page loads /dest"]
    style B fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test** (`src/browser/tests/window/location.html`, picked up by `WebApi: Window` in `src/browser/webapi/Window.zig`): two new `<script>` blocks (`location_pathname_setter`, `location_search_setter`) assert that `Object.getOwnPropertyDescriptor(Location.prototype, 'pathname').set` and the equivalent for `search` are both `function`. Verified via `git stash`: the suite goes from `485/485 passed` to `WebApi: Window failure` when only the Zig change is reverted, confirming the new assertions actually exercise the JsApi binding.
- **Reproducer**: see #2256. Drives the CDP endpoint via `chrome-remote-interface`, navigates to `/start.html`, sets `location.pathname = '/dest.html'`, then re-reads `document.location.pathname`. On `main` the script prints `PATHNAME_AFTER: "/start.html"` and exits 1; with this commit it would print `"/dest.html"` and exit 0.

## Notes

- Scope intentionally limited to `pathname` and `search` (the two setters whose absence is observable from a CDP client driving navigation). `protocol`, `host`, `hostname`, `port` are also spec'd as writable on `Location` but are far less commonly assigned and have additional URL-validity edge cases — happy to file as a follow-up if useful.
- `Location.setHash` already exists and is unchanged.
- Both new setters use `kind = .push`. The existing `setHash` uses `kind = .replace`, which is a separate question (per spec, a same-document hash change is conventionally treated as a fresh history entry in Chrome) — left untouched here to keep this PR focused.
