### PR TITLE
On window.close, reset the frame's scheduler

### DIFF
--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -568,6 +568,8 @@ pub fn close(self: *Window) void {
         }
     }
 
+    frame.js.scheduler.reset();
+
     // We can't tear the Frame down here — close() is invoked from JS still
     // running on top of this Frame's V8 context, often deep inside a script
     // eval whose parser is still holding the Frame. Destroying the context


### PR DESCRIPTION
Saw that worker.close() does this and it makes sense to do for window.close() too.