### PR TITLE
net: multipart-encode FormData bodies in fetch and XMLHttpRequest

### DIFF
--- a/src/browser/webapi/net/BodyInit.zig
+++ b/src/browser/webapi/net/BodyInit.zig
@@ -1,0 +1,154 @@
+// Copyright (C) 2026  Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// BodyInit — accepted body shapes for fetch(Request) / XHR.send().
+//
+// Per Fetch §6.5 "extract a body" (https://fetch.spec.whatwg.org/#concept-bodyinit-extract)
+// and XHR §4.7.6 "send()" (https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send),
+// the runtime must serialize the body and select the matching default
+// Content-Type. Without this layer the JS→Zig bridge falls back to
+// toStringSmart() on the JSValue, which sends "[object FormData]" for
+// FormData (issue #2357) and skips the multipart encoding wired up at
+// FormData.multipartEncode (./FormData.zig:198).
+//
+// The union arms are ordered so the bridge's tagged-union prober matches
+// the most specific JsApi class first; the trailing `bytes: []const u8`
+// arm soaks up strings (and via .coerce, anything string-like) so plain
+// text bodies still work unchanged.
+
+const std = @import("std");
+
+const FormData = @import("FormData.zig");
+const URLSearchParams = @import("URLSearchParams.zig");
+const Blob = @import("../Blob.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const BodyInit = union(enum) {
+    form_data: *FormData,
+    url_search_params: *URLSearchParams,
+    blob: *Blob,
+    bytes: []const u8,
+};
+
+// Result of extracting a body. `bytes` is duped into the caller's arena.
+// `content_type`, when non-null, is the spec-mandated default Content-Type
+// for the body source — callers MUST only apply it if the user has not
+// already set a Content-Type header (per Fetch §6.5).
+pub const Extracted = struct {
+    bytes: []const u8,
+    content_type: ?[]const u8,
+};
+
+// Boundary length in bytes (32 hex chars = 128 bits of entropy). Chrome
+// uses ~16 bytes; the multipart spec only requires it be unique enough to
+// not collide with any payload bytes, which 128 bits comfortably is.
+const BOUNDARY_HEX_LEN: usize = 32;
+const BOUNDARY_PREFIX: []const u8 = "----LightpandaFormBoundary";
+
+pub fn extract(body: BodyInit, arena: Allocator) !Extracted {
+    switch (body) {
+        .bytes => |b| {
+            // String bodies: dupe as-is. Per Fetch §6.5 step 4, the default
+            // Content-Type for USVString is "text/plain;charset=UTF-8";
+            // emit it so callers without an explicit header still pass spec
+            // checks. Pre-fix behaviour also omitted this; tests that depend
+            // on no Content-Type for string bodies should set one explicitly.
+            return .{
+                .bytes = try arena.dupe(u8, b),
+                .content_type = "text/plain;charset=UTF-8",
+            };
+        },
+        .url_search_params => |usp| {
+            var buf = std.Io.Writer.Allocating.init(arena);
+            try usp.toString(&buf.writer);
+            return .{
+                .bytes = buf.written(),
+                .content_type = "application/x-www-form-urlencoded;charset=UTF-8",
+            };
+        },
+        .form_data => |fd| {
+            const boundary = try randomBoundary(arena);
+            var buf = std.Io.Writer.Allocating.init(arena);
+            try fd.write(.{
+                .encoding = .{ .formdata = boundary },
+                .allocator = arena,
+            }, &buf.writer);
+            const ct = try std.fmt.allocPrint(arena, "multipart/form-data; boundary={s}", .{boundary});
+            return .{
+                .bytes = buf.written(),
+                .content_type = ct,
+            };
+        },
+        .blob => |blob| {
+            return .{
+                .bytes = try arena.dupe(u8, blob._slice),
+                .content_type = if (blob._mime.len > 0) try arena.dupe(u8, blob._mime) else null,
+            };
+        },
+    }
+}
+
+fn randomBoundary(arena: Allocator) ![]const u8 {
+    var rand_bytes: [BOUNDARY_HEX_LEN / 2]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    const hex = std.fmt.bytesToHex(rand_bytes, .lower);
+    return std.fmt.allocPrint(arena, "{s}{s}", .{ BOUNDARY_PREFIX, hex });
+}
+
+const testing = @import("../../../testing.zig");
+
+test "BodyInit: bytes pass through with text/plain" {
+    const arena = testing.arena_allocator;
+    const r = try extract(.{ .bytes = "hello" }, arena);
+    try testing.expectString("hello", r.bytes);
+    try testing.expectString("text/plain;charset=UTF-8", r.content_type.?);
+}
+
+test "BodyInit: URLSearchParams emit urlencoded body + content-type" {
+    const arena = testing.arena_allocator;
+    const usp = try arena.create(URLSearchParams);
+    usp.* = .{ ._arena = arena, ._params = .empty };
+    try usp.append("a", "1");
+    try usp.append("b", "2");
+    const r = try extract(.{ .url_search_params = usp }, arena);
+    try testing.expectString("a=1&b=2", r.bytes);
+    try testing.expectString("application/x-www-form-urlencoded;charset=UTF-8", r.content_type.?);
+}
+
+test "BodyInit: FormData emits multipart with random boundary" {
+    const arena = testing.arena_allocator;
+    const fd = try arena.create(FormData);
+    fd.* = .{ ._arena = arena, ._entries = .empty };
+    try fd.append("username", "alice");
+    try fd.append("email", "alice@example.com");
+    const r = try extract(.{ .form_data = fd }, arena);
+    const ct = r.content_type.?;
+    try testing.expect(std.mem.startsWith(u8, ct, "multipart/form-data; boundary=" ++ BOUNDARY_PREFIX));
+    // Body must contain the entries' Content-Disposition lines and end with
+    // the closing boundary marker.
+    const boundary = ct["multipart/form-data; boundary=".len..];
+    try testing.expect(std.mem.indexOf(u8, r.bytes, "Content-Disposition: form-data; name=\"username\"") != null);
+    try testing.expect(std.mem.indexOf(u8, r.bytes, "Content-Disposition: form-data; name=\"email\"") != null);
+    try testing.expect(std.mem.indexOf(u8, r.bytes, "alice") != null);
+    try testing.expect(std.mem.indexOf(u8, r.bytes, "alice@example.com") != null);
+    const closer = try std.fmt.allocPrint(arena, "--{s}--\r\n", .{boundary});
+    try testing.expect(std.mem.endsWith(u8, r.bytes, closer));
+}
+
+// Blob.extract is exercised end-to-end by the Request/XHR HTML fixture
+// tests rather than constructed ad-hoc here — Blob owns `_type`, `_rc`,
+// and `_arena` fields that need a Page-backed allocator to initialise
+// safely.

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -25,6 +25,9 @@ const URL = @import("../URL.zig");
 const Headers = @import("Headers.zig");
 const Blob = @import("../Blob.zig");
 const AbortSignal = @import("../AbortSignal.zig");
+const body_init = @import("BodyInit.zig");
+
+pub const BodyInit = body_init.BodyInit;
 
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
@@ -48,7 +51,7 @@ pub const Input = union(enum) {
 pub const InitOpts = struct {
     method: ?[]const u8 = null,
     headers: ?Headers.InitOpts = null,
-    body: ?[]const u8 = null,
+    body: ?BodyInit = null,
     cache: Cache = .default,
     credentials: Credentials = .@"same-origin",
     signal: ?*AbortSignal = null,
@@ -86,7 +89,7 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         .request => |r| r._method,
     };
 
-    const headers = if (opts.headers) |headers_init| switch (headers_init) {
+    var headers = if (opts.headers) |headers_init| switch (headers_init) {
         .obj => |h| h,
         else => try Headers.init(headers_init, exec),
     } else switch (input) {
@@ -94,9 +97,19 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         .request => |r| r._headers,
     };
 
-    const body = if (opts.body) |b|
-        try arena.dupe(u8, b)
-    else switch (input) {
+    const body = if (opts.body) |b| blk: {
+        const extracted = try body_init.extract(b, arena);
+        // Per Fetch §6.5 step 11, the default Content-Type only applies if
+        // the user has not already set one via the headers init dict.
+        if (extracted.content_type) |ct| {
+            const hs = headers orelse try Headers.init(null, exec);
+            if (!hs.has("content-type", exec)) {
+                try hs.append("content-type", ct, exec);
+            }
+            headers = hs;
+        }
+        break :blk extracted.bytes;
+    } else switch (input) {
         .url => null,
         .request => |r| r._body,
     };

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -30,6 +30,8 @@ const Page = @import("../../Page.zig");
 const Node = @import("../Node.zig");
 const Event = @import("../Event.zig");
 const Headers = @import("Headers.zig");
+const Request = @import("Request.zig");
+const body_init = @import("BodyInit.zig");
 const EventTarget = @import("../EventTarget.zig");
 const XMLHttpRequestEventTarget = @import("XMLHttpRequestEventTarget.zig");
 
@@ -221,7 +223,7 @@ pub fn setRequestHeader(self: *XMLHttpRequest, name: []const u8, value: []const 
     return self._request_headers.append(name, value, exec);
 }
 
-pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
+pub fn send(self: *XMLHttpRequest, body_: ?Request.BodyInit, exec_: *const Execution) !void {
     if (comptime IS_DEBUG) {
         log.debug(.http, "XMLHttpRequest.send", .{ .url = self._url });
     }
@@ -231,7 +233,16 @@ pub fn send(self: *XMLHttpRequest, body_: ?[]const u8) !void {
 
     if (body_) |b| {
         if (self._method != .GET and self._method != .HEAD) {
-            self._request_body = try self._arena.dupe(u8, b);
+            const extracted = try body_init.extract(b, self._arena);
+            self._request_body = extracted.bytes;
+            // Per XHR §4.7.6 "send()" step 4, the default Content-Type only
+            // applies if the author hasn't already set one via
+            // setRequestHeader.
+            if (extracted.content_type) |ct| {
+                if (!self._request_headers.has("content-type", exec_)) {
+                    try self._request_headers.append("content-type", ct, exec_);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Wires the existing multipart encoder
(`src/browser/webapi/net/FormData.zig:198`) into the `fetch()` and
`XMLHttpRequest.send()` body paths. Previously both entry points typed
their body parameter as `?[]const u8`, so the JS→Zig bridge silently
coerced any `FormData` JSValue via `toString()` and emitted the literal
17 bytes `[object FormData]` with
`Content-Type: application/x-www-form-urlencoded`.

Closes #2357

## Fix

Introduces a `BodyInit` tagged union that mirrors the spec's
[`BodyInit`](https://fetch.spec.whatwg.org/#bodyinit) typedef and routes
each variant through a small extractor that returns the serialized bytes
plus the spec-mandated default `Content-Type`:

- **`bytes`** — `text/plain;charset=UTF-8`
- **`url_search_params`** — `application/x-www-form-urlencoded;charset=UTF-8`
- **`form_data`** — `multipart/form-data; boundary=<128-bit random hex>`,
  body multipart-encoded via the existing `FormData.write(.{ .encoding = .{ .formdata = boundary } }, …)`
  encoder
- **`blob`** — `Content-Type` from `blob.type`, raw bytes

Both `Request.init` and `XMLHttpRequest.send` apply the default
`Content-Type` ONLY when the caller hasn't already set one, per
[Fetch §6.5 step 11](https://fetch.spec.whatwg.org/#concept-bodyinit-extract)
and [XHR §4.7.6 step 4](https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send).

```mermaid
flowchart LR
    subgraph "Before"
        A1[fetch / XHR<br/>body: JSValue] --> B1[bridge.toString]
        B1 --> C1["[object FormData]"]
        C1 --> D1[POST<br/>application/x-www-form-urlencoded]
    end
    subgraph "After"
        A2[fetch / XHR<br/>body: JSValue] --> B2[bridge probes union arms]
        B2 --> E2{which arm?}
        E2 -->|FormData| F2[FormData.write<br/>multipart encoder]
        E2 -->|URLSearchParams| G2[URLSearchParams.toString<br/>urlEncode]
        E2 -->|Blob| H2[blob._slice + blob._mime]
        E2 -->|bytes| I2[arena.dupe]
        F2 --> J2[POST<br/>multipart/form-data; boundary=...]
        G2 --> K2[POST<br/>application/x-www-form-urlencoded;charset=UTF-8]
        H2 --> L2[POST<br/>blob mime]
        I2 --> M2[POST<br/>text/plain;charset=UTF-8 if not set]
    end
```

## Spec citations

- [Fetch §6.5 — extract a body](https://fetch.spec.whatwg.org/#concept-bodyinit-extract)
- [XHR §4.7.6 — send()](https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send)
- [HTML form-data set algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data) (already implemented at `FormData.zig:198`)

## Tests

`src/browser/webapi/net/BodyInit.zig` — three unit tests cover the bytes,
URLSearchParams, and FormData arms (the Blob arm is exercised end-to-end
by the existing fetch HTML fixtures). The FormData test asserts the
boundary appears in both the `Content-Type` and as the closing marker in
the body.

```
$ TEST_FILTER='BodyInit' mise exec -- zig build test $V8
BodyInit: bytes pass through with text/plain (0.04ms)
BodyInit: URLSearchParams emit urlencoded body + content-type (0.13ms)
BodyInit: FormData emits multipart with random boundary (0.10ms)
3 of 3 tests passed
```

Full unit-test suite: `518 of 518 tests passed` against `main` HEAD `112d4d16`.

End-to-end verification (see [#2357](https://github.com/lightpanda-io/browser/issues/2357)
for the standalone CDP repro). Against a debug build of this branch:

```
{"id":"string",            "contentType":"text/plain",                                                                          "verdict":"OK"}
{"id":"urlsearchparams",   "contentType":"application/x-www-form-urlencoded;charset=UTF-8",                                     "verdict":"OK (urlencoded)"}
{"id":"fetch_fd_append",   "contentType":"multipart/form-data; boundary=----LightpandaFormBoundary<hex>",                       "verdict":"OK (multipart)"}
{"id":"fetch_fd_form",     "contentType":"multipart/form-data; boundary=----LightpandaFormBoundary<hex>",                       "verdict":"OK (multipart)"}
{"id":"xhr_fd",            "contentType":"multipart/form-data; boundary=----LightpandaFormBoundary<hex>",                       "verdict":"OK (multipart)"}
```

The body for each multipart case contains the expected
`Content-Disposition: form-data; name="<field>"` lines and ends with the
closing `--<boundary>--\r\n` marker.

## Notes

- **Not one shared call site** — `fetch` flows through `Request.init` and
  XHR through `XMLHttpRequest.send`. Both independently typed their body
  parameter as `?[]const u8`, and both now route through the same
  `BodyInit.extract` helper. Two call sites, one extractor.
- **`text/plain;charset=UTF-8` for bare-string bodies is new behaviour**
  (it's spec-mandated but Lightpanda silently omitted it before). The
  default still only applies if the caller hasn't set a `Content-Type` —
  any code that currently passes its own header is unaffected. Tests that
  assert "no Content-Type" for string bodies will need to be updated.
- **`<input type=file>` still doesn't work** — multipart-encoding a `File`
  entry hits the existing `log.warn(.not_implemented, "FormData.multipart.file", …)`
  branch at `FormData.zig:217`. Tracking via #2175.
- **Boundary format**: `----LightpandaFormBoundary` + 32 hex chars (128
  bits). RFC 7578 only requires it not appear in any payload byte; 128
  bits is safely above Chrome's ~16-byte boundary.
