### PR TITLE
cdp: fall back to dialog defaultText when LP.handleJavaScriptDialog promptText is null

### DIFF
--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -1105,7 +1105,7 @@ pub const JsApi = struct {
         }
     }.confirm, .{});
     pub const prompt = bridge.function(struct {
-        fn prompt(_: *const Window, message: ?[]const u8, _: ?[]const u8, frame: *Frame) ?[]const u8 {
+        fn prompt(_: *const Window, message: ?[]const u8, default_text: ?[]const u8, frame: *Frame) ?[]const u8 {
             var response: Notification.DialogResponse = .{};
             frame._session.notification.dispatch(.javascript_dialog_opening, &.{
                 .url = frame.url,
@@ -1114,9 +1114,12 @@ pub const JsApi = struct {
                 .response = &response,
             });
             if (!response.accept) return null;
-            // promptText omitted with accept=true is "" per CDP spec
+            // Pre-armed promptText wins when present. Otherwise fall back to
+            // the dialog's defaultText (second arg to window.prompt) — Chrome's
+            // accept-without-typing behavior. If both are absent, return ""
+            // per CDP spec
             // (https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-handleJavaScriptDialog).
-            return response.prompt_text orelse "";
+            return response.prompt_text orelse default_text orelse "";
         }
     }.prompt, .{});
 

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -569,7 +569,7 @@ test "cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values
     const p_text_str = try p_text.toStringSlice();
     try testing.expectEqualSlices(u8, "hello", p_text_str);
 
-    // ---- prompt: accept=true without promptText returns "" per CDP spec ----
+    // ---- prompt: accept=true without promptText AND no dialog defaultText returns "" ----
     try ctx.processMessage(.{ .id = 4, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = true } });
     try ctx.expectSentResult(null, .{ .id = 4 });
 
@@ -577,9 +577,34 @@ test "cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values
     const p_empty_str = try p_empty.toStringSlice();
     try testing.expectEqualSlices(u8, "", p_empty_str);
 
-    // ---- prompt: accept=false makes prompt() return null ----
-    try ctx.processMessage(.{ .id = 5, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = false } });
+    // ---- prompt: accept=true without promptText falls back to dialog defaultText ----
+    // Mirrors Chrome's accept-without-typing behavior: with no client-supplied
+    // promptText, the prompt's return value is the second arg to window.prompt.
+    try ctx.processMessage(.{ .id = 5, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = true } });
     try ctx.expectSentResult(null, .{ .id = 5 });
+
+    const p_default_text = try ls.local.exec("prompt('name?', 'John Smith')", null);
+    const p_default_text_str = try p_default_text.toStringSlice();
+    try testing.expectEqualSlices(u8, "John Smith", p_default_text_str);
+
+    // ---- prompt: pre-armed promptText overrides the dialog defaultText ----
+    try ctx.processMessage(.{ .id = 6, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = true, .promptText = "typed" } });
+    try ctx.expectSentResult(null, .{ .id = 6 });
+
+    const p_override = try ls.local.exec("prompt('name?', 'John Smith')", null);
+    const p_override_str = try p_override.toStringSlice();
+    try testing.expectEqualSlices(u8, "typed", p_override_str);
+
+    // ---- prompt: accept=false returns null regardless of dialog defaultText ----
+    try ctx.processMessage(.{ .id = 7, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = false } });
+    try ctx.expectSentResult(null, .{ .id = 7 });
+
+    const p_dismiss_with_default = try ls.local.exec("prompt('cancel?', 'John Smith')", null);
+    try testing.expect(p_dismiss_with_default.isNull());
+
+    // ---- prompt: accept=false makes prompt() return null ----
+    try ctx.processMessage(.{ .id = 8, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = false } });
+    try ctx.expectSentResult(null, .{ .id = 8 });
 
     const p_dismiss = try ls.local.exec("prompt('cancel?')", null);
     try testing.expect(p_dismiss.isNull());
@@ -589,8 +614,8 @@ test "cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values
     try testing.expect(p_default.isNull());
 
     // ---- alert: dispatches the event but has no return value to override ----
-    try ctx.processMessage(.{ .id = 6, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = true } });
-    try ctx.expectSentResult(null, .{ .id = 6 });
+    try ctx.processMessage(.{ .id = 9, .method = "LP.handleJavaScriptDialog", .params = .{ .accept = true } });
+    try ctx.expectSentResult(null, .{ .id = 9 });
     _ = try ls.local.exec("alert('important')", null);
     try ctx.expectSentEvent("Page.javascriptDialogOpening", .{
         .message = "important",


### PR DESCRIPTION
## What

When a CDP client pre-arms `LP.handleJavaScriptDialog {accept: true}` with no `promptText` and the page subsequently calls `window.prompt(message, defaultText)`, Lightpanda discarded the dialog's `defaultText` argument and returned `""`. Per the HTML simple-dialog algorithm and Chrome's behavior, accepting without supplying input should surface `defaultText` as the prompt's return value.

Closes #2321.

## Root cause

`Window.zig`'s `prompt` JS binding declared its second parameter as `_: ?[]const u8`, throwing the page-supplied `defaultText` away before the body of the function ran. The pre-arm flow from #2261 fills `BrowserContext.pending_dialog_response`, but the binding's only fallback after `accept = true` was `response.prompt_text orelse ""`. With `prompt_text` null and `defaultText` discarded, the JS world saw `""`.

```mermaid
flowchart LR
    A[window.prompt msg, defaultText] --> B[Window.zig prompt binding]
    B --> C[default_text dropped as `_`]
    C --> D[returns prompt_text orelse '']
    D --> E[empty string in JS]
    style C fill:#fdd
    style D fill:#fdd
    style E fill:#fdd
```

## Fix

- `src/browser/webapi/Window.zig` — the `prompt` binding now keeps its second argument named (`default_text`) and returns `response.prompt_text orelse default_text orelse ""`. Pre-armed `promptText` still wins when present; `accept = false` still returns `null`; both-absent still returns `""` per CDP spec.

```mermaid
flowchart LR
    A[window.prompt msg, defaultText] --> B[Window.zig prompt binding]
    B --> C[default_text named, kept]
    C --> D[returns prompt_text orelse default_text orelse '']
    D --> E[defaultText surfaces in JS]
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values` (extended) — adds four new assertions covering the matrix: `defaultText` fallback when `promptText` is absent, pre-armed `promptText` overriding `defaultText`, `accept = false` ignoring `defaultText`, plus the existing no-defaultText-no-promptText case (still `""`). Toggle-off verified: reverting `Window.zig` to `main` makes the new `expectEqualSlices(u8, "John Smith", ...)` assertion fail (line 588), confirming the test exercises this code path.
- **Reproducer**: `bash repro.sh` from #2321 exits 1 against the current nightly (`1.0.0-dev.5918`) and exits 0 against this branch's debug build. The script drives three pre-arm scenarios via `LP.handleJavaScriptDialog`, fires `prompt('msg', 'John Smith')`, and asserts the returned values match Chrome.

Full unit-test suite: 504 / 504 passing on this branch.

## Notes

The CDP spec text for `Page.handleJavaScriptDialog` describes `promptText` as "the text to enter into the dialog prompt before accepting". Falling back to `defaultText` when the client omits `promptText` matches Chrome's behavior and the natural reading of "user accepted without typing". The pre-existing test that asserted `prompt('name?')` returns `""` when accepted with no `promptText` still passes — that case has no `defaultText` either, so the `orelse ""` tail still applies.
