### PR TITLE
forms: normalize CR/LF to CRLF in form-data set encoding

### DIFF
--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -259,7 +259,12 @@ fn urlEncodeValueUtf8(value: []const u8, comptime mode: URLEncodeMode, writer: *
         return writer.writeAll(value);
     }
 
-    for (value) |b| {
+    var i: usize = 0;
+    while (i < value.len) : (i += 1) {
+        const b = value[i];
+        if (comptime mode == .form) {
+            if (try writeFormLineEnd(value, &i, b, writer)) continue;
+        }
         if (urlEncodeUnreserved(b, mode)) {
             try writer.writeByte(b);
         } else if (b == ' ') {
@@ -272,7 +277,12 @@ fn urlEncodeValueUtf8(value: []const u8, comptime mode: URLEncodeMode, writer: *
 
 /// Percent-encode a legacy-encoded value - must also encode & and ; to preserve NCRs.
 fn urlEncodeValueLegacy(value: []const u8, comptime mode: URLEncodeMode, writer: *std.Io.Writer) !void {
-    for (value) |b| {
+    var i: usize = 0;
+    while (i < value.len) : (i += 1) {
+        const b = value[i];
+        if (comptime mode == .form) {
+            if (try writeFormLineEnd(value, &i, b, writer)) continue;
+        }
         if (urlEncodeUnreserved(b, mode)) {
             try writer.writeByte(b);
         } else if (b == ' ') {
@@ -284,6 +294,25 @@ fn urlEncodeValueLegacy(value: []const u8, comptime mode: URLEncodeMode, writer:
             try writer.print("%{X:0>2}", .{b});
         }
     }
+}
+
+// HTML form-data set encoding algorithm: every U+000D (CR) not followed by
+// U+000A (LF), and every U+000A (LF) not preceded by U+000D (CR), is replaced
+// with the two-byte sequence CR+LF before percent-encoding. Returns true (and
+// emits "%0D%0A") when `b` is CR or LF; on CR, advances the caller's index
+// past a following LF so existing CRLF pairs aren't doubled.
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#url-encoded-form-data
+fn writeFormLineEnd(value: []const u8, i: *usize, b: u8, writer: *std.Io.Writer) !bool {
+    if (b == '\r') {
+        try writer.writeAll("%0D%0A");
+        if (i.* + 1 < value.len and value[i.* + 1] == '\n') i.* += 1;
+        return true;
+    }
+    if (b == '\n') {
+        try writer.writeAll("%0D%0A");
+        return true;
+    }
+    return false;
 }
 
 fn urlEncodeShouldEscape(value: []const u8, comptime mode: URLEncodeMode) bool {
@@ -408,4 +437,91 @@ test "KeyValueList: urlEncode Big5 unmappable character" {
 
     // &#28835; percent-encoded is %26%2328835%3B
     try testing.expectString("q=%26%2328835%3B", buf.written());
+}
+
+// HTML form-data set encoding algorithm: line endings in entry names and values
+// are normalized to CRLF — every stray LF (not preceded by CR) and every stray
+// CR (not followed by LF) is replaced with CR+LF before percent-encoding. The
+// normalization applies only to .form mode; URLSearchParams (.query) follows
+// the URL standard's serializer, which doesn't normalize.
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#url-encoded-form-data
+test "KeyValueList: urlEncode .form normalizes stray LF to CRLF" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "msg", "line1\nline2\nline3");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("msg=line1%0D%0Aline2%0D%0Aline3", buf.written());
+}
+
+test "KeyValueList: urlEncode .form normalizes stray CR to CRLF" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "msg", "line1\rline2");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("msg=line1%0D%0Aline2", buf.written());
+}
+
+test "KeyValueList: urlEncode .form preserves existing CRLF" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "msg", "line1\r\nline2");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("msg=line1%0D%0Aline2", buf.written());
+}
+
+test "KeyValueList: urlEncode .form handles mixed line endings" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    // CR LF, then bare LF, then bare CR -> three CRLF sequences.
+    try list.append(allocator, "msg", "a\r\nb\nc\rd");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("msg=a%0D%0Ab%0D%0Ac%0D%0Ad", buf.written());
+}
+
+test "KeyValueList: urlEncode .form normalizes line endings in entry names" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "n\nm", "v");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("n%0D%0Am=v", buf.written());
+}
+
+test "KeyValueList: urlEncode .form normalizes legacy charsets too" {
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "msg", "a\nb");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.form, allocator, "GBK", &buf.writer);
+
+    try testing.expectString("msg=a%0D%0Ab", buf.written());
+}
+
+test "KeyValueList: urlEncode .query does NOT normalize line endings" {
+    // URL standard's application/x-www-form-urlencoded serializer (used by
+    // URLSearchParams) does not perform CRLF normalization — only the HTML
+    // form-data set encoding wrapper does. https://url.spec.whatwg.org/#concept-urlencoded-serializer
+    const allocator = testing.arena_allocator;
+    var list = KeyValueList.init();
+    try list.append(allocator, "msg", "a\nb\rc");
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try list.urlEncode(.query, null, "UTF-8", &buf.writer);
+
+    try testing.expectString("msg=a%0Ab%0Dc", buf.written());
 }


### PR DESCRIPTION
## What

Implements the HTML form-data set encoding algorithm's CR/LF → CRLF normalization step. After this commit, a `<textarea>` field whose API value contains line feeds (per the [textarea wrapping transformation](https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element)) surfaces on the wire with `%0D%0A` separators instead of raw `%0A`. The fix covers both `application/x-www-form-urlencoded` POST bodies and the equivalent GET query-string path.

Closes #2307.

## Root cause

`KeyValueList.urlEncodeValueUtf8` and `urlEncodeValueLegacy` (`src/browser/webapi/KeyValueList.zig`) percent-encode each byte individually. CR (0x0D) and LF (0x0A) both go through the generic `%XX` branch, so a stray LF inside a textarea value emits `%0A` on the wire. The HTML form-data set encoding algorithm requires a normalization pass — every U+000A not preceded by U+000D, and every U+000D not followed by U+000A, is replaced with the two-byte CR+LF sequence before percent-encoding. The encoders skip this pass entirely.

```mermaid
flowchart LR
    A[Frame.submitForm] --> B[FormData.write urlencoded]
    B --> C[urlEncodeValueUtf8 byte-by-byte]
    C --> D[POST body msg=a%0Ab%0Ac]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/webapi/KeyValueList.zig` — new helper `writeFormLineEnd` emits `%0D%0A` for each CR or LF and advances the caller's index past a following LF when the byte was CR (so existing CRLF pairs aren't doubled).
- `src/browser/webapi/KeyValueList.zig` — `urlEncodeValueUtf8` and `urlEncodeValueLegacy` consult `writeFormLineEnd` first when `mode == .form`. URLSearchParams (`mode == .query`) is unaffected, matching the [URL standard serializer](https://url.spec.whatwg.org/#concept-urlencoded-serializer) which doesn't perform this normalization.
- The `for` byte loop becomes a `while` index loop in both encoders so the helper can swallow the LF half of a CRLF pair via `i.* += 1`.

```mermaid
flowchart LR
    A[Frame.submitForm] --> B[FormData.write urlencoded]
    B --> C[urlEncodeValueUtf8 normalizes CR/LF]
    C --> D[POST body msg=a%0D%0Ab%0D%0Ac]
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit tests** in `src/browser/webapi/KeyValueList.zig` — 7 new `test "KeyValueList: urlEncode .form ..."` blocks: stray LF, stray CR, existing CRLF preserved, mixed line endings, normalization in entry names, legacy charsets (GBK), and `.query` mode does NOT normalize. All 7 fail without the helper, all 7 pass with it. Full unit-test suite still passes (501/501).
- **End-to-end reproducer** from #2307 — a Python capture server + Node CDP driver. Against the current public nightly (`1.0.0-dev.5839+2bbf23b3`) it observes `captured body: "msg=line1%0Aline2%0Aline3"` and exits `1`. Against this branch's locally-built binary it observes `captured body: "msg=line1%0D%0Aline2%0D%0Aline3"` and exits `0`. Repro: see issue #2307.

## Notes

- The encoders are also used by `URLSearchParams.toString()` via `mode = .query`. That path is intentionally untouched: the URL standard's `application/x-www-form-urlencoded` serializer doesn't perform CR/LF normalization, only the HTML form-data set encoding wrapper does. The `.query` mode test in this PR pins that behavior.
- For `.form` mode with a legacy charset (e.g. GBK), normalization runs on the encoded bytes after the html5ever encoder pass. CR (0x0D) and LF (0x0A) round-trip identically through every charset html5ever supports, so the result matches "normalize-then-encode" byte-for-byte.
