### PR TITLE
Input file foundation

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3861,12 +3861,19 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     // button, its formaction/formmethod/formenctype attributes override the
     // form's corresponding attributes (matching how formtarget is honored above).
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit
-    const enctype = blk: {
+    const enctype_attr = blk: {
         if (submitter_) |s| {
             if (s.getAttributeSafe(comptime .wrap("formenctype"))) |fe| break :blk fe;
         }
         break :blk form_element.getAttributeSafe(comptime .wrap("enctype"));
     };
+    const method = blk: {
+        if (submitter_) |s| {
+            if (s.getAttributeSafe(comptime .wrap("formmethod"))) |fm| break :blk fm;
+        }
+        break :blk form_element.getAttributeSafe(comptime .wrap("method")) orelse "";
+    };
+    const is_post = std.ascii.eqlIgnoreCase(method, "post");
 
     // Get charset from accept-charset attribute or fall back to document charset
     const charset: []const u8 = blk: {
@@ -3880,15 +3887,26 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
         break :blk self.charset;
     };
 
-    var buf = std.Io.Writer.Allocating.init(arena);
-    try form_data.write(.{ .enctype = enctype, .charset = charset, .allocator = arena }, &buf.writer);
-
-    const method = blk: {
-        if (submitter_) |s| {
-            if (s.getAttributeSafe(comptime .wrap("formmethod"))) |fm| break :blk fm;
+    var boundary_buf: [36]u8 = undefined;
+    // GET ignores enctype per HTML spec; only resolve the union for POST.
+    const encoding: FormData.EncType = blk: {
+        if (is_post) {
+            if (enctype_attr) |attr| {
+                if (std.ascii.eqlIgnoreCase(attr, "multipart/form-data")) {
+                    @import("../id.zig").uuidv4(&boundary_buf);
+                    break :blk .{ .formdata = &boundary_buf };
+                }
+                if (!std.ascii.eqlIgnoreCase(attr, "application/x-www-form-urlencoded")) {
+                    log.warn(.not_implemented, "FormData.encoding", .{ .encoding = attr });
+                }
+            }
         }
-        break :blk form_element.getAttributeSafe(comptime .wrap("method")) orelse "";
+        break :blk .urlencode;
     };
+
+    var buf = std.Io.Writer.Allocating.init(arena);
+    try form_data.write(.{ .encoding = encoding, .charset = charset, .allocator = arena }, &buf.writer);
+
     var action = blk: {
         if (submitter_) |s| {
             if (s.getAttributeSafe(comptime .wrap("formaction"))) |fa| break :blk fa;
@@ -3900,11 +3918,13 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
         .reason = .form,
         .kind = .{ .push = null },
     };
-    if (std.ascii.eqlIgnoreCase(method, "post")) {
+    if (is_post) {
         opts.method = .POST;
         opts.body = buf.written();
-        // form_data.write currently only supports this encoding, so we know this has to be the content type
-        opts.header = "Content-Type: application/x-www-form-urlencoded";
+        opts.header = switch (encoding) {
+            .urlencode => "Content-Type: application/x-www-form-urlencoded",
+            .formdata => |b| try std.fmt.allocPrintSentinel(arena, "Content-Type: multipart/form-data; boundary={s}", .{b}, 0),
+        };
     } else {
         action = try URL.concatQueryString(arena, action, buf.written());
     }

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -206,6 +206,11 @@ fn urlEncodeEntry(entry: Entry, comptime mode: URLEncodeMode, allocator_: ?Alloc
     try urlEncodeValue(entry.value.str(), mode, allocator_, charset, writer);
 }
 
+// Exposed so FormData (which keeps its own entry list) can reuse the charset/NCR-aware encoder.
+pub fn urlEncodeFormValue(value: []const u8, allocator_: ?Allocator, charset: []const u8, writer: *std.Io.Writer) !void {
+    return urlEncodeValue(value, .form, allocator_, charset, writer);
+}
+
 fn urlEncodeValue(value: []const u8, comptime mode: URLEncodeMode, allocator_: ?Allocator, charset: []const u8, writer: *std.Io.Writer) !void {
     // For UTF-8, do standard percent encoding
     if (std.mem.eql(u8, charset, "UTF-8")) {

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -23,22 +23,41 @@ const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
 const Form = @import("../element/html/Form.zig");
 const Element = @import("../Element.zig");
+const File = @import("../File.zig");
 const KeyValueList = @import("../KeyValueList.zig");
 
 const log = lp.log;
+const String = lp.String;
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 
 const FormData = @This();
 
 _arena: Allocator,
-_list: KeyValueList,
+_entries: std.ArrayList(Entry),
+
+pub const Entry = struct {
+    name: String,
+    value: Value,
+
+    const Value = union(enum) {
+        file: *File,
+        string: String,
+
+        fn asString(self: *const Value) []const u8 {
+            return switch (self.*) {
+                .string => |*s| s.str(),
+                .file => unreachable, // nothing currently creates this type of value
+            };
+        }
+    };
+};
 
 pub fn init(form_: ?*Form, submitter: ?*Element, exec: *const Execution) !*FormData {
     const form = form_ orelse {
         return try exec._factory.create(FormData{
             ._arena = exec.arena,
-            ._list = KeyValueList.init(),
+            ._entries = .empty,
         });
     };
 
@@ -49,7 +68,7 @@ pub fn init(form_: ?*Form, submitter: ?*Element, exec: *const Execution) !*FormD
 
     const form_data = try exec._factory.create(FormData{
         ._arena = exec.arena,
-        ._list = try collectForm(frame.arena, form, submitter, frame),
+        ._entries = try collectForm(frame.arena, form, submitter, frame),
     });
 
     const form_data_event = try (@import("../event/FormDataEvent.zig")).initTrusted(
@@ -62,47 +81,78 @@ pub fn init(form_: ?*Form, submitter: ?*Element, exec: *const Execution) !*FormD
     return form_data;
 }
 
-pub fn get(self: *const FormData, name: []const u8) ?[]const u8 {
-    return self._list.get(name);
+pub fn get(self: *const FormData, name: String) ?[]const u8 {
+    for (self._entries.items) |*entry| {
+        if (entry.name.eql(name)) {
+            return entry.value.asString();
+        }
+    }
+    return null;
 }
 
-pub fn getAll(self: *const FormData, name: []const u8, exec: *const Execution) ![]const []const u8 {
-    return self._list.getAll(exec.call_arena, name);
+pub fn getAll(self: *const FormData, name: String, exec: *const Execution) ![]const []const u8 {
+    var arr: std.ArrayList([]const u8) = .empty;
+    for (self._entries.items) |*entry| {
+        if (entry.name.eql(name)) {
+            try arr.append(exec.call_arena, entry.value.asString());
+        }
+    }
+    return arr.items;
 }
 
-pub fn has(self: *const FormData, name: []const u8) bool {
-    return self._list.has(name);
+pub fn has(self: *const FormData, name: String) bool {
+    for (self._entries.items) |*entry| {
+        if (entry.name.eql(name)) {
+            return true;
+        }
+    }
+    return false;
 }
 
-pub fn set(self: *FormData, name: []const u8, value: []const u8) !void {
-    return self._list.set(self._arena, name, value);
+pub fn set(self: *FormData, name: String, value: []const u8) !void {
+    self.deleteByName(name);
+    return self.append(name.str(), value);
 }
 
 pub fn append(self: *FormData, name: []const u8, value: []const u8) !void {
-    return self._list.append(self._arena, name, value);
+    try self._entries.append(self._arena, .{
+        .name = try String.init(self._arena, name, .{}),
+        .value = .{ .string = try String.init(self._arena, value, .{}) },
+    });
 }
 
-pub fn delete(self: *FormData, name: []const u8) void {
-    self._list.delete(name, null);
+pub fn delete(self: *FormData, name: String) void {
+    self.deleteByName(name);
 }
 
-pub fn keys(self: *FormData, exec: *const js.Execution) !*KeyValueList.KeyIterator {
-    return KeyValueList.KeyIterator.init(.{ .list = self, .kv = &self._list }, exec);
+fn deleteByName(self: *FormData, name: String) void {
+    var i: usize = 0;
+    while (i < self._entries.items.len) {
+        if (self._entries.items[i].name.eql(name)) {
+            _ = self._entries.swapRemove(i);
+            continue;
+        }
+        i += 1;
+    }
 }
 
-pub fn values(self: *FormData, exec: *const js.Execution) !*KeyValueList.ValueIterator {
-    return KeyValueList.ValueIterator.init(.{ .list = self, .kv = &self._list }, exec);
+pub fn keys(self: *FormData, exec: *const js.Execution) !*KeyIterator {
+    return KeyIterator.init(.{ .fd = self, .list = self }, exec);
 }
 
-pub fn entries(self: *FormData, exec: *const js.Execution) !*KeyValueList.EntryIterator {
-    return KeyValueList.EntryIterator.init(.{ .list = self, .kv = &self._list }, exec);
+pub fn values(self: *FormData, exec: *const js.Execution) !*ValueIterator {
+    return ValueIterator.init(.{ .fd = self, .list = self }, exec);
+}
+
+pub fn entries(self: *FormData, exec: *const js.Execution) !*EntryIterator {
+    return EntryIterator.init(.{ .fd = self, .list = self }, exec);
 }
 
 pub fn forEach(self: *FormData, cb_: js.Function, js_this_: ?js.Object) !void {
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
-    for (self._list._entries.items) |entry| {
-        cb.call(void, .{ entry.value.str(), entry.name.str(), self }) catch |err| {
+    for (self._entries.items) |*entry| {
+        cb.call(void, .{ entry.value.asString(), entry.name.str(), self }) catch |err| {
             // this is a non-JS error
             log.warn(.js, "FormData.forEach", .{ .err = err });
         };
@@ -117,11 +167,11 @@ pub const WriteOpts = struct {
 
 pub fn write(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !void {
     const enctype = opts.enctype orelse {
-        return self._list.urlEncode(.form, opts.allocator, opts.charset, writer);
+        return self.urlEncode(opts, writer);
     };
 
     if (std.ascii.eqlIgnoreCase(enctype, "application/x-www-form-urlencoded")) {
-        return self._list.urlEncode(.form, opts.allocator, opts.charset, writer);
+        return self.urlEncode(opts, writer);
     }
 
     log.warn(.not_implemented, "FormData.encoding", .{
@@ -129,27 +179,71 @@ pub fn write(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !vo
     });
 }
 
+fn urlEncode(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !void {
+    const items = self._entries.items;
+    if (items.len == 0) return;
+
+    try urlEncodeEntry(&items[0], opts, writer);
+    for (items[1..]) |*entry| {
+        try writer.writeByte('&');
+        try urlEncodeEntry(entry, opts, writer);
+    }
+}
+
+fn urlEncodeEntry(entry: *const Entry, opts: WriteOpts, writer: *std.Io.Writer) !void {
+    try KeyValueList.urlEncodeFormValue(entry.name.str(), opts.allocator, opts.charset, writer);
+    try writer.writeByte('=');
+    try KeyValueList.urlEncodeFormValue(entry.value.asString(), opts.allocator, opts.charset, writer);
+}
+
+// Used by URLSearchParams to ingest a FormData; file entries collapse via Value.asString.
+pub fn toKeyValueList(self: *const FormData, arena: Allocator) !KeyValueList {
+    var list: KeyValueList = .empty;
+    try list.ensureTotalCapacity(arena, self._entries.items.len);
+    for (self._entries.items) |*entry| {
+        try list.appendAssumeCapacity(arena, entry.name.str(), entry.value.asString());
+    }
+    return list;
+}
+
 pub const Iterator = struct {
     index: u32 = 0,
-    list: *const FormData,
+    fd: *FormData,
 
-    const Entry = struct { []const u8, []const u8 };
+    // See KeyValueList.Iterator.list — required by the GenericIterator wrapper.
+    list: *anyopaque,
 
-    pub fn next(self: *Iterator, _: *Frame) !?Iterator.Entry {
+    pub const Entry = struct { []const u8, []const u8 };
+
+    pub fn next(self: *Iterator, _: *const Execution) ?Iterator.Entry {
         const index = self.index;
-        const items = self.list._list.items();
+        const items = self.fd._entries.items;
         if (index >= items.len) {
             return null;
         }
         self.index = index + 1;
 
         const e = &items[index];
-        return .{ e.name.str(), e.value.str() };
+        return .{ e.name.str(), e.value.asString() };
     }
 };
 
-fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *Frame) !KeyValueList {
-    var list: KeyValueList = .empty;
+const GenericIterator = @import("../collections/iterator.zig").Entry;
+pub const KeyIterator = GenericIterator(Iterator, "0");
+pub const ValueIterator = GenericIterator(Iterator, "1");
+pub const EntryIterator = GenericIterator(Iterator, null);
+
+pub fn registerTypes() []const type {
+    return &.{
+        FormData,
+        KeyIterator,
+        ValueIterator,
+        EntryIterator,
+    };
+}
+
+fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *Frame) !std.ArrayList(Entry) {
+    var list: std.ArrayList(Entry) = .empty;
     const form = form_ orelse return list;
 
     var elements = try form.getElements(frame);
@@ -170,8 +264,8 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
                 const name = element.getAttributeSafe(comptime .wrap("name"));
                 const x_key = if (name) |n| try std.fmt.allocPrint(arena, "{s}.x", .{n}) else "x";
                 const y_key = if (name) |n| try std.fmt.allocPrint(arena, "{s}.y", .{n}) else "y";
-                try list.append(arena, x_key, "0");
-                try list.append(arena, y_key, "0");
+                try appendString(&list, arena, x_key, "0");
+                try appendString(&list, arena, y_key, "0");
                 continue;
             }
         }
@@ -206,7 +300,7 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
 
                 var options = try select.getSelectedOptions(frame);
                 while (options.next()) |option| {
-                    try list.append(arena, name, option.as(Form.Select.Option).getValue(frame));
+                    try appendString(&list, arena, name, option.as(Form.Select.Option).getValue(frame));
                 }
                 continue;
             }
@@ -224,9 +318,16 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
             }
             continue;
         };
-        try list.append(arena, name, value);
+        try appendString(&list, arena, name, value);
     }
     return list;
+}
+
+fn appendString(list: *std.ArrayList(Entry), arena: Allocator, name: []const u8, value: []const u8) !void {
+    try list.append(arena, .{
+        .name = try String.init(arena, name, .{}),
+        .value = .{ .string = try String.init(arena, value, .{}) },
+    });
 }
 
 pub const JsApi = struct {

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -159,24 +159,23 @@ pub fn forEach(self: *FormData, cb_: js.Function, js_this_: ?js.Object) !void {
     }
 }
 
+pub const EncType = union(enum) {
+    urlencode,
+    // Boundary delimiter; caller owns the bytes (must outlive the write).
+    formdata: []const u8,
+};
+
 pub const WriteOpts = struct {
-    enctype: ?[]const u8 = null,
+    encoding: EncType = .urlencode,
     charset: []const u8 = "UTF-8",
     allocator: ?std.mem.Allocator = null,
 };
 
 pub fn write(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !void {
-    const enctype = opts.enctype orelse {
-        return self.urlEncode(opts, writer);
-    };
-
-    if (std.ascii.eqlIgnoreCase(enctype, "application/x-www-form-urlencoded")) {
-        return self.urlEncode(opts, writer);
+    switch (opts.encoding) {
+        .urlencode => return self.urlEncode(opts, writer),
+        .formdata => |boundary| return self.multipartEncode(boundary, writer),
     }
-
-    log.warn(.not_implemented, "FormData.encoding", .{
-        .encoding = enctype,
-    });
 }
 
 fn urlEncode(self: *const FormData, opts: WriteOpts, writer: *std.Io.Writer) !void {
@@ -194,6 +193,42 @@ fn urlEncodeEntry(entry: *const Entry, opts: WriteOpts, writer: *std.Io.Writer) 
     try KeyValueList.urlEncodeFormValue(entry.name.str(), opts.allocator, opts.charset, writer);
     try writer.writeByte('=');
     try KeyValueList.urlEncodeFormValue(entry.value.asString(), opts.allocator, opts.charset, writer);
+}
+
+fn multipartEncode(self: *const FormData, boundary: []const u8, writer: *std.Io.Writer) !void {
+    for (self._entries.items) |*entry| {
+        try multipartEncodeEntry(entry, boundary, writer);
+    }
+    try writer.print("--{s}--\r\n", .{boundary});
+}
+
+fn multipartEncodeEntry(entry: *const Entry, boundary: []const u8, writer: *std.Io.Writer) !void {
+    try writer.print("--{s}\r\n", .{boundary});
+    const value_ptr = &entry.value;
+    switch (value_ptr.*) {
+        .string => |*s| {
+            try writer.writeAll("Content-Disposition: form-data; name=\"");
+            try writeMultipartName(writer, entry.name.str());
+            try writer.writeAll("\"\r\n\r\n");
+            try writer.writeAll(s.str());
+            try writer.writeAll("\r\n");
+        },
+        // File entries need a real payload (filename + bytes + Content-Type) — not yet wired.
+        .file => log.warn(.not_implemented, "FormData.multipart.file", .{}),
+    }
+}
+
+// Per RFC 7578 §4.2, Content-Disposition names are quoted-string form;
+// CR/LF/" must be escaped.
+fn writeMultipartName(writer: *std.Io.Writer, name: []const u8) !void {
+    for (name) |c| {
+        switch (c) {
+            '"' => try writer.writeAll("%22"),
+            '\r' => try writer.writeAll("%0D"),
+            '\n' => try writer.writeAll("%0A"),
+            else => try writer.writeByte(c),
+        }
+    }
 }
 
 // Used by URLSearchParams to ingest a FormData; file entries collapse via Value.asString.
@@ -356,4 +391,73 @@ pub const JsApi = struct {
 const testing = @import("../../../testing.zig");
 test "WebApi: FormData" {
     try testing.htmlRunner("net/form_data.html", .{});
+}
+
+test "FormData: multipart write" {
+    const allocator = testing.arena_allocator;
+
+    var fd = FormData{
+        ._arena = allocator,
+        ._entries = .empty,
+    };
+    try fd.append("name", "John");
+    try fd.append("note", "two\r\nlines");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try fd.write(.{
+        .encoding = .{ .formdata = "BOUNDARY" },
+        .allocator = allocator,
+    }, &buf.writer);
+
+    try testing.expectString(
+        "--BOUNDARY\r\n" ++
+            "Content-Disposition: form-data; name=\"name\"\r\n\r\n" ++
+            "John\r\n" ++
+            "--BOUNDARY\r\n" ++
+            "Content-Disposition: form-data; name=\"note\"\r\n\r\n" ++
+            "two\r\nlines\r\n" ++
+            "--BOUNDARY--\r\n",
+        buf.written(),
+    );
+}
+
+test "FormData: multipart escapes name CR/LF/quote" {
+    const allocator = testing.arena_allocator;
+
+    var fd = FormData{
+        ._arena = allocator,
+        ._entries = .empty,
+    };
+    try fd.append("a\"b\r\nc", "v");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try fd.write(.{
+        .encoding = .{ .formdata = "B" },
+        .allocator = allocator,
+    }, &buf.writer);
+
+    try testing.expectString(
+        "--B\r\n" ++
+            "Content-Disposition: form-data; name=\"a%22b%0D%0Ac\"\r\n\r\n" ++
+            "v\r\n" ++
+            "--B--\r\n",
+        buf.written(),
+    );
+}
+
+test "FormData: multipart empty body" {
+    const allocator = testing.arena_allocator;
+
+    var fd = FormData{
+        ._arena = allocator,
+        ._entries = .empty,
+    };
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try fd.write(.{
+        .encoding = .{ .formdata = "B" },
+        .allocator = allocator,
+    }, &buf.writer);
+
+    try testing.expectString("--B--\r\n", buf.written());
 }

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -46,7 +46,7 @@ pub fn init(opts_: ?InitOpts, exec: *const Execution) !*URLSearchParams {
         const opts = opts_ orelse break :blk .empty;
         switch (opts) {
             .query_string => |qs| break :blk try paramsFromString(arena, qs, exec.buf),
-            .form_data => |fd| break :blk try KeyValueList.copy(arena, fd._list),
+            .form_data => |fd| break :blk try fd.toKeyValueList(arena),
             .value => |js_val| {
                 // Order matters here; Array is also an Object.
                 if (js_val.isArray()) {


### PR DESCRIPTION
Initial work on supporting input type=file. This makes two changes:

1 - FormData is now based on its own ArrayList(Entry) rather than re-using KeyValueList. This allows its values to be a union{string, *File}.

2 - FormData.write can now encode multipart form data.

Neither of these enables input type=file, they both just add some foundation. Both these treat `entry.value == file` as `unreachable` since nothing can currently create such an entry.

Issue: https://github.com/lightpanda-io/browser/issues/2175