### PR TITLE
Fix failed navigation assertion

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -602,6 +602,11 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         // force next request id manually b/c we won't create a real req.
         _ = session.browser.http_client.incrReqId();
 
+        if (self.parent == null) {
+            session.navigation._current_navigation_kind = opts.kind;
+            try session.navigation.commitNavigation(self);
+        }
+
         self.documentIsComplete();
         return;
     }

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -486,3 +486,34 @@ pub const JsApi = struct {
         .{},
     );
 };
+
+const testing = @import("../../../testing.zig");
+
+test "Navigation: about:blank commits entry" {
+    const frame = try testing.test_session.createPage();
+    defer testing.test_session.removePage();
+
+    // The test_session is shared; prior tests leak entries into it via
+    // session.navigation. Reset it so we exercise a fresh session-style state.
+    testing.test_session.navigation._entries.clearRetainingCapacity();
+    testing.test_session.navigation._index = 0;
+
+    try frame.navigate("about:blank", .{});
+
+    var runner = try testing.test_session.runner(.{});
+    try runner.wait(.{ .ms = 1000 });
+
+    // about:blank / blob: handling in Frame.navigate bypasses rameDoneCallback,
+    // so commitNavigation never runs and _entries stays empty. Reading
+    // `navigation.currentEntry` from JS then hits the `lp.assert(len > 0, ...)`
+    // in Navigation.getCurrentEntry
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const result = try ls.local.exec(
+        "navigation.currentEntry.url === 'about:blank'",
+        "Navigation.test",
+    );
+    try testing.expect(result.isTrue());
+}


### PR DESCRIPTION
When the root frame navigates to about:blank, we still need to create an navigation entry, else navigation's expectation (via assertions) fail.