### PR TITLE
docs(readme): clarify browser vs npm package versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Due to the nature of Playwright, a script that works with the current version of
 
 ## Quick start
 
+### Package naming note
+
+The browser binary in this repository is versioned independently from npm packages under the
+`@lightpanda/*` scope.
+
+- `lightpanda-io/browser` releases track the browser binary/runtime.
+- npm packages are SDK/integration packages and may use a different version sequence.
+
 ### Install
 **Install from the nightly builds**
 


### PR DESCRIPTION
## Summary
- add a short package naming note to the quick start section
- clarify that the browser binary in this repository is versioned independently from npm packages under the `@lightpanda/*` scope
- explain that the npm packages are SDK/integration packages rather than the browser runtime itself

## Why
Issue #1986 reports confusion when users compare GitHub browser releases with npm package versions and assume they should match. This note makes the separation explicit in the main install path without renaming packages.

## Testing
- `git diff --check origin/main...HEAD`