### PR TITLE
build: provide strchrnul shim for libidn2 on macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -551,26 +551,23 @@ fn buildLibidn2(
         // libc itself; on musl it would also need a separate -liconv.
         mod.linkSystemLibrary("iconv", .{});
 
-        // libidn2's lib/lookup.c calls strchrnul() unconditionally — a glibc
-        // extension absent from macOS libc and not declared by <string.h>.
-        // Upstream relies on gnulib substituting <string.h> + linking
-        // gl/strchrnul.c; we don't wire up that overlay, so ship a small
-        // Darwin-only shim and inject its prototype via -include.
-        mod.addIncludePath(b.path("vendor/libidn2/darwin"));
+        // libidn2's lib/lookup.c calls strchrnul(), a glibc extension that
+        // macOS libc lacked before 15.4 and that lookup.c never gets a
+        // declaration for (it doesn't include <string.h>). Upstream solves
+        // this through gnulib's substituted <string.h> + gl/strchrnul.c;
+        // we don't wire up that overlay. Provide our own implementation —
+        // the matching prototype is declared in vendor/libidn2/config.h
+        // under #ifdef __APPLE__, so every libidn2 TU sees it via the
+        // existing #include <config.h>.
         lib.addCSourceFile(.{
             .file = b.path("vendor/libidn2/darwin/strchrnul.c"),
             .flags = &.{},
         });
     }
 
-    const lib_flags: []const []const u8 = if (is_darwin)
-        &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC", "-include", "strchrnul.h" }
-    else
-        &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC" };
-
     lib.addCSourceFiles(.{
         .root = dep.path("lib"),
-        .flags = lib_flags,
+        .flags = &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC" },
         .files = &.{
             "bidi.c",     "context.c",  "data.c",   "decode.c",
             "error.c",    "free.c",     "idna.c",   "lookup.c",

--- a/build.zig
+++ b/build.zig
@@ -550,11 +550,27 @@ fn buildLibidn2(
         // in libiconv (separate from libSystem). On glibc Linux iconv is in
         // libc itself; on musl it would also need a separate -liconv.
         mod.linkSystemLibrary("iconv", .{});
+
+        // libidn2's lib/lookup.c calls strchrnul() unconditionally — a glibc
+        // extension absent from macOS libc and not declared by <string.h>.
+        // Upstream relies on gnulib substituting <string.h> + linking
+        // gl/strchrnul.c; we don't wire up that overlay, so ship a small
+        // Darwin-only shim and inject its prototype via -include.
+        mod.addIncludePath(b.path("vendor/libidn2/darwin"));
+        lib.addCSourceFile(.{
+            .file = b.path("vendor/libidn2/darwin/strchrnul.c"),
+            .flags = &.{},
+        });
     }
+
+    const lib_flags: []const []const u8 = if (is_darwin)
+        &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC", "-include", "strchrnul.h" }
+    else
+        &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC" };
 
     lib.addCSourceFiles(.{
         .root = dep.path("lib"),
-        .flags = &.{ "-DHAVE_CONFIG_H", "-DIDN2_STATIC" },
+        .flags = lib_flags,
         .files = &.{
             "bidi.c",     "context.c",  "data.c",   "decode.c",
             "error.c",    "free.c",     "idna.c",   "lookup.c",

--- a/build.zig
+++ b/build.zig
@@ -551,14 +551,11 @@ fn buildLibidn2(
         // libc itself; on musl it would also need a separate -liconv.
         mod.linkSystemLibrary("iconv", .{});
 
-        // libidn2's lib/lookup.c calls strchrnul(), a glibc extension that
-        // macOS libc lacked before 15.4 and that lookup.c never gets a
-        // declaration for (it doesn't include <string.h>). Upstream solves
-        // this through gnulib's substituted <string.h> + gl/strchrnul.c;
-        // we don't wire up that overlay. Provide our own implementation —
-        // the matching prototype is declared in vendor/libidn2/config.h
-        // under #ifdef __APPLE__, so every libidn2 TU sees it via the
-        // existing #include <config.h>.
+        // libidn2's lib/lookup.c calls strchrnul() without including
+        // <string.h>; the prototype is declared in vendor/libidn2/config.h
+        // alongside the existing strverscmp shim. macOS libc lacked the
+        // symbol entirely before 15.4 — provide it here so the link
+        // succeeds. Mirrors how gl/strverscmp.c is wired up below.
         lib.addCSourceFile(.{
             .file = b.path("vendor/libidn2/darwin/strchrnul.c"),
             .flags = &.{},

--- a/vendor/libidn2/config.h
+++ b/vendor/libidn2/config.h
@@ -429,6 +429,17 @@
 /* Define to 1 if you have the `strchrnul' function. */
 #define HAVE_STRCHRNUL 1
 
+/* lib/lookup.c calls strchrnul() but never #include <string.h>, so it relies
+   on a declaration being visible by the time it processes config.h. Upstream
+   gets it from gnulib's substituted <string.h>; we don't wire up that overlay
+   (see build.zig::buildLibidn2). On macOS the symbol is also missing from
+   libc before 15.4 — build.zig adds vendor/libidn2/darwin/strchrnul.c on
+   Darwin to satisfy the link. Declare the prototype here so every libidn2
+   TU that includes config.h sees a real declaration before preprocessing. */
+#ifdef __APPLE__
+char *strchrnul(const char *s, int c_in);
+#endif
+
 /* Define if you have `strerror_r'. */
 #define HAVE_STRERROR_R 1
 

--- a/vendor/libidn2/config.h
+++ b/vendor/libidn2/config.h
@@ -429,17 +429,6 @@
 /* Define to 1 if you have the `strchrnul' function. */
 #define HAVE_STRCHRNUL 1
 
-/* lib/lookup.c calls strchrnul() but never #include <string.h>, so it relies
-   on a declaration being visible by the time it processes config.h. Upstream
-   gets it from gnulib's substituted <string.h>; we don't wire up that overlay
-   (see build.zig::buildLibidn2). On macOS the symbol is also missing from
-   libc before 15.4 — build.zig adds vendor/libidn2/darwin/strchrnul.c on
-   Darwin to satisfy the link. Declare the prototype here so every libidn2
-   TU that includes config.h sees a real declaration before preprocessing. */
-#ifdef __APPLE__
-char *strchrnul(const char *s, int c_in);
-#endif
-
 /* Define if you have `strerror_r'. */
 #define HAVE_STRERROR_R 1
 
@@ -1915,4 +1904,12 @@ char *strchrnul(const char *s, int c_in);
 #ifndef _LIBIDN2_LP_DECLS
 #define _LIBIDN2_LP_DECLS
 extern int strverscmp(const char *, const char *);
+
+/* lightpanda: lib/lookup.c calls strchrnul() without including <string.h>,
+   so the prototype must reach it through this header. macOS libc also
+   lacked the symbol entirely before 15.4 — build.zig::buildLibidn2 adds
+   vendor/libidn2/darwin/strchrnul.c on Darwin to provide the definition. */
+#ifdef __APPLE__
+extern char *strchrnul(const char *, int);
+#endif
 #endif

--- a/vendor/libidn2/darwin/strchrnul.c
+++ b/vendor/libidn2/darwin/strchrnul.c
@@ -1,10 +1,12 @@
 /* Darwin-only strchrnul shim for libidn2.
 
-   strchrnul is a glibc extension. On macOS it is missing from libc before
-   15.4 and is never made visible to libidn2's lib/lookup.c (which calls it
-   without including <string.h>). The matching prototype is declared in
-   vendor/libidn2/config.h under #ifdef __APPLE__, so callers compile;
-   this file provides the symbol so they link.
+   strchrnul is a glibc extension. macOS libc lacks it before 15.4, and
+   libidn2's lib/lookup.c never includes <string.h> — so even on newer
+   macOS the declaration would not reach the call site. The matching
+   prototype is declared next to the strverscmp shim in
+   vendor/libidn2/config.h (within the _LIBIDN2_LP_DECLS block, gated on
+   __APPLE__), so callers compile; this file provides the symbol so
+   they link.
 
    gnulib's strchrnul.c falls through to rawmemchr() when the search byte
    is NUL — also a glibc extension. libidn2 only ever searches for '.', so

--- a/vendor/libidn2/darwin/strchrnul.c
+++ b/vendor/libidn2/darwin/strchrnul.c
@@ -1,15 +1,14 @@
-/* macOS libc lacks strchrnul (a glibc extension). libidn2's lib/lookup.c
-   calls it directly to walk DNS label boundaries. Upstream's portable build
-   relies on gnulib substituting <string.h> with a declaration and linking
-   gl/strchrnul.c, but this build does not wire up that overlay. We provide
-   a small Darwin-only shim with the same semantics.
+/* Darwin-only strchrnul shim for libidn2.
 
-   gnulib's strchrnul.c falls through to rawmemchr() when the search byte is
-   NUL — also a glibc extension. libidn2 only ever searches for '.', so a
-   straightforward byte scan is sufficient and avoids pulling in a second
-   shim. */
+   strchrnul is a glibc extension. On macOS it is missing from libc before
+   15.4 and is never made visible to libidn2's lib/lookup.c (which calls it
+   without including <string.h>). The matching prototype is declared in
+   vendor/libidn2/config.h under #ifdef __APPLE__, so callers compile;
+   this file provides the symbol so they link.
 
-#include "strchrnul.h"
+   gnulib's strchrnul.c falls through to rawmemchr() when the search byte
+   is NUL — also a glibc extension. libidn2 only ever searches for '.', so
+   a straight byte scan is enough and avoids dragging in a second shim. */
 
 char *strchrnul(const char *s, int c_in) {
     const unsigned char c = (unsigned char) c_in;

--- a/vendor/libidn2/darwin/strchrnul.c
+++ b/vendor/libidn2/darwin/strchrnul.c
@@ -1,0 +1,19 @@
+/* macOS libc lacks strchrnul (a glibc extension). libidn2's lib/lookup.c
+   calls it directly to walk DNS label boundaries. Upstream's portable build
+   relies on gnulib substituting <string.h> with a declaration and linking
+   gl/strchrnul.c, but this build does not wire up that overlay. We provide
+   a small Darwin-only shim with the same semantics.
+
+   gnulib's strchrnul.c falls through to rawmemchr() when the search byte is
+   NUL — also a glibc extension. libidn2 only ever searches for '.', so a
+   straightforward byte scan is sufficient and avoids pulling in a second
+   shim. */
+
+#include "strchrnul.h"
+
+char *strchrnul(const char *s, int c_in) {
+    const unsigned char c = (unsigned char) c_in;
+    const unsigned char *p = (const unsigned char *) s;
+    while (*p && *p != c) p++;
+    return (char *) p;
+}

--- a/vendor/libidn2/darwin/strchrnul.h
+++ b/vendor/libidn2/darwin/strchrnul.h
@@ -1,0 +1,8 @@
+/* Prototype for the macOS strchrnul shim. See strchrnul.c. */
+
+#ifndef LPD_LIBIDN2_DARWIN_STRCHRNUL_H
+#define LPD_LIBIDN2_DARWIN_STRCHRNUL_H
+
+char *strchrnul(const char *s, int c_in);
+
+#endif

--- a/vendor/libidn2/darwin/strchrnul.h
+++ b/vendor/libidn2/darwin/strchrnul.h
@@ -1,8 +1,0 @@
-/* Prototype for the macOS strchrnul shim. See strchrnul.c. */
-
-#ifndef LPD_LIBIDN2_DARWIN_STRCHRNUL_H
-#define LPD_LIBIDN2_DARWIN_STRCHRNUL_H
-
-char *strchrnul(const char *s, int c_in);
-
-#endif


### PR DESCRIPTION
## Summary

Nightly macOS release builds (`x86_64, macos-14-large` and `aarch64, macos-14`) have failed at the **v8 snapshot** step ever since libidn2 was vendored in [`9fe628dd`](https://github.com/lightpanda-io/browser/commit/9fe628dd). libidn2 itself doesn't compile on macOS:

```
.zig-cache/p/N-V-…/lib/lookup.c:561:40: error: call to undeclared function 'strchrnul';
  ISO C99 and later do not support implicit function declarations

+- compile lib idn2 ReleaseFast native 2 errors
```

Failing run for reference: https://github.com/lightpanda-io/browser/actions/runs/25242467548/job/74020732072. Linux jobs build fine.

## Root cause

- **The declaration never reaches the call site.** `lib/lookup.c:561` calls `strchrnul(src, '.')` directly. The file includes `<errno.h>` and `<stdlib.h>` but **never `<string.h>`** — it relies on the prototype reaching it through `#include <config.h>`.
- **gnulib's substituted `<string.h>` is the upstream source of that prototype.** `buildLibidn2` deliberately doesn't wire up `gl/string.in.h` (only the `unistring/*.in.h` headers are substituted), so the prototype never makes it into `<config.h>`.
- **The symbol itself is also missing on macOS 14.** `strchrnul` is a glibc extension; Apple's libc didn't add it until macOS 15.4. CI runs macOS 14, so even with a visible declaration we'd still hit a link error.
- **`#define HAVE_STRCHRNUL 1` in `config.h` doesn't help.** `lookup.c` doesn't gate on the macro. The (Linux-generated) value isn't load-bearing on either platform.

Linux glibc declares the prototype through `_GNU_SOURCE` propagation and provides the symbol in libc — that's why Linux jobs are unaffected.

## Fix

Two small Darwin-targeted additions, no patches to the libidn2 source:

1. **`vendor/libidn2/config.h`** — declare `extern char *strchrnul(const char *, int)` inside the existing `_LIBIDN2_LP_DECLS` block at the end of the file, gated on `#ifdef __APPLE__`. Every libidn2 TU does `#include <config.h>` first, so the prototype reaches `lookup.c`. **This is the same pattern the project already uses for `strverscmp`** in [config.h:1912-1918](https://github.com/lightpanda-io/browser/blob/main/vendor/libidn2/config.h#L1912-L1918) — same situation (glibc-only function called from libidn2 sources without `<string.h>`), same approach.
2. **`vendor/libidn2/darwin/strchrnul.c`** — minimal `strchrnul` implementation, compiled only on Darwin via `build.zig`. The gnulib version (`gl/strchrnul.c`) delegates to `rawmemchr` (also glibc-only) when the search byte is `\0`; libidn2 only ever searches for `'.'`, so a straight byte scan is enough and avoids dragging in a second shim.

`build.zig` change is one extra `addCSourceFile` inside the existing `if (is_darwin)` block — no per-platform flag asymmetry, no extra include path. Linux builds unchanged.

## Why this shape, not a band-aid

- **Mirrors the existing `strverscmp` precedent in this same file.** The codebase already solved this exact class of problem when libidn2 was first vendored. The deliberate refinement here: gate on `#ifdef __APPLE__` rather than declaring unconditionally. glibc Linux declares `strchrnul` natively, so a blanket declaration would only force redundant redeclarations there.
- **Wiring up gnulib's `<string.h>` overlay** was rejected — `string.in.h` has hundreds of `@VAR@` substitutions and pulls in much of gnulib's portability scaffolding. Disproportionate for one missing symbol.
- **Reusing `gl/strchrnul.c`** was rejected — it pulls in `rawmemchr` (also glibc-only); we'd then need `gl/rawmemchr.c` plus its config.h tweaks. All of it would be unreachable code at runtime since libidn2 only ever calls `strchrnul(s, '.')`.
- **Patching `lib/lookup.c` to add `#include <string.h>`** was rejected — keeps the dep dirty and re-bump-hostile, and the symbol is missing on macOS 14 regardless.
- **`-Wno-error=implicit-function-declaration`** was rejected — Clang treats implicit declarations as a hard error in C23 mode (can't be downgraded), and the link-time symbol would still be missing.
- **Flipping `HAVE_STRCHRNUL` to 0** was rejected — `lookup.c` doesn't gate on the macro, so the change would have no effect and would just muddy an autoconf-generated section of the file.

## Compatibility

- **Linux:** zero impact — declaration gated on `__APPLE__`, .c file gated on `is_darwin`.
- **macOS 14 (CI):** declaration becomes visible to `lookup.c` via `config.h`; shim provides the missing symbol.
- **macOS 15.4+ (where libc has `strchrnul`):** our prototype matches Apple's signature. `lookup.c` only sees ours (no `<string.h>` include there). Three other TUs include both `<config.h>` and `<string.h>` — `punycode.c`, `tr46map.c`, `version.c` — but none of them call `strchrnul`, so the compatible-signature redeclaration is silently merged by Clang and the `-Wunguarded-availability-new` warning never triggers.

## Test plan

- [x] Reproduced the exact CI error locally — `mise exec -- zig cc -target x86_64-macos -c …/lib/lookup.c` on `main` produces `call to undeclared function 'strchrnul'`.
- [x] Mimicked the `lookup.c` pattern (`#include "config.h"`, no `<string.h>`, then call `strchrnul`) under `-Wall -Wextra -Werror` on `-target x86_64-macos.{13.0, 14.0, 15.4}` — all three compile cleanly with the patched `config.h` + shim.
- [x] Mimicked the three TUs that include both `<config.h>` and `<string.h>` (`punycode.c`, `tr46map.c`, `version.c`) under the same flags + targets — no warnings, no errors.
- [x] `x86_64-linux-gnu` compile unchanged — declaration not added.
- [x] Compiled the shim and ran a sanity program: `strchrnul("foo.bar", '.') → +3`, `strchrnul("nodot", '.') → +5` (pointer to terminating NUL). Matches glibc semantics.
- [x] `mise exec -- zig fmt --check build.zig` clean.
- [ ] CI macOS jobs (x86_64 + aarch64) green.