### PR TITLE
WIP: common libcurl

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -70,6 +70,10 @@ pub fn nextFrameId(self: *Browser) u32 {
     return id;
 }
 
+pub fn httpClient(self: *Browser) *HttpClient {
+    return &self.http_client;
+}
+
 pub fn init(self: *Browser, app: *App, opts: InitOpts, cdp: ?*CDP) !void {
     const allocator = app.allocator;
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -809,7 +809,7 @@ fn processOneMessage(self: *Client, msg: Network.Handle.Completion, transfer: *T
     if (body.len > 0) {
         try transfer.req.data_callback(Response.fromTransfer(transfer), body);
 
-        if (transfer.state == .aborted) {
+        if (transfer.isAborted()) {
             transfer.requestFailed(error.Abort, true);
             return true;
         }
@@ -1095,6 +1095,7 @@ pub const Transfer = struct {
     client: *Client,
 
     start_time: u64,
+    aborted: std.atomic.Value(bool) = .init(false),
 
     _notified_fail: bool = false,
 
@@ -1199,6 +1200,15 @@ pub const Transfer = struct {
         arena_pool.release(arena);
     }
 
+    pub fn isAborted(self: *const Transfer) bool {
+        return self.aborted.load(.acquire);
+    }
+
+    fn setAborted(self: *Transfer) void {
+        self.aborted.store(true, .release);
+        self.state = .aborted;
+    }
+
     // Cancel this transfer with `err`. Fires error_callback once (latched
     // via _notified_fail), then either deinits synchronously or, if we're
     // mid-perform with a libcurl handle still in the multi, detaches and
@@ -1237,8 +1247,8 @@ pub const Transfer = struct {
     // nothing left referencing this transfer and we can safely deinit
     // inline.
     fn detachOrDeinit(self: *Transfer) void {
+        if (self.isAborted()) return;
         switch (self.state) {
-            .aborted => return,
             .completing => self.detachInPerform(),
             .inflight => {
                 if (self._conn) |conn| {
@@ -1266,9 +1276,7 @@ pub const Transfer = struct {
     //     `owner == null` and skips the list-remove that would otherwise
     //     UAF against a freed list.
     fn detachInPerform(self: *Transfer) void {
-        // `_conn` (if any) rides through .aborted untouched; deinit
-        // releases it once libcurl is done.
-        self.state = .aborted;
+        self.setAborted();
         self.req.start_callback = null;
         self.req.shutdown_callback = null;
         self.req.header_callback = Noop.headerCallback;
@@ -1546,7 +1554,7 @@ pub const Transfer = struct {
             return err;
         };
 
-        return proceed and transfer.state != .aborted;
+        return proceed and !transfer.isAborted();
     }
 
     fn dataCallback(buffer: [*]const u8, chunk_count: usize, chunk_len: usize, data: *anyopaque) usize {
@@ -1596,7 +1604,7 @@ pub const Transfer = struct {
             return http.writefunc_error;
         };
 
-        if (transfer.state == .aborted) {
+        if (transfer.isAborted()) {
             return http.writefunc_error;
         }
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -65,8 +65,7 @@ pub const HeaderIterator = http.HeaderIterator;
 // impacting those other http requests.
 pub const Client = @This();
 
-// Our curl multi handle. Owns in_use/ready_queue/http_active/ws_active/
-// performing — see Network.Handle.
+// Our curl multi handle. Owns in_use/http_active/ws_active — see Network.Handle.
 handle: Network.Handle,
 
 // WebSockets with queued events to be drained from the worker thread.
@@ -214,6 +213,30 @@ pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) 
 
 pub fn deinit(self: *Client) void {
     self.abort();
+
+    // Cancellations submitted by abort flow through the network thread
+    // and come back as canceled completions. If the network thread has
+    // already stopped, drive its queues ourselves; otherwise spin until
+    // they all arrive and we drained them.
+    var spins: usize = 0;
+    while (self.handle.in_use.first != null and spins < 1000) : (spins += 1) {
+        if (self.network.shutdown.load(.acquire)) {
+            self.network.drainPendingForShutdown();
+        }
+        _ = self.processMessages() catch {};
+        self.drainReadyWs();
+        if (self.handle.in_use.first == null) break;
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    if (self.handle.in_use.first != null) {
+        log.warn(.http, "deinit with active conns", .{
+            .count = self.handle.http_active + self.handle.ws_active,
+        });
+    } else if (comptime IS_DEBUG) {
+        std.debug.assert(self.transfers.size == 0);
+        std.debug.assert(self.queue.first == null);
+    }
+
     self.handle.deinit();
 
     self.ws_ready.deinit(self.allocator);
@@ -269,14 +292,8 @@ pub fn setTlsVerify(self: *Client, verify: bool) !void {
 
     var it = self.handle.in_use.first;
     while (it) |node| : (it = node.next) {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
-    }
-
-    it = self.handle.ready_queue.first;
-    while (it) |node| : (it = node.next) {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
+        const conn: *http.Connection = @fieldParentPtr("_worker_node", node);
+        self.handle.submitTlsVerify(conn, verify, self.use_proxy);
     }
 
     self.tls_verify = verify;
@@ -318,22 +335,6 @@ pub fn abort(self: *Client) void {
 
     for (snapshot.items) |t| {
         t.kill();
-    }
-
-    // After the kill loop, every internal list should drain itself via
-    // each transfer's deinit:
-    //   - self.transfers : transfers.remove(self.id)
-    //   - self.queue     : unlinked if _queued is set
-    //   - handle.in_use / handle.ready_queue : via submitRemove
-    //   - handle.dirty  : drained at end of each perform
-    // Any non-empty list means a transfer escaped cleanup — assert so we
-    // catch the regression rather than silently leaking on next use.
-    if (comptime IS_DEBUG) {
-        std.debug.assert(self.transfers.size == 0);
-        std.debug.assert(self.queue.first == null);
-        std.debug.assert(self.handle.in_use.first == null);
-        std.debug.assert(self.handle.ready_queue.first == null);
-        std.debug.assert(self.handle.dirty.first == null);
     }
 }
 
@@ -560,14 +561,9 @@ pub fn syncRequest(self: *Client, allocator: Allocator, req: Request) !SyncRespo
 // cases, the interceptor is expected to call resume to continue the transfer
 // or transfer.abort() to abort it.
 fn process(self: *Client, transfer: *Transfer) !void {
-    // libcurl doesn't allow recursive calls, if we're in a `perform()` operation
-    // then we _have_ to queue this.
-    if (self.handle.performing == false) {
-        if (self.handle.getConnection()) |conn| {
-            return self.makeRequest(conn, transfer);
-        }
+    if (self.handle.getConnection()) |conn| {
+        return self.makeRequest(conn, transfer);
     }
-
     self.queue.append(&transfer._node);
     transfer.state = .queued;
 }
@@ -640,38 +636,23 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
 }
 
 fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
-    // Handle.perform manages performing flag, drains the dirty queue
-    // before, and the ready_queue after curl_multi_perform.
-    const running = try self.handle.perform();
-
-    // Drain queued WebSocket events. ws callbacks (called from libcurl during
-    // perform above) only buffer/queue — actual JS dispatch happens here, on
-    // the worker thread.
+    // The network thread drives the multi; this just drains whatever
+    // it's already pushed (WS events queued by callbacks, completions
+    // delivered through Handle's wake pipe).
     self.drainReadyWs();
 
-    // We just processed completions; their done_callbacks may have
-    // scheduled microtasks (JS continuations) or queued new transfers.
-    // Return without polling so the caller (_tick) can run macrotasks
-    // and re-evaluate. Otherwise we'd sleep on cdp_link_active for up
-    // to timeout_ms while pending JS work sits idle.
+    // Process completions we already have before deciding to block.
     if (try self.processMessages()) {
         return;
     }
 
-    // Poll for HTTP I/O. The Network thread will call curl_multi_wakeup
-    // on our multi handle whenever it pushes to our inbox, so we drop
-    // out of poll promptly even when we have no curl handles in flight
-    // — but ONLY if a producer is actually wired up. `cdp_link_active`
-    // is set by Server.handleConnection once network.registerCdp has
-    // returned; in tests (which never register) and during the
-    // pre-handshake window the flag stays false and we don't waste a
-    // poll timeout waiting for a wakeup that won't arrive.
-    if (running > 0 or self.cdp_link_active) {
-        // when cdp_link_active == true, the network thread will unblock this
-        // by calling wakup on our multi.
+    // Poll for HTTP I/O or CDP inbox wakeups. cdp_link_active is set only
+    // after Network.registerCdp wires a producer that can wake this Handle.
+    if (self.handle.in_use.first != null or self.cdp_link_active) {
         try self.handle.poll(&.{}, timeout_ms);
     }
 
+    self.drainReadyWs();
     _ = try self.processMessages();
 }
 
@@ -762,7 +743,7 @@ fn processOneMessage(self: *Client, msg: Network.Handle.Completion, transfer: *T
             // release the easy handle back into the pool. The transfer
             // is still valid/alive (just has no handle); park it for
             // continueWithAuth.
-            self.handle.submitRemove(transfer._conn.?);
+            self.handle.finishConn(transfer._conn.?);
             transfer._conn = null;
             transfer.state = .{ .parked = .intercept_auth };
             return false;
@@ -837,7 +818,7 @@ fn processOneMessage(self: *Client, msg: Network.Handle.Completion, transfer: *T
     // release conn ASAP so that it's available; some done_callbacks
     // will load more resources. State stays .completing — the
     // processMessages caller still owns deinit.
-    self.handle.submitRemove(msg.conn);
+    self.handle.finishConn(msg.conn);
     transfer._conn = null;
 
     try transfer.req.done_callback(transfer.req.ctx);
@@ -1191,7 +1172,7 @@ pub const Transfer = struct {
 
     pub fn deinit(self: *Transfer) void {
         if (self._conn) |c| {
-            self.client.handle.submitRemove(c);
+            self.client.handle.finishConn(c);
             self._conn = null;
         }
 
@@ -1242,30 +1223,32 @@ pub const Transfer = struct {
     }
 
     // Decide whether to tear down now or defer until processOneMessage
-    // eventually drains the in-flight curl handle.
+    // eventually receives the canceled/completed connection.
     //
     // Two states force deferral:
     //   * `.completing` — processOneMessage is currently processing
     //     this transfer. It will call `transfer.deinit` itself after the
     //     chain returns; deiniting here would double-free. This covers
     //     both the with-conn and post-release-ASAP windows.
-    //   * `.inflight` while `client.handle.performing` — libcurl could still
-    //     fire callbacks for us. Releasing the arena now would UAF
-    //     from inside curl.
+    //   * `.inflight` with `_conn != null` — the network thread owns the
+    //     easy. Submit a cancellation and let the completion path call deinit.
     //
     // Otherwise (created / queued / parked / fully drained), there is
     // nothing left referencing this transfer and we can safely deinit
     // inline.
     fn detachOrDeinit(self: *Transfer) void {
-        const must_defer = switch (self.state) {
-            .completing => true,
-            .inflight => self.client.handle.performing,
-            else => false,
-        };
-        if (must_defer) {
-            self.detachInPerform();
-        } else {
-            self.deinit();
+        switch (self.state) {
+            .aborted => return,
+            .completing => self.detachInPerform(),
+            .inflight => {
+                if (self._conn) |conn| {
+                    self.detachInPerform();
+                    self.client.handle.submitRemove(conn);
+                } else {
+                    self.detachInPerform();
+                }
+            },
+            else => self.deinit(),
         }
     }
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -65,20 +65,9 @@ pub const HeaderIterator = http.HeaderIterator;
 // impacting those other http requests.
 pub const Client = @This();
 
-// Count of active ws requests
-ws_active: usize = 0,
-
-// Count of active http requests
-http_active: usize = 0,
-
-// Our curl multi handle.
+// Our curl multi handle. Owns in_use/ready_queue/http_active/ws_active/
+// performing — see Network.Handle.
 handle: Network.Handle,
-
-// Connections currently in this client's curl_multi.
-in_use: std.DoublyLinkedList = .{},
-
-// Whether we're currently inside a curl_multi_perform call.
-performing: bool = false,
 
 // WebSockets with queued events to be drained from the worker thread.
 // Populated by libcurl callbacks (currently same thread, future cross-thread).
@@ -95,15 +84,8 @@ next_request_id: u32 = 0,
 // only valid for the lifetime of the entry.
 transfers: std.AutoHashMapUnmanaged(u32, *Transfer) = .empty,
 
-// When handles has no more available easys, requests get queued.
+// Transfers waiting for a free Connection from the pool.
 queue: std.DoublyLinkedList = .{},
-
-// Queue is for Transfers that have no connection. ready_queue is for connections
-// that were initiated when performing == true and thus need to wait until
-// performing == false before being added. I'm hoping this is temporary and that
-// we can unify the two queues. But HTTP is being changed a lot right now, and
-// I'm trying to minimize the surface area.
-ready_queue: std.DoublyLinkedList = .{},
 
 // The main app allocator
 allocator: Allocator,
@@ -285,13 +267,13 @@ pub fn setTlsVerify(self: *Client, verify: bool) !void {
     // Remove inflight connections check on enable TLS b/c chromiumoxide calls
     // the command during navigate and Curl seems to accept it...
 
-    var it = self.in_use.first;
+    var it = self.handle.in_use.first;
     while (it) |node| : (it = node.next) {
         const conn: *http.Connection = @fieldParentPtr("node", node);
         try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
     }
 
-    it = self.ready_queue.first;
+    it = self.handle.ready_queue.first;
     while (it) |node| : (it = node.next) {
         const conn: *http.Connection = @fieldParentPtr("node", node);
         try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
@@ -342,15 +324,15 @@ pub fn abort(self: *Client) void {
     // each transfer's deinit:
     //   - self.transfers : transfers.remove(self.id)
     //   - self.queue     : unlinked if _queued is set
-    //   - self.in_use / self.ready_queue : via removeConn
-    //   - self.dirty     : drained at end of each perform; nothing left here
+    //   - handle.in_use / handle.ready_queue : via submitRemove
+    //   - handle.dirty  : drained at end of each perform
     // Any non-empty list means a transfer escaped cleanup — assert so we
     // catch the regression rather than silently leaking on next use.
     if (comptime IS_DEBUG) {
         std.debug.assert(self.transfers.size == 0);
         std.debug.assert(self.queue.first == null);
-        std.debug.assert(self.in_use.first == null);
-        std.debug.assert(self.ready_queue.first == null);
+        std.debug.assert(self.handle.in_use.first == null);
+        std.debug.assert(self.handle.ready_queue.first == null);
         std.debug.assert(self.handle.dirty.first == null);
     }
 }
@@ -580,7 +562,7 @@ pub fn syncRequest(self: *Client, allocator: Allocator, req: Request) !SyncRespo
 fn process(self: *Client, transfer: *Transfer) !void {
     // libcurl doesn't allow recursive calls, if we're in a `perform()` operation
     // then we _have_ to queue this.
-    if (self.performing == false) {
+    if (self.handle.performing == false) {
         if (self.handle.getConnection()) |conn| {
             return self.makeRequest(conn, transfer);
         }
@@ -622,7 +604,7 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
         // pool — `transfer.state` stays `.created`, and the caller
         // (Client.request's errdefer or drainQueue's catch) aborts
         // the transfer.
-        errdefer self.releaseConn(conn);
+        errdefer self.handle.releaseConnection(conn);
 
         try transfer.configureConn(conn);
     }
@@ -630,8 +612,10 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
     // As soon as trackConn succeeds, the multi handle owns the transfer's
     // lifecycle. perform/processMessages will eventually invoke completion
     // callbacks and call transfer.deinit.
-    self.trackConn(conn) catch |err| {
-        self.releaseConn(conn);
+    self.handle.submitRequest(conn) catch |err| {
+        // submitRequest rolled back its own bookkeeping; we still own
+        // the conn — release it.
+        self.handle.releaseConnection(conn);
         return err;
     };
     transfer._conn = conn;
@@ -640,8 +624,8 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
     if (transfer.req.start_callback) |cb| {
         cb(Response.fromTransfer(transfer)) catch |err| {
             // We're now committed to the multi. transfer.abort fires the
-            // error_callback and tears down (removeConn handles the
-            // already-in-multi case via the dirty queue).
+            // error_callback and tears down (Handle.submitRemove handles
+            // the already-in-multi case via the dirty queue).
             transfer.abort(err);
             return err;
         };
@@ -652,31 +636,18 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
     // wouldn't be so bad. But curl can synchronously fire callbacks for the
     // request we JUST added, which we do not want (it results in incorrect
     // execution).
-    self.performing = true;
-    defer self.performing = false;
     _ = try self.handle.perform();
 }
 
 fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
-    const running = blk: {
-        self.performing = true;
-        defer self.performing = false;
-
-        break :blk try self.handle.perform();
-    };
+    // Handle.perform manages performing flag, drains the dirty queue
+    // before, and the ready_queue after curl_multi_perform.
+    const running = try self.handle.perform();
 
     // Drain queued WebSocket events. ws callbacks (called from libcurl during
     // perform above) only buffer/queue — actual JS dispatch happens here, on
     // the worker thread.
     self.drainReadyWs();
-
-    // Process dirty connections — return them to Network pool.
-    self.handle.drainDirty();
-
-    while (self.ready_queue.popFirst()) |node| {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        try self.trackConn(conn);
-    }
 
     // We just processed completions; their done_callbacks may have
     // scheduled microtasks (JS continuations) or queued new transfers.
@@ -766,7 +737,7 @@ fn isFetchInterceptionMethod(method: []const u8) bool {
         std.mem.eql(u8, method, "Fetch.continueWithAuth");
 }
 
-fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: *Transfer) !bool {
+fn processOneMessage(self: *Client, msg: Network.Handle.Completion, transfer: *Transfer) !bool {
     // State at entry: .inflight = conn (multi just delivered a completion).
     if (msg.err == null or msg.err.? == error.RecvError) {
         transfer.detectAuthChallenge(msg.conn);
@@ -791,7 +762,7 @@ fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: 
             // release the easy handle back into the pool. The transfer
             // is still valid/alive (just has no handle); park it for
             // continueWithAuth.
-            self.removeConn(transfer._conn.?);
+            self.handle.submitRemove(transfer._conn.?);
             transfer._conn = null;
             transfer.state = .{ .parked = .intercept_auth };
             return false;
@@ -806,16 +777,9 @@ fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: 
 
             const conn = transfer._conn.?;
 
-            try self.handle.remove(conn);
-            // Conn temporarily out of multi during reconfigure.
-            // _detached_conn lets processMessages release it if any of
-            // the steps below throw. State stays .inflight; _conn stays set
-            transfer._detached_conn = conn;
-
             transfer.reset();
             try transfer.configureConn(conn);
-            try self.handle.add(conn);
-            transfer._detached_conn = null;
+            try self.handle.submitRequest(conn);
 
             _ = try self.perform(0);
 
@@ -873,7 +837,7 @@ fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: 
     // release conn ASAP so that it's available; some done_callbacks
     // will load more resources. State stays .completing — the
     // processMessages caller still owns deinit.
-    self.removeConn(msg.conn);
+    self.handle.submitRemove(msg.conn);
     transfer._conn = null;
 
     try transfer.req.done_callback(transfer.req.ctx);
@@ -883,20 +847,12 @@ fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: 
 
 fn processMessages(self: *Client) !bool {
     var processed = false;
-    while (try self.handle.readMessage()) |msg| {
+    while (try self.handle.nextCompletion()) |msg| {
         switch (msg.conn.transport) {
             .http => |transfer| {
                 const done = self.processOneMessage(msg, transfer) catch |err| blk: {
                     log.err(.http, "process_messages", .{ .err = err, .req = transfer });
                     transfer.requestFailed(err, true);
-                    if (transfer._detached_conn) |c| {
-                        // Conn was removed from handles during redirect reconfiguration
-                        // but not re-added. Release it directly to avoid double-remove.
-                        self.in_use.remove(&c.node);
-                        self.http_active -= 1;
-                        self.releaseConn(c);
-                        transfer._detached_conn = null;
-                    }
                     break :blk true;
                 };
                 if (done) {
@@ -922,59 +878,6 @@ fn processMessages(self: *Client) !bool {
     return processed;
 }
 
-pub fn trackConn(self: *Client, conn: *http.Connection) !void {
-    if (self.performing) {
-        conn.in_use = false;
-        self.ready_queue.append(&conn.node);
-        return;
-    }
-
-    self.in_use.append(&conn.node);
-    conn.in_use = true;
-    // Set private pointer so readMessage can find the Connection.
-    // Must be done each time since curl_easy_reset clears it when
-    // connections are returned to pool.
-    conn.setPrivate(conn) catch |err| {
-        self.in_use.remove(&conn.node);
-        conn.in_use = false;
-        self.releaseConn(conn);
-        return err;
-    };
-    self.handle.add(conn) catch |err| {
-        self.in_use.remove(&conn.node);
-        conn.in_use = false;
-        self.releaseConn(conn);
-        return err;
-    };
-
-    switch (conn.transport) {
-        .http => self.http_active += 1,
-        .websocket => self.ws_active += 1,
-        else => unreachable,
-    }
-}
-
-pub fn removeConn(self: *Client, conn: *http.Connection) void {
-    if (conn.in_use == false) {
-        self.ready_queue.remove(&conn.node);
-        self.releaseConn(conn);
-        return;
-    }
-
-    self.in_use.remove(&conn.node);
-    conn.in_use = false;
-    switch (conn.transport) {
-        .http => self.http_active -= 1,
-        .websocket => self.ws_active -= 1,
-        else => unreachable,
-    }
-    self.handle.cancelConn(conn);
-}
-
-fn releaseConn(self: *Client, conn: *http.Connection) void {
-    self.handle.releaseConnection(conn);
-}
-
 // Called from WebSocket libcurl callbacks (currently same worker thread, but
 // the API is mutex-protected so it stays correct if libcurl moves off-thread).
 pub fn addReadyWs(self: *Client, ws: *WebSocket) void {
@@ -997,7 +900,7 @@ fn drainReadyWs(self: *Client) void {
 }
 
 fn ensureNoActiveConnection(self: *const Client) !void {
-    if (self.http_active > 0 or self.ws_active > 0) {
+    if (self.handle.http_active > 0 or self.handle.ws_active > 0) {
         return error.InflightConnection;
     }
 }
@@ -1214,11 +1117,6 @@ pub const Transfer = struct {
 
     _notified_fail: bool = false,
 
-    // Set when conn is temporarily detached from transfer during redirect
-    // reconfiguration. Used by processMessages to release the orphaned conn
-    // if reconfiguration fails. Transient inside the redirect path only.
-    _detached_conn: ?*http.Connection = null,
-
     _auth_challenge: ?http.AuthChallenge = null,
 
     // number of times the transfer has been tried.
@@ -1293,7 +1191,7 @@ pub const Transfer = struct {
 
     pub fn deinit(self: *Transfer) void {
         if (self._conn) |c| {
-            self.client.removeConn(c);
+            self.client.handle.submitRemove(c);
             self._conn = null;
         }
 
@@ -1351,7 +1249,7 @@ pub const Transfer = struct {
     //     this transfer. It will call `transfer.deinit` itself after the
     //     chain returns; deiniting here would double-free. This covers
     //     both the with-conn and post-release-ASAP windows.
-    //   * `.inflight` while `client.performing` — libcurl could still
+    //   * `.inflight` while `client.handle.performing` — libcurl could still
     //     fire callbacks for us. Releasing the arena now would UAF
     //     from inside curl.
     //
@@ -1361,7 +1259,7 @@ pub const Transfer = struct {
     fn detachOrDeinit(self: *Transfer) void {
         const must_defer = switch (self.state) {
             .completing => true,
-            .inflight => self.client.performing,
+            .inflight => self.client.handle.performing,
             else => false,
         };
         if (must_defer) {
@@ -1619,7 +1517,7 @@ pub const Transfer = struct {
     }
 
     // abortAuthChallenge is called when an auth challenge interception is
-    // abort. We don't call self.releaseConn here b/c it has been done
+    // abort. We don't call submitRemove here b/c it has been done
     // before interception process.
     pub fn abortAuthChallenge(self: *Transfer) void {
         if (comptime IS_DEBUG) {

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -72,13 +72,10 @@ ws_active: usize = 0,
 http_active: usize = 0,
 
 // Our curl multi handle.
-handles: http.Handles,
+handle: Network.Handle,
 
 // Connections currently in this client's curl_multi.
 in_use: std.DoublyLinkedList = .{},
-
-// Connections that failed to be removed from curl_multi during perform.
-dirty: std.DoublyLinkedList = .{},
 
 // Whether we're currently inside a curl_multi_perform call.
 performing: bool = false,
@@ -186,13 +183,13 @@ fn layerWith(self: anytype, next: Layer) Layer {
 }
 
 pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) !void {
-    var handles = try http.Handles.init(network.config);
-    errdefer handles.deinit();
+    var handle = try network.getHandle();
+    errdefer handle.deinit();
 
     const http_proxy = network.config.httpProxy();
 
     self.* = Client{
-        .handles = handles,
+        .handle = handle,
         .network = network,
         .allocator = allocator,
         .cdp = cdp,
@@ -235,7 +232,7 @@ pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) 
 
 pub fn deinit(self: *Client) void {
     self.abort();
-    self.handles.deinit();
+    self.handle.deinit();
 
     self.ws_ready.deinit(self.allocator);
     self.clearUserAgentOverride();
@@ -291,13 +288,13 @@ pub fn setTlsVerify(self: *Client, verify: bool) !void {
     var it = self.in_use.first;
     while (it) |node| : (it = node.next) {
         const conn: *http.Connection = @fieldParentPtr("node", node);
-        try conn.setTlsVerify(verify, self.use_proxy);
+        try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
     }
 
     it = self.ready_queue.first;
     while (it) |node| : (it = node.next) {
         const conn: *http.Connection = @fieldParentPtr("node", node);
-        try conn.setTlsVerify(verify, self.use_proxy);
+        try self.handle.submitTlsVerify(conn, verify, self.use_proxy);
     }
 
     self.tls_verify = verify;
@@ -354,7 +351,7 @@ pub fn abort(self: *Client) void {
         std.debug.assert(self.queue.first == null);
         std.debug.assert(self.in_use.first == null);
         std.debug.assert(self.ready_queue.first == null);
-        std.debug.assert(self.dirty.first == null);
+        std.debug.assert(self.handle.dirty.first == null);
     }
 }
 
@@ -422,7 +419,7 @@ pub fn tick(self: *Client, timeout_ms: u32, mode: DrainMode) !void {
 fn drainQueue(self: *Client) !void {
     while (self.queue.popFirst()) |queue_node| {
         const transfer: *Transfer = @fieldParentPtr("_node", queue_node);
-        const conn = self.network.getConnection() orelse {
+        const conn = self.handle.getConnection() orelse {
             self.queue.prepend(queue_node);
             return;
         };
@@ -584,7 +581,7 @@ fn process(self: *Client, transfer: *Transfer) !void {
     // libcurl doesn't allow recursive calls, if we're in a `perform()` operation
     // then we _have_ to queue this.
     if (self.performing == false) {
-        if (self.network.getConnection()) |conn| {
+        if (self.handle.getConnection()) |conn| {
             return self.makeRequest(conn, transfer);
         }
     }
@@ -657,7 +654,7 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
     // execution).
     self.performing = true;
     defer self.performing = false;
-    _ = try self.handles.perform();
+    _ = try self.handle.perform();
 }
 
 fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
@@ -665,7 +662,7 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
         self.performing = true;
         defer self.performing = false;
 
-        break :blk try self.handles.perform();
+        break :blk try self.handle.perform();
     };
 
     // Drain queued WebSocket events. ws callbacks (called from libcurl during
@@ -674,14 +671,7 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
     self.drainReadyWs();
 
     // Process dirty connections — return them to Network pool.
-    while (self.dirty.popFirst()) |node| {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        self.handles.remove(conn) catch |err| {
-            log.fatal(.http, "multi remove handle", .{ .err = err, .src = "perform" });
-            @panic("multi_remove_handle");
-        };
-        self.releaseConn(conn);
-    }
+    self.handle.drainDirty();
 
     while (self.ready_queue.popFirst()) |node| {
         const conn: *http.Connection = @fieldParentPtr("node", node);
@@ -708,7 +698,7 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
     if (running > 0 or self.cdp_link_active) {
         // when cdp_link_active == true, the network thread will unblock this
         // by calling wakup on our multi.
-        try self.handles.poll(&.{}, timeout_ms);
+        try self.handle.poll(&.{}, timeout_ms);
     }
 
     _ = try self.processMessages();
@@ -776,7 +766,7 @@ fn isFetchInterceptionMethod(method: []const u8) bool {
         std.mem.eql(u8, method, "Fetch.continueWithAuth");
 }
 
-fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *Transfer) !bool {
+fn processOneMessage(self: *Client, msg: Network.Handle.MultiMessage, transfer: *Transfer) !bool {
     // State at entry: .inflight = conn (multi just delivered a completion).
     if (msg.err == null or msg.err.? == error.RecvError) {
         transfer.detectAuthChallenge(msg.conn);
@@ -816,7 +806,7 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
 
             const conn = transfer._conn.?;
 
-            try self.handles.remove(conn);
+            try self.handle.remove(conn);
             // Conn temporarily out of multi during reconfigure.
             // _detached_conn lets processMessages release it if any of
             // the steps below throw. State stays .inflight; _conn stays set
@@ -824,7 +814,7 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
 
             transfer.reset();
             try transfer.configureConn(conn);
-            try self.handles.add(conn);
+            try self.handle.add(conn);
             transfer._detached_conn = null;
 
             _ = try self.perform(0);
@@ -893,7 +883,7 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
 
 fn processMessages(self: *Client) !bool {
     var processed = false;
-    while (try self.handles.readMessage()) |msg| {
+    while (try self.handle.readMessage()) |msg| {
         switch (msg.conn.transport) {
             .http => |transfer| {
                 const done = self.processOneMessage(msg, transfer) catch |err| blk: {
@@ -950,7 +940,7 @@ pub fn trackConn(self: *Client, conn: *http.Connection) !void {
         self.releaseConn(conn);
         return err;
     };
-    self.handles.add(conn) catch |err| {
+    self.handle.add(conn) catch |err| {
         self.in_use.remove(&conn.node);
         conn.in_use = false;
         self.releaseConn(conn);
@@ -978,17 +968,11 @@ pub fn removeConn(self: *Client, conn: *http.Connection) void {
         .websocket => self.ws_active -= 1,
         else => unreachable,
     }
-    if (self.handles.remove(conn)) {
-        self.releaseConn(conn);
-    } else |_| {
-        // Can happen if we're in a perform() call, so we'll queue this
-        // for cleanup later.
-        self.dirty.append(&conn.node);
-    }
+    self.handle.cancelConn(conn);
 }
 
 fn releaseConn(self: *Client, conn: *http.Connection) void {
-    self.network.releaseConnection(conn);
+    self.handle.releaseConnection(conn);
 }
 
 // Called from WebSocket libcurl callbacks (currently same worker thread, but

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -68,10 +68,14 @@ pub const Client = @This();
 // Our curl multi handle. Owns in_use/http_active/ws_active — see Network.Handle.
 handle: Network.Handle,
 
-// WebSockets with queued events to be drained from the worker thread.
-// Populated by libcurl callbacks (currently same thread, future cross-thread).
-ws_ready: std.ArrayList(*WebSocket) = .{},
-ws_ready_mutex: std.Thread.Mutex = .{},
+// WebSocket cross-thread queues. Inbound events mirror the completion queue:
+// producers append under a short lock and wake the Handle pipe; the browser
+// thread drains into a local list before dispatching JS events. Outbound
+// commands are produced by the browser thread and consumed by libcurl read
+// callbacks on the network side.
+ws_event_queue: std.DoublyLinkedList = .{},
+ws_command_queue: std.DoublyLinkedList = .{},
+ws_queue_mutex: std.Thread.Mutex = .{},
 
 // Use to generate the next request ID
 next_request_id: u32 = 0,
@@ -231,10 +235,16 @@ pub fn deinit(self: *Client) void {
         std.debug.assert(self.transfers.size == 0);
         std.debug.assert(self.queue.first == null);
     }
+    if (self.transfers.size != 0) {
+        log.err(.http, "deinit with active transfers", .{
+            .count = self.transfers.size,
+        });
+        unreachable;
+    }
 
     self.handle.deinit();
 
-    self.ws_ready.deinit(self.allocator);
+    self.clearWebSocketQueues();
     self.clearUserAgentOverride();
 
     self.robots_layer.deinit(self.allocator);
@@ -366,6 +376,12 @@ pub fn abort(self: *Client) void {
 
     for (snapshot.items) |t| {
         t.kill();
+    }
+
+    // Queued transfers deinit synchronously, and in-flight transfers
+    // complete through Handle completions after submitRemove.
+    if (comptime IS_DEBUG) {
+        std.debug.assert(self.queue.first == null);
     }
 }
 
@@ -890,24 +906,107 @@ fn processMessages(self: *Client) !bool {
     return processed;
 }
 
-// Called from WebSocket libcurl callbacks (currently same worker thread, but
-// the API is mutex-protected so it stays correct if libcurl moves off-thread).
-pub fn addReadyWs(self: *Client, ws: *WebSocket) void {
-    self.ws_ready_mutex.lock();
-    defer self.ws_ready_mutex.unlock();
-    self.ws_ready.append(self.allocator, ws) catch {};
+pub fn addWebSocketEvent(self: *Client, ws: *WebSocket, data: WebSocket.EventData) void {
+    const event = self.allocator.create(WebSocket.QueuedEvent) catch {
+        data.deinit(self.allocator);
+        return;
+    };
+    event.* = .{
+        .ws = ws,
+        .data = data,
+    };
+    ws.acquireRef();
+    {
+        self.ws_queue_mutex.lock();
+        defer self.ws_queue_mutex.unlock();
+        self.ws_event_queue.append(&event.node);
+    }
+    self.handle.wake();
+}
+
+pub fn addWebSocketCommand(self: *Client, ws: *WebSocket, data: WebSocket.CommandData) !void {
+    const command = try self.allocator.create(WebSocket.QueuedCommand);
+    command.* = .{
+        .ws = ws,
+        .data = data,
+    };
+    {
+        self.ws_queue_mutex.lock();
+        defer self.ws_queue_mutex.unlock();
+        self.ws_command_queue.append(&command.node);
+    }
+    if (ws._conn) |conn| {
+        self.handle.submitUnpause(conn);
+    }
+}
+
+pub fn drainWebSocketCommandsLocked(
+    self: *Client,
+    ws: *WebSocket,
+    send_queue: *std.ArrayList(WebSocket.CommandData),
+    arena: Allocator,
+) !void {
+    var maybe_node = self.ws_command_queue.first;
+    while (maybe_node) |node| {
+        const next = node.next;
+        const command: *WebSocket.QueuedCommand = @fieldParentPtr("node", node);
+        if (command.ws == ws) {
+            try send_queue.append(arena, command.data);
+            self.ws_command_queue.remove(node);
+            self.allocator.destroy(command);
+        }
+        maybe_node = next;
+    }
+}
+
+pub fn clearWebSocketCommandsLocked(self: *Client, ws: *WebSocket) void {
+    var maybe_node = self.ws_command_queue.first;
+    while (maybe_node) |node| {
+        const next = node.next;
+        const command: *WebSocket.QueuedCommand = @fieldParentPtr("node", node);
+        if (command.ws == ws) {
+            self.ws_command_queue.remove(node);
+            command.data.deinit(ws._arena_pool);
+            self.allocator.destroy(command);
+        }
+        maybe_node = next;
+    }
 }
 
 pub fn drainReadyWs(self: *Client) void {
-    self.ws_ready_mutex.lock();
-    const items = self.ws_ready.toOwnedSlice(self.allocator) catch {
-        self.ws_ready_mutex.unlock();
-        return;
-    };
-    self.ws_ready_mutex.unlock();
-    defer self.allocator.free(items);
-    for (items) |ws| {
-        ws.drainPending();
+    var events: std.DoublyLinkedList = .{};
+    {
+        self.ws_queue_mutex.lock();
+        defer self.ws_queue_mutex.unlock();
+        while (self.ws_event_queue.popFirst()) |node| {
+            events.append(node);
+        }
+    }
+
+    while (events.popFirst()) |node| {
+        const event: *WebSocket.QueuedEvent = @fieldParentPtr("node", node);
+        defer {
+            event.data.deinit(self.allocator);
+            event.ws.releaseRef(event.ws._frame._page);
+            self.allocator.destroy(event);
+        }
+        event.ws.drainEvent(event.data);
+    }
+}
+
+fn clearWebSocketQueues(self: *Client) void {
+    self.ws_queue_mutex.lock();
+    defer self.ws_queue_mutex.unlock();
+    while (self.ws_event_queue.popFirst()) |node| {
+        const event: *WebSocket.QueuedEvent = @fieldParentPtr("node", node);
+        event.data.deinit(self.allocator);
+        event.ws.releaseRef(event.ws._frame._page);
+        self.allocator.destroy(event);
+    }
+    while (self.ws_command_queue.popFirst()) |node| {
+        const command: *WebSocket.QueuedCommand = @fieldParentPtr("node", node);
+        command.data.deinit(command.ws._arena_pool);
+        self.allocator.destroy(command);
     }
 }
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -213,23 +213,18 @@ pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) 
 
 pub fn deinit(self: *Client) void {
     self.abort();
+    self.abortWebSockets();
 
-    // Cancellations submitted by abort flow through the network thread
-    // and come back as canceled completions. If the network thread has
-    // already stopped, drive its queues ourselves; otherwise spin until
-    // they all arrive and we drained them.
-    var spins: usize = 0;
-    while (self.handle.in_use.first != null and spins < 1000) : (spins += 1) {
-        if (self.network.shutdown.load(.acquire)) {
-            self.network.drainPendingForShutdown();
-        }
-        _ = self.processMessages() catch {};
-        self.drainReadyWs();
-        if (self.handle.in_use.first == null) break;
-        std.Thread.sleep(std.time.ns_per_ms);
+    if (self.handle.in_use.first != null) {
+        self.drainShutdownCompletions() catch |err| {
+            log.err(.http, "deinit drain", .{
+                .err = err,
+                .count = self.handle.http_active + self.handle.ws_active,
+            });
+        };
     }
     if (self.handle.in_use.first != null) {
-        log.warn(.http, "deinit with active conns", .{
+        log.err(.http, "deinit with active conns", .{
             .count = self.handle.http_active + self.handle.ws_active,
         });
     } else if (comptime IS_DEBUG) {
@@ -245,6 +240,42 @@ pub fn deinit(self: *Client) void {
     self.robots_layer.deinit(self.allocator);
     self.transfers.deinit(self.allocator);
     self.inbox.deinit(self.arena_pool);
+}
+
+fn abortWebSockets(self: *Client) void {
+    var n = self.handle.in_use.first;
+    while (n) |node| {
+        n = node.next;
+        const conn: *http.Connection = @fieldParentPtr("_worker_node", node);
+        switch (conn.transport) {
+            .websocket => |ws| ws.kill(),
+            else => {},
+        }
+    }
+}
+
+fn drainShutdownCompletions(self: *Client) !void {
+    var timer = try std.time.Timer.start();
+    const timeout_ms: u64 = 1000;
+
+    while (self.handle.in_use.first != null) {
+        if (self.network.shutdown.load(.acquire)) {
+            self.network.drainPendingForShutdown();
+        } else {
+            try self.handle.poll(&.{}, 10);
+        }
+
+        while (try self.handle.nextCompletion()) |msg| {
+            switch (msg.conn.transport) {
+                .http => |transfer| transfer.deinit(),
+                .websocket => |ws| ws.completeShutdown(),
+                .none => self.handle.finishConn(msg.conn),
+            }
+        }
+
+        const elapsed_ms = timer.read() / std.time.ns_per_ms;
+        if (elapsed_ms >= timeout_ms) return error.Timeout;
+    }
 }
 
 // Look up a live transfer by its id. Returns null if the transfer has been
@@ -867,7 +898,7 @@ pub fn addReadyWs(self: *Client, ws: *WebSocket) void {
     self.ws_ready.append(self.allocator, ws) catch {};
 }
 
-fn drainReadyWs(self: *Client) void {
+pub fn drainReadyWs(self: *Client) void {
     self.ws_ready_mutex.lock();
     const items = self.ws_ready.toOwnedSlice(self.allocator) catch {
         self.ws_ready_mutex.unlock();

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -26,6 +26,7 @@ const timestamp = @import("../datetime.zig").timestamp;
 
 const URL = @import("URL.zig");
 const CookieJar = @import("webapi/storage/Cookie.zig").Jar;
+const WebSocket = @import("webapi/net/WebSocket.zig");
 
 const http = @import("../network/http.zig");
 const Robots = @import("../network/Robots.zig");
@@ -81,6 +82,11 @@ dirty: std.DoublyLinkedList = .{},
 
 // Whether we're currently inside a curl_multi_perform call.
 performing: bool = false,
+
+// WebSockets with queued events to be drained from the worker thread.
+// Populated by libcurl callbacks (currently same thread, future cross-thread).
+ws_ready: std.ArrayList(*WebSocket) = .{},
+ws_ready_mutex: std.Thread.Mutex = .{},
 
 // Use to generate the next request ID
 next_request_id: u32 = 0,
@@ -231,6 +237,7 @@ pub fn deinit(self: *Client) void {
     self.abort();
     self.handles.deinit();
 
+    self.ws_ready.deinit(self.allocator);
     self.clearUserAgentOverride();
 
     self.robots_layer.deinit(self.allocator);
@@ -661,6 +668,11 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!void {
         break :blk try self.handles.perform();
     };
 
+    // Drain queued WebSocket events. ws callbacks (called from libcurl during
+    // perform above) only buffer/queue — actual JS dispatch happens here, on
+    // the worker thread.
+    self.drainReadyWs();
+
     // Process dirty connections — return them to Network pool.
     while (self.dirty.popFirst()) |node| {
         const conn: *http.Connection = @fieldParentPtr("node", node);
@@ -977,6 +989,27 @@ pub fn removeConn(self: *Client, conn: *http.Connection) void {
 
 fn releaseConn(self: *Client, conn: *http.Connection) void {
     self.network.releaseConnection(conn);
+}
+
+// Called from WebSocket libcurl callbacks (currently same worker thread, but
+// the API is mutex-protected so it stays correct if libcurl moves off-thread).
+pub fn addReadyWs(self: *Client, ws: *WebSocket) void {
+    self.ws_ready_mutex.lock();
+    defer self.ws_ready_mutex.unlock();
+    self.ws_ready.append(self.allocator, ws) catch {};
+}
+
+fn drainReadyWs(self: *Client) void {
+    self.ws_ready_mutex.lock();
+    const items = self.ws_ready.toOwnedSlice(self.allocator) catch {
+        self.ws_ready_mutex.unlock();
+        return;
+    };
+    self.ws_ready_mutex.unlock();
+    defer self.allocator.free(items);
+    for (items) |ws| {
+        ws.drainPending();
+    }
 }
 
 fn ensureNoActiveConnection(self: *const Client) !void {
@@ -1795,8 +1828,6 @@ const Noop = struct {
 pub const Owner = struct {
     transfers: std.DoublyLinkedList = .{},
     websockets: std.DoublyLinkedList = .{},
-
-    const WebSocket = @import("webapi/net/WebSocket.zig");
 
     pub fn addTransfer(self: *Owner, t: *Transfer) void {
         self.transfers.append(&t.owner_node);

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -183,6 +183,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
             // store http_client.handle.http_active BEFORE this call and then use
             // it AFTER.
             try browser.runMacrotasks();
+            http_client.drainReadyWs();
 
             const http_active = http_client.handle.http_active;
             const total_network_activity = http_active + http_client.interception_layer.intercepted;

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -158,7 +158,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
             // There's no JS to run, and no reason to run the scheduler
             // — unless we're the CDP worker, in which case we want
             // http_client.tick to drain the inbox.
-            if (http_client.http_active == 0 and (comptime is_cdp) == false) {
+            if (http_client.handle.http_active == 0 and (comptime is_cdp) == false) {
                 // haven't started navigating, I guess.
                 return .done;
             }
@@ -180,11 +180,11 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
             // download, or scheduled tasks to execute, or both.
 
             // scheduler.run could trigger new http transfers, so do not
-            // store http_client.http_active BEFORE this call and then use
+            // store http_client.handle.http_active BEFORE this call and then use
             // it AFTER.
             try browser.runMacrotasks();
 
-            const http_active = http_client.http_active;
+            const http_active = http_client.handle.http_active;
             const total_network_activity = http_active + http_client.interception_layer.intercepted;
             if (frame._notified_network_almost_idle.check(total_network_activity <= 2)) {
                 frame.notifyNetworkAlmostIdle();
@@ -206,7 +206,11 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
                 },
             }
 
-            if (http_active == 0 and http_client.ws_active == 0 and http_client.queue.first == null and http_client.ready_queue.first == null and (comptime is_cdp) == false) {
+            if (http_active == 0 and http_client.handle.ws_active == 0 and http_client.queue.first == null and http_client.handle.ready_queue.first == null and (comptime is_cdp) == false) {
+                // we don't need to consider http_client.interception_layer.intercepted
+                // here because is_cdp is false, and that can only be
+                // the case when interception isn't possible.
+                //
                 // ready_queue is also part of the check: makeRequest now
                 // wraps its handles.perform() in a performing=true window,
                 // and any synchronous libcurl callback that ends up
@@ -216,8 +220,8 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
                 // http_client.tick returns.
                 //
                 // intercepted is only non-zero in serve mode, and
-                // serve mode implies cdp_client != null — so if we got
-                // here, intercepted == 0.
+                // serve mode implies is_cdp — so if we got here,
+                // intercepted == 0.
                 if (comptime IS_DEBUG) {
                     std.debug.assert(http_client.interception_layer.intercepted == 0);
                 }

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -206,18 +206,10 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
                 },
             }
 
-            if (http_active == 0 and http_client.handle.ws_active == 0 and http_client.queue.first == null and http_client.handle.ready_queue.first == null and (comptime is_cdp) == false) {
+            if (http_active == 0 and http_client.handle.ws_active == 0 and http_client.queue.first == null and (comptime is_cdp) == false) {
                 // we don't need to consider http_client.interception_layer.intercepted
                 // here because is_cdp is false, and that can only be
                 // the case when interception isn't possible.
-                //
-                // ready_queue is also part of the check: makeRequest now
-                // wraps its handles.perform() in a performing=true window,
-                // and any synchronous libcurl callback that ends up
-                // calling trackConn during that window (e.g. JS creating
-                // a WebSocket) will append to ready_queue. Without this
-                // check we could observe it non-empty after
-                // http_client.tick returns.
                 //
                 // intercepted is only non-zero in serve mode, and
                 // serve mode implies is_cdp — so if we got here,

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -576,7 +576,7 @@ pub const Script = struct {
                     .a9 = self.debug_transfer_easy_id,
                     .b1 = transfer.id,
                     .b2 = transfer._tries,
-                    .b3 = transfer.state == .aborted,
+                    .b3 = transfer.isAborted(),
                     .b4 = transfer.res.bytes_received,
                     .b5 = transfer._notified_fail,
                     .b8 = transfer._auth_challenge != null,
@@ -585,7 +585,7 @@ pub const Script = struct {
                 self.header_callback_called = true;
                 self.debug_transfer_id = transfer.id;
                 self.debug_transfer_tries = transfer._tries;
-                self.debug_transfer_aborted = transfer.state == .aborted;
+                self.debug_transfer_aborted = transfer.isAborted();
                 self.debug_transfer_bytes_received = transfer.res.bytes_received;
                 self.debug_transfer_notified_fail = transfer._notified_fail;
                 self.debug_transfer_auth_challenge = transfer._auth_challenge != null;

--- a/src/browser/tests/net/websocket_basic_close.html
+++ b/src/browser/tests/net/websocket_basic_close.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=basic_echo type=module>
+{
+  const state = await testing.async();
+  let received = [];
+
+  let ws = new WebSocket('ws://127.0.0.1:9584/');
+
+  ws.addEventListener('open', () => {
+    ws.send('msg1');
+  });
+
+  ws.addEventListener('close', (e) => {
+    received.push(['close', e.code, e.reason]);
+    state.resolve();
+  });
+
+  ws.addEventListener('message', (e) => {
+    received.push(e.data);
+    ws.close(1000, 'bye');
+  });
+
+  await state.done(() => {
+    testing.expectEqual([
+      'echo-msg1',
+      ['close', 1000, 'bye'],
+    ], received);
+  });
+}
+</script>

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -256,6 +256,17 @@ pub fn kill(self: *WebSocket) void {
     self.cleanup(false);
 }
 
+pub fn completeShutdown(self: *WebSocket) void {
+    self._mutex.lock();
+    self._ready_state = .closed;
+    self._pending_open = false;
+    self._pending_close = null;
+    self._pending_messages.clearRetainingCapacity();
+    self._recv_buffer.clearRetainingCapacity();
+    self._mutex.unlock();
+    self.cleanup(true);
+}
+
 pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
     defer self.cleanup(true);
 
@@ -608,6 +619,7 @@ pub fn drainPending(self: *WebSocket) void {
         self.dispatchCloseEvent(pc.code, pc.reason, pc.was_clean) catch |err| {
             log.err(.websocket, "close event dispatch failed", .{ .err = err });
         };
+        self.cleanup(false);
     }
 }
 
@@ -768,8 +780,14 @@ fn receivedDataCallback(buffer: [*]const u8, buf_count: usize, buf_len: usize, d
 
 fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
     const self = conn.transport.websocket;
+    var close_after_unlock = false;
     self._mutex.lock();
-    defer self._mutex.unlock();
+    defer {
+        self._mutex.unlock();
+        if (close_after_unlock) {
+            self.cleanup(false);
+        }
+    }
 
     const meta = conn.wsMeta() orelse {
         log.err(.websocket, "missing meta", .{ .url = self._url });
@@ -809,12 +827,26 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
             else
                 1005; // No status code received
 
-            if (self._ready_state == .closing) {
-                // Client-initiated close — server's response. Don't
-                // disconnect inline: we're inside a libcurl callback
-                // and tearing the conn down here would UAF the easy
-                // handle. Curl will deliver normal completion when the
-                // server closes the socket per RFC 6455 §5.5.1.
+            if (self._ready_state == .closed) {
+                // Already completed locally after sending our close frame.
+            } else if (self._ready_state == .closing) {
+                // Client-initiated close: this is the server's response.
+                // Finish the JS close flow now, then remove the easy after
+                // the callback returns. Some servers reply with a close
+                // frame but keep the TCP socket open.
+                self._close_code = received_code;
+                if (message.len > 2) {
+                    self._close_reason = try self._arena.dupe(u8, message[2..]);
+                }
+                self._ready_state = .closed;
+                self._pending_close = .{
+                    .code = self._close_code,
+                    .reason = self._close_reason,
+                    .was_clean = true,
+                    .with_error = false,
+                };
+                self.markReadyLocked();
+                close_after_unlock = true;
             } else {
                 self._close_code = received_code;
                 if (message.len > 2) {
@@ -941,4 +973,8 @@ pub const JsApi = struct {
 const testing = @import("../../../testing.zig");
 test "WebApi: WebSocket" {
     try testing.htmlRunner("net/websocket.html", .{});
+}
+
+test "WebApi: WebSocket basic close" {
+    try testing.htmlRunner("net/websocket_basic_close.html", .{});
 }

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -59,6 +59,7 @@ _http_client: *HttpClient,
 _req_headers: http.Headers,
 
 _owner_node: std.DoublyLinkedList.Node = .{},
+_owner_linked: bool = false,
 
 // buffered outgoing messages
 _send_queue: std.ArrayList(Message) = .empty,
@@ -87,6 +88,11 @@ _pending_close: ?PendingClose = null,
 // flag and the marker that we hold one extra "pending events" ref so the
 // WebSocket stays alive between queueing and drain.
 _in_ready_list: bool = false,
+
+// Set while a cancel is in flight. We hold an extra ref so the WS
+// can't be freed before the canceled completion arrives via
+// drainCompletions → disconnected.
+_cancel_pending: bool = false,
 
 // close info for event dispatch
 _close_code: u16 = 1000,
@@ -185,6 +191,7 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
     conn.transport = .{ .websocket = self };
     try http_client.handle.submitRequest(conn);
     frame._http_owner.addWS(self);
+    self._owner_linked = true;
 
     if (comptime IS_DEBUG) {
         log.info(.websocket, "connecting", .{ .url = url });
@@ -199,7 +206,10 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
 }
 
 pub fn deinit(self: *WebSocket, page: *Page) void {
-    self.cleanup();
+    // By the time we reach deinit (RC=0) the canceled completion has
+    // already routed through cleanup(true). If conn is still set
+    // here it's an upstream invariant break — defensively finish.
+    self.cleanup(true);
 
     if (self._on_open) |func| {
         func.release();
@@ -235,15 +245,18 @@ fn asEventTarget(self: *WebSocket) *EventTarget {
 
 // we're being aborted internally (e.g. frame shutting down)
 pub fn kill(self: *WebSocket) void {
-    self.cleanup();
+    self._ready_state = .closed;
+    self.cleanup(false);
 }
 
 pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
-    if (self._ready_state == .closed) {
-        // already disconnected (e.g. close-handshake disconnected us, then
-        // libcurl reports the same connection completion).
-        return;
-    }
+    // Always run terminal cleanup — even on the already-closed early
+    // out, since the canceled completion delivery still needs to run
+    // finishConn and drop the cancel-pending ref.
+    defer self.cleanup(true);
+
+    if (self._ready_state == .closed) return;
+
     const was_clean = self._ready_state == .closing and err_ == null;
     self._ready_state = .closed;
 
@@ -253,9 +266,6 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
         log.info(.websocket, "disconnected", .{ .url = self._url, .reason = "closed" });
     }
 
-    // Queue events first (markReady acquires a "pending" ref), then cleanup
-    // (which releases the create-time ref). The pending ref keeps us alive
-    // until drainPending dispatches and releases it.
     self._pending_close = .{
         .code = if (was_clean) self._close_code else 1006,
         .reason = if (was_clean) self._close_reason else "",
@@ -263,19 +273,37 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
         .with_error = !was_clean,
     };
     self.markReady();
-
-    self.cleanup();
 }
 
-fn cleanup(self: *WebSocket) void {
-    if (self._conn) |conn| {
+// completed=true: terminal — conn already detached (delivered via
+// drainCompletions). Decrements counters via finishConn, releases
+// create-time ref (and cancel-pending ref if held).
+//
+// completed=false: initiate cancel — submitRemove queues the network
+// remove; we hold an extra ref until the canceled completion routes
+// back through disconnected → cleanup(true).
+fn cleanup(self: *WebSocket, completed: bool) void {
+    const conn = self._conn orelse return;
+    if (self._owner_linked) {
         self._frame._http_owner.removeWS(self);
-        self._http_client.handle.submitRemove(conn);
-        self._req_headers.deinit();
-        self._conn = null;
-        self.releaseRef(self._frame._page);
-        self._send_queue.clearRetainingCapacity();
+        self._owner_linked = false;
     }
+    if (!completed) {
+        if (self._cancel_pending) return;
+        self._cancel_pending = true;
+        self.acquireRef();
+        self._http_client.handle.submitRemove(conn);
+        return;
+    }
+    self._http_client.handle.finishConn(conn);
+    self._req_headers.deinit();
+    self._conn = null;
+    self.releaseRef(self._frame._page); // create-time
+    if (self._cancel_pending) {
+        self._cancel_pending = false;
+        self.releaseRef(self._frame._page); // pending-cancel
+    }
+    self._send_queue.clearRetainingCapacity();
 }
 
 fn queueMessage(self: *WebSocket, msg: Message) !void {
@@ -285,7 +313,7 @@ fn queueMessage(self: *WebSocket, msg: Message) !void {
     if (was_empty) {
         // Unpause the send callback so libcurl will request data
         if (self._conn) |conn| {
-            try self._http_client.handle.submitUnpause(conn);
+            self._http_client.handle.submitUnpause(conn);
         }
     }
 }
@@ -396,7 +424,7 @@ pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
             .with_error = false,
         };
         self.markReady();
-        self.cleanup();
+        self.cleanup(false);
         return;
     }
 
@@ -742,9 +770,11 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
                 1005; // No status code received
 
             if (self._ready_state == .closing) {
-                // Client-initiated close: this is the server's response.
-                // Close handshake complete - disconnect.
-                self.disconnected(null);
+                // Client-initiated close — server's response. Don't
+                // disconnect inline: we're inside a libcurl callback
+                // and tearing the conn down here would UAF the easy
+                // handle. Curl will deliver normal completion when the
+                // server closes the socket per RFC 6455 §5.5.1.
             } else {
                 // Server-initiated close: send reciprocal close frame per RFC 6455 §5.5.1
                 self._close_code = received_code;

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -64,8 +64,29 @@ _owner_node: std.DoublyLinkedList.Node = .{},
 _send_queue: std.ArrayList(Message) = .empty,
 _send_offset: usize = 0,
 
-// buffered incoming frame
+// Single growing buffer for assembled ws frame bytes — both "currently
+// assembling" and "completed but not yet dispatched" messages live here.
+// Reset to zero length only by drainPending. Capacity grows to fit the
+// largest message ever received, then stays put (arena allocation, never
+// freed mid-life). Pending message data is referenced via _pending_messages
+// offset/length pairs into items — slices stay valid until drain clears.
 _recv_buffer: std.ArrayList(u8) = .empty,
+
+// Offset within _recv_buffer where the current in-flight frame began.
+// Used to slice out the message when bytes_left reaches 0.
+_assembling_start: usize = 0,
+
+// Events queued by libcurl callbacks; drained from the worker thread via
+// drainPending. Callbacks must NEVER enter V8 directly (they can run from
+// any thread driving curl_multi_perform), so all dispatch happens here.
+_pending_messages: std.ArrayList(QueuedMessage) = .empty,
+_pending_open: bool = false,
+_pending_close: ?PendingClose = null,
+
+// Set while we're sitting in HttpClient.ws_ready. Doubles as the dedup
+// flag and the marker that we hold one extra "pending events" ref so the
+// WebSocket stays alive between queueing and drain.
+_in_ready_list: bool = false,
 
 // close info for event dispatch
 _close_code: u16 = 1000,
@@ -85,6 +106,19 @@ pub const ReadyState = enum(u8) {
     open = 1,
     closing = 2,
     closed = 3,
+};
+
+const QueuedMessage = struct {
+    offset: usize,
+    len: usize,
+    frame_type: http.WsFrameType,
+};
+
+const PendingClose = struct {
+    code: u16,
+    reason: []const u8,
+    was_clean: bool,
+    with_error: bool,
 };
 
 pub const BinaryType = enum {
@@ -205,6 +239,11 @@ pub fn kill(self: *WebSocket) void {
 }
 
 pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
+    if (self._ready_state == .closed) {
+        // already disconnected (e.g. close-handshake disconnected us, then
+        // libcurl reports the same connection completion).
+        return;
+    }
     const was_clean = self._ready_state == .closing and err_ == null;
     self._ready_state = .closed;
 
@@ -214,24 +253,18 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
         log.info(.websocket, "disconnected", .{ .url = self._url, .reason = "closed" });
     }
 
-    defer self.cleanup();
-
-    // Use 1006 (abnormal closure) if connection wasn't cleanly closed
-    const code = if (was_clean) self._close_code else 1006;
-    const reason = if (was_clean) self._close_reason else "";
-
-    // Spec requires error event before close on abnormal closure.
-    // Dispatch events before cleanup since cleanup releases the ref count
-    // which may free our event handler references.
-    if (!was_clean) {
-        self.dispatchErrorEvent() catch |err| {
-            log.err(.websocket, "error event dispatch failed", .{ .err = err });
-        };
-    }
-
-    self.dispatchCloseEvent(code, reason, was_clean) catch |err| {
-        log.err(.websocket, "close event dispatch failed", .{ .err = err });
+    // Queue events first (markReady acquires a "pending" ref), then cleanup
+    // (which releases the create-time ref). The pending ref keeps us alive
+    // until drainPending dispatches and releases it.
+    self._pending_close = .{
+        .code = if (was_clean) self._close_code else 1006,
+        .reason = if (was_clean) self._close_reason else "",
+        .was_clean = was_clean,
+        .with_error = !was_clean,
     };
+    self.markReady();
+
+    self.cleanup();
 }
 
 fn cleanup(self: *WebSocket) void {
@@ -356,8 +389,14 @@ pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
     if (self._ready_state == .connecting) {
         // Connection not yet established - fail it
         self._ready_state = .closed;
+        self._pending_close = .{
+            .code = code,
+            .reason = try self._arena.dupe(u8, reason),
+            .was_clean = false,
+            .with_error = false,
+        };
+        self.markReady();
         self.cleanup();
-        try self.dispatchCloseEvent(code, reason, false);
         return;
     }
 
@@ -449,6 +488,53 @@ pub fn setOnClose(self: *WebSocket, cb_: ?js.Function) !void {
         self._on_close = try cb.tempWithThis(self);
     } else {
         self._on_close = null;
+    }
+}
+
+// Register self as having pending events to drain. Called from any thread
+// that produces ws events (currently libcurl callbacks on the worker thread,
+// future: Network thread). Acquires one extra ref to keep the WebSocket
+// alive between queueing and the drainPending call.
+fn markReady(self: *WebSocket) void {
+    if (self._in_ready_list) return;
+    self._in_ready_list = true;
+    self.acquireRef();
+    self._http_client.addReadyWs(self);
+}
+
+// Dispatches all queued events to JS. Must be called from the worker thread
+// (the one that owns the V8 isolate). HttpClient calls this from its perform
+// loop after curl_multi_perform.
+pub fn drainPending(self: *WebSocket) void {
+    self._in_ready_list = false;
+    defer self.releaseRef(self._frame._page);
+
+    if (self._pending_open) {
+        self._pending_open = false;
+        self.dispatchOpenEvent() catch |err| {
+            log.err(.websocket, "open event fail", .{ .err = err });
+        };
+    }
+
+    for (self._pending_messages.items) |msg| {
+        const data = self._recv_buffer.items[msg.offset..][0..msg.len];
+        self.dispatchMessageEvent(data, msg.frame_type) catch |err| {
+            log.warn(.websocket, "message dispatch", .{ .err = err });
+        };
+    }
+    self._pending_messages.clearRetainingCapacity();
+    self._recv_buffer.clearRetainingCapacity();
+
+    if (self._pending_close) |pc| {
+        self._pending_close = null;
+        if (pc.with_error) {
+            self.dispatchErrorEvent() catch |err| {
+                log.err(.websocket, "error event dispatch failed", .{ .err = err });
+            };
+        }
+        self.dispatchCloseEvent(pc.code, pc.reason, pc.was_clean) catch |err| {
+            log.err(.websocket, "close event dispatch failed", .{ .err = err });
+        };
     }
 }
 
@@ -616,12 +702,14 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
         if (comptime IS_DEBUG) {
             log.debug(.websocket, "incoming message", .{ .url = self._url, .len = meta.len, .bytes_left = meta.bytes_left, .type = meta.frame_type });
         }
-        // Start of new frame. Pre-allocate buffer
-        self._recv_buffer.clearRetainingCapacity();
+        // Start of new frame. Record where it begins inside the shared buffer
+        // (the buffer is only cleared by drainPending, so messages from the
+        // same drain cycle live side-by-side).
         if (meta.len > self._http_client.max_response_size) {
             return error.MessageTooLarge;
         }
-        try self._recv_buffer.ensureTotalCapacity(self._arena, meta.len);
+        self._assembling_start = self._recv_buffer.items.len;
+        try self._recv_buffer.ensureTotalCapacity(self._arena, self._assembling_start + meta.len);
     }
 
     try self._recv_buffer.appendSlice(self._arena, data);
@@ -631,11 +719,23 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
         return;
     }
 
-    const message = self._recv_buffer.items;
+    const start = self._assembling_start;
+    const len = self._recv_buffer.items.len - start;
     switch (meta.frame_type) {
-        .text, .binary => try self.dispatchMessageEvent(message, meta.frame_type),
+        .text, .binary => {
+            // Queue the message — actual JS dispatch happens in drainPending
+            // on the worker thread. Slice [start..start+len] of _recv_buffer
+            // stays valid until drain clears it.
+            try self._pending_messages.append(self._arena, .{
+                .offset = start,
+                .len = len,
+                .frame_type = meta.frame_type,
+            });
+            self.markReady();
+        },
         .close => {
             // Parse close frame: 2-byte code (big-endian) + optional reason
+            const message = self._recv_buffer.items[start..][0..len];
             const received_code = if (message.len >= 2)
                 @as(u16, message[0]) << 8 | message[1]
             else
@@ -654,8 +754,13 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
                 self._ready_state = .closing;
                 try self.queueMessage(.close);
             }
+            // Close payload isn't a queued message — discard from buffer.
+            self._recv_buffer.shrinkRetainingCapacity(start);
         },
-        .ping, .pong, .cont => {},
+        .ping, .pong, .cont => {
+            // Not dispatched as messages — discard from buffer.
+            self._recv_buffer.shrinkRetainingCapacity(start);
+        },
     }
 }
 
@@ -685,9 +790,8 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
         self._ready_state = .open;
         log.info(.websocket, "connected", .{ .url = self._url });
 
-        self.dispatchOpenEvent() catch |err| {
-            log.err(.websocket, "open event fail", .{ .err = err });
-        };
+        self._pending_open = true;
+        self.markReady();
         return buf_len;
     }
 

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -28,6 +28,7 @@ const URL = @import("../../URL.zig");
 const Page = @import("../../Page.zig");
 const Frame = @import("../../Frame.zig");
 const HttpClient = @import("../../HttpClient.zig");
+const ArenaPool = @import("../../../ArenaPool.zig");
 
 const Event = @import("../Event.zig");
 const EventTarget = @import("../EventTarget.zig");
@@ -44,6 +45,12 @@ _rc: lp.RC(u8) = .{},
 _frame: *Frame,
 _proto: *EventTarget,
 _arena: Allocator,
+// Cached so deinit can release the arena even after `_frame._page` has
+// been torn down.
+_arena_pool: *ArenaPool,
+// Guards mutable state shared between the network thread (libcurl
+// callbacks) and the worker thread (close, drainPending, etc.).
+_mutex: std.Thread.Mutex = .{},
 
 // Connection state
 _ready_state: ReadyState = .connecting,
@@ -183,6 +190,7 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
         ._frame = frame,
         ._conn = conn,
         ._arena = arena,
+        ._arena_pool = frame._session.browser.arena_pool,
         ._proto = undefined,
         ._url = resolved_url,
         ._req_headers = headers,
@@ -206,9 +214,7 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
 }
 
 pub fn deinit(self: *WebSocket, page: *Page) void {
-    // By the time we reach deinit (RC=0) the canceled completion has
-    // already routed through cleanup(true). If conn is still set
-    // here it's an upstream invariant break — defensively finish.
+    _ = page;
     self.cleanup(true);
 
     if (self._on_open) |func| {
@@ -225,10 +231,9 @@ pub fn deinit(self: *WebSocket, page: *Page) void {
     }
 
     for (self._send_queue.items) |msg| {
-        msg.deinit(page);
+        msg.deinit(self._arena_pool);
     }
-
-    page.releaseArena(self._arena);
+    self._arena_pool.release(self._arena);
 }
 
 pub fn releaseRef(self: *WebSocket, page: *Page) void {
@@ -245,15 +250,17 @@ fn asEventTarget(self: *WebSocket) *EventTarget {
 
 // we're being aborted internally (e.g. frame shutting down)
 pub fn kill(self: *WebSocket) void {
+    self._mutex.lock();
     self._ready_state = .closed;
+    self._mutex.unlock();
     self.cleanup(false);
 }
 
 pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
-    // Always run terminal cleanup — even on the already-closed early
-    // out, since the canceled completion delivery still needs to run
-    // finishConn and drop the cancel-pending ref.
     defer self.cleanup(true);
+
+    self._mutex.lock();
+    defer self._mutex.unlock();
 
     if (self._ready_state == .closed) return;
 
@@ -272,46 +279,56 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
         .was_clean = was_clean,
         .with_error = !was_clean,
     };
-    self.markReady();
+    self.markReadyLocked();
 }
 
-// completed=true: terminal — conn already detached (delivered via
-// drainCompletions). Decrements counters via finishConn, releases
-// create-time ref (and cancel-pending ref if held).
-//
-// completed=false: initiate cancel — submitRemove queues the network
-// remove; we hold an extra ref until the canceled completion routes
-// back through disconnected → cleanup(true).
 fn cleanup(self: *WebSocket, completed: bool) void {
-    const conn = self._conn orelse return;
+    self._mutex.lock();
+    const conn = self._conn orelse {
+        self._mutex.unlock();
+        return;
+    };
     if (self._owner_linked) {
         self._frame._http_owner.removeWS(self);
         self._owner_linked = false;
     }
     if (!completed) {
-        if (self._cancel_pending) return;
+        if (self._cancel_pending) {
+            self._mutex.unlock();
+            return;
+        }
         self._cancel_pending = true;
         self.acquireRef();
+        self._mutex.unlock();
         self._http_client.handle.submitRemove(conn);
         return;
     }
-    self._http_client.handle.finishConn(conn);
+
     self._req_headers.deinit();
     self._conn = null;
+    const release_cancel_ref = self._cancel_pending;
+    self._cancel_pending = false;
+    self._send_queue.clearRetainingCapacity();
+    self._mutex.unlock();
+
+    self._http_client.handle.finishConn(conn);
     self.releaseRef(self._frame._page); // create-time
-    if (self._cancel_pending) {
-        self._cancel_pending = false;
+    if (release_cancel_ref) {
         self.releaseRef(self._frame._page); // pending-cancel
     }
-    self._send_queue.clearRetainingCapacity();
 }
 
 fn queueMessage(self: *WebSocket, msg: Message) !void {
+    self._mutex.lock();
+    defer self._mutex.unlock();
+    return self.queueMessageLocked(msg);
+}
+
+fn queueMessageLocked(self: *WebSocket, msg: Message) !void {
     const was_empty = self._send_queue.items.len == 0;
     try self._send_queue.append(self._arena, msg);
 
     if (was_empty) {
-        // Unpause the send callback so libcurl will request data
         if (self._conn) |conn| {
             self._http_client.handle.submitUnpause(conn);
         }
@@ -400,10 +417,6 @@ pub fn send(self: *WebSocket, data: SendData) !void {
 }
 
 pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
-    if (self._ready_state == .closing or self._ready_state == .closed) {
-        return;
-    }
-
     // Validate close code per spec: must be 1000 or in range 3000-4999
     if (code_) |code| {
         if (code != 1000 and (code < 3000 or code > 4999)) {
@@ -414,24 +427,39 @@ pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
     const code = code_ orelse 1000;
     const reason = reason_ orelse "";
 
+    self._mutex.lock();
+    if (self._ready_state == .closing or self._ready_state == .closed) {
+        self._mutex.unlock();
+        return;
+    }
+
     if (self._ready_state == .connecting) {
-        // Connection not yet established - fail it
+        const reason_dup = self._arena.dupe(u8, reason) catch |err| {
+            self._mutex.unlock();
+            return err;
+        };
         self._ready_state = .closed;
         self._pending_close = .{
             .code = code,
-            .reason = try self._arena.dupe(u8, reason),
+            .reason = reason_dup,
             .was_clean = false,
             .with_error = false,
         };
-        self.markReady();
+        self.markReadyLocked();
+        self._mutex.unlock();
         self.cleanup(false);
         return;
     }
 
     self._ready_state = .closing;
     self._close_code = code;
-    self._close_reason = try self._arena.dupe(u8, reason);
-    try self.queueMessage(.close);
+    self._close_reason = self._arena.dupe(u8, reason) catch |err| {
+        self._mutex.unlock();
+        return err;
+    };
+    const queue_err = self.queueMessageLocked(.close);
+    self._mutex.unlock();
+    return queue_err;
 }
 
 pub fn getUrl(self: *const WebSocket) []const u8 {
@@ -439,15 +467,22 @@ pub fn getUrl(self: *const WebSocket) []const u8 {
 }
 
 pub fn getReadyState(self: *const WebSocket) u16 {
-    return @intFromEnum(self._ready_state);
+    const ws: *WebSocket = @constCast(self);
+    ws._mutex.lock();
+    defer ws._mutex.unlock();
+    return @intFromEnum(ws._ready_state);
 }
 
 pub fn getBufferedAmount(self: *const WebSocket) u32 {
+    const ws: *WebSocket = @constCast(self);
+    ws._mutex.lock();
+    defer ws._mutex.unlock();
+
     var buffered: u32 = 0;
-    for (self._send_queue.items) |msg| {
+    for (ws._send_queue.items) |msg| {
         switch (msg) {
             .text, .binary => |byte_msg| buffered += @intCast(byte_msg.data.len),
-            .close => buffered += @intCast(2 + self._close_reason.len),
+            .close => buffered += @intCast(2 + ws._close_reason.len),
         }
     }
     return buffered;
@@ -519,42 +554,52 @@ pub fn setOnClose(self: *WebSocket, cb_: ?js.Function) !void {
     }
 }
 
-// Register self as having pending events to drain. Called from any thread
-// that produces ws events (currently libcurl callbacks on the worker thread,
-// future: Network thread). Acquires one extra ref to keep the WebSocket
-// alive between queueing and the drainPending call.
 fn markReady(self: *WebSocket) void {
+    self._mutex.lock();
+    defer self._mutex.unlock();
+    self.markReadyLocked();
+}
+
+fn markReadyLocked(self: *WebSocket) void {
     if (self._in_ready_list) return;
     self._in_ready_list = true;
     self.acquireRef();
     self._http_client.addReadyWs(self);
 }
 
-// Dispatches all queued events to JS. Must be called from the worker thread
-// (the one that owns the V8 isolate). HttpClient calls this from its perform
-// loop after curl_multi_perform.
+// Dispatches all queued events to JS. Must be called from the worker
+// thread (the one that owns the V8 isolate). Snapshots all pending
+// state under the mutex so JS callbacks can safely re-enter while we
+// dispatch — they observe a fresh, empty queue.
 pub fn drainPending(self: *WebSocket) void {
+    self._mutex.lock();
     self._in_ready_list = false;
+    const pending_open = self._pending_open;
+    self._pending_open = false;
+    const pending_close = self._pending_close;
+    self._pending_close = null;
+    const pending_messages = self._pending_messages;
+    self._pending_messages = .empty;
+    const recv_buffer = self._recv_buffer;
+    self._recv_buffer = .empty;
+    self._mutex.unlock();
+
     defer self.releaseRef(self._frame._page);
 
-    if (self._pending_open) {
-        self._pending_open = false;
+    if (pending_open) {
         self.dispatchOpenEvent() catch |err| {
             log.err(.websocket, "open event fail", .{ .err = err });
         };
     }
 
-    for (self._pending_messages.items) |msg| {
-        const data = self._recv_buffer.items[msg.offset..][0..msg.len];
+    for (pending_messages.items) |msg| {
+        const data = recv_buffer.items[msg.offset..][0..msg.len];
         self.dispatchMessageEvent(data, msg.frame_type) catch |err| {
             log.warn(.websocket, "message dispatch", .{ .err = err });
         };
     }
-    self._pending_messages.clearRetainingCapacity();
-    self._recv_buffer.clearRetainingCapacity();
 
-    if (self._pending_close) |pc| {
-        self._pending_close = null;
+    if (pending_close) |pc| {
         if (pc.with_error) {
             self.dispatchErrorEvent() catch |err| {
                 log.err(.websocket, "error event dispatch failed", .{ .err = err });
@@ -640,6 +685,8 @@ fn _sendDataCallback(conn: *http.Connection, buf: []u8) !usize {
     lp.assert(buf.len >= 2, "WS short buffer", .{ .len = buf.len });
 
     const self = conn.transport.websocket;
+    self._mutex.lock();
+    defer self._mutex.unlock();
 
     if (self._send_queue.items.len == 0) {
         // No data to send - pause until queueMessage is called
@@ -694,7 +741,7 @@ fn writeContent(self: *WebSocket, conn: *http.Connection, buf: []u8, byte_msg: M
 
     if (self._send_offset >= byte_msg.data.len) {
         const removed = self._send_queue.orderedRemove(0);
-        removed.deinit(self._frame._page);
+        removed.deinit(self._arena_pool);
         if (comptime IS_DEBUG) {
             log.debug(.websocket, "send complete", .{ .url = self._url, .len = byte_msg.data.len, .queue = self._send_queue.items.len });
         }
@@ -721,6 +768,9 @@ fn receivedDataCallback(buffer: [*]const u8, buf_count: usize, buf_len: usize, d
 
 fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
     const self = conn.transport.websocket;
+    self._mutex.lock();
+    defer self._mutex.unlock();
+
     const meta = conn.wsMeta() orelse {
         log.err(.websocket, "missing meta", .{ .url = self._url });
         return error.NoFrameMeta;
@@ -730,9 +780,6 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
         if (comptime IS_DEBUG) {
             log.debug(.websocket, "incoming message", .{ .url = self._url, .len = meta.len, .bytes_left = meta.bytes_left, .type = meta.frame_type });
         }
-        // Start of new frame. Record where it begins inside the shared buffer
-        // (the buffer is only cleared by drainPending, so messages from the
-        // same drain cycle live side-by-side).
         if (meta.len > self._http_client.max_response_size) {
             return error.MessageTooLarge;
         }
@@ -742,27 +789,20 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
 
     try self._recv_buffer.appendSlice(self._arena, data);
 
-    if (meta.bytes_left > 0) {
-        // still more data waiting for this frame
-        return;
-    }
+    if (meta.bytes_left > 0) return;
 
     const start = self._assembling_start;
     const len = self._recv_buffer.items.len - start;
     switch (meta.frame_type) {
         .text, .binary => {
-            // Queue the message — actual JS dispatch happens in drainPending
-            // on the worker thread. Slice [start..start+len] of _recv_buffer
-            // stays valid until drain clears it.
             try self._pending_messages.append(self._arena, .{
                 .offset = start,
                 .len = len,
                 .frame_type = meta.frame_type,
             });
-            self.markReady();
+            self.markReadyLocked();
         },
         .close => {
-            // Parse close frame: 2-byte code (big-endian) + optional reason
             const message = self._recv_buffer.items[start..][0..len];
             const received_code = if (message.len >= 2)
                 @as(u16, message[0]) << 8 | message[1]
@@ -776,19 +816,16 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
                 // handle. Curl will deliver normal completion when the
                 // server closes the socket per RFC 6455 §5.5.1.
             } else {
-                // Server-initiated close: send reciprocal close frame per RFC 6455 §5.5.1
                 self._close_code = received_code;
                 if (message.len > 2) {
                     self._close_reason = try self._arena.dupe(u8, message[2..]);
                 }
                 self._ready_state = .closing;
-                try self.queueMessage(.close);
+                try self.queueMessageLocked(.close);
             }
-            // Close payload isn't a queued message — discard from buffer.
             self._recv_buffer.shrinkRetainingCapacity(start);
         },
         .ping, .pong, .cont => {
-            // Not dispatched as messages — discard from buffer.
             self._recv_buffer.shrinkRetainingCapacity(start);
         },
     }
@@ -802,6 +839,9 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
     }
     const conn: *http.Connection = @ptrCast(@alignCast(data));
     const self = conn.transport.websocket;
+    self._mutex.lock();
+    defer self._mutex.unlock();
+
     const header = buffer[0..buf_len];
 
     if (self._got_101 == false and std.mem.startsWith(u8, header, "HTTP/")) {
@@ -821,7 +861,7 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
         log.info(.websocket, "connected", .{ .url = self._url });
 
         self._pending_open = true;
-        self.markReady();
+        self.markReadyLocked();
         return buf_len;
     }
 
@@ -857,9 +897,9 @@ const Message = union(enum) {
         arena: Allocator,
         data: []const u8,
     };
-    fn deinit(self: Message, page: *Page) void {
+    fn deinit(self: Message, pool: *ArenaPool) void {
         switch (self) {
-            .text, .binary => |msg| page.releaseArena(msg.arena),
+            .text, .binary => |msg| pool.release(msg.arena),
             .close => {},
         }
     }

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -183,7 +183,7 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
         ._http_client = http_client,
     });
     conn.transport = .{ .websocket = self };
-    try http_client.trackConn(conn);
+    try http_client.handle.submitRequest(conn);
     frame._http_owner.addWS(self);
 
     if (comptime IS_DEBUG) {
@@ -270,7 +270,7 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
 fn cleanup(self: *WebSocket) void {
     if (self._conn) |conn| {
         self._frame._http_owner.removeWS(self);
-        self._http_client.removeConn(conn);
+        self._http_client.handle.submitRemove(conn);
         self._req_headers.deinit();
         self._conn = null;
         self.releaseRef(self._frame._page);

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -48,9 +48,6 @@ _arena: Allocator,
 // Cached so deinit can release the arena even after `_frame._page` has
 // been torn down.
 _arena_pool: *ArenaPool,
-// Guards mutable state shared between the network thread (libcurl
-// callbacks) and the worker thread (close, drainPending, etc.).
-_mutex: std.Thread.Mutex = .{},
 
 // Connection state
 _ready_state: ReadyState = .connecting,
@@ -68,33 +65,18 @@ _req_headers: http.Headers,
 _owner_node: std.DoublyLinkedList.Node = .{},
 _owner_linked: bool = false,
 
-// buffered outgoing messages
-_send_queue: std.ArrayList(Message) = .empty,
+// Network-side outgoing messages. Browser APIs enqueue CommandData through
+// HttpClient; libcurl read callbacks drain those commands here.
+_send_queue: std.ArrayList(CommandData) = .empty,
 _send_offset: usize = 0,
 
-// Single growing buffer for assembled ws frame bytes — both "currently
-// assembling" and "completed but not yet dispatched" messages live here.
-// Reset to zero length only by drainPending. Capacity grows to fit the
-// largest message ever received, then stays put (arena allocation, never
-// freed mid-life). Pending message data is referenced via _pending_messages
-// offset/length pairs into items — slices stay valid until drain clears.
+// Network-side frame assembly buffer. Completed frames are copied into
+// HttpClient's WebSocket event queue and dispatched by the browser thread.
 _recv_buffer: std.ArrayList(u8) = .empty,
 
 // Offset within _recv_buffer where the current in-flight frame began.
 // Used to slice out the message when bytes_left reaches 0.
 _assembling_start: usize = 0,
-
-// Events queued by libcurl callbacks; drained from the worker thread via
-// drainPending. Callbacks must NEVER enter V8 directly (they can run from
-// any thread driving curl_multi_perform), so all dispatch happens here.
-_pending_messages: std.ArrayList(QueuedMessage) = .empty,
-_pending_open: bool = false,
-_pending_close: ?PendingClose = null,
-
-// Set while we're sitting in HttpClient.ws_ready. Doubles as the dedup
-// flag and the marker that we hold one extra "pending events" ref so the
-// WebSocket stays alive between queueing and drain.
-_in_ready_list: bool = false,
 
 // Set while a cancel is in flight. We hold an extra ref so the WS
 // can't be freed before the canceled completion arrives via
@@ -121,12 +103,6 @@ pub const ReadyState = enum(u8) {
     closed = 3,
 };
 
-const QueuedMessage = struct {
-    offset: usize,
-    len: usize,
-    frame_type: http.WsFrameType,
-};
-
 const PendingClose = struct {
     code: u16,
     reason: []const u8,
@@ -137,6 +113,60 @@ const PendingClose = struct {
 pub const BinaryType = enum {
     blob,
     arraybuffer,
+};
+
+pub const QueuedEvent = struct {
+    node: std.DoublyLinkedList.Node = .{},
+    ws: *WebSocket,
+    data: EventData,
+};
+
+pub const QueuedCommand = struct {
+    node: std.DoublyLinkedList.Node = .{},
+    ws: *WebSocket,
+    data: CommandData,
+};
+
+pub const EventData = union(enum) {
+    open: ?[]const u8,
+    message: MessageData,
+    close: PendingClose,
+
+    pub const MessageData = struct {
+        data: []const u8,
+        frame_type: http.WsFrameType,
+    };
+
+    pub fn deinit(self: EventData, allocator: Allocator) void {
+        switch (self) {
+            .open => {},
+            .message => |msg| allocator.free(msg.data),
+            .close => {},
+        }
+    }
+};
+
+pub const CommandData = union(enum) {
+    close: CloseCommand,
+    text: Content,
+    binary: Content,
+
+    pub const CloseCommand = struct {
+        code: u16,
+        reason: []const u8,
+    };
+
+    pub const Content = struct {
+        arena: Allocator,
+        data: []const u8,
+    };
+
+    pub fn deinit(self: CommandData, pool: *ArenaPool) void {
+        switch (self) {
+            .text, .binary => |msg| pool.release(msg.arena),
+            .close => {},
+        }
+    }
 };
 
 pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket {
@@ -250,28 +280,18 @@ fn asEventTarget(self: *WebSocket) *EventTarget {
 
 // we're being aborted internally (e.g. frame shutting down)
 pub fn kill(self: *WebSocket) void {
-    self._mutex.lock();
     self._ready_state = .closed;
-    self._mutex.unlock();
     self.cleanup(false);
 }
 
 pub fn completeShutdown(self: *WebSocket) void {
-    self._mutex.lock();
     self._ready_state = .closed;
-    self._pending_open = false;
-    self._pending_close = null;
-    self._pending_messages.clearRetainingCapacity();
     self._recv_buffer.clearRetainingCapacity();
-    self._mutex.unlock();
     self.cleanup(true);
 }
 
 pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
     defer self.cleanup(true);
-
-    self._mutex.lock();
-    defer self._mutex.unlock();
 
     if (self._ready_state == .closed) return;
 
@@ -284,19 +304,26 @@ pub fn disconnected(self: *WebSocket, err_: ?anyerror) void {
         log.info(.websocket, "disconnected", .{ .url = self._url, .reason = "closed" });
     }
 
-    self._pending_close = .{
+    const pc = PendingClose{
         .code = if (was_clean) self._close_code else 1006,
         .reason = if (was_clean) self._close_reason else "",
         .was_clean = was_clean,
         .with_error = !was_clean,
     };
-    self.markReadyLocked();
+    if (pc.with_error) {
+        self.dispatchErrorEvent() catch |err| {
+            log.err(.websocket, "error event dispatch failed", .{ .err = err });
+        };
+    }
+    self.dispatchCloseEvent(pc.code, pc.reason, pc.was_clean) catch |err| {
+        log.err(.websocket, "close event dispatch failed", .{ .err = err });
+    };
 }
 
 fn cleanup(self: *WebSocket, completed: bool) void {
-    self._mutex.lock();
+    self._http_client.ws_queue_mutex.lock();
     const conn = self._conn orelse {
-        self._mutex.unlock();
+        self._http_client.ws_queue_mutex.unlock();
         return;
     };
     if (self._owner_linked) {
@@ -305,12 +332,12 @@ fn cleanup(self: *WebSocket, completed: bool) void {
     }
     if (!completed) {
         if (self._cancel_pending) {
-            self._mutex.unlock();
+            self._http_client.ws_queue_mutex.unlock();
             return;
         }
         self._cancel_pending = true;
         self.acquireRef();
-        self._mutex.unlock();
+        self._http_client.ws_queue_mutex.unlock();
         self._http_client.handle.submitRemove(conn);
         return;
     }
@@ -319,8 +346,9 @@ fn cleanup(self: *WebSocket, completed: bool) void {
     self._conn = null;
     const release_cancel_ref = self._cancel_pending;
     self._cancel_pending = false;
+    self._http_client.clearWebSocketCommandsLocked(self);
     self._send_queue.clearRetainingCapacity();
-    self._mutex.unlock();
+    self._http_client.ws_queue_mutex.unlock();
 
     self._http_client.handle.finishConn(conn);
     self.releaseRef(self._frame._page); // create-time
@@ -329,21 +357,8 @@ fn cleanup(self: *WebSocket, completed: bool) void {
     }
 }
 
-fn queueMessage(self: *WebSocket, msg: Message) !void {
-    self._mutex.lock();
-    defer self._mutex.unlock();
-    return self.queueMessageLocked(msg);
-}
-
-fn queueMessageLocked(self: *WebSocket, msg: Message) !void {
-    const was_empty = self._send_queue.items.len == 0;
-    try self._send_queue.append(self._arena, msg);
-
-    if (was_empty) {
-        if (self._conn) |conn| {
-            self._http_client.handle.submitUnpause(conn);
-        }
-    }
+fn queueCommand(self: *WebSocket, command: CommandData) !void {
+    try self._http_client.addWebSocketCommand(self, command);
 }
 
 fn isValidProtocol(protocol: []const u8) bool {
@@ -399,7 +414,7 @@ pub fn send(self: *WebSocket, data: SendData) !void {
         .blob => |blob| {
             const arena = try self._frame.getArena(blob._slice.len, "WebSocket.message");
             errdefer self._frame.releaseArena(arena);
-            try self.queueMessage(.{ .binary = .{
+            try self.queueCommand(.{ .binary = .{
                 .arena = arena,
                 .data = try arena.dupe(u8, blob._slice),
             } });
@@ -408,7 +423,7 @@ pub fn send(self: *WebSocket, data: SendData) !void {
             if (js_val.isString()) |str| {
                 const arena = try self._frame.getArena(str.len(), "WebSocket.message");
                 errdefer self._frame.releaseArena(arena);
-                try self.queueMessage(.{ .text = .{
+                try self.queueCommand(.{ .text = .{
                     .arena = arena,
                     .data = try str.toSliceWithAlloc(arena),
                 } });
@@ -418,7 +433,7 @@ pub fn send(self: *WebSocket, data: SendData) !void {
 
                 const arena = try self._frame.getArena(buffer.len, "WebSocket.message");
                 errdefer self._frame.releaseArena(arena);
-                try self.queueMessage(.{ .binary = .{
+                try self.queueCommand(.{ .binary = .{
                     .arena = arena,
                     .data = try arena.dupe(u8, buffer),
                 } });
@@ -438,26 +453,25 @@ pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
     const code = code_ orelse 1000;
     const reason = reason_ orelse "";
 
-    self._mutex.lock();
+    self._http_client.ws_queue_mutex.lock();
     if (self._ready_state == .closing or self._ready_state == .closed) {
-        self._mutex.unlock();
+        self._http_client.ws_queue_mutex.unlock();
         return;
     }
 
     if (self._ready_state == .connecting) {
         const reason_dup = self._arena.dupe(u8, reason) catch |err| {
-            self._mutex.unlock();
+            self._http_client.ws_queue_mutex.unlock();
             return err;
         };
         self._ready_state = .closed;
-        self._pending_close = .{
+        self._http_client.ws_queue_mutex.unlock();
+        self.queueEvent(.{ .close = .{
             .code = code,
             .reason = reason_dup,
             .was_clean = false,
             .with_error = false,
-        };
-        self.markReadyLocked();
-        self._mutex.unlock();
+        } });
         self.cleanup(false);
         return;
     }
@@ -465,11 +479,14 @@ pub fn close(self: *WebSocket, code_: ?u16, reason_: ?[]const u8) !void {
     self._ready_state = .closing;
     self._close_code = code;
     self._close_reason = self._arena.dupe(u8, reason) catch |err| {
-        self._mutex.unlock();
+        self._http_client.ws_queue_mutex.unlock();
         return err;
     };
-    const queue_err = self.queueMessageLocked(.close);
-    self._mutex.unlock();
+    self._http_client.ws_queue_mutex.unlock();
+    const queue_err = self.queueCommand(.{ .close = .{
+        .code = code,
+        .reason = self._close_reason,
+    } });
     return queue_err;
 }
 
@@ -478,23 +495,31 @@ pub fn getUrl(self: *const WebSocket) []const u8 {
 }
 
 pub fn getReadyState(self: *const WebSocket) u16 {
-    const ws: *WebSocket = @constCast(self);
-    ws._mutex.lock();
-    defer ws._mutex.unlock();
-    return @intFromEnum(ws._ready_state);
+    return @intFromEnum(self._ready_state);
 }
 
 pub fn getBufferedAmount(self: *const WebSocket) u32 {
     const ws: *WebSocket = @constCast(self);
-    ws._mutex.lock();
-    defer ws._mutex.unlock();
+    ws._http_client.ws_queue_mutex.lock();
+    defer ws._http_client.ws_queue_mutex.unlock();
 
     var buffered: u32 = 0;
     for (ws._send_queue.items) |msg| {
         switch (msg) {
             .text, .binary => |byte_msg| buffered += @intCast(byte_msg.data.len),
-            .close => buffered += @intCast(2 + ws._close_reason.len),
+            .close => |close_cmd| buffered += @intCast(2 + close_cmd.reason.len),
         }
+    }
+    var maybe_node = ws._http_client.ws_command_queue.first;
+    while (maybe_node) |node| {
+        const command: *QueuedCommand = @fieldParentPtr("node", node);
+        if (command.ws == ws) {
+            switch (command.data) {
+                .text, .binary => |byte_msg| buffered += @intCast(byte_msg.data.len),
+                .close => |close_cmd| buffered += @intCast(2 + close_cmd.reason.len),
+            }
+        }
+        maybe_node = node.next;
     }
     return buffered;
 }
@@ -565,61 +590,38 @@ pub fn setOnClose(self: *WebSocket, cb_: ?js.Function) !void {
     }
 }
 
-fn markReady(self: *WebSocket) void {
-    self._mutex.lock();
-    defer self._mutex.unlock();
-    self.markReadyLocked();
+fn queueEvent(self: *WebSocket, data: EventData) void {
+    self._http_client.addWebSocketEvent(self, data);
 }
 
-fn markReadyLocked(self: *WebSocket) void {
-    if (self._in_ready_list) return;
-    self._in_ready_list = true;
-    self.acquireRef();
-    self._http_client.addReadyWs(self);
-}
-
-// Dispatches all queued events to JS. Must be called from the worker
-// thread (the one that owns the V8 isolate). Snapshots all pending
-// state under the mutex so JS callbacks can safely re-enter while we
-// dispatch — they observe a fresh, empty queue.
-pub fn drainPending(self: *WebSocket) void {
-    self._mutex.lock();
-    self._in_ready_list = false;
-    const pending_open = self._pending_open;
-    self._pending_open = false;
-    const pending_close = self._pending_close;
-    self._pending_close = null;
-    const pending_messages = self._pending_messages;
-    self._pending_messages = .empty;
-    const recv_buffer = self._recv_buffer;
-    self._recv_buffer = .empty;
-    self._mutex.unlock();
-
-    defer self.releaseRef(self._frame._page);
-
-    if (pending_open) {
-        self.dispatchOpenEvent() catch |err| {
-            log.err(.websocket, "open event fail", .{ .err = err });
-        };
-    }
-
-    for (pending_messages.items) |msg| {
-        const data = recv_buffer.items[msg.offset..][0..msg.len];
-        self.dispatchMessageEvent(data, msg.frame_type) catch |err| {
-            log.warn(.websocket, "message dispatch", .{ .err = err });
-        };
-    }
-
-    if (pending_close) |pc| {
-        if (pc.with_error) {
-            self.dispatchErrorEvent() catch |err| {
-                log.err(.websocket, "error event dispatch failed", .{ .err = err });
+pub fn drainEvent(self: *WebSocket, data: EventData) void {
+    switch (data) {
+        .open => |protocol| {
+            if (protocol) |p| self._protocol = p;
+            self._ready_state = .open;
+            self.dispatchOpenEvent() catch |err| {
+                log.err(.websocket, "open event fail", .{ .err = err });
             };
-        }
-        self.dispatchCloseEvent(pc.code, pc.reason, pc.was_clean) catch |err| {
-            log.err(.websocket, "close event dispatch failed", .{ .err = err });
-        };
-        self.cleanup(false);
+        },
+        .message => |msg| {
+            self.dispatchMessageEvent(msg.data, msg.frame_type) catch |err| {
+                log.warn(.websocket, "message dispatch", .{ .err = err });
+            };
+        },
+        .close => |pc| {
+            self._ready_state = .closed;
+            self._close_code = pc.code;
+            self._close_reason = pc.reason;
+            if (pc.with_error) {
+                self.dispatchErrorEvent() catch |err| {
+                    log.err(.websocket, "error event dispatch failed", .{ .err = err });
+                };
+            }
+            self.dispatchCloseEvent(pc.code, pc.reason, pc.was_clean) catch |err| {
+                log.err(.websocket, "close event dispatch failed", .{ .err = err });
+            };
+            self.cleanup(false);
+        },
     }
 }
 
@@ -697,23 +699,24 @@ fn _sendDataCallback(conn: *http.Connection, buf: []u8) !usize {
     lp.assert(buf.len >= 2, "WS short buffer", .{ .len = buf.len });
 
     const self = conn.transport.websocket;
-    self._mutex.lock();
-    defer self._mutex.unlock();
+    self._http_client.ws_queue_mutex.lock();
+    defer self._http_client.ws_queue_mutex.unlock();
+
+    try self._http_client.drainWebSocketCommandsLocked(self, &self._send_queue, self._arena);
 
     if (self._send_queue.items.len == 0) {
-        // No data to send - pause until queueMessage is called
+        // No data to send - pause until a queued command unpauses the socket.
         return http.readfunc_pause;
     }
 
     const msg = &self._send_queue.items[0];
 
     switch (msg.*) {
-        .close => {
-            const code = self._close_code;
-            const reason = self._close_reason;
-
+        .close => |close_cmd| {
             // Close frame: 2 bytes for code (big-endian) + optional reason
             // Truncate reason to fit in buf (max 123 bytes per spec)
+            const code = close_cmd.code;
+            const reason = close_cmd.reason;
             const reason_len: usize = @min(reason.len, 123, buf.len -| 2);
             const frame_len = 2 + reason_len;
             const to_copy = @min(buf.len, frame_len);
@@ -728,7 +731,8 @@ fn _sendDataCallback(conn: *http.Connection, buf: []u8) !usize {
             try conn.wsStartFrame(.close, to_copy);
             @memcpy(buf[0..to_copy], close_payload[0..to_copy]);
 
-            _ = self._send_queue.orderedRemove(0);
+            const removed = self._send_queue.orderedRemove(0);
+            removed.deinit(self._arena_pool);
             return to_copy;
         },
         .text => |content| return self.writeContent(conn, buf, content, .text),
@@ -736,7 +740,7 @@ fn _sendDataCallback(conn: *http.Connection, buf: []u8) !usize {
     }
 }
 
-fn writeContent(self: *WebSocket, conn: *http.Connection, buf: []u8, byte_msg: Message.Content, frame_type: http.WsFrameType) !usize {
+fn writeContent(self: *WebSocket, conn: *http.Connection, buf: []u8, byte_msg: CommandData.Content, frame_type: http.WsFrameType) !usize {
     if (self._send_offset == 0) {
         // start of the message
         if (comptime IS_DEBUG) {
@@ -780,14 +784,6 @@ fn receivedDataCallback(buffer: [*]const u8, buf_count: usize, buf_len: usize, d
 
 fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
     const self = conn.transport.websocket;
-    var close_after_unlock = false;
-    self._mutex.lock();
-    defer {
-        self._mutex.unlock();
-        if (close_after_unlock) {
-            self.cleanup(false);
-        }
-    }
 
     const meta = conn.wsMeta() orelse {
         log.err(.websocket, "missing meta", .{ .url = self._url });
@@ -813,12 +809,12 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
     const len = self._recv_buffer.items.len - start;
     switch (meta.frame_type) {
         .text, .binary => {
-            try self._pending_messages.append(self._arena, .{
-                .offset = start,
-                .len = len,
+            const message = self._recv_buffer.items[start..][0..len];
+            self.queueEvent(.{ .message = .{
+                .data = try self._http_client.allocator.dupe(u8, message),
                 .frame_type = meta.frame_type,
-            });
-            self.markReadyLocked();
+            } });
+            self._recv_buffer.shrinkRetainingCapacity(start);
         },
         .close => {
             const message = self._recv_buffer.items[start..][0..len];
@@ -839,21 +835,22 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
                     self._close_reason = try self._arena.dupe(u8, message[2..]);
                 }
                 self._ready_state = .closed;
-                self._pending_close = .{
+                self.queueEvent(.{ .close = .{
                     .code = self._close_code,
                     .reason = self._close_reason,
                     .was_clean = true,
                     .with_error = false,
-                };
-                self.markReadyLocked();
-                close_after_unlock = true;
+                } });
             } else {
                 self._close_code = received_code;
                 if (message.len > 2) {
                     self._close_reason = try self._arena.dupe(u8, message[2..]);
                 }
                 self._ready_state = .closing;
-                try self.queueMessageLocked(.close);
+                try self.queueCommand(.{ .close = .{
+                    .code = self._close_code,
+                    .reason = self._close_reason,
+                } });
             }
             self._recv_buffer.shrinkRetainingCapacity(start);
         },
@@ -871,8 +868,6 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
     }
     const conn: *http.Connection = @ptrCast(@alignCast(data));
     const self = conn.transport.websocket;
-    self._mutex.lock();
-    defer self._mutex.unlock();
 
     const header = buffer[0..buf_len];
 
@@ -889,11 +884,8 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
             return 0;
         }
 
-        self._ready_state = .open;
         log.info(.websocket, "connected", .{ .url = self._url });
-
-        self._pending_open = true;
-        self.markReadyLocked();
+        self.queueEvent(.{ .open = if (self._protocol.len > 0) self._protocol else null });
         return buf_len;
     }
 
@@ -919,23 +911,6 @@ fn receivedHeaderCallback(buffer: [*]const u8, header_count: usize, buf_len: usi
 
     return buf_len;
 }
-
-const Message = union(enum) {
-    close,
-    text: Content,
-    binary: Content,
-
-    const Content = struct {
-        arena: Allocator,
-        data: []const u8,
-    };
-    fn deinit(self: Message, pool: *ArenaPool) void {
-        switch (self) {
-            .text, .binary => |msg| pool.release(msg.arena),
-            .close => {},
-        }
-    }
-};
 
 pub const JsApi = struct {
     pub const bridge = js.Bridge(WebSocket);

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -152,11 +152,11 @@ pub fn init(url: []const u8, protocols: [][]const u8, frame: *Frame) !*WebSocket
     const resolved_url = try URL.resolve(arena, frame.base(), url, .{ .always_dupe = true, .encoding = frame.charset });
 
     const http_client = &frame._session.browser.http_client;
-    const conn = http_client.network.newConnection() orelse {
+    const conn = http_client.handle.newConnection() orelse {
         return error.NoFreeConnection;
     };
 
-    errdefer http_client.network.releaseConnection(conn);
+    errdefer http_client.handle.releaseConnection(conn);
 
     try conn.setURL(resolved_url);
     try conn.setConnectOnly(false);
@@ -285,7 +285,7 @@ fn queueMessage(self: *WebSocket, msg: Message) !void {
     if (was_empty) {
         // Unpause the send callback so libcurl will request data
         if (self._conn) |conn| {
-            try conn.pause(.{ .cont = true });
+            try self._http_client.handle.submitUnpause(conn);
         }
     }
 }

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -118,7 +118,7 @@ pub fn init(
         .cdp = self,
         .state = .live,
         .socket = socket,
-        .handles = http_client.handles,
+        .handle = http_client.handle,
     };
 }
 

--- a/src/cdp/Connection.zig
+++ b/src/cdp/Connection.zig
@@ -35,6 +35,7 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 pub const Connection = @This();
 
 pub const State = enum { handshaking, live };
+const HANDSHAKE_TIMEOUT_MS: u32 = 10_000;
 
 // reference to http_client.inbox
 inbox: *Inbox,
@@ -160,13 +161,27 @@ pub fn sendJSONRaw(
 pub const HttpResult = enum { more, upgraded, close };
 
 pub fn handshake(self: *Connection) !bool {
+    return self.handshakeWithTimeout(HANDSHAKE_TIMEOUT_MS);
+}
+
+pub fn handshakeWithTimeout(self: *Connection, timeout_ms: u32) !bool {
+    var timer = try std.time.Timer.start();
     while (true) {
+        const elapsed_ms: u32 = @intCast(@min(
+            timer.read() / std.time.ns_per_ms,
+            std.math.maxInt(u32),
+        ));
+        if (elapsed_ms >= timeout_ms) {
+            log.info(.cdp, "CDP handshake timeout", .{});
+            return false;
+        }
+        const wait_ms: i32 = @intCast(@min(timeout_ms - elapsed_ms, std.math.maxInt(i32)));
         var pfds = [_]posix.pollfd{.{
             .fd = self.socket,
             .events = posix.POLL.IN,
             .revents = 0,
         }};
-        const n = try posix.poll(&pfds, 5000);
+        const n = try posix.poll(&pfds, wait_ms);
         if (n == 0) {
             log.info(.cdp, "CDP handshake timeout", .{});
             return false;
@@ -561,4 +576,27 @@ fn toLower(str: []u8) []u8 {
         str[i] = std.ascii.toLower(ch);
     }
     return str;
+}
+
+test "Connection: handshake times out silent client" {
+    var pair: [2]posix.socket_t = undefined;
+    const rc = std.c.socketpair(posix.AF.LOCAL, posix.SOCK.STREAM, 0, &pair);
+    if (rc != 0) return error.SocketPairFailed;
+    defer posix.close(pair[1]);
+
+    var arena_pool = ArenaPool.init(std.testing.allocator, .{});
+    defer arena_pool.deinit();
+
+    var inbox: Inbox = .{};
+    defer inbox.deinit(&arena_pool);
+
+    var conn: Connection = undefined;
+    try conn.init(std.testing.allocator, pair[0], "", &inbox, &arena_pool);
+    defer {
+        conn.deinit();
+        posix.close(pair[0]);
+    }
+
+    const upgraded = try conn.handshakeWithTimeout(10);
+    try std.testing.expectEqual(false, upgraded);
 }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -148,7 +148,7 @@ fn setLifecycleEventsEnabled(cmd: *CDP.Command) !void {
         try sendPageLifecycle(bc, "load", now, frame_id, loader_id);
 
         const http_client = frame._session.browser.http_client;
-        const http_active = http_client.http_active;
+        const http_active = http_client.handle.http_active;
         const total_network_activity = http_active + http_client.interception_layer.intercepted;
         if (frame._notified_network_almost_idle.check(total_network_activity <= 2)) {
             try sendPageLifecycle(bc, "networkAlmostIdle", now, frame_id, loader_id);

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -147,7 +147,7 @@ fn setLifecycleEventsEnabled(cmd: *CDP.Command) !void {
         try sendPageLifecycle(bc, "DOMContentLoaded", now, frame_id, loader_id);
         try sendPageLifecycle(bc, "load", now, frame_id, loader_id);
 
-        const http_client = frame._session.browser.http_client;
+        const http_client = frame._session.browser.httpClient();
         const http_active = http_client.handle.http_active;
         const total_network_activity = http_active + http_client.interception_layer.intercepted;
         if (frame._notified_network_almost_idle.check(total_network_activity <= 2)) {

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -123,6 +123,8 @@ submission_mutex: std.Thread.Mutex = .{},
 pending_add: std.DoublyLinkedList = .{},
 pending_remove: std.DoublyLinkedList = .{},
 pending_ops: std.DoublyLinkedList = .{},
+drain_to_add: std.ArrayList(*http.Connection) = .empty,
+drain_to_remove: std.ArrayList(*http.Connection) = .empty,
 
 callbacks: [MAX_TICK_CALLBACKS]TickCallback = undefined,
 callbacks_len: usize = 0,
@@ -449,6 +451,9 @@ pub fn deinit(self: *Network) void {
         f.deinit(self.allocator);
         self.allocator.destroy(f);
     }
+
+    self.drain_to_add.deinit(self.allocator);
+    self.drain_to_remove.deinit(self.allocator);
 
     globalDeinit();
 }
@@ -904,8 +909,18 @@ fn submitRemove(self: *Network, conn: *http.Connection) void {
                 conn._submission = .pending_remove;
                 self.pending_remove.append(&conn.node);
             },
-            .idle, .pending_remove => {
+            .idle => {
+                // Cancel raced with a completion that already removed the
+                // easy from the multi. The worker still has the conn in
+                // Handle.in_use and will finish it when it drains that
+                // completion.
+                if (conn.in_use) return;
                 lp.log.warn(.app, "submitRemove bad state", .{ .state = @tagName(conn._submission) });
+                return;
+            },
+            .pending_remove => {
+                // Duplicate cancel; the queued remove will deliver the
+                // canceled completion.
                 return;
             },
         }
@@ -973,8 +988,8 @@ fn drainQueue(self: *Network) void {
     // conn.node in another DoublyLinkedList: a worker submitRequest /
     // submitRemove racing with the outside-lock loop would observe
     // unsynchronized writes to conn.node otherwise.
-    var to_remove: std.ArrayList(*http.Connection) = .empty;
-    defer to_remove.deinit(self.allocator);
+    const to_remove = &self.drain_to_remove;
+    to_remove.clearRetainingCapacity();
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
@@ -990,8 +1005,8 @@ fn drainQueue(self: *Network) void {
     }
     for (to_remove.items) |conn| self.handleRemove(conn);
 
-    var to_add: std.ArrayList(*http.Connection) = .empty;
-    defer to_add.deinit(self.allocator);
+    const to_add = &self.drain_to_add;
+    to_add.clearRetainingCapacity();
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
@@ -1120,26 +1135,6 @@ fn acceptConnections(self: *Network) void {
     }
 }
 
-fn preparePollFds(self: *Network, multi: *libcurl.CurlM) void {
-    // Only the curl slice — NOT through to the end of pollfds. The CDP
-    // socket fds live in [cdp_start..] and are owned by
-    // prepareCdpPollFds, which only rebuilds them when cdp_dirty is set
-    // (a steady-state optimization). Slicing to the end here would
-    // @memset those fds to -1 every iteration once a multi exists (which
-    // happens as soon as telemetry sends its first request), silently
-    // dropping every live CDP socket from the poll set — Network then
-    // never reads another CDP message (#2508) nor observes peer
-    // EOF/shutdown (#2507).
-    const curl_fds = self.pollfds[PSEUDO_POLLFDS..self.cdp_start];
-    @memset(curl_fds, .{ .fd = -1, .events = 0, .revents = 0 });
-
-    var fd_count: c_uint = 0;
-    const wait_fds: []libcurl.CurlWaitFd = @ptrCast(curl_fds);
-    libcurl.curl_multi_waitfds(multi, wait_fds, &fd_count) catch |err| {
-        lp.log.err(.app, "curl waitfds", .{ .err = err });
-    };
-}
-
 fn getCurlTimeout(self: *Network) i32 {
     var timeout_ms: c_long = -1;
     libcurl.curl_multi_timeout(self.multi, &timeout_ms) catch return -1;
@@ -1153,15 +1148,22 @@ fn processCompletions(self: *Network, multi: *libcurl.CurlM) void {
             .done => |e| e,
             else => continue,
         };
-        if (maybe_err) |err| {
-            lp.log.warn(.app, "curl transfer error", .{ .err = err });
-        }
-
         const easy: *libcurl.Curl = msg.easy_handle;
         var ptr: *anyopaque = undefined;
         libcurl.curl_easy_getinfo(easy, .private, &ptr) catch
             lp.assert(false, "curl getinfo private", .{});
         const conn: *http.Connection = @ptrCast(@alignCast(ptr));
+
+        if (maybe_err) |err| {
+            switch (conn.transport) {
+                .websocket => {
+                    if (err != error.GotNothing) {
+                        lp.log.warn(.app, "curl transfer error", .{ .err = err });
+                    }
+                },
+                else => lp.log.warn(.app, "curl transfer error", .{ .err = err }),
+            }
+        }
 
         libcurl.curl_multi_remove_handle(multi, easy) catch {};
 
@@ -1623,41 +1625,4 @@ fn loadCerts(allocator: Allocator) !libcurl.CurlBlob {
         .data = result.ptr,
         .flags = 0,
     };
-}
-
-const testing = @import("../testing.zig");
-
-test "Network: preparePollFds leaves the CDP fd region untouched" {
-    // Regression for #2507 / #2508. Once a multi exists (telemetry creates
-    // one in optimized builds), preparePollFds runs every loop iteration.
-    // It rebuilds only the curl slice [PSEUDO_POLLFDS..cdp_start]; the CDP
-    // region [cdp_start..] is owned by prepareCdpPollFds, which keeps its
-    // entries across iterations and only rebuilds when cdp_dirty is set.
-    // A slice that ran to the end of pollfds @memset those CDP sockets to
-    // -1, silently dropping every live CDP connection from the poll set —
-    // so Network stopped reading CDP messages (#2508) and never observed
-    // peer EOF/shutdown (#2507). curl global is initialized by the test
-    // harness (App.init -> Network.init).
-    const multi = libcurl.curl_multi_init() orelse return error.FailedToInitMulti;
-    defer libcurl.curl_multi_cleanup(multi) catch {};
-
-    const curl_slots = 4;
-    const cdp_slots = 3;
-    var pollfds: [PSEUDO_POLLFDS + curl_slots + cdp_slots]posix.pollfd = undefined;
-    @memset(&pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
-
-    // preparePollFds only reads self.pollfds and self.cdp_start.
-    var nw: Network = undefined;
-    nw.pollfds = &pollfds;
-    nw.cdp_start = PSEUDO_POLLFDS + curl_slots;
-
-    // Two live CDP sockets parked in the CDP region, mimicking the steady
-    // state between cdp_dirty rebuilds.
-    pollfds[nw.cdp_start] = .{ .fd = 4242, .events = posix.POLL.IN, .revents = 0 };
-    pollfds[nw.cdp_start + 1] = .{ .fd = 4243, .events = posix.POLL.IN, .revents = 0 };
-
-    nw.preparePollFds(multi);
-
-    try testing.expectEqual(@as(posix.fd_t, 4242), pollfds[nw.cdp_start].fd);
-    try testing.expectEqual(@as(posix.fd_t, 4243), pollfds[nw.cdp_start + 1].fd);
 }

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -102,6 +102,7 @@ ws_max: u8,
 ws_mutex: std.Thread.Mutex = .{},
 
 pollfds: []posix.pollfd,
+curl_extra_fds: []libcurl.CurlWaitFd,
 listener: ?Listener = null,
 accept: std.atomic.Value(bool) = .init(true),
 shutdown: std.atomic.Value(bool) = .init(false),
@@ -113,8 +114,18 @@ wakeup_pipe: [2]posix.fd_t = .{ -1, -1 },
 // Currently, Network is used sparingly, and we only create it on demand.
 // When Network becomes truly shared, it should become a regular field.
 multi: ?*libcurl.CurlM = null,
+
+// Cross-thread submission to the network thread.
+//
+// Workers push via submit*; the network thread pops in drainQueue.
+// `conn.node` is shared across pending_add/pending_remove (mutually
+// exclusive); `conn._op_node` is independent and only ever lives in
+// pending_ops. All transitions of `conn._submission` and list
+// membership happen together under `submission_mutex`.
 submission_mutex: std.Thread.Mutex = .{},
-submission_queue: DoublyLinkedList = .{},
+pending_add: std.DoublyLinkedList = .{},
+pending_remove: std.DoublyLinkedList = .{},
+pending_ops: std.DoublyLinkedList = .{},
 
 callbacks: [MAX_TICK_CALLBACKS]TickCallback = undefined,
 callbacks_len: usize = 0,
@@ -296,6 +307,9 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     const pollfds = try allocator.alloc(posix.pollfd, PSEUDO_POLLFDS + config.httpMaxConcurrent() + max_cdp);
     errdefer allocator.free(pollfds);
 
+    const curl_extra_fds = try allocator.alloc(libcurl.CurlWaitFd, PSEUDO_POLLFDS + max_cdp);
+    errdefer allocator.free(curl_extra_fds);
+
     const cdp_poll_snapshot = try allocator.alloc(?*CdpLink, max_cdp);
     errdefer allocator.free(cdp_poll_snapshot);
     @memset(cdp_poll_snapshot, null);
@@ -363,6 +377,7 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
         .ca_blob = ca_blob,
 
         .pollfds = pollfds,
+        .curl_extra_fds = curl_extra_fds,
         .wakeup_pipe = pipe,
         .cdp_poll_snapshot = cdp_poll_snapshot,
         .cdp_start = PSEUDO_POLLFDS + config.httpMaxConcurrent(),
@@ -396,6 +411,7 @@ pub fn deinit(self: *Network) void {
     }
 
     self.allocator.free(self.pollfds);
+    self.allocator.free(self.curl_extra_fds);
     self.allocator.free(self.cdp_poll_snapshot);
 
     if (self.ca_blob) |ca_blob| {
@@ -714,8 +730,7 @@ pub fn run(self: *Network) void {
             libcurl.curl_multi_perform(multi, &running_handles) catch |err| {
                 lp.log.err(.app, "curl perform", .{ .err = err });
             };
-
-            self.preparePollFds(multi);
+            self.processCompletions(multi);
         }
 
         self.prepareCdpPollFds();
@@ -728,24 +743,73 @@ pub fn run(self: *Network) void {
             }
 
             // curl_multi_timeout reports -1 when curl has no timeout
-            // preference (idle) and 0 when it wants to be serviced
-            // immediately. Treat both as "no curl-imposed deadline" and
-            // fall back to min_timeout — otherwise @min(min_timeout, -1)
-            // would be -1, i.e. poll() blocks forever, starving onTick
-            // (telemetry's periodic flush) and removing the safety net
-            // that bounds any missed wakeup to min_timeout.
+            // preference (idle), and 0 when it wants immediate service.
+            // Bound idle waits by min_timeout so onTick still fires and
+            // missed wakeups cannot block the loop forever.
             const curl_timeout = self.getCurlTimeout();
-            if (curl_timeout <= 0) {
+            if (curl_timeout < 0) {
                 break :blk min_timeout;
+            }
+            if (curl_timeout == 0) {
+                break :blk 0;
             }
 
             break :blk @min(min_timeout, curl_timeout);
         };
 
-        _ = posix.poll(self.pollfds, timeout) catch |err| {
-            lp.log.err(.app, "poll", .{ .err = err });
-            continue;
-        };
+        if (self.multi != null and running_handles > 0) {
+            // Use curl_multi_poll so libcurl can wait on all sockets it
+            // currently owns, and pass our wake/listener/CDP fds as extras.
+            const multi = self.multi.?;
+            var extra_len: usize = 0;
+            self.curl_extra_fds[extra_len] = .{
+                .fd = poll_fd.fd,
+                .events = .{ .pollin = true },
+                .revents = .{},
+            };
+            const wake_idx = extra_len;
+            extra_len += 1;
+
+            const listen_idx: ?usize = if (listen_fd.fd >= 0) blk: {
+                const idx = extra_len;
+                self.curl_extra_fds[extra_len] = .{
+                    .fd = listen_fd.fd,
+                    .events = .{ .pollin = true },
+                    .revents = .{},
+                };
+                extra_len += 1;
+                break :blk idx;
+            } else null;
+
+            const cdp_extra_start = extra_len;
+            for (0..self.cdp_poll_count) |i| {
+                const pfd = self.pollfds[self.cdp_start + i];
+                self.curl_extra_fds[extra_len] = .{
+                    .fd = pfd.fd,
+                    .events = .{ .pollin = true },
+                    .revents = .{},
+                };
+                extra_len += 1;
+            }
+
+            libcurl.curl_multi_poll(multi, self.curl_extra_fds[0..extra_len], timeout, null) catch |err| {
+                lp.log.err(.app, "curl poll", .{ .err = err });
+                continue;
+            };
+            poll_fd.revents = if (self.curl_extra_fds[wake_idx].revents.pollin) posix.POLL.IN else 0;
+            if (listen_idx) |idx| {
+                listen_fd.revents = if (self.curl_extra_fds[idx].revents.pollin) posix.POLL.IN else 0;
+            }
+            for (0..self.cdp_poll_count) |i| {
+                self.pollfds[self.cdp_start + i].revents = if (self.curl_extra_fds[cdp_extra_start + i].revents.pollin) posix.POLL.IN else 0;
+            }
+        } else {
+            const poll_len = self.cdp_start + self.cdp_poll_count;
+            _ = posix.poll(self.pollfds[0..poll_len], timeout) catch |err| {
+                lp.log.err(.app, "poll", .{ .err = err });
+                continue;
+            };
+        }
 
         // check wakeup pipe
         if (poll_fd.revents != 0) {
@@ -776,7 +840,9 @@ pub fn run(self: *Network) void {
             // Check if fireTicks submitted new requests (e.g. telemetry flush).
             // If so, continue the loop to drain and send them before exiting.
             self.submission_mutex.lock();
-            const has_pending = self.submission_queue.first != null;
+            const has_pending = self.pending_add.first != null or
+                self.pending_remove.first != null or
+                self.pending_ops.first != null;
             self.submission_mutex.unlock();
             if (!has_pending) break;
         }
@@ -796,11 +862,91 @@ pub fn run(self: *Network) void {
     }
 }
 
+pub const Op = union(enum) {
+    unpause,
+    tls_verify: http.Connection.TlsVerifyOp,
+};
+
+// Hand off conn to the network thread for adding to the multi.
 pub fn submitRequest(self: *Network, conn: *http.Connection) void {
-    self.submission_mutex.lock();
-    self.submission_queue.append(&conn.node);
-    self.submission_mutex.unlock();
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+        lp.assert(conn._submission == .idle, "submitRequest: conn not idle", .{});
+        conn._submission = .pending_add;
+        self.pending_add.append(&conn.node);
+    }
     self.wakeupPoll();
+}
+
+// Cancel a conn. If it never reached the multi (still in pending_add),
+// short-circuit: deliver the canceled completion synchronously via
+// on_complete. Otherwise queue a remove for the network thread.
+pub fn submitRemove(self: *Network, conn: *http.Connection) void {
+    var local_cancel: bool = false;
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+        switch (conn._submission) {
+            .pending_add => {
+                self.pending_add.remove(&conn.node);
+                conn._submission = .idle;
+                self.removeFromOpsLocked(conn);
+                local_cancel = true;
+            },
+            .in_multi => {
+                conn._submission = .pending_remove;
+                self.pending_remove.append(&conn.node);
+            },
+            .idle, .pending_remove => {
+                lp.log.warn(.app, "submitRemove bad state", .{ .state = @tagName(conn._submission) });
+                return;
+            },
+        }
+    }
+    if (local_cancel) {
+        if (conn.on_complete) |cb| {
+            cb(conn, error.Canceled);
+        } else {
+            self.releaseConnection(conn);
+        }
+        return;
+    }
+    self.wakeupPoll();
+}
+
+// Fire-and-forget op queued for the network thread to apply on a conn
+// that's currently in (or about to enter) the multi. Dropped if the
+// conn isn't in flight.
+pub fn submitOp(self: *Network, conn: *http.Connection, op: Op) void {
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+        switch (conn._submission) {
+            .pending_add, .in_multi => {},
+            .idle, .pending_remove => return,
+        }
+        switch (op) {
+            .unpause => conn._op_unpause = true,
+            .tls_verify => |t| conn._op_tls_verify = t,
+        }
+        if (!conn._op_in_list) {
+            conn._op_in_list = true;
+            self.pending_ops.append(&conn._op_node);
+        }
+    }
+    self.wakeupPoll();
+}
+
+// Caller holds submission_mutex. Called on every transition out of
+// .pending_add/.in_multi.
+fn removeFromOpsLocked(self: *Network, conn: *http.Connection) void {
+    if (conn._op_in_list) {
+        self.pending_ops.remove(&conn._op_node);
+        conn._op_in_list = false;
+    }
+    conn._op_unpause = false;
+    conn._op_tls_verify = null;
 }
 
 fn wakeupPoll(self: *Network) void {
@@ -808,11 +954,70 @@ fn wakeupPoll(self: *Network) void {
 }
 
 fn drainQueue(self: *Network) void {
-    self.submission_mutex.lock();
-    defer self.submission_mutex.unlock();
+    // add/remove are queued for execution outside the lock so that
+    // on_complete / releaseConnection can run unblocked. Ops execute
+    // *under* the lock — that's what keeps the conn alive (every path
+    // that releases the conn first transitions out of .in_multi here).
+    // pause/setopt only flip libcurl flags, no callbacks fire.
+    var to_add: std.DoublyLinkedList = .{};
+    var to_remove: std.DoublyLinkedList = .{};
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
 
-    if (self.submission_queue.first == null) return;
+        while (self.pending_remove.popFirst()) |node| {
+            const conn: *http.Connection = @fieldParentPtr("node", node);
+            lp.assert(conn._submission == .pending_remove, "drainQueue: conn not in pending_remove", .{});
+            conn._submission = .idle;
+            self.removeFromOpsLocked(conn);
+            to_remove.append(node);
+        }
+        while (self.pending_add.popFirst()) |node| {
+            const conn: *http.Connection = @fieldParentPtr("node", node);
+            lp.assert(conn._submission == .pending_add, "drainQueue: conn not in pending_add", .{});
+            // .in_multi is the target; handleAdd may roll back to .idle on failure.
+            conn._submission = .in_multi;
+            to_add.append(node);
+        }
+        while (self.pending_ops.popFirst()) |node| {
+            const conn: *http.Connection = @fieldParentPtr("_op_node", node);
+            conn._op_in_list = false;
+            // Conn raced out of multi between submitOp and now; drop ops.
+            if (conn._submission != .in_multi) {
+                conn._op_unpause = false;
+                conn._op_tls_verify = null;
+                continue;
+            }
+            if (conn._op_unpause) {
+                conn._op_unpause = false;
+                conn.pause(.{ .cont = true }) catch |err| {
+                    lp.log.warn(.app, "curl pause", .{ .err = err });
+                };
+            }
+            if (conn._op_tls_verify) |t| {
+                conn._op_tls_verify = null;
+                conn.setTlsVerify(t.verify, t.use_proxy) catch |err| {
+                    lp.log.warn(.app, "curl setTlsVerify", .{ .err = err });
+                };
+            }
+        }
+    }
 
+    // Process removes before adds: cancellations should take effect
+    // before we admit new transfers.
+    while (to_remove.popFirst()) |node| {
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        self.handleRemove(conn);
+    }
+    while (to_add.popFirst()) |node| {
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        self.handleAdd(conn);
+    }
+}
+
+// Caller has already set conn._submission = .in_multi. On failure we
+// roll back to .idle and either fire on_complete or release.
+fn handleAdd(self: *Network, conn: *http.Connection) void {
     const multi = self.multi orelse blk: {
         const m = libcurl.curl_multi_init() orelse {
             lp.assert(false, "curl multi init failed", .{});
@@ -822,17 +1027,51 @@ fn drainQueue(self: *Network) void {
         break :blk m;
     };
 
-    while (self.submission_queue.popFirst()) |node| {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        conn.setPrivate(conn) catch |err| {
-            lp.log.err(.app, "curl set private", .{ .err = err });
-            self.releaseConnection(conn);
-            continue;
-        };
-        libcurl.curl_multi_add_handle(multi, conn._easy) catch |err| {
-            lp.log.err(.app, "curl multi add", .{ .err = err });
-            self.releaseConnection(conn);
-        };
+    conn.setPrivate(conn) catch |err| {
+        lp.log.err(.app, "curl set private", .{ .err = err });
+        self.handleAddFailure(conn, err);
+        return;
+    };
+    libcurl.curl_multi_add_handle(multi, conn._easy) catch |err| {
+        lp.log.err(.app, "curl multi add", .{ .err = err });
+        self.handleAddFailure(conn, err);
+    };
+}
+
+fn handleAddFailure(self: *Network, conn: *http.Connection, err: anyerror) void {
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+        conn._submission = .idle;
+        self.removeFromOpsLocked(conn);
+    }
+    if (conn.on_complete) |cb| {
+        cb(conn, err);
+    } else {
+        self.releaseConnection(conn);
+    }
+}
+
+// Caller has already set conn._submission = .idle and the conn is no
+// longer in any submission list. The conn may still be in the multi
+// (normal cancel path).
+fn handleRemove(self: *Network, conn: *http.Connection) void {
+    if (self.multi) |multi| {
+        _ = libcurl.curl_multi_remove_handle(multi, conn._easy) catch {};
+    }
+    if (conn.on_complete) |cb| {
+        cb(conn, error.Canceled);
+    } else {
+        self.releaseConnection(conn);
+    }
+}
+
+// Caller guarantees Network.run is not executing. Used to drive
+// late-cancel completions through after Network.stop()+join().
+pub fn drainPendingForShutdown(self: *Network) void {
+    self.drainQueue();
+    if (self.multi) |multi| {
+        self.processCompletions(multi);
     }
 }
 
@@ -901,13 +1140,12 @@ fn getCurlTimeout(self: *Network) i32 {
 fn processCompletions(self: *Network, multi: *libcurl.CurlM) void {
     var msgs_in_queue: c_int = 0;
     while (libcurl.curl_multi_info_read(multi, &msgs_in_queue)) |msg| {
-        switch (msg.data) {
-            .done => |maybe_err| {
-                if (maybe_err) |err| {
-                    lp.log.warn(.app, "curl transfer error", .{ .err = err });
-                }
-            },
+        const maybe_err: ?anyerror = switch (msg.data) {
+            .done => |e| e,
             else => continue,
+        };
+        if (maybe_err) |err| {
+            lp.log.warn(.app, "curl transfer error", .{ .err = err });
         }
 
         const easy: *libcurl.Curl = msg.easy_handle;
@@ -917,7 +1155,27 @@ fn processCompletions(self: *Network, multi: *libcurl.CurlM) void {
         const conn: *http.Connection = @ptrCast(@alignCast(ptr));
 
         libcurl.curl_multi_remove_handle(multi, easy) catch {};
-        self.releaseConnection(conn);
+
+        // Race with worker submitRemove: if a remove was queued just
+        // before the completion fired, absorb it (cancel-after-complete
+        // is a no-op).
+        {
+            self.submission_mutex.lock();
+            defer self.submission_mutex.unlock();
+            switch (conn._submission) {
+                .in_multi => {},
+                .pending_remove => self.pending_remove.remove(&conn.node),
+                else => lp.assert(false, "completion bad state", .{ .state = @tagName(conn._submission) }),
+            }
+            conn._submission = .idle;
+            self.removeFromOpsLocked(conn);
+        }
+
+        if (conn.on_complete) |cb| {
+            cb(conn, maybe_err);
+        } else {
+            self.releaseConnection(conn);
+        }
     }
 }
 
@@ -988,100 +1246,133 @@ pub fn newConnection(self: *Network) ?*http.Connection {
     return conn;
 }
 
+// A Handle is a per-client view onto the shared multi owned by Network.
+// Worker code goes through here for every interaction with libcurl /
+// network state; the multi itself is driven by the network thread.
+//
+// Worker-side bookkeeping (in_use, counters) lives here. Network-side
+// state (multi, submission queues) lives on Network. Cross-thread
+// completion delivery happens via the wake pipe + completion queue:
+// the network thread calls pushCompletion (via on_complete), the worker
+// thread drains it via nextCompletion.
 pub const Handle = struct {
-    multi: *libcurl.CurlM,
     network: *Network,
 
-    // Active conns (added to multi). Iterated externally by abort,
-    // setTlsVerify, etc. — pub for direct access.
+    // Active conns (in network's multi or about to enter). Iterated
+    // externally by abort, setTlsVerify, etc. — pub for direct access.
     in_use: std.DoublyLinkedList = .{},
-
-    // Conns whose submit was deferred because we were inside
-    // curl_multi_perform. Drained automatically after perform completes.
-    ready_queue: std.DoublyLinkedList = .{},
-
-    // Conns whose remove was deferred because we were inside
-    // curl_multi_perform. Drained by drainDirty before the next perform.
-    dirty: std.DoublyLinkedList = .{},
 
     // Counters for in-flight conns by transport. Read externally
     // (ensureNoActiveConnection, abort assertion).
     http_active: usize = 0,
     ws_active: usize = 0,
 
-    // True while inside curl_multi_perform. Reads-only externally; checked
-    // by HttpClient.process to defer new submits.
-    performing: bool = false,
+    // Cross-thread completion delivery. The network thread pushes
+    // completed conns via pushCompletion (write to pipe + append to
+    // queue under mutex); the worker thread drains them via nextCompletion.
+    _wake_pipe: [2]posix.fd_t = .{ -1, -1 },
+    _completion_mutex: std.Thread.Mutex = .{},
+    _completion_queue: std.DoublyLinkedList = .{},
+    // Local buffer of conns moved out of _completion_queue under the
+    // mutex; nextCompletion delivers them one at a time without
+    // re-locking.
+    _drained: std.DoublyLinkedList = .{},
 
     pub fn init(network: *Network) !Handle {
-        const multi = libcurl.curl_multi_init() orelse return error.FailedToInitializeMulti;
-        errdefer libcurl.curl_multi_cleanup(multi) catch {};
-
-        try libcurl.curl_multi_setopt(multi, .max_host_connections, network.config.httpMaxHostOpen());
-
-        return .{ .network = network, .multi = multi };
+        const wake_pipe = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
+        return .{
+            .network = network,
+            ._wake_pipe = wake_pipe,
+        };
     }
 
     pub fn deinit(self: *Handle) void {
-        libcurl.curl_multi_cleanup(self.multi) catch {};
-    }
-
-    pub fn perform(self: *Handle) !c_int {
-        // Drain removes deferred by submitRemove during the previous
-        // curl_multi_perform call.
-        self.drainDirty();
-
-        var running: c_int = undefined;
-        {
-            self.performing = true;
-            defer self.performing = false;
-            try libcurl.curl_multi_perform(self.multi, &running);
+        for (&self._wake_pipe) |*fd| {
+            if (fd.* >= 0) {
+                posix.close(fd.*);
+                fd.* = -1;
+            }
         }
-
-        // Drain submits deferred during the perform we just exited.
-        self.drainReadyQueue();
-        return running;
     }
 
+    // Returns the read end of the wake pipe so the worker can include
+    // it in its poll set. Becomes readable when pushCompletion runs.
+    pub fn pollFd(self: *const Handle) posix.fd_t {
+        return self._wake_pipe[0];
+    }
+
+    // Producer side (network thread). Stashes the err on the conn,
+    // appends to the cross-thread queue and wakes the worker.
+    fn pushCompletion(self: *Handle, conn: *http.Connection, err: ?anyerror) void {
+        conn._completion_err = err;
+        {
+            self._completion_mutex.lock();
+            defer self._completion_mutex.unlock();
+            self._completion_queue.append(&conn.node);
+        }
+        _ = posix.write(self._wake_pipe[1], &.{1}) catch {};
+    }
+
+    // No-op: the network thread drives the multi. Kept for API
+    // symmetry with the previous sync model.
+    pub fn perform(self: *Handle) !c_int {
+        _ = self;
+        return 0;
+    }
+
+    // Poll the wake pipe alongside any caller-supplied fds.
     pub fn poll(self: *Handle, extra_fds: []posix.pollfd, timeout_ms: c_int) !void {
-        // posix.pollfd and CurlWaitFd are layout-compatible (verified at
-        // comptime in Network.zig).
-        const wait_fds: []libcurl.CurlWaitFd = @ptrCast(extra_fds);
-        try libcurl.curl_multi_poll(self.multi, wait_fds, timeout_ms, null);
+        // 1 wake pipe + extra_fds.
+        var buf: [PSEUDO_POLLFDS + 8]posix.pollfd = undefined;
+        const total = 1 + extra_fds.len;
+        if (total > buf.len) return error.TooManyPollFds;
+
+        buf[0] = .{ .fd = self._wake_pipe[0], .events = posix.POLL.IN, .revents = 0 };
+        for (extra_fds, 0..) |fd, i| buf[1 + i] = fd;
+
+        _ = posix.poll(buf[0..total], timeout_ms) catch |err| return err;
+
+        // Copy revents back to caller.
+        for (extra_fds, 0..) |*fd, i| fd.revents = buf[1 + i].revents;
     }
 
-    // Thread-safe wake of a poll() in progress on this multi. Used by
-    // the Network thread to nudge the worker out of curl_multi_poll
-    // when it pushes work onto the worker's inbox.
+    // Wake a worker poll when Network pushes work onto its inbox.
     pub fn wakeup(self: *Handle) !void {
-        try libcurl.curl_multi_wakeup(self.multi);
+        _ = try posix.write(self._wake_pipe[1], &.{1});
     }
 
     pub const Completion = struct {
         conn: *http.Connection,
-        err: ?Error,
+        err: ?anyerror,
     };
 
+    // Pull the next completed conn (already removed from the multi by
+    // the network thread). Drains the wake pipe and moves the queued
+    // conns into a local buffer on the first call after a wake-up.
     pub fn nextCompletion(self: *Handle) !?Completion {
-        var messages_count: c_int = 0;
-        const msg = libcurl.curl_multi_info_read(self.multi, &messages_count) orelse return null;
-        return switch (msg.data) {
-            .done => |err| {
-                var private: *anyopaque = undefined;
-                try libcurl.curl_easy_getinfo(msg.easy_handle, .private, &private);
-                // Detach from the multi before returning. The conn is
-                // delivered already-removed, matching the future async
-                // semantics. Subsequent submitRemove calls on the same
-                // conn (e.g. from transfer.deinit) tolerate the missing
-                // handle.
-                libcurl.curl_multi_remove_handle(self.multi, msg.easy_handle) catch {};
-                return .{
-                    .conn = @ptrCast(@alignCast(private)),
-                    .err = err,
-                };
-            },
-            else => unreachable,
-        };
+        if (self._drained.popFirst()) |node| return takeCompletion(node);
+
+        // Drain pipe wake bytes.
+        var buf: [64]u8 = undefined;
+        while (true) {
+            _ = posix.read(self._wake_pipe[0], &buf) catch break;
+        }
+
+        {
+            self._completion_mutex.lock();
+            defer self._completion_mutex.unlock();
+            while (self._completion_queue.popFirst()) |n| self._drained.append(n);
+        }
+
+        if (self._drained.popFirst()) |node| return takeCompletion(node);
+        return null;
+    }
+
+    fn takeCompletion(node: *std.DoublyLinkedList.Node) Completion {
+        const conn: *http.Connection = @fieldParentPtr("node", node);
+        const err = conn._completion_err;
+        conn._completion_err = null;
+        return .{ .conn = conn, .err = err };
     }
 
     // connection pool delegates ----------------------------------------
@@ -1098,112 +1389,66 @@ pub const Handle = struct {
         self.network.releaseConnection(conn);
     }
 
-    // Hand off a configured conn to the multi.
+    // Hand off a configured conn for the network thread to add to the
+    // multi.
     //
-    // First-time submit: bookkeeps in_use + counter, sets the private
-    // pointer, adds to multi. If we're inside curl_multi_perform, the
-    // submit is deferred to ready_queue and replayed by drainReadyQueue.
+    // First-time: tracks in_use + counter, sets on_complete cb, queues.
+    // Re-submit (conn already tracked, e.g. redirect): just queues — no
+    // bookkeep change.
     //
-    // Re-submit (conn already tracked, e.g. redirect): just sets the
-    // private pointer and re-adds to multi. Bookkeeping is untouched.
-    //
-    // On failure, bookkeeping is rolled back. The conn is NOT released
-    // — caller is responsible.
+    // On failure (only possible if conn.transport is invalid for our
+    // bookkeeping), state is rolled back; caller releases the conn.
     pub fn submitRequest(self: *Handle, conn: *http.Connection) !void {
-        const first_time = !conn.in_use;
-
-        if (first_time) {
-            if (self.performing) {
-                self.ready_queue.append(&conn.node);
-                return;
-            }
-            self.in_use.append(&conn.node);
+        if (!conn.in_use) {
+            self.in_use.append(&conn._worker_node);
             conn.in_use = true;
             switch (conn.transport) {
                 .http => self.http_active += 1,
                 .websocket => self.ws_active += 1,
                 else => unreachable,
             }
+            conn.on_complete = httpCompletionCallback;
         }
-        errdefer if (first_time) {
-            self.in_use.remove(&conn.node);
-            conn.in_use = false;
-            switch (conn.transport) {
-                .http => self.http_active -= 1,
-                .websocket => self.ws_active -= 1,
-                else => unreachable,
-            }
-        };
-
-        try conn.setPrivate(conn);
-        try self.add(conn);
+        self.network.submitRequest(conn);
     }
 
-    // Cancel a tracked conn: untrack, remove from multi, return to pool.
-    //
-    // If conn is in ready_queue (deferred submit), just untrack and
-    // release. If it's in in_use, decrement counters and try to remove
-    // from multi: on RecursiveApiCall (we're inside perform) defer via
-    // dirty; on BadEasyHandle the conn was already detached (e.g. by
-    // nextCompletion) and we fall through to release.
+    // Initiate cancellation of an active conn. Bookkeeping (in_use,
+    // counters) stays in place until the canceled completion arrives
+    // and finishConn runs.
     pub fn submitRemove(self: *Handle, conn: *http.Connection) void {
+        self.network.submitRemove(conn);
+    }
+
+    // Terminal cleanup. Called from drainCompletions handlers after
+    // a conn was delivered through nextCompletion (already detached
+    // from the multi). Decrements counters, removes from in_use,
+    // returns the conn to the pool.
+    pub fn finishConn(self: *Handle, conn: *http.Connection) void {
         if (!conn.in_use) {
-            // Was deferred to ready_queue; never reached in_use/multi.
-            self.ready_queue.remove(&conn.node);
-            self.releaseConnection(conn);
+            // Already finished or never tracked (e.g. submit failure
+            // path). Nothing to undo besides the pool release.
+            self.network.releaseConnection(conn);
             return;
         }
-
-        self.in_use.remove(&conn.node);
+        self.in_use.remove(&conn._worker_node);
         conn.in_use = false;
         switch (conn.transport) {
             .http => self.http_active -= 1,
             .websocket => self.ws_active -= 1,
             else => unreachable,
         }
+        self.network.releaseConnection(conn);
+    }
 
-        self.remove(conn) catch |err| switch (err) {
-            error.RecursiveApiCall => {
-                self.dirty.append(&conn.node);
-                return;
-            },
-            error.BadEasyHandle => {}, // already detached, fall through
-            else => log.warn(.http, "curl multi remove", .{ .err = err }),
+    // Routes a completed conn (from the network thread) back to its
+    // owning Handle's wake pipe and completion queue.
+    fn httpCompletionCallback(conn: *http.Connection, err: ?anyerror) void {
+        const handle = switch (conn.transport) {
+            .http => |t| &t.client.handle,
+            .websocket => |ws| &ws._http_client.handle,
+            .none => return,
         };
-        self.releaseConnection(conn);
-    }
-
-    // --- internals --------------------------------------------------
-
-    fn add(self: *Handle, conn: *const http.Connection) !void {
-        try libcurl.curl_multi_add_handle(self.multi, conn._easy);
-    }
-
-    fn remove(self: *Handle, conn: *const http.Connection) !void {
-        try libcurl.curl_multi_remove_handle(self.multi, conn._easy);
-    }
-
-    fn drainDirty(self: *Handle) void {
-        while (self.dirty.popFirst()) |node| {
-            const conn: *http.Connection = @fieldParentPtr("node", node);
-            self.remove(conn) catch |err| {
-                log.fatal(.http, "multi remove handle", .{ .err = err, .src = "drainDirty" });
-                @panic("multi_remove_handle");
-            };
-            self.releaseConnection(conn);
-        }
-    }
-
-    fn drainReadyQueue(self: *Handle) void {
-        // submitRequest will see conn.in_use=false and run the first-time
-        // path. self.performing is false here (set by perform's defer).
-        while (self.ready_queue.popFirst()) |node| {
-            const conn: *http.Connection = @fieldParentPtr("node", node);
-            self.submitRequest(conn) catch |err| {
-                log.warn(.http, "ready_queue submit", .{ .err = err });
-                self.releaseConnection(conn);
-            };
-        }
+        handle.pushCompletion(conn, err);
     }
 
     pub const AbortOpts = struct {
@@ -1211,44 +1456,24 @@ pub const Handle = struct {
     };
 
     // Abort all tracked conns. Each kill() initiates teardown via
-    // submitRemove, which mutates in_use — the iteration captures `next`
-    // before kill() to stay safe.
+    // submitRemove; the iteration below captures `next` before kill() in
+    // case the call mutates the list.
     pub fn abort(self: *Handle) void {
-        abortList(self.in_use, null, .{ .scope = .full });
-        abortList(self.ready_queue, null, .{ .scope = .full });
-
-        if (comptime builtin.mode == .Debug) {
-            // After abort, any leftover http transfers should be flagged
-            // aborted (in-callback transfers can't be deinit'd
-            // synchronously). leftover count must match counters.
-            var it = self.in_use.first;
-            var leftover: usize = 0;
-            while (it) |node| : (it = node.next) {
-                const conn: *http.Connection = @fieldParentPtr("node", node);
-                switch (conn.transport) {
-                    .http => |transfer| std.debug.assert(transfer.state == .aborted),
-                    .websocket => {},
-                    .none => {},
-                }
-                leftover += 1;
-            }
-            std.debug.assert(self.http_active + self.ws_active == leftover);
-        }
+        self._abort(null, .{ .scope = .full });
     }
 
     // Abort tracked conns belonging to frame_id. With .normal scope, http
     // transfers flagged protect_from_abort are spared; .full scope kills
     // them too. WebSockets ignore the scope flag.
     pub fn abortFrame(self: *Handle, frame_id: u32, opts: AbortOpts) void {
-        abortList(self.in_use, frame_id, opts);
-        abortList(self.ready_queue, frame_id, opts);
+        self._abort(frame_id, opts);
     }
 
-    fn abortList(list: std.DoublyLinkedList, frame_id: ?u32, opts: AbortOpts) void {
-        var n = list.first;
+    fn _abort(self: *Handle, frame_id: ?u32, opts: AbortOpts) void {
+        var n = self.in_use.first;
         while (n) |node| {
             n = node.next;
-            const conn: *http.Connection = @fieldParentPtr("node", node);
+            const conn: *http.Connection = @fieldParentPtr("_worker_node", node);
             switch (conn.transport) {
                 .http => |transfer| {
                     const params = transfer.req.params;
@@ -1270,23 +1495,37 @@ pub const Handle = struct {
                 .none => unreachable,
             }
         }
+
+        if (frame_id == null and comptime builtin.mode == .Debug) {
+            // After abort_all, any leftover http transfers should be
+            // flagged aborted (in-callback transfers can't be deinit'd
+            // synchronously). leftover count must match counters.
+            var it = self.in_use.first;
+            var leftover: usize = 0;
+            while (it) |node| : (it = node.next) {
+                const conn: *http.Connection = @fieldParentPtr("_worker_node", node);
+                switch (conn.transport) {
+                    .http => |transfer| std.debug.assert(transfer.state == .aborted),
+                    .websocket => {},
+                    .none => {},
+                }
+                leftover += 1;
+            }
+            std.debug.assert(self.http_active + self.ws_active == leftover);
+        }
     }
 
     // per-conn ops on active conns -------------------------------------
     //
-    // These wrap libcurl mutators that today run synchronously on the
-    // worker thread. The seam exists so the same call sites stay valid
-    // once the network thread owns the multi and these become
-    // cross-thread submits.
+    // submitOp: the network thread will apply the op when it sees the
+    // conn in pending_ops. Op is dropped if the conn isn't in flight.
 
-    pub fn submitTlsVerify(self: *Handle, conn: *http.Connection, verify: bool, use_proxy: bool) !void {
-        _ = self;
-        try conn.setTlsVerify(verify, use_proxy);
+    pub fn submitTlsVerify(self: *Handle, conn: *http.Connection, verify: bool, use_proxy: bool) void {
+        self.network.submitOp(conn, .{ .tls_verify = .{ .verify = verify, .use_proxy = use_proxy } });
     }
 
-    pub fn submitUnpause(self: *Handle, conn: *http.Connection) !void {
-        _ = self;
-        try conn.pause(.{ .cont = true });
+    pub fn submitUnpause(self: *Handle, conn: *http.Connection) void {
+        self.network.submitOp(conn, .unpause);
     }
 };
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -110,10 +110,7 @@ shutdown: std.atomic.Value(bool) = .init(false),
 // Wakeup pipe: workers write to [1], main thread polls [0]
 wakeup_pipe: [2]posix.fd_t = .{ -1, -1 },
 
-// Multi is a heavy structure that can consume up to 2MB of RAM.
-// Currently, Network is used sparingly, and we only create it on demand.
-// When Network becomes truly shared, it should become a regular field.
-multi: ?*libcurl.CurlM = null,
+multi: *libcurl.CurlM,
 
 // Cross-thread submission to the network thread.
 //
@@ -158,6 +155,11 @@ cdp_start: usize,
 
 /// Optional IP filter for blocking requests to private/internal networks (--block-private-networks).
 ip_filter: ?*IpFilter = null,
+
+pub const Op = union(enum) {
+    unpause,
+    tls_verify: http.Connection.TlsVerifyOp,
+};
 
 const TickCallback = struct {
     ctx: *anyopaque,
@@ -291,12 +293,10 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     errdefer globalDeinit();
 
     const pipe = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
-
-    // IMPORTANT: This is a bit messy, and it exists specifically because
-    // self.multi is optional. self.multi is optional so that, when telemetry is
-    // disabled, we don't need the overhead of a multi. If self.multi wasn't
-    // optional, then we wouldn't need to use posix.poll, we could use
-    // curl_multi_poll. This is to do in a follow up.
+    errdefer {
+        posix.close(pipe[0]);
+        posix.close(pipe[1]);
+    }
 
     // The structure is: 0 is wakeup, 1 is listener, rest for curl fds:
     //   [0]                                          wakeup pipe
@@ -317,10 +317,14 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     @memset(pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
     pollfds[0] = .{ .fd = pipe[0], .events = posix.POLL.IN, .revents = 0 };
 
-    var ca_blob: ?http.Blob = null;
-    if (config.tlsVerifyHost()) {
-        ca_blob = try loadCerts(allocator);
-    }
+    const ca_blob: ?http.Blob = if (config.tlsVerifyHost())
+        try loadCerts(allocator)
+    else
+        null;
+    errdefer if (ca_blob) |cb| {
+        const data: [*]u8 = @ptrCast(cb.data);
+        allocator.free(data[0..cb.len]);
+    };
 
     // IP filter for blocking requests to private/internal networks.
     const block_private = config.blockPrivateNetworks();
@@ -349,13 +353,15 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
         connections[i] = try http.Connection.init(ca_blob, config, ip_filter);
         available.append(&connections[i].node);
     }
+    errdefer for (0..count) |i| connections[i].deinit();
 
     const web_bot_auth = if (config.webBotAuth()) |wba_cfg|
         try WebBotAuth.fromConfig(allocator, &wba_cfg)
     else
         null;
+    errdefer if (web_bot_auth) |wba| wba.deinit(allocator);
 
-    const cache = if (config.httpCacheDir()) |cache_dir_path|
+    var cache = if (config.httpCacheDir()) |cache_dir_path|
         Cache{
             .kind = .{
                 .fs = FsCache.init(cache_dir_path) catch |e| {
@@ -370,38 +376,44 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
         }
     else
         null;
+    errdefer if (cache) |*c| c.deinit();
+
+    var robot_store = RobotStore.init(allocator);
+    errdefer robot_store.deinit();
+
+    var ws_pool = std.heap.MemoryPool(http.Connection).init(allocator);
+    errdefer ws_pool.deinit();
+
+    const multi = libcurl.curl_multi_init() orelse return Error.FailedInit;
+    errdefer libcurl.curl_multi_cleanup(multi) catch {};
 
     return .{
-        .allocator = allocator,
+        .app = app,
         .config = config,
         .ca_blob = ca_blob,
+        .allocator = allocator,
 
+        .multi = multi,
         .pollfds = pollfds,
         .curl_extra_fds = curl_extra_fds,
         .wakeup_pipe = pipe,
         .cdp_poll_snapshot = cdp_poll_snapshot,
         .cdp_start = PSEUDO_POLLFDS + config.httpMaxConcurrent(),
+        .ws_pool = ws_pool,
+        .ws_max = config.wsMaxConcurrent(),
 
         .available = available,
         .connections = connections,
 
-        .app = app,
-
         .cache = cache,
-        .robot_store = RobotStore.init(allocator),
-        .web_bot_auth = web_bot_auth,
-
-        .ws_pool = .init(allocator),
-        .ws_max = config.wsMaxConcurrent(),
-
         .ip_filter = ip_filter,
+        .robot_store = robot_store,
+        .web_bot_auth = web_bot_auth,
     };
 }
 
 pub fn deinit(self: *Network) void {
-    if (self.multi) |multi| {
-        libcurl.curl_multi_cleanup(multi) catch {};
-    }
+    libcurl.curl_multi_cleanup(self.multi) catch {};
 
     for (&self.wakeup_pipe) |*fd| {
         if (fd.* >= 0) {
@@ -439,10 +451,6 @@ pub fn deinit(self: *Network) void {
     }
 
     globalDeinit();
-}
-
-pub fn getHandle(self: *Network) !Handle {
-    return try Handle.init(self);
 }
 
 pub fn bind(
@@ -506,7 +514,7 @@ pub fn onTick(self: *Network, ctx: *anyopaque, callback: *const fn (*anyopaque) 
     self.wakeupPoll();
 }
 
-pub fn fireTicks(self: *Network) void {
+fn fireTicks(self: *Network) void {
     self.callbacks_mutex.lock();
     defer self.callbacks_mutex.unlock();
 
@@ -724,23 +732,18 @@ pub fn run(self: *Network) void {
 
         self.drainQueue();
 
-        if (self.multi) |multi| {
-            // Kickstart newly added handles (DNS/connect) so that
-            // curl registers its sockets before we poll.
-            libcurl.curl_multi_perform(multi, &running_handles) catch |err| {
-                lp.log.err(.app, "curl perform", .{ .err = err });
-            };
-            self.processCompletions(multi);
-        }
+        // Kickstart newly added handles (DNS/connect) so that
+        // curl registers its sockets before we poll.
+        libcurl.curl_multi_perform(self.multi, &running_handles) catch |err| {
+            lp.log.err(.app, "curl perform", .{ .err = err });
+        };
+        self.processCompletions(self.multi);
 
         self.prepareCdpPollFds();
 
         // for ontick to work, you need to wake up periodically
         const timeout = blk: {
             const min_timeout = 250; // 250ms
-            if (self.multi == null) {
-                break :blk min_timeout;
-            }
 
             // curl_multi_timeout reports -1 when curl has no timeout
             // preference (idle), and 0 when it wants immediate service.
@@ -757,10 +760,9 @@ pub fn run(self: *Network) void {
             break :blk @min(min_timeout, curl_timeout);
         };
 
-        if (self.multi != null and running_handles > 0) {
+        if (running_handles > 0) {
             // Use curl_multi_poll so libcurl can wait on all sockets it
             // currently owns, and pass our wake/listener/CDP fds as extras.
-            const multi = self.multi.?;
             var extra_len: usize = 0;
             self.curl_extra_fds[extra_len] = .{
                 .fd = poll_fd.fd,
@@ -792,7 +794,7 @@ pub fn run(self: *Network) void {
                 extra_len += 1;
             }
 
-            libcurl.curl_multi_poll(multi, self.curl_extra_fds[0..extra_len], timeout, null) catch |err| {
+            libcurl.curl_multi_poll(self.multi, self.curl_extra_fds[0..extra_len], timeout, null) catch |err| {
                 lp.log.err(.app, "curl poll", .{ .err = err });
                 continue;
             };
@@ -824,13 +826,11 @@ pub fn run(self: *Network) void {
             self.acceptConnections();
         }
 
-        if (self.multi) |multi| {
-            // Drive transfers and process completions.
-            libcurl.curl_multi_perform(multi, &running_handles) catch |err| {
-                lp.log.err(.app, "curl perform", .{ .err = err });
-            };
-            self.processCompletions(multi);
-        }
+        // Drive transfers and process completions.
+        libcurl.curl_multi_perform(self.multi, &running_handles) catch |err| {
+            lp.log.err(.app, "curl perform", .{ .err = err });
+        };
+        self.processCompletions(self.multi);
 
         self.processCdpEvents();
 
@@ -862,31 +862,37 @@ pub fn run(self: *Network) void {
     }
 }
 
-pub const Op = union(enum) {
-    unpause,
-    tls_verify: http.Connection.TlsVerifyOp,
-};
+pub fn getHandle(self: *Network) !Handle {
+    return try Handle.init(self);
+}
+
+pub fn request(self: *Network, conn: *http.Connection) void {
+    self.submitRequest(conn);
+}
 
 // Hand off conn to the network thread for adding to the multi.
-pub fn submitRequest(self: *Network, conn: *http.Connection) void {
+fn submitRequest(self: *Network, conn: *http.Connection) void {
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
+
         lp.assert(conn._submission == .idle, "submitRequest: conn not idle", .{});
         conn._submission = .pending_add;
         self.pending_add.append(&conn.node);
     }
+
     self.wakeupPoll();
 }
 
 // Cancel a conn. If it never reached the multi (still in pending_add),
 // short-circuit: deliver the canceled completion synchronously via
 // on_complete. Otherwise queue a remove for the network thread.
-pub fn submitRemove(self: *Network, conn: *http.Connection) void {
+fn submitRemove(self: *Network, conn: *http.Connection) void {
     var local_cancel: bool = false;
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
+
         switch (conn._submission) {
             .pending_add => {
                 self.pending_add.remove(&conn.node);
@@ -910,26 +916,29 @@ pub fn submitRemove(self: *Network, conn: *http.Connection) void {
         } else {
             self.releaseConnection(conn);
         }
-        return;
+    } else {
+        self.wakeupPoll();
     }
-    self.wakeupPoll();
 }
 
 // Fire-and-forget op queued for the network thread to apply on a conn
 // that's currently in (or about to enter) the multi. Dropped if the
 // conn isn't in flight.
-pub fn submitOp(self: *Network, conn: *http.Connection, op: Op) void {
+fn submitOp(self: *Network, conn: *http.Connection, op: Op) void {
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
+
         switch (conn._submission) {
             .pending_add, .in_multi => {},
             .idle, .pending_remove => return,
         }
+
         switch (op) {
             .unpause => conn._op_unpause = true,
             .tls_verify => |t| conn._op_tls_verify = t,
         }
+
         if (!conn._op_in_list) {
             conn._op_in_list = true;
             self.pending_ops.append(&conn._op_node);
@@ -964,8 +973,6 @@ fn drainQueue(self: *Network) void {
     // conn.node in another DoublyLinkedList: a worker submitRequest /
     // submitRemove racing with the outside-lock loop would observe
     // unsynchronized writes to conn.node otherwise.
-    var to_add: std.ArrayList(*http.Connection) = .empty;
-    defer to_add.deinit(self.allocator);
     var to_remove: std.ArrayList(*http.Connection) = .empty;
     defer to_remove.deinit(self.allocator);
     {
@@ -975,17 +982,35 @@ fn drainQueue(self: *Network) void {
         while (self.pending_remove.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             lp.assert(conn._submission == .pending_remove, "drainQueue: conn not in pending_remove", .{});
+
             conn._submission = .idle;
             self.removeFromOpsLocked(conn);
             to_remove.append(self.allocator, conn) catch @panic("OOM");
         }
+    }
+    for (to_remove.items) |conn| self.handleRemove(conn);
+
+    var to_add: std.ArrayList(*http.Connection) = .empty;
+    defer to_add.deinit(self.allocator);
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+
         while (self.pending_add.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             lp.assert(conn._submission == .pending_add, "drainQueue: conn not in pending_add", .{});
+
             // .in_multi is the target; handleAdd may roll back to .idle on failure.
             conn._submission = .in_multi;
             to_add.append(self.allocator, conn) catch @panic("OOM");
         }
+    }
+    for (to_add.items) |conn| self.handleAdd(conn);
+
+    {
+        self.submission_mutex.lock();
+        defer self.submission_mutex.unlock();
+
         while (self.pending_ops.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("_op_node", node);
             conn._op_in_list = false;
@@ -1009,31 +1034,17 @@ fn drainQueue(self: *Network) void {
             }
         }
     }
-
-    // Process removes before adds: cancellations should take effect
-    // before we admit new transfers.
-    for (to_remove.items) |conn| self.handleRemove(conn);
-    for (to_add.items) |conn| self.handleAdd(conn);
 }
 
 // Caller has already set conn._submission = .in_multi. On failure we
 // roll back to .idle and either fire on_complete or release.
 fn handleAdd(self: *Network, conn: *http.Connection) void {
-    const multi = self.multi orelse blk: {
-        const m = libcurl.curl_multi_init() orelse {
-            lp.assert(false, "curl multi init failed", .{});
-            unreachable;
-        };
-        self.multi = m;
-        break :blk m;
-    };
-
     conn.setPrivate(conn) catch |err| {
         lp.log.err(.app, "curl set private", .{ .err = err });
         self.handleAddFailure(conn, err);
         return;
     };
-    libcurl.curl_multi_add_handle(multi, conn._easy) catch |err| {
+    libcurl.curl_multi_add_handle(self.multi, conn._easy) catch |err| {
         lp.log.err(.app, "curl multi add", .{ .err = err });
         self.handleAddFailure(conn, err);
     };
@@ -1043,6 +1054,7 @@ fn handleAddFailure(self: *Network, conn: *http.Connection, err: anyerror) void 
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
+
         conn._submission = .idle;
         self.removeFromOpsLocked(conn);
     }
@@ -1057,9 +1069,8 @@ fn handleAddFailure(self: *Network, conn: *http.Connection, err: anyerror) void 
 // longer in any submission list. The conn may still be in the multi
 // (normal cancel path).
 fn handleRemove(self: *Network, conn: *http.Connection) void {
-    if (self.multi) |multi| {
-        _ = libcurl.curl_multi_remove_handle(multi, conn._easy) catch {};
-    }
+    _ = libcurl.curl_multi_remove_handle(self.multi, conn._easy) catch {};
+
     if (conn.on_complete) |cb| {
         cb(conn, error.Canceled);
     } else {
@@ -1071,9 +1082,7 @@ fn handleRemove(self: *Network, conn: *http.Connection) void {
 // late-cancel completions through after Network.stop()+join().
 pub fn drainPendingForShutdown(self: *Network) void {
     self.drainQueue();
-    if (self.multi) |multi| {
-        self.processCompletions(multi);
-    }
+    self.processCompletions(self.multi);
 }
 
 pub fn stop(self: *Network) void {
@@ -1132,9 +1141,8 @@ fn preparePollFds(self: *Network, multi: *libcurl.CurlM) void {
 }
 
 fn getCurlTimeout(self: *Network) i32 {
-    const multi = self.multi orelse return -1;
     var timeout_ms: c_long = -1;
-    libcurl.curl_multi_timeout(multi, &timeout_ms) catch return -1;
+    libcurl.curl_multi_timeout(self.multi, &timeout_ms) catch return -1;
     return @intCast(@min(timeout_ms, std.math.maxInt(i32)));
 }
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -61,9 +61,8 @@ pub const CdpLink = struct {
     cdp: *CDP,
     state: State,
     socket: posix.socket_t,
-    // The worker's Handle (by value — it's two pointers wide).
-    // Network calls handle.wakeup() to unblock the worker from
-    // curl_multi_poll whenever it pushes to the worker's inbox.
+    // Worker handle used to unblock curl_multi_poll whenever Network
+    // pushes to the worker's inbox.
     handle: Handle,
     node: DoublyLinkedList.Node = .{},
 
@@ -89,6 +88,7 @@ app: *App,
 cache: ?Cache,
 config: *const Config,
 ca_blob: ?http.Blob,
+
 robot_store: RobotStore,
 web_bot_auth: ?WebBotAuth,
 
@@ -104,11 +104,10 @@ ws_mutex: std.Thread.Mutex = .{},
 pollfds: []posix.pollfd,
 listener: ?Listener = null,
 accept: std.atomic.Value(bool) = .init(true),
+shutdown: std.atomic.Value(bool) = .init(false),
 
 // Wakeup pipe: workers write to [1], main thread polls [0]
 wakeup_pipe: [2]posix.fd_t = .{ -1, -1 },
-
-shutdown: std.atomic.Value(bool) = .init(false),
 
 // Multi is a heavy structure that can consume up to 2MB of RAM.
 // Currently, Network is used sparingly, and we only create it on demand.
@@ -993,9 +992,26 @@ pub const Handle = struct {
     multi: *libcurl.CurlM,
     network: *Network,
 
+    // Active conns (added to multi). Iterated externally by abort,
+    // setTlsVerify, etc. — pub for direct access.
+    in_use: std.DoublyLinkedList = .{},
+
+    // Conns whose submit was deferred because we were inside
+    // curl_multi_perform. Drained automatically after perform completes.
+    ready_queue: std.DoublyLinkedList = .{},
+
     // Conns whose remove was deferred because we were inside
     // curl_multi_perform. Drained by drainDirty before the next perform.
     dirty: std.DoublyLinkedList = .{},
+
+    // Counters for in-flight conns by transport. Read externally
+    // (ensureNoActiveConnection, abort assertion).
+    http_active: usize = 0,
+    ws_active: usize = 0,
+
+    // True while inside curl_multi_perform. Reads-only externally; checked
+    // by HttpClient.process to defer new submits.
+    performing: bool = false,
 
     pub fn init(network: *Network) !Handle {
         const multi = libcurl.curl_multi_init() orelse return error.FailedToInitializeMulti;
@@ -1010,22 +1026,28 @@ pub const Handle = struct {
         libcurl.curl_multi_cleanup(self.multi) catch {};
     }
 
-    pub fn add(self: *Handle, conn: *const http.Connection) !void {
-        try libcurl.curl_multi_add_handle(self.multi, conn._easy);
-    }
-
-    pub fn remove(self: *Handle, conn: *const http.Connection) !void {
-        try libcurl.curl_multi_remove_handle(self.multi, conn._easy);
-    }
-
     pub fn perform(self: *Handle) !c_int {
+        // Drain removes deferred by submitRemove during the previous
+        // curl_multi_perform call.
+        self.drainDirty();
+
         var running: c_int = undefined;
-        try libcurl.curl_multi_perform(self.multi, &running);
+        {
+            self.performing = true;
+            defer self.performing = false;
+            try libcurl.curl_multi_perform(self.multi, &running);
+        }
+
+        // Drain submits deferred during the perform we just exited.
+        self.drainReadyQueue();
         return running;
     }
 
-    pub fn poll(self: *Handle, extra_fds: []libcurl.CurlWaitFd, timeout_ms: c_int) !void {
-        try libcurl.curl_multi_poll(self.multi, extra_fds, timeout_ms, null);
+    pub fn poll(self: *Handle, extra_fds: []posix.pollfd, timeout_ms: c_int) !void {
+        // posix.pollfd and CurlWaitFd are layout-compatible (verified at
+        // comptime in Network.zig).
+        const wait_fds: []libcurl.CurlWaitFd = @ptrCast(extra_fds);
+        try libcurl.curl_multi_poll(self.multi, wait_fds, timeout_ms, null);
     }
 
     // Thread-safe wake of a poll() in progress on this multi. Used by
@@ -1035,18 +1057,24 @@ pub const Handle = struct {
         try libcurl.curl_multi_wakeup(self.multi);
     }
 
-    pub const MultiMessage = struct {
+    pub const Completion = struct {
         conn: *http.Connection,
         err: ?Error,
     };
 
-    pub fn readMessage(self: *Handle) !?MultiMessage {
+    pub fn nextCompletion(self: *Handle) !?Completion {
         var messages_count: c_int = 0;
         const msg = libcurl.curl_multi_info_read(self.multi, &messages_count) orelse return null;
         return switch (msg.data) {
             .done => |err| {
                 var private: *anyopaque = undefined;
                 try libcurl.curl_easy_getinfo(msg.easy_handle, .private, &private);
+                // Detach from the multi before returning. The conn is
+                // delivered already-removed, matching the future async
+                // semantics. Subsequent submitRemove calls on the same
+                // conn (e.g. from transfer.deinit) tolerate the missing
+                // handle.
+                libcurl.curl_multi_remove_handle(self.multi, msg.easy_handle) catch {};
                 return .{
                     .conn = @ptrCast(@alignCast(private)),
                     .err = err,
@@ -1070,19 +1098,92 @@ pub const Handle = struct {
         self.network.releaseConnection(conn);
     }
 
-    // Cancel an active conn: remove from multi and return to pool. If
-    // we're inside curl_multi_perform (libcurl forbids remove from a
-    // callback), defer the remove via the dirty queue and let
-    // drainDirty pick it up before the next perform.
-    pub fn cancelConn(self: *Handle, conn: *http.Connection) void {
-        if (self.remove(conn)) {
-            self.releaseConnection(conn);
-        } else |_| {
-            self.dirty.append(&conn.node);
+    // Hand off a configured conn to the multi.
+    //
+    // First-time submit: bookkeeps in_use + counter, sets the private
+    // pointer, adds to multi. If we're inside curl_multi_perform, the
+    // submit is deferred to ready_queue and replayed by drainReadyQueue.
+    //
+    // Re-submit (conn already tracked, e.g. redirect): just sets the
+    // private pointer and re-adds to multi. Bookkeeping is untouched.
+    //
+    // On failure, bookkeeping is rolled back. The conn is NOT released
+    // — caller is responsible.
+    pub fn submitRequest(self: *Handle, conn: *http.Connection) !void {
+        const first_time = !conn.in_use;
+
+        if (first_time) {
+            if (self.performing) {
+                self.ready_queue.append(&conn.node);
+                return;
+            }
+            self.in_use.append(&conn.node);
+            conn.in_use = true;
+            switch (conn.transport) {
+                .http => self.http_active += 1,
+                .websocket => self.ws_active += 1,
+                else => unreachable,
+            }
         }
+        errdefer if (first_time) {
+            self.in_use.remove(&conn.node);
+            conn.in_use = false;
+            switch (conn.transport) {
+                .http => self.http_active -= 1,
+                .websocket => self.ws_active -= 1,
+                else => unreachable,
+            }
+        };
+
+        try conn.setPrivate(conn);
+        try self.add(conn);
     }
 
-    pub fn drainDirty(self: *Handle) void {
+    // Cancel a tracked conn: untrack, remove from multi, return to pool.
+    //
+    // If conn is in ready_queue (deferred submit), just untrack and
+    // release. If it's in in_use, decrement counters and try to remove
+    // from multi: on RecursiveApiCall (we're inside perform) defer via
+    // dirty; on BadEasyHandle the conn was already detached (e.g. by
+    // nextCompletion) and we fall through to release.
+    pub fn submitRemove(self: *Handle, conn: *http.Connection) void {
+        if (!conn.in_use) {
+            // Was deferred to ready_queue; never reached in_use/multi.
+            self.ready_queue.remove(&conn.node);
+            self.releaseConnection(conn);
+            return;
+        }
+
+        self.in_use.remove(&conn.node);
+        conn.in_use = false;
+        switch (conn.transport) {
+            .http => self.http_active -= 1,
+            .websocket => self.ws_active -= 1,
+            else => unreachable,
+        }
+
+        self.remove(conn) catch |err| switch (err) {
+            error.RecursiveApiCall => {
+                self.dirty.append(&conn.node);
+                return;
+            },
+            error.BadEasyHandle => {}, // already detached, fall through
+            else => log.warn(.http, "curl multi remove", .{ .err = err }),
+        };
+        self.releaseConnection(conn);
+    }
+
+    // --- internals --------------------------------------------------
+
+    fn add(self: *Handle, conn: *const http.Connection) !void {
+        try libcurl.curl_multi_add_handle(self.multi, conn._easy);
+    }
+
+    fn remove(self: *Handle, conn: *const http.Connection) !void {
+        try libcurl.curl_multi_remove_handle(self.multi, conn._easy);
+    }
+
+    fn drainDirty(self: *Handle) void {
         while (self.dirty.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             self.remove(conn) catch |err| {
@@ -1090,6 +1191,84 @@ pub const Handle = struct {
                 @panic("multi_remove_handle");
             };
             self.releaseConnection(conn);
+        }
+    }
+
+    fn drainReadyQueue(self: *Handle) void {
+        // submitRequest will see conn.in_use=false and run the first-time
+        // path. self.performing is false here (set by perform's defer).
+        while (self.ready_queue.popFirst()) |node| {
+            const conn: *http.Connection = @fieldParentPtr("node", node);
+            self.submitRequest(conn) catch |err| {
+                log.warn(.http, "ready_queue submit", .{ .err = err });
+                self.releaseConnection(conn);
+            };
+        }
+    }
+
+    pub const AbortOpts = struct {
+        scope: enum { normal, full } = .normal,
+    };
+
+    // Abort all tracked conns. Each kill() initiates teardown via
+    // submitRemove, which mutates in_use — the iteration captures `next`
+    // before kill() to stay safe.
+    pub fn abort(self: *Handle) void {
+        abortList(self.in_use, null, .{ .scope = .full });
+        abortList(self.ready_queue, null, .{ .scope = .full });
+
+        if (comptime builtin.mode == .Debug) {
+            // After abort, any leftover http transfers should be flagged
+            // aborted (in-callback transfers can't be deinit'd
+            // synchronously). leftover count must match counters.
+            var it = self.in_use.first;
+            var leftover: usize = 0;
+            while (it) |node| : (it = node.next) {
+                const conn: *http.Connection = @fieldParentPtr("node", node);
+                switch (conn.transport) {
+                    .http => |transfer| std.debug.assert(transfer.state == .aborted),
+                    .websocket => {},
+                    .none => {},
+                }
+                leftover += 1;
+            }
+            std.debug.assert(self.http_active + self.ws_active == leftover);
+        }
+    }
+
+    // Abort tracked conns belonging to frame_id. With .normal scope, http
+    // transfers flagged protect_from_abort are spared; .full scope kills
+    // them too. WebSockets ignore the scope flag.
+    pub fn abortFrame(self: *Handle, frame_id: u32, opts: AbortOpts) void {
+        abortList(self.in_use, frame_id, opts);
+        abortList(self.ready_queue, frame_id, opts);
+    }
+
+    fn abortList(list: std.DoublyLinkedList, frame_id: ?u32, opts: AbortOpts) void {
+        var n = list.first;
+        while (n) |node| {
+            n = node.next;
+            const conn: *http.Connection = @fieldParentPtr("node", node);
+            switch (conn.transport) {
+                .http => |transfer| {
+                    const params = transfer.req.params;
+                    if (frame_id) |fid| {
+                        if (params.frame_id == fid and (opts.scope == .full or !params.protect_from_abort)) {
+                            transfer.kill();
+                        }
+                    } else {
+                        transfer.kill();
+                    }
+                },
+                .websocket => |ws| {
+                    if (frame_id) |fid| {
+                        if (ws._frame._frame_id == fid) ws.kill();
+                    } else {
+                        ws.kill();
+                    }
+                },
+                .none => unreachable,
+            }
         }
     }
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -1312,6 +1312,10 @@ pub const Handle = struct {
         return self._wake_pipe[0];
     }
 
+    pub fn wake(self: *Handle) void {
+        _ = posix.write(self._wake_pipe[1], &.{1}) catch {};
+    }
+
     // Producer side (network thread). Stashes the err on the conn,
     // appends to the cross-thread queue and wakes the worker.
     fn pushCompletion(self: *Handle, conn: *http.Connection, err: ?anyerror) void {
@@ -1321,7 +1325,7 @@ pub const Handle = struct {
             defer self._completion_mutex.unlock();
             self._completion_queue.append(&conn.node);
         }
-        _ = posix.write(self._wake_pipe[1], &.{1}) catch {};
+        self.wake();
     }
 
     // No-op: the network thread drives the multi. Kept for API

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -48,6 +48,8 @@ const Listener = struct {
     onAccept: *const fn (ctx: *anyopaque, socket: posix.socket_t) void,
 };
 
+const Error = libcurl.Error;
+
 // Read side of a CDP WebSocket, registered with the Network thread so
 // bytes are read off the socket from here and dispatched into the CDP
 // layer via direct method calls on `cdp`. Network never sends on the
@@ -59,10 +61,10 @@ pub const CdpLink = struct {
     cdp: *CDP,
     state: State,
     socket: posix.socket_t,
-    // The worker's HttpClient.Handles (by value — it's one pointer
-    // wide). Network calls handles.wakeup() to unblock the worker
-    // from curl_multi_poll whenever it pushes to the worker's inbox.
-    handles: http.Handles,
+    // The worker's Handle (by value — it's two pointers wide).
+    // Network calls handle.wakeup() to unblock the worker from
+    // curl_multi_poll whenever it pushes to the worker's inbox.
+    handle: Handle,
     node: DoublyLinkedList.Node = .{},
 
     pub const State = enum {
@@ -424,6 +426,10 @@ pub fn deinit(self: *Network) void {
     globalDeinit();
 }
 
+pub fn getHandle(self: *Network) !Handle {
+    return try Handle.init(self);
+}
+
 pub fn bind(
     self: *Network,
     address: *net.Address,
@@ -542,7 +548,7 @@ fn dropCdp(self: *Network, link: *CdpLink, err: ?anyerror, notify: bool) void {
         // case) or are about to be unblocked via cdp_unregister.broadcast
         // (unregister case); no extra wakeup needed.
         link.cdp.onLinkDisconnect(err);
-        link.handles.wakeup() catch |e| {
+        link.handle.wakeup() catch |e| {
             lp.log.warn(.cdp, "CDP link wakeup", .{ .err = e });
         };
     }
@@ -665,7 +671,7 @@ fn processCdpEvents(self: *Network) void {
 
         // on_bytes succeeded — wake the worker so it observes anything
         // new in the inbox (data / ping / close).
-        link.handles.wakeup() catch |err| {
+        link.handle.wakeup() catch |err| {
             lp.log.warn(.cdp, "CDP link wakeup", .{ .err = err });
         };
 
@@ -982,6 +988,128 @@ pub fn newConnection(self: *Network) ?*http.Connection {
 
     return conn;
 }
+
+pub const Handle = struct {
+    multi: *libcurl.CurlM,
+    network: *Network,
+
+    // Conns whose remove was deferred because we were inside
+    // curl_multi_perform. Drained by drainDirty before the next perform.
+    dirty: std.DoublyLinkedList = .{},
+
+    pub fn init(network: *Network) !Handle {
+        const multi = libcurl.curl_multi_init() orelse return error.FailedToInitializeMulti;
+        errdefer libcurl.curl_multi_cleanup(multi) catch {};
+
+        try libcurl.curl_multi_setopt(multi, .max_host_connections, network.config.httpMaxHostOpen());
+
+        return .{ .network = network, .multi = multi };
+    }
+
+    pub fn deinit(self: *Handle) void {
+        libcurl.curl_multi_cleanup(self.multi) catch {};
+    }
+
+    pub fn add(self: *Handle, conn: *const http.Connection) !void {
+        try libcurl.curl_multi_add_handle(self.multi, conn._easy);
+    }
+
+    pub fn remove(self: *Handle, conn: *const http.Connection) !void {
+        try libcurl.curl_multi_remove_handle(self.multi, conn._easy);
+    }
+
+    pub fn perform(self: *Handle) !c_int {
+        var running: c_int = undefined;
+        try libcurl.curl_multi_perform(self.multi, &running);
+        return running;
+    }
+
+    pub fn poll(self: *Handle, extra_fds: []libcurl.CurlWaitFd, timeout_ms: c_int) !void {
+        try libcurl.curl_multi_poll(self.multi, extra_fds, timeout_ms, null);
+    }
+
+    // Thread-safe wake of a poll() in progress on this multi. Used by
+    // the Network thread to nudge the worker out of curl_multi_poll
+    // when it pushes work onto the worker's inbox.
+    pub fn wakeup(self: *Handle) !void {
+        try libcurl.curl_multi_wakeup(self.multi);
+    }
+
+    pub const MultiMessage = struct {
+        conn: *http.Connection,
+        err: ?Error,
+    };
+
+    pub fn readMessage(self: *Handle) !?MultiMessage {
+        var messages_count: c_int = 0;
+        const msg = libcurl.curl_multi_info_read(self.multi, &messages_count) orelse return null;
+        return switch (msg.data) {
+            .done => |err| {
+                var private: *anyopaque = undefined;
+                try libcurl.curl_easy_getinfo(msg.easy_handle, .private, &private);
+                return .{
+                    .conn = @ptrCast(@alignCast(private)),
+                    .err = err,
+                };
+            },
+            else => unreachable,
+        };
+    }
+
+    // connection pool delegates ----------------------------------------
+
+    pub fn getConnection(self: *Handle) ?*http.Connection {
+        return self.network.getConnection();
+    }
+
+    pub fn newConnection(self: *Handle) ?*http.Connection {
+        return self.network.newConnection();
+    }
+
+    pub fn releaseConnection(self: *Handle, conn: *http.Connection) void {
+        self.network.releaseConnection(conn);
+    }
+
+    // Cancel an active conn: remove from multi and return to pool. If
+    // we're inside curl_multi_perform (libcurl forbids remove from a
+    // callback), defer the remove via the dirty queue and let
+    // drainDirty pick it up before the next perform.
+    pub fn cancelConn(self: *Handle, conn: *http.Connection) void {
+        if (self.remove(conn)) {
+            self.releaseConnection(conn);
+        } else |_| {
+            self.dirty.append(&conn.node);
+        }
+    }
+
+    pub fn drainDirty(self: *Handle) void {
+        while (self.dirty.popFirst()) |node| {
+            const conn: *http.Connection = @fieldParentPtr("node", node);
+            self.remove(conn) catch |err| {
+                log.fatal(.http, "multi remove handle", .{ .err = err, .src = "drainDirty" });
+                @panic("multi_remove_handle");
+            };
+            self.releaseConnection(conn);
+        }
+    }
+
+    // per-conn ops on active conns -------------------------------------
+    //
+    // These wrap libcurl mutators that today run synchronously on the
+    // worker thread. The seam exists so the same call sites stay valid
+    // once the network thread owns the multi and these become
+    // cross-thread submits.
+
+    pub fn submitTlsVerify(self: *Handle, conn: *http.Connection, verify: bool, use_proxy: bool) !void {
+        _ = self;
+        try conn.setTlsVerify(verify, use_proxy);
+    }
+
+    pub fn submitUnpause(self: *Handle, conn: *http.Connection) !void {
+        _ = self;
+        try conn.pause(.{ .cont = true });
+    }
+};
 
 // Wraps lines @ 64 columns. A PEM is basically a base64 encoded DER (which is
 // what Zig has), with lines wrapped at 64 characters and with a basic header

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -959,8 +959,15 @@ fn drainQueue(self: *Network) void {
     // *under* the lock — that's what keeps the conn alive (every path
     // that releases the conn first transitions out of .in_multi here).
     // pause/setopt only flip libcurl flags, no callbacks fire.
-    var to_add: std.DoublyLinkedList = .{};
-    var to_remove: std.DoublyLinkedList = .{};
+    //
+    // We collect into ArrayList(*Connection) rather than reusing
+    // conn.node in another DoublyLinkedList: a worker submitRequest /
+    // submitRemove racing with the outside-lock loop would observe
+    // unsynchronized writes to conn.node otherwise.
+    var to_add: std.ArrayList(*http.Connection) = .empty;
+    defer to_add.deinit(self.allocator);
+    var to_remove: std.ArrayList(*http.Connection) = .empty;
+    defer to_remove.deinit(self.allocator);
     {
         self.submission_mutex.lock();
         defer self.submission_mutex.unlock();
@@ -970,14 +977,14 @@ fn drainQueue(self: *Network) void {
             lp.assert(conn._submission == .pending_remove, "drainQueue: conn not in pending_remove", .{});
             conn._submission = .idle;
             self.removeFromOpsLocked(conn);
-            to_remove.append(node);
+            to_remove.append(self.allocator, conn) catch @panic("OOM");
         }
         while (self.pending_add.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("node", node);
             lp.assert(conn._submission == .pending_add, "drainQueue: conn not in pending_add", .{});
             // .in_multi is the target; handleAdd may roll back to .idle on failure.
             conn._submission = .in_multi;
-            to_add.append(node);
+            to_add.append(self.allocator, conn) catch @panic("OOM");
         }
         while (self.pending_ops.popFirst()) |node| {
             const conn: *http.Connection = @fieldParentPtr("_op_node", node);
@@ -1005,14 +1012,8 @@ fn drainQueue(self: *Network) void {
 
     // Process removes before adds: cancellations should take effect
     // before we admit new transfers.
-    while (to_remove.popFirst()) |node| {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        self.handleRemove(conn);
-    }
-    while (to_add.popFirst()) |node| {
-        const conn: *http.Connection = @fieldParentPtr("node", node);
-        self.handleAdd(conn);
-    }
+    for (to_remove.items) |conn| self.handleRemove(conn);
+    for (to_add.items) |conn| self.handleAdd(conn);
 }
 
 // Caller has already set conn._submission = .in_multi. On failure we
@@ -1505,7 +1506,7 @@ pub const Handle = struct {
             while (it) |node| : (it = node.next) {
                 const conn: *http.Connection = @fieldParentPtr("_worker_node", node);
                 switch (conn.transport) {
-                    .http => |transfer| std.debug.assert(transfer.state == .aborted),
+                    .http => |transfer| std.debug.assert(transfer.isAborted()),
                     .websocket => {},
                     .none => {},
                 }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -271,7 +271,54 @@ pub const Connection = struct {
     _easy: *libcurl.Curl,
     in_use: bool,
     transport: Transport,
+
+    // Network-side node. Selects ownership: available pool /
+    // pending_add / pending_remove / Handle._completion_queue /
+    // Handle._drained. Mutated by the network thread under
+    // `Network.submission_mutex`, then handed off to worker via Slot.
     node: std.DoublyLinkedList.Node = .{},
+
+    // Worker-side node. Lives in Handle.in_use for the duration of a
+    // tracked submission, independent of `node`.
+    _worker_node: std.DoublyLinkedList.Node = .{},
+
+    // Network-side submission state. Transitions of `_submission` and
+    // membership in pending_add/pending_remove/Slot lists must happen
+    // together under `Network.submission_mutex`.
+    _submission: SubmissionState = .idle,
+
+    // Op channel guarded by Network.submission_mutex. The conn lives in
+    // Network.pending_ops while `_op_in_list` is true; flags below
+    // accumulate work for drainQueue to apply on the network thread.
+    _op_node: std.DoublyLinkedList.Node = .{},
+    _op_in_list: bool = false,
+    _op_unpause: bool = false,
+    _op_tls_verify: ?TlsVerifyOp = null,
+
+    // Set by trackers (HttpClient, telemetry) before submitRequest. The
+    // network thread invokes it after curl_multi_remove_handle, passing
+    // the cause; the callback then takes ownership of the conn (must
+    // eventually release it back to the pool).
+    on_complete: ?*const fn (conn: *Connection, err: ?anyerror) void = null,
+
+    // Stash for the callback to forward to the worker via Slot.
+    _completion_err: ?anyerror = null,
+
+    pub const SubmissionState = enum(u8) {
+        // Not in any submission list, not in the curl multi.
+        idle,
+        // Queued for the network thread to add to the multi.
+        pending_add,
+        // Active in the curl multi.
+        in_multi,
+        // Queued for the network thread to remove from the multi.
+        pending_remove,
+    };
+
+    pub const TlsVerifyOp = struct {
+        verify: bool,
+        use_proxy: bool,
+    };
 
     pub const Transport = union(enum) {
         none, // used for cases that manage their own connection, e.g. telemetry
@@ -418,6 +465,10 @@ pub const Connection = struct {
     ) !void {
         libcurl.curl_easy_reset(self._easy);
         self.transport = .none;
+        self.on_complete = null;
+        self._completion_err = null;
+        // _submission and _op_* fields are guarded by submission_mutex
+        // and cleared by Network on every transition to .idle.
 
         // timeouts
         try libcurl.curl_easy_setopt(self._easy, .timeout_ms, config.httpTimeout());

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -34,8 +34,6 @@ pub const readfunc_pause = libcurl.curl_readfunc_pause;
 pub const writefunc_error = libcurl.curl_writefunc_error;
 pub const WsFrameType = libcurl.WsFrameType;
 
-const Error = libcurl.Error;
-
 pub fn curl_version() [*c]const u8 {
     return libcurl.curl_version();
 }
@@ -572,85 +570,12 @@ pub const Connection = struct {
         }
     }
 
-    pub fn request(self: *const Connection, http_headers: *const Config.HttpHeaders) !u16 {
-        var header_list = try Headers.init(http_headers.user_agent_header);
-        defer header_list.deinit();
-        try self.secretHeaders(&header_list, http_headers);
-        try self.setHeaders(&header_list);
-
-        try libcurl.curl_easy_perform(self._easy);
-        return self.getResponseCode();
-    }
-
     pub fn wsStartFrame(self: *const Connection, frame_type: libcurl.WsFrameType, size: usize) !void {
         try libcurl.curl_ws_start_frame(self._easy, frame_type, @intCast(size));
     }
 
     pub fn wsMeta(self: *const Connection) ?libcurl.WsFrameMeta {
         return libcurl.curl_ws_meta(self._easy);
-    }
-};
-
-pub const Handles = struct {
-    multi: *libcurl.CurlM,
-
-    pub fn init(config: *const Config) !Handles {
-        const multi = libcurl.curl_multi_init() orelse return error.FailedToInitializeMulti;
-        errdefer libcurl.curl_multi_cleanup(multi) catch {};
-
-        try libcurl.curl_multi_setopt(multi, .max_host_connections, config.httpMaxHostOpen());
-
-        return .{ .multi = multi };
-    }
-
-    pub fn deinit(self: *Handles) void {
-        libcurl.curl_multi_cleanup(self.multi) catch {};
-    }
-
-    pub fn add(self: *Handles, conn: *const Connection) !void {
-        try libcurl.curl_multi_add_handle(self.multi, conn._easy);
-    }
-
-    pub fn remove(self: *Handles, conn: *const Connection) !void {
-        try libcurl.curl_multi_remove_handle(self.multi, conn._easy);
-    }
-
-    pub fn perform(self: *Handles) !c_int {
-        var running: c_int = undefined;
-        try libcurl.curl_multi_perform(self.multi, &running);
-        return running;
-    }
-
-    pub fn poll(self: *Handles, extra_fds: []libcurl.CurlWaitFd, timeout_ms: c_int) !void {
-        try libcurl.curl_multi_poll(self.multi, extra_fds, timeout_ms, null);
-    }
-
-    // Thread-safe wake of a poll() in progress on this multi. Used by
-    // the Network thread to nudge the worker out of curl_multi_poll
-    // when it pushes work onto the worker's inbox.
-    pub fn wakeup(self: *Handles) !void {
-        try libcurl.curl_multi_wakeup(self.multi);
-    }
-
-    pub const MultiMessage = struct {
-        conn: *Connection,
-        err: ?Error,
-    };
-
-    pub fn readMessage(self: *Handles) !?MultiMessage {
-        var messages_count: c_int = 0;
-        const msg = libcurl.curl_multi_info_read(self.multi, &messages_count) orelse return null;
-        return switch (msg.data) {
-            .done => |err| {
-                var private: *anyopaque = undefined;
-                try libcurl.curl_easy_getinfo(msg.easy_handle, .private, &private);
-                return .{
-                    .conn = @ptrCast(@alignCast(private)),
-                    .err = err,
-                };
-            },
-            else => unreachable,
-        };
     }
 };
 

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -105,7 +105,7 @@ fn postEvent(self: *LightPanda) !void {
     try conn.setBody(self.writer.written());
 
     self.head.store(h + sent, .release);
-    self.network.submitRequest(conn);
+    self.network.request(conn);
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {


### PR DESCRIPTION
This PR finally moves network requests to a shared event pool.

In serve mode, Lightpanda creates a Network object on the main thread that owns the ws listener and libcurl multi handler. A separate thread with separate CDP and Browser objects is created for each CDP connection. A Network.Handle object is created for each thread, which services the current thread's requests, passes them to the Network, and manages synchronization.

HttpClient acts as a small wrapper around Network.Handle, adding browser-specific logic (caches, robots, etc.). XMLHttpRequest/Fetch/WebSocket, in turn, wrap HttpClient in a JavaScript API.

Future changes: Currently, CDP and pages are tightly coupled to a single thread. To create multiple pages in a single connection and maintain a detachable browse context, we'll have to move CDP to the main thread (even though it's not part of Network), and leave only Browser on worker threads.

It would also be helpful to clean up the Network<->HttpClient<->Connection relationship. Currently, request state is spread across Transfer, Connection, and queues in Handles, while WebSocket depends on HttpClient (even though it only needs a Handle pointer). We need to move the libcurl logic entirely to Handles, leaving the operations in http.Connection (since not all libcurl calls are thread-safe), and move some network logic (such as redirects and buffer ownership) to Network.

```mermaid
flowchart
  Server == "spawn(handleConnection)" ==> WorkerT

  Handle == "submit*<br/>(pending_add/remove/ops)" ==> Network
  Network == "on_complete<br/>(pushCompletion)" ==> Handle

  subgraph MainT["Main thread — Network.run()"]
    Network["Network<br/>(libcurl multi, accept)"]
    Server["Server<br/>(onAccept)"]
    Network -- "accept → onAccept" --> Server
  end

  subgraph WorkerT["CDP worker thread × N"]
    CDP --> Browser
    CDP --> Handle
    Browser --> HttpClient
    HttpClient --> Handle
  end
```