### PR TITLE
dom: route <input type=image> click into form submission

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3648,7 +3648,11 @@ pub fn handleClick(self: *Frame, target: *Node) !void {
         },
         .input => |input| {
             try element.focus(self);
-            if (input._input_type == .submit) {
+            // Per HTML §4.10.18.6.4 "Image Button state (type=image)", clicking an
+            // image button submits its form. The form-data set already gets the
+            // submitter's coordinate fields appended via FormData.collectForm
+            // (see src/browser/webapi/net/FormData.zig).
+            if (input._input_type == .submit or input._input_type == .image) {
                 return self.submitForm(element, input.getForm(self), .{});
             }
         },

--- a/src/browser/tests/element/html/input_image_submit.html
+++ b/src/browser/tests/element/html/input_image_submit.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<form id="img-form" action="/should-not-navigate-img" method="get">
+  <input type="hidden" name="hidden_field" value="hv">
+  <input id="img-named" type="image" name="img_btn" src="x.png">
+</form>
+
+<form id="img-form-unnamed" action="/should-not-navigate-img2" method="get">
+  <input type="hidden" name="hidden_field" value="hv2">
+  <input id="img-unnamed" type="image" src="x.png">
+</form>
+
+<form id="img-form-disabled" action="/should-not-navigate-img3" method="get">
+  <input id="img-disabled" type="image" name="d" src="x.png" disabled>
+</form>
+
+<form id="img-form-prevent" action="/should-not-navigate-img4" method="get">
+  <input id="img-prevent" type="image" name="p" src="x.png">
+</form>
+
+<form id="img-form-orphan" action="/should-not-navigate-img5" method="get">
+  <input type="hidden" name="orphan_field" value="ov">
+</form>
+<input id="img-orphan" type="image" form="img-form-orphan" name="o" src="x.png">
+
+<script id="image_click_fires_submit_event">
+  {
+    const form = document.getElementById('img-form');
+    let submitFired = false;
+    let submitter = null;
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      submitFired = true;
+      submitter = e.submitter;
+    });
+    document.getElementById('img-named').click();
+    testing.expectEqual(true, submitFired);
+    testing.expectEqual(document.getElementById('img-named'), submitter);
+  }
+</script>
+
+<script id="image_submitter_appends_named_coordinate_fields">
+  {
+    // The form-data set algorithm appends "name.x" / "name.y" coordinate
+    // entries when the submitter is an image button with a name attribute.
+    // Constructing FormData directly with the submitter exercises the same
+    // path the click handler reaches via Frame.submitForm.
+    const form = document.getElementById('img-form');
+    const fd = new FormData(form, document.getElementById('img-named'));
+    testing.expectEqual('hv', fd.get('hidden_field'));
+    testing.expectEqual('0',  fd.get('img_btn.x'));
+    testing.expectEqual('0',  fd.get('img_btn.y'));
+  }
+</script>
+
+<script id="unnamed_image_submitter_appends_bare_xy_fields">
+  {
+    const form = document.getElementById('img-form-unnamed');
+    const fd = new FormData(form, document.getElementById('img-unnamed'));
+    // An unnamed image submitter contributes bare "x" and "y" entries.
+    testing.expectEqual('0',   fd.get('x'));
+    testing.expectEqual('0',   fd.get('y'));
+    testing.expectEqual('hv2', fd.get('hidden_field'));
+  }
+</script>
+
+<script id="disabled_image_click_does_not_submit">
+  {
+    const form = document.getElementById('img-form-disabled');
+    let submitFired = false;
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      submitFired = true;
+    });
+    document.getElementById('img-disabled').click();
+    testing.expectEqual(false, submitFired);
+  }
+</script>
+
+<script id="image_click_preventDefault_blocks_navigation">
+  {
+    const form = document.getElementById('img-form-prevent');
+    let submitFired = false;
+    form.addEventListener('submit', (e) => {
+      submitFired = true;
+      e.preventDefault();
+    });
+    document.getElementById('img-prevent').click();
+    // submit event fired, but preventDefault stops the actual navigation.
+    testing.expectEqual(true, submitFired);
+  }
+</script>
+
+<script id="image_with_form_attribute_submits_referenced_form">
+  {
+    const form = document.getElementById('img-form-orphan');
+    let submitFired = false;
+    let submitter = null;
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      submitFired = true;
+      submitter = e.submitter;
+    });
+    document.getElementById('img-orphan').click();
+    testing.expectEqual(true, submitFired);
+    testing.expectEqual(document.getElementById('img-orphan'), submitter);
+  }
+</script>

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -1114,6 +1114,7 @@ const testing = @import("../../../../testing.zig");
 test "WebApi: HTML.Input" {
     try testing.htmlRunner("element/html/input.html", .{});
     try testing.htmlRunner("element/html/input_click.html", .{});
+    try testing.htmlRunner("element/html/input_image_submit.html", .{});
     try testing.htmlRunner("element/html/input_radio.html", .{});
     try testing.htmlRunner("element/html/input-attrs.html", .{});
 }


### PR DESCRIPTION
## What

`<input type="image">.click()` did not submit its form because `Frame.handleClick`'s `.input` arm matched only `_input_type == .submit`. Per [HTML §4.10.18.6.4 — Image Button state](https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)), an image button is a submit button — clicking it must submit the owning form, with `name.x` / `name.y` coordinate fields appended to the form-data set.

Closes #2311.

## Root cause

`src/browser/Frame.zig:3611` — `handleClick` runs as the click event's default action and routes form-control activation. The `.input` switch arm checked for `.submit` only; `.image` fell through silently. `submitForm` (and the form-data set construction in `FormData.collectForm`) already handle image submitters correctly — the coordinate-field branch at `src/browser/webapi/net/FormData.zig:162-176` emits `name.x` / `name.y` (or bare `x` / `y` when the input is unnamed). Only the routing was missing.

```mermaid
flowchart LR
    A[imageBtn.click] --> B[handleClick switch]
    B --> C[.input arm matches only .submit]
    C --> D[no submitForm — fall through]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `handleClick`: extend the `.input` arm's predicate from `_input_type == .submit` to `_input_type == .submit or _input_type == .image`. The `submitForm` call already passes the input element as the submitter, which `FormData.collectForm` consumes to emit the coordinate fields.
- `src/browser/tests/element/html/input_image_submit.html` — new fixture: 6 sub-tests covering submit-event firing + submitter identity, FormData entries with named and unnamed image submitters, disabled-input no-op, `preventDefault` on submit, and a cross-form image button using the `form` attribute.
- `src/browser/webapi/element/html/Input.zig` — register the new fixture in the existing `WebApi: HTML.Input` runner.

```mermaid
flowchart LR
    A[imageBtn.click] --> B[handleClick switch]
    B --> C[.input matches .submit OR .image]
    C --> D[submitForm with submitter=imageBtn]
    D --> E[FormData appends name.x, name.y]
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `WebApi: HTML.Input` (subtest `input_image_submit.html`) — fails on `main` because clicking the image button never fires `submit` and `new FormData(form, imageBtn)` is the only path that exercises the coordinate-field code; passes with this commit.
- **Reproducer**: `repro.sh` from #2311 exits 1 on `main` (`after image-btn: (no nav)`) and exits 0 with this commit (`after image-btn: ?hidden_field=hv&img_btn.x=0&img_btn.y=0`). The probe directly compares `<input type=submit>.click()` (works today) against `<input type=image>.click()` (the bug).

## Notes

The coordinate values are hardcoded to `0` because `.click()` is a programmatic activation; per [HTML §4.10.18.6.4](https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)), "if the user activated the form using a pointing device, … else let x and y both be 0." A future PR could plumb real click coordinates through when the dispatcher receives them via `Input.dispatchMouseEvent`, but that's orthogonal to the routing fix here.
