### PR TITLE
browser: fix HTMLCollection empty name WPT

### DIFF
--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -72,6 +72,10 @@ pub fn getAtIndex(self: *HTMLCollection, index: usize, frame: *const Frame) ?*El
 }
 
 pub fn getByName(self: *HTMLCollection, name: []const u8, frame: *Frame) ?*Element {
+    if (name.len == 0) {
+        return null;
+    }
+
     return switch (self._data) {
         .empty => null,
         inline else => |*impl| impl.getByName(name, frame),
@@ -146,7 +150,15 @@ pub const JsApi = struct {
 
     pub const length = bridge.accessor(HTMLCollection.length, null, .{});
     pub const @"[int]" = bridge.indexed(HTMLCollection.getAtIndex, null, .{ .null_as_undefined = true });
-    pub const @"[str]" = bridge.namedIndexed(HTMLCollection.getByName, null, null, .{ .null_as_undefined = true });
+    pub const @"[str]" = bridge.namedIndexed(struct {
+        pub fn wrap(self: *HTMLCollection, name: []const u8, frame: *Frame) !?*Element {
+            if (name.len == 0) {
+                return error.NotHandled;
+            }
+
+            return self.getByName(name, frame);
+        }
+    }.wrap, null, null, .{ .null_as_undefined = true });
 
     pub const item = bridge.function(_item, .{});
     fn _item(self: *HTMLCollection, index: i32, frame: *Frame) ?*Element {


### PR DESCRIPTION
This PR fixes the /dom/collections/HTMLCollection-empty-name.html tests. Attached screenshot below for the same

<img width="2560" height="1220" alt="image" src="https://github.com/user-attachments/assets/cc755eca-bccf-48fd-a28e-612bae69bb94" />