### PR TITLE
Abort http_client _before_ destroying context

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -405,6 +405,10 @@ pub fn deinit(self: *Frame) void {
     }
 
     const browser = page.session.browser;
+
+    // don't abort pending frames.
+    browser.http_client.abortFrame(self._frame_id, .{});
+
     browser.env.destroyContext(self.js);
 
     // Must be after context is destroyed. A finalizer can reach into the *Worker
@@ -414,9 +418,6 @@ pub fn deinit(self: *Frame) void {
     }
 
     self._script_manager.base.shutdown = true;
-
-    // don't abort pending frames.
-    browser.http_client.abortFrame(self._frame_id, .{});
 
     self._script_manager.deinit();
     self._style_manager.deinit();


### PR DESCRIPTION
XHR, for example, needs the context to properly shutdown. It get the page via exec.context.page. Now, we could store the page on the XHR instance, sure. But the point is the js.Context should never need the HttpClient, so it should always be safe to abort inflight requests before canceling the context.

Fixes some flaky WPT crashes.