### PR TITLE
Split ScriptManager to support worker module imports

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -411,7 +411,7 @@ pub fn deinit(self: *Frame, abort_http: bool) void {
     const browser = page.session.browser;
     browser.env.destroyContext(self.js);
 
-    self._script_manager.shutdown = true;
+    self._script_manager.base.shutdown = true;
 
     if (self.parent == null) {
         browser.http_client.abort();

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -21,124 +21,69 @@ const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
 const HttpClient = @import("HttpClient.zig");
-const http = @import("../network/http.zig");
 
 const js = @import("js/js.zig");
 const URL = @import("URL.zig");
 const Frame = @import("Frame.zig");
+const ScriptManagerBase = @import("ScriptManagerBase.zig");
 
 const Element = @import("webapi/Element.zig");
 
 const log = lp.log;
-const String = lp.String;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
 
 const ScriptManager = @This();
 
+// Re-exports so Frame / Context callers don't need to import Base directly.
+pub const Script = ScriptManagerBase.Script;
+pub const ModuleSource = ScriptManagerBase.ModuleSource;
+
+base: ScriptManagerBase,
 frame: *Frame,
 
-// used to prevent recursive evaluation
-is_evaluating: bool,
-
-// Only once this is true can deferred scripts be run
-static_scripts_done: bool,
-
-// List of async scripts. We don't care about the execution order of these, but
-// on shutdown/abort, we need to cleanup any pending ones.
-async_scripts: std.DoublyLinkedList,
-
-// List of deferred scripts. These must be executed in order, but only once
-// dom_loaded == true,
-defer_scripts: std.DoublyLinkedList,
-
-// When an async script is ready, it's queued here. We played with executing
-// them as they complete, but it can cause timing issues with v8 module loading.
-ready_scripts: std.DoublyLinkedList,
-
-shutdown: bool = false,
-
-client: *HttpClient,
-allocator: Allocator,
-
-// We can download multiple sync modules in parallel, but we want to process
-// them in order. We can't use an std.DoublyLinkedList, like the other script types,
-// because the order we load them might not be the order we want to process
-// them in (I'm not sure this is true, but as far as I can tell, v8 doesn't
-// make any guarantees about the list of sub-module dependencies it gives us
-// So this is more like a cache. When an imported module is completed, its
-// source is placed here (keyed by the full url) for some point in the future
-// when v8 asks for it.
-// The type is confusing (too confusing? move to a union). Starts of as `null`
-// then transitions to either an error (from errorCallback) or the completed
-// buffer from doneCallback
-imported_modules: std.StringHashMapUnmanaged(ImportedModule),
-
-// Mapping between module specifier and resolution.
-// see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
-// importmap contains resolved urls.
-importmap: std.StringHashMapUnmanaged([:0]const u8),
-
-// have we notified the frame that all scripts are loaded (used to fire the "load"
-// event).
+// have we notified the frame that all scripts are loaded (used to fire the
+// "load" event).
 frame_notified_of_completion: bool,
 
 pub fn init(allocator: Allocator, http_client: *HttpClient, frame: *Frame) ScriptManager {
+    var base = ScriptManagerBase.init(allocator, http_client, .{ .frame = frame });
+    base.tail_hook = tailHook;
     return .{
         .frame = frame,
-        .async_scripts = .{},
-        .defer_scripts = .{},
-        .ready_scripts = .{},
-        .importmap = .empty,
-        .is_evaluating = false,
-        .allocator = allocator,
-        .imported_modules = .empty,
-        .client = http_client,
-        .static_scripts_done = false,
+        .base = base,
         .frame_notified_of_completion = false,
     };
 }
 
 pub fn deinit(self: *ScriptManager) void {
-    // necessary to free any arenas scripts may be referencing
-    self.reset();
-
-    self.imported_modules.deinit(self.allocator);
-    // we don't deinit self.importmap b/c we use the frame's arena for its
-    // allocations.
+    self.base.deinit();
 }
 
 pub fn reset(self: *ScriptManager) void {
-    var it = self.imported_modules.valueIterator();
-    while (it.next()) |value_ptr| {
-        switch (value_ptr.state) {
-            .done => |script| script.deinit(),
-            else => {},
-        }
-    }
-    self.imported_modules.clearRetainingCapacity();
-
-    // Our allocator is the frame arena, it's been reset. We cannot use
-    // clearAndRetainCapacity, since that space is no longer ours
-    self.importmap = .empty;
-
-    clearList(&self.defer_scripts);
-    clearList(&self.async_scripts);
-    clearList(&self.ready_scripts);
-    self.static_scripts_done = false;
+    self.base.reset();
+    self.frame_notified_of_completion = false;
 }
 
-fn clearList(list: *std.DoublyLinkedList) void {
-    while (list.popFirst()) |n| {
-        const script: *Script = @fieldParentPtr("node", n);
-        script.deinit();
+// Frame wrapper uses this to fire documentIsLoaded and scriptsCompletedLoading
+// once Base has finished processing its ready / defer queues.
+pub fn tailHook(base: *ScriptManagerBase) void {
+    const self: *ScriptManager = @fieldParentPtr("base", base);
+    const frame = self.frame;
+
+    // When all scripts (normal and deferred) are done loading, the document
+    // state changes (this ultimately triggers the DOMContentLoaded event).
+    // Page makes this safe to call multiple times.
+    frame.documentIsLoaded();
+
+    if (base.async_scripts.first == null and self.frame_notified_of_completion == false) {
+        self.frame_notified_of_completion = true;
+        frame.scriptsCompletedLoading();
     }
 }
 
-fn getHeaders(self: *ScriptManager) !http.Headers {
-    var headers = try self.client.newHeaders();
-    try self.frame.headersForRequest(&headers);
-    return headers;
+fn getHeaders(self: *ScriptManager) !HttpClient.Headers {
+    return self.base.getHeaders();
 }
 
 pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_element: *Element.Html.Script, comptime ctx: []const u8) !void {
@@ -226,7 +171,7 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
         .kind = kind,
         .node = .{},
         .arena = arena,
-        .manager = self,
+        .manager = &self.base,
         .source = source,
         .script_element = script_element,
         .complete = is_inline,
@@ -261,7 +206,7 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
 
     const is_blocking = script.mode == .normal;
     if (is_blocking == false) {
-        self.scriptList(script).append(&script.node);
+        self.base.scriptList(script).append(&script.node);
     }
 
     if (remote_url) |url| {
@@ -278,15 +223,15 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
             });
         }
 
-        const was_evaluating = self.is_evaluating;
-        self.is_evaluating = true;
-        defer self.is_evaluating = was_evaluating;
+        const was_evaluating = self.base.is_evaluating;
+        self.base.is_evaluating = true;
+        defer self.base.is_evaluating = was_evaluating;
 
         const headers = try self.getHeaders();
         errdefer headers.deinit();
 
         if (is_blocking) {
-            const response = try self.client.syncRequest(arena, .{
+            const response = try self.base.client.syncRequest(arena, .{
                 .url = url,
                 .method = .GET,
                 .frame_id = frame._frame_id,
@@ -303,11 +248,11 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
             script.complete = true;
         } else {
             errdefer {
-                self.scriptList(script).remove(&script.node);
+                self.base.scriptList(script).remove(&script.node);
                 // Let the outer errdefer handle releasing the arena if client.request fails
             }
 
-            try self.client.request(.{
+            try self.base.client.request(.{
                 .ctx = script,
                 .params = .{
                     .url = url,
@@ -342,292 +287,17 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
     }
 
     // could have already been evaluating if this is dynamically added
-    const was_evaluating = self.is_evaluating;
-    self.is_evaluating = true;
+    const was_evaluating = self.base.is_evaluating;
+    self.base.is_evaluating = true;
     defer {
-        self.is_evaluating = was_evaluating;
+        self.base.is_evaluating = was_evaluating;
         script.deinit();
     }
 
     script.eval(frame);
 }
 
-fn scriptList(self: *ScriptManager, script: *const Script) *std.DoublyLinkedList {
-    return switch (script.mode) {
-        .normal => unreachable, // not added to a list, executed immediately
-        .@"defer" => &self.defer_scripts,
-        .async, .import_async, .import => &self.async_scripts,
-    };
-}
-
-// Resolve a module specifier to an valid URL.
-pub fn resolveSpecifier(self: *ScriptManager, arena: Allocator, base: [:0]const u8, specifier: [:0]const u8) ![:0]const u8 {
-    // If the specifier is mapped in the importmap, return the pre-resolved value.
-    if (self.importmap.get(specifier)) |s| {
-        return s;
-    }
-
-    return URL.resolve(arena, base, specifier, .{ .always_dupe = true });
-}
-
-pub fn preloadImport(self: *ScriptManager, url: [:0]const u8, referrer: []const u8) !void {
-    const gop = try self.imported_modules.getOrPut(self.allocator, url);
-    if (gop.found_existing) {
-        gop.value_ptr.waiters += 1;
-        return;
-    }
-    errdefer _ = self.imported_modules.remove(url);
-
-    const frame = self.frame;
-    const arena = try frame.getArena(.large, "SM.preloadImport");
-    errdefer frame.releaseArena(arena);
-
-    const script = try arena.create(Script);
-    script.* = .{
-        .kind = .module,
-        .arena = arena,
-        .url = url,
-        .node = .{},
-        .manager = self,
-        .complete = false,
-        .script_element = null,
-        .source = .{ .remote = .{} },
-        .mode = .import,
-    };
-
-    gop.value_ptr.* = ImportedModule{};
-
-    if (comptime IS_DEBUG) {
-        var ls: js.Local.Scope = undefined;
-        frame.js.localScope(&ls);
-        defer ls.deinit();
-
-        log.debug(.http, "script queue", .{
-            .url = url,
-            .ctx = "module",
-            .referrer = referrer,
-            .stack = ls.local.stackTrace() catch "???",
-        });
-    }
-
-    // This seems wrong since we're not dealing with an async import (unlike
-    // getAsyncModule below), but all we're trying to do here is pre-load the
-    // script for execution at some point in the future (when waitForImport is
-    // called).
-    self.async_scripts.append(&script.node);
-
-    self.client.request(.{
-        .ctx = script,
-        .params = .{
-            .url = url,
-            .method = .GET,
-            .frame_id = frame._frame_id,
-            .loader_id = frame._loader_id,
-            .headers = try self.getHeaders(),
-            .cookie_jar = &frame._session.cookie_jar,
-            .cookie_origin = frame.url,
-            .resource_type = .script,
-            .notification = frame._session.notification,
-        },
-        .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
-        .header_callback = Script.headerCallback,
-        .data_callback = Script.dataCallback,
-        .done_callback = Script.doneCallback,
-        .error_callback = Script.errorCallback,
-    }) catch |err| {
-        self.async_scripts.remove(&script.node);
-        return err;
-    };
-}
-
-pub fn waitForImport(self: *ScriptManager, url: [:0]const u8) !ModuleSource {
-    const entry = self.imported_modules.getEntry(url) orelse {
-        // It shouldn't be possible for v8 to ask for a module that we didn't
-        // `preloadImport` above.
-        return error.UnknownModule;
-    };
-
-    const was_evaluating = self.is_evaluating;
-    self.is_evaluating = true;
-    defer self.is_evaluating = was_evaluating;
-
-    var client = self.client;
-    while (true) {
-        switch (entry.value_ptr.state) {
-            .loading => {
-                _ = try client.tick(200);
-                continue;
-            },
-            .done => |script| {
-                var shared = false;
-                const buffer = entry.value_ptr.buffer;
-                const waiters = entry.value_ptr.waiters;
-
-                if (waiters == 1) {
-                    self.imported_modules.removeByPtr(entry.key_ptr);
-                } else {
-                    shared = true;
-                    entry.value_ptr.waiters = waiters - 1;
-                }
-                return .{
-                    .buffer = buffer,
-                    .shared = shared,
-                    .script = script,
-                };
-            },
-            .err => return error.Failed,
-        }
-    }
-}
-
-pub fn getAsyncImport(self: *ScriptManager, url: [:0]const u8, cb: ImportAsync.Callback, cb_data: *anyopaque, referrer: []const u8) !void {
-    const frame = self.frame;
-    const arena = try frame.getArena(.large, "SM.getAsyncImport");
-    errdefer frame.releaseArena(arena);
-
-    const script = try arena.create(Script);
-    script.* = .{
-        .kind = .module,
-        .arena = arena,
-        .url = url,
-        .node = .{},
-        .manager = self,
-        .complete = false,
-        .script_element = null,
-        .source = .{ .remote = .{} },
-        .mode = .{ .import_async = .{
-            .callback = cb,
-            .data = cb_data,
-        } },
-    };
-
-    if (comptime IS_DEBUG) {
-        var ls: js.Local.Scope = undefined;
-        frame.js.localScope(&ls);
-        defer ls.deinit();
-
-        log.debug(.http, "script queue", .{
-            .url = url,
-            .ctx = "dynamic module",
-            .referrer = referrer,
-            .stack = ls.local.stackTrace() catch "???",
-        });
-    }
-
-    // It's possible, but unlikely, for client.request to immediately finish
-    // a request, thus calling our callback. We generally don't want a call
-    // from v8 (which is why we're here), to result in a new script evaluation.
-    // So we block even the slightest change that `client.request` immediately
-    // executes a callback.
-    const was_evaluating = self.is_evaluating;
-    self.is_evaluating = true;
-    defer self.is_evaluating = was_evaluating;
-
-    self.async_scripts.append(&script.node);
-    self.client.request(.{
-        .ctx = script,
-        .params = .{
-            .url = url,
-            .method = .GET,
-            .frame_id = frame._frame_id,
-            .loader_id = frame._loader_id,
-            .headers = try self.getHeaders(),
-            .resource_type = .script,
-            .cookie_jar = &frame._session.cookie_jar,
-            .cookie_origin = frame.url,
-            .notification = frame._session.notification,
-        },
-        .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
-        .header_callback = Script.headerCallback,
-        .data_callback = Script.dataCallback,
-        .done_callback = Script.doneCallback,
-        .error_callback = Script.errorCallback,
-    }) catch |err| {
-        self.async_scripts.remove(&script.node);
-        return err;
-    };
-}
-
-// Called from the Page to let us know it's done parsing the HTML. Necessary that
-// we know this so that we know that we can start evaluating deferred scripts.
-pub fn staticScriptsDone(self: *ScriptManager) void {
-    lp.assert(self.static_scripts_done == false, "ScriptManager.staticScriptsDone", .{});
-    self.static_scripts_done = true;
-    self.evaluate();
-}
-
-fn evaluate(self: *ScriptManager) void {
-    if (self.is_evaluating) {
-        // It's possible for a script.eval to cause evaluate to be called again.
-        return;
-    }
-
-    const frame = self.frame;
-    self.is_evaluating = true;
-    defer self.is_evaluating = false;
-
-    while (self.ready_scripts.popFirst()) |n| {
-        var script: *Script = @fieldParentPtr("node", n);
-        switch (script.mode) {
-            .async => {
-                defer script.deinit();
-                script.eval(frame);
-            },
-            .import_async => |ia| {
-                if (script.status < 200 or script.status > 299) {
-                    script.deinit();
-                    ia.callback(ia.data, error.FailedToLoad);
-                } else {
-                    ia.callback(ia.data, .{
-                        .shared = false,
-                        .script = script,
-                        .buffer = script.source.remote,
-                    });
-                }
-            },
-            else => unreachable, // no other script is put in this list
-        }
-    }
-
-    if (self.static_scripts_done == false) {
-        // We can only execute deferred scripts if
-        // 1 - all the normal scripts are done
-        // 2 - we've finished parsing the HTML and at least queued all the scripts
-        // The last one isn't obvious, but it's possible for self.scripts to
-        // be empty not because we're done executing all the normal scripts
-        // but because we're done executing some (or maybe none), but we're still
-        // parsing the HTML.
-        return;
-    }
-
-    while (self.defer_scripts.first) |n| {
-        var script: *Script = @fieldParentPtr("node", n);
-        if (script.complete == false) {
-            return;
-        }
-        defer {
-            _ = self.defer_scripts.popFirst();
-            script.deinit();
-        }
-        script.eval(frame);
-    }
-
-    // At this point all normal scripts and deferred scripts are done, PLUS
-    // the frame has signaled that it's done parsing HTML (static_scripts_done == true).
-    //
-
-    // When all scripts (normal and deferred) are done loading, the document
-    // state changes (this ultimately triggers the DOMContentLoaded event).
-    // Page makes this safe to call multiple times.
-    frame.documentIsLoaded();
-
-    if (self.async_scripts.first == null and self.frame_notified_of_completion == false) {
-        self.frame_notified_of_completion = true;
-        frame.scriptsCompletedLoading();
-    }
-}
-
-fn parseImportmap(self: *ScriptManager, script: *const Script) !void {
+pub fn parseImportmap(self: *ScriptManager, script: *const Script) !void {
     const content = script.source.content();
 
     const Imports = struct {
@@ -653,364 +323,13 @@ fn parseImportmap(self: *ScriptManager, script: *const Script) !void {
             .{},
         );
 
-        try self.importmap.put(self.frame.arena, entry.key_ptr.*, resolved_url);
+        try self.base.importmap.put(self.frame.arena, entry.key_ptr.*, resolved_url);
     }
 }
 
-pub const Script = struct {
-    kind: Kind,
-    complete: bool,
-    status: u16 = 0,
-    source: Source,
-    url: []const u8,
-    arena: Allocator,
-    mode: ExecutionMode,
-    node: std.DoublyLinkedList.Node,
-    script_element: ?*Element.Html.Script,
-    manager: *ScriptManager,
-
-    // for debugging a rare production issue
-    header_callback_called: bool = false,
-
-    // for debugging a rare production issue
-    debug_transfer_id: u32 = 0,
-    debug_transfer_tries: u8 = 0,
-    debug_transfer_aborted: bool = false,
-    debug_transfer_bytes_received: usize = 0,
-    debug_transfer_notified_fail: bool = false,
-    debug_transfer_auth_challenge: bool = false,
-    debug_transfer_easy_id: usize = 0,
-
-    const Kind = enum {
-        module,
-        javascript,
-        importmap,
-    };
-
-    const Callback = union(enum) {
-        string: []const u8,
-        function: js.Function,
-    };
-
-    const Source = union(enum) {
-        @"inline": []const u8,
-        remote: std.ArrayList(u8),
-
-        fn content(self: Source) []const u8 {
-            return switch (self) {
-                .remote => |buf| buf.items,
-                .@"inline" => |c| c,
-            };
-        }
-    };
-
-    const ExecutionMode = union(enum) {
-        normal,
-        @"defer",
-        async,
-        import,
-        import_async: ImportAsync,
-    };
-
-    fn deinit(self: *Script) void {
-        self.manager.frame.releaseArena(self.arena);
-    }
-
-    fn startCallback(response: HttpClient.Response) !void {
-        log.debug(.http, "script fetch start", .{ .req = response });
-    }
-
-    fn headerCallback(response: HttpClient.Response) !bool {
-        const self: *Script = @ptrCast(@alignCast(response.ctx));
-
-        self.status = response.status().?;
-        if (response.status() != 200) {
-            log.info(.http, "script header", .{
-                .req = response,
-                .status = response.status(),
-                .content_type = response.contentType(),
-            });
-            return false;
-        }
-
-        if (comptime IS_DEBUG) {
-            log.debug(.http, "script header", .{
-                .req = response,
-                .status = response.status(),
-                .content_type = response.contentType(),
-            });
-        }
-
-        switch (response.inner) {
-            .transfer => |transfer| {
-                // temp debug, trying to figure out why the next assert sometimes
-                // fails. Is the buffer just corrupt or is headerCallback really
-                // being called twice?
-                lp.assert(self.header_callback_called == false, "ScriptManager.Header recall", .{
-                    .m = @tagName(std.meta.activeTag(self.mode)),
-                    .a1 = self.debug_transfer_id,
-                    .a2 = self.debug_transfer_tries,
-                    .a3 = self.debug_transfer_aborted,
-                    .a4 = self.debug_transfer_bytes_received,
-                    .a5 = self.debug_transfer_notified_fail,
-                    .a8 = self.debug_transfer_auth_challenge,
-                    .a9 = self.debug_transfer_easy_id,
-                    .b1 = transfer.id,
-                    .b2 = transfer._tries,
-                    .b3 = transfer.aborted,
-                    .b4 = transfer.bytes_received,
-                    .b5 = transfer._notified_fail,
-                    .b8 = transfer._auth_challenge != null,
-                    .b9 = if (transfer._conn) |c| @intFromPtr(c._easy) else 0,
-                });
-                self.header_callback_called = true;
-                self.debug_transfer_id = transfer.id;
-                self.debug_transfer_tries = transfer._tries;
-                self.debug_transfer_aborted = transfer.aborted;
-                self.debug_transfer_bytes_received = transfer.bytes_received;
-                self.debug_transfer_notified_fail = transfer._notified_fail;
-                self.debug_transfer_auth_challenge = transfer._auth_challenge != null;
-                self.debug_transfer_easy_id = if (transfer._conn) |c| @intFromPtr(c._easy) else 0;
-            },
-            else => {},
-        }
-
-        lp.assert(self.source.remote.capacity == 0, "ScriptManager.Header buffer", .{ .capacity = self.source.remote.capacity });
-        var buffer: std.ArrayList(u8) = .empty;
-        if (response.contentLength()) |cl| {
-            try buffer.ensureTotalCapacity(self.arena, cl);
-        }
-        self.source = .{ .remote = buffer };
-        return true;
-    }
-
-    fn dataCallback(response: HttpClient.Response, data: []const u8) !void {
-        const self: *Script = @ptrCast(@alignCast(response.ctx));
-        self._dataCallback(response, data) catch |err| {
-            log.err(.http, "SM.dataCallback", .{ .err = err, .transfer = response, .len = data.len });
-            return err;
-        };
-    }
-
-    fn _dataCallback(self: *Script, _: HttpClient.Response, data: []const u8) !void {
-        try self.source.remote.appendSlice(self.arena, data);
-    }
-
-    fn doneCallback(ctx: *anyopaque) !void {
-        const self: *Script = @ptrCast(@alignCast(ctx));
-        self.complete = true;
-        if (comptime IS_DEBUG) {
-            log.debug(.http, "script fetch complete", .{ .req = self.url });
-        }
-
-        const manager = self.manager;
-        if (self.mode == .async or self.mode == .import_async) {
-            manager.async_scripts.remove(&self.node);
-            manager.ready_scripts.append(&self.node);
-        } else if (self.mode == .import) {
-            manager.async_scripts.remove(&self.node);
-            const entry = manager.imported_modules.getPtr(self.url).?;
-            entry.state = .{ .done = self };
-            entry.buffer = self.source.remote;
-        }
-        manager.evaluate();
-    }
-
-    fn errorCallback(ctx: *anyopaque, err: anyerror) void {
-        const self: *Script = @ptrCast(@alignCast(ctx));
-        log.warn(.http, "script fetch error", .{
-            .err = err,
-            .req = self.url,
-            .mode = std.meta.activeTag(self.mode),
-            .kind = self.kind,
-            .status = self.status,
-        });
-
-        if (self.mode == .normal) {
-            // This is blocked in a loop at the end of addFromElement, setting
-            // it to complete with a status of 0 will signal the error.
-            self.status = 0;
-            self.complete = true;
-            return;
-        }
-
-        const manager = self.manager;
-        manager.scriptList(self).remove(&self.node);
-        if (manager.shutdown) {
-            self.deinit();
-            return;
-        }
-
-        switch (self.mode) {
-            .import_async => |ia| ia.callback(ia.data, error.FailedToLoad),
-            .import => {
-                const entry = manager.imported_modules.getPtr(self.url).?;
-                entry.state = .err;
-            },
-            else => {},
-        }
-        self.deinit();
-        manager.evaluate();
-    }
-
-    fn eval(self: *Script, frame: *Frame) void {
-        // never evaluated, source is passed back to v8, via callbacks.
-        if (comptime IS_DEBUG) {
-            std.debug.assert(self.mode != .import_async);
-
-            // never evaluated, source is passed back to v8 when asked for it.
-            std.debug.assert(self.mode != .import);
-        }
-
-        if (frame.isGoingAway()) {
-            // don't evaluate scripts for a dying frame.
-            return;
-        }
-
-        const script_element = self.script_element.?;
-
-        const previous_script = frame.document._current_script;
-        frame.document._current_script = script_element;
-        defer frame.document._current_script = previous_script;
-
-        // Clear the document.write insertion point for this script
-        const previous_write_insertion_point = frame.document._write_insertion_point;
-        frame.document._write_insertion_point = null;
-        defer frame.document._write_insertion_point = previous_write_insertion_point;
-
-        // inline scripts aren't cached. remote ones are.
-        const cacheable = self.source == .remote;
-
-        const url = self.url;
-
-        log.info(.browser, "executing script", .{
-            .src = url,
-            .kind = self.kind,
-            .cacheable = cacheable,
-        });
-
-        var ls: js.Local.Scope = undefined;
-        frame.js.localScope(&ls);
-        defer ls.deinit();
-
-        const local = &ls.local;
-
-        // Handle importmap special case here: the content is a JSON containing
-        // imports.
-        if (self.kind == .importmap) {
-            frame._script_manager.parseImportmap(self) catch |err| {
-                log.err(.browser, "parse importmap script", .{
-                    .err = err,
-                    .src = url,
-                    .kind = self.kind,
-                    .cacheable = cacheable,
-                });
-                self.executeCallback(comptime .wrap("error"), frame);
-                return;
-            };
-            self.executeCallback(comptime .wrap("load"), frame);
-            return;
-        }
-
-        defer frame._event_manager.clearIgnoreList();
-
-        var try_catch: js.TryCatch = undefined;
-        try_catch.init(local);
-        defer try_catch.deinit();
-
-        const success = blk: {
-            const content = self.source.content();
-            switch (self.kind) {
-                .javascript => _ = local.eval(content, url) catch break :blk false,
-                .module => {
-                    // We don't care about waiting for the evaluation here.
-                    frame.js.module(false, local, content, url, cacheable) catch break :blk false;
-                },
-                .importmap => unreachable, // handled before the try/catch.
-            }
-            break :blk true;
-        };
-
-        if (comptime IS_DEBUG) {
-            log.debug(.browser, "executed script", .{ .src = url, .success = success });
-        }
-
-        defer {
-            local.runMacrotasks(); // also runs microtasks
-            _ = frame.js.scheduler.run() catch |err| {
-                log.err(.frame, "scheduler", .{ .err = err });
-            };
-        }
-
-        if (success) {
-            self.executeCallback(comptime .wrap("load"), frame);
-            return;
-        }
-
-        const caught = try_catch.caughtOrError(frame.call_arena, error.Unknown);
-        log.warn(.js, "eval script", .{
-            .url = url,
-            .caught = caught,
-            .cacheable = cacheable,
-        });
-
-        self.executeCallback(comptime .wrap("error"), frame);
-    }
-
-    fn executeCallback(self: *const Script, typ: String, frame: *Frame) void {
-        const Event = @import("webapi/Event.zig");
-        const event = Event.initTrusted(typ, .{}, frame._page) catch |err| {
-            log.warn(.js, "script internal callback", .{
-                .url = self.url,
-                .type = typ,
-                .err = err,
-            });
-            return;
-        };
-        frame._event_manager.dispatchOpts(self.script_element.?.asNode().asEventTarget(), event, .{ .apply_ignore = true }) catch |err| {
-            log.warn(.js, "script callback", .{
-                .url = self.url,
-                .type = typ,
-                .err = err,
-            });
-        };
-    }
-};
-
-const ImportAsync = struct {
-    data: *anyopaque,
-    callback: ImportAsync.Callback,
-
-    pub const Callback = *const fn (ptr: *anyopaque, result: anyerror!ModuleSource) void;
-};
-
-pub const ModuleSource = struct {
-    shared: bool,
-    script: *Script,
-    buffer: std.ArrayList(u8),
-
-    pub fn deinit(self: *ModuleSource) void {
-        if (self.shared == false) {
-            self.script.deinit();
-        }
-    }
-
-    pub fn src(self: *const ModuleSource) []const u8 {
-        return self.buffer.items;
-    }
-};
-
-const ImportedModule = struct {
-    waiters: u16 = 1,
-    state: State = .loading,
-    buffer: std.ArrayList(u8) = .{},
-
-    const State = union(enum) {
-        err,
-        loading,
-        done: *Script,
-    };
-};
+pub fn staticScriptsDone(self: *ScriptManager) void {
+    self.base.staticScriptsDone();
+}
 
 // Parses data:[<media-type>][;base64],<data>
 fn parseDataURI(allocator: Allocator, src: []const u8) !?[]const u8 {

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -1,0 +1,810 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+const builtin = @import("builtin");
+
+const HttpClient = @import("HttpClient.zig");
+const http = @import("../network/http.zig");
+
+const js = @import("js/js.zig");
+const URL = @import("URL.zig");
+const Session = @import("Session.zig");
+const Frame = @import("Frame.zig");
+const WorkerGlobalScope = @import("webapi/WorkerGlobalScope.zig");
+
+const Element = @import("webapi/Element.zig");
+
+const log = lp.log;
+const String = lp.String;
+const Allocator = std.mem.Allocator;
+const IS_DEBUG = builtin.mode == .Debug;
+
+const ScriptManagerBase = @This();
+
+// Either a *Frame (for page ScriptManagers) or *WorkerGlobalScope (for workers).
+// Used from HTTP callbacks that only have a *Script in hand; the Script reaches
+// the owner through its manager pointer.
+pub const Owner = union(enum) {
+    frame: *Frame,
+    worker: *WorkerGlobalScope,
+
+    pub fn url(self: Owner) [:0]const u8 {
+        return switch (self) {
+            .frame => |f| f.url,
+            .worker => |w| w.url,
+        };
+    }
+
+    pub fn frameId(self: Owner) u32 {
+        return switch (self) {
+            .frame => |f| f._frame_id,
+            .worker => |w| w._worker._frame_id,
+        };
+    }
+
+    pub fn loaderId(self: Owner) u32 {
+        return switch (self) {
+            .frame => |f| f._loader_id,
+            .worker => |w| w._worker._loader_id,
+        };
+    }
+
+    pub fn session(self: Owner) *Session {
+        return switch (self) {
+            .frame => |f| f._session,
+            .worker => |w| w._session,
+        };
+    }
+
+    pub fn jsContext(self: Owner) *js.Context {
+        return switch (self) {
+            .frame => |f| f.js,
+            .worker => |w| w.js,
+        };
+    }
+
+    pub fn addHeaders(self: Owner, headers: *HttpClient.Headers) !void {
+        switch (self) {
+            .frame => |f| try f.headersForRequest(headers),
+            .worker => {},
+        }
+    }
+};
+
+owner: Owner,
+
+// used to prevent recursive evaluation
+is_evaluating: bool,
+
+// Only once this is true can deferred scripts be run
+static_scripts_done: bool,
+
+// List of async scripts. We don't care about the execution order of these, but
+// on shutdown/abort, we need to cleanup any pending ones. Used for both
+// frame-side .async scripts and .import / .import_async modules.
+async_scripts: std.DoublyLinkedList,
+
+// List of deferred scripts. These must be executed in order, but only once
+// dom_loaded == true. Workers never populate this list.
+defer_scripts: std.DoublyLinkedList,
+
+// When an async script is ready, it's queued here.
+ready_scripts: std.DoublyLinkedList,
+
+shutdown: bool = false,
+
+client: *HttpClient,
+allocator: Allocator,
+
+// See ScriptManager.zig for the type's documentation.
+imported_modules: std.StringHashMapUnmanaged(ImportedModule),
+
+// Mapping between module specifier and resolution.
+// see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
+// For workers this stays empty (only Frame authors importmaps via
+// ScriptManager.parseImportmap).
+importmap: std.StringHashMapUnmanaged([:0]const u8),
+
+// Called at the end of evaluate() after all Base-owned work has run. Frame
+// wrapper uses this to drain defer_scripts and fire documentIsLoaded /
+// scriptsCompletedLoading. Null for workers.
+tail_hook: ?*const fn (*ScriptManagerBase) void,
+
+pub fn init(allocator: Allocator, http_client: *HttpClient, owner: Owner) ScriptManagerBase {
+    return .{
+        .owner = owner,
+        .async_scripts = .{},
+        .defer_scripts = .{},
+        .ready_scripts = .{},
+        .importmap = .empty,
+        .is_evaluating = false,
+        .allocator = allocator,
+        .imported_modules = .empty,
+        .client = http_client,
+        .static_scripts_done = false,
+        .tail_hook = null,
+    };
+}
+
+pub fn deinit(self: *ScriptManagerBase) void {
+    // necessary to free any arenas scripts may be referencing
+    self.reset();
+
+    self.imported_modules.deinit(self.allocator);
+    // we don't deinit self.importmap b/c we use the owner's arena for its
+    // allocations.
+}
+
+pub fn reset(self: *ScriptManagerBase) void {
+    var it = self.imported_modules.valueIterator();
+    while (it.next()) |value_ptr| {
+        switch (value_ptr.state) {
+            .done => |script| script.deinit(),
+            else => {},
+        }
+    }
+    self.imported_modules.clearRetainingCapacity();
+
+    // The importmap's keys/values were allocated from the owner's arena, which
+    // has been reset. Can't use clearAndRetainCapacity — that space is no
+    // longer ours.
+    self.importmap = .empty;
+
+    clearList(&self.defer_scripts);
+    clearList(&self.async_scripts);
+    clearList(&self.ready_scripts);
+    self.static_scripts_done = false;
+}
+
+fn clearList(list: *std.DoublyLinkedList) void {
+    while (list.popFirst()) |n| {
+        const script: *Script = @fieldParentPtr("node", n);
+        script.deinit();
+    }
+}
+
+pub fn getHeaders(self: *ScriptManagerBase) !http.Headers {
+    var headers = try self.client.newHeaders();
+    try self.owner.addHeaders(&headers);
+    return headers;
+}
+
+fn acquireArena(self: *ScriptManagerBase, size_or_bucket: anytype, debug: []const u8) !Allocator {
+    return self.owner.session().getArena(size_or_bucket, debug);
+}
+
+fn releaseArena(self: *ScriptManagerBase, arena: Allocator) void {
+    self.owner.session().releaseArena(arena);
+}
+
+pub fn scriptList(self: *ScriptManagerBase, script: *const Script) *std.DoublyLinkedList {
+    return switch (script.mode) {
+        .normal => unreachable, // not added to a list, executed immediately
+        .@"defer" => &self.defer_scripts,
+        .async, .import_async, .import => &self.async_scripts,
+    };
+}
+
+// Resolve a module specifier to a valid URL.
+pub fn resolveSpecifier(self: *ScriptManagerBase, arena: Allocator, base: [:0]const u8, specifier: [:0]const u8) ![:0]const u8 {
+    // If the specifier is mapped in the importmap, return the pre-resolved
+    // value. For workers this map is empty.
+    if (self.importmap.get(specifier)) |s| {
+        return s;
+    }
+
+    return URL.resolve(arena, base, specifier, .{ .always_dupe = true });
+}
+
+pub fn preloadImport(self: *ScriptManagerBase, url: [:0]const u8, referrer: []const u8) !void {
+    const gop = try self.imported_modules.getOrPut(self.allocator, url);
+    if (gop.found_existing) {
+        gop.value_ptr.waiters += 1;
+        return;
+    }
+    errdefer _ = self.imported_modules.remove(url);
+
+    const arena = try self.acquireArena(.large, "SM.preloadImport");
+    errdefer self.releaseArena(arena);
+
+    const script = try arena.create(Script);
+    script.* = .{
+        .kind = .module,
+        .arena = arena,
+        .url = url,
+        .node = .{},
+        .manager = self,
+        .complete = false,
+        .script_element = null,
+        .source = .{ .remote = .{} },
+        .mode = .import,
+    };
+
+    gop.value_ptr.* = ImportedModule{};
+
+    if (comptime IS_DEBUG) {
+        var ls: js.Local.Scope = undefined;
+        self.owner.jsContext().localScope(&ls);
+        defer ls.deinit();
+
+        log.debug(.http, "script queue", .{
+            .url = url,
+            .ctx = "module",
+            .referrer = referrer,
+            .stack = ls.local.stackTrace() catch "???",
+        });
+    }
+
+    // This seems wrong since we're not dealing with an async import (unlike
+    // getAsyncModule below), but all we're trying to do here is pre-load the
+    // script for execution at some point in the future (when waitForImport is
+    // called).
+    self.async_scripts.append(&script.node);
+
+    const session = self.owner.session();
+    self.client.request(.{
+        .ctx = script,
+        .params = .{
+            .url = url,
+            .method = .GET,
+            .frame_id = self.owner.frameId(),
+            .loader_id = self.owner.loaderId(),
+            .headers = try self.getHeaders(),
+            .cookie_jar = &session.cookie_jar,
+            .cookie_origin = self.owner.url(),
+            .resource_type = .script,
+            .notification = session.notification,
+        },
+        .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
+        .header_callback = Script.headerCallback,
+        .data_callback = Script.dataCallback,
+        .done_callback = Script.doneCallback,
+        .error_callback = Script.errorCallback,
+    }) catch |err| {
+        self.async_scripts.remove(&script.node);
+        return err;
+    };
+}
+
+pub fn waitForImport(self: *ScriptManagerBase, url: [:0]const u8) !ModuleSource {
+    const entry = self.imported_modules.getEntry(url) orelse {
+        // It shouldn't be possible for v8 to ask for a module that we didn't
+        // `preloadImport` above.
+        return error.UnknownModule;
+    };
+
+    const was_evaluating = self.is_evaluating;
+    self.is_evaluating = true;
+    defer self.is_evaluating = was_evaluating;
+
+    var client = self.client;
+    while (true) {
+        switch (entry.value_ptr.state) {
+            .loading => {
+                _ = try client.tick(200);
+                continue;
+            },
+            .done => |script| {
+                var shared = false;
+                const buffer = entry.value_ptr.buffer;
+                const waiters = entry.value_ptr.waiters;
+
+                if (waiters == 1) {
+                    self.imported_modules.removeByPtr(entry.key_ptr);
+                } else {
+                    shared = true;
+                    entry.value_ptr.waiters = waiters - 1;
+                }
+                return .{
+                    .buffer = buffer,
+                    .shared = shared,
+                    .script = script,
+                };
+            },
+            .err => return error.Failed,
+        }
+    }
+}
+
+pub fn getAsyncImport(self: *ScriptManagerBase, url: [:0]const u8, cb: ImportAsync.Callback, cb_data: *anyopaque, referrer: []const u8) !void {
+    const arena = try self.acquireArena(.large, "SM.getAsyncImport");
+    errdefer self.releaseArena(arena);
+
+    const script = try arena.create(Script);
+    script.* = .{
+        .kind = .module,
+        .arena = arena,
+        .url = url,
+        .node = .{},
+        .manager = self,
+        .complete = false,
+        .script_element = null,
+        .source = .{ .remote = .{} },
+        .mode = .{ .import_async = .{
+            .callback = cb,
+            .data = cb_data,
+        } },
+    };
+
+    if (comptime IS_DEBUG) {
+        var ls: js.Local.Scope = undefined;
+        self.owner.jsContext().localScope(&ls);
+        defer ls.deinit();
+
+        log.debug(.http, "script queue", .{
+            .url = url,
+            .ctx = "dynamic module",
+            .referrer = referrer,
+            .stack = ls.local.stackTrace() catch "???",
+        });
+    }
+
+    // It's possible, but unlikely, for client.request to immediately finish
+    // a request, thus calling our callback. We generally don't want a call
+    // from v8 (which is why we're here), to result in a new script evaluation.
+    // So we block even the slightest change that `client.request` immediately
+    // executes a callback.
+    const was_evaluating = self.is_evaluating;
+    self.is_evaluating = true;
+    defer self.is_evaluating = was_evaluating;
+
+    const session = self.owner.session();
+    self.async_scripts.append(&script.node);
+    self.client.request(.{
+        .ctx = script,
+        .params = .{
+            .url = url,
+            .method = .GET,
+            .frame_id = self.owner.frameId(),
+            .loader_id = self.owner.loaderId(),
+            .headers = try self.getHeaders(),
+            .resource_type = .script,
+            .cookie_jar = &session.cookie_jar,
+            .cookie_origin = self.owner.url(),
+            .notification = session.notification,
+        },
+        .start_callback = if (log.enabled(.http, .debug)) Script.startCallback else null,
+        .header_callback = Script.headerCallback,
+        .data_callback = Script.dataCallback,
+        .done_callback = Script.doneCallback,
+        .error_callback = Script.errorCallback,
+    }) catch |err| {
+        self.async_scripts.remove(&script.node);
+        return err;
+    };
+}
+
+// Called from the Page / Frame to signal it's done parsing the HTML, so
+// deferred scripts can start evaluating. Workers never call this.
+pub fn staticScriptsDone(self: *ScriptManagerBase) void {
+    lp.assert(self.static_scripts_done == false, "ScriptManagerBase.staticScriptsDone", .{});
+    self.static_scripts_done = true;
+    self.evaluate();
+}
+
+pub fn evaluate(self: *ScriptManagerBase) void {
+    if (self.is_evaluating) {
+        // It's possible for a script.eval to cause evaluate to be called again.
+        return;
+    }
+
+    self.is_evaluating = true;
+    defer self.is_evaluating = false;
+
+    while (self.ready_scripts.popFirst()) |n| {
+        var script: *Script = @fieldParentPtr("node", n);
+        switch (script.mode) {
+            .async => {
+                defer script.deinit();
+                // Workers never create .async mode scripts.
+                script.eval(self.owner.frame);
+            },
+            .import_async => |ia| {
+                if (script.status < 200 or script.status > 299) {
+                    script.deinit();
+                    ia.callback(ia.data, error.FailedToLoad);
+                } else {
+                    ia.callback(ia.data, .{
+                        .shared = false,
+                        .script = script,
+                        .buffer = script.source.remote,
+                    });
+                }
+            },
+            else => unreachable, // no other script is put in this list
+        }
+    }
+
+    if (self.static_scripts_done == false) {
+        // We can only execute deferred scripts if
+        // 1 - all the normal scripts are done
+        // 2 - we've finished parsing the HTML and at least queued all the scripts
+        // The last one isn't obvious, but it's possible for self.scripts to
+        // be empty not because we're done executing all the normal scripts
+        // but because we're done executing some (or maybe none), but we're still
+        // parsing the HTML.
+        return;
+    }
+
+    while (self.defer_scripts.first) |n| {
+        var script: *Script = @fieldParentPtr("node", n);
+        if (script.complete == false) return;
+        defer {
+            _ = self.defer_scripts.popFirst();
+            script.deinit();
+        }
+        // Only Frames populate defer_scripts.
+        script.eval(self.owner.frame);
+    }
+
+    // Frame wrapper uses this to fire documentIsLoaded and
+    // scriptsCompletedLoading. Null for workers.
+    if (self.tail_hook) |hook| hook(self);
+}
+
+pub const Script = struct {
+    kind: Kind,
+    complete: bool,
+    status: u16 = 0,
+    source: Source,
+    url: []const u8,
+    arena: Allocator,
+    mode: ExecutionMode,
+    node: std.DoublyLinkedList.Node,
+    script_element: ?*Element.Html.Script,
+    manager: *ScriptManagerBase,
+
+    // for debugging a rare production issue
+    header_callback_called: bool = false,
+
+    // for debugging a rare production issue
+    debug_transfer_id: u32 = 0,
+    debug_transfer_tries: u8 = 0,
+    debug_transfer_aborted: bool = false,
+    debug_transfer_bytes_received: usize = 0,
+    debug_transfer_notified_fail: bool = false,
+    debug_transfer_auth_challenge: bool = false,
+    debug_transfer_easy_id: usize = 0,
+
+    pub const Kind = enum {
+        module,
+        javascript,
+        importmap,
+    };
+
+    pub const Source = union(enum) {
+        @"inline": []const u8,
+        remote: std.ArrayList(u8),
+
+        pub fn content(self: Source) []const u8 {
+            return switch (self) {
+                .remote => |buf| buf.items,
+                .@"inline" => |c| c,
+            };
+        }
+    };
+
+    pub const ExecutionMode = union(enum) {
+        normal,
+        @"defer",
+        async,
+        import,
+        import_async: ImportAsync,
+    };
+
+    pub fn deinit(self: *Script) void {
+        self.manager.releaseArena(self.arena);
+    }
+
+    pub fn startCallback(response: HttpClient.Response) !void {
+        log.debug(.http, "script fetch start", .{ .req = response });
+    }
+
+    pub fn headerCallback(response: HttpClient.Response) !bool {
+        const self: *Script = @ptrCast(@alignCast(response.ctx));
+
+        self.status = response.status().?;
+        if (response.status() != 200) {
+            log.info(.http, "script header", .{
+                .req = response,
+                .status = response.status(),
+                .content_type = response.contentType(),
+            });
+            return false;
+        }
+
+        if (comptime IS_DEBUG) {
+            log.debug(.http, "script header", .{
+                .req = response,
+                .status = response.status(),
+                .content_type = response.contentType(),
+            });
+        }
+
+        switch (response.inner) {
+            .transfer => |transfer| {
+                // temp debug, trying to figure out why the next assert sometimes
+                // fails. Is the buffer just corrupt or is headerCallback really
+                // being called twice?
+                lp.assert(self.header_callback_called == false, "ScriptManagerBase.Header recall", .{
+                    .m = @tagName(std.meta.activeTag(self.mode)),
+                    .a1 = self.debug_transfer_id,
+                    .a2 = self.debug_transfer_tries,
+                    .a3 = self.debug_transfer_aborted,
+                    .a4 = self.debug_transfer_bytes_received,
+                    .a5 = self.debug_transfer_notified_fail,
+                    .a8 = self.debug_transfer_auth_challenge,
+                    .a9 = self.debug_transfer_easy_id,
+                    .b1 = transfer.id,
+                    .b2 = transfer._tries,
+                    .b3 = transfer.aborted,
+                    .b4 = transfer.bytes_received,
+                    .b5 = transfer._notified_fail,
+                    .b8 = transfer._auth_challenge != null,
+                    .b9 = if (transfer._conn) |c| @intFromPtr(c._easy) else 0,
+                });
+                self.header_callback_called = true;
+                self.debug_transfer_id = transfer.id;
+                self.debug_transfer_tries = transfer._tries;
+                self.debug_transfer_aborted = transfer.aborted;
+                self.debug_transfer_bytes_received = transfer.bytes_received;
+                self.debug_transfer_notified_fail = transfer._notified_fail;
+                self.debug_transfer_auth_challenge = transfer._auth_challenge != null;
+                self.debug_transfer_easy_id = if (transfer._conn) |c| @intFromPtr(c._easy) else 0;
+            },
+            else => {},
+        }
+
+        lp.assert(self.source.remote.capacity == 0, "ScriptManagerBase.Header buffer", .{ .capacity = self.source.remote.capacity });
+        var buffer: std.ArrayList(u8) = .empty;
+        if (response.contentLength()) |cl| {
+            try buffer.ensureTotalCapacity(self.arena, cl);
+        }
+        self.source = .{ .remote = buffer };
+        return true;
+    }
+
+    pub fn dataCallback(response: HttpClient.Response, data: []const u8) !void {
+        const self: *Script = @ptrCast(@alignCast(response.ctx));
+        self._dataCallback(response, data) catch |err| {
+            log.err(.http, "SM.dataCallback", .{ .err = err, .transfer = response, .len = data.len });
+            return err;
+        };
+    }
+
+    fn _dataCallback(self: *Script, _: HttpClient.Response, data: []const u8) !void {
+        try self.source.remote.appendSlice(self.arena, data);
+    }
+
+    pub fn doneCallback(ctx: *anyopaque) !void {
+        const self: *Script = @ptrCast(@alignCast(ctx));
+        self.complete = true;
+        if (comptime IS_DEBUG) {
+            log.debug(.http, "script fetch complete", .{ .req = self.url });
+        }
+
+        const manager = self.manager;
+        if (self.mode == .async or self.mode == .import_async) {
+            manager.async_scripts.remove(&self.node);
+            manager.ready_scripts.append(&self.node);
+        } else if (self.mode == .import) {
+            manager.async_scripts.remove(&self.node);
+            const entry = manager.imported_modules.getPtr(self.url).?;
+            entry.state = .{ .done = self };
+            entry.buffer = self.source.remote;
+        }
+        manager.evaluate();
+    }
+
+    pub fn errorCallback(ctx: *anyopaque, err: anyerror) void {
+        const self: *Script = @ptrCast(@alignCast(ctx));
+        log.warn(.http, "script fetch error", .{
+            .err = err,
+            .req = self.url,
+            .mode = std.meta.activeTag(self.mode),
+            .kind = self.kind,
+            .status = self.status,
+        });
+
+        if (self.mode == .normal) {
+            // This is blocked in a loop at the end of addFromElement, setting
+            // it to complete with a status of 0 will signal the error.
+            self.status = 0;
+            self.complete = true;
+            return;
+        }
+
+        const manager = self.manager;
+        manager.scriptList(self).remove(&self.node);
+        if (manager.shutdown) {
+            self.deinit();
+            return;
+        }
+
+        switch (self.mode) {
+            .import_async => |ia| ia.callback(ia.data, error.FailedToLoad),
+            .import => {
+                const entry = manager.imported_modules.getPtr(self.url).?;
+                entry.state = .err;
+            },
+            else => {},
+        }
+        self.deinit();
+        manager.evaluate();
+    }
+
+    pub fn eval(self: *Script, frame: *Frame) void {
+        // never evaluated, source is passed back to v8, via callbacks.
+        if (comptime IS_DEBUG) {
+            std.debug.assert(self.mode != .import_async);
+
+            // never evaluated, source is passed back to v8 when asked for it.
+            std.debug.assert(self.mode != .import);
+        }
+
+        if (frame.isGoingAway()) {
+            // don't evaluate scripts for a dying frame.
+            return;
+        }
+
+        const script_element = self.script_element.?;
+
+        const previous_script = frame.document._current_script;
+        frame.document._current_script = script_element;
+        defer frame.document._current_script = previous_script;
+
+        // Clear the document.write insertion point for this script
+        const previous_write_insertion_point = frame.document._write_insertion_point;
+        frame.document._write_insertion_point = null;
+        defer frame.document._write_insertion_point = previous_write_insertion_point;
+
+        // inline scripts aren't cached. remote ones are.
+        const cacheable = self.source == .remote;
+
+        const url = self.url;
+
+        log.info(.browser, "executing script", .{
+            .src = url,
+            .kind = self.kind,
+            .cacheable = cacheable,
+        });
+
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+
+        const local = &ls.local;
+
+        // Handle importmap special case here: the content is a JSON containing
+        // imports.
+        if (self.kind == .importmap) {
+            frame._script_manager.parseImportmap(self) catch |err| {
+                log.err(.browser, "parse importmap script", .{
+                    .err = err,
+                    .src = url,
+                    .kind = self.kind,
+                    .cacheable = cacheable,
+                });
+                self.executeCallback(comptime .wrap("error"), frame);
+                return;
+            };
+            self.executeCallback(comptime .wrap("load"), frame);
+            return;
+        }
+
+        defer frame._event_manager.clearIgnoreList();
+
+        var try_catch: js.TryCatch = undefined;
+        try_catch.init(local);
+        defer try_catch.deinit();
+
+        const success = blk: {
+            const content = self.source.content();
+            switch (self.kind) {
+                .javascript => _ = local.eval(content, url) catch break :blk false,
+                .module => {
+                    // We don't care about waiting for the evaluation here.
+                    frame.js.module(false, local, content, url, cacheable) catch break :blk false;
+                },
+                .importmap => unreachable, // handled before the try/catch.
+            }
+            break :blk true;
+        };
+
+        if (comptime IS_DEBUG) {
+            log.debug(.browser, "executed script", .{ .src = url, .success = success });
+        }
+
+        defer {
+            local.runMacrotasks(); // also runs microtasks
+            _ = frame.js.scheduler.run() catch |err| {
+                log.err(.frame, "scheduler", .{ .err = err });
+            };
+        }
+
+        if (success) {
+            self.executeCallback(comptime .wrap("load"), frame);
+            return;
+        }
+
+        const caught = try_catch.caughtOrError(frame.call_arena, error.Unknown);
+        log.warn(.js, "eval script", .{
+            .url = url,
+            .caught = caught,
+            .cacheable = cacheable,
+        });
+
+        self.executeCallback(comptime .wrap("error"), frame);
+    }
+
+    fn executeCallback(self: *const Script, typ: String, frame: *Frame) void {
+        const Event = @import("webapi/Event.zig");
+        const event = Event.initTrusted(typ, .{}, frame._page) catch |err| {
+            log.warn(.js, "script internal callback", .{
+                .url = self.url,
+                .type = typ,
+                .err = err,
+            });
+            return;
+        };
+        frame._event_manager.dispatchOpts(self.script_element.?.asNode().asEventTarget(), event, .{ .apply_ignore = true }) catch |err| {
+            log.warn(.js, "script callback", .{
+                .url = self.url,
+                .type = typ,
+                .err = err,
+            });
+        };
+    }
+};
+
+pub const ImportAsync = struct {
+    data: *anyopaque,
+    callback: ImportAsync.Callback,
+
+    pub const Callback = *const fn (ptr: *anyopaque, result: anyerror!ModuleSource) void;
+};
+
+pub const ModuleSource = struct {
+    shared: bool,
+    script: *Script,
+    buffer: std.ArrayList(u8),
+
+    pub fn deinit(self: *ModuleSource) void {
+        if (self.shared == false) {
+            self.script.deinit();
+        }
+    }
+
+    pub fn src(self: *const ModuleSource) []const u8 {
+        return self.buffer.items;
+    }
+};
+
+pub const ImportedModule = struct {
+    waiters: u16 = 1,
+    state: State = .loading,
+    buffer: std.ArrayList(u8) = .{},
+
+    pub const State = union(enum) {
+        err,
+        loading,
+        done: *Script,
+    };
+};

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -134,7 +134,7 @@ pub fn createPage(self: *Session) !*Frame {
 
 pub fn removePage(self: *Session) void {
     lp.assert(self.page != null, "Session.removePage - page is null", .{});
-    if (self.page.?.frame._script_manager.is_evaluating) {
+    if (self.page.?.frame._script_manager.base.is_evaluating) {
         // Reentrant teardown from a CDP message drained inside syncRequest;
         // Session.deinit reclaims the page when the connection closes.
         return;

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -28,7 +28,7 @@ const Execution = @import("Execution.zig");
 const Frame = @import("../Frame.zig");
 const Page = @import("../Page.zig");
 const Session = @import("../Session.zig");
-const ScriptManager = @import("../ScriptManager.zig");
+const ScriptManagerBase = @import("../ScriptManagerBase.zig");
 const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
 
 const v8 = js.v8;
@@ -138,8 +138,9 @@ module_cache: std.StringHashMapUnmanaged(ModuleEntry) = .empty,
 // necessary to lookup/store the dependent module in the module_cache.
 module_identifier: std.AutoHashMapUnmanaged(u32, [:0]const u8) = .empty,
 
-// the frame's script manager
-script_manager: ?*ScriptManager,
+// Module-loading plumbing. Frame contexts point at the ScriptManager's
+// embedded Base; worker contexts point at WorkerGlobalScope's Base directly.
+script_manager: *ScriptManagerBase,
 
 // Our macrotasks
 scheduler: Scheduler,
@@ -484,7 +485,7 @@ fn postCompileModule(self: *Context, mod: js.Module, url: [:0]const u8, local: *
     // dependent modules this module has and start downloading them asap.
     const requests = mod.getModuleRequests();
     const request_len = requests.len();
-    const script_manager = self.script_manager.?;
+    const script_manager = self.script_manager;
     for (0..request_len) |i| {
         const specifier = requests.get(i).specifier(local);
         const normalized_specifier = try script_manager.resolveSpecifier(
@@ -590,7 +591,7 @@ pub fn dynamicModuleCallback(
         return @constCast(local.rejectPromise(.{ .generic_error = "Out of memory" }).handle);
     };
 
-    const normalized_specifier = self.script_manager.?.resolveSpecifier(
+    const normalized_specifier = self.script_manager.resolveSpecifier(
         self.arena, // might need to survive until the module is loaded
         resource,
         specifier,
@@ -643,7 +644,7 @@ fn _resolveModuleCallback(self: *Context, referrer: js.Module, specifier: [:0]co
         return error.UnknownModuleReferrer;
     };
 
-    const normalized_specifier = try self.script_manager.?.resolveSpecifier(
+    const normalized_specifier = try self.script_manager.resolveSpecifier(
         self.arena,
         referrer_path,
         specifier,
@@ -654,12 +655,12 @@ fn _resolveModuleCallback(self: *Context, referrer: js.Module, specifier: [:0]co
         return local.toLocal(m).handle;
     }
 
-    var source = self.script_manager.?.waitForImport(normalized_specifier) catch |err| switch (err) {
+    var source = self.script_manager.waitForImport(normalized_specifier) catch |err| switch (err) {
         error.UnknownModule => blk: {
             // Module is in cache but was consumed from imported_modules
             // (e.g., by a previous failed resolution). Re-preload and retry.
-            try self.script_manager.?.preloadImport(normalized_specifier, referrer_path);
-            break :blk try self.script_manager.?.waitForImport(normalized_specifier);
+            try self.script_manager.preloadImport(normalized_specifier, referrer_path);
+            break :blk try self.script_manager.waitForImport(normalized_specifier);
         },
         else => return err,
     };
@@ -728,7 +729,7 @@ fn _dynamicModuleCallback(self: *Context, specifier: [:0]const u8, referrer: []c
         };
 
         // Next, we need to actually load it.
-        self.script_manager.?.getAsyncImport(specifier, dynamicModuleSourceCallback, state, referrer) catch |err| {
+        self.script_manager.getAsyncImport(specifier, dynamicModuleSourceCallback, state, referrer) catch |err| {
             const error_msg = local.newString(@errorName(err));
             _ = resolver.reject("dynamic module get async", error_msg);
         };
@@ -797,7 +798,7 @@ fn _dynamicModuleCallback(self: *Context, specifier: [:0]const u8, referrer: []c
     return promise;
 }
 
-fn dynamicModuleSourceCallback(ctx: *anyopaque, module_source_: anyerror!ScriptManager.ModuleSource) void {
+fn dynamicModuleSourceCallback(ctx: *anyopaque, module_source_: anyerror!ScriptManagerBase.ModuleSource) void {
     const state: *DynamicModuleResolveState = @ptrCast(@alignCast(ctx));
     var self = state.context;
 

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -296,7 +296,7 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
         .templates = self.templates,
         .call_arena = params.call_arena,
         .microtask_queue = microtask_queue,
-        .script_manager = if (comptime is_frame) &global._script_manager else null,
+        .script_manager = if (comptime is_frame) &global._script_manager.base else &global._script_manager,
         .scheduler = .init(context_arena),
         .identity = params.identity,
         .identity_arena = params.identity_arena,

--- a/src/browser/tests/worker/import-module.js
+++ b/src/browser/tests/worker/import-module.js
@@ -1,0 +1,4 @@
+export const message = 'imported from module';
+export function multiply(a, b) {
+  return a * b;
+}

--- a/src/browser/tests/worker/import-worker.js
+++ b/src/browser/tests/worker/import-worker.js
@@ -1,0 +1,14 @@
+// Dynamic import() in a classic worker — before the ScriptManagerBase
+// split, this path crashed on a null script_manager unwrap.
+(async function() {
+  try {
+    const mod = await import('./import-module.js');
+    postMessage({
+      ok: true,
+      message: mod.message,
+      product: mod.multiply(6, 7),
+    });
+  } catch (e) {
+    postMessage({ ok: false, err: String(e) });
+  }
+})();

--- a/src/browser/tests/worker/module-test-worker.js
+++ b/src/browser/tests/worker/module-test-worker.js
@@ -1,0 +1,49 @@
+// Exercises module imports inside a worker. Classic workers can't use
+// top-level `import`, so all imports go through dynamic import() — which
+// is the path the ScriptManagerBase split was made to enable.
+(async function () {
+  const results = {};
+  try {
+    const m1 = await import('./modules/base.js');
+    results.basic_baseValue = m1.baseValue;
+
+    const m2 = await import('./modules/importer.js');
+    results.transitive_importedValue = m2.importedValue;
+    results.transitive_localValue = m2.localValue;
+
+    const m3 = await import('./modules/re-exporter.js');
+    results.reexport_baseValue = m3.baseValue;
+    results.reexport_importedValue = m3.importedValue;
+    results.reexport_localValue = m3.localValue;
+
+    const m4a = await import('./modules/shared.js');
+    results.shared_first_inc = m4a.increment();
+    results.shared_first_count = m4a.getCount();
+    const m4b = await import('./modules/shared.js');
+    results.shared_second_inc = m4b.increment();
+    results.shared_second_count = m4b.getCount();
+    results.shared_same_module = m4a === m4b;
+
+    const ma = await import('./modules/circular-a.js');
+    const mb = await import('./modules/circular-b.js');
+    results.circular_aValue = ma.aValue;
+    results.circular_bValue = mb.bValue;
+    results.circular_getFromB = ma.getFromB();
+    results.circular_getFromA = mb.getFromA();
+
+    const mm = await import('./modules/meta.js');
+    results.meta_url_endsWith = mm.moduleUrl.endsWith('/tests/worker/modules/meta.js');
+
+    let import_404_threw = false;
+    try {
+      await import('./modules/nonexistent.js');
+    } catch (e) {
+      import_404_threw = e.toString().includes('FailedToLoad');
+    }
+    results.import_404_threw = import_404_threw;
+
+    postMessage({ ok: true, results });
+  } catch (e) {
+    postMessage({ ok: false, err: String(e), stack: e.stack });
+  }
+})();

--- a/src/browser/tests/worker/module.html
+++ b/src/browser/tests/worker/module.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<body></body>
+<script src="../testing.js"></script>
+
+<script id="worker_module_imports" type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./module-test-worker.js');
+
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+
+    await state.done((response) => {
+      testing.expectTrue(response.ok, 'worker module error: ' + response.err);
+      const r = response.results;
+
+      // basic dynamic import
+      testing.expectEqual('from-base', r.basic_baseValue);
+
+      // transitive (static-from-dynamic) imports
+      testing.expectEqual('from-base', r.transitive_importedValue);
+      testing.expectEqual('local', r.transitive_localValue);
+
+      // re-exports
+      testing.expectEqual('from-base', r.reexport_baseValue);
+      testing.expectEqual('from-base', r.reexport_importedValue);
+      testing.expectEqual('local', r.reexport_localValue);
+
+      // module identity is preserved across two import() calls in the
+      // same worker — counter state persists.
+      testing.expectEqual(1, r.shared_first_inc);
+      testing.expectEqual(1, r.shared_first_count);
+      testing.expectEqual(2, r.shared_second_inc);
+      testing.expectEqual(2, r.shared_second_count);
+      testing.expectTrue(r.shared_same_module);
+
+      // circular static imports between two dynamically-imported modules
+      testing.expectEqual('a', r.circular_aValue);
+      testing.expectEqual('b', r.circular_bValue);
+      testing.expectEqual('b', r.circular_getFromB);
+      testing.expectEqual('a', r.circular_getFromA);
+
+      // import.meta.url resolves to the imported module's URL
+      testing.expectTrue(r.meta_url_endsWith);
+
+      // missing module surfaces FailedToLoad to the import() caller
+      testing.expectTrue(r.import_404_threw);
+    });
+  }
+</script>

--- a/src/browser/tests/worker/modules/base.js
+++ b/src/browser/tests/worker/modules/base.js
@@ -1,0 +1,1 @@
+export const baseValue = 'from-base';

--- a/src/browser/tests/worker/modules/circular-a.js
+++ b/src/browser/tests/worker/modules/circular-a.js
@@ -1,0 +1,7 @@
+import { getBValue } from './circular-b.js';
+
+export const aValue = 'a';
+
+export function getFromB() {
+  return getBValue();
+}

--- a/src/browser/tests/worker/modules/circular-b.js
+++ b/src/browser/tests/worker/modules/circular-b.js
@@ -1,0 +1,11 @@
+import { aValue } from './circular-a.js';
+
+export const bValue = 'b';
+
+export function getBValue() {
+  return bValue;
+}
+
+export function getFromA() {
+  return aValue;
+}

--- a/src/browser/tests/worker/modules/importer.js
+++ b/src/browser/tests/worker/modules/importer.js
@@ -1,0 +1,4 @@
+import { baseValue } from './base.js';
+
+export const importedValue = baseValue;
+export const localValue = 'local';

--- a/src/browser/tests/worker/modules/meta.js
+++ b/src/browser/tests/worker/modules/meta.js
@@ -1,0 +1,1 @@
+export const moduleUrl = import.meta.url;

--- a/src/browser/tests/worker/modules/re-exporter.js
+++ b/src/browser/tests/worker/modules/re-exporter.js
@@ -1,0 +1,2 @@
+export { baseValue } from './base.js';
+export { importedValue, localValue } from './importer.js';

--- a/src/browser/tests/worker/modules/shared.js
+++ b/src/browser/tests/worker/modules/shared.js
@@ -1,0 +1,9 @@
+let counter = 0;
+
+export function increment() {
+  return ++counter;
+}
+
+export function getCount() {
+  return counter;
+}

--- a/src/browser/tests/worker/worker.html
+++ b/src/browser/tests/worker/worker.html
@@ -224,6 +224,23 @@
   }
 </script>
 
+<script id="worker_dynamic_import" type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./import-worker.js');
+
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+
+    await state.done((response) => {
+      testing.expectTrue(response.ok, 'worker import error: ' + response.err);
+      testing.expectEqual('imported from module', response.message);
+      testing.expectEqual(42, response.product);
+    });
+  }
+</script>
+
 <script id="worker_structured_clone_nested" type=module>
   {
     const state = await testing.async();

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -28,6 +28,7 @@ const Page = @import("../Page.zig");
 const Factory = @import("../Factory.zig");
 const Session = @import("../Session.zig");
 const EventManagerBase = @import("../EventManagerBase.zig");
+const ScriptManagerBase = @import("../ScriptManagerBase.zig");
 
 const Blob = @import("Blob.zig");
 const Worker = @import("Worker.zig");
@@ -71,6 +72,10 @@ _worker: *Worker,
 // Event management for non-DOM targets in worker context
 _event_manager: EventManagerBase,
 
+// Handles module imports (static + dynamic). No parser integration since
+// workers don't have <script> tags.
+_script_manager: ScriptManagerBase,
+
 // These fields represent the "Window"-like component of the WGS
 _closed: bool = false,
 _proto: *EventTarget,
@@ -104,8 +109,15 @@ pub fn init(worker: *Worker, url: [:0]const u8) !*WorkerGlobalScope {
         ._factory = factory,
         ._worker = worker,
         ._event_manager = .init(arena),
+        ._script_manager = undefined,
     });
     errdefer factory.destroy(self);
+
+    self._script_manager = ScriptManagerBase.init(
+        arena,
+        session.browser.http_client,
+        .{ .worker = self },
+    );
 
     self.js = try session.browser.env.createWorkerContext(self, .{
         .call_arena = call_arena,
@@ -118,6 +130,8 @@ pub fn init(worker: *Worker, url: [:0]const u8) !*WorkerGlobalScope {
 
 pub fn deinit(self: *WorkerGlobalScope) void {
     self._identity.deinit();
+    self._script_manager.deinit();
+
     const page = self._page;
     var it = self._blob_urls.valueIterator();
     while (it.next()) |blob| {


### PR DESCRIPTION
Extract module-loading plumbing into ScriptManagerBase so workers can use it. Previously Context.script_manager was null for worker contexts, which crashed on dynamic import() via the unwrap in dynamicModuleCallback.

ScriptManagerBase owns the HTTP fetch + V8 module resolution path (preloadImport, waitForImport, getAsyncImport, resolveSpecifier, the Script struct) and reaches per-owner fields through an Owner union. ScriptManager wraps it for Frame and keeps the parser/DOM-bound surface (addFromElement, parseImportmap, Frame-specific evaluate tail via tail_hook). WorkerGlobalScope gets its own ScriptManagerBase directly.

This is similar to the work done in https://github.com/lightpanda-io/browser/pull/2093 which split EventManager into EventManager + EventManagerBase (for the same reason).

add tests