### PR TITLE
cdp: implement Console

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
+const js = @import("browser/js/js.zig");
 const Frame = @import("browser/Frame.zig");
 const Transfer = @import("browser/HttpClient.zig").Transfer;
 const Request = @import("browser/HttpClient.zig").Request;
@@ -87,6 +88,7 @@ const EventListeners = struct {
     http_response_header_done: List = .{},
     javascript_dialog_opening: List = .{},
     console_message: List = .{},
+    runtime_console_message: List = .{},
 };
 
 const Events = union(enum) {
@@ -108,6 +110,7 @@ const Events = union(enum) {
     http_response_header_done: *const ResponseHeaderDone,
     javascript_dialog_opening: *const JavascriptDialogOpening,
     console_message: *const ConsoleMessage,
+    runtime_console_message: *const ConsoleMessage,
 };
 const EventType = std.meta.FieldEnum(Events);
 
@@ -226,6 +229,7 @@ pub const DialogResponse = struct {
 };
 
 pub const ConsoleMessage = struct {
+    timestamp: u64,
     source: enum {
         xml,
         javascript,
@@ -240,7 +244,7 @@ pub const ConsoleMessage = struct {
         worker,
     },
     level: log.Level,
-    text: []const u8,
+    values: []js.Value,
     url: ?[]const u8 = null,
     line: ?u32 = null,
     columns: ?u32 = null,

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -228,6 +228,15 @@ pub const DialogResponse = struct {
     prompt_text: ?[]const u8 = null,
 };
 
+pub const ConsoleMessageType = enum {
+    debug,
+    info,
+    warn,
+    @"error",
+    fatal,
+    trace,
+};
+
 pub const ConsoleMessage = struct {
     timestamp: u64,
     source: enum {
@@ -243,7 +252,7 @@ pub const ConsoleMessage = struct {
         deprecation,
         worker,
     },
-    level: log.Level,
+    type: ConsoleMessageType,
     values: []js.Value,
     url: ?[]const u8 = null,
     line: ?u32 = null,

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -86,6 +86,7 @@ const EventListeners = struct {
     http_response_data: List = .{},
     http_response_header_done: List = .{},
     javascript_dialog_opening: List = .{},
+    console_message: List = .{},
 };
 
 const Events = union(enum) {
@@ -106,6 +107,7 @@ const Events = union(enum) {
     http_response_data: *const ResponseData,
     http_response_header_done: *const ResponseHeaderDone,
     javascript_dialog_opening: *const JavascriptDialogOpening,
+    console_message: *const ConsoleMessage,
 };
 const EventType = std.meta.FieldEnum(Events);
 
@@ -221,6 +223,27 @@ pub const DialogResponse = struct {
     // is owned by whoever filled in the response (typically the BrowserContext
     // arena) and must outlive a single dispatch call.
     prompt_text: ?[]const u8 = null,
+};
+
+pub const ConsoleMessage = struct {
+    source: enum {
+        xml,
+        javascript,
+        network,
+        console_api,
+        storage,
+        appcache,
+        rendering,
+        security,
+        other,
+        deprecation,
+        worker,
+    },
+    level: log.Level,
+    text: []const u8,
+    url: ?[]const u8 = null,
+    line: ?u32 = null,
+    columns: ?u32 = null,
 };
 
 pub fn init(allocator: Allocator) !*Notification {

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -301,6 +301,14 @@ pub fn toJson(self: Value, allocator: Allocator) ![]u8 {
     return js.String.toSliceWithAlloc(.{ .local = local, .handle = str_handle }, allocator);
 }
 
+pub fn jsonStringify(self: Value, jws: anytype) !void {
+    const local = self.local;
+    const v = self.toJson(local.call_arena) catch return error.WriteFailed;
+    jws.beginWriteRaw() catch return error.WriteFailed;
+    jws.writer.writeAll(v) catch return error.WriteFailed;
+    jws.endWriteRaw();
+}
+
 // Throws a DataCloneError for host objects (Blob, File, etc.) that cannot be serialized.
 // Does not support transferables which require additional delegate callbacks.
 pub fn structuredClone(self: Value) !Value {

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -20,7 +20,10 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
+const Notification = @import("../../Notification.zig");
+
 const logger = lp.log;
+const LogLevel = lp.log.Level;
 
 const Console = @This();
 
@@ -29,27 +32,54 @@ _counts: std.StringHashMapUnmanaged(u64) = .{},
 
 pub const init: Console = .{};
 
+fn dispatchConsoleMessage(values: []js.Value, level: LogLevel, exec: *js.Execution) void {
+    const notification = exec.context.page.session.notification;
+    const text = formatValues(values, exec.call_arena) catch return;
+    notification.dispatch(.console_message, &.{
+        .source = .javascript,
+        .level = level,
+        .text = text,
+    });
+}
+
+fn formatValues(values: []js.Value, allocator: std.mem.Allocator) ![]const u8 {
+    var aw: std.io.Writer.Allocating = .init(allocator);
+    const w = &aw.writer;
+    for (values, 0..) |v, i| {
+        if (i != 0) try w.writeByte(' ');
+
+        const js_str = try v.toString();
+        try js_str.format(w);
+    }
+    return aw.written();
+}
+
 pub fn trace(_: *const Console, values: []js.Value, exec: *js.Execution) !void {
     logger.debug(.js, "console.trace", .{
         .stack = exec.context.local.?.stackTrace() catch "???",
         .args = ValueWriter{ .values = values },
     });
+    dispatchConsoleMessage(values, .debug, exec);
 }
 
-pub fn debug(_: *const Console, values: []js.Value) void {
+pub fn debug(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.debug(.js, "console.debug", .{ValueWriter{ .values = values }});
+    dispatchConsoleMessage(values, .debug, exec);
 }
 
-pub fn info(_: *const Console, values: []js.Value) void {
+pub fn info(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.info(.js, "console.info", .{ValueWriter{ .values = values }});
+    dispatchConsoleMessage(values, .info, exec);
 }
 
-pub fn log(_: *const Console, values: []js.Value) void {
+pub fn log(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.info(.js, "console.log", .{ValueWriter{ .values = values }});
+    dispatchConsoleMessage(values, .info, exec);
 }
 
-pub fn warn(_: *const Console, values: []js.Value) void {
+pub fn warn(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.warn(.js, "console.warn", .{ValueWriter{ .values = values }});
+    dispatchConsoleMessage(values, .info, exec);
 }
 
 pub fn clear(_: *const Console) void {}
@@ -63,6 +93,7 @@ pub fn assert(_: *const Console, assertion: js.Value, values: []js.Value) void {
 
 pub fn @"error"(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.warn(.js, "console.error", .{ValueWriter{ .values = values, .stack = exec.context.local.?.stackTrace() catch |err| @errorName(err) orelse "???" }});
+    dispatchConsoleMessage(values, .err, exec);
 }
 
 pub fn table(_: *const Console, data: js.Value, columns: ?js.Value) void {

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
 const Notification = @import("../../Notification.zig");
+const datetime = @import("../../datetime.zig");
 
 const logger = lp.log;
 const LogLevel = lp.log.Level;
@@ -34,24 +35,21 @@ pub const init: Console = .{};
 
 fn dispatchConsoleMessage(values: []js.Value, level: LogLevel, exec: *js.Execution) void {
     const notification = exec.context.page.session.notification;
-    const text = formatValues(values, exec.call_arena) catch return;
+    const ts = datetime.timestamp(.monotonic);
+
     notification.dispatch(.console_message, &.{
         .source = .javascript,
         .level = level,
-        .text = text,
+        .values = values,
+        .timestamp = ts,
     });
-}
 
-fn formatValues(values: []js.Value, allocator: std.mem.Allocator) ![]const u8 {
-    var aw: std.io.Writer.Allocating = .init(allocator);
-    const w = &aw.writer;
-    for (values, 0..) |v, i| {
-        if (i != 0) try w.writeByte(' ');
-
-        const js_str = try v.toString();
-        try js_str.format(w);
-    }
-    return aw.written();
+    notification.dispatch(.runtime_console_message, &.{
+        .source = .javascript,
+        .level = level,
+        .values = values,
+        .timestamp = ts,
+    });
 }
 
 pub fn trace(_: *const Console, values: []js.Value, exec: *js.Execution) !void {

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -33,20 +33,20 @@ _counts: std.StringHashMapUnmanaged(u64) = .{},
 
 pub const init: Console = .{};
 
-fn dispatchConsoleMessage(values: []js.Value, level: LogLevel, exec: *js.Execution) void {
+fn dispatchConsoleMessage(values: []js.Value, console_type: Notification.ConsoleMessageType, exec: *js.Execution) void {
     const notification = exec.context.page.session.notification;
     const ts = datetime.timestamp(.monotonic);
 
     notification.dispatch(.console_message, &.{
         .source = .javascript,
-        .level = level,
+        .type = console_type,
         .values = values,
         .timestamp = ts,
     });
 
     notification.dispatch(.runtime_console_message, &.{
         .source = .javascript,
-        .level = level,
+        .type = console_type,
         .values = values,
         .timestamp = ts,
     });
@@ -57,7 +57,7 @@ pub fn trace(_: *const Console, values: []js.Value, exec: *js.Execution) !void {
         .stack = exec.context.local.?.stackTrace() catch "???",
         .args = ValueWriter{ .values = values },
     });
-    dispatchConsoleMessage(values, .debug, exec);
+    dispatchConsoleMessage(values, .trace, exec);
 }
 
 pub fn debug(_: *const Console, values: []js.Value, exec: *js.Execution) void {
@@ -91,7 +91,7 @@ pub fn assert(_: *const Console, assertion: js.Value, values: []js.Value) void {
 
 pub fn @"error"(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.warn(.js, "console.error", .{ValueWriter{ .values = values, .stack = exec.context.local.?.stackTrace() catch |err| @errorName(err) orelse "???" }});
-    dispatchConsoleMessage(values, .err, exec);
+    dispatchConsoleMessage(values, .@"error", exec);
 }
 
 pub fn table(_: *const Console, data: js.Value, columns: ?js.Value) void {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -641,6 +641,14 @@ pub const BrowserContext = struct {
         self.notification.unregister(.console_message, self);
     }
 
+    pub fn runtimeEnable(self: *BrowserContext) !void {
+        try self.notification.register(.runtime_console_message, self, onRuntimeConsoleMessage);
+    }
+
+    pub fn runtimeDisable(self: *BrowserContext) void {
+        self.notification.unregister(.runtime_console_message, self);
+    }
+
     pub fn onFrameRemove(ctx: *anyopaque, _: Notification.FrameRemove) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         @import("domains/page.zig").frameRemove(self);
@@ -802,11 +810,6 @@ pub const BrowserContext = struct {
         };
     }
 
-    pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
-        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
-        return @import("domains/console.zig").consoleMessage(self, msg);
-    }
-
     // This is hacky x 2. First, we create the JSON payload by gluing our
     // session_id onto it. Second, we're much more client/websocket aware than
     // we should be.
@@ -845,6 +848,20 @@ pub const BrowserContext = struct {
         }
 
         try cdp.client.sendJSONRaw(buf);
+    }
+
+    pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        defer self.resetNotificationArena();
+
+        return @import("domains/console.zig").consoleMessage(self, msg);
+    }
+
+    pub fn onRuntimeConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        defer self.resetNotificationArena();
+
+        return @import("domains/runtime.zig").consoleMessage(self, msg);
     }
 };
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -236,6 +236,7 @@ fn dispatchCommand(command: *Command, method: []const u8) !void {
             asUint(u56, "Runtime") => return @import("domains/runtime.zig").processMessage(command),
             asUint(u56, "Network") => return @import("domains/network.zig").processMessage(command),
             asUint(u56, "Storage") => return @import("domains/storage.zig").processMessage(command),
+            asUint(u56, "Console") => return @import("domains/console.zig").processMessage(command),
             else => {},
         },
         8 => switch (@as(u64, @bitCast(domain[0..8].*))) {
@@ -631,6 +632,9 @@ pub const BrowserContext = struct {
         self.notification.unregister(.frame_network_idle, self);
         self.notification.unregister(.frame_network_almost_idle, self);
     }
+
+    pub fn consoleEnable(_: *BrowserContext) !void {}
+    pub fn consoleDisable(_: *BrowserContext) void {}
 
     pub fn onFrameRemove(ctx: *anyopaque, _: Notification.FrameRemove) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -778,6 +778,18 @@ pub const BrowserContext = struct {
         try @import("domains/fetch.zig").requestAuthRequired(self, data);
     }
 
+    pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        defer self.resetNotificationArena();
+        return @import("domains/console.zig").consoleMessage(self.notification_arena, self, msg);
+    }
+
+    pub fn onRuntimeConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        defer self.resetNotificationArena();
+        return @import("domains/runtime.zig").consoleMessage(self.notification_arena, self, msg);
+    }
+
     fn resetNotificationArena(self: *BrowserContext) void {
         defer _ = self.cdp.notification_arena.reset(.{ .retain_with_limit = 1024 * 64 });
     }
@@ -848,20 +860,6 @@ pub const BrowserContext = struct {
         }
 
         try cdp.client.sendJSONRaw(buf);
-    }
-
-    pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
-        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
-        defer self.resetNotificationArena();
-
-        return @import("domains/console.zig").consoleMessage(self, msg);
-    }
-
-    pub fn onRuntimeConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
-        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
-        defer self.resetNotificationArena();
-
-        return @import("domains/runtime.zig").consoleMessage(self, msg);
     }
 };
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -633,8 +633,13 @@ pub const BrowserContext = struct {
         self.notification.unregister(.frame_network_almost_idle, self);
     }
 
-    pub fn consoleEnable(_: *BrowserContext) !void {}
-    pub fn consoleDisable(_: *BrowserContext) void {}
+    pub fn consoleEnable(self: *BrowserContext) !void {
+        try self.notification.register(.console_message, self, onConsoleMessage);
+    }
+
+    pub fn consoleDisable(self: *BrowserContext) void {
+        self.notification.unregister(.console_message, self);
+    }
 
     pub fn onFrameRemove(ctx: *anyopaque, _: Notification.FrameRemove) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
@@ -795,6 +800,11 @@ pub const BrowserContext = struct {
         sendInspectorMessage(@ptrCast(@alignCast(ctx)), msg) catch |err| {
             log.err(.cdp, "send inspector event", .{ .err = err });
         };
+    }
+
+    pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/console.zig").consoleMessage(self, msg);
     }
 
     // This is hacky x 2. First, we create the JSON payload by gluing our

--- a/src/cdp/domains/console.zig
+++ b/src/cdp/domains/console.zig
@@ -18,17 +18,21 @@
 
 const std = @import("std");
 
+const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
+const Notification = @import("../../Notification.zig");
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
         disable,
+        clearMessages,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
+        .clearMessages => return cmd.sendResult(null, .{}),
     }
 }
 
@@ -42,4 +46,23 @@ fn disable(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     bc.consoleDisable();
     return cmd.sendResult(null, .{});
+}
+
+const ConsoleMessage = struct {
+    source: []const u8,
+    level: []const u8,
+    text: []const u8,
+    url: ?[]const u8 = null,
+    line: ?u32 = null,
+    columns: ?u32 = null,
+};
+
+pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
+    const session_id = bc.session_id orelse return;
+
+    return bc.cdp.sendEvent("Console.messageAdded", ConsoleMessage{
+        .source = @tagName(event.source),
+        .level = @tagName(event.level),
+        .text = event.text,
+    }, .{ .session_id = session_id });
 }

--- a/src/cdp/domains/console.zig
+++ b/src/cdp/domains/console.zig
@@ -1,0 +1,45 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const CDP = @import("../CDP.zig");
+
+pub fn processMessage(cmd: *CDP.Command) !void {
+    const action = std.meta.stringToEnum(enum {
+        enable,
+        disable,
+    }, cmd.input.action) orelse return error.UnknownMethod;
+
+    switch (action) {
+        .enable => return enable(cmd),
+        .disable => return disable(cmd),
+    }
+}
+
+fn enable(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    try bc.consoleEnable();
+    return cmd.sendResult(null, .{});
+}
+
+fn disable(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.consoleDisable();
+    return cmd.sendResult(null, .{});
+}

--- a/src/cdp/domains/console.zig
+++ b/src/cdp/domains/console.zig
@@ -72,7 +72,7 @@ pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.Consol
 
     return bc.cdp.sendEvent("Console.messageAdded", ConsoleMessage{
         .source = @tagName(event.source),
-        .level = @tagName(event.level),
+        .level = @tagName(event.type),
         .text = aw.written(),
     }, .{ .session_id = session_id });
 }

--- a/src/cdp/domains/console.zig
+++ b/src/cdp/domains/console.zig
@@ -60,9 +60,19 @@ const ConsoleMessage = struct {
 pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
     const session_id = bc.session_id orelse return;
 
+    // format values
+    var aw: std.io.Writer.Allocating = .init(bc.notification_arena);
+    const w = &aw.writer;
+    for (event.values, 0..) |v, i| {
+        if (i != 0) try w.writeByte(' ');
+
+        const js_str = try v.toString();
+        try js_str.format(w);
+    }
+
     return bc.cdp.sendEvent("Console.messageAdded", ConsoleMessage{
         .source = @tagName(event.source),
         .level = @tagName(event.level),
-        .text = event.text,
+        .text = aw.written(),
     }, .{ .session_id = session_id });
 }

--- a/src/cdp/domains/console.zig
+++ b/src/cdp/domains/console.zig
@@ -22,6 +22,8 @@ const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 const Notification = @import("../../Notification.zig");
 
+const Allocator = std.mem.Allocator;
+
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
@@ -57,11 +59,11 @@ const ConsoleMessage = struct {
     columns: ?u32 = null,
 };
 
-pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
+pub fn consoleMessage(arena: Allocator, bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
     const session_id = bc.session_id orelse return;
 
     // format values
-    var aw: std.io.Writer.Allocating = .init(bc.notification_arena);
+    var aw: std.io.Writer.Allocating = .init(arena);
     const w = &aw.writer;
     for (event.values, 0..) |v, i| {
         if (i != 0) try w.writeByte(' ');

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -19,11 +19,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const js = @import("../../browser/js/js.zig");
 const CDP = @import("../CDP.zig");
+const Notification = @import("../../Notification.zig");
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
+        disable,
         runIfWaitingForDebugger,
         evaluate,
         addBinding,
@@ -34,8 +37,22 @@ pub fn processMessage(cmd: *CDP.Command) !void {
 
     switch (action) {
         .runIfWaitingForDebugger => return cmd.sendResult(null, .{}),
+        .enable => return enable(cmd),
+        .disable => return disable(cmd),
         else => return sendInspector(cmd, action),
     }
+}
+
+fn enable(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    try bc.runtimeEnable();
+    return sendInspector(cmd, .enable);
+}
+
+fn disable(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    bc.runtimeDisable();
+    return sendInspector(cmd, .disable);
 }
 
 fn sendInspector(cmd: *CDP.Command, action: anytype) !void {
@@ -90,4 +107,58 @@ fn logInspector(cmd: *CDP.Command, action: anytype) !void {
     const f = try dir.createFile(name, .{});
     defer f.close();
     try f.writeAll(script);
+}
+
+const RemoteObject = struct {
+    type: []const u8,
+    subtype: ?[]const u8,
+    className: ?[]const u8,
+    description: ?[]const u8,
+    objectId: ?[]const u8,
+    value: js.Value,
+};
+
+const ConsoleMessage = struct {
+    type: []const u8,
+    executionContextId: i32,
+    timestamp: u64,
+    args: []RemoteObject,
+};
+
+pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
+    const session_id = bc.session_id orelse return;
+    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const context_id = bc.inspector_session.inspector.getContextId(&ls.local);
+    const arena = bc.notification_arena;
+
+    var args: std.ArrayList(RemoteObject) = .empty;
+    for (event.values) |value| {
+        const remote_object = try bc.inspector_session.getRemoteObject(
+            &ls.local,
+            "",
+            value,
+        );
+        defer remote_object.deinit();
+
+        try args.append(arena, .{
+            .type = try remote_object.getType(arena),
+            .subtype = try remote_object.getSubtype(arena),
+            .className = try remote_object.getClassName(arena),
+            .description = try remote_object.getDescription(arena),
+            .objectId = try remote_object.getObjectId(arena),
+            .value = value,
+        });
+    }
+
+    return bc.cdp.sendEvent("Runtime.consoleAPICalled", ConsoleMessage{
+        .type = @tagName(event.level),
+        .timestamp = event.timestamp,
+        .executionContextId = context_id,
+        .args = args.items,
+    }, .{ .session_id = session_id });
 }

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -156,7 +156,7 @@ pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.Consol
     }
 
     return bc.cdp.sendEvent("Runtime.consoleAPICalled", ConsoleMessage{
-        .type = @tagName(event.level),
+        .type = @tagName(event.type),
         .timestamp = event.timestamp,
         .executionContextId = context_id,
         .args = args.items,

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -23,6 +23,8 @@ const js = @import("../../browser/js/js.zig");
 const CDP = @import("../CDP.zig");
 const Notification = @import("../../Notification.zig");
 
+const Allocator = std.mem.Allocator;
+
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
         enable,
@@ -125,7 +127,7 @@ const ConsoleMessage = struct {
     args: []RemoteObject,
 };
 
-pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
+pub fn consoleMessage(arena: Allocator, bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
     const session_id = bc.session_id orelse return;
     const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
 
@@ -134,7 +136,6 @@ pub fn consoleMessage(bc: *CDP.BrowserContext, event: *const Notification.Consol
     defer ls.deinit();
 
     const context_id = bc.inspector_session.inspector.getContextId(&ls.local);
-    const arena = bc.notification_arena;
 
     var args: std.ArrayList(RemoteObject) = .empty;
     for (event.values) |value| {


### PR DESCRIPTION
Relates with #1953

* [x] add `Console` CDP domain
* [x] support `Console.messageAdded` event
* [x] implement the `Console.messageAdded` event for all `Console` API (and compare behavior w/ Chrome)
* [ ] ~~implement `Log` CDP domain for `Console` API (Puppeteer uses `Log` instead of `Console`)~~
* [x] implement `Runtime.consoleAPICalled` events (when `Runtime.enable` is `on`) (Puppeteer uses this)
* [x] Add e2e tests https://github.com/lightpanda-io/demo/pull/170