### PR TITLE
browser: change node filter from lower to tag_name

### DIFF
--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -989,7 +989,7 @@ pub fn getElementsByTagName(self: *Node, tag_name: []const u8, frame: *Frame) !G
     }
 
     const arena = frame.arena;
-    const filter = try String.init(arena, lower, .{});
+    const filter = try String.init(arena, tag_name, .{});
     return .{ .tag_name = collections.NodeLive(.tag_name).init(self, filter, frame) };
 }
 


### PR DESCRIPTION
This circumvents the tag name lower logic, as the same matching happens in node_live.zig based on namespace. 
WPT tests after.
```json
== WPT Results==
{
  "url": "http://127.0.0.1:8000/dom/nodes/Element-getElementsByTagName.html",
  "status": "",
  "summary": {
    "total": 19,
    "passed": 17,
    "failed": 2,
    "timeout": 0,
    "notrun": 0,
    "unsupported": 0
  },
  "not_passed": [
    {
      "name": "Shouldn't be able to set unsigned properties on a HTMLCollection (strict mode)",
      "status": "Fail",
      "message": "assert_throws_js: function \"function() {       \"use strict\";       l[5] = \"foopy\"     }\" did not throw"
    },
    {
      "name": "hasOwnProperty, getOwnPropertyDescriptor, getOwnPropertyNames",
      "status": "Fail",
      "message": "assert_equals: expected (object) Element node <pre id=\"x\"></pre> but got (undefined) undefined"
    }
  ]
}
```