### PR TITLE
forms: skip FormData entry for <select> with no selectedness candidate

### DIFF
--- a/src/browser/tests/net/form_data.html
+++ b/src/browser/tests/net/form_data.html
@@ -813,6 +813,72 @@
 }
 </script>
 
+<script id=selectWithoutOptions>
+{
+  // Per HTML spec (constructing form data set, step 5.5), a <select> only
+  // appends entries for options whose selectedness is true. With zero options,
+  // nothing is selected and no entry is appended.
+  const form = document.createElement('form');
+
+  const sel = document.createElement('select');
+  sel.name = 'choice';
+  form.appendChild(sel);
+
+  const sibling = document.createElement('input');
+  sibling.name = 'sibling';
+  sibling.value = 'kept';
+  form.appendChild(sibling);
+
+  const fd = new FormData(form);
+  testing.expectEqual(false, fd.has('choice'));
+  testing.expectEqual(null, fd.get('choice'));
+  testing.expectEqual([], fd.getAll('choice'));
+  testing.expectEqual('kept', fd.get('sibling'));
+  testing.expectEqual([['sibling', 'kept']], Array.from(fd.entries()));
+}
+</script>
+
+<script id=selectMultipleWithoutOptions>
+{
+  // Same rule for <select multiple> — with zero options, no entry.
+  const form = document.createElement('form');
+
+  const sel = document.createElement('select');
+  sel.name = 'tags';
+  sel.multiple = true;
+  form.appendChild(sel);
+
+  const fd = new FormData(form);
+  testing.expectEqual(false, fd.has('tags'));
+  testing.expectEqual([], fd.getAll('tags'));
+  testing.expectEqual([], Array.from(fd.entries()));
+}
+</script>
+
+<script id=selectAllOptionsDisabled>
+{
+  // A single-select with only disabled options has no auto-selected option,
+  // so no entry is appended.
+  const form = document.createElement('form');
+
+  const sel = document.createElement('select');
+  sel.name = 'mode';
+
+  const opt = document.createElement('option');
+  opt.value = 'off';
+  opt.disabled = true;
+  opt.textContent = 'off';
+  sel.appendChild(opt);
+
+  form.appendChild(sel);
+
+  const fd = new FormData(form);
+  testing.expectEqual(false, fd.has('mode'));
+  testing.expectEqual(null, fd.get('mode'));
+  testing.expectEqual([], fd.getAll('mode'));
+}
+</script>
+
 <script id=formDataEventModifyFormData>
 {
   // Listeners can modify formData during the event

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -44,8 +44,13 @@ pub fn asConstNode(self: *const Select) *const Node {
     return self.asConstElement().asConstNode();
 }
 
-pub fn getValue(self: *Select, frame: *Frame) []const u8 {
-    // Return value of first selected option, or first option if none selected
+// Resolves the option whose selectedness contributes to the select's value
+// per HTML §form-elements§selectedness-setting-algorithm: an explicitly
+// selected non-disabled option, falling back to the first non-disabled
+// option in tree order. Returns null if there is no candidate (zero options
+// or every option disabled), in which case the select has no selectedness
+// and contributes no entry to a FormData set.
+pub fn effectiveOption(self: *Select) ?*Option {
     var first_option: ?*Option = null;
     var iter = self.asNode().childrenIterator();
     while (iter.next()) |child| {
@@ -55,14 +60,17 @@ pub fn getValue(self: *Select, frame: *Frame) []const u8 {
         }
 
         if (option.getSelected()) {
-            return option.getValue(frame);
+            return option;
         }
         if (first_option == null) {
             first_option = option;
         }
     }
-    // No explicitly selected option, return first option's value
-    if (first_option) |opt| {
+    return first_option;
+}
+
+pub fn getValue(self: *Select, frame: *Frame) []const u8 {
+    if (self.effectiveOption()) |opt| {
         return opt.getValue(frame);
     }
     return "";

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -196,6 +196,17 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
 
             if (element.is(Form.Select)) |select| {
                 if (select.getMultiple() == false) {
+                    // Per the HTML spec, a single-select's selectedness comes
+                    // from an explicitly-selected option, falling back to the
+                    // first non-disabled option in tree order. With no options
+                    // (or only disabled ones), nothing is selected and no
+                    // entry is appended.
+                    var children = select.asNode().childrenIterator();
+                    const has_candidate = while (children.next()) |child| {
+                        const option = child.is(Form.Select.Option) orelse continue;
+                        if (!option.getDisabled()) break true;
+                    } else false;
+                    if (!has_candidate) continue;
                     break :blk select.getValue(frame);
                 }
 

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -196,18 +196,12 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
 
             if (element.is(Form.Select)) |select| {
                 if (select.getMultiple() == false) {
-                    // Per the HTML spec, a single-select's selectedness comes
-                    // from an explicitly-selected option, falling back to the
-                    // first non-disabled option in tree order. With no options
-                    // (or only disabled ones), nothing is selected and no
-                    // entry is appended.
-                    var children = select.asNode().childrenIterator();
-                    const has_candidate = while (children.next()) |child| {
-                        const option = child.is(Form.Select.Option) orelse continue;
-                        if (!option.getDisabled()) break true;
-                    } else false;
-                    if (!has_candidate) continue;
-                    break :blk select.getValue(frame);
+                    // Per the HTML spec, a single-select with no selectedness
+                    // candidate (zero options or every option disabled)
+                    // contributes no entry. Otherwise emit the candidate's
+                    // value.
+                    const opt = select.effectiveOption() orelse continue;
+                    break :blk opt.getValue(frame);
                 }
 
                 var options = try select.getSelectedOptions(frame);


### PR DESCRIPTION
## What

A `FormData` constructed from a form containing a `<select>` with zero `<option>` children leaks a phantom `(name, "")` entry. Per the HTML Living Standard ["constructing the form data set" step 5.5](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set), a `<select>` should only contribute entries for options whose selectedness is true; with no options, that set is empty and nothing should be appended. This patch guards the singular-select fast path in `collectForm` on the presence of at least one non-disabled `<option>` and skips the entry otherwise.

Closes #2262.

## Root cause

In `src/browser/webapi/net/FormData.zig#collectForm`, the non-multiple branch unconditionally falls through to `try list.append(arena, name, value)` with `value = select.getValue(frame)`. `Form.Select.getValue` returns the empty string for a `<select>` with no options, so the entry is appended as `(name, "")` even though the HTML spec says no entry should be appended at all. The same shortcut also misfires when every option is `disabled`: the auto-selectedness rule in [HTML §form-elements§selectedness-setting-algorithm](https://html.spec.whatwg.org/multipage/form-elements.html#selectedness-setting-algorithm) only auto-selects the first **non-disabled** option, so an all-disabled `<select>` likewise has no selectedness candidate.

```mermaid
flowchart LR
    A[FormData ctor with form arg] --> B["collectForm: select.getMultiple() == false branch"]
    B --> C["append name, select.getValue() unconditionally"]
    C --> D["Phantom (name, &quot;&quot;) entry"]
    style B fill:#fdd
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/webapi/net/FormData.zig` — `collectForm`: in the non-multiple `<select>` branch, walk the children once before emitting; if there is no non-disabled `<option>` child, `continue` past the trailing `list.append` call so no entry is appended. The existing `getValue(frame)` fallback is preserved for the common case where at least one candidate exists.

```mermaid
flowchart LR
    A[FormData ctor with form arg] --> B["collectForm: select.getMultiple() == false branch"]
    B --> C{"any non-disabled &lt;option&gt; child?"}
    C -->|yes| D["append name, select.getValue()"]
    C -->|no| E[skip — no selectedness candidate]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `src/browser/tests/net/form_data.html` — three new fixture blocks (`selectWithoutOptions`, `selectMultipleWithoutOptions`, `selectAllOptionsDisabled`) covering single-select with zero options, multi-select with zero options, and single-select where every option is disabled. The existing `WebApi: FormData` runner picks them up automatically. All three fixtures assert `fd.has(name) === false`, `fd.get(name) === null`, `fd.getAll(name)` is empty, and the entry list contains no row for the `<select>`'s name.
- **Reproducer**: a self-contained `repro.html` + `repro.sh` + `repro.js` (Node CDP driver) drives `Page.navigate` against a `<select name="empty"></select>` fixture, reads back the FormData state, and asserts no `empty` key. Today it prints `FAIL: a <select> with zero options leaked an entry into FormData.` and exits 1; with this commit it prints `OK: empty <select> contributed no entries (matches HTML spec).` and exits 0. See the issue for the full scripts.
- Verified locally with `mise exec -- zig build test -Dprebuilt_v8_path=...` (487 of 487 tests pass) and end-to-end via the reproducer against `./zig-out/bin/lightpanda` built from this branch.

## Notes

The behavior matches Chrome and Firefox in interactive testing: both omit the entry for a zero-option or all-disabled `<select>`. No public API surface changes; `Form.Select.getValue` is left untouched (it still returns `""` for callers like `select.value` that document a string return type even when no option is selected).
