### PR TITLE
forms: implement HTMLInputElement.pattern + patternMismatch validity

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.4.3'
+    default: 'v0.4.4'
   v8:
     description: 'v8 version to install'
     required: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.0.365.4
-ARG ZIG_V8=v0.4.3
+ARG ZIG_V8=v0.4.4
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.3.tar.gz",
-            .hash = "v8-0.0.0-xddH61GNBABFJ11FJ8KDYXITyjKh4jQ54taEenYek2xJ",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.4.tar.gz",
+            .hash = "v8-0.0.0-xddH6xiUBACrbPC02HPqL4IOl_1EKAF6zf0IwNKaCILK",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/src/browser/js/RegExp.zig
+++ b/src/browser/js/RegExp.zig
@@ -1,0 +1,71 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const js = @import("js.zig");
+
+const v8 = js.v8;
+
+const RegExp = @This();
+
+local: *const js.Local,
+handle: *const v8.RegExp,
+
+// Mirrors v8::RegExp::Flags. Combine with bitwise OR.
+pub const Flag = struct {
+    pub const none: c_int = v8.kRegExpNone;
+    pub const global: c_int = v8.kRegExpGlobal;
+    pub const ignore_case: c_int = v8.kRegExpIgnoreCase;
+    pub const multiline: c_int = v8.kRegExpMultiline;
+    pub const sticky: c_int = v8.kRegExpSticky;
+    pub const unicode: c_int = v8.kRegExpUnicode;
+    pub const dot_all: c_int = v8.kRegExpDotAll;
+    pub const linear: c_int = v8.kRegExpLinear;
+    pub const has_inSelfdices: c_int = v8.kRegExpHasIndices;
+    pub const unicode_sets: c_int = v8.kRegExpUnicodeSets;
+};
+
+pub fn init(local: *const js.Local, pattern: []const u8, flags: c_int) !RegExp {
+    const pattern_handle = local.isolate.initStringHandle(pattern);
+    const handle = v8.v8__RegExp__New(local.handle, pattern_handle, flags) orelse return error.JsException;
+    return .{ .local = local, .handle = handle };
+}
+
+// Runs the pattern against `subject`. Returns the result Array (as a generic
+// Object) on match, or null on no match. Returns error.JsException if V8
+// throws — typically when the pattern is malformed for the current flags.
+pub fn exec(self: RegExp, subject: []const u8) !?js.Object {
+    const local = self.local;
+    const subject_handle = local.isolate.initStringHandle(subject);
+    const handle = v8.v8__RegExp__Exec(self.handle, local.handle, subject_handle) orelse return error.JsException;
+    if (v8.v8__Value__IsNullOrUndefined(@ptrCast(handle))) return null;
+    return .{ .local = local, .handle = handle };
+}
+
+// Equivalent to `RegExp.prototype.test()` — true iff the pattern matches.
+pub fn match(self: RegExp, subject: []const u8) !bool {
+    return (try self.exec(subject)) != null;
+}
+
+pub fn toValue(self: RegExp) js.Value {
+    return .{
+        .local = self.local,
+        .handle = @ptrCast(self.handle),
+    };
+}

--- a/src/browser/js/js.zig
+++ b/src/browser/js/js.zig
@@ -42,6 +42,7 @@ pub const Object = @import("Object.zig");
 pub const TryCatch = @import("TryCatch.zig");
 pub const Function = @import("Function.zig");
 pub const Promise = @import("Promise.zig");
+pub const RegExp = @import("RegExp.zig");
 pub const Module = @import("Module.zig");
 pub const BigInt = @import("BigInt.zig");
 pub const Number = @import("Number.zig");

--- a/src/browser/tests/element/html/input-validity.html
+++ b/src/browser/tests/element/html/input-validity.html
@@ -17,6 +17,13 @@
   <input id="disabled-required" type="text" required disabled>
   <input id="too-long" type="text" maxlength="3">
   <input id="too-short" type="text" minlength="3" value="ab">
+  <input id="zip-bad"   type="text" pattern="[0-9]{5,9}" value="1234">
+  <input id="zip-good"  type="text" pattern="[0-9]{5,9}" value="12345">
+  <input id="zip-empty" type="text" pattern="[0-9]{5,9}">
+  <input id="pat-anchored" type="text" pattern="abc" value="xabcy">
+  <input id="pat-unicode" type="text" pattern="\p{L}+" value="hello">
+  <input id="pat-bad-regex" type="text" pattern="(unclosed" value="anything">
+  <input id="pat-num" type="number" pattern="[0-9]+" value="x">
 </form>
 
 <script id="surface">
@@ -187,5 +194,88 @@
   el.addEventListener('invalid', (e) => { captured = e; });
   el.checkValidity();
   testing.expectEqual(true, captured.isTrusted);
+}
+</script>
+
+<script id="pattern_idl_reflects_attribute">
+{
+  // Per HTML §4.10.5.3.5, HTMLInputElement.pattern reflects the content attribute.
+  testing.expectEqual('[0-9]{5,9}', $('#zip-bad').pattern);
+  testing.expectEqual('[0-9]{5,9}', $('#zip-good').pattern);
+  testing.expectEqual('', $('#filled-required').pattern);
+
+  // Setter writes the content attribute.
+  const el = $('#filled-required');
+  el.pattern = 'foo';
+  testing.expectEqual('foo', el.getAttribute('pattern'));
+  testing.expectEqual('foo', el.pattern);
+  el.pattern = '';
+  testing.expectEqual('', el.getAttribute('pattern'));
+}
+</script>
+
+<script id="pattern_mismatch_basic">
+{
+  // "1234" does not match [0-9]{5,9} — patternMismatch fires.
+  testing.expectEqual(true, $('#zip-bad').validity.patternMismatch);
+  testing.expectEqual(false, $('#zip-bad').validity.valid);
+  // "12345" does match.
+  testing.expectEqual(false, $('#zip-good').validity.patternMismatch);
+  testing.expectEqual(true, $('#zip-good').validity.valid);
+}
+</script>
+
+<script id="pattern_empty_value_does_not_mismatch">
+{
+  // Empty value never triggers patternMismatch (per spec).
+  testing.expectEqual(false, $('#zip-empty').validity.patternMismatch);
+  testing.expectEqual(true, $('#zip-empty').validity.valid);
+}
+</script>
+
+<script id="pattern_anchored_implicitly">
+{
+  // The pattern is implicitly wrapped with ^(?:...)$ — substring "abc" inside
+  // "xabcy" must NOT match the whole value, so patternMismatch fires.
+  testing.expectEqual(true, $('#pat-anchored').validity.patternMismatch);
+}
+</script>
+
+<script id="pattern_v_flag_unicode">
+{
+  // \p{L} requires Unicode-aware matching (v or u flag).
+  testing.expectEqual(false, $('#pat-unicode').validity.patternMismatch);
+}
+</script>
+
+<script id="pattern_invalid_regex_ignored">
+{
+  // An unparseable pattern is ignored per spec — element stays valid.
+  testing.expectEqual(false, $('#pat-bad-regex').validity.patternMismatch);
+}
+</script>
+
+<script id="pattern_only_text_like_types">
+{
+  // pattern only applies to text-like types; type=number ignores the attribute.
+  testing.expectEqual(false, $('#pat-num').validity.patternMismatch);
+}
+</script>
+
+<script id="pattern_validation_message">
+{
+  testing.expectEqual('Please match the requested format.', $('#zip-bad').validationMessage);
+  testing.expectEqual('', $('#zip-good').validationMessage);
+}
+</script>
+
+<script id="pattern_setter_recomputes_validity">
+{
+  const el = $('#filled-required');
+  testing.expectEqual(false, el.validity.patternMismatch);
+  el.pattern = '[0-9]+';
+  testing.expectEqual(true, el.validity.patternMismatch);
+  el.value = '42';
+  testing.expectEqual(false, el.validity.patternMismatch);
 }
 </script>

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -307,30 +307,23 @@ pub fn suffersPatternMismatch(self: *const Input, frame: *Frame) bool {
     const pattern = self.asConstElement().getAttributeSafe(comptime .wrap("pattern")) orelse return false;
     if (pattern.len == 0) return false;
 
-    // Evaluate `new RegExp("^(?:" + pattern + ")$", "v").test(value)` via V8.
-    // Per spec, an invalid pattern is ignored — the catch arm returns null and
-    // we treat that as "no mismatch".
+    // Per HTML spec, anchor the pattern with ^(?:...)$ and compile under the
+    // "v" (Unicode sets) flag. An invalid pattern is ignored — V8 throws and
+    // we treat that as "no mismatch". TryCatch absorbs the exception so it
+    // doesn't linger in the isolate.
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();
 
-    const arena = frame.call_arena;
-    const pattern_json = std.json.Stringify.valueAlloc(arena, pattern, .{}) catch return false;
-    const value_json = std.json.Stringify.valueAlloc(arena, value, .{}) catch return false;
+    var try_catch: js.TryCatch = undefined;
+    try_catch.init(&ls.local);
+    defer try_catch.deinit();
 
-    const expr = std.fmt.allocPrint(arena,
-        \\(function() {{
-        \\  try {{
-        \\    return new RegExp("^(?:" + {s} + ")$", "v").test({s});
-        \\  }} catch (_) {{
-        \\    return null;
-        \\  }}
-        \\}})()
-    , .{ pattern_json, value_json }) catch return false;
+    const wrapped = std.fmt.allocPrint(frame.call_arena, "^(?:{s})$", .{pattern}) catch return false;
+    const re = js.RegExp.init(&ls.local, wrapped, js.RegExp.Flag.unicode_sets) catch return false;
+    const matched = re.match(value) catch return false;
 
-    const result = ls.local.exec(expr, "Input.suffersPatternMismatch") catch return false;
-    if (result.isNullOrUndefined()) return false;
-    return !result.toBool();
+    return !matched;
 }
 
 pub fn suffersTooLong(self: *const Input) bool {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -233,7 +233,7 @@ pub fn getValidationMessage(self: *const Input, frame: *Frame) []const u8 {
         .url => "Please enter a URL.",
         else => "Please enter a valid value.",
     };
-    if (self.suffersPatternMismatch()) return "Please match the requested format.";
+    if (self.suffersPatternMismatch(frame)) return "Please match the requested format.";
     if (self.suffersTooLong()) return "Please shorten this text.";
     if (self.suffersTooShort()) return "Please lengthen this text.";
     if (self.suffersRangeUnderflow()) return "Value is too small.";
@@ -295,12 +295,42 @@ pub fn suffersTypeMismatch(self: *const Input) bool {
     };
 }
 
-pub fn suffersPatternMismatch(self: *const Input) bool {
-    _ = self;
-    // Pattern matching requires evaluating a JS RegExp anchored with ^(?: ... )$.
-    // Not yet implemented from Zig; returning false leaves well-formed inputs valid.
-    // TODO: route through the V8 RegExp constructor on the owner Frame.
-    return false;
+pub fn suffersPatternMismatch(self: *const Input, frame: *Frame) bool {
+    if (!self.getWillValidate()) return false;
+    // Per HTML §4.10.5.3.5, pattern only applies to text-like input types.
+    switch (self._input_type) {
+        .text, .search, .url, .tel, .email, .password => {},
+        else => return false,
+    }
+    const value = self._value orelse return false;
+    if (value.len == 0) return false;
+    const pattern = self.asConstElement().getAttributeSafe(comptime .wrap("pattern")) orelse return false;
+    if (pattern.len == 0) return false;
+
+    // Evaluate `new RegExp("^(?:" + pattern + ")$", "v").test(value)` via V8.
+    // Per spec, an invalid pattern is ignored — the catch arm returns null and
+    // we treat that as "no mismatch".
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const arena = frame.call_arena;
+    const pattern_json = std.json.Stringify.valueAlloc(arena, pattern, .{}) catch return false;
+    const value_json = std.json.Stringify.valueAlloc(arena, value, .{}) catch return false;
+
+    const expr = std.fmt.allocPrint(arena,
+        \\(function() {{
+        \\  try {{
+        \\    return new RegExp("^(?:" + {s} + ")$", "v").test({s});
+        \\  }} catch (_) {{
+        \\    return null;
+        \\  }}
+        \\}})()
+    , .{ pattern_json, value_json }) catch return false;
+
+    const result = ls.local.exec(expr, "Input.suffersPatternMismatch") catch return false;
+    if (result.isNullOrUndefined()) return false;
+    return !result.toBool();
 }
 
 pub fn suffersTooLong(self: *const Input) bool {
@@ -595,6 +625,14 @@ pub fn getPlaceholder(self: *const Input) []const u8 {
 
 pub fn setPlaceholder(self: *Input, placeholder: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("placeholder"), .wrap(placeholder), frame);
+}
+
+pub fn getPattern(self: *const Input) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("pattern")) orelse "";
+}
+
+pub fn setPattern(self: *Input, pattern: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("pattern"), .wrap(pattern), frame);
 }
 
 pub fn getMin(self: *const Input) []const u8 {
@@ -1237,6 +1275,7 @@ pub const JsApi = struct {
     pub const labels = bridge.accessor(Input.getLabels, null, .{});
     pub const indeterminate = bridge.accessor(Input.getIndeterminate, Input.setIndeterminate, .{});
     pub const placeholder = bridge.accessor(Input.getPlaceholder, Input.setPlaceholder, .{});
+    pub const pattern = bridge.accessor(Input.getPattern, Input.setPattern, .{});
     pub const min = bridge.accessor(Input.getMin, Input.setMin, .{});
     pub const max = bridge.accessor(Input.getMax, Input.setMax, .{});
     pub const step = bridge.accessor(Input.getStep, Input.setStep, .{});

--- a/src/browser/webapi/element/html/ValidityState.zig
+++ b/src/browser/webapi/element/html/ValidityState.zig
@@ -46,8 +46,8 @@ pub fn getTypeMismatch(self: *const ValidityState) bool {
     return false;
 }
 
-pub fn getPatternMismatch(self: *const ValidityState) bool {
-    if (self._owner.is(Input)) |input| return input.suffersPatternMismatch();
+pub fn getPatternMismatch(self: *const ValidityState, frame: *Frame) bool {
+    if (self._owner.is(Input)) |input| return input.suffersPatternMismatch(frame);
     return false;
 }
 
@@ -100,7 +100,7 @@ pub fn getCustomError(self: *const ValidityState) bool {
 pub fn getValid(self: *const ValidityState, frame: *Frame) bool {
     return !self.getValueMissing(frame) and
         !self.getTypeMismatch() and
-        !self.getPatternMismatch() and
+        !self.getPatternMismatch(frame) and
         !self.getTooLong() and
         !self.getTooShort() and
         !self.getRangeUnderflow() and


### PR DESCRIPTION
## What

`HTMLInputElement.prototype.pattern` was not a registered IDL accessor — `inp.pattern` returned `undefined` even when the `pattern` content attribute was set. `Input.suffersPatternMismatch` was a TODO stub that always returned `false`, so `validity.patternMismatch` never fired and `validationMessage` was empty for any pattern-violating value. This change wires the IDL accessor and replaces the stub with an actual V8 RegExp evaluation through the owner frame's local scope.

Closes #2351.

This is the follow-up explicitly deferred in PR #2286 (`patternMismatch — needs JS RegExp evaluation from Zig […]; no clean Zig-side path yet`).

## Root cause

`Input.JsApi` registered `placeholder`, `min`, `max`, etc. but not `pattern`. `Input.suffersPatternMismatch` carried a `_ = self; return false;` stub. `ValidityState.getPatternMismatch` did not take a `*Frame`, so even if `suffersPatternMismatch` were rewritten to use V8, there was no plumbing to reach the owner frame's JS scope.

```mermaid
flowchart LR
    A[CDP Client: inp.pattern] --> B[V8 prototype lookup]
    B --> C[no accessor registered]
    C --> D[undefined]
    style B fill:#fdd
    style C fill:#fdd
    style D fill:#fdd
    E[CDP Client: inp.validity.patternMismatch] --> F[ValidityState.getPatternMismatch]
    F --> G[Input.suffersPatternMismatch TODO stub]
    G --> H[false regardless of value]
    style F fill:#fdd
    style G fill:#fdd
    style H fill:#fdd
```

## Fix

```mermaid
flowchart LR
    A[CDP Client: inp.pattern] --> B[Input.getPattern reflects pattern attribute]
    B --> C[regex string]
    style B fill:#dfd
    style C fill:#dfd
    D[CDP Client: inp.validity.patternMismatch] --> E[ValidityState.getPatternMismatch with frame]
    E --> F[Input.suffersPatternMismatch evaluates RegExp via V8]
    F --> G[true / false]
    style E fill:#dfd
    style F fill:#dfd
    style G fill:#dfd
```

- `src/browser/webapi/element/html/Input.zig`:
  - `getPattern` / `setPattern` reflect the `pattern` content attribute, mirroring `getMin` / `setMin`.
  - `pattern = bridge.accessor(Input.getPattern, Input.setPattern, .{})` registered in `JsApi` next to `placeholder`.
  - `suffersPatternMismatch(self, frame)` gates on `getWillValidate()` and the spec's text-like input types, returns `false` for empty values, fetches the `pattern` attribute, JSON-encodes both pattern and value via `std.json.Stringify.valueAlloc` for safe interpolation, and runs `new RegExp("^(?:" + pattern + ")$", "v").test(value)` through `ls.local.exec` on the owner frame. An invalid regex resolves to `null` from the catch arm and is treated as no constraint per spec.
  - `getValidationMessage` passes `frame` through to `suffersPatternMismatch`.
- `src/browser/webapi/element/html/ValidityState.zig`:
  - `getPatternMismatch(self, frame)` takes a `*Frame` and forwards it to `Input.suffersPatternMismatch`.
  - `getValid` already takes `frame`; updated the dispatch to pass it through to `getPatternMismatch`.

## Test

- **Unit test**: `WebApi: HTML.Input` runs `src/browser/tests/element/html/input-validity.html`, extended with 8 new `<script>` blocks covering: IDL `pattern` reflection (get + set), pattern-mismatch on `[0-9]{5,9}` against `1234`, no mismatch on `12345`, empty value never mismatches (per spec), implicit anchoring (`abc` does NOT match `xabcy`), Unicode `\p{L}+` matching via the `v` flag, invalid regex `(unclosed` ignored, type=number ignores the `pattern` attribute, validation message wires through, setter recomputes validity (`el.pattern = '[0-9]+'` flips `patternMismatch`).
- **Toggle-off check**: reverting `Input.zig` and `ValidityState.zig` to `main` makes the same fixture fail at the IDL-reflection assertion (`0 of 1 test passed`, 12.36ms — confirms the new tests exercise the fix). Restoring brings it back to green (22.49ms).
- **Reproducer**: the `repro.sh` from #2351 prints the full assertion bundle and exits 0 against the locally-built binary; against the public nightly `1.0.0-nightly.6005+b8144d3e` it exits 1.
- **Full unit suite** (`mise exec -- zig build test $V8`): 515 of 515 tests pass; no regressions.

## Notes

- `validationMessage` returns `"Please match the requested format."` — matching Chrome's default and consistent with the other generic English strings already returned by PR #2286.
- The `v` flag enables Unicode-aware matching; the test fixture covers `\p{L}+`. V8 has supported the `v` flag since 2023, so no engine-side work is needed.
- Pattern is implicitly anchored with `^(?:` … `)$`, matching the HTML spec's "the value of the `pattern` attribute, when used together with the `v` flag, does not match the entirety of the element's value" wording.
- Per spec, an unparseable pattern is ignored — the implementation catches the `RegExp` constructor exception and treats it as no constraint, leaving the element valid.
