### PR TITLE
forms: honor formaction / formmethod / formenctype on submit button

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3735,7 +3735,16 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     const arena = try self._session.getArena(.medium, "submitForm");
     errdefer self._session.releaseArena(arena);
 
-    const enctype = form_element.getAttributeSafe(comptime .wrap("enctype"));
+    // Per HTML spec form-submission algorithm, when the submitter is a submit
+    // button, its formaction/formmethod/formenctype attributes override the
+    // form's corresponding attributes (matching how formtarget is honored above).
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit
+    const enctype = blk: {
+        if (submitter_) |s| {
+            if (s.getAttributeSafe(comptime .wrap("formenctype"))) |fe| break :blk fe;
+        }
+        break :blk form_element.getAttributeSafe(comptime .wrap("enctype"));
+    };
 
     // Get charset from accept-charset attribute or fall back to document charset
     const charset: []const u8 = blk: {
@@ -3752,8 +3761,18 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     var buf = std.Io.Writer.Allocating.init(arena);
     try form_data.write(.{ .enctype = enctype, .charset = charset, .allocator = arena }, &buf.writer);
 
-    const method = form_element.getAttributeSafe(comptime .wrap("method")) orelse "";
-    var action = form_element.getAttributeSafe(comptime .wrap("action")) orelse self.url;
+    const method = blk: {
+        if (submitter_) |s| {
+            if (s.getAttributeSafe(comptime .wrap("formmethod"))) |fm| break :blk fm;
+        }
+        break :blk form_element.getAttributeSafe(comptime .wrap("method")) orelse "";
+    };
+    var action = blk: {
+        if (submitter_) |s| {
+            if (s.getAttributeSafe(comptime .wrap("formaction"))) |fa| break :blk fa;
+        }
+        break :blk form_element.getAttributeSafe(comptime .wrap("action")) orelse self.url;
+    };
 
     var opts = NavigateOpts{
         .reason = .form,

--- a/src/browser/tests/frames/target.html
+++ b/src/browser/tests/frames/target.html
@@ -56,3 +56,73 @@
     });
   }
 </script>
+
+<!-- Per HTML spec, formaction on the submit button overrides the form's action.
+     https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit -->
+<iframe name=frame4 id=f4></iframe>
+<form target="frame4" action="support/should-not-load.html">
+  <input type=submit id=submit_formaction formaction="support/page.html">
+</form>
+
+<script id=formaction type=module>
+  {
+    const state = await testing.async();
+    $('#submit_formaction').click();
+    $('#f4').onload = () => {
+      state.resolve();
+    };
+
+    await state.done(() => {
+      testing.expectEqual('a-page\n', $('#f4').contentDocument.body.textContent);
+    });
+  }
+</script>
+
+<!-- Per HTML spec, formmethod on the submit button overrides the form's method.
+     A form with method=GET would append the FormData as ?x=probe to the action;
+     formmethod=POST should suppress that and send the values in the request body.
+     We verify the override by asserting the loaded iframe URL has no query string. -->
+<iframe name=frame5 id=f5></iframe>
+<form target="frame5" method="GET" action="support/page.html">
+  <input name="x" value="probe">
+  <input type=submit id=submit_formmethod formmethod="POST">
+</form>
+
+<script id=formmethod type=module>
+  {
+    const state = await testing.async();
+    $('#submit_formmethod').click();
+    $('#f5').onload = () => {
+      state.resolve();
+    };
+
+    await state.done(() => {
+      // formmethod=POST overrode form's GET, so the FormData entry was NOT
+      // appended to the action URL as a query string.
+      testing.expectEqual(false, $('#f5').contentDocument.URL.includes('?'));
+      testing.expectEqual('a-page\n', $('#f5').contentDocument.body.textContent);
+    });
+  }
+</script>
+
+<!-- Combined: formaction + formmethod on the same submit button. -->
+<iframe name=frame6 id=f6></iframe>
+<form target="frame6" method="GET" action="support/should-not-load.html">
+  <input name="x" value="probe">
+  <input type=submit id=submit_form_both formaction="support/page.html" formmethod="POST">
+</form>
+
+<script id=formaction_and_formmethod type=module>
+  {
+    const state = await testing.async();
+    $('#submit_form_both').click();
+    $('#f6').onload = () => {
+      state.resolve();
+    };
+
+    await state.done(() => {
+      testing.expectEqual(false, $('#f6').contentDocument.URL.includes('?'));
+      testing.expectEqual('a-page\n', $('#f6').contentDocument.body.textContent);
+    });
+  }
+</script>


### PR DESCRIPTION
## What

When a form is submitted via a click on a submit button (or `form.requestSubmit(button)`), the submitter's `formaction` / `formmethod` / `formenctype` attributes are silently ignored — the form's own attributes always win. Per the HTML form-submission algorithm these per-submitter attributes must override the form's, and the symmetrical lookup already exists for `formtarget`. This PR adds the same submitter-first lookup for the other three.

Closes #2278.

## Root cause

`Frame.submitForm` in `src/browser/Frame.zig` reads `action`, `method`, and `enctype` only from the form element. The submitter parameter (already plumbed through for the `disabled` check, `SubmitEvent.submitter`, and `FormData.init`) is ignored in those three lookups. `formtarget` works because that lookup is correct (lines 3684-3691 on `main`).

```mermaid
flowchart LR
    A[click submit button] --> B[Frame.submitForm]
    B --> C[action = form.action]
    B --> D[method = form.method]
    B --> E[enctype = form.enctype]
    C --> F[wrong URL]
    D --> F
    E --> F
    style C fill:#fdd
    style D fill:#fdd
    style E fill:#fdd
    style F fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `submitForm`: wrap the `enctype` / `method` / `action` lookups in submitter-first blocks, falling back to the form's attribute when the submitter has none. Mirrors the existing `formtarget` block.

```mermaid
flowchart LR
    A[click submit button] --> B[Frame.submitForm]
    B --> C[action = submitter.formaction OR form.action]
    B --> D[method = submitter.formmethod OR form.method]
    B --> E[enctype = submitter.formenctype OR form.enctype]
    C --> F[correct URL]
    D --> F
    E --> F
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
    style F fill:#dfd
```

## Test

- **HTML test**: `src/browser/tests/frames/target.html` adds three new fixtures next to the existing `formtarget` test:
  - `formaction` — form action `support/should-not-load.html`, button `formaction="support/page.html"` → iframe loads `page.html`
  - `formmethod` — form method `GET` action `support/page.html`, input `name=x value=probe`, button `formmethod="POST"` → iframe URL has no query string (POST sent the FormData in the body, not appended to the URL)
  - `formaction_and_formmethod` — both overrides on the same submitter
- Verified locally: `TEST_FILTER='WebApi: Frames#target' mise exec -- zig build test $V8` passes with the fix, fails on `main`.
- **Reproducer**: a self-contained `repro.sh` (HTML fixture + Python static server + Node CDP driver via raw `ws`) is documented in #2278. Exits 1 on `main` (3 of 4 cases FAIL), exits 0 with this commit (all 4 PASS) when run against a local debug build of this branch.

## Notes

- DOM-level IDL accessors `formAction` / `formMethod` / `formEnctype` are not exposed on `HTMLButtonElement` / `HTMLInputElement` upstream yet — the `getAttribute('formaction')` / etc. content-attribute path used here works regardless. Adding the IDL accessors is independent and out of scope for this PR.
- The submit-button check is intentionally not gated on `isSubmitButton(submitter)` — the existing `formtarget` lookup at lines 3684-3691 doesn't gate either, and a non-button submitter (e.g. an `<input type=text>` after Enter) won't have these attributes set on it in well-formed HTML, so the `getAttributeSafe` returns `null` and the form's attribute is used. Matches precedent.
