### PR TITLE
Use Rust Cache in CI for `html5ever`

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -43,6 +43,9 @@ runs:
 
     # Rust Toolchain for html5ever
     - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: src/html5ever
 
     - name: Cache v8
       id: cache-v8


### PR DESCRIPTION
This adds `Swatinem/rust-cache@v2` for use in caching the `html5ever` artifacts so we don't have to always rebuild them (hopefully).