### PR TITLE
keep the existing page active until the pending one is loaded

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -118,6 +118,11 @@ pub const FrameNavigate = struct {
     timestamp: u64,
     url: [:0]const u8,
     opts: Frame.NavigateOpts,
+    // True when this navigation is being issued against a Page that is in
+    // .pending state (i.e. an in-flight root navigation whose old Page is
+    // still alive). CDP uses this to skip BrowserContext.reset() — the old
+    // page's nodes must remain live and addressable until commit.
+    is_pending_root: bool = false,
 };
 
 pub const FrameNavigated = struct {

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -27,6 +27,7 @@ const HttpClient = @import("HttpClient.zig");
 const ArenaPool = App.ArenaPool;
 
 const Session = @import("Session.zig");
+const Page = @import("Page.zig");
 const Notification = @import("../Notification.zig");
 
 // Browser is an instance of the browser.
@@ -40,6 +41,9 @@ session: ?Session,
 allocator: Allocator,
 arena_pool: *ArenaPool,
 http_client: *HttpClient,
+
+// used by sessions to allocate pages.
+page_pool: std.heap.MemoryPool(Page),
 
 const InitOpts = struct {
     env: js.Env.InitOpts = .{},
@@ -59,12 +63,14 @@ pub fn init(app: *App, opts: InitOpts) !Browser {
         .allocator = allocator,
         .arena_pool = &app.arena_pool,
         .http_client = opts.http_client,
+        .page_pool = std.heap.MemoryPool(Page).init(allocator),
     };
 }
 
 pub fn deinit(self: *Browser) void {
     self.closeSession();
     self.env.deinit();
+    self.page_pool.deinit();
 }
 
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -632,7 +632,8 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     // Session.initiateRootNavigation) flags both the notification and the
     // HTTP request itself: CDP skips its node-registry reset until commit,
     // and the in-flight transfer survives the OLD page's frame.deinit which
-    // calls http_client.abort() during commitPendingPage.
+    // calls http_client.abortFrame(frame_id) on the shared frame_id during
+    // commitPendingPage.
     const is_pending_root = self._page._state == .pending;
 
     // We dispatch frame_navigate event before sending the request.
@@ -971,11 +972,13 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !bool {
     // tears down the OLD page, flips the pointer, and dispatches
     // frame_created against the new (now active) frame.
     //
-    // The OLD page's frame.deinit calls http_client.abort() — our transfer
+    // The OLD page's frame.deinit calls http_client.abortFrame(frame_id) on
+    // the frame_id it shares with the (now-active) pending page; our transfer
     // survives because Session.initiateRootNavigation flagged the request
-    // protect_from_abort. Once we are past commit, that protection is no
-    // longer needed and may interfere with subsequent aborts (e.g. another
-    // navigation while we are still streaming the body), so clear it.
+    // protect_from_abort, which abortFrame's default .normal scope honors.
+    // Once we are past commit, that protection is no longer needed and may
+    // interfere with subsequent aborts (e.g. another navigation while we are
+    // still streaming the body), so clear it.
     if (self._page._state == .pending) {
         try self._session.commitPendingPage();
         switch (response.inner) {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -413,7 +413,8 @@ pub fn deinit(self: *Frame) void {
 
     self._script_manager.base.shutdown = true;
 
-    browser.http_client.abortFrame(self._frame_id);
+    // don't abort pending frames.
+    browser.http_client.abortFrame(self._frame_id, .{});
 
     self._script_manager.deinit();
     self._style_manager.deinit();
@@ -758,7 +759,7 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
         .type = target._type,
     });
 
-    session.browser.http_client.abortFrame(target._frame_id);
+    session.browser.http_client.abortFrame(target._frame_id, .{});
 
     // Capture the originating frame's URL as the Referer for this
     // navigation. The originator's frame may be torn down before navigate()

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -633,6 +633,14 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         const ref_header = try std.mem.concatWithSentinel(self.arena, u8, &.{ "Referer: ", ref }, 0);
         try headers.add(ref_header);
     }
+
+    // A root navigation issued against a pending Page (i.e. one allocated by
+    // Session.initiateRootNavigation) flags both the notification and the
+    // HTTP request itself: CDP skips its node-registry reset until commit,
+    // and the in-flight transfer survives the OLD page's frame.deinit which
+    // calls http_client.abort() during commitPendingPage.
+    const is_pending_root = self._page._state == .pending;
+
     // We dispatch frame_navigate event before sending the request.
     // It ensures the event frame_navigated is not dispatched before this one.
     session.notification.dispatch(.frame_navigate, &.{
@@ -642,6 +650,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         .frame_id = self._frame_id,
         .loader_id = self._loader_id,
         .timestamp = timestamp(.monotonic),
+        .is_pending_root = is_pending_root,
     });
 
     // Record telemetry for navigation
@@ -665,6 +674,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
             .cookie_origin = self.url,
             .resource_type = .document,
             .notification = self._session.notification,
+            .protect_from_abort = is_pending_root,
         },
         .header_callback = frameHeaderDoneCallback,
         .data_callback = frameDataCallback,
@@ -970,6 +980,26 @@ fn notifyParentLoadComplete(self: *Frame) void {
 fn frameHeaderDoneCallback(response: HttpClient.Response) !bool {
     var self: *Frame = @ptrCast(@alignCast(response.ctx));
 
+    // Commit point for a pending root navigation. The session has been
+    // holding the OLD page alive during the round-trip; now that response
+    // headers have arrived, swap pending → active. This dispatches
+    // frame_remove (clears OLD V8 context group + CDP node_registry),
+    // tears down the OLD page, flips the pointer, and dispatches
+    // frame_created against the new (now active) frame.
+    //
+    // The OLD page's frame.deinit calls http_client.abort() — our transfer
+    // survives because Session.initiateRootNavigation flagged the request
+    // protect_from_abort. Once we are past commit, that protection is no
+    // longer needed and may interfere with subsequent aborts (e.g. another
+    // navigation while we are still streaming the body), so clear it.
+    if (self._page._state == .pending) {
+        try self._session.commitPendingPage();
+        switch (response.inner) {
+            .transfer => |t| t.req.params.protect_from_abort = false,
+            .fulfilled, .cached => {},
+        }
+    }
+
     const response_url = response.url();
     if (std.mem.eql(u8, response_url, self.url) == false) {
         // would be different than self.url in the case of a redirect
@@ -1199,6 +1229,16 @@ fn frameErrorCallback(ctx: *anyopaque, err: anyerror) void {
     var self: *Frame = @ptrCast(@alignCast(ctx));
 
     log.err(.frame, "navigate failed", .{ .err = err, .type = self._type, .url = self.url });
+
+    // A pending root navigation that failed before commit: discard the
+    // pending Page; the OLD active Page (and its V8 context) is untouched.
+    // We do NOT run frameDoneCallback against the pending frame — the frame
+    // is about to be freed.
+    if (self._page._state == .pending) {
+        self._session.discardPendingPage();
+        return;
+    }
+
     self._parse_state.deinit(self);
     self._parse_state = .{ .err = err };
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -351,9 +351,9 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
     }
 }
 
-pub fn deinit(self: *Frame, abort_http: bool) void {
+pub fn deinit(self: *Frame) void {
     for (self.child_frames.items) |frame| {
-        frame.deinit(abort_http);
+        frame.deinit();
     }
 
     for (self.workers.items) |worker| {
@@ -413,14 +413,7 @@ pub fn deinit(self: *Frame, abort_http: bool) void {
 
     self._script_manager.base.shutdown = true;
 
-    if (self.parent == null) {
-        browser.http_client.abort();
-    } else if (abort_http) {
-        // a small optimization, it's faster to abort _everything_ on the root
-        // frame, so we prefer that. But if it's just the frame that's going
-        // away (a frame navigation) then we'll abort the frame-related requests
-        browser.http_client.abortFrame(self._frame_id);
-    }
+    browser.http_client.abortFrame(self._frame_id);
 
     self._script_manager.deinit();
     self._style_manager.deinit();
@@ -765,17 +758,7 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
         .type = target._type,
     });
 
-    // This is a micro-optimization. Terminate any inflight request as early
-    // as we can. This will be more properly shutdown when we process the
-    // scheduled navigation.
-    if (target.parent == null) {
-        session.browser.http_client.abort();
-    } else {
-        // This doesn't terminate any inflight requests for nested frames, but
-        // again, this is just an optimization. We'll correctly shut down all
-        // nested inflight requests when we process the navigation.
-        session.browser.http_client.abortFrame(target._frame_id);
-    }
+    session.browser.http_client.abortFrame(target._frame_id);
 
     // Capture the originating frame's URL as the Referer for this
     // navigation. The originator's frame may be torn down before navigate()
@@ -1314,7 +1297,7 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
     const frame_id = session.nextFrameId();
 
     try Frame.init(new_frame, frame_id, self._page, self);
-    errdefer new_frame.deinit(true);
+    errdefer new_frame.deinit();
 
     self._pending_loads += 1;
     new_frame.iframe = iframe;
@@ -1423,7 +1406,7 @@ pub fn openPopup(self: *Frame, opts: OpenPopupOpts) !*Frame {
 
     const frame_id = session.nextFrameId();
     try Frame.init(popup, frame_id, page, null);
-    errdefer popup.deinit(true);
+    errdefer popup.deinit();
 
     popup.window._opener = opts.opener;
     if (opts.name.len > 0 and

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -340,13 +340,14 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
 
     if (comptime IS_DEBUG and abort_all) {
         // Even after an abort_all, we could still have transfers, but, at the
-        // very least, they should all be flagged as aborted.
+        // very least, they should all be flagged as aborted (or be a transfer
+        // we explicitly protected with protect_from_abort).
         var it = self.in_use.first;
         var leftover: usize = 0;
         while (it) |node| : (it = node.next) {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             switch (conn.transport) {
-                .http => |transfer| std.debug.assert(transfer.aborted),
+                .http => |transfer| std.debug.assert(transfer.aborted or transfer.req.params.protect_from_abort),
                 .websocket => {},
                 .none => {},
             }
@@ -363,7 +364,8 @@ fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_
         const conn: *http.Connection = @fieldParentPtr("node", node);
         switch (conn.transport) {
             .http => |transfer| {
-                if ((comptime abort_all) or transfer.req.params.frame_id == frame_id) {
+                const matches = (comptime abort_all) or transfer.req.params.frame_id == frame_id;
+                if (matches and !transfer.req.params.protect_from_abort) {
                     transfer.kill();
                 }
             },
@@ -877,6 +879,13 @@ pub const RequestParams = struct {
     credentials: ?[:0]const u8 = null,
     notification: *Notification,
     timeout_ms: u32 = 0,
+
+    // Set on an in-flight root-navigation transfer that was issued against a
+    // pending Page. The old Page's frame.deinit (called from Session.commit
+    // PendingPage when response headers arrive) calls http_client.abort() —
+    // that abort_all path skips transfers with this flag so the callback
+    // chain we are sitting inside isn't killed mid-flight.
+    protect_from_abort: bool = false,
 
     const ResourceType = enum {
         document,

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -324,9 +324,10 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
         while (n) |node| {
             n = node.next;
             const transfer: *Transfer = @fieldParentPtr("_node", node);
+            const params = transfer.req.params;
             if (comptime abort_all) {
                 transfer.kill();
-            } else if (transfer.req.params.frame_id == frame_id) {
+            } else if (params.frame_id == frame_id and !params.protect_from_abort) {
                 q.remove(node);
                 transfer.kill();
             }
@@ -339,15 +340,12 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
     }
 
     if (comptime IS_DEBUG and abort_all) {
-        // Even after an abort_all, we could still have transfers, but, at the
-        // very least, they should all be flagged as aborted (or be a transfer
-        // we explicitly protected with protect_from_abort).
         var it = self.in_use.first;
         var leftover: usize = 0;
         while (it) |node| : (it = node.next) {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             switch (conn.transport) {
-                .http => |transfer| std.debug.assert(transfer.aborted or transfer.req.params.protect_from_abort),
+                .http => |transfer| std.debug.assert(transfer.aborted),
                 .websocket => {},
                 .none => {},
             }
@@ -364,8 +362,9 @@ fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_
         const conn: *http.Connection = @fieldParentPtr("node", node);
         switch (conn.transport) {
             .http => |transfer| {
-                const matches = (comptime abort_all) or transfer.req.params.frame_id == frame_id;
-                if (matches and !transfer.req.params.protect_from_abort) {
+                const params = transfer.req.params;
+                const matches = (comptime abort_all) or (params.frame_id == frame_id and !params.protect_from_abort);
+                if (matches) {
                     transfer.kill();
                 }
             },

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -54,9 +54,9 @@ pub const InterceptionLayer = @import("../network/layer/InterceptionLayer.zig");
 //
 // The app has other secondary http needs, like telemetry. While we want to
 // share some things (namely the ca blob, and maybe some configuration
-// (TODO: ??? should proxy settings be global ???)), we're able to do call
-// client.abort() to abort the transfers being made by a frame, without impacting
-// those other http requests.
+// (TODO: ??? should proxy settings be global ???)), we're able to call
+// client.abortFrame() to abort the transfers being made by a frame, without
+// impacting those other http requests.
 pub const Client = @This();
 
 // Count of active ws requests
@@ -892,9 +892,11 @@ pub const RequestParams = struct {
 
     // Set on an in-flight root-navigation transfer that was issued against a
     // pending Page. The old Page's frame.deinit (called from Session.commit
-    // PendingPage when response headers arrive) calls http_client.abort() —
-    // that abort_all path skips transfers with this flag so the callback
-    // chain we are sitting inside isn't killed mid-flight.
+    // PendingPage when response headers arrive) calls abortFrame() on the
+    // shared frame_id; abortFrame's default .normal scope skips transfers
+    // with this flag so the callback chain we are sitting inside isn't killed
+    // mid-flight. Session.discardPendingPage uses .full scope to override
+    // the flag in failure paths.
     protect_from_abort: bool = false,
 
     const ResourceType = enum {

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -304,19 +304,25 @@ pub fn getUserAgent(self: *const Client) [:0]const u8 {
     return self.user_agent_override orelse self.network.config.http_headers.user_agent;
 }
 
+const AbortOpts = struct {
+    scope: enum { normal, full } = .normal,
+};
+
 pub fn abort(self: *Client) void {
-    self._abort(true, 0);
+    self._abort(true, 0, .{ .scope = .full });
 }
 
-pub fn abortFrame(self: *Client, frame_id: u32) void {
-    self._abort(false, frame_id);
+// abortFrame with .normal doesn't abort protect_from_abort requests.
+// .full abort all relqtive requests.
+pub fn abortFrame(self: *Client, frame_id: u32, opts: AbortOpts) void {
+    self._abort(false, frame_id, opts);
 }
 
 // Written this way so that both abort and abortFrame can share the same code
 // but abort can avoid the frame_id check at comptime.
-fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
-    abortConnections(self.in_use, abort_all, frame_id);
-    abortConnections(self.ready_queue, abort_all, frame_id);
+fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32, opts: AbortOpts) void {
+    abortConnections(self.in_use, abort_all, frame_id, opts);
+    abortConnections(self.ready_queue, abort_all, frame_id, opts);
 
     {
         var q = &self.queue;
@@ -327,9 +333,11 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
             const params = transfer.req.params;
             if (comptime abort_all) {
                 transfer.kill();
-            } else if (params.frame_id == frame_id and !params.protect_from_abort) {
-                q.remove(node);
-                transfer.kill();
+            } else if (params.frame_id == frame_id) {
+                if (opts.scope == .full or !params.protect_from_abort) {
+                    q.remove(node);
+                    transfer.kill();
+                }
             }
         }
     }
@@ -355,7 +363,7 @@ fn _abort(self: *Client, comptime abort_all: bool, frame_id: u32) void {
     }
 }
 
-fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_id: u32) void {
+fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_id: u32, opts: AbortOpts) void {
     var n = list.first;
     while (n) |node| {
         n = node.next;
@@ -363,9 +371,12 @@ fn abortConnections(list: std.DoublyLinkedList, comptime abort_all: bool, frame_
         switch (conn.transport) {
             .http => |transfer| {
                 const params = transfer.req.params;
-                const matches = (comptime abort_all) or (params.frame_id == frame_id and !params.protect_from_abort);
-                if (matches) {
+                if (comptime abort_all) {
                     transfer.kill();
+                } else if (params.frame_id == frame_id) {
+                    if (opts.scope == .full or !params.protect_from_abort) {
+                        transfer.kill();
+                    }
                 }
             },
             .websocket => |ws| {

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -102,6 +102,16 @@ popups: std.ArrayList(*Frame) = .empty,
 // from a script eval whose parser still holds the Frame).
 queued_close: std.ArrayList(*Frame) = .empty,
 
+// Lifecycle state. A Page is `.pending` while we hold it as the in-flight
+// destination of a root navigation — its V8 context exists but is not yet the
+// session's active context. Flipped to `.active` by Session.commitPendingPage
+// when response headers arrive. Frame.navigate / frameHeaderDoneCallback
+// branch on this to: (a) stamp `is_pending_root` on the frame_navigate
+// notification (so CDP doesn't reset its node registry yet) and
+// (b) flag the HTTP request `protect_from_abort` (so the old page's deinit
+// can't kill the transfer we're sitting inside).
+_state: enum { active, pending } = .active,
+
 // Initialize a Page and its root Frame.
 pub fn init(self: *Page, session: *Session, frame_id: u32) !void {
     const frame_arena = try session.arena_pool.acquire(.large, "Page.frame_arena");

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -130,15 +130,15 @@ pub fn init(self: *Page, session: *Session, frame_id: u32) !void {
 
 // Tear down the Page and its root Frame. Equivalent to the old
 // Session.removePage + Session.resetFrameResources.
-pub fn deinit(self: *Page, abort_http: bool) void {
+pub fn deinit(self: *Page) void {
     self.cleanupClosedPopups();
 
     for (self.popups.items) |popup| {
-        popup.deinit(abort_http);
+        popup.deinit();
     }
     self.popups = .empty;
 
-    self.frame.deinit(abort_http);
+    self.frame.deinit();
 
     const session = self.session;
     defer session.browser.env.memoryPressureNotification(.moderate);
@@ -188,7 +188,7 @@ pub fn deinit(self: *Page, abort_http: bool) void {
 
 pub fn cleanupClosedPopups(self: *Page) void {
     for (self.queued_close.items) |popup| {
-        popup.deinit(true);
+        popup.deinit();
     }
     self.queued_close = .empty;
 }

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -142,6 +142,10 @@ pub fn tickCDP(self: *Runner, opts: TickOpts) !CDPTickResult {
 }
 
 fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
+    // Refresh self.frame from session — the previous _tick's http_client.tick()
+    // may have fired frameHeaderDoneCallback → Session.commitPendingPage,
+    // freeing the OLD page and replacing it with the pending one.
+    self.frame = self.session.currentFrame() orelse return .done;
     const frame = self.frame;
     const http_client = self.http_client;
 

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -142,10 +142,10 @@ pub fn tickCDP(self: *Runner, opts: TickOpts) !CDPTickResult {
 }
 
 fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
-    // Refresh self.frame from session — the previous _tick's http_client.tick()
-    // may have fired frameHeaderDoneCallback → Session.commitPendingPage,
-    // freeing the OLD page and replacing it with the pending one.
-    self.frame = self.session.currentFrame() orelse return .done;
+    // Refresh self.frame from session. In case of pending page, we want to
+    // take its state while loading. If we use only the current frame, we will
+    // return a .done result immediately.
+    self.frame = self.session.currentOrPendingFrame() orelse return .done;
     const frame = self.frame;
     const http_client = self.http_client;
 

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -145,7 +145,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
     // Refresh self.frame from session. In case of pending page, we want to
     // take its state while loading. If we use only the current frame, we will
     // return a .done result immediately.
-    self.frame = self.session.currentOrPendingFrame() orelse return .done;
+    self.frame = self.session.pendingOrCurrentFrame() orelse return .done;
     const frame = self.frame;
     const http_client = self.http_client;
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -182,7 +182,9 @@ fn freeSlot(self: *Session, slot: u1) void {
 fn tearDownActivePage(self: *Session) void {
     self.notification.dispatch(.frame_remove, .{});
     const idx = self._active_idx orelse {
-        lp.assert(false, "Session.tearDownActivePage - no active page", .{});
+        if (comptime IS_DEBUG) {
+            lp.assert(false, "Session.tearDownActivePage - no active page", .{});
+        }
         return;
     };
     self._pages[idx].?.deinit();
@@ -232,7 +234,6 @@ pub fn createPage(self: *Session) !*Frame {
 pub fn removePage(self: *Session) void {
     const idx = self._active_idx orelse {
         lp.assert(false, "Session.removePage - page is null", .{});
-        return;
     };
 
     if (self._pages[idx].?.frame._script_manager.base.is_evaluating) {
@@ -470,7 +471,6 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
 fn processRootQueuedNavigation(self: *Session) !void {
     const active_idx = self._active_idx orelse {
         lp.assert(false, "Session.processRootQueuedNavigation - no active page", .{});
-        return;
     };
     const current_frame = &self._pages[active_idx].?.frame;
 
@@ -579,11 +579,9 @@ pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, 
 pub fn commitPendingPage(self: *Session) !void {
     const pending_idx = self._pending_idx orelse {
         lp.assert(false, "Session.commitPendingPage - no pending page", .{});
-        return error.NoPendingPage;
     };
     const old_active_idx = self._active_idx orelse {
         lp.assert(false, "Session.commitPendingPage - no active page", .{});
-        return error.NoActivePage;
     };
 
     if (comptime IS_DEBUG) {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -169,13 +169,41 @@ fn freeSlot(self: *Session, slot: u1) void {
     self._pages[slot] = null;
 }
 
-// NOTE: the caller is not the owner of the returned value,
-// the pointer on Frame is just returned as a convenience
-pub fn createPage(self: *Session) !*Frame {
-    lp.assert(self._active_idx == null, "Session.createPage - page not null", .{});
+// Tear down the currently-active Page. Dispatches `frame_remove` first
+// so CDP can clear inspector state while the OLD page is still walkable,
+// then frees the slot and notifies Navigation. Resets `frame_id_gen` to
+// match pre-pending-page behavior. Used by removePage and by the
+// synthetic-nav path (replaceRootImmediate). Does NOT touch any pending
+// page — callers handle that themselves.
+//
+// NOT a substitute for the careful 5-step sequence in commitPendingPage,
+// which interleaves the OLD-page teardown with the pending-page promotion
+// in a specific order.
+fn tearDownActivePage(self: *Session) void {
+    self.notification.dispatch(.frame_remove, .{});
+    const idx = self._active_idx orelse {
+        lp.assert(false, "Session.tearDownActivePage - no active page", .{});
+        return;
+    };
+    self._pages[idx].?.deinit();
+    self.freeSlot(idx);
+    self._active_idx = null;
+    self.navigation.onRemoveFrame();
+    self.frame_id_gen = 0;
+}
 
+// Allocate a Page in a free slot, publish it as the active page, and
+// dispatch `frame_created` so CDP creates fresh isolated-world V8
+// contexts. Used by createPage and by the synthetic-nav path. Does NOT
+// dispatch `frame_navigate` — the caller does that (or doesn't, for a
+// blank initial page).
+//
+// On any failure after slot allocation, the errdefers roll back the slot
+// and `_active_idx`, leaving the session pageless (the caller is
+// responsible for any prior teardown of an old page).
+fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     const slot = try self.findFreeSlot();
-    const page = try self.pageInit(slot, self.nextFrameId());
+    const page = try self.pageInit(slot, frame_id);
     errdefer {
         page.deinit();
         self.freeSlot(slot);
@@ -184,18 +212,21 @@ pub fn createPage(self: *Session) !*Frame {
     errdefer self._active_idx = null;
 
     const frame = &page.frame;
-
-    // Creates a new NavigationEventTarget for this frame.
     try self.navigation.onNewFrame(frame);
+    // Inform CDP the main frame has been created such that additional
+    // context for other Worlds can be created as well.
+    self.notification.dispatch(.frame_created, frame);
+    return frame;
+}
 
+// NOTE: the caller is not the owner of the returned value,
+// the pointer on Frame is just returned as a convenience
+pub fn createPage(self: *Session) !*Frame {
+    lp.assert(self._active_idx == null, "Session.createPage - page not null", .{});
     if (comptime IS_DEBUG) {
         log.debug(.browser, "create page", .{});
     }
-    // start JS env
-    // Inform CDP the main frame has been created such that additional context for other Worlds can be created as well
-    self.notification.dispatch(.frame_created, frame);
-
-    return frame;
+    return self.installNewActivePage(self.nextFrameId());
 }
 
 pub fn removePage(self: *Session) void {
@@ -217,20 +248,7 @@ pub fn removePage(self: *Session) void {
     if (self._pending_idx != null) {
         self.discardPendingPage();
     }
-
-    // Inform CDP the frame is going to be removed, allowing other worlds to remove themselves before the main one
-    self.notification.dispatch(.frame_remove, .{});
-
-    self._pages[idx].?.deinit();
-    self.freeSlot(idx);
-    self._active_idx = null;
-
-    self.navigation.onRemoveFrame();
-
-    // resetting frame_id_gen preserves previous behavior where removing the
-    // root page returned us to a clean-slate state.
-    self.frame_id_gen = 0;
-
+    self.tearDownActivePage();
     if (comptime IS_DEBUG) {
         log.debug(.browser, "remove page", .{});
     }
@@ -487,40 +505,8 @@ fn processRootQueuedNavigation(self: *Session) !void {
 fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !void {
     defer self.arena_pool.release(qn.arena);
 
-    const old_idx = self._active_idx orelse {
-        lp.assert(false, "Session.replaceRootImmediate - no active page", .{});
-        return;
-    };
-
-    // Dispatch frame_remove (same as removePage) then tear down the OLD
-    // page's slot.
-    self.notification.dispatch(.frame_remove, .{});
-    self._pages[old_idx].?.deinit();
-    self.freeSlot(old_idx);
-    self._active_idx = null;
-
-    self.navigation.onRemoveFrame();
-
-    // Preserve prior behavior: the old resetFrameResources reset frame_id_gen.
-    self.frame_id_gen = 0;
-
-    const new_slot = try self.findFreeSlot();
-    const page = try self.pageInit(new_slot, frame_id);
-    errdefer {
-        page.deinit();
-        self.freeSlot(new_slot);
-    }
-    self._active_idx = new_slot;
-    const new_frame = &page.frame;
-
-    // Creates a new NavigationEventTarget for this frame.
-    self.navigation.onNewFrame(new_frame) catch |err| {
-        log.err(.browser, "createPage onNewNewFrame", .{ .err = err });
-    };
-
-    // start JS env
-    // Inform CDP the main frame has been created such that additional context for other Worlds can be created as well
-    self.notification.dispatch(.frame_created, new_frame);
+    self.tearDownActivePage();
+    const new_frame = try self.installNewActivePage(frame_id);
 
     new_frame.navigate(qn.url, qn.opts) catch |err| {
         log.err(.browser, "queued navigation error", .{ .err = err });

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -534,7 +534,9 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
 // trip — Runtime.evaluate, DOM.*, etc. continue to operate on the OLD page
 // until commitPendingPage swaps the pointer when response headers arrive.
 pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
-    lp.assert(self._pending_idx == null, "Session.initiateRootNavigation - pending already set", .{});
+    if (self._pending_idx != null) {
+        self.discardPendingPage();
+    }
 
     // Pick the slot NOT occupied by the active page.
     const slot = try self.findFreeSlot();
@@ -643,8 +645,13 @@ pub fn discardPendingPage(self: *Session) void {
         log.debug(.browser, "discard pending page", .{});
     }
 
+    const pending_page = &self._pages[idx].?;
+
+    // Force abort all inflight queries.
+    self.browser.http_client.abortFrame(pending_page.frame._frame_id, .{ .scope = .full });
+
     self._pending_idx = null;
-    self._pages[idx].?.deinit();
+    pending_page.deinit();
     self.freeSlot(idx);
 }
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -65,31 +65,12 @@ arena_pool: *ArenaPool,
 // teardowns so V8 weak callbacks can validate the FC before dereferencing it.
 fc_identity_pool: std.heap.MemoryPool(FinalizerCallback.Identity),
 
-// Two physical slots for Pages, both stored inline in the Session struct.
-// Each slot has a stable address, so Frame self-pointers (window._frame,
-// document._frame, EventManager.frame, etc.) — which point inside the
-// slot's Page — remain valid across the pending → active promotion done
-// by commitPendingPage. We never move a Page; we only flip the index that
-// names the active vs pending slot.
-//
-// Why two slots: at any given moment we may need to hold one active Page
-// (the user-visible page) AND one pending Page (the in-flight destination
-// of a root navigation, kept alive across the HTTP round-trip per Chrome's
-// behavior). After commit, the OLD active slot is freed and becomes
-// available for the next pending allocation.
-//
-// Convention: a slot is "occupied" iff its `?Page` is non-null.
-_pages: [2]?Page = .{ null, null },
+// The currently-active Page
+// flips this pointer.
+_active: ?*Page = null,
 
-// Index into `_pages` for the currently-active page, or null when no Page
-// exists (between removePage and createPage, or at startup).
-_active_idx: ?u1 = null,
-
-// Index into `_pages` for an in-flight root navigation, or null when no
-// pending navigation is in flight. CDP commands and the rest of the
-// codebase MUST NOT see this as the current page; it is invisible to
-// Target.* / DOM.* / Runtime.* until commit promotes it to `_active_idx`.
-_pending_idx: ?u1 = null,
+// In-flight root navigation
+_pending: ?*Page = null,
 
 // IDs. Kept at Session level so IDs can remain unique across Page replacements.
 frame_id_gen: u32 = 0,
@@ -117,10 +98,10 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
 }
 
 pub fn deinit(self: *Session) void {
-    if (self._pending_idx != null) {
+    if (self._pending != null) {
         self.discardPendingPage();
     }
-    if (self._active_idx != null) {
+    if (self._active != null) {
         self.removePage();
     }
     self.cookie_jar.deinit();
@@ -131,39 +112,24 @@ pub fn deinit(self: *Session) void {
 }
 
 // True iff there is an active Page. CDP / external callers should use this
-// (or `currentPage()`) rather than poking at the underlying slots.
+// (or `currentPage()`) rather than poking at the underlying field.
 pub fn hasPage(self: *const Session) bool {
-    return self._active_idx != null;
+    return self._active != null;
 }
 
-// Pick a free slot index — i.e. one whose `_pages` entry is null.
-// In normal operation we always have at most one of (active, pending), so
-// at least one slot is free. Returns null only if both slots are occupied,
-// which is an invariant violation.
-fn findFreeSlot(self: *const Session) !u1 {
-    if (self._pages[0] == null) return 0;
-    if (self._pages[1] == null) return 1;
+// Allocate and initialize a Page.
+fn allocatePage(self: *Session, frame_id: u32) !*Page {
+    const page = try self.browser.page_pool.create();
+    errdefer self.browser.page_pool.destroy(page);
 
-    return error.NoFreePageSlot;
-}
-
-// Initialize a Page in the given inline slot and return a stable pointer
-// to it. The slot must be currently empty. The returned Page is in the
-// .active state by default; callers that want a pending page
-// (initiateRootNavigation) must flip _state themselves.
-fn pageInit(self: *Session, slot: u1, frame_id: u32) !*Page {
-    lp.assert(self._pages[slot] == null, "Session.pageInit - slot occupied", .{});
-    self._pages[slot] = @as(Page, undefined);
-    const page = &self._pages[slot].?;
-    errdefer self._pages[slot] = null;
     try Page.init(page, self, frame_id);
     return page;
 }
 
-// Free the inline slot whose Page has already been Page.deinit'd. After
-// this, the slot is available for a future allocation.
-fn freeSlot(self: *Session, slot: u1) void {
-    self._pages[slot] = null;
+// Tear down and free a Page allocated via allocatePage.
+fn destroyPage(self: *Session, page: *Page) void {
+    page.deinit();
+    self.browser.page_pool.destroy(page);
 }
 
 // Tear down the currently-active Page. Dispatches `frame_remove` first
@@ -178,15 +144,14 @@ fn freeSlot(self: *Session, slot: u1) void {
 // in a specific order.
 fn tearDownActivePage(self: *Session) void {
     self.notification.dispatch(.frame_remove, .{});
-    const idx = self._active_idx orelse {
+    const page = self._active orelse {
         if (comptime IS_DEBUG) {
             lp.assert(false, "Session.tearDownActivePage - no active page", .{});
         }
         return;
     };
-    self._pages[idx].?.deinit();
-    self.freeSlot(idx);
-    self._active_idx = null;
+    self.destroyPage(page);
+    self._active = null;
     self.navigation.onRemoveFrame();
     self.frame_id_gen = 0;
 }
@@ -197,18 +162,14 @@ fn tearDownActivePage(self: *Session) void {
 // dispatch `frame_navigate` — the caller does that (or doesn't, for a
 // blank initial page).
 //
-// On any failure after slot allocation, the errdefers roll back the slot
-// and `_active_idx`, leaving the session pageless (the caller is
-// responsible for any prior teardown of an old page).
+// On any failure after allocation, the errdefers roll back the Page
+// and `active`, leaving the session pageless (the caller is responsible
+// for any prior teardown of an old page).
 fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
-    const slot = try self.findFreeSlot();
-    const page = try self.pageInit(slot, frame_id);
-    errdefer {
-        page.deinit();
-        self.freeSlot(slot);
-    }
-    self._active_idx = slot;
-    errdefer self._active_idx = null;
+    const page = try self.allocatePage(frame_id);
+    errdefer self.destroyPage(page);
+    self._active = page;
+    errdefer self._active = null;
 
     const frame = &page.frame;
     try self.navigation.onNewFrame(frame);
@@ -221,7 +182,7 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
 // NOTE: the caller is not the owner of the returned value,
 // the pointer on Frame is just returned as a convenience
 pub fn createPage(self: *Session) !*Frame {
-    lp.assert(self._active_idx == null, "Session.createPage - page not null", .{});
+    lp.assert(self._active == null, "Session.createPage - page not null", .{});
     if (comptime IS_DEBUG) {
         log.debug(.browser, "create page", .{});
     }
@@ -229,11 +190,11 @@ pub fn createPage(self: *Session) !*Frame {
 }
 
 pub fn removePage(self: *Session) void {
-    const idx = self._active_idx orelse {
+    const page = self._active orelse {
         lp.assert(false, "Session.removePage - page is null", .{});
     };
 
-    if (self._pages[idx].?.frame._script_manager.base.is_evaluating) {
+    if (page.frame._script_manager.base.is_evaluating) {
         // Reentrant teardown from a CDP message drained inside syncRequest;
         // Session.deinit reclaims the page when the connection closes.
         return;
@@ -243,7 +204,7 @@ pub fn removePage(self: *Session) void {
     // transfer was protected from abort to survive commitPendingPage's
     // teardown of the old page, but we are now permanently removing the
     // session's page state — the pending transfer should die with it.
-    if (self._pending_idx != null) {
+    if (self._pending != null) {
         self.discardPendingPage();
     }
     self.tearDownActivePage();
@@ -269,16 +230,11 @@ pub fn releaseOrigin(self: *Session, origin: *js.Origin) void {
 }
 
 pub fn currentPage(self: *Session) ?*Page {
-    const idx = self._active_idx orelse return null;
-    return &self._pages[idx].?;
+    return self._active;
 }
 
-// Returns the pending Page if a root navigation is in flight. CDP / DOM /
-// Runtime callers MUST NOT use this; it is only for the navigation
-// machinery (Frame.navigate / commitPendingPage).
 pub fn pendingPage(self: *Session) ?*Page {
-    const idx = self._pending_idx orelse return null;
-    return &self._pages[idx].?;
+    return self._pending;
 }
 
 pub fn pendingOrCurrentFrame(self: *Session) ?*Frame {
@@ -466,10 +422,10 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
 }
 
 fn processRootQueuedNavigation(self: *Session) !void {
-    const active_idx = self._active_idx orelse {
+    const active = self._active orelse {
         lp.assert(false, "Session.processRootQueuedNavigation - no active page", .{});
     };
-    const current_frame = &self._pages[active_idx].?.frame;
+    const current_frame = &active.frame;
 
     // Detach the QueuedNavigation. Whether we keep it on the active frame
     // (synthetic path) or transfer it to the pending frame (HTTP path), the
@@ -516,21 +472,14 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
 // trip — Runtime.evaluate, DOM.*, etc. continue to operate on the OLD page
 // until commitPendingPage swaps the pointer when response headers arrive.
 pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
-    if (self._pending_idx != null) {
-        self.discardPendingPage();
-    }
+    self.discardPendingPage();
 
-    // Pick the slot NOT occupied by the active page.
-    const slot = try self.findFreeSlot();
-    const page = try self.pageInit(slot, frame_id);
-    errdefer {
-        page.deinit();
-        self.freeSlot(slot);
-    }
+    const page = try self.allocatePage(frame_id);
+    errdefer self.destroyPage(page);
 
     page._state = .pending;
-    self._pending_idx = slot;
-    errdefer self._pending_idx = null;
+    self._pending = page;
+    errdefer self._pending = null;
 
     if (comptime IS_DEBUG) {
         log.debug(.browser, "initiate root navigation", .{ .url = url });
@@ -573,10 +522,10 @@ pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, 
 //      by protect_from_abort, which abortFrame's default .normal scope
 //      honors. The caller clears the flag AFTER we return.
 pub fn commitPendingPage(self: *Session) !void {
-    const pending_idx = self._pending_idx orelse {
+    const pending = self._pending orelse {
         lp.assert(false, "Session.commitPendingPage - no pending page", .{});
     };
-    const old_active_idx = self._active_idx orelse {
+    const old_active = self._active orelse {
         lp.assert(false, "Session.commitPendingPage - no active page", .{});
     };
 
@@ -584,19 +533,17 @@ pub fn commitPendingPage(self: *Session) !void {
         log.debug(.browser, "commit pending page", .{});
     }
 
-    const pending = &self._pages[pending_idx].?;
-
     // Step 1: clear the OLD page's CDP / V8 inspector state.
     self.notification.dispatch(.frame_remove, .{});
     self.navigation.onRemoveFrame();
 
-    // Step 2: index flip. Page slot addresses are stable (inline in
-    // Session), so every self-pointer inside `pending` (window._frame,
+    // Step 2: pointer flip. Page addresses are stable (heap-allocated),
+    // so every self-pointer inside `pending` (window._frame,
     // document._frame, EventManager.frame, etc.) remains valid.
-    self._active_idx = pending_idx;
+    self._active = pending;
     pending._state = .active;
 
-    // Step 3: register the new page with CDP. _pending_idx is still set at
+    // Step 3: register the new page with CDP. `pending` is still set at
     // this point — CDP's frameCreated handler reads `pendingPage() != null`
     // to skip the captured_responses / frame_arena resets that would wipe
     // the in-flight response we just received.
@@ -605,8 +552,8 @@ pub fn commitPendingPage(self: *Session) !void {
     };
     self.notification.dispatch(.frame_created, &pending.frame);
 
-    // Step 4: _pending_idx = null AFTER frame_created so step 3 saw it.
-    self._pending_idx = null;
+    // Step 4: `pending` = null AFTER frame_created so step 3 saw it.
+    self._pending = null;
 
     // Step 5: tear down the OLD page LAST. Anything in steps 1-4 that
     // needed to walk the OLD page's state (CDP node_registry, inspector
@@ -614,28 +561,24 @@ pub fn commitPendingPage(self: *Session) !void {
     // frame.deinit calls http_client.abortFrame(frame_id) on the frame_id
     // shared with the pending page; the in-flight transfer survives via
     // protect_from_abort.
-    self._pages[old_active_idx].?.deinit();
-    self.freeSlot(old_active_idx);
+    self.destroyPage(old_active);
 }
 
 // Discard a pending Page without committing. Used for failure paths
 // (HTTP error before commit, session deinit during pending, etc.). The
 // active page is untouched.
 pub fn discardPendingPage(self: *Session) void {
-    const idx = self._pending_idx orelse return;
+    const page = self._pending orelse return;
 
     if (comptime IS_DEBUG) {
         log.debug(.browser, "discard pending page", .{});
     }
 
-    const pending_page = &self._pages[idx].?;
-
     // Force abort all inflight queries.
-    self.browser.http_client.abortFrame(pending_page.frame._frame_id, .{ .scope = .full });
+    self.browser.http_client.abortFrame(page.frame._frame_id, .{ .scope = .full });
 
-    self._pending_idx = null;
-    pending_page.deinit();
-    self.freeSlot(idx);
+    self._pending = null;
+    self.destroyPage(page);
 }
 
 pub fn nextFrameId(self: *Session) u32 {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -478,10 +478,9 @@ fn processRootQueuedNavigation(self: *Session) !void {
     current_frame._queued_navigation = null;
 
     // Synthetic navigations (about:blank, blob:) commit instantly — no HTTP,
-    // so there is no in-flight window to worry about. Use the legacy
+    // so there is no in-flight window to worry about. Use the optimized
     // immediate-swap path for them.
-    const is_synthetic = std.mem.eql(u8, qn.url, "about:blank") or
-        std.mem.startsWith(u8, qn.url, "blob:");
+    const is_synthetic = qn.is_about_blank or std.mem.startsWith(u8, qn.url, "blob:");
 
     if (is_synthetic) {
         return self.replaceRootImmediate(current_frame._frame_id, qn);

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -265,6 +265,11 @@ pub fn pendingPage(self: *Session) ?*Page {
     return &self._pages[idx].?;
 }
 
+pub fn currentOrPendingFrame(self: *Session) ?*Frame {
+    const page = self.pendingPage() orelse self.currentPage() orelse return null;
+    return &page.frame;
+}
+
 pub fn currentFrame(self: *Session) ?*Frame {
     const page = self.currentPage() orelse return null;
     return &page.frame;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -585,9 +585,11 @@ pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, 
 //      onHttpResponseHeadersDone moments earlier and must survive).
 //   4. pending_page = null. Order matters: step 3 reads it.
 //   5. OLD Page.deinit + free LAST. Its frame.deinit calls
-//      http_client.abort() unconditionally — the in-flight navigation
-//      transfer (whose callback we are inside) is shielded by
-//      protect_from_abort, which the caller clears AFTER we return.
+//      http_client.abortFrame(frame_id) on the frame_id that the OLD
+//      page shares with the now-active pending page; the in-flight
+//      navigation transfer (whose callback we are inside) is shielded
+//      by protect_from_abort, which abortFrame's default .normal scope
+//      honors. The caller clears the flag AFTER we return.
 pub fn commitPendingPage(self: *Session) !void {
     const pending_idx = self._pending_idx orelse {
         lp.assert(false, "Session.commitPendingPage - no pending page", .{});
@@ -629,8 +631,9 @@ pub fn commitPendingPage(self: *Session) !void {
     // Step 5: tear down the OLD page LAST. Anything in steps 1-4 that
     // needed to walk the OLD page's state (CDP node_registry, inspector
     // context group, isolated worlds) has already done so. The OLD page's
-    // frame.deinit calls http_client.abort() unconditionally; the in-flight
-    // transfer survives via protect_from_abort.
+    // frame.deinit calls http_client.abortFrame(frame_id) on the frame_id
+    // shared with the pending page; the in-flight transfer survives via
+    // protect_from_abort.
     self._pages[old_idx].?.deinit();
     self.freeSlot(old_idx);
 }

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -265,9 +265,17 @@ pub fn replacePage(self: *Session) !*Frame {
     lp.assert(old_page.frame.parent == null, "Session.replacePage with parent", .{});
 
     const frame_id = old_page.frame._frame_id;
+
+    // Dispatch frame_remove so CDP can tear down the OLD page's isolated
+    // world V8 contexts and inspector state. Without this, old V8 contexts
+    // leak (and a later frameNavigated would localScope() into a freed
+    // handle — UAF).
+    self.notification.dispatch(.frame_remove, .{});
+
     old_page.deinit();
     self.freeSlot(old_idx);
     self._active_idx = null;
+    self.navigation.onRemoveFrame();
 
     // Preserve prior behavior: frame_id_gen reset on root replacement so a
     // subsequent createPage starts from id 1. The captured frame_id is
@@ -281,7 +289,19 @@ pub fn replacePage(self: *Session) !*Frame {
         self.freeSlot(new_slot);
     }
     self._active_idx = new_slot;
-    return &page.frame;
+    const new_frame = &page.frame;
+
+    // Creates a new NavigationEventTarget for this frame.
+    self.navigation.onNewFrame(new_frame) catch |err| {
+        log.err(.browser, "replacePage onNewFrame", .{ .err = err });
+    };
+
+    // Dispatch frame_created so CDP creates fresh isolated world V8 contexts
+    // for the new frame. The subsequent frame.navigate call will dispatch
+    // frame_navigated which registers them with the inspector.
+    self.notification.dispatch(.frame_created, new_frame);
+
+    return new_frame;
 }
 
 pub fn currentPage(self: *Session) ?*Page {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -581,7 +581,7 @@ pub fn commitPendingPage(self: *Session) !void {
         lp.assert(false, "Session.commitPendingPage - no pending page", .{});
         return error.NoPendingPage;
     };
-    const old_idx = self._active_idx orelse {
+    const old_active_idx = self._active_idx orelse {
         lp.assert(false, "Session.commitPendingPage - no active page", .{});
         return error.NoActivePage;
     };
@@ -620,8 +620,8 @@ pub fn commitPendingPage(self: *Session) !void {
     // frame.deinit calls http_client.abortFrame(frame_id) on the frame_id
     // shared with the pending page; the in-flight transfer survives via
     // protect_from_abort.
-    self._pages[old_idx].?.deinit();
-    self.freeSlot(old_idx);
+    self._pages[old_active_idx].?.deinit();
+    self.freeSlot(old_active_idx);
 }
 
 // Discard a pending Page without committing. Used for failure paths

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -120,9 +120,6 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
 }
 
 pub fn deinit(self: *Session) void {
-    // Tear down a pending navigation first so its in-flight transfer is
-    // aborted before we shutter the active Page (which calls
-    // http_client.abort() unconditionally from frame.deinit).
     if (self._pending_idx != null) {
         self.discardPendingPage();
     }
@@ -180,7 +177,7 @@ pub fn createPage(self: *Session) !*Frame {
     const slot = try self.findFreeSlot();
     const page = try self.pageInit(slot, self.nextFrameId());
     errdefer {
-        page.deinit(false);
+        page.deinit();
         self.freeSlot(slot);
     }
     self._active_idx = slot;
@@ -224,7 +221,7 @@ pub fn removePage(self: *Session) void {
     // Inform CDP the frame is going to be removed, allowing other worlds to remove themselves before the main one
     self.notification.dispatch(.frame_remove, .{});
 
-    self._pages[idx].?.deinit(false);
+    self._pages[idx].?.deinit();
     self.freeSlot(idx);
     self._active_idx = null;
 
@@ -268,7 +265,7 @@ pub fn replacePage(self: *Session) !*Frame {
     lp.assert(old_page.frame.parent == null, "Session.replacePage with parent", .{});
 
     const frame_id = old_page.frame._frame_id;
-    old_page.deinit(true);
+    old_page.deinit();
     self.freeSlot(old_idx);
     self._active_idx = null;
 
@@ -280,7 +277,7 @@ pub fn replacePage(self: *Session) !*Frame {
     const new_slot = try self.findFreeSlot();
     const page = try self.pageInit(new_slot, frame_id);
     errdefer {
-        page.deinit(false);
+        page.deinit();
         self.freeSlot(new_slot);
     }
     self._active_idx = new_slot;
@@ -408,7 +405,7 @@ fn processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
 
     const frame_id = frame._frame_id;
     const page = self.currentPage().?;
-    frame.deinit(true);
+    frame.deinit();
     frame.* = undefined;
 
     errdefer {
@@ -428,7 +425,7 @@ fn processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
         if (parent_notified) {
             parent._pending_loads -= 1;
         }
-        frame.deinit(true);
+        frame.deinit();
     }
 
     frame.iframe = iframe;
@@ -454,7 +451,7 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
     const frame_id = frame._frame_id;
     const page = self.currentPage().?;
 
-    frame.deinit(true);
+    frame.deinit();
     frame.* = undefined;
 
     errdefer {
@@ -468,7 +465,7 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
     }
 
     try Frame.init(frame, frame_id, page, null);
-    errdefer frame.deinit(true);
+    errdefer frame.deinit();
 
     frame.window._name = saved_name;
     frame.window._opener = saved_opener;
@@ -520,7 +517,7 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
     // Dispatch frame_remove (same as removePage) then tear down the OLD
     // page's slot.
     self.notification.dispatch(.frame_remove, .{});
-    self._pages[old_idx].?.deinit(true);
+    self._pages[old_idx].?.deinit();
     self.freeSlot(old_idx);
     self._active_idx = null;
 
@@ -532,7 +529,7 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
     const new_slot = try self.findFreeSlot();
     const page = try self.pageInit(new_slot, frame_id);
     errdefer {
-        page.deinit(false);
+        page.deinit();
         self.freeSlot(new_slot);
     }
     self._active_idx = new_slot;
@@ -570,7 +567,7 @@ fn initiateRootNavigation(self: *Session, frame_id: u32, qn: *QueuedNavigation) 
     const slot = try self.findFreeSlot();
     const page = try self.pageInit(slot, frame_id);
     errdefer {
-        page.deinit(false);
+        page.deinit();
         self.freeSlot(slot);
     }
 
@@ -659,7 +656,7 @@ pub fn commitPendingPage(self: *Session) !void {
     // context group, isolated worlds) has already done so. The OLD page's
     // frame.deinit calls http_client.abort() unconditionally; the in-flight
     // transfer survives via protect_from_abort.
-    self._pages[old_idx].?.deinit(false);
+    self._pages[old_idx].?.deinit();
     self.freeSlot(old_idx);
 }
 
@@ -674,7 +671,7 @@ pub fn discardPendingPage(self: *Session) void {
     }
 
     self._pending_idx = null;
-    self._pages[idx].?.deinit(false);
+    self._pages[idx].?.deinit();
     self.freeSlot(idx);
 }
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -103,9 +103,6 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     errdefer arena_pool.release(arena);
 
     self.* = .{
-        ._pages = .{ null, null },
-        ._active_idx = null,
-        ._pending_idx = null,
         .arena = arena,
         .arena_pool = arena_pool,
         .history = .{},

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -283,7 +283,7 @@ pub fn pendingPage(self: *Session) ?*Page {
     return &self._pages[idx].?;
 }
 
-pub fn currentOrPendingFrame(self: *Session) ?*Frame {
+pub fn pendingOrCurrentFrame(self: *Session) ?*Frame {
     const page = self.pendingPage() orelse self.currentPage() orelse return null;
     return &page.frame;
 }

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -252,58 +252,6 @@ pub fn releaseOrigin(self: *Session, origin: *js.Origin) void {
     self.currentPage().?.releaseOrigin(origin);
 }
 
-pub fn replacePage(self: *Session) !*Frame {
-    if (comptime IS_DEBUG) {
-        log.debug(.browser, "replace page", .{});
-    }
-
-    const old_idx = self._active_idx orelse {
-        lp.assert(false, "Session.replacePage null page", .{});
-        return error.NoActivePage;
-    };
-    const old_page = &self._pages[old_idx].?;
-    lp.assert(old_page.frame.parent == null, "Session.replacePage with parent", .{});
-
-    const frame_id = old_page.frame._frame_id;
-
-    // Dispatch frame_remove so CDP can tear down the OLD page's isolated
-    // world V8 contexts and inspector state. Without this, old V8 contexts
-    // leak (and a later frameNavigated would localScope() into a freed
-    // handle — UAF).
-    self.notification.dispatch(.frame_remove, .{});
-
-    old_page.deinit();
-    self.freeSlot(old_idx);
-    self._active_idx = null;
-    self.navigation.onRemoveFrame();
-
-    // Preserve prior behavior: frame_id_gen reset on root replacement so a
-    // subsequent createPage starts from id 1. The captured frame_id is
-    // passed into Page.init explicitly, so it isn't affected.
-    self.frame_id_gen = 0;
-
-    const new_slot = try self.findFreeSlot();
-    const page = try self.pageInit(new_slot, frame_id);
-    errdefer {
-        page.deinit();
-        self.freeSlot(new_slot);
-    }
-    self._active_idx = new_slot;
-    const new_frame = &page.frame;
-
-    // Creates a new NavigationEventTarget for this frame.
-    self.navigation.onNewFrame(new_frame) catch |err| {
-        log.err(.browser, "replacePage onNewFrame", .{ .err = err });
-    };
-
-    // Dispatch frame_created so CDP creates fresh isolated world V8 contexts
-    // for the new frame. The subsequent frame.navigate call will dispatch
-    // frame_navigated which registers them with the inspector.
-    self.notification.dispatch(.frame_created, new_frame);
-
-    return new_frame;
-}
-
 pub fn currentPage(self: *Session) ?*Page {
     const idx = self._active_idx orelse return null;
     return &self._pages[idx].?;
@@ -519,7 +467,12 @@ fn processRootQueuedNavigation(self: *Session) !void {
         return self.replaceRootImmediate(current_frame._frame_id, qn);
     }
 
-    return self.initiateRootNavigation(current_frame._frame_id, qn);
+    // The qn arena is consumed here regardless of success — frame.navigate
+    // dupes the URL into the page's own arena, so we can release the qn
+    // arena as soon as navigate returns.
+    defer self.arena_pool.release(qn.arena);
+
+    return self.initiateRootNavigation(current_frame._frame_id, qn.url, qn.opts);
 }
 
 // Legacy immediate-swap path: tear down the active page and create a new one
@@ -575,13 +528,8 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
 // The active Page (and its V8 context) stays addressable across the round-
 // trip — Runtime.evaluate, DOM.*, etc. continue to operate on the OLD page
 // until commitPendingPage swaps the pointer when response headers arrive.
-fn initiateRootNavigation(self: *Session, frame_id: u32, qn: *QueuedNavigation) !void {
+pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
     lp.assert(self._pending_idx == null, "Session.initiateRootNavigation - pending already set", .{});
-
-    // The qn arena is consumed here regardless of success — frame.navigate
-    // dupes the URL into the page's own arena, so we can release the qn
-    // arena as soon as navigate returns.
-    defer self.arena_pool.release(qn.arena);
 
     // Pick the slot NOT occupied by the active page.
     const slot = try self.findFreeSlot();
@@ -596,7 +544,7 @@ fn initiateRootNavigation(self: *Session, frame_id: u32, qn: *QueuedNavigation) 
     errdefer self._pending_idx = null;
 
     if (comptime IS_DEBUG) {
-        log.debug(.browser, "initiate root navigation", .{ .url = qn.url });
+        log.debug(.browser, "initiate root navigation", .{ .url = url });
     }
 
     // No frame_created notification yet — CDP must not see the pending page
@@ -604,8 +552,8 @@ fn initiateRootNavigation(self: *Session, frame_id: u32, qn: *QueuedNavigation) 
     // world and the isolated worlds get registered with the V8 inspector at
     // commit, after frame_remove tears down the OLD page's context group.
 
-    page.frame.navigate(qn.url, qn.opts) catch |err| {
-        log.err(.browser, "pending navigation start", .{ .err = err, .url = qn.url });
+    page.frame.navigate(url, opts) catch |err| {
+        log.err(.browser, "pending navigation start", .{ .err = err, .url = url });
         return err;
     };
 }

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -65,9 +65,31 @@ arena_pool: *ArenaPool,
 // teardowns so V8 weak callbacks can validate the FC before dereferencing it.
 fc_identity_pool: std.heap.MemoryPool(FinalizerCallback.Identity),
 
-// The currently-active Page. Null when no Page exists (between removePage
-// and createPage, or at startup).
-page: ?Page,
+// Two physical slots for Pages, both stored inline in the Session struct.
+// Each slot has a stable address, so Frame self-pointers (window._frame,
+// document._frame, EventManager.frame, etc.) — which point inside the
+// slot's Page — remain valid across the pending → active promotion done
+// by commitPendingPage. We never move a Page; we only flip the index that
+// names the active vs pending slot.
+//
+// Why two slots: at any given moment we may need to hold one active Page
+// (the user-visible page) AND one pending Page (the in-flight destination
+// of a root navigation, kept alive across the HTTP round-trip per Chrome's
+// behavior). After commit, the OLD active slot is freed and becomes
+// available for the next pending allocation.
+//
+// Convention: a slot is "occupied" iff its `?Page` is non-null.
+_pages: [2]?Page = .{ null, null },
+
+// Index into `_pages` for the currently-active page, or null when no Page
+// exists (between removePage and createPage, or at startup).
+_active_idx: ?u1 = null,
+
+// Index into `_pages` for an in-flight root navigation, or null when no
+// pending navigation is in flight. CDP commands and the rest of the
+// codebase MUST NOT see this as the current page; it is invisible to
+// Target.* / DOM.* / Runtime.* until commit promotes it to `_active_idx`.
+_pending_idx: ?u1 = null,
 
 // IDs. Kept at Session level so IDs can remain unique across Page replacements.
 frame_id_gen: u32 = 0,
@@ -81,7 +103,9 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     errdefer arena_pool.release(arena);
 
     self.* = .{
-        .page = null,
+        ._pages = .{ null, null },
+        ._active_idx = null,
+        ._pending_idx = null,
         .arena = arena,
         .arena_pool = arena_pool,
         .history = .{},
@@ -96,7 +120,13 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
 }
 
 pub fn deinit(self: *Session) void {
-    if (self.page != null) {
+    // Tear down a pending navigation first so its in-flight transfer is
+    // aborted before we shutter the active Page (which calls
+    // http_client.abort() unconditionally from frame.deinit).
+    if (self._pending_idx != null) {
+        self.discardPendingPage();
+    }
+    if (self._active_idx != null) {
         self.removePage();
     }
     self.cookie_jar.deinit();
@@ -106,17 +136,56 @@ pub fn deinit(self: *Session) void {
     self.arena_pool.release(self.arena);
 }
 
+// True iff there is an active Page. CDP / external callers should use this
+// (or `currentPage()`) rather than poking at the underlying slots.
+pub fn hasPage(self: *const Session) bool {
+    return self._active_idx != null;
+}
+
+// Pick a free slot index — i.e. one whose `_pages` entry is null.
+// In normal operation we always have at most one of (active, pending), so
+// at least one slot is free. Returns null only if both slots are occupied,
+// which is an invariant violation.
+fn findFreeSlot(self: *const Session) !u1 {
+    if (self._pages[0] == null) return 0;
+    if (self._pages[1] == null) return 1;
+
+    return error.NoFreePageSlot;
+}
+
+// Initialize a Page in the given inline slot and return a stable pointer
+// to it. The slot must be currently empty. The returned Page is in the
+// .active state by default; callers that want a pending page
+// (initiateRootNavigation) must flip _state themselves.
+fn pageInit(self: *Session, slot: u1, frame_id: u32) !*Page {
+    lp.assert(self._pages[slot] == null, "Session.pageInit - slot occupied", .{});
+    self._pages[slot] = @as(Page, undefined);
+    const page = &self._pages[slot].?;
+    errdefer self._pages[slot] = null;
+    try Page.init(page, self, frame_id);
+    return page;
+}
+
+// Free the inline slot whose Page has already been Page.deinit'd. After
+// this, the slot is available for a future allocation.
+fn freeSlot(self: *Session, slot: u1) void {
+    self._pages[slot] = null;
+}
+
 // NOTE: the caller is not the owner of the returned value,
 // the pointer on Frame is just returned as a convenience
 pub fn createPage(self: *Session) !*Frame {
-    lp.assert(self.page == null, "Session.createPage - page not null", .{});
+    lp.assert(self._active_idx == null, "Session.createPage - page not null", .{});
 
-    self.page = @as(Page, undefined);
-    const page = &self.page.?;
+    const slot = try self.findFreeSlot();
+    const page = try self.pageInit(slot, self.nextFrameId());
+    errdefer {
+        page.deinit(false);
+        self.freeSlot(slot);
+    }
+    self._active_idx = slot;
+    errdefer self._active_idx = null;
 
-    errdefer self.page = null;
-
-    try Page.init(page, self, self.nextFrameId());
     const frame = &page.frame;
 
     // Creates a new NavigationEventTarget for this frame.
@@ -133,18 +202,31 @@ pub fn createPage(self: *Session) !*Frame {
 }
 
 pub fn removePage(self: *Session) void {
-    lp.assert(self.page != null, "Session.removePage - page is null", .{});
-    if (self.page.?.frame._script_manager.base.is_evaluating) {
+    const idx = self._active_idx orelse {
+        lp.assert(false, "Session.removePage - page is null", .{});
+        return;
+    };
+
+    if (self._pages[idx].?.frame._script_manager.base.is_evaluating) {
         // Reentrant teardown from a CDP message drained inside syncRequest;
         // Session.deinit reclaims the page when the connection closes.
         return;
     }
 
+    // If a navigation is in flight, drop the pending Page first. Its
+    // transfer was protected from abort to survive commitPendingPage's
+    // teardown of the old page, but we are now permanently removing the
+    // session's page state — the pending transfer should die with it.
+    if (self._pending_idx != null) {
+        self.discardPendingPage();
+    }
+
     // Inform CDP the frame is going to be removed, allowing other worlds to remove themselves before the main one
     self.notification.dispatch(.frame_remove, .{});
 
-    self.page.?.deinit(false);
-    self.page = null;
+    self._pages[idx].?.deinit(false);
+    self.freeSlot(idx);
+    self._active_idx = null;
 
     self.navigation.onRemoveFrame();
 
@@ -166,11 +248,11 @@ pub fn releaseArena(self: *Session, allocator: Allocator) void {
 }
 
 pub fn getOrCreateOrigin(self: *Session, key_: ?[]const u8) !*js.Origin {
-    return self.page.?.getOrCreateOrigin(key_);
+    return self.currentPage().?.getOrCreateOrigin(key_);
 }
 
 pub fn releaseOrigin(self: *Session, origin: *js.Origin) void {
-    return self.page.?.releaseOrigin(origin);
+    self.currentPage().?.releaseOrigin(origin);
 }
 
 pub fn replacePage(self: *Session) !*Frame {
@@ -178,30 +260,44 @@ pub fn replacePage(self: *Session) !*Frame {
         log.debug(.browser, "replace page", .{});
     }
 
-    lp.assert(self.page != null, "Session.replacePage null page", .{});
-    const current = &self.page.?;
-    lp.assert(current.frame.parent == null, "Session.replacePage with parent", .{});
+    const old_idx = self._active_idx orelse {
+        lp.assert(false, "Session.replacePage null page", .{});
+        return error.NoActivePage;
+    };
+    const old_page = &self._pages[old_idx].?;
+    lp.assert(old_page.frame.parent == null, "Session.replacePage with parent", .{});
 
-    const frame_id = current.frame._frame_id;
-    current.deinit(true);
-    self.page = null;
+    const frame_id = old_page.frame._frame_id;
+    old_page.deinit(true);
+    self.freeSlot(old_idx);
+    self._active_idx = null;
 
     // Preserve prior behavior: frame_id_gen reset on root replacement so a
     // subsequent createPage starts from id 1. The captured frame_id is
     // passed into Page.init explicitly, so it isn't affected.
     self.frame_id_gen = 0;
 
-    self.page = @as(Page, undefined);
-    const page = &self.page.?;
-
-    errdefer self.page = null;
-
-    try Page.init(page, self, frame_id);
+    const new_slot = try self.findFreeSlot();
+    const page = try self.pageInit(new_slot, frame_id);
+    errdefer {
+        page.deinit(false);
+        self.freeSlot(new_slot);
+    }
+    self._active_idx = new_slot;
     return &page.frame;
 }
 
 pub fn currentPage(self: *Session) ?*Page {
-    return &(self.page orelse return null);
+    const idx = self._active_idx orelse return null;
+    return &self._pages[idx].?;
+}
+
+// Returns the pending Page if a root navigation is in flight. CDP / DOM /
+// Runtime callers MUST NOT use this; it is only for the navigation
+// machinery (Frame.navigate / commitPendingPage).
+pub fn pendingPage(self: *Session) ?*Page {
+    const idx = self._pending_idx orelse return null;
+    return &self._pages[idx].?;
 }
 
 pub fn currentFrame(self: *Session) ?*Frame {
@@ -219,7 +315,7 @@ pub fn runner(self: *Session, opts: Runner.Opts) !Runner {
 }
 
 pub fn scheduleNavigation(self: *Session, frame: *Frame) !void {
-    return self.page.?.scheduleNavigation(frame);
+    return self.currentPage().?.scheduleNavigation(frame);
 }
 
 pub fn processQueuedNavigation(self: *Session) !void {
@@ -384,32 +480,62 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
 }
 
 fn processRootQueuedNavigation(self: *Session) !void {
-    const current_frame = &self.page.?.frame;
-    const frame_id = current_frame._frame_id;
+    const active_idx = self._active_idx orelse {
+        lp.assert(false, "Session.processRootQueuedNavigation - no active page", .{});
+        return;
+    };
+    const current_frame = &self._pages[active_idx].?.frame;
 
-    // create a copy before the frame is cleared
+    // Detach the QueuedNavigation. Whether we keep it on the active frame
+    // (synthetic path) or transfer it to the pending frame (HTTP path), the
+    // current frame must no longer claim it.
     const qn = current_frame._queued_navigation.?;
     current_frame._queued_navigation = null;
 
+    // Synthetic navigations (about:blank, blob:) commit instantly — no HTTP,
+    // so there is no in-flight window to worry about. Use the legacy
+    // immediate-swap path for them.
+    const is_synthetic = std.mem.eql(u8, qn.url, "about:blank") or
+        std.mem.startsWith(u8, qn.url, "blob:");
+
+    if (is_synthetic) {
+        return self.replaceRootImmediate(current_frame._frame_id, qn);
+    }
+
+    return self.initiateRootNavigation(current_frame._frame_id, qn);
+}
+
+// Legacy immediate-swap path: tear down the active page and create a new one
+// in its place before issuing the navigation. Used for synthetic navigations
+// (about:blank, blob:) where there is no in-flight HTTP and therefore no
+// "pending" window to span.
+fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !void {
     defer self.arena_pool.release(qn.arena);
 
-    // Dispatch frame_remove (same as removePage) then replace the Page
-    // in-place, keeping the frame_id stable.
+    const old_idx = self._active_idx orelse {
+        lp.assert(false, "Session.replaceRootImmediate - no active page", .{});
+        return;
+    };
+
+    // Dispatch frame_remove (same as removePage) then tear down the OLD
+    // page's slot.
     self.notification.dispatch(.frame_remove, .{});
-    self.page.?.deinit(true);
-    self.page = null;
+    self._pages[old_idx].?.deinit(true);
+    self.freeSlot(old_idx);
+    self._active_idx = null;
 
     self.navigation.onRemoveFrame();
 
     // Preserve prior behavior: the old resetFrameResources reset frame_id_gen.
     self.frame_id_gen = 0;
 
-    self.page = @as(Page, undefined);
-    const page = &self.page.?;
-
-    errdefer self.page = null;
-
-    try Page.init(page, self, frame_id);
+    const new_slot = try self.findFreeSlot();
+    const page = try self.pageInit(new_slot, frame_id);
+    errdefer {
+        page.deinit(false);
+        self.freeSlot(new_slot);
+    }
+    self._active_idx = new_slot;
     const new_frame = &page.frame;
 
     // Creates a new NavigationEventTarget for this frame.
@@ -425,6 +551,131 @@ fn processRootQueuedNavigation(self: *Session) !void {
         log.err(.browser, "queued navigation error", .{ .err = err });
         return err;
     };
+}
+
+// Real HTTP root navigation: allocate a pending Page, leave the active Page
+// alive, and dispatch the navigation HTTP request against the pending frame.
+// The active Page (and its V8 context) stays addressable across the round-
+// trip — Runtime.evaluate, DOM.*, etc. continue to operate on the OLD page
+// until commitPendingPage swaps the pointer when response headers arrive.
+fn initiateRootNavigation(self: *Session, frame_id: u32, qn: *QueuedNavigation) !void {
+    lp.assert(self._pending_idx == null, "Session.initiateRootNavigation - pending already set", .{});
+
+    // The qn arena is consumed here regardless of success — frame.navigate
+    // dupes the URL into the page's own arena, so we can release the qn
+    // arena as soon as navigate returns.
+    defer self.arena_pool.release(qn.arena);
+
+    // Pick the slot NOT occupied by the active page.
+    const slot = try self.findFreeSlot();
+    const page = try self.pageInit(slot, frame_id);
+    errdefer {
+        page.deinit(false);
+        self.freeSlot(slot);
+    }
+
+    page._state = .pending;
+    self._pending_idx = slot;
+    errdefer self._pending_idx = null;
+
+    if (comptime IS_DEBUG) {
+        log.debug(.browser, "initiate root navigation", .{ .url = qn.url });
+    }
+
+    // No frame_created notification yet — CDP must not see the pending page
+    // (no isolated worlds, no Target.* visibility). Both the pending main
+    // world and the isolated worlds get registered with the V8 inspector at
+    // commit, after frame_remove tears down the OLD page's context group.
+
+    page.frame.navigate(qn.url, qn.opts) catch |err| {
+        log.err(.browser, "pending navigation start", .{ .err = err, .url = qn.url });
+        return err;
+    };
+}
+
+// Promote the pending Page to be the active Page. Called from
+// frameHeaderDoneCallback when the in-flight pending root navigation's
+// response headers arrive.
+//
+// Order matters here:
+//   1. frame_remove dispatch — CDP's frameRemove resets the V8 inspector
+//      context group (emits Runtime.executionContextsCleared) and clears
+//      isolated world contexts plus the node_registry. The OLD page's
+//      memory is still alive at this point (intentional: CDP teardown can
+//      walk old-page state without UAF).
+//   2. Pointer flip and _state = .active. session.page now points at the
+//      pending page.
+//   3. frame_created dispatch — CDP creates fresh isolated world contexts
+//      against the new (now active) frame. While pending_page is still
+//      non-null at this point, CDP's frameCreated handler skips its
+//      frame_arena reset and captured_responses zeroing (the captured_
+//      response for the request we are committing was just inserted by
+//      onHttpResponseHeadersDone moments earlier and must survive).
+//   4. pending_page = null. Order matters: step 3 reads it.
+//   5. OLD Page.deinit + free LAST. Its frame.deinit calls
+//      http_client.abort() unconditionally — the in-flight navigation
+//      transfer (whose callback we are inside) is shielded by
+//      protect_from_abort, which the caller clears AFTER we return.
+pub fn commitPendingPage(self: *Session) !void {
+    const pending_idx = self._pending_idx orelse {
+        lp.assert(false, "Session.commitPendingPage - no pending page", .{});
+        return error.NoPendingPage;
+    };
+    const old_idx = self._active_idx orelse {
+        lp.assert(false, "Session.commitPendingPage - no active page", .{});
+        return error.NoActivePage;
+    };
+
+    if (comptime IS_DEBUG) {
+        log.debug(.browser, "commit pending page", .{});
+    }
+
+    const pending = &self._pages[pending_idx].?;
+
+    // Step 1: clear the OLD page's CDP / V8 inspector state.
+    self.notification.dispatch(.frame_remove, .{});
+    self.navigation.onRemoveFrame();
+
+    // Step 2: index flip. Page slot addresses are stable (inline in
+    // Session), so every self-pointer inside `pending` (window._frame,
+    // document._frame, EventManager.frame, etc.) remains valid.
+    self._active_idx = pending_idx;
+    pending._state = .active;
+
+    // Step 3: register the new page with CDP. _pending_idx is still set at
+    // this point — CDP's frameCreated handler reads `pendingPage() != null`
+    // to skip the captured_responses / frame_arena resets that would wipe
+    // the in-flight response we just received.
+    self.navigation.onNewFrame(&pending.frame) catch |err| {
+        log.err(.browser, "commitPendingPage onNewFrame", .{ .err = err });
+    };
+    self.notification.dispatch(.frame_created, &pending.frame);
+
+    // Step 4: _pending_idx = null AFTER frame_created so step 3 saw it.
+    self._pending_idx = null;
+
+    // Step 5: tear down the OLD page LAST. Anything in steps 1-4 that
+    // needed to walk the OLD page's state (CDP node_registry, inspector
+    // context group, isolated worlds) has already done so. The OLD page's
+    // frame.deinit calls http_client.abort() unconditionally; the in-flight
+    // transfer survives via protect_from_abort.
+    self._pages[old_idx].?.deinit(false);
+    self.freeSlot(old_idx);
+}
+
+// Discard a pending Page without committing. Used for failure paths
+// (HTTP error before commit, session deinit during pending, etc.). The
+// active page is untouched.
+pub fn discardPendingPage(self: *Session) void {
+    const idx = self._pending_idx orelse return;
+
+    if (comptime IS_DEBUG) {
+        log.debug(.browser, "discard pending page", .{});
+    }
+
+    self._pending_idx = null;
+    self._pages[idx].?.deinit(false);
+    self.freeSlot(idx);
 }
 
 pub fn nextFrameId(self: *Session) u32 {

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -121,6 +121,7 @@ pub fn init(url: []const u8, exec: *Execution) !*Worker {
 // Called from Frame.deinit when the frame is destroyed, so we don't need to
 // remove from the frame's worker list.
 pub fn deinit(self: *Worker) void {
+    self._frame._session.browser.http_client.abortFrame(self._frame_id);
     if (self._http_response) |res| {
         res.abort(error.Abort);
         self._http_response = null;

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -121,7 +121,8 @@ pub fn init(url: []const u8, exec: *Execution) !*Worker {
 // Called from Frame.deinit when the frame is destroyed, so we don't need to
 // remove from the frame's worker list.
 pub fn deinit(self: *Worker) void {
-    self._frame._session.browser.http_client.abortFrame(self._frame_id);
+    // No pending frame for workers, so we can abort all frames.
+    self._frame._session.browser.http_client.abortFrame(self._frame_id, .{ .scope = .full });
     if (self._http_response) |res| {
         res.abort(error.Abort);
         self._http_response = null;

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -692,7 +692,9 @@ pub const BrowserContext = struct {
         const arena = self.frame_arena;
 
         // Prepare the captured response value.
-        const id = msg.request.params.request_id;
+        const params = msg.request.params;
+        // for documents, CDP uses the loarder id as request id.
+        const id = if (params.resource_type == .document) params.loader_id else params.request_id;
         const gop = try self.captured_responses.getOrPut(arena, id);
         if (!gop.found_existing) {
             gop.value_ptr.* = .{
@@ -729,7 +731,9 @@ pub const BrowserContext = struct {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         const arena = self.frame_arena;
 
-        const id = msg.request.params.request_id;
+        const params = msg.request.params;
+        // for documents, CDP uses the loarder id as request id.
+        const id = if (params.resource_type == .document) params.loader_id else params.request_id;
         const resp = self.captured_responses.getPtr(id) orelse lp.assert(false, "onHttpResponseData missinf captured response", .{});
 
         return resp.data.appendSlice(arena, msg.data);

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -28,6 +28,7 @@ const Frame = @import("../browser/Frame.zig");
 const Mime = @import("../browser/Mime.zig");
 const Element = @import("../browser/webapi/Element.zig");
 const Label = @import("../browser/webapi/element/html/Label.zig");
+const Request = @import("../browser/HttpClient.zig").Request;
 
 const Incrementing = @import("id.zig").Incrementing;
 const InterceptState = @import("domains/fetch.zig").InterceptState;
@@ -317,6 +318,18 @@ pub const BrowserContext = struct {
         data: std.ArrayList(u8),
     };
 
+    // Key for `captured_responses`. Documents are keyed by `loader_id`,
+    // everything else by `request_id` — the two id-spaces are independent
+    // counters and overlap numerically (loader 1 / request 1, loader 2 /
+    // request 2, ...), so the map key has to carry the namespace or
+    // entries collide. The wire-format prefix (`LID-` / `REQ-`) provides
+    // the same disambiguation on lookup; see `idFromRequestId` in
+    // domains/network.zig.
+    pub const CapturedResponseKey = struct {
+        kind: enum { request, loader },
+        id: u32,
+    };
+
     id: []const u8,
     cdp: *CDP,
 
@@ -382,7 +395,7 @@ pub const BrowserContext = struct {
     // ever streamed. So if CDP is the only thing that needs bodies in
     // memory for an arbitrary amount of time, then that's where we're going
     // to store the,
-    captured_responses: std.AutoHashMapUnmanaged(usize, CapturedResponse),
+    captured_responses: std.AutoHashMapUnmanaged(CapturedResponseKey, CapturedResponse),
 
     notification: *Notification,
 
@@ -685,6 +698,13 @@ pub const BrowserContext = struct {
         return @import("domains/page.zig").javascriptDialogOpening(self, msg);
     }
 
+    fn keyFromRequestReq(req: *const Request) CDP.BrowserContext.CapturedResponseKey {
+        return if (req.params.resource_type == .document)
+            .{ .kind = .loader, .id = req.params.loader_id }
+        else
+            .{ .kind = .request, .id = req.params.request_id };
+    }
+
     pub fn onHttpResponseHeadersDone(ctx: *anyopaque, msg: *const Notification.ResponseHeaderDone) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         defer self.resetNotificationArena();
@@ -692,10 +712,8 @@ pub const BrowserContext = struct {
         const arena = self.frame_arena;
 
         // Prepare the captured response value.
-        const params = msg.request.params;
-        // for documents, CDP uses the loarder id as request id.
-        const id = if (params.resource_type == .document) params.loader_id else params.request_id;
-        const gop = try self.captured_responses.getOrPut(arena, id);
+        const key = keyFromRequestReq(msg.request);
+        const gop = try self.captured_responses.getOrPut(arena, key);
         if (!gop.found_existing) {
             gop.value_ptr.* = .{
                 .data = .empty,
@@ -731,10 +749,8 @@ pub const BrowserContext = struct {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         const arena = self.frame_arena;
 
-        const params = msg.request.params;
-        // for documents, CDP uses the loarder id as request id.
-        const id = if (params.resource_type == .document) params.loader_id else params.request_id;
-        const resp = self.captured_responses.getPtr(id) orelse lp.assert(false, "onHttpResponseData missinf captured response", .{});
+        const key = keyFromRequestReq(msg.request);
+        const resp = self.captured_responses.getPtr(key) orelse lp.assert(false, "onHttpResponseData missing captured response", .{});
 
         return resp.data.appendSlice(arena, msg.data);
     }

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -229,9 +229,9 @@ fn getResponseBody(cmd: *CDP.Command) !void {
         requestId: []const u8, // "REQ-{d}" or "LID-{d}"
     })) orelse return error.InvalidParams;
 
-    const request_id = try idFromRequestId(params.requestId);
+    const key = try keyFromRequestId(params.requestId);
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const resp = bc.captured_responses.getPtr(request_id) orelse return error.RequestNotFound;
+    const resp = bc.captured_responses.getPtr(key) orelse return error.RequestNotFound;
 
     if (!resp.must_encode) {
         return cmd.sendResult(.{
@@ -476,12 +476,13 @@ const ResponseWriter = struct {
     }
 };
 
-fn idFromRequestId(request_id: []const u8) !u64 {
-    // The requesIid for the original document is its loaderId.
-    if (!std.mem.startsWith(u8, request_id, "REQ-") and !std.mem.startsWith(u8, request_id, "LID-")) {
-        return error.InvalidParams;
-    }
-    return std.fmt.parseInt(u64, request_id[4..], 10) catch return error.InvalidParams;
+fn keyFromRequestId(request_id: []const u8) !CDP.BrowserContext.CapturedResponseKey {
+    const key = std.fmt.parseInt(u32, request_id[4..], 10) catch return error.InvalidParams;
+
+    return if (std.mem.startsWith(u8, request_id, "LID-"))
+        .{ .id = key, .kind = .loader }
+    else
+        .{ .id = key, .kind = .request };
 }
 
 const testing = @import("../testing.zig");

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -258,7 +258,7 @@ pub fn httpRequestFail(bc: *CDP.BrowserContext, msg: *const Notification.Request
 
     // Isn't possible to do a network request within a Browser (which our
     // notification is tied to), without a frame.
-    lp.assert(bc.session.page != null, "CDP.network.httpRequestFail null frame", .{});
+    lp.assert(bc.session.hasPage(), "CDP.network.httpRequestFail null frame", .{});
 
     // We're missing a bunch of fields, but, for now, this seems like enough
     try bc.cdp.sendEvent("Network.loadingFailed", .{

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -417,12 +417,13 @@ pub fn frameRemove(bc: *CDP.BrowserContext) void {
         isolated_world.removeContext();
     }
 
-    // node_registry / node_search_list reference Nodes that live in the page
-    // about to be torn down. Clear them now — for legacy navigations this is
-    // a no-op-equivalent of the bc.reset() that frameNavigate used to do up
-    // front; for pending root commits this is the moment that registry was
-    // deferred to (frameNavigate skipped it because the OLD page was still
-    // live during the in-flight HTTP).
+    // node_registry / node_search_list reference Nodes from the page being
+    // torn down — clear them before the page's memory is freed. For pending
+    // root commits this is the only reset, because frameNavigate set
+    // is_pending_root=true and deliberately skipped its own reset so the
+    // OLD page's nodes stayed addressable during the in-flight HTTP. For
+    // synthetic / non-pending navs frameNavigate also calls bc.reset()
+    // (via the !is_pending_root branch); the two are redundant but harmless.
     bc.reset();
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -301,12 +301,6 @@ fn navigate(cmd: *CDP.Command) !void {
     var frame = session.currentFrame() orelse return error.FrameNotLoaded;
 
     if (frame._load_state != .waiting) {
-        // Reset isolated world identities to disable V8 weak callbacks before
-        // resetPageResources releases refs. Prevents double-release crashes.
-        for (bc.isolated_worlds.items) |isolated_world| {
-            isolated_world.identity.deinit();
-            isolated_world.identity = .{};
-        }
         frame = try session.replacePage();
     }
 
@@ -348,12 +342,6 @@ fn doReload(cmd: *CDP.Command) !void {
     };
 
     if (frame._load_state != .waiting) {
-        // Reset isolated world identities to disable V8 weak callbacks before
-        // resetPageResources releases refs. Prevents double-release crashes.
-        for (bc.isolated_worlds.items) |isolated_world| {
-            isolated_world.identity.deinit();
-            isolated_world.identity = .{};
-        }
         frame = try session.replacePage();
     }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -212,7 +212,7 @@ fn close(cmd: *CDP.Command) !void {
     const target_id = bc.target_id orelse return error.TargetNotLoaded;
 
     // can't be null if we have a target_id
-    lp.assert(bc.session.page != null, "CDP.frame.close null frame", .{});
+    lp.assert(bc.session.hasPage(), "CDP.frame.close null frame", .{});
 
     try cmd.sendResult(.{}, .{});
 
@@ -372,7 +372,14 @@ pub fn frameNavigate(bc: *CDP.BrowserContext, event: *const Notification.FrameNa
     // detachTarget could be called, in which case, we still have a frame doing
     // things, but no session.
     const session_id = bc.session_id orelse return;
-    bc.reset();
+
+    // is_pending_root means this navigation is in flight against a pending
+    // Page while the OLD page is still alive and addressable. Don't blow
+    // away the node_registry — the OLD page's nodes are still referenced
+    // by client-held objectIds. The reset moves to frameRemove (commit).
+    if (!event.is_pending_root) {
+        bc.reset();
+    }
 
     const frame_id = &id.toFrameId(event.frame_id);
     const loader_id = &id.toLoaderId(event.loader_id);
@@ -429,18 +436,39 @@ pub fn frameRemove(bc: *CDP.BrowserContext) void {
     for (bc.isolated_worlds.items) |isolated_world| {
         isolated_world.removeContext();
     }
+
+    // node_registry / node_search_list reference Nodes that live in the page
+    // about to be torn down. Clear them now — for legacy navigations this is
+    // a no-op-equivalent of the bc.reset() that frameNavigate used to do up
+    // front; for pending root commits this is the moment that registry was
+    // deferred to (frameNavigate skipped it because the OLD page was still
+    // live during the in-flight HTTP).
+    bc.reset();
 }
 
 pub fn frameCreated(bc: *CDP.BrowserContext, frame: *Frame) !void {
-    _ = bc.cdp.frame_arena.reset(.{ .retain_with_limit = 1024 * 512 });
+    // Detect "in commit" mode: Session.commitPendingPage dispatches frame_
+    // created BEFORE clearing pending_page (deliberate ordering — see
+    // Session.commitPendingPage). The captured_response for the request we
+    // just committed was inserted by onHttpResponseHeadersDone moments ago
+    // and lives in cdp.frame_arena; resetting either would lose it.
+    const in_commit = bc.session.pendingPage() != null;
+
+    if (!in_commit) {
+        _ = bc.cdp.frame_arena.reset(.{ .retain_with_limit = 1024 * 512 });
+    }
 
     for (bc.isolated_worlds.items) |isolated_world| {
         _ = try isolated_world.createContext(frame);
     }
-    // Only retain captured responses until a navigation event. In CDP term,
-    // this is called a "renderer" and the cache-duration can be controlled via
-    // the Network.configureDurableMessages message (which we don't support)
-    bc.captured_responses = .empty;
+
+    if (!in_commit) {
+        // Only retain captured responses until a navigation event. In CDP
+        // terms, this is called a "renderer" and the cache-duration can be
+        // controlled via Network.configureDurableMessages (which we don't
+        // support).
+        bc.captured_responses = .empty;
+    }
 }
 
 pub fn frameChildFrameCreated(bc: *CDP.BrowserContext, event: *const Notification.FrameChildFrameCreated) !void {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -300,7 +300,6 @@ fn navigate(cmd: *CDP.Command) !void {
     const session = bc.session;
     const frame = session.currentFrame() orelse return error.FrameNotLoaded;
 
-
     const encoded_url = try URL.ensureEncoded(frame.call_arena, params.url, "UTF-8");
     try session.initiateRootNavigation(frame._frame_id, encoded_url, .{
         .reason = .address_bar,
@@ -1025,17 +1024,21 @@ test "cdp.frame: reload" {
         try ctx.expectSentError(-31998, "BrowserContextNotLoaded", .{ .id = 30 });
     }
 
-    _ = try ctx.loadBrowserContext(.{ .id = "BID-9", .url = "hi.html", .target_id = "FID-000000000X".* });
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-9", .url = "hi.html", .target_id = "FID-000000000X".* });
 
     {
         // reload with no params — should not error (navigation is async,
         // so no result is sent synchronously; we just verify no error)
         try ctx.processMessage(.{ .id = 31, .method = "Page.reload" });
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
     }
 
     {
         // reload with ignoreCache param
         try ctx.processMessage(.{ .id = 32, .method = "Page.reload", .params = .{ .ignoreCache = true } });
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
     }
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -298,14 +298,11 @@ fn navigate(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    var frame = session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = session.currentFrame() orelse return error.FrameNotLoaded;
 
-    if (frame._load_state != .waiting) {
-        frame = try session.replacePage();
-    }
 
     const encoded_url = try URL.ensureEncoded(frame.call_arena, params.url, "UTF-8");
-    try frame.navigate(encoded_url, .{
+    try session.initiateRootNavigation(frame._frame_id, encoded_url, .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
         .kind = .{ .push = null },
@@ -325,10 +322,10 @@ fn doReload(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    var frame = session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = session.currentFrame() orelse return error.FrameNotLoaded;
 
     // Capture URL plus the prior navigation's method/body/header before
-    // replacePage() frees the old frame's arena. Replaying the same HTTP
+    // we free the old frame's arena. Replaying the same HTTP
     // method on reload matches Chrome's F5 behavior — POST navigations
     // re-submit, GET navigations re-fetch.
     const reload_url = try cmd.arena.dupeZ(u8, frame.url);
@@ -341,11 +338,7 @@ fn doReload(cmd: *CDP.Command) !void {
         };
     };
 
-    if (frame._load_state != .waiting) {
-        frame = try session.replacePage();
-    }
-
-    try frame.navigate(reload_url, .{
+    try session.initiateRootNavigation(frame._frame_id, reload_url, .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
         .kind = .reload,

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -171,7 +171,7 @@ fn createTarget(cmd: *CDP.Command) !void {
     }
 
     // if target_id is null, we should never have a blank frame
-    lp.assert(bc.session.page == null, "CDP.target.createTarget not null page", .{});
+    lp.assert(!bc.session.hasPage(), "CDP.target.createTarget not null page", .{});
 
     // if target_id is null, we should never have a session_id
     lp.assert(bc.session_id == null, "CDP.target.createTarget not null session_id", .{});
@@ -284,7 +284,7 @@ fn closeTarget(cmd: *CDP.Command) !void {
     }
 
     // can't be null if we have a target_id
-    lp.assert(bc.session.page != null, "CDP.target.closeTarget null frame", .{});
+    lp.assert(bc.session.hasPage(), "CDP.target.closeTarget null frame", .{});
 
     try cmd.sendResult(.{ .success = true }, .{ .include_session_id = false });
 
@@ -636,7 +636,7 @@ test "cdp.target: closeTarget" {
     {
         try ctx.processMessage(.{ .id = 11, .method = "Target.closeTarget", .params = .{ .targetId = "TID-000000000A" } });
         try ctx.expectSentResult(.{ .success = true }, .{ .id = 11 });
-        try testing.expectEqual(null, bc.session.page);
+        try testing.expectEqual(false, bc.session.hasPage());
         try testing.expectEqual(null, bc.target_id);
     }
 }

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -204,7 +204,7 @@ const TestContext = struct {
 
             if (self.cdp_) |*cdp__| {
                 if (cdp__.browser_context) |*bc| {
-                    if (bc.session.page != null) {
+                    if (bc.session.hasPage()) {
                         var runner = try bc.session.runner(.{});
                         _ = try runner.tick(.{ .ms = 1000 });
                     }

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -920,7 +920,7 @@ fn parseArgs(comptime T: type, arena: std.mem.Allocator, arguments: ?std.json.Va
 
 fn performGoto(server: *Server, url: [:0]const u8, id: std.json.Value, timeout: ?u32, waitUntil: ?lp.Config.WaitUntil) !void {
     const session = server.session;
-    if (session.page != null) {
+    if (session.hasPage()) {
         session.removePage();
     }
     const frame = session.createPage() catch {


### PR DESCRIPTION
During a root navigation, we keep the existing page active until we get
the headers callback from the pending page. Then
Session.commitPendingPage makes the switch.

It delays the deinit of CPD execution context to handle JS execution in
the meantime.

Now session has an array of two pages, _active_idx points to the main
page.

Both active and pending pages share the same frame_id, it must remains
stable. So this PR adds a Request.protect_from_abort to avoid removing
the request form the pending page when deinit the previous active page.

fix #2187