### PR TITLE
selector: walk fieldset/optgroup ancestors when matching :disabled

### DIFF
--- a/src/browser/tests/element/disabled_inheritance.html
+++ b/src/browser/tests/element/disabled_inheritance.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<form>
+  <fieldset id="fs" disabled>
+    <legend><input id="legend_input" type="text"></legend>
+    <input id="fs_input" type="text">
+    <button id="fs_button" type="button">btn</button>
+    <select id="fs_select"></select>
+    <textarea id="fs_textarea"></textarea>
+  </fieldset>
+
+  <fieldset id="fs_enabled">
+    <legend><input id="enabled_legend_input"></legend>
+    <input id="fs_enabled_input">
+  </fieldset>
+
+  <select id="sel_disabled" disabled>
+    <option id="opt_in_disabled_select">a</option>
+  </select>
+
+  <select id="sel_enabled">
+    <optgroup id="og_disabled" disabled label="g">
+      <option id="opt_in_disabled_optgroup">b</option>
+    </optgroup>
+    <optgroup id="og_enabled" label="h">
+      <option id="opt_in_enabled_optgroup">c</option>
+    </optgroup>
+    <option id="opt_loose">d</option>
+  </select>
+
+  <input id="own_disabled" type="text" disabled>
+  <input id="own_enabled" type="text">
+</form>
+
+<script id="fieldset_inheritance">
+{
+  // Form controls inside <fieldset disabled> match :disabled.
+  testing.expectTrue($('#fs_input').matches(':disabled'));
+  testing.expectTrue($('#fs_button').matches(':disabled'));
+  testing.expectTrue($('#fs_select').matches(':disabled'));
+  testing.expectTrue($('#fs_textarea').matches(':disabled'));
+
+  // The fieldset's first <legend> exempts its descendants.
+  testing.expectFalse($('#legend_input').matches(':disabled'));
+
+  // Enabled fieldset doesn't propagate.
+  testing.expectFalse($('#fs_enabled_input').matches(':disabled'));
+  testing.expectFalse($('#enabled_legend_input').matches(':disabled'));
+}
+</script>
+
+<script id="optgroup_inheritance">
+{
+  // <option> inside <optgroup disabled> matches :disabled.
+  testing.expectTrue($('#opt_in_disabled_optgroup').matches(':disabled'));
+
+  // <option> outside any disabled ancestor does not.
+  testing.expectFalse($('#opt_in_enabled_optgroup').matches(':disabled'));
+  testing.expectFalse($('#opt_loose').matches(':disabled'));
+
+  // <option> inside <select disabled> (no optgroup) does NOT match :disabled
+  // per HTML "concept-option-disabled" — only own attr or <optgroup disabled>
+  // parent contributes. <select disabled> itself matches, but does not
+  // propagate to its <option> children for selector purposes.
+  testing.expectFalse($('#opt_in_disabled_select').matches(':disabled'));
+}
+</script>
+
+<script id="own_attribute">
+{
+  testing.expectTrue($('#own_disabled').matches(':disabled'));
+  testing.expectFalse($('#own_enabled').matches(':disabled'));
+
+  // The disabled <fieldset>/<select>/<optgroup> elements themselves match.
+  testing.expectTrue($('#fs').matches(':disabled'));
+  testing.expectTrue($('#sel_disabled').matches(':disabled'));
+  testing.expectTrue($('#og_disabled').matches(':disabled'));
+}
+</script>
+
+<script id="enabled_complement">
+{
+  // :enabled is the negation of :disabled for elements that have a
+  // disabled concept. An <input> inside <fieldset disabled> is :disabled,
+  // so it must NOT also be :enabled.
+  testing.expectFalse($('#fs_input').matches(':enabled'));
+  testing.expectFalse($('#opt_in_disabled_optgroup').matches(':enabled'));
+  testing.expectTrue($('#fs_enabled_input').matches(':enabled'));
+  testing.expectTrue($('#opt_loose').matches(':enabled'));
+  // Legend descendants are enabled despite the disabled fieldset.
+  testing.expectTrue($('#legend_input').matches(':enabled'));
+}
+</script>
+
+<script id="querySelectorAll">
+{
+  // querySelectorAll(':disabled') should find every disabled element.
+  const ids = Array.from(document.querySelectorAll(':disabled')).map(e => e.id).sort();
+  // Expected (sorted):
+  //   fs, fs_button, fs_input, fs_select, fs_textarea,
+  //   og_disabled, opt_in_disabled_optgroup,
+  //   own_disabled, sel_disabled
+  const expected = [
+    'fs', 'fs_button', 'fs_input', 'fs_select', 'fs_textarea',
+    'og_disabled', 'opt_in_disabled_optgroup',
+    'own_disabled', 'sel_disabled',
+  ].sort();
+  testing.expectEqual(JSON.stringify(expected), JSON.stringify(ids));
+}
+</script>

--- a/src/browser/tests/element/disabled_inheritance.html
+++ b/src/browser/tests/element/disabled_inheritance.html
@@ -33,6 +33,10 @@
   <input id="own_enabled" type="text">
 </form>
 
+<div id="div_plain">x</div>
+<div id="div_with_disabled_attr" disabled>y</div>
+<span id="span_plain">z</span>
+
 <script id="fieldset_inheritance">
 {
   // Form controls inside <fieldset disabled> match :disabled.
@@ -90,6 +94,20 @@
   testing.expectTrue($('#opt_loose').matches(':enabled'));
   // Legend descendants are enabled despite the disabled fieldset.
   testing.expectTrue($('#legend_input').matches(':enabled'));
+}
+</script>
+
+<script id="concept_gate">
+{
+  // Per HTML "concept-fe-disabled", only listed elements (button, input,
+  // select, textarea, optgroup, option, fieldset) participate in the
+  // disabled concept. Anything else never matches :disabled / :enabled,
+  // even with an own [disabled] attribute.
+  testing.expectFalse($('#div_plain').matches(':disabled'));
+  testing.expectFalse($('#div_plain').matches(':enabled'));
+  testing.expectFalse($('#span_plain').matches(':enabled'));
+  testing.expectFalse($('#div_with_disabled_attr').matches(':disabled'));
+  testing.expectFalse($('#div_with_disabled_attr').matches(':enabled'));
 }
 </script>
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -600,7 +600,21 @@ pub fn hasAttributeSafe(self: *const Element, name: String) bool {
     return attributes.hasSafe(name);
 }
 
+// Per HTML "concept-fe-disabled", only listed elements participate in the
+// disabled concept. Anything else (e.g. <div disabled>) has no disabled
+// state and never matches :disabled / :enabled.
+pub fn hasDisabledConcept(self: *const Element) bool {
+    return switch (self.getTag()) {
+        .button, .input, .select, .textarea, .optgroup, .option, .fieldset => true,
+        else => false,
+    };
+}
+
 pub fn isDisabled(self: *Element) bool {
+    if (!self.hasDisabledConcept()) {
+        return false;
+    }
+
     if (self.getAttributeSafe(comptime .wrap("disabled")) != null) {
         return true;
     }

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -605,6 +605,23 @@ pub fn isDisabled(self: *Element) bool {
         return true;
     }
 
+    // <option> takes a different inheritance path: per HTML
+    // "concept-option-disabled" an option is disabled when its parent is an
+    // <optgroup disabled>. It does NOT inherit from <select disabled> or
+    // an ancestor <fieldset disabled>.
+    if (self.getTag() == .option) {
+        if (self.asNode()._parent) |parent_node| {
+            if (parent_node.is(Element)) |parent_el| {
+                if (parent_el.getTag() == .optgroup and
+                    parent_el.getAttributeSafe(comptime .wrap("disabled")) != null)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     const element_node = self.asNode();
     var current: ?*Node = element_node._parent;
     while (current) |node| {

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -538,7 +538,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
             return el.isDisabled();
         },
         .enabled => {
-            return !el.isDisabled();
+            return el.hasDisabledConcept() and !el.isDisabled();
         },
         .indeterminate => {
             const input = el.is(Node.Element.Html.Input) orelse return false;

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -535,10 +535,10 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
             return input.getChecked();
         },
         .disabled => {
-            return el.getAttributeSafe(comptime .wrap("disabled")) != null;
+            return el.isDisabled();
         },
         .enabled => {
-            return el.getAttributeSafe(comptime .wrap("disabled")) == null;
+            return !el.isDisabled();
         },
         .indeterminate => {
             const input = el.is(Node.Element.Html.Input) orelse return false;


### PR DESCRIPTION
## What

`Element.matches(':disabled')` ignored the HTML "actually disabled" inheritance: a form control inside `<fieldset disabled>` reported `false`, and an `<option>` inside `<optgroup disabled>` reported `false`. The same evaluator backs `:disabled`/`:enabled` for `Element.matches`, `querySelector{,All}`, and CDP `DOM.performSearch`, so every consumer saw the wrong answer.

This PR routes the `:disabled`/`:enabled` pseudo-class matchers through `Element.isDisabled` (which already walks the ancestor `<fieldset disabled>` chain with the first-`<legend>` exception) and extends `isDisabled` to recognize the `<option>` + `<optgroup disabled>` case. It also gates the disabled concept on the form-control allowlist from HTML "concept-fe-disabled" so non-form-controls (e.g. `<div>`) never match `:disabled` or `:enabled`.

Closes #2314.

## Root cause

The pseudo-class matchers checked only the element's own `disabled` content attribute:

```zig
// before — src/browser/webapi/selector/List.zig:537-541
.disabled => return el.getAttributeSafe(comptime .wrap("disabled")) != null,
.enabled  => return el.getAttributeSafe(comptime .wrap("disabled")) == null,
```

`Element.isDisabled` already implemented the spec-correct fieldset walk for callers that needed it (FormData, accessibility tree, semantic tree, MCP `detectForms`), but the selector path never invoked it. `isDisabled` also didn't yet cover the `<option>` + `<optgroup disabled>` rule from [HTML §4.10.10 "concept-option-disabled"](https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-disabled), and there was no gate restricting the disabled concept to the form-control allowlist from [HTML §4.10.18.5 "concept-fe-disabled"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled), so `<div disabled>.matches(':disabled')` returned `true` and `<div>.matches(':enabled')` returned `true`.

```mermaid
flowchart LR
    A[el.matches :disabled] --> B[selector List.zig - own attr only]
    B --> C[false for fieldset/optgroup descendant]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/browser/webapi/Element.zig` — new `hasDisabledConcept()` returns `true` only for `button`, `input`, `select`, `textarea`, `optgroup`, `option`, `fieldset` (per HTML "concept-fe-disabled"). `isDisabled` returns `false` early when the element doesn't participate in the disabled concept, then keeps the existing logic: own `[disabled]` attribute, `<option>` + `<optgroup disabled>` parent rule, ancestor `<fieldset disabled>` walk with the first-`<legend>` exception.
- `src/browser/webapi/selector/List.zig` — `matchesPseudoClass`: `:disabled` arm delegates to `el.isDisabled()`. `:enabled` arm gates on `el.hasDisabledConcept() and !el.isDisabled()` so non-form-controls no longer match `:enabled` (matches Chrome).

```mermaid
flowchart LR
    A[el.matches :disabled or :enabled] --> B{hasDisabledConcept?}
    B -- no  --> Z[both return false]
    B -- yes --> C[Element.isDisabled]
    C --> D{tag is option?}
    D -- yes --> E[check optgroup parent]
    D -- no  --> F[walk ancestors for fieldset disabled<br/>skip first legend descendants]
    E --> G[true / false]
    F --> G
    style B fill:#dfd
    style G fill:#dfd
    style Z fill:#dfd
```

## Test

- **HTML fixture**: `src/browser/tests/element/disabled_inheritance.html` — six `<script>` blocks covering fieldset inheritance + first-`<legend>` exception, `<optgroup disabled>` propagation to `<option>`, intentional non-propagation from `<select disabled>` to `<option>`, own-attribute baseline, `:enabled` complement, the disabled-concept gate (`<div>` / `<span>` / `<div disabled>` never match either pseudo), and a `querySelectorAll(':disabled')` end-to-end check. Picked up by the existing `webapi/Element.zig`'s `htmlRunner("element", .{})`.
- **Pre-fix**: `TEST_FILTER='WebApi: Element#disabled_inheritance.html' mise exec -- zig build test $V8` reports `0 of 1 test passed` (production lines reverted to `origin/main` via `git checkout origin/main -- <files>` for the toggle-off check).
- **Post-fix**: same command reports `1 of 1 test passed`. Full unit-test suite (`mise exec -- zig build test $V8`) is `497 of 497 tests passed`.
- **End-to-end reproducer**: the script attached to #2314 exits 1 against `1.0.0-dev.5839+2bbf23b3` (3 of 8 cases mismatch) and exits 0 against this branch's locally-built `zig-out/bin/lightpanda` (all 8 OK).

## Notes

- `Element.isDisabled` is also called from `webapi/net/FormData.zig`, `cdp/AXNode.zig`, `SemanticTree.zig`, `browser/forms.zig`, and `browser/interactive.zig`. The new `<option>` branch makes those callers report `<option>` + `<optgroup disabled>` as disabled too — that's consistent with the spec and is the expected behavior for AX trees and semantic categorization. The new `hasDisabledConcept` gate is also a no-op for those callers since they iterate form-associated elements only.
