### PR TITLE
dom: toggle <details>.open when its first <summary> is clicked

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3728,6 +3728,28 @@ pub fn handleClick(self: *Frame, target: *Node) !void {
             }
         },
         .select, .textarea => try element.focus(self),
+        .generic => |generic| {
+            // Per HTML §4.11.1.2 "The summary element", a summary's activation
+            // behavior runs the toggle details state algorithm on its parent
+            // details, but only when this summary is the first summary
+            // element child of that details.
+            if (generic._tag != .summary) return;
+
+            const parent_element = element.asNode().parentElement() orelse return;
+            const parent_html = parent_element.is(Element.Html) orelse return;
+            const details = parent_html.is(Element.Html.Details) orelse return;
+
+            var maybe_child = parent_element.firstElementChild();
+            while (maybe_child) |child| : (maybe_child = child.nextElementSibling()) {
+                const child_html = child.is(Element.Html) orelse continue;
+                const child_generic = child_html.is(Element.Html.Generic) orelse continue;
+                if (child_generic._tag != .summary) continue;
+                if (child != element) return;
+                break;
+            }
+
+            try details.setOpen(!details.getOpen(), self);
+        },
         else => {},
     }
 }

--- a/src/browser/tests/element/html/details.html
+++ b/src/browser/tests/element/html/details.html
@@ -61,3 +61,103 @@
     testing.expectEqual('group1', details.getAttribute('name'))
   }
 </script>
+
+<!-- Summary click activation: per HTML §4.11.1.2, clicking a <summary>
+     that is a child of a <details> toggles the parent's `open` attribute. -->
+<details id="details_click_closed">
+  <summary id="summary_click_closed">click me</summary>
+  <p>content</p>
+</details>
+<details id="details_click_open" open>
+  <summary id="summary_click_open">click me</summary>
+  <p>content</p>
+</details>
+
+<script id="summary_click_opens_details">
+  {
+    const d = $('#details_click_closed');
+    const s = $('#summary_click_closed');
+    testing.expectEqual(false, d.open);
+    s.click();
+    testing.expectEqual(true, d.open);
+  }
+</script>
+
+<script id="summary_click_closes_open_details">
+  {
+    const d = $('#details_click_open');
+    const s = $('#summary_click_open');
+    testing.expectEqual(true, d.open);
+    s.click();
+    testing.expectEqual(false, d.open);
+  }
+</script>
+
+<script id="summary_click_toggles_repeatedly">
+  {
+    const d = document.createElement('details');
+    const s = document.createElement('summary');
+    d.appendChild(s);
+    document.body.appendChild(d);
+
+    testing.expectEqual(false, d.open);
+    s.click();
+    testing.expectEqual(true, d.open);
+    s.click();
+    testing.expectEqual(false, d.open);
+    s.click();
+    testing.expectEqual(true, d.open);
+
+    document.body.removeChild(d);
+  }
+</script>
+
+<script id="summary_click_preventDefault_blocks_toggle">
+  {
+    const d = document.createElement('details');
+    const s = document.createElement('summary');
+    d.appendChild(s);
+    document.body.appendChild(d);
+
+    s.addEventListener('click', (e) => e.preventDefault());
+
+    testing.expectEqual(false, d.open);
+    s.click();
+    testing.expectEqual(false, d.open);
+
+    document.body.removeChild(d);
+  }
+</script>
+
+<script id="summary_click_only_first_summary_toggles">
+  {
+    const d = document.createElement('details');
+    const s1 = document.createElement('summary');
+    const s2 = document.createElement('summary');
+    d.appendChild(s1);
+    d.appendChild(s2);
+    document.body.appendChild(d);
+
+    testing.expectEqual(false, d.open);
+    // Per spec, only the first <summary> child of <details> is the "summary
+    // for its parent details" — clicking a non-first summary doesn't toggle.
+    s2.click();
+    testing.expectEqual(false, d.open);
+    // The first summary still toggles.
+    s1.click();
+    testing.expectEqual(true, d.open);
+
+    document.body.removeChild(d);
+  }
+</script>
+
+<script id="summary_click_outside_details_does_nothing">
+  {
+    const s = document.createElement('summary');
+    document.body.appendChild(s);
+    // No throw, no side-effect — there is no parent <details> to toggle.
+    s.click();
+    testing.expectEqual(true, document.body.contains(s));
+    document.body.removeChild(s);
+  }
+</script>


### PR DESCRIPTION
## What

Clicking a `<summary>` element today fires the click event but never runs the spec-mandated activation behavior, so `parentElement.open` on the enclosing `<details>` stays unchanged. Per [HTML §4.11.1.2 "The summary element"](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element), the activation behavior is to run the toggle-details-state algorithm on the parent details when the summary is the first summary element child of that details.

Closes #2325.

## Root cause

`Frame.handleClick(target)` in `src/browser/Frame.zig` switches on `html_element._type` with arms for `.anchor` / `.input` / `.button` / `.select` / `.textarea` and an `else => {}` catch-all. `<summary>` is created as `Element.Html.Generic` with `_tag = .summary` (`Frame.zig:2366-2371`), so it falls into the catch-all and no activation runs.

```mermaid
flowchart LR
    A[summary.click] --> B[switch html_element._type]
    B --> C[else catch-all]
    C --> D[details.open unchanged]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `handleClick`: add a `.generic` arm that gates on `generic._tag == .summary`, resolves `parentElement().is(Element.Html.Details)`, walks `parent_element.firstElementChild()` / `nextElementSibling()` to confirm the click target is the first `<summary>` child, then toggles via the existing `Details.setOpen(!Details.getOpen(), self)` helper.
- `src/browser/tests/element/html/details.html` — five new `<script>` blocks exercising the new path: closed-then-open toggle, open-then-close toggle, repeated toggling, `preventDefault` blocks the toggle, only the first `<summary>` child of `<details>` activates, and a no-op when summary has no parent `<details>`.

```mermaid
flowchart LR
    A[summary.click] --> B[switch html_element._type]
    B --> C[generic arm, _tag == summary]
    C --> D[walk parent siblings, first-summary check]
    D --> E[Details.setOpen toggle]
    E --> F[details.open toggled]
    style C fill:#dfd
    style E fill:#dfd
    style F fill:#dfd
```

## Test

- **Unit test**: `WebApi: HTML.Details` (extended with `summary_click_opens_details`, `summary_click_closes_open_details`, `summary_click_toggles_repeatedly`, `summary_click_preventDefault_blocks_toggle`, `summary_click_only_first_summary_toggles`, `summary_click_outside_details_does_nothing`). Fails on `main` (4× `expectEqual failed`); passes with this commit. Verified via toggle-off (`git checkout main -- src/browser/Frame.zig` reproduces the failure; restoring brings it back to green). Full `mise exec -- zig build test $V8` also clean: 504/504 passing.
- **Reproducer**: a self-contained CDP harness (`repro.html` + `repro.sh` + raw-`ws` `probe.js`) drives `summary.click()` via `Runtime.evaluate` and asserts the parent details's `open` toggled. Exits 1 on nightly `1.0.0-dev.5839+2bbf23b3` (both cases FAIL with `delta: false`); exits 0 against this branch's local debug build (both PASS).

## Notes

Two follow-ups deliberately out of scope:

- **Firing `ToggleEvent` on the parent details.** Per spec the toggle-details-state algorithm queues a task that fires `ToggleEvent` on the details. Lightpanda doesn't expose `ToggleEvent` yet (no `webapi/event/Toggle*.zig`); the `open`-attribute mutation is the primary observable effect and Capybara-style tests assert on it. A separate PR can add the event once `ToggleEvent` lands.
- **Activating the summary on a *descendant*-click.** `Frame.handleClick(target)` only checks the original click target, not ancestors — the same gap exists today for `<a>` and `<label>`. A spec-correct walk-up-the-path activation refactor is broader scope and should be its own change.

The first-summary-child check is per the spec's [definition of "the summary for its parent details"](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element). Verified against Chrome 130: clicking a non-first `<summary>` inside `<details>` does not toggle.
