### PR TITLE
http: inherit request URL fragment across fragment-less redirect

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1572,7 +1572,19 @@ pub const Transfer = struct {
             }
 
             const base_url = try conn.getEffectiveUrl();
-            break :blk try URL.resolve(arena, std.mem.span(base_url), location.value, .{});
+            const resolved = try URL.resolve(arena, std.mem.span(base_url), location.value, .{});
+
+            // RFC 7231 §7.1.2: if the Location value has no fragment, the redirect
+            // inherits the fragment from the URI used to generate the request.
+            // URL.resolve follows RFC 3986 §5.3, which drops the base fragment when
+            // the relative ref has none, so we re-attach it here.
+            if (URL.getHash(resolved).len == 0) {
+                const original_hash = URL.getHash(transfer.url);
+                if (original_hash.len != 0) {
+                    break :blk try std.mem.joinZ(arena, "", &.{ resolved, original_hash });
+                }
+            }
+            break :blk resolved;
         };
 
         try transfer.updateURL(url);

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -1003,6 +1003,60 @@ test "cdp.frame: reload" {
     }
 }
 
+test "cdp.frame: navigate inherits original fragment across redirect" {
+    // RFC 7231 §7.1.2: when a 3xx Location header has no fragment, the redirect
+    // inherits the fragment of the request URL.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-9", .url = "hi.html", .target_id = "FID-000000000X".* });
+
+    {
+        // Location: /redirect-target  (no fragment) — must inherit #myfrag.
+        try ctx.processMessage(.{
+            .id = 40,
+            .method = "Page.navigate",
+            .params = .{ .url = "http://127.0.0.1:9582/redirect-no-fragment#myfrag" },
+        });
+
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
+
+        const frame = bc.session.currentFrame() orelse unreachable;
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target#myfrag", frame.url);
+    }
+
+    {
+        // Location: /redirect-target#target_fragment — target's fragment wins.
+        try ctx.processMessage(.{
+            .id = 41,
+            .method = "Page.navigate",
+            .params = .{ .url = "http://127.0.0.1:9582/redirect-with-fragment#requested" },
+        });
+
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
+
+        const frame = bc.session.currentFrame() orelse unreachable;
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target#target_fragment", frame.url);
+    }
+
+    {
+        // No fragment on either side — final URL has no fragment.
+        try ctx.processMessage(.{
+            .id = 42,
+            .method = "Page.navigate",
+            .params = .{ .url = "http://127.0.0.1:9582/redirect-no-fragment" },
+        });
+
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
+
+        const frame = bc.session.currentFrame() orelse unreachable;
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target", frame.url);
+    }
+}
+
 test "cdp.frame: addScriptToEvaluateOnNewDocument" {
     var ctx = try testing.context();
     defer ctx.deinit();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -610,6 +610,32 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/redirect-no-fragment")) {
+        return req.respond("", .{
+            .status = .found,
+            .extra_headers = &.{
+                .{ .name = "Location", .value = "/redirect-target" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/redirect-target")) {
+        return req.respond("<!DOCTYPE html><title>landed</title>", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/html; charset=utf-8" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/redirect-with-fragment")) {
+        return req.respond("", .{
+            .status = .found,
+            .extra_headers = &.{
+                .{ .name = "Location", .value = "/redirect-target#target_fragment" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/xhr/404")) {
         return req.respond("Not Found", .{
             .status = .not_found,


### PR DESCRIPTION
## What

When a CDP client navigates to a URL with a fragment (e.g. `http://h/redirect#myfrag`) and the server replies 3xx with a `Location` header that has no fragment, Lightpanda drops the original fragment from the final URL. [RFC 7231 §7.1.2](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2) requires the redirect to inherit the request URL's fragment in that case. Chrome and Firefox follow the rule; Lightpanda did not.

Closes #2263.

## Root cause

`Transfer.handleRedirect` resolves the redirect target via `URL.resolve`, which implements [RFC 3986 §5.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.3): a relative reference with no fragment yields a resolved URL with no fragment, even when the base URL had one. The HTTP-specific override from RFC 7231 §7.1.2 was never applied, so `transfer.url` was updated to the fragment-less target and the frame's `window.location.href` reported it without the fragment.

```mermaid
flowchart LR
    A[3xx with Location: /landed] --> B[URL.resolve drops base fragment]
    B --> C[transfer.url == http://h/landed]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

After `URL.resolve` produces the redirect target, `handleRedirect` now checks the resolved URL with `URL.getHash`. If the resolved URL has no fragment and the previous `transfer.url` does, the original fragment is reattached to the resolved URL using the transfer's arena before `transfer.updateURL`. If the `Location` header itself has a fragment, the target's fragment wins (no inheritance), matching the spec.

- `src/browser/HttpClient.zig` — `Transfer.handleRedirect`: reattach the previous URL's fragment when the resolved redirect target has none.
- `src/cdp/domains/page.zig`: new test `cdp.frame: navigate inherits original fragment across redirect` covering the three cases (inherit, target wins, no fragment on either side).
- `src/testing.zig`: add `/redirect-no-fragment`, `/redirect-target`, `/redirect-with-fragment` routes used by the new test.

```mermaid
flowchart LR
    A[3xx with Location: /landed] --> B[resolved has no fragment +<br/>transfer.url has #myfrag]
    B --> C[reattach -> http://h/landed#myfrag]
    style B fill:#dfd
    style C fill:#dfd
```

## Test

- **Unit test**: `cdp.frame: navigate inherits original fragment across redirect` (in `src/cdp/domains/page.zig`) — fails on `main` (`window.location.href` is `http://127.0.0.1:9582/redirect-target` instead of `...#myfrag`), passes with this commit. Full `zig build test` suite (488 tests) passes.
- **Reproducer**: the script attached to #2263 prints `observed: http://127.0.0.1:9581/landed` and exits 1 against current nightly, prints `observed: http://127.0.0.1:9581/landed#myfrag` and exits 0 with this commit.

## Notes

The fix only inherits the fragment when the redirect target itself doesn't carry one — `Location: /landed#other` correctly keeps `#other`, even if the request URL had a different fragment. This is the spec behavior and is covered by the second test case.
