### PR TITLE
Encode script urls before making request

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -144,7 +144,7 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
         if (try parseDataURI(arena, src)) |data_uri| {
             source = .{ .@"inline" = data_uri };
         } else {
-            remote_url = try URL.resolve(arena, base_url, src, .{});
+            remote_url = try URL.resolve(arena, base_url, src, .{ .encoding = frame.charset });
             source = .{ .remote = .{} };
         }
     } else {

--- a/src/browser/tests/page/meta.html
+++ b/src/browser/tests/page/meta.html
@@ -40,3 +40,6 @@
 
   testing.expectEqual("[object Intl.DateTimeFormat]", new Intl.DateTimeFormat().toString());
 </script>
+
+<!-- Leave it, it used to crash -->
+<script src='empty.js=["violated-directive=worker-src","TEST COMPLETE"]'></script>


### PR DESCRIPTION
This comes from a WPT crash in /content-security-policy/blob/self-doesnt-match-blob.sub.html

The core issue is double-free on the request header list. This is a fundamental issue about ambiguous ownership. On error, who's responsible for freeing the request? The caller or the HttpClient. Answer: it depends when/where the error happens. That just doesnt' work, and needs to be fixed. BUT....

There's also the issue that this specific test is failing because we aren't properly encoding script URLs. This is a real and separate issue that also needs to be fixed. That's what this commit does. In some ways, it's a bit superficial because there's a real double-free issue, but this is a real issue to fix.