### PR TITLE
Make Fetch and XHR usable from Worker

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2823,6 +2823,10 @@ pub fn dispatch(
     return self._event_manager.dispatchDirect(target, event, handler, opts);
 }
 
+pub fn hasDirectListeners(self: *Frame, target: *EventTarget, typ: []const u8, handler: anytype) bool {
+    return self._event_manager.hasDirectListeners(target, typ, handler);
+}
+
 pub fn dupeSSO(self: *Frame, value: []const u8) !String {
     return String.init(self.arena, value, .{ .dupe = true });
 }

--- a/src/browser/js/Execution.zig
+++ b/src/browser/js/Execution.zig
@@ -31,6 +31,12 @@ const lp = @import("lightpanda");
 const Context = @import("Context.zig");
 const Scheduler = @import("Scheduler.zig");
 const Factory = @import("../Factory.zig");
+const HttpClient = @import("../HttpClient.zig");
+const EventManagerBase = @import("../EventManagerBase.zig");
+
+const Blob = @import("../webapi/Blob.zig");
+const Event = @import("../webapi/Event.zig");
+const EventTarget = @import("../webapi/EventTarget.zig");
 
 const String = lp.String;
 const Allocator = std.mem.Allocator;
@@ -62,4 +68,60 @@ pub fn dupeString(self: *const Execution, value: []const u8) ![]const u8 {
         return v;
     }
     return self.arena.dupe(u8, value);
+}
+
+pub fn getArena(self: *const Execution, size_or_bucket: anytype, debug: []const u8) !Allocator {
+    return self.context.page.getArena(size_or_bucket, debug);
+}
+
+pub fn releaseArena(self: *const Execution, allocator: Allocator) void {
+    self.context.page.releaseArena(allocator);
+}
+
+pub fn headersForRequest(self: *const Execution, headers: *HttpClient.Headers) !void {
+    return switch (self.context.global) {
+        inline else => |g| g.headersForRequest(headers),
+    };
+}
+
+pub fn isSameOrigin(self: *const Execution, url: [:0]const u8) bool {
+    return switch (self.context.global) {
+        inline else => |g| g.isSameOrigin(url),
+    };
+}
+
+pub fn lookupBlobUrl(self: *const Execution, url: []const u8) ?*Blob {
+    return switch (self.context.global) {
+        inline else => |g| g.lookupBlobUrl(url),
+    };
+}
+
+pub fn dispatch(
+    self: *const Execution,
+    target: *EventTarget,
+    event: *Event,
+    handler: anytype,
+    comptime opts: EventManagerBase.DispatchDirectOptions,
+) !void {
+    return switch (self.context.global) {
+        inline else => |g| g.dispatch(target, event, handler, opts),
+    };
+}
+
+pub fn hasDirectListeners(self: *const Execution, target: *EventTarget, typ: []const u8, handler: anytype) bool {
+    return switch (self.context.global) {
+        inline else => |g| g.hasDirectListeners(target, typ, handler),
+    };
+}
+
+pub fn frameId(self: *const Execution) u32 {
+    return switch (self.context.global) {
+        inline else => |g| g._frame_id,
+    };
+}
+
+pub fn loaderId(self: *const Execution) u32 {
+    return switch (self.context.global) {
+        inline else => |g| g._loader_id,
+    };
 }

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -966,6 +966,9 @@ pub const WorkerJsApis = flattenTypes(&.{
     @import("../webapi/AbortController.zig"),
     @import("../webapi/URL.zig"),
     @import("../webapi/canvas/OffscreenCanvas.zig"),
+    @import("../webapi/net/XMLHttpRequest.zig"),
+    @import("../webapi/net/XMLHttpRequestEventTarget.zig"),
+    @import("../webapi/FileReader.zig"),
     // @import("../webapi/Performance.zig"),
 });
 

--- a/src/browser/tests/net/fetch-worker.js
+++ b/src/browser/tests/net/fetch-worker.js
@@ -1,0 +1,50 @@
+// Exercises fetch() inside a worker. Receives a command from the page,
+// performs the fetch, and posts the results back.
+self.onmessage = async function(e) {
+  const cmd = e.data;
+  try {
+    if (cmd.kind === 'basic') {
+      const response = await fetch('http://127.0.0.1:9582/xhr');
+      const text = await response.text();
+      postMessage({
+        ok: true,
+        status: response.status,
+        url: response.url,
+        type: response.type,
+        content_type: response.headers.get('Content-Type'),
+        length: text.length,
+      });
+      return;
+    }
+
+    if (cmd.kind === 'post') {
+      const response = await fetch('http://127.0.0.1:9582/xhr', {
+        method: 'POST',
+        body: 'hello-from-worker',
+      });
+      const text = await response.text();
+      postMessage({ ok: true, status: response.status, length: text.length });
+      return;
+    }
+
+    if (cmd.kind === 'blob') {
+      const blob = new Blob(['Hello from worker blob!'], { type: 'text/plain' });
+      const blobUrl = URL.createObjectURL(blob);
+      const response = await fetch(blobUrl);
+      const text = await response.text();
+      URL.revokeObjectURL(blobUrl);
+      postMessage({
+        ok: true,
+        status: response.status,
+        url_matches: response.url === blobUrl,
+        content_type: response.headers.get('Content-Type'),
+        text,
+      });
+      return;
+    }
+
+    postMessage({ ok: false, err: 'unknown command' });
+  } catch (err) {
+    postMessage({ ok: false, err: String(err), stack: err.stack });
+  }
+};

--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -280,3 +280,53 @@
     }
   }
 </script>
+
+<script id=fetch_in_worker type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./fetch-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'basic' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker fetch error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', data.url);
+      testing.expectEqual('basic', data.type);
+      testing.expectEqual('text/html; charset=utf-8', data.content_type);
+      testing.expectEqual(100, data.length);
+    });
+  }
+</script>
+
+<script id=fetch_post_in_worker type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./fetch-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'post' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker fetch error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual(true, data.length > 64);
+    });
+  }
+</script>
+
+<script id=fetch_blob_url_in_worker type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./fetch-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'blob' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker fetch error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual(true, data.url_matches);
+      testing.expectEqual('text/plain', data.content_type);
+      testing.expectEqual('Hello from worker blob!', data.text);
+    });
+  }
+</script>

--- a/src/browser/tests/net/xhr-worker.js
+++ b/src/browser/tests/net/xhr-worker.js
@@ -1,0 +1,74 @@
+// Exercises XMLHttpRequest inside a worker. Receives a command from the page,
+// performs the XHR, and posts the results back.
+self.onmessage = function(e) {
+  const cmd = e.data;
+  try {
+    if (cmd.kind === 'basic') {
+      const req = new XMLHttpRequest();
+      const states = [];
+      req.onreadystatechange = () => states.push(req.readyState);
+      req.onload = () => {
+        postMessage({
+          ok: true,
+          status: req.status,
+          status_text: req.statusText,
+          response_url: req.responseURL,
+          response_text_length: req.responseText.length,
+          content_type: req.getResponseHeader('Content-Type'),
+          states,
+        });
+      };
+      req.onerror = () => postMessage({ ok: false, err: 'xhr error', status: req.status });
+      req.open('GET', 'http://127.0.0.1:9582/xhr');
+      req.send();
+      return;
+    }
+
+    if (cmd.kind === 'arraybuffer') {
+      const req = new XMLHttpRequest();
+      req.responseType = 'arraybuffer';
+      req.onload = () => {
+        const view = new Uint8Array(req.response);
+        postMessage({
+          ok: true,
+          status: req.status,
+          byte_length: req.response.byteLength,
+          first: view[0],
+          third: view[2],
+          last: view[6],
+          response_type: req.responseType,
+        });
+      };
+      req.onerror = () => postMessage({ ok: false, err: 'xhr error', status: req.status });
+      req.open('GET', 'http://127.0.0.1:9582/xhr/binary');
+      req.send();
+      return;
+    }
+
+    if (cmd.kind === 'document_unsupported') {
+      const req = new XMLHttpRequest();
+      req.responseType = 'document';
+      req.onload = () => {
+        let threw = false;
+        let err = null;
+        try {
+          // Reading .response in worker context with responseType=document
+          // must error: workers have no DOM document.
+          void req.response;
+        } catch (e) {
+          threw = true;
+          err = String(e);
+        }
+        postMessage({ ok: true, status: req.status, threw, err });
+      };
+      req.onerror = () => postMessage({ ok: false, err: 'xhr error', status: req.status });
+      req.open('GET', 'http://127.0.0.1:9582/xhr');
+      req.send();
+      return;
+    }
+
+    postMessage({ ok: false, err: 'unknown command' });
+  } catch (err) {
+    postMessage({ ok: false, err: String(err), stack: err.stack });
+  }
+};

--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -333,3 +333,60 @@
     });
   }
 </script>
+
+<script id=xhr_in_worker type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./xhr-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'basic' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker xhr error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual('OK', data.status_text);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', data.response_url);
+      testing.expectEqual(100, data.response_text_length);
+      testing.expectEqual('text/html; charset=utf-8', data.content_type);
+      testing.expectEqual(4, data.states.length);
+      testing.expectEqual(1, data.states[0]);
+      testing.expectEqual(2, data.states[1]);
+      testing.expectEqual(3, data.states[2]);
+      testing.expectEqual(4, data.states[3]);
+    });
+  }
+</script>
+
+<script id=xhr_arraybuffer_in_worker type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./xhr-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'arraybuffer' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker xhr error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual(7, data.byte_length);
+      testing.expectEqual(0, data.first);
+      testing.expectEqual(1, data.third);
+      testing.expectEqual(9, data.last);
+      testing.expectEqual('arraybuffer', data.response_type);
+    });
+  }
+</script>
+
+<script id=xhr_document_in_worker_unsupported type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./xhr-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'document_unsupported' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker xhr error: ' + data.err);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual(true, data.threw);
+    });
+  }
+</script>

--- a/src/browser/webapi/FileReader.zig
+++ b/src/browser/webapi/FileReader.zig
@@ -27,6 +27,7 @@ const EventTarget = @import("EventTarget.zig");
 const ProgressEvent = @import("event/ProgressEvent.zig");
 const Blob = @import("Blob.zig");
 
+const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 
 /// https://w3c.github.io/FileAPI/#dfn-filereader
@@ -34,7 +35,7 @@ const Allocator = std.mem.Allocator;
 const FileReader = @This();
 
 _rc: lp.RC(u8) = .{},
-_frame: *Frame,
+_exec: *Execution,
 _proto: *EventTarget,
 _arena: Allocator,
 
@@ -63,12 +64,12 @@ const Result = union(enum) {
     arraybuffer: js.ArrayBuffer,
 };
 
-pub fn init(frame: *Frame) !*FileReader {
-    const arena = try frame.getArena(.tiny, "FileReader");
-    errdefer frame.releaseArena(arena);
+pub fn init(exec: *Execution) !*FileReader {
+    const arena = try exec.getArena(.tiny, "FileReader");
+    errdefer exec.releaseArena(arena);
 
-    return frame._factory.eventTargetWithAllocator(arena, FileReader{
-        ._frame = frame,
+    return exec._factory.eventTargetWithAllocator(arena, FileReader{
+        ._exec = exec,
         ._arena = arena,
         ._proto = undefined,
     });
@@ -192,9 +193,9 @@ fn readInternal(self: *FileReader, blob: *Blob, read_type: ReadType) !void {
     self._error = null;
     self._aborted = false;
 
-    const frame = self._frame;
+    const exec = self._exec;
 
-    try self.dispatch(.load_start, .{ .loaded = 0, .total = blob.getSize() }, frame);
+    try self.dispatch(.load_start, .{ .loaded = 0, .total = blob.getSize() }, exec);
     if (self._aborted) {
         return;
     }
@@ -202,7 +203,7 @@ fn readInternal(self: *FileReader, blob: *Blob, read_type: ReadType) !void {
     // Perform the read (synchronous since data is in memory)
     const data = blob._slice;
     const size = data.len;
-    try self.dispatch(.progress, .{ .loaded = size, .total = size }, frame);
+    try self.dispatch(.progress, .{ .loaded = size, .total = size }, exec);
     if (self._aborted) {
         return;
     }
@@ -222,8 +223,8 @@ fn readInternal(self: *FileReader, blob: *Blob, read_type: ReadType) !void {
 
     self._ready_state = .done;
 
-    try self.dispatch(.load, .{ .loaded = size, .total = size }, frame);
-    try self.dispatch(.load_end, .{ .loaded = size, .total = size }, frame);
+    try self.dispatch(.load, .{ .loaded = size, .total = size }, exec);
+    try self.dispatch(.load_end, .{ .loaded = size, .total = size }, exec);
 }
 
 pub fn abort(self: *FileReader) !void {
@@ -235,14 +236,12 @@ pub fn abort(self: *FileReader) !void {
     self._ready_state = .done;
     self._result = null;
 
-    const frame = self._frame;
-
-    try self.dispatch(.abort, null, frame);
-
-    try self.dispatch(.load_end, null, frame);
+    const exec = self._exec;
+    try self.dispatch(.abort, null, exec);
+    try self.dispatch(.load_end, null, exec);
 }
 
-fn dispatch(self: *FileReader, comptime event_type: DispatchType, progress_: ?Progress, frame: *Frame) !void {
+fn dispatch(self: *FileReader, comptime event_type: DispatchType, progress_: ?Progress, exec: *Execution) !void {
     const field, const typ = comptime blk: {
         break :blk switch (event_type) {
             .abort => .{ "_on_abort", "abort" },
@@ -258,10 +257,10 @@ fn dispatch(self: *FileReader, comptime event_type: DispatchType, progress_: ?Pr
     const event = (try ProgressEvent.initTrusted(
         comptime .wrap(typ),
         .{ .total = progress.total, .loaded = progress.loaded },
-        frame,
+        exec.context.page,
     )).asEvent();
 
-    return frame._event_manager.dispatchDirect(
+    return exec.dispatch(
         self.asEventTarget(),
         event,
         @field(self, field),

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -282,8 +282,8 @@ pub fn setOnUnhandledRejection(self: *Window, setter: ?FunctionSetter) void {
     self._on_unhandled_rejection = getFunctionFromSetter(setter);
 }
 
-pub fn fetch(_: *const Window, input: Fetch.Input, options: ?Fetch.InitOpts, frame: *Frame) !js.Promise {
-    return Fetch.init(input, options, frame);
+pub fn fetch(_: *const Window, input: Fetch.Input, options: ?Fetch.InitOpts, exec: *const js.Execution) !js.Promise {
+    return Fetch.init(input, options, exec);
 }
 
 const LegacyHandler = union(enum) {

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -68,7 +68,7 @@ pub fn init(url: []const u8, exec: *Execution) !*Worker {
     const arena = try session.getArena(.large, "Worker");
     errdefer session.releaseArena(arena);
 
-    const resolved_url = try URL.resolve(arena, exec.url.*, url, .{});
+    const resolved_url = try URL.resolve(arena, exec.url.*, url, .{ .encoding = frame.charset });
     const self = try frame._page.factory.eventTargetWithAllocator(arena, Worker{
         ._arena = arena,
         ._proto = undefined,

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -24,9 +24,11 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const JS = @import("../js/js.zig");
+const URL = @import("../URL.zig");
 const Page = @import("../Page.zig");
 const Factory = @import("../Factory.zig");
 const Session = @import("../Session.zig");
+const HttpClient = @import("../HttpClient.zig");
 const EventManagerBase = @import("../EventManagerBase.zig");
 const ScriptManagerBase = @import("../ScriptManagerBase.zig");
 
@@ -37,6 +39,7 @@ const Console = @import("Console.zig");
 const EventTarget = @import("EventTarget.zig");
 const MessageEvent = @import("event/MessageEvent.zig");
 const ErrorEvent = @import("event/ErrorEvent.zig");
+const Fetch = @import("net/Fetch.zig");
 
 const builtin = @import("builtin");
 const IS_DEBUG = builtin.mode == .Debug;
@@ -49,8 +52,8 @@ const WorkerGlobalScope = @This();
 // Meant to follow the same field naming as Page so that an anytype of generic
 // can access these the same for a Page of a WGS.
 // These fields represent the "Page"-like component of the WGS
-_session: *Session,
 _page: *Page,
+_session: *Session,
 _factory: *Factory,
 _identity: JS.Identity = .{},
 arena: Allocator,
@@ -68,6 +71,12 @@ _blob_urls: std.StringHashMapUnmanaged(*Blob) = .{},
 
 // Reference back to the Worker object (for postMessage to frame)
 _worker: *Worker,
+
+// HTTP attribution. Mirrors Frame's fields so that generic code over
+// (Frame|WorkerGlobalScope) can read them uniformly. Populated from the
+// owning Worker at init.
+_frame_id: u32,
+_loader_id: u32,
 
 // Event management for non-DOM targets in worker context
 _event_manager: EventManagerBase,
@@ -108,6 +117,8 @@ pub fn init(worker: *Worker, url: [:0]const u8) !*WorkerGlobalScope {
         ._proto = undefined,
         ._factory = factory,
         ._worker = worker,
+        ._frame_id = worker._frame_id,
+        ._loader_id = worker._loader_id,
         ._event_manager = .init(arena),
         ._script_manager = undefined,
     });
@@ -168,6 +179,29 @@ pub fn dispatch(
         self._page,
         opts,
     );
+}
+
+pub fn hasDirectListeners(self: *WorkerGlobalScope, target: *EventTarget, typ: []const u8, handler: anytype) bool {
+    return self._event_manager.hasDirectListeners(target, typ, handler);
+}
+
+// Workers don't have their own Referer; per spec, dedicated worker requests
+// use the parent document's URL. Delegate to the owning frame.
+pub fn headersForRequest(self: *WorkerGlobalScope, headers: *HttpClient.Headers) !void {
+    return self._worker._frame.headersForRequest(headers);
+}
+
+pub fn isSameOrigin(self: *const WorkerGlobalScope, url: [:0]const u8) bool {
+    const current_origin = self.origin orelse return false;
+
+    if (!std.mem.startsWith(u8, url, current_origin)) {
+        return false;
+    }
+    return std.mem.eql(u8, URL.getHost(url), URL.getHost(current_origin));
+}
+
+pub fn lookupBlobUrl(self: *WorkerGlobalScope, url: []const u8) ?*Blob {
+    return self._blob_urls.get(url);
 }
 
 pub fn getSelf(self: *WorkerGlobalScope) *WorkerGlobalScope {
@@ -359,6 +393,10 @@ pub fn reportError(self: *WorkerGlobalScope, err: JS.Value) !void {
     }
 }
 
+pub fn fetch(_: *const WorkerGlobalScope, input: Fetch.Input, options: ?Fetch.InitOpts, exec: *const JS.Execution) !JS.Promise {
+    return Fetch.init(input, options, exec);
+}
+
 // TODO: importScripts - needs script loading infrastructure
 // TODO: location - needs WorkerLocation
 // TODO: navigator - needs WorkerNavigator
@@ -454,6 +492,7 @@ pub const JsApi = struct {
     pub const postMessage = bridge.function(WorkerGlobalScope.postMessage, .{});
     pub const reportError = bridge.function(WorkerGlobalScope.reportError, .{});
     pub const close = bridge.function(WorkerGlobalScope.close, .{});
+    pub const fetch = bridge.function(WorkerGlobalScope.fetch, .{});
 
     pub const onmessage = bridge.accessor(WorkerGlobalScope.getOnMessage, WorkerGlobalScope.setOnMessage, .{});
     pub const onmessageerror = bridge.accessor(WorkerGlobalScope.getOnMessageError, WorkerGlobalScope.setOnMessageError, .{});

--- a/src/browser/webapi/event/ProgressEvent.zig
+++ b/src/browser/webapi/event/ProgressEvent.zig
@@ -19,7 +19,7 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
-const Frame = @import("../../Frame.zig");
+const Page = @import("../../Page.zig");
 const Event = @import("../Event.zig");
 
 const String = lp.String;
@@ -39,23 +39,23 @@ const ProgressEventOptions = struct {
 
 const Options = Event.inheritOptions(ProgressEvent, ProgressEventOptions);
 
-pub fn init(typ: []const u8, _opts: ?Options, frame: *Frame) !*ProgressEvent {
-    const arena = try frame.getArena(.tiny, "ProgressEvent");
-    errdefer frame.releaseArena(arena);
+pub fn init(typ: []const u8, _opts: ?Options, page: *Page) !*ProgressEvent {
+    const arena = try page.getArena(.tiny, "ProgressEvent");
+    errdefer page.releaseArena(arena);
     const type_string = try String.init(arena, typ, .{});
-    return initWithTrusted(arena, type_string, _opts, false, frame);
+    return initWithTrusted(arena, type_string, _opts, false, page);
 }
 
-pub fn initTrusted(typ: String, _opts: ?Options, frame: *Frame) !*ProgressEvent {
-    const arena = try frame.getArena(.tiny, "ProgressEvent.trusted");
-    errdefer frame.releaseArena(arena);
-    return initWithTrusted(arena, typ, _opts, true, frame);
+pub fn initTrusted(typ: String, _opts: ?Options, page: *Page) !*ProgressEvent {
+    const arena = try page.getArena(.tiny, "ProgressEvent.trusted");
+    errdefer page.releaseArena(arena);
+    return initWithTrusted(arena, typ, _opts, true, page);
 }
 
-fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool, frame: *Frame) !*ProgressEvent {
+fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool, page: *Page) !*ProgressEvent {
     const opts = _opts orelse Options{};
 
-    const event = try frame._factory.event(
+    const event = try page.factory.event(
         arena,
         typ,
         ProgressEvent{

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -21,7 +21,7 @@ const lp = @import("lightpanda");
 const HttpClient = @import("../../HttpClient.zig");
 
 const js = @import("../../js/js.zig");
-const Frame = @import("../../Frame.zig");
+const Page = @import("../../Page.zig");
 const URL = @import("../../URL.zig");
 
 const Blob = @import("../Blob.zig");
@@ -31,11 +31,12 @@ const AbortSignal = @import("../AbortSignal.zig");
 const DOMException = @import("../DOMException.zig");
 
 const log = lp.log;
+const Execution = js.Execution;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Fetch = @This();
 
-_frame: *Frame,
+_exec: *const Execution,
 _url: []const u8,
 _buf: std.ArrayList(u8),
 _response: *Response,
@@ -46,9 +47,9 @@ _signal: ?*AbortSignal,
 pub const Input = Request.Input;
 pub const InitOpts = Request.InitOpts;
 
-pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
-    const request = try Request.init(input, options, &frame.js.execution);
-    const resolver = frame.js.local.?.createPromiseResolver();
+pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promise {
+    const request = try Request.init(input, options, exec);
+    const resolver = exec.context.local.?.createPromiseResolver();
 
     if (request._signal) |signal| {
         if (signal._aborted) {
@@ -58,15 +59,15 @@ pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
     }
 
     if (std.mem.startsWith(u8, request._url, "blob:")) {
-        return handleBlobUrl(request._url, resolver, frame);
+        return handleBlobUrl(request._url, resolver, exec);
     }
 
-    const response = try Response.init(null, .{ .status = 0 }, &frame.js.execution);
-    errdefer response.deinit(frame._page);
+    const response = try Response.init(null, .{ .status = 0 }, exec);
+    errdefer response.deinit(exec.context.page);
 
     const fetch = try response._arena.create(Fetch);
     fetch.* = .{
-        ._frame = frame,
+        ._exec = exec,
         ._buf = .empty,
         ._url = try response._arena.dupe(u8, request._url),
         ._resolver = try resolver.persist(),
@@ -75,12 +76,13 @@ pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
         ._signal = request._signal,
     };
 
-    const http_client = frame._session.browser.http_client;
+    const session = exec.context.page.session;
+    const http_client = session.browser.http_client;
     var headers = try http_client.newHeaders();
     if (request._headers) |h| {
-        try h.populateHttpHeader(frame.call_arena, &headers);
+        try h.populateHttpHeader(exec.call_arena, &headers);
     }
-    try frame.headersForRequest(&headers);
+    try exec.headersForRequest(&headers);
 
     if (comptime IS_DEBUG) {
         log.debug(.http, "fetch", .{ .url = request._url });
@@ -88,8 +90,8 @@ pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
 
     const cookie_jar = switch (request._credentials) {
         .omit => null,
-        .include => &frame._session.cookie_jar,
-        .@"same-origin" => if (frame.isSameOrigin(request._url)) &frame._session.cookie_jar else null,
+        .include => &session.cookie_jar,
+        .@"same-origin" => if (exec.isSameOrigin(request._url)) &session.cookie_jar else null,
     };
 
     try http_client.request(.{
@@ -97,14 +99,14 @@ pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
         .params = .{
             .url = request._url,
             .method = request._method,
-            .frame_id = frame._frame_id,
-            .loader_id = frame._loader_id,
+            .frame_id = exec.frameId(),
+            .loader_id = exec.loaderId(),
             .body = request._body,
             .headers = headers,
             .resource_type = .fetch,
             .cookie_jar = cookie_jar,
-            .cookie_origin = frame.url,
-            .notification = frame._session.notification,
+            .cookie_origin = exec.url.*,
+            .notification = session.notification,
         },
         .start_callback = httpStartCallback,
         .header_callback = httpHeaderDoneCallback,
@@ -116,22 +118,22 @@ pub fn init(input: Input, options: ?InitOpts, frame: *Frame) !js.Promise {
     return resolver.promise();
 }
 
-fn handleBlobUrl(url: []const u8, resolver: js.PromiseResolver, frame: *Frame) !js.Promise {
-    const blob: *Blob = frame.lookupBlobUrl(url) orelse {
+fn handleBlobUrl(url: []const u8, resolver: js.PromiseResolver, exec: *const Execution) !js.Promise {
+    const blob: *Blob = exec.lookupBlobUrl(url) orelse {
         resolver.rejectError("fetch blob error", .{ .type_error = "BlobNotFound" });
         return resolver.promise();
     };
 
-    const response = try Response.init(null, .{ .status = 200 }, &frame.js.execution);
+    const response = try Response.init(null, .{ .status = 200 }, exec);
     response._body = .{ .bytes = try response._arena.dupe(u8, blob._slice) };
     response._url = try response._arena.dupeZ(u8, url);
     response._type = .basic;
 
     if (blob._mime.len > 0) {
-        try response._headers.append("Content-Type", blob._mime, &frame.js.execution);
+        try response._headers.append("Content-Type", blob._mime, exec);
     }
 
-    const js_val = try frame.js.local.?.zigValueToJs(response, .{});
+    const js_val = try exec.context.local.?.zigValueToJs(response, .{});
     resolver.resolve("fetch blob done", js_val);
     return resolver.promise();
 }
@@ -174,10 +176,11 @@ fn httpHeaderDoneCallback(response: HttpClient.Response) !bool {
     res._is_redirected = response.redirectCount().? > 0;
 
     // Determine response type based on origin comparison
-    const frame_origin = URL.getOrigin(arena, self._frame.url) catch null;
+    const exec = self._exec;
+    const requesting_origin = URL.getOrigin(arena, exec.url.*) catch null;
     const response_origin = URL.getOrigin(arena, res._url) catch null;
 
-    if (frame_origin) |fo| {
+    if (requesting_origin) |fo| {
         if (response_origin) |ro| {
             if (std.mem.eql(u8, fo, ro)) {
                 res._type = .basic; // Same-origin
@@ -193,7 +196,7 @@ fn httpHeaderDoneCallback(response: HttpClient.Response) !bool {
 
     var it = response.headerIterator();
     while (it.next()) |hdr| {
-        try res._headers.append(hdr.name, hdr.value, &self._frame.js.execution);
+        try res._headers.append(hdr.name, hdr.value, exec);
     }
 
     return true;
@@ -226,7 +229,7 @@ fn httpDoneCallback(ctx: *anyopaque) !void {
     });
 
     var ls: js.Local.Scope = undefined;
-    self._frame.js.localScope(&ls);
+    self._exec.context.localScope(&ls);
     defer ls.deinit();
 
     const js_val = try ls.local.zigValueToJs(self._response, .{});
@@ -250,11 +253,11 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     // clear this. (defer since `self is in the response's arena).
 
     defer if (self._owns_response) {
-        response.deinit(self._frame._page);
+        response.deinit(self._exec.context.page);
     };
 
     var ls: js.Local.Scope = undefined;
-    self._frame.js.localScope(&ls);
+    self._exec.context.localScope(&ls);
     defer ls.deinit();
 
     // fetch() must reject with a TypeError on network errors per spec
@@ -271,7 +274,7 @@ fn httpShutdownCallback(ctx: *anyopaque) void {
     if (self._owns_response) {
         var response = self._response;
         response._http_response = null;
-        response.deinit(self._frame._page);
+        response.deinit(self._exec.context.page);
         // Do not access `self` after this point: the Fetch struct was
         // allocated from response._arena which has been released.
     }

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -26,7 +26,6 @@ const http = @import("../../../network/http.zig");
 const URL = @import("../../URL.zig");
 const Mime = @import("../../Mime.zig");
 const Page = @import("../../Page.zig");
-const Frame = @import("../../Frame.zig");
 
 const Node = @import("../Node.zig");
 const Event = @import("../Event.zig");
@@ -35,12 +34,13 @@ const EventTarget = @import("../EventTarget.zig");
 const XMLHttpRequestEventTarget = @import("XMLHttpRequestEventTarget.zig");
 
 const log = lp.log;
+const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const XMLHttpRequest = @This();
 _rc: lp.RC(u8) = .{},
-_frame: *Frame,
+_exec: *const Execution,
 _proto: *XMLHttpRequestEventTarget,
 _arena: Allocator,
 _http_response: ?HttpClient.Response = null,
@@ -88,14 +88,14 @@ const ResponseType = enum {
     // TODO: other types to support
 };
 
-pub fn init(frame: *Frame) !*XMLHttpRequest {
-    const arena = try frame.getArena(.large, "XMLHttpRequest");
-    errdefer frame.releaseArena(arena);
-    const self = try frame._factory.xhrEventTarget(arena, XMLHttpRequest{
-        ._frame = frame,
+pub fn init(exec: *const Execution) !*XMLHttpRequest {
+    const arena = try exec.getArena(.large, "XMLHttpRequest");
+    errdefer exec.releaseArena(arena);
+    const self = try exec._factory.xhrEventTarget(arena, XMLHttpRequest{
+        ._exec = exec,
         ._arena = arena,
         ._proto = undefined,
-        ._request_headers = try Headers.init(null, &frame.js.execution),
+        ._request_headers = try Headers.init(null, exec),
     });
     return self;
 }
@@ -142,7 +142,7 @@ fn releaseSelfRef(self: *XMLHttpRequest) void {
     if (self._active_request == false) {
         return;
     }
-    self.releaseRef(self._frame._page);
+    self.releaseRef(self._exec.context.page);
     self._active_request = false;
 }
 
@@ -208,17 +208,17 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8) !void
     self._response_headers.clearRetainingCapacity();
     self._request_body = null;
 
-    const frame = self._frame;
+    const exec = self._exec;
     self._method = try parseMethod(method_);
-    self._url = try URL.resolve(self._arena, frame.base(), url, .{ .always_dupe = true, .encoding = frame.charset });
-    try self.stateChanged(.opened, frame);
+    self._url = try URL.resolve(self._arena, exec.base(), url, .{ .always_dupe = true, .encoding = exec.charset.* });
+    try self.stateChanged(.opened, exec);
 }
 
-pub fn setRequestHeader(self: *XMLHttpRequest, name: []const u8, value: []const u8, frame: *Frame) !void {
+pub fn setRequestHeader(self: *XMLHttpRequest, name: []const u8, value: []const u8, exec: *const Execution) !void {
     if (self._ready_state != .opened) {
         return error.InvalidStateError;
     }
-    return self._request_headers.append(name, value, &frame.js.execution);
+    return self._request_headers.append(name, value, exec);
 }
 
 pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
@@ -235,21 +235,22 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
         }
     }
 
-    const frame = self._frame;
+    const exec = self._exec;
 
     if (std.mem.startsWith(u8, self._url, "blob:")) {
-        return self.handleBlobUrl(frame);
+        return self.handleBlobUrl(exec);
     }
 
-    const http_client = frame._session.browser.http_client;
+    const session = exec.context.page.session;
+    const http_client = session.browser.http_client;
     var headers = try http_client.newHeaders();
 
     // Only add cookies for same-origin or when withCredentials is true
-    const cookie_support = self._with_credentials or frame.isSameOrigin(self._url);
+    const cookie_support = self._with_credentials or exec.isSameOrigin(self._url);
 
-    try self._request_headers.populateHttpHeader(frame.call_arena, &headers);
+    try self._request_headers.populateHttpHeader(exec.call_arena, &headers);
     if (cookie_support) {
-        try frame.headersForRequest(&headers);
+        try exec.headersForRequest(&headers);
     }
 
     self.acquireRef();
@@ -261,14 +262,14 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
             .url = self._url,
             .method = self._method,
             .headers = headers,
-            .frame_id = frame._frame_id,
-            .loader_id = frame._loader_id,
+            .frame_id = exec.frameId(),
+            .loader_id = exec.loaderId(),
             .body = self._request_body,
-            .cookie_jar = if (cookie_support) &frame._session.cookie_jar else null,
-            .cookie_origin = frame.url,
+            .cookie_jar = if (cookie_support) &session.cookie_jar else null,
+            .cookie_origin = exec.url.*,
             .resource_type = .xhr,
             .timeout_ms = self._timeout,
-            .notification = frame._session.notification,
+            .notification = session.notification,
         },
         .start_callback = httpStartCallback,
         .header_callback = httpHeaderDoneCallback,
@@ -282,8 +283,8 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
     };
 }
 
-fn handleBlobUrl(self: *XMLHttpRequest, frame: *Frame) !void {
-    const blob = frame.lookupBlobUrl(self._url) orelse {
+fn handleBlobUrl(self: *XMLHttpRequest, exec: *const Execution) !void {
+    const blob = exec.lookupBlobUrl(self._url) orelse {
         self.handleError(error.BlobNotFound);
         return;
     };
@@ -294,24 +295,24 @@ fn handleBlobUrl(self: *XMLHttpRequest, frame: *Frame) !void {
     try self._response_data.appendSlice(self._arena, blob._slice);
     self._response_len = blob._slice.len;
 
-    try self.stateChanged(.headers_received, frame);
-    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, frame);
-    try self.stateChanged(.loading, frame);
+    try self.stateChanged(.headers_received, exec);
+    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, exec);
+    try self.stateChanged(.loading, exec);
     try self._proto.dispatch(.progress, .{
         .total = self._response_len orelse 0,
         .loaded = self._response_data.items.len,
-    }, frame);
-    try self.stateChanged(.done, frame);
+    }, exec);
+    try self.stateChanged(.done, exec);
 
     const loaded = self._response_data.items.len;
     try self._proto.dispatch(.load, .{
         .total = loaded,
         .loaded = loaded,
-    }, frame);
+    }, exec);
     try self._proto.dispatch(.load_end, .{
         .total = loaded,
         .loaded = loaded,
-    }, frame);
+    }, exec);
 }
 
 pub fn getReadyState(self: *const XMLHttpRequest) u32 {
@@ -334,14 +335,14 @@ pub fn getResponseHeader(self: *const XMLHttpRequest, name: []const u8) ?[]const
     return null;
 }
 
-pub fn getAllResponseHeaders(self: *const XMLHttpRequest, frame: *Frame) ![]const u8 {
+pub fn getAllResponseHeaders(self: *const XMLHttpRequest, exec: *const Execution) ![]const u8 {
     if (self._ready_state != .done) {
         // MDN says this should return null, but it seems to return an empty string
         // in every browser. Specs are too hard for a dumbo like me to understand.
         return "";
     }
 
-    var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+    var buf = std.Io.Writer.Allocating.init(exec.call_arena);
     for (self._response_headers.items) |entry| {
         try buf.writer.writeAll(entry);
         try buf.writer.writeAll("\r\n");
@@ -378,7 +379,7 @@ pub fn getResponseURL(self: *XMLHttpRequest) []const u8 {
     return self._response_url;
 }
 
-pub fn getResponse(self: *XMLHttpRequest, frame: *Frame) !?Response {
+pub fn getResponse(self: *XMLHttpRequest, exec: *const Execution) !?Response {
     if (self._ready_state != .done) {
         return null;
     }
@@ -392,13 +393,20 @@ pub fn getResponse(self: *XMLHttpRequest, frame: *Frame) !?Response {
     const res: Response = switch (self._response_type) {
         .text => .{ .text = data },
         .json => blk: {
-            const value = try frame.js.local.?.parseJSON(data);
+            const value = try exec.context.local.?.parseJSON(data);
             break :blk .{ .json = try value.persist() };
         },
         .document => blk: {
-            const document = try frame._factory.node(Node.Document{ ._proto = undefined, ._type = .generic });
-            try frame.parseHtmlAsChildren(document.asNode(), data);
-            break :blk .{ .document = document };
+            // responseType=document is only meaningful in a Frame; workers
+            // have no DOM. Drastically different impls -> switch on global.
+            switch (exec.context.global) {
+                .frame => |frame| {
+                    const document = try exec._factory.node(Node.Document{ ._proto = undefined, ._type = .generic });
+                    try frame.parseHtmlAsChildren(document.asNode(), data);
+                    break :blk .{ .document = document };
+                },
+                .worker => return error.NotSupportedInWorker,
+            }
         },
         .arraybuffer => .{ .arraybuffer = .{ .values = data } },
     };
@@ -407,8 +415,8 @@ pub fn getResponse(self: *XMLHttpRequest, frame: *Frame) !?Response {
     return res;
 }
 
-pub fn getResponseXML(self: *XMLHttpRequest, frame: *Frame) !?*Node.Document {
-    const res = (try self.getResponse(frame)) orelse return null;
+pub fn getResponseXML(self: *XMLHttpRequest, exec: *const Execution) !?*Node.Document {
+    const res = (try self.getResponse(exec)) orelse return null;
     return switch (res) {
         .document => |doc| doc,
         else => null,
@@ -464,15 +472,15 @@ fn httpHeaderDoneCallback(response: HttpClient.Response) !bool {
     }
     self._response_url = try self._arena.dupeZ(u8, response.url());
 
-    const frame = self._frame;
+    const exec = self._exec;
 
     var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
+    exec.context.localScope(&ls);
     defer ls.deinit();
 
-    try self.stateChanged(.headers_received, frame);
-    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, frame);
-    try self.stateChanged(.loading, frame);
+    try self.stateChanged(.headers_received, exec);
+    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, exec);
+    try self.stateChanged(.loading, exec);
 
     return true;
 }
@@ -481,12 +489,10 @@ fn httpDataCallback(response: HttpClient.Response, data: []const u8) !void {
     const self: *XMLHttpRequest = @ptrCast(@alignCast(response.ctx));
     try self._response_data.appendSlice(self._arena, data);
 
-    const frame = self._frame;
-
     try self._proto.dispatch(.progress, .{
         .total = self._response_len orelse 0,
         .loaded = self._response_data.items.len,
-    }, frame);
+    }, self._exec);
 }
 
 fn httpDoneCallback(ctx: *anyopaque) !void {
@@ -503,19 +509,19 @@ fn httpDoneCallback(ctx: *anyopaque) !void {
     // object. It isn't safe to keep it around.
     self._http_response = null;
 
-    const frame = self._frame;
+    const exec = self._exec;
 
-    try self.stateChanged(.done, frame);
+    try self.stateChanged(.done, exec);
 
     const loaded = self._response_data.items.len;
     try self._proto.dispatch(.load, .{
         .total = loaded,
         .loaded = loaded,
-    }, frame);
+    }, exec);
     try self._proto.dispatch(.load_end, .{
         .total = loaded,
         .loaded = loaded,
-    }, frame);
+    }, exec);
 
     self.releaseSelfRef();
 }
@@ -559,18 +565,18 @@ fn _handleError(self: *XMLHttpRequest, err: anyerror) !void {
 
     const new_state: ReadyState = if (is_abort) .unsent else .done;
     if (new_state != self._ready_state) {
-        const frame = self._frame;
+        const exec = self._exec;
 
-        try self.stateChanged(new_state, frame);
+        try self.stateChanged(new_state, exec);
         if (is_abort) {
-            try self._proto.dispatch(.abort, null, frame);
+            try self._proto.dispatch(.abort, null, exec);
         } else if (is_timeout) {
-            try self._proto.dispatch(.timeout, null, frame);
+            try self._proto.dispatch(.timeout, null, exec);
         }
         if (!is_timeout) {
-            try self._proto.dispatch(.err, null, frame);
+            try self._proto.dispatch(.err, null, exec);
         }
-        try self._proto.dispatch(.load_end, null, frame);
+        try self._proto.dispatch(.load_end, null, exec);
     }
 
     const level: log.Level = if (err == error.Abort) .debug else .err;
@@ -581,7 +587,7 @@ fn _handleError(self: *XMLHttpRequest, err: anyerror) !void {
     });
 }
 
-fn stateChanged(self: *XMLHttpRequest, state: ReadyState, frame: *Frame) !void {
+fn stateChanged(self: *XMLHttpRequest, state: ReadyState, exec: *const Execution) !void {
     if (state == self._ready_state) {
         return;
     }
@@ -589,9 +595,9 @@ fn stateChanged(self: *XMLHttpRequest, state: ReadyState, frame: *Frame) !void {
     self._ready_state = state;
 
     const target = self.asEventTarget();
-    if (frame._event_manager.hasDirectListeners(target, "readystatechange", self._on_ready_state_change)) {
-        const event = try Event.initTrusted(.wrap("readystatechange"), .{}, frame._page);
-        try frame._event_manager.dispatchDirect(target, event, self._on_ready_state_change, .{ .context = "XHR state change" });
+    if (exec.hasDirectListeners(target, "readystatechange", self._on_ready_state_change)) {
+        const event = try Event.initTrusted(.wrap("readystatechange"), .{}, exec.context.page);
+        try exec.dispatch(target, event, self._on_ready_state_change, .{ .context = "XHR state change" });
     }
 }
 

--- a/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
+++ b/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
@@ -18,9 +18,10 @@
 
 const js = @import("../../js/js.zig");
 
-const Frame = @import("../../Frame.zig");
 const EventTarget = @import("../EventTarget.zig");
 const ProgressEvent = @import("../event/ProgressEvent.zig");
+
+const Execution = js.Execution;
 
 const XMLHttpRequestEventTarget = @This();
 
@@ -43,7 +44,7 @@ pub fn asEventTarget(self: *XMLHttpRequestEventTarget) *EventTarget {
     return self._proto;
 }
 
-pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchType, progress_: ?Progress, frame: *Frame) !void {
+pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchType, progress_: ?Progress, exec: *const Execution) !void {
     const field, const typ = comptime blk: {
         break :blk switch (event_type) {
             .abort => .{ "_on_abort", "abort" },
@@ -60,10 +61,10 @@ pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchT
     const event = (try ProgressEvent.initTrusted(
         comptime .wrap(typ),
         .{ .total = progress.total, .loaded = progress.loaded },
-        frame,
+        exec.context.page,
     )).asEvent();
 
-    return frame._event_manager.dispatchDirect(
+    return exec.dispatch(
         self.asEventTarget(),
         event,
         @field(self, field),


### PR DESCRIPTION
Follows previous changes to make a WebAPI worker-compatible by replacing any dependency on *Frame with *js.Execute, *Page and/or *Session. The changes here are relatively minor since most of the existing supporting WebApis (e.g. Blob, Response, Request) have already been migrated.