### PR TITLE
Display actual port when binding --port 0

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -57,8 +57,9 @@ pub fn init(app: *App, address: net.Address) !*Server {
         .clients_pool = std.heap.MemoryPool(Client).init(allocator),
     };
 
-    try self.app.network.bind(address, self, onAccept);
-    log.info(.app, "server running", .{ .address = address });
+    var bound_address = address;
+    try self.app.network.bind(&bound_address, self, onAccept);
+    log.info(.app, "server running", .{ .address = bound_address });
 
     return self;
 }

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -351,7 +351,7 @@ pub fn deinit(self: *Network) void {
 
 pub fn bind(
     self: *Network,
-    address: net.Address,
+    address: *net.Address,
     ctx: *anyopaque,
     on_accept: *const fn (ctx: *anyopaque, socket: posix.socket_t) void,
 ) !void {
@@ -366,6 +366,13 @@ pub fn bind(
 
     try posix.bind(listener, &address.any, address.getOsSockLen());
     try posix.listen(listener, self.config.maxPendingConnections());
+
+    // When the caller requests port 0, the OS assigns an ephemeral port; read
+    // the actual bound address back so callers (e.g. logging) see the real port.
+    var bound: posix.sockaddr.storage = undefined;
+    var bound_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+    try posix.getsockname(listener, @ptrCast(&bound), &bound_len);
+    address.* = net.Address.initPosix(@ptrCast(@alignCast(&bound)));
 
     if (self.listener != null) return error.TooManyListeners;
 


### PR DESCRIPTION
## Summary
- When `--port 0` is used, the OS assigns an ephemeral port. After binding, call `getsockname` to read back the actual port and update the address so log output shows the real port instead of `0`.
- Changes `Network.bind` to take `*net.Address` (pointer) so the bound address can be written back to the caller.

## Test plan
- [x] Run `zig-out/bin/browser --port 0` and verify the log line shows the actual assigned port (e.g. `:54321`) instead of `:0`
- [x] Run with an explicit port (`--port 8080`) and verify behavior is unchanged