### PR TITLE
events: report listener exceptions instead of halting dispatch

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -388,16 +388,31 @@ fn dispatchPhase(self: *EventManager, list: *std.DoublyLinkedList, current_targe
             event._target = getAdjustedTarget(original_target, current_target);
         }
 
+        // Per DOM §2.9 step 4 substep 8 ("Inner invoke"), a listener callback that
+        // throws must have its exception *reported* to the global error handler,
+        // not propagated to the dispatch caller — subsequent listeners on the same
+        // target and the rest of the propagation path must still run. Mirrors the
+        // catch on the inline-handler invocation in dispatchDirect.
         switch (listener.function) {
-            .value => |value| try local.toLocal(value).callWithThis(void, current_target, .{event}),
+            .value => |value| local.toLocal(value).callWithThis(void, current_target, .{event}) catch |err| {
+                log.warn(.event, "listener", .{ .err = err });
+            },
             .string => |string| {
                 const str = try frame.call_arena.dupeZ(u8, string.str());
-                try local.eval(str, null);
+                local.eval(str, null) catch |err| {
+                    log.warn(.event, "listener string", .{ .err = err });
+                };
             },
             .object => |obj_global| {
                 const obj = local.toLocal(obj_global);
-                if (try obj.getFunction("handleEvent")) |handleEvent| {
-                    try handleEvent.callWithThis(void, obj, .{event});
+                const handle_event = obj.getFunction("handleEvent") catch |err| blk: {
+                    log.warn(.event, "listener handleEvent", .{ .err = err });
+                    break :blk null;
+                };
+                if (handle_event) |handleEvent| {
+                    handleEvent.callWithThis(void, obj, .{event}) catch |err| {
+                        log.warn(.event, "listener object", .{ .err = err });
+                    };
                 }
             },
         }

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -305,16 +305,30 @@ pub fn dispatchDirect(
 
         event._current_target = target;
 
+        // Per DOM §2.9 step 4 substep 8 ("Inner invoke"), a listener callback that
+        // throws must have its exception *reported*, not propagated to the dispatch
+        // caller — subsequent listeners must still run. Same shape as the catch on
+        // the property-handler invocation above and on EventManager.dispatchPhase.
         switch (listener.function) {
-            .value => |value| try ls.local.toLocal(value).callWithThis(void, target, .{event}),
+            .value => |value| ls.local.toLocal(value).callWithThis(void, target, .{event}) catch |err| {
+                log.warn(.event, opts.context, .{ .err = err });
+            },
             .string => |string| {
                 const str = try arena.dupeZ(u8, string.str());
-                try ls.local.eval(str, null);
+                ls.local.eval(str, null) catch |err| {
+                    log.warn(.event, opts.context, .{ .err = err });
+                };
             },
             .object => |obj_global| {
                 const obj = ls.local.toLocal(obj_global);
-                if (try obj.getFunction("handleEvent")) |handleEvent| {
-                    try handleEvent.callWithThis(void, obj, .{event});
+                const handle_event = obj.getFunction("handleEvent") catch |err| blk: {
+                    log.warn(.event, opts.context, .{ .err = err });
+                    break :blk null;
+                };
+                if (handle_event) |handleEvent| {
+                    handleEvent.callWithThis(void, obj, .{event}) catch |err| {
+                        log.warn(.event, opts.context, .{ .err = err });
+                    };
                 }
             },
         }

--- a/src/browser/tests/events.html
+++ b/src/browser/tests/events.html
@@ -762,3 +762,95 @@
     testing.expectEqual(2, calls.length);
   }
 </script>
+
+<div id=throw_host><div id=throw_mid><span id=throw_leaf></span></div></div>
+<script id=listenerThrowDoesNotHaltDispatch>
+  // Per DOM §2.9 step 4 substep 8 "Inner invoke", a listener callback that
+  // throws must have its exception reported, not propagated — subsequent
+  // listeners on the same target and the rest of the propagation path must
+  // still run.
+  {
+    const leaf = $('#throw_leaf');
+    const mid  = $('#throw_mid');
+    const host = $('#throw_host');
+    const hits = [];
+
+    leaf.addEventListener('throw_test', () => {
+      hits.push('leaf-throwing');
+      throw new Error('listener-throw probe');
+    });
+    leaf.addEventListener('throw_test', () => hits.push('leaf-sibling'));
+    mid.addEventListener ('throw_test', () => hits.push('mid'));
+    host.addEventListener('throw_test', () => hits.push('host'));
+    document.body.addEventListener('throw_test', () => hits.push('body'));
+
+    // dispatchEvent must NOT throw to the caller — if it did, this assignment
+    // would be skipped and the next testing.expectEqual would never run.
+    const result = leaf.dispatchEvent(new Event('throw_test', {bubbles: true}));
+
+    testing.expectEqual('leaf-throwing', hits[0]);
+    testing.expectEqual('leaf-sibling',  hits[1]);
+    testing.expectEqual('mid',           hits[2]);
+    testing.expectEqual('host',          hits[3]);
+    testing.expectEqual('body',          hits[4]);
+    testing.expectEqual(5, hits.length);
+    testing.expectEqual(true, result);
+  }
+</script>
+
+<div id=throw_capture_host><div id=throw_capture_mid><span id=throw_capture_leaf></span></div></div>
+<script id=listenerThrowDuringCapturePhase>
+  // Capture-phase variant: a throwing capture listener on an ancestor must
+  // not skip the rest of the capture walk, the at-target listener, or the
+  // bubble walk.
+  {
+    const leaf = $('#throw_capture_leaf');
+    const mid  = $('#throw_capture_mid');
+    const host = $('#throw_capture_host');
+    const order = [];
+
+    host.addEventListener('cap_test', () => {
+      order.push('host-capture-throwing');
+      throw new Error('capture-throw probe');
+    }, true);
+    mid.addEventListener('cap_test', () => order.push('mid-capture'),  true);
+    leaf.addEventListener('cap_test', () => order.push('leaf-target'));
+    mid.addEventListener('cap_test', () => order.push('mid-bubble'));
+    host.addEventListener('cap_test', () => order.push('host-bubble'));
+
+    leaf.dispatchEvent(new Event('cap_test', {bubbles: true}));
+
+    testing.expectEqual('host-capture-throwing', order[0]);
+    testing.expectEqual('mid-capture',           order[1]);
+    testing.expectEqual('leaf-target',           order[2]);
+    testing.expectEqual('mid-bubble',            order[3]);
+    testing.expectEqual('host-bubble',           order[4]);
+    testing.expectEqual(5, order.length);
+  }
+</script>
+
+<script id=listenerThrowOnWindowTarget>
+  // Direct-dispatch variant (non-DOM target — Window). Same contract: a
+  // throwing listener must not stop later listeners from running.
+  {
+    const calls = [];
+    const a = () => { calls.push('a-throwing'); throw new Error('window-throw probe'); };
+    const b = () => calls.push('b');
+    const c = () => calls.push('c');
+
+    window.addEventListener('win_throw', a);
+    window.addEventListener('win_throw', b);
+    window.addEventListener('win_throw', c);
+
+    window.dispatchEvent(new Event('win_throw'));
+
+    testing.expectEqual('a-throwing', calls[0]);
+    testing.expectEqual('b',          calls[1]);
+    testing.expectEqual('c',          calls[2]);
+    testing.expectEqual(3, calls.length);
+
+    window.removeEventListener('win_throw', a);
+    window.removeEventListener('win_throw', b);
+    window.removeEventListener('win_throw', c);
+  }
+</script>


### PR DESCRIPTION
## What

When a listener registered via `addEventListener` throws, the event-dispatch loop currently halts: subsequent listeners on the same target are skipped, the rest of the capture/bubble walk is skipped, and the exception escapes `dispatchEvent` to the caller (surfacing as a `JsException` at the `Runtime.evaluate` boundary).

Per [DOM §2.9 "Inner invoke" step 4 substep 8](https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke), each listener callback runs in its own try/catch — exceptions are *reported* to the realm's global error handler, not propagated to the dispatch caller. This PR brings the listener invocations in line with the inline-handler invocation a few lines above, which already follows that pattern.

Closes #2367.

## Root cause

Both dispatch paths wrapped the V8 callback invocation in raw `try`:

- `src/browser/EventManager.zig` — `dispatchPhase` (capturing / at-target / bubbling for DOM targets).
- `src/browser/EventManagerBase.zig` — `dispatchDirect` (non-DOM targets — Window, XHR, AbortSignal, etc.).

Any `error.JsException` from V8 unwinds the dispatch loop, exits early, and surfaces at the CDP boundary. The inline-handler invocation in `dispatchDirect:244-246` was already `catch |err| log.warn(...)` — only the `addEventListener`-registered listener switch used raw `try`.

```mermaid
flowchart LR
    A[dispatchEvent] --> B[try callback]
    B -->|JsException| C[loop unwinds]
    C --> D[caller sees Uncaught]
    style B fill:#fdd
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

Each listener invocation is now wrapped in `catch |err| log.warn(.event, ...)`, mirroring the existing inline-handler pattern. All three union variants — `.value` (function), `.string` (eval'd source), `.object` (handleEvent) — receive the same treatment. Comments on both call sites cite DOM §2.9 step 4 so the next reader knows why the catch is there.

- `src/browser/EventManager.zig` — `dispatchPhase`: wrap the listener switch's V8 invocations.
- `src/browser/EventManagerBase.zig` — `dispatchDirect`: same shape, using `opts.context` as the log message.
- `src/browser/tests/events.html` — three new fixture blocks covering bubble-phase throw, capture-phase throw, and direct-dispatch (Window) throw.

```mermaid
flowchart LR
    A[dispatchEvent] --> B[catch JsException]
    B --> C[log.warn report]
    C --> D[continue dispatch]
    D --> E[caller sees true]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `WebApi: EventTarget` in `src/browser/tests/events.html`. Three new `<script>` blocks:
  - `listenerThrowDoesNotHaltDispatch` — bubble-phase: leaf throws, asserts all 5 listeners (leaf-throwing → leaf-sibling → mid → host → body) ran in order and `dispatchEvent` returned `true`.
  - `listenerThrowDuringCapturePhase` — capture-phase ancestor throws, asserts capture walk continues to mid, target listener fires, bubble walk continues.
  - `listenerThrowOnWindowTarget` — direct-dispatch path on `window`, asserts later listeners still fire.
- Toggle-off verified: with the production files reverted to `main`, the targeted test fails (`0 of 1 tests passed`); restored, all 515 tests pass.
- **Reproducer** (full repro in #2367): pure CDP via `ws`. Exits 1 on `main` with `hits: ["leaf-throwing"]`; exits 0 with this commit and all five listeners fire.

## Notes

- "Report" here is implemented as `log.warn(.event, "listener", .{ .err = err })`, matching the existing `dispatchDirect` inline-handler precedent. Routing the exception into a proper `error` event on the realm's global (per HTML's "report an exception" algorithm) would be a follow-up — out of scope for this PR.
- Behavior unchanged when no listener throws: same number of V8 invocations, same control flow, same return values.
