### PR TITLE
Fix Request Arena Leak on CacheLayer Hit

### DIFF
--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -63,7 +63,9 @@ fn request(ptr: *anyopaque, client: *Client, req: Request) anyerror!void {
         .timestamp = std.time.timestamp(),
         .request_headers = req_header_list.items,
     })) |cached| {
-        return serveFromCache(req, &cached);
+        try serveFromCache(req, &cached);
+        client.deinitRequest(req);
+        return;
     }
 
     const cache_ctx = try arena.create(CacheContext);


### PR DESCRIPTION
Discovered a Request Arena leak in the `CacheLayer` when we get a CacheHit. The request doesn't end up traveling down to the `Transfer` because we fulfill it with the Cache so the `Request` arena is never released.

This version serves from the Cache (allowing the error to propagate up if needed) and then cleans if successful.