### PR TITLE
dom: run label activation behavior on click

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3728,6 +3728,14 @@ pub fn handleClick(self: *Frame, target: *Node) !void {
             }
         },
         .select, .textarea => try element.focus(self),
+        .label => |label| {
+            // Per HTML §4.10.4 "The label element", a label's activation
+            // behavior is to run the synthetic click activation steps on the
+            // labeled control. Mirrors Chrome's HTMLLabelElement::DefaultEventHandler.
+            const control = label.getControl(self) orelse return;
+            const control_html = control.is(Element.Html) orelse return;
+            try control_html.click(self);
+        },
         else => {},
     }
 }

--- a/src/browser/tests/element/html/label_click.html
+++ b/src/browser/tests/element/html/label_click.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<!-- HTMLLabelElement activation behavior (HTML §4.10.4 "The label element"):
+     calling .click() on a <label> must run the synthetic click activation
+     steps on the labeled control. -->
+
+<input id="cb_for" type="checkbox">
+<label id="lab_for" for="cb_for">Toggle by for=</label>
+
+<label id="lab_wrap"><input id="cb_wrap" type="checkbox"><span>Toggle wrapped</span></label>
+
+<input id="r_a" type="radio" name="g1" checked>
+<input id="r_b" type="radio" name="g1">
+<label id="lab_radio" for="r_b">Pick r_b</label>
+
+<input id="cb_disabled" type="checkbox" disabled>
+<label id="lab_disabled" for="cb_disabled">Disabled</label>
+
+<input id="cb_for_missing" type="checkbox">
+<label id="lab_missing" for="does-not-exist">No such control</label>
+
+<input id="cb_no_control" type="checkbox">
+<label id="lab_empty">No for, no descendant control</label>
+
+<input id="cb_outer_only" type="checkbox">
+<label id="lab_outer">No for, with non-labelable child <span>x</span></label>
+
+<form id="f_submit" action="javascript:void(0)">
+  <label id="lab_submit"><button id="btn_submit" type="submit">Submit</button></label>
+</form>
+
+<script id="for_attr_toggles_checkbox">
+  {
+    const cb = $('#cb_for');
+    const lab = $('#lab_for');
+    testing.expectEqual(false, cb.checked);
+
+    lab.click();
+    testing.expectEqual(true, cb.checked);
+
+    lab.click();
+    testing.expectEqual(false, cb.checked);
+  }
+</script>
+
+<script id="wrapping_label_toggles_checkbox">
+  {
+    const cb = $('#cb_wrap');
+    const lab = $('#lab_wrap');
+    testing.expectEqual(false, cb.checked);
+
+    lab.click();
+    testing.expectEqual(true, cb.checked);
+
+    lab.click();
+    testing.expectEqual(false, cb.checked);
+  }
+</script>
+
+<script id="for_attr_checks_radio">
+  {
+    const a = $('#r_a');
+    const b = $('#r_b');
+    testing.expectEqual(true, a.checked);
+    testing.expectEqual(false, b.checked);
+
+    $('#lab_radio').click();
+    testing.expectEqual(false, a.checked);
+    testing.expectEqual(true, b.checked);
+  }
+</script>
+
+<script id="disabled_control_does_not_toggle">
+  {
+    const cb = $('#cb_disabled');
+    testing.expectEqual(false, cb.checked);
+
+    $('#lab_disabled').click();
+    testing.expectEqual(false, cb.checked, 'disabled control must not activate');
+  }
+</script>
+
+<script id="missing_for_target_no_op">
+  {
+    // No exception, no side-effect.
+    $('#lab_missing').click();
+    testing.expectEqual(false, $('#cb_for_missing').checked);
+  }
+</script>
+
+<script id="no_for_no_descendant_no_op">
+  {
+    $('#lab_empty').click();
+    testing.expectEqual(false, $('#cb_no_control').checked);
+  }
+</script>
+
+<script id="no_labelable_descendant_no_op">
+  {
+    $('#lab_outer').click();
+    testing.expectEqual(false, $('#cb_outer_only').checked);
+  }
+</script>
+
+<script id="label_click_dispatches_click_on_control">
+  {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = 'cb_evt';
+    document.body.appendChild(cb);
+
+    const lab = document.createElement('label');
+    lab.htmlFor = 'cb_evt';
+    document.body.appendChild(lab);
+
+    const events = [];
+    lab.addEventListener('click', e => events.push(['label', e.target.tagName]));
+    cb.addEventListener('click', e => events.push(['cb', e.target.tagName]));
+    cb.addEventListener('input', () => events.push(['cb', 'input']));
+    cb.addEventListener('change', () => events.push(['cb', 'change']));
+
+    lab.click();
+
+    // The label's own click fires first, then the synthetic click on the
+    // control fires + bubbles, then input/change fire on the control.
+    testing.expectEqual(true, cb.checked);
+    testing.expectEqual('label', events[0][0]);
+    testing.expectEqual('LABEL', events[0][1]);
+    testing.expectEqual('cb', events[1][0]);
+    testing.expectEqual('INPUT', events[1][1]);
+    testing.expectEqual('input', events[2][1]);
+    testing.expectEqual('change', events[3][1]);
+
+    document.body.removeChild(lab);
+    document.body.removeChild(cb);
+  }
+</script>
+
+<script id="label_click_preventDefault_on_label_blocks_activation">
+  {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = 'cb_pd';
+    document.body.appendChild(cb);
+
+    const lab = document.createElement('label');
+    lab.htmlFor = 'cb_pd';
+    lab.addEventListener('click', (e) => e.preventDefault());
+    document.body.appendChild(lab);
+
+    lab.click();
+    testing.expectEqual(false, cb.checked, 'preventDefault on label must skip activation');
+
+    document.body.removeChild(lab);
+    document.body.removeChild(cb);
+  }
+</script>

--- a/src/browser/webapi/element/html/Label.zig
+++ b/src/browser/webapi/element/html/Label.zig
@@ -145,4 +145,5 @@ pub const JsApi = struct {
 const testing = @import("../../../../testing.zig");
 test "WebApi: HTML.Label" {
     try testing.htmlRunner("element/html/label.html", .{});
+    try testing.htmlRunner("element/html/label_click.html", .{});
 }


### PR DESCRIPTION
## What

Add the `<label>` activation behavior so clicking a label dispatches the synthetic click on its labeled control. Without this, `lab.click()` on `<label for="cb">` fires the click event but leaves `cb.checked` unchanged — the labeled checkbox/radio never toggles, and `input`/`change` never fire.

Closes #2323.

## Root cause

`Frame.handleClick` (`src/browser/Frame.zig:3676`) is the single dispatcher that runs each interactive element's default action after a `click` event has finished propagating. It branches on `html_element._type` and has explicit arms for `.anchor`, `.input`, `.button`, `.select`, `.textarea`, but no `.label` — labels fall through to `else => {}`. Per [HTML Living Standard §4.10.4 "The label element"](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), a label's activation behavior is to run the synthetic click activation steps on the labeled control. The dispatcher should resolve the labeled control via `Label.getControl(frame)` (already implemented at `src/browser/webapi/element/html/Label.zig:28`, handles both `for=` and wrapping-descendant cases) and call `.click()` on it.

```mermaid
flowchart LR
    A[lab.click] --> B[Frame.handleClick label]
    B --> C[switch falls to else]
    C --> D[no activation, checked unchanged]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `handleClick`: add a `.label` arm that resolves the labeled control via `Label.getControl(self)` and dispatches a synthetic `click()` on it. The recursive dispatch reuses the existing `EventManager.ActivationState.create` path that toggles checkbox / radio state and fires `input` / `change`. `getControl` returns null for labels with `for=` pointing at missing or non-labelable controls, for labels with a `disabled` labelled control via `for=` (delegates to the input's own gate), and for labels with no labelable descendants — making the fix a no-op in those cases.
- `src/browser/tests/element/html/label_click.html` — new fixture covering: `for=` activates checkbox; wrapping label activates wrapped checkbox; `for=` activates radio; disabled control no-ops; missing `for=` target no-ops; no-control labels no-op; `preventDefault` on the label cancels activation; the synthetic click on the control bubbles correctly with the right event order (label-click then control-click then input then change).
- `src/browser/webapi/element/html/Label.zig` — register `label_click.html` alongside the existing `label.html` runner.

```mermaid
flowchart LR
    A[lab.click] --> B[Frame.handleClick label]
    B --> C[label.getControl returns input]
    C --> D[control.click dispatch]
    D --> E[ActivationState toggles, input/change fire]
    style B fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `WebApi: HTML.Label#label_click.html` — fails on `main` (`document.getElementById('cb_for').checked` stays `false` after `lab.click()`), passes with this commit. 8 assertion blocks cover `for=`, wrapping, radio, disabled-passthrough, missing-target, no-control, `preventDefault`, and bubble-order.
- **Reproducer**: a self-contained `repro.sh` (described in the linked issue) using raw `ws` against `Target.createTarget` + `Target.attachToTarget` exits 1 on `main` with `{"after":false}` for all three sub-cases (checkbox via `for=`, checkbox via wrapping, radio via `for=`), exits 0 with this commit emitting `{"after":true}`.
- **Full unit-test suite**: `mise exec -- zig build test $V8` reports `504 of 504 tests passed`. No regressions.

## Notes

The synthetic click on the labeled control fully redispatches through the DOM, so user-attached listeners on the label fire twice with different `event.target` values (once for the label-targeted click, once during the bubble of the control-targeted click). This matches Chrome's behavior — see e.g. `lab.click()` against `<label><input id=cb></label>` in DevTools. Tests that assert on this can disambiguate via `event.target.tagName`.

The fix only handles the case where the click target is the label itself; the spec also mentions activation when the target is a non-interactive descendant of the label (the bubble-up case). That's a follow-up — the gem-side workaround being obsoleted by this PR only exercises `lab.click()` directly, and keeping the change minimal lets reviewers focus on the dispatcher arm.
