### PR TITLE
dom: toggle parent <details>.open on <summary> click

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3736,6 +3736,26 @@ pub fn handleClick(self: *Frame, target: *Node) !void {
             const control_html = control.is(Element.Html) orelse return;
             try control_html.click(self);
         },
+        .generic => |generic| {
+            // Per HTML §4.11.1.2 "The summary element", clicking a summary
+            // toggles its parent details's open state, but only when the
+            // summary is the first summary child of that details.
+            if (generic._tag != .summary) return;
+            const parent_el = element.asNode().parentElement() orelse return;
+            const parent_html = parent_el.is(Element.Html) orelse return;
+            const details = switch (parent_html._type) {
+                .details => |d| d,
+                else => return,
+            };
+            var maybe_child = parent_el.firstElementChild();
+            while (maybe_child) |child| : (maybe_child = child.nextElementSibling()) {
+                if (child.getTag() == .summary) {
+                    if (child != element) return;
+                    break;
+                }
+            }
+            try details.setOpen(!details.getOpen(), self);
+        },
         else => {},
     }
 }

--- a/src/browser/tests/element/html/summary_click.html
+++ b/src/browser/tests/element/html/summary_click.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<!-- HTMLSummaryElement activation behavior (HTML §4.11.1.2 "The summary element"):
+     when summary is the first summary child of its parent <details>, clicking
+     it must toggle the parent details's `open` attribute. -->
+
+<details id="d_closed">
+  <summary id="s_closed">click me</summary>
+  <p>hidden by default</p>
+</details>
+
+<details id="d_open" open>
+  <summary id="s_open">starts open</summary>
+  <p>visible by default</p>
+</details>
+
+<details id="d_two">
+  <summary id="s_first">first</summary>
+  <summary id="s_second">second</summary>
+  <p>content</p>
+</details>
+
+<section id="orphan_parent">
+  <summary id="s_orphan">orphan summary</summary>
+</section>
+
+<script id="closed_details_opens_on_summary_click">
+  {
+    const d = $('#d_closed');
+    testing.expectEqual(false, d.open);
+    $('#s_closed').click();
+    testing.expectEqual(true, d.open);
+  }
+</script>
+
+<script id="open_details_closes_on_summary_click">
+  {
+    const d = $('#d_open');
+    testing.expectEqual(true, d.open);
+    $('#s_open').click();
+    testing.expectEqual(false, d.open);
+  }
+</script>
+
+<script id="only_first_summary_toggles">
+  {
+    const d = $('#d_two');
+    testing.expectEqual(false, d.open);
+
+    $('#s_second').click();
+    testing.expectEqual(false, d.open, 'non-first summary must not toggle');
+
+    $('#s_first').click();
+    testing.expectEqual(true, d.open);
+  }
+</script>
+
+<script id="summary_outside_details_no_op">
+  {
+    // No exception, no side-effect.
+    $('#s_orphan').click();
+  }
+</script>

--- a/src/browser/webapi/element/html/Details.zig
+++ b/src/browser/webapi/element/html/Details.zig
@@ -56,3 +56,7 @@ const testing = @import("../../../../testing.zig");
 test "WebApi: HTML.Details" {
     try testing.htmlRunner("element/html/details.html", .{});
 }
+
+test "WebApi: HTML.Summary click toggles parent details" {
+    try testing.htmlRunner("element/html/summary_click.html", .{});
+}


### PR DESCRIPTION
Fixes #2325.

## Summary

Per [HTML §4.11.1.2](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element), a `<summary>`'s activation behavior runs the toggle-details-state algorithm on its parent `<details>`, but only when the summary is the first summary child of that details.

`Frame.handleClick` previously had no arm for `.generic`, so summary clicks fell into `else => {}` and `details.open` never changed.

## Change

`src/browser/Frame.zig` — add a `.generic` arm to the `switch (html_element._type)` in `handleClick`:

- gate on `generic._tag == .summary`
- resolve `parentElement` and require `_type == .details`
- walk parent's element children; the first `.summary`-tagged child must be this element
- toggle via the existing `Details.setOpen(!Details.getOpen(), self)`

No changes to `Details.zig`'s `getOpen` / `setOpen` — they already do the right thing.

## Out of scope

- Firing `ToggleEvent` on the parent details. Spec queues a task that fires `ToggleEvent` on the details — Lightpanda doesn't expose `ToggleEvent` yet (no `src/browser/webapi/event/Toggle*.zig`). The `open`-attribute mutation is the primary observable effect; the event can land once `ToggleEvent` does.
- Activating the summary when a *descendant* of `<summary>` is clicked. The same gap exists for `<a>` and `<label>` today (`handleClick` only inspects the original target). A spec-correct walk-up-the-path activation refactor is broader scope.

## Tests

`src/browser/tests/element/html/summary_click.html`, registered from `Details.zig`:

- closed details + summary click → opens
- open details + summary click → closes
- two summaries: clicking the *non-first* must not toggle; clicking the first toggles
- summary outside any `<details>` is a no-op (no exception)

## Test plan

- [ ] `make test F=details` (or equivalent webapi test runner) passes the new `summary_click.html` cases
- [ ] Existing `details.html` tests still pass
- [ ] Manual: against the issue's `repro.sh`, both `closed→open` and `open→closed` assertions PASS