### PR TITLE
HTTP Cache Testing + CDP

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: 'lightpanda-io/demo'
+          ref: 'http-cache-cdp'
           fetch-depth: 0
 
       - run: npm install
@@ -150,6 +151,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: 'lightpanda-io/demo'
+          ref: 'http-cache-cdp'
           fetch-depth: 0
 
       - run: npm install
@@ -216,6 +218,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: 'lightpanda-io/demo'
+          ref: 'http-cache-cdp'
           fetch-depth: 0
 
       - name: download artifact
@@ -270,6 +273,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: 'lightpanda-io/demo'
+          ref: 'http-cache-cdp'
           fetch-depth: 0
 
       - run: npm install

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -83,6 +83,7 @@ const EventListeners = struct {
     http_request_intercept: List = .{},
     http_request_done: List = .{},
     http_request_auth_required: List = .{},
+    http_request_served_from_cache: List = .{},
     http_response_data: List = .{},
     http_response_header_done: List = .{},
     javascript_dialog_opening: List = .{},
@@ -103,6 +104,7 @@ const Events = union(enum) {
     http_request_intercept: *const RequestIntercept,
     http_request_auth_required: *const RequestAuthRequired,
     http_request_done: *const RequestDone,
+    http_request_served_from_cache: *const RequestServedFromCache,
     http_response_data: *const ResponseData,
     http_response_header_done: *const ResponseHeaderDone,
     javascript_dialog_opening: *const JavascriptDialogOpening,
@@ -196,6 +198,10 @@ pub const RequestDone = struct {
 pub const RequestFail = struct {
     request: *Request,
     err: anyerror,
+};
+
+pub const RequestServedFromCache = struct {
+    request: *Request,
 };
 
 pub const JavascriptDialogOpening = struct {

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -396,17 +396,22 @@ pub fn _request(ptr: *anyopaque, _: *Client, req: Request) !void {
     return self.process(transfer);
 }
 
-pub fn request(self: *Client, req: Request) !void {
+pub fn request(self: *Client, in_req: Request) !void {
     // Assign Request Id.
-    var our_req = req;
-    our_req.params.request_id = self.incrReqId();
+    var req = in_req;
+    req.params.request_id = self.incrReqId();
 
     const arena = try self.network.app.arena_pool.acquire(.small, "Request.arena");
-    our_req.params.arena = arena;
+    req.params.arena = arena;
 
-    return self.entry_layer.request(self, our_req) catch |err| {
-        our_req.error_callback(our_req.ctx, err);
-        self.deinitRequest(our_req);
+    req.params.notification.dispatch(
+        .http_request_start,
+        &.{ .request = &req },
+    );
+
+    return self.entry_layer.request(self, req) catch |err| {
+        req.error_callback(req.ctx, err);
+        self.deinitRequest(req);
         return err;
     };
 }

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -199,7 +199,9 @@ pub fn init(allocator: Allocator, network: *Network) !*Client {
 
     var next = client.layer();
 
-    next = layerWith(&client.interception_layer, next);
+    if (network.config.mode == .serve) {
+        next = layerWith(&client.interception_layer, next);
+    }
 
     if (network.config.obeyRobots()) {
         next = layerWith(&client.robots_layer, next);

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -203,11 +203,11 @@ pub fn init(allocator: Allocator, network: *Network) !*Client {
         next = layerWith(&client.robots_layer, next);
     }
 
+    next = layerWith(&client.interception_layer, next);
+
     if (network.config.httpCacheDir() != null) {
         next = layerWith(&client.cache_layer, next);
     }
-
-    next = layerWith(&client.interception_layer, next);
 
     if (network.config.webBotAuth() != null) {
         next = layerWith(&client.web_bot_auth_layer, next);

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -199,11 +199,11 @@ pub fn init(allocator: Allocator, network: *Network) !*Client {
 
     var next = client.layer();
 
+    next = layerWith(&client.interception_layer, next);
+
     if (network.config.obeyRobots()) {
         next = layerWith(&client.robots_layer, next);
     }
-
-    next = layerWith(&client.interception_layer, next);
 
     if (network.config.httpCacheDir() != null) {
         next = layerWith(&client.cache_layer, next);
@@ -404,10 +404,12 @@ pub fn request(self: *Client, in_req: Request) !void {
     const arena = try self.network.app.arena_pool.acquire(.small, "Request.arena");
     req.params.arena = arena;
 
-    req.params.notification.dispatch(
-        .http_request_start,
-        &.{ .request = &req },
-    );
+    if (!req.params.internal) {
+        req.params.notification.dispatch(
+            .http_request_start,
+            &.{ .request = &req },
+        );
+    }
 
     return self.entry_layer.request(self, req) catch |err| {
         req.error_callback(req.ctx, err);
@@ -882,6 +884,7 @@ pub const RequestParams = struct {
     credentials: ?[:0]const u8 = null,
     notification: *Notification,
     timeout_ms: u32 = 0,
+    internal: bool = false,
 
     const ResourceType = enum {
         document,

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -576,6 +576,7 @@ pub const BrowserContext = struct {
         try self.notification.register(.http_request_fail, self, onHttpRequestFail);
         try self.notification.register(.http_request_start, self, onHttpRequestStart);
         try self.notification.register(.http_request_done, self, onHttpRequestDone);
+        try self.notification.register(.http_request_served_from_cache, self, onHttpRequestServedFromCache);
         try self.notification.register(.http_response_data, self, onHttpResponseData);
         try self.notification.register(.http_response_header_done, self, onHttpResponseHeadersDone);
     }
@@ -584,6 +585,7 @@ pub const BrowserContext = struct {
         self.notification.unregister(.http_request_fail, self);
         self.notification.unregister(.http_request_start, self);
         self.notification.unregister(.http_request_done, self);
+        self.notification.unregister(.http_request_served_from_cache, self);
         self.notification.unregister(.http_response_data, self);
         self.notification.unregister(.http_response_header_done, self);
     }
@@ -732,6 +734,11 @@ pub const BrowserContext = struct {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         defer self.resetNotificationArena();
         try @import("domains/fetch.zig").requestAuthRequired(self, data);
+    }
+
+    pub fn onHttpRequestServedFromCache(ctx: *anyopaque, msg: *const Notification.RequestServedFromCache) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/network.zig").httpServedFromCache(self, msg);
     }
 
     fn resetNotificationArena(self: *BrowserContext) void {

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -328,6 +328,15 @@ pub fn httpRequestDone(bc: *CDP.BrowserContext, msg: *const Notification.Request
     }, .{ .session_id = session_id });
 }
 
+pub fn httpServedFromCache(bc: *CDP.BrowserContext, msg: *const Notification.RequestServedFromCache) !void {
+    const session_id = bc.session_id orelse return;
+    const req = msg.request;
+
+    try bc.cdp.sendEvent("Network.requestServedFromCache", .{
+        .requestId = &id.toRequestId(req),
+    }, .{ .session_id = session_id });
+}
+
 pub const RequestWriter = struct {
     request: *Request,
 

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -441,6 +441,9 @@ const ResponseWriter = struct {
             try jws.write(mime.charsetString());
         }
 
+        try jws.objectField("fromDiskCache");
+        try jws.write(response.inner == .cached);
+
         {
             try jws.objectField("timing");
             try jws.write(.{

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -45,6 +45,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         deleteCookies,
         clearBrowserCookies,
         clearBrowserCache,
+        canClearBrowserCache,
         setCookie,
         setCookies,
         getCookies,
@@ -61,6 +62,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .deleteCookies => return deleteCookies(cmd),
         .clearBrowserCookies => return clearBrowserCookies(cmd),
         .clearBrowserCache => return clearBrowserCache(cmd),
+        .canClearBrowserCache => return canClearBrowserCache(cmd),
         .setCookie => return setCookie(cmd),
         .setCookies => return setCookies(cmd),
         .getCookies => return getCookies(cmd),
@@ -184,6 +186,12 @@ fn clearBrowserCache(cmd: *CDP.Command) !void {
     const network = bc.cdp.browser.http_client.network;
     if (network.cache) |*c| try c.clear();
     return cmd.sendResult(null, .{});
+}
+
+fn canClearBrowserCache(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const network = bc.cdp.browser.http_client.network;
+    return cmd.sendResult(.{ .result = network.cache != null }, .{});
 }
 
 fn setCookie(cmd: *CDP.Command) !void {
@@ -769,4 +777,18 @@ test "cdp.Network: cache enabled by default" {
 
     const client = ctx.cdp().browser.http_client;
     try testing.expectEqual(true, client.cache_layer.enabled);
+}
+
+test "cdp.Network: canClearBrowserCache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC3" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.canClearBrowserCache",
+    });
+
+    // Cache is disabled in testing I'm pretty sure.
+    try ctx.expectSentResult(.{ .result = false }, .{ .id = 1 });
 }

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -44,6 +44,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         setUserAgentOverride,
         deleteCookies,
         clearBrowserCookies,
+        clearBrowserCache,
         setCookie,
         setCookies,
         getCookies,
@@ -59,6 +60,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .setExtraHTTPHeaders => return setExtraHTTPHeaders(cmd),
         .deleteCookies => return deleteCookies(cmd),
         .clearBrowserCookies => return clearBrowserCookies(cmd),
+        .clearBrowserCache => return clearBrowserCache(cmd),
         .setCookie => return setCookie(cmd),
         .setCookies => return setCookies(cmd),
         .getCookies => return getCookies(cmd),
@@ -159,6 +161,17 @@ fn clearBrowserCookies(cmd: *CDP.Command) !void {
     // Chrome accepts that and clears the jar; reject only on truly malformed JSON.
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     bc.session.cookie_jar.clearRetainingCapacity();
+    return cmd.sendResult(null, .{});
+}
+
+fn clearBrowserCache(cmd: *CDP.Command) !void {
+    // Network.clearBrowserCache takes no parameters per the CDP spec, but most
+    // CDP clients (chrome-remote-interface, chromedp, custom websocket clients)
+    // include an empty `"params":{}` object on every command for ergonomics.
+    // Chrome accepts that and clears the jar; reject only on truly malformed JSON.
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const network = bc.cdp.browser.http_client.network;
+    if (network.cache) |*c| try c.clear();
     return cmd.sendResult(null, .{});
 }
 
@@ -672,4 +685,29 @@ test "cdp.Network: getAllCookies returns whole jar regardless of current origin"
             .{ .name = "b", .value = "2", .domain = "other.test", .path = "/", .size = 2, .secure = true },
         },
     }, .{ .id = 3 });
+}
+
+test "cdp.Network: clearBrowserCache succeeds" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.clearBrowserCache",
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+}
+
+test "cdp.Network: clearBrowserCache accepts empty params object" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC2" });
+
+    // Most CDP clients always include a `params` field on every command,
+    // even for methods that take none. Chrome ignores the empty object; we should too.
+    try ctx.processMessage(
+        \\{"id":1,"method":"Network.clearBrowserCache","params":{}}
+    );
+    try ctx.expectSentResult(null, .{ .id = 1 });
 }

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -55,7 +55,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
     switch (action) {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
-        .setCacheDisabled => return cmd.sendResult(null, .{}),
+        .setCacheDisabled => return setCacheDisabled(cmd),
         .setUserAgentOverride => return @import("emulation.zig").setUserAgentOverride(cmd),
         .setExtraHTTPHeaders => return setExtraHTTPHeaders(cmd),
         .deleteCookies => return deleteCookies(cmd),
@@ -161,6 +161,17 @@ fn clearBrowserCookies(cmd: *CDP.Command) !void {
     // Chrome accepts that and clears the jar; reject only on truly malformed JSON.
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     bc.session.cookie_jar.clearRetainingCapacity();
+    return cmd.sendResult(null, .{});
+}
+
+fn setCacheDisabled(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        cacheDisabled: bool,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const client = bc.cdp.browser.http_client;
+    client.cache_layer.setEnabled(!params.cacheDisabled);
     return cmd.sendResult(null, .{});
 }
 
@@ -710,4 +721,52 @@ test "cdp.Network: clearBrowserCache accepts empty params object" {
         \\{"id":1,"method":"Network.clearBrowserCache","params":{}}
     );
     try ctx.expectSentResult(null, .{ .id = 1 });
+}
+
+test "cdp.Network: setCacheDisabled disables cache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CD1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(false, client.cache_layer.enabled);
+}
+
+test "cdp.Network: setCacheDisabled re-enables cache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CD2" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = false },
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(true, client.cache_layer.enabled);
+}
+
+test "cdp.Network: cache enabled by default" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CD3" });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(true, client.cache_layer.enabled);
 }

--- a/src/network/cache/Cache.zig
+++ b/src/network/cache/Cache.zig
@@ -49,6 +49,12 @@ pub fn put(self: *Cache, metadata: CachedMetadata, body: []const u8) !void {
     };
 }
 
+pub fn clear(self: *Cache) !void {
+    return switch (self.kind) {
+        inline else => |*c| c.clear(),
+    };
+}
+
 pub const CacheControl = struct {
     max_age: u64,
 

--- a/src/network/cache/FsCache.zig
+++ b/src/network/cache/FsCache.zig
@@ -265,6 +265,9 @@ pub fn put(self: *FsCache, meta: CachedMetadata, body: []const u8) !void {
 }
 
 pub fn clear(self: *FsCache) !void {
+    for (&self.locks) |*lock| lock.lock();
+    defer for (&self.locks) |*lock| lock.unlock();
+
     var iter = self.dir.iterate();
     while (try iter.next()) |entry| {
         if (entry.kind != .file) continue;

--- a/src/network/cache/FsCache.zig
+++ b/src/network/cache/FsCache.zig
@@ -264,6 +264,19 @@ pub fn put(self: *FsCache, meta: CachedMetadata, body: []const u8) !void {
     log.debug(.cache, "put", .{ .url = meta.url, .hash = &hashed_key, .body_len = body.len });
 }
 
+pub fn clear(self: *FsCache) !void {
+    var iter = self.dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".cache") and
+            !std.mem.endsWith(u8, entry.name, ".cache.tmp")) continue;
+
+        self.dir.deleteFile(entry.name) catch |e| {
+            log.err(.cache, "clear delete fail", .{ .file = entry.name, .err = e });
+        };
+    }
+}
+
 const testing = std.testing;
 
 fn setupCache() !struct { tmp: testing.TmpDir, cache: Cache } {
@@ -616,4 +629,101 @@ test "FsCache: vary multiple headers" {
             .{ .name = "Accept-Language", .value = "fr" },
         },
     }));
+}
+
+test "FsCache: clear removes all entries" {
+    var setup = try setupCache();
+    defer {
+        setup.cache.deinit();
+        setup.tmp.cleanup();
+    }
+
+    const cache = &setup.cache;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const now = std.time.timestamp();
+    const base_meta_a = CachedMetadata{
+        .url = "https://example.com/a",
+        .status = 200,
+        .stored_at = now,
+        .age_at_store = 0,
+        .cache_control = .{ .max_age = 600 },
+        .headers = &.{},
+        .vary_headers = &.{},
+        .content_type = "text/html",
+    };
+
+    const base_meta_b = CachedMetadata{
+        .url = "https://example.com/b",
+        .status = 200,
+        .stored_at = now,
+        .age_at_store = 0,
+        .cache_control = .{ .max_age = 600 },
+        .headers = &.{},
+        .vary_headers = &.{},
+        .content_type = "text/html",
+    };
+
+    try cache.put(base_meta_a, "body a");
+    try cache.put(base_meta_b, "body b");
+
+    // Sanity check: both are cached
+    const r1 = cache.get(arena.allocator(), .{ .url = "https://example.com/a", .timestamp = now, .request_headers = &.{} });
+    try testing.expect(r1 != null);
+    r1.?.data.file.file.close();
+
+    const r2 = cache.get(arena.allocator(), .{ .url = "https://example.com/b", .timestamp = now, .request_headers = &.{} });
+    try testing.expect(r2 != null);
+    r2.?.data.file.file.close();
+
+    try cache.clear();
+
+    try testing.expectEqual(null, cache.get(arena.allocator(), .{ .url = "https://example.com/a", .timestamp = now, .request_headers = &.{} }));
+    try testing.expectEqual(null, cache.get(arena.allocator(), .{ .url = "https://example.com/b", .timestamp = now, .request_headers = &.{} }));
+}
+
+test "FsCache: put after clear works" {
+    var setup = try setupCache();
+    defer {
+        setup.cache.deinit();
+        setup.tmp.cleanup();
+    }
+
+    const cache = &setup.cache;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const now = std.time.timestamp();
+    const meta = CachedMetadata{
+        .url = "https://example.com",
+        .content_type = "text/html",
+        .status = 200,
+        .stored_at = now,
+        .age_at_store = 0,
+        .cache_control = .{ .max_age = 600 },
+        .headers = &.{},
+        .vary_headers = &.{},
+    };
+
+    try cache.put(meta, "before clear");
+    try cache.clear();
+
+    // Should be a miss after clear
+    try testing.expectEqual(null, cache.get(arena.allocator(), .{ .url = "https://example.com", .timestamp = now, .request_headers = &.{} }));
+
+    // Put again after clear — should work normally
+    try cache.put(meta, "after clear");
+    const result = cache.get(arena.allocator(), .{ .url = "https://example.com", .timestamp = now, .request_headers = &.{} }) orelse return error.CacheMiss;
+    const f = result.data.file;
+    defer f.file.close();
+
+    var buf: [64]u8 = undefined;
+    var file_reader = f.file.reader(&buf);
+    try file_reader.seekTo(f.offset);
+    const read_buf = try file_reader.interface.readAlloc(testing.allocator, f.len);
+    defer testing.allocator.free(read_buf);
+    try testing.expectEqualStrings("after clear", read_buf);
 }

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -34,6 +34,7 @@ const Forward = @import("Forward.zig");
 
 const CacheLayer = @This();
 
+enabled: bool = true,
 next: Layer = undefined,
 
 pub fn layer(self: *CacheLayer) Layer {
@@ -49,7 +50,7 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
     const self: *CacheLayer = @ptrCast(@alignCast(ptr));
     const network = client.network;
 
-    if (req.params.method != .GET) {
+    if (req.params.method != .GET or !self.enabled) {
         return self.next.request(client, req);
     }
 
@@ -90,6 +91,10 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
     );
 
     return self.next.request(client, wrapped);
+}
+
+pub fn setEnabled(self: *CacheLayer, enabled: bool) void {
+    self.enabled = enabled;
 }
 
 fn serveFromCache(req: Request, cached: *const CachedResponse) !void {

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -169,6 +169,10 @@ const CacheContext = struct {
         const self: *CacheContext = @ptrCast(@alignCast(response.ctx));
         const allocator = self.arena;
 
+        if (response.inner != .transfer) {
+            return self.forward.forwardHeader(response);
+        }
+
         var vary: ?[]const u8 = null;
         var cache_control: ?[]const u8 = null;
         var age: ?[]const u8 = null;

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -22,7 +22,6 @@ const log = lp.log;
 
 const http = @import("../http.zig");
 const Client = @import("../../browser/HttpClient.zig").Client;
-const Transfer = @import("../../browser/HttpClient.zig").Transfer;
 const Request = @import("../../browser/HttpClient.zig").Request;
 const Response = @import("../../browser/HttpClient.zig").Response;
 const Layer = @import("../../browser/HttpClient.zig").Layer;
@@ -46,9 +45,10 @@ pub fn layer(self: *CacheLayer) Layer {
     };
 }
 
-fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
+fn request(ptr: *anyopaque, client: *Client, in_req: Request) anyerror!void {
     const self: *CacheLayer = @ptrCast(@alignCast(ptr));
     const network = client.network;
+    var req = in_req;
 
     if (req.params.method != .GET or !self.enabled) {
         return self.next.request(client, req);
@@ -64,8 +64,16 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
         .timestamp = std.time.timestamp(),
         .request_headers = req_header_list.items,
     })) |cached| {
+        req.params.notification.dispatch(
+            .http_request_served_from_cache,
+            &.{
+                .request = &req,
+            },
+        );
+
         try serveFromCache(req, &cached);
         client.deinitRequest(req);
+
         return;
     }
 
@@ -82,8 +90,8 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
         req,
         cache_ctx,
         .{
-            .start = CacheContext.startCallback,
             .header = CacheContext.headerCallback,
+            .data = CacheContext.dataCallback,
             .done = CacheContext.doneCallback,
             .shutdown = CacheContext.shutdownCallback,
             .err = CacheContext.errorCallback,
@@ -97,7 +105,9 @@ pub fn setEnabled(self: *CacheLayer, enabled: bool) void {
     self.enabled = enabled;
 }
 
-fn serveFromCache(req: Request, cached: *const CachedResponse) !void {
+fn serveFromCache(in_req: Request, cached: *const CachedResponse) !void {
+    var req = in_req;
+
     const response = Response.fromCached(req.ctx, cached);
     defer switch (cached.data) {
         .buffer => |_| {},
@@ -112,6 +122,12 @@ fn serveFromCache(req: Request, cached: *const CachedResponse) !void {
     if (!proceed) {
         return error.Abort;
     }
+
+    // This dispatches the Network.responseReceived that we should send.
+    req.params.notification.dispatch(.http_response_header_done, &.{
+        .request = &req,
+        .response = &response,
+    });
 
     switch (cached.data) {
         .buffer => |data| {
@@ -143,45 +159,47 @@ fn serveFromCache(req: Request, cached: *const CachedResponse) !void {
 const CacheContext = struct {
     arena: std.mem.Allocator,
     client: *Client,
-    transfer: ?*Transfer = null,
     forward: Forward,
     req_url: [:0]const u8,
     req_headers: http.Headers,
     pending_metadata: ?*CachedMetadata = null,
-
-    fn startCallback(response: Response) anyerror!void {
-        const self: *CacheContext = @ptrCast(@alignCast(response.ctx));
-        self.transfer = response.inner.transfer;
-        return self.forward.forwardStart(response);
-    }
+    body_buffer: std.ArrayList(u8) = .empty,
 
     fn headerCallback(response: Response) anyerror!bool {
         const self: *CacheContext = @ptrCast(@alignCast(response.ctx));
         const allocator = self.arena;
 
-        const transfer = response.inner.transfer;
-        var rh = &transfer.response_header.?;
+        var vary: ?[]const u8 = null;
+        var cache_control: ?[]const u8 = null;
+        var age: ?[]const u8 = null;
+        var has_set_cookie = false;
+        var has_authorization = false;
 
-        const conn = transfer._conn.?;
-
-        const vary = if (conn.getResponseHeader("vary", 0)) |h| h.value else null;
+        var iter = response.headerIterator();
+        while (iter.next()) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, "vary")) vary = h.value;
+            if (std.ascii.eqlIgnoreCase(h.name, "cache-control")) cache_control = h.value;
+            if (std.ascii.eqlIgnoreCase(h.name, "age")) age = h.value;
+            if (std.ascii.eqlIgnoreCase(h.name, "set-cookie")) has_set_cookie = true;
+            if (std.ascii.eqlIgnoreCase(h.name, "authorization")) has_authorization = true;
+        }
 
         const maybe_cm = try Cache.tryCache(
             allocator,
             std.time.timestamp(),
-            transfer.url,
-            rh.status,
-            rh.contentType(),
-            if (conn.getResponseHeader("cache-control", 0)) |h| h.value else null,
+            response.url(),
+            response.status() orelse @panic("Response must have status"),
+            response.contentType(),
+            cache_control,
             vary,
-            if (conn.getResponseHeader("age", 0)) |h| h.value else null,
-            conn.getResponseHeader("set-cookie", 0) != null,
-            conn.getResponseHeader("authorization", 0) != null,
+            age,
+            has_set_cookie,
+            has_authorization,
         );
 
         if (maybe_cm) |cm| {
-            var iter = transfer.responseHeaderIterator();
-            var header_list = try iter.collect(allocator);
+            var cache_iter = response.headerIterator();
+            var header_list = try cache_iter.collect(allocator);
             const end_of_response = header_list.items.len;
 
             if (vary) |vary_str| {
@@ -205,20 +223,31 @@ const CacheContext = struct {
             metadata.headers = header_list.items[0..end_of_response];
             metadata.vary_headers = header_list.items[end_of_response..];
             self.pending_metadata = metadata;
+
+            if (response.contentLength()) |len| {
+                try self.body_buffer.ensureTotalCapacity(self.arena, len);
+            }
         }
 
         return self.forward.forwardHeader(response);
     }
 
+    fn dataCallback(response: Response, data: []const u8) anyerror!void {
+        const self: *CacheContext = @ptrCast(@alignCast(response.ctx));
+        if (self.pending_metadata != null) {
+            try self.body_buffer.appendSlice(self.arena, data);
+        }
+        return self.forward.forwardData(response, data);
+    }
+
     fn doneCallback(ctx: *anyopaque) anyerror!void {
         const self: *CacheContext = @ptrCast(@alignCast(ctx));
-        const transfer = self.transfer orelse @panic("Start Callback didn't set CacheLayer.transfer");
 
         if (self.pending_metadata) |metadata| {
             const cache = &self.client.network.cache.?;
 
             log.debug(.browser, "http cache", .{ .key = self.req_url, .metadata = metadata });
-            cache.put(metadata.*, transfer._stream_buffer.items) catch |err| {
+            cache.put(metadata.*, self.body_buffer.items) catch |err| {
                 log.warn(.http, "cache put failed", .{ .err = err });
             };
             log.debug(.browser, "http.cache.put", .{ .url = self.req_url });

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -54,6 +54,10 @@ pub fn layer(self: *InterceptionLayer) Layer {
 fn request(ptr: *anyopaque, client: *Client, in_req: Request) anyerror!void {
     const self: *InterceptionLayer = @ptrCast(@alignCast(ptr));
 
+    if (in_req.params.internal) {
+        return try self.next.request(client, in_req);
+    }
+
     const intercept_ctx = try in_req.params.arena.create(InterceptContext);
     intercept_ctx.* = .{
         .client = client,

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -75,8 +75,6 @@ fn request(ptr: *anyopaque, client: *Client, in_req: Request) anyerror!void {
         },
     );
 
-    req.params.notification.dispatch(.http_request_start, &.{ .request = &req });
-
     var wait_for_interception = false;
     req.params.notification.dispatch(.http_request_intercept, &.{
         .request = &req,

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -109,13 +109,6 @@ pub const InterceptContext = struct {
     fn startCallback(response: Response) anyerror!void {
         const self: *InterceptContext = @ptrCast(@alignCast(response.ctx));
         log.debug(.http, "intercept start", .{ .url = self.request.params.url });
-
-        if (response.inner == .cached) {
-            self.request.params.notification.dispatch(.http_request_served_from_cache, &.{
-                .request = &self.request,
-            });
-        }
-
         return self.forward.forwardStart(response);
     }
 

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -109,6 +109,13 @@ pub const InterceptContext = struct {
     fn startCallback(response: Response) anyerror!void {
         const self: *InterceptContext = @ptrCast(@alignCast(response.ctx));
         log.debug(.http, "intercept start", .{ .url = self.request.params.url });
+
+        if (response.inner == .cached) {
+            self.request.params.notification.dispatch(.http_request_served_from_cache, &.{
+                .request = &self.request,
+            });
+        }
+
         return self.forward.forwardStart(response);
     }
 

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -103,22 +103,29 @@ pub const InterceptContext = struct {
     layer: *InterceptionLayer,
     request: Request,
     content_length: usize = 0,
+    is_from_network: bool = false,
 
     fn startCallback(response: Response) anyerror!void {
         const self: *InterceptContext = @ptrCast(@alignCast(response.ctx));
-        log.debug(.http, "intercept start", .{ .url = self.request.params.url });
+        self.is_from_network = response.inner == .transfer;
+
+        if (self.is_from_network) {
+            log.debug(.http, "intercept start", .{ .url = self.request.params.url });
+        }
         return self.forward.forwardStart(response);
     }
 
     fn headerCallback(response: Response) anyerror!bool {
         const self: *InterceptContext = @ptrCast(@alignCast(response.ctx));
-        log.debug(.http, "intercept header", .{
-            .url = self.request.params.url,
-            .status = response.status(),
-            .content_length = response.contentLength(),
-        });
+        if (self.is_from_network) {
+            log.debug(.http, "intercept header", .{
+                .url = self.request.params.url,
+                .status = response.status(),
+                .content_length = response.contentLength(),
+            });
 
-        self.content_length = response.contentLength() orelse 0;
+            self.content_length = response.contentLength() orelse 0;
+        }
 
         self.request.params.notification.dispatch(.http_response_header_done, &.{
             .request = &self.request,
@@ -130,15 +137,18 @@ pub const InterceptContext = struct {
 
     fn dataCallback(response: Response, chunk: []const u8) anyerror!void {
         const self: *InterceptContext = @ptrCast(@alignCast(response.ctx));
-        log.debug(.http, "intercept data", .{
-            .url = self.request.params.url,
-            .len = chunk.len,
-        });
 
-        self.request.params.notification.dispatch(.http_response_data, &.{
-            .data = chunk,
-            .request = &self.request,
-        });
+        if (self.is_from_network) {
+            log.debug(.http, "intercept data", .{
+                .url = self.request.params.url,
+                .len = chunk.len,
+            });
+
+            self.request.params.notification.dispatch(.http_response_data, &.{
+                .data = chunk,
+                .request = &self.request,
+            });
+        }
 
         return self.forward.forwardData(response, chunk);
     }
@@ -146,40 +156,49 @@ pub const InterceptContext = struct {
     fn doneCallback(ctx: *anyopaque) anyerror!void {
         const self: *InterceptContext = @ptrCast(@alignCast(ctx));
 
-        log.debug(.http, "intercept done", .{
-            .url = self.request.params.url,
-            .content_length = self.content_length,
-        });
+        if (self.is_from_network) {
+            log.debug(.http, "intercept done", .{
+                .url = self.request.params.url,
+                .content_length = self.content_length,
+            });
 
-        self.request.params.notification.dispatch(.http_request_done, &.{
-            .request = &self.request,
-            .content_length = self.content_length,
-        });
+            self.request.params.notification.dispatch(.http_request_done, &.{
+                .request = &self.request,
+                .content_length = self.content_length,
+            });
+        }
+
         return self.forward.forwardDone();
     }
 
     fn errorCallback(ctx: *anyopaque, err: anyerror) void {
         const self: *InterceptContext = @ptrCast(@alignCast(ctx));
 
-        log.debug(.http, "intercept error", .{
-            .url = self.request.params.url,
-            .err = err,
-        });
-        self.request.params.notification.dispatch(.http_request_fail, &.{
-            .request = &self.request,
-            .err = err,
-        });
+        if (self.is_from_network) {
+            log.debug(.http, "intercept error", .{
+                .url = self.request.params.url,
+                .err = err,
+            });
+            self.request.params.notification.dispatch(.http_request_fail, &.{
+                .request = &self.request,
+                .err = err,
+            });
+        }
+
         self.forward.forwardErr(err);
     }
 
     fn shutdownCallback(ctx: *anyopaque) void {
         const self: *InterceptContext = @ptrCast(@alignCast(ctx));
 
-        log.debug(.http, "intercept shutdown", .{ .url = self.request.params.url });
-        self.request.params.notification.dispatch(.http_request_fail, &.{
-            .request = &self.request,
-            .err = error.Shutdown,
-        });
+        if (self.is_from_network) {
+            log.debug(.http, "intercept shutdown", .{ .url = self.request.params.url });
+            self.request.params.notification.dispatch(.http_request_fail, &.{
+                .request = &self.request,
+                .err = error.Shutdown,
+            });
+        }
+
         self.forward.forwardShutdown();
     }
 };

--- a/src/network/layer/RobotsLayer.zig
+++ b/src/network/layer/RobotsLayer.zig
@@ -57,6 +57,10 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
     const arena = req.params.arena;
     const robots_url = try URL.getRobotsUrl(arena, req.params.url);
 
+    if (req.params.internal) {
+        return self.next.request(client, req);
+    }
+
     if (client.network.robot_store.get(robots_url)) |robot_entry| {
         switch (robot_entry) {
             .present => |robots| {
@@ -104,28 +108,33 @@ fn fetchRobotsThenRequest(
         const headers = try client.newHeaders();
         log.debug(.browser, "fetching robots.txt", .{ .robots_url = robots_url });
 
-        try self.next.request(client, .{
-            .ctx = robots_ctx,
-            .params = .{
-                // We have to do this ourselves because we are not going through the top level `request`.
-                .arena = new_arena,
-                .request_id = client.incrReqId(),
-                .url = robots_url,
-                .method = .GET,
-                .headers = headers,
-                .frame_id = req.params.frame_id,
-                .loader_id = req.params.loader_id,
-                .cookie_jar = req.params.cookie_jar,
-                .cookie_origin = req.params.cookie_origin,
-                .notification = req.params.notification,
-                .resource_type = .fetch,
+        try self.next.request(
+            client,
+            .{
+                .ctx = robots_ctx,
+                .params = .{
+                    // We have to do these ourselves since we don't go through request.
+                    .arena = new_arena,
+                    .request_id = client.nextReqId(),
+
+                    .url = robots_url,
+                    .method = .GET,
+                    .headers = headers,
+                    .frame_id = req.params.frame_id,
+                    .loader_id = req.params.loader_id,
+                    .cookie_jar = req.params.cookie_jar,
+                    .cookie_origin = req.params.cookie_origin,
+                    .notification = req.params.notification,
+                    .resource_type = .fetch,
+                    .internal = true,
+                },
+                .header_callback = RobotsContext.headerCallback,
+                .data_callback = RobotsContext.dataCallback,
+                .done_callback = RobotsContext.doneCallback,
+                .error_callback = RobotsContext.errorCallback,
+                .shutdown_callback = RobotsContext.shutdownCallback,
             },
-            .header_callback = RobotsContext.headerCallback,
-            .data_callback = RobotsContext.dataCallback,
-            .done_callback = RobotsContext.doneCallback,
-            .error_callback = RobotsContext.errorCallback,
-            .shutdown_callback = RobotsContext.shutdownCallback,
-        });
+        );
     }
 
     try entry.value_ptr.append(self.allocator, req);
@@ -169,11 +178,6 @@ const RobotsContext = struct {
     buffer: std.ArrayListUnmanaged(u8),
     status: u16 = 0,
 
-    fn deinit(self: *RobotsContext) void {
-        self.buffer.deinit(self.layer.allocator);
-        self.layer.allocator.destroy(self);
-    }
-
     fn headerCallback(response: Response) anyerror!bool {
         const self: *RobotsContext = @ptrCast(@alignCast(response.ctx));
         switch (response.inner) {
@@ -198,6 +202,7 @@ const RobotsContext = struct {
 
     fn doneCallback(ctx_ptr: *anyopaque) anyerror!void {
         const self: *RobotsContext = @ptrCast(@alignCast(ctx_ptr));
+
         const l = self.layer;
         const client = self.client;
         const robots_url = self.robots_url;
@@ -241,6 +246,7 @@ const RobotsContext = struct {
 
     fn errorCallback(ctx_ptr: *anyopaque, err: anyerror) void {
         const self: *RobotsContext = @ptrCast(@alignCast(ctx_ptr));
+
         const l = self.layer;
         const client = self.client;
         const robots_url = self.robots_url;
@@ -251,6 +257,7 @@ const RobotsContext = struct {
 
     fn shutdownCallback(ctx_ptr: *anyopaque) void {
         const self: *RobotsContext = @ptrCast(@alignCast(ctx_ptr));
+
         const l = self.layer;
         const client = self.client;
         const robots_url = self.robots_url;


### PR DESCRIPTION
This does a few things. It mostly adds a few CDP Events that allow us to better test caching behavior. It is correlated to the `demo` branch of the same name (`http-cache-cdp`).

This adds:
- `clear` fn to Cache to clear out all of the entries
- `Network.requestServedFromCache` CDP Event that gets emitted by `InterceptionLayer` when request is `.cached`.
- `fromDiskCache` field on `Network.Response` CDP type that signifies that the Response is from Cache.
- `Network.setCacheDisabled` CDP method that allows you to disable putting and getting from the Cache. This uses a simple flag in `CacheLayer`.
- Fulfilled Requests from CDP do not cache (or more generically, only responses from the Network (`.transfer`) are cached).
- `InterceptionLayer` is only enabled on `.serve` mode.