### PR TITLE
Protect assertion when reload from about:blank

### DIFF
--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -153,10 +153,14 @@ pub fn updateEntries(
 pub fn commitNavigation(self: *Navigation, frame: *Frame) !void {
     const url = frame.url;
 
-    const kind: NavigationKind = self._current_navigation_kind orelse .{ .push = null };
+    var kind: NavigationKind = self._current_navigation_kind orelse .{ .push = null };
     defer self._current_navigation_kind = null;
 
     const from_entry = self.getCurrentEntryOrNull();
+    if (from_entry == null) {
+        kind = .{ .push = null };
+    }
+
     try self.updateEntries(url, kind, frame, false);
 
     self._activation = NavigationActivation{
@@ -507,6 +511,34 @@ test "Navigation: about:blank commits entry" {
     // so commitNavigation never runs and _entries stays empty. Reading
     // `navigation.currentEntry` from JS then hits the `lp.assert(len > 0, ...)`
     // in Navigation.getCurrentEntry
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const result = try ls.local.exec(
+        "navigation.currentEntry.url === 'about:blank'",
+        "Navigation.test",
+    );
+    try testing.expect(result.isTrue());
+}
+
+test "Navigation: reload on empty stack seeds an entry" {
+    const frame = try testing.test_session.createPage();
+    defer testing.test_session.removePage();
+
+    testing.test_session.navigation._entries.clearRetainingCapacity();
+    testing.test_session.navigation._index = 0;
+
+    // Mirrors CDP Page.reload arriving on a fresh session: doReload reads
+    // frame.url (default "about:blank") and routes through the synchronous
+    // about:blank commit with kind=.reload. updateEntries is a no-op for
+    // .reload, so without the empty-stack guard this would assert
+    // `len: 0` in getCurrentEntry.
+    try frame.navigate("about:blank", .{ .kind = .reload });
+
+    var runner = try testing.test_session.runner(.{});
+    try runner.wait(.{ .ms = 1000 });
+
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();


### PR DESCRIPTION
(and hopefully all other cases) where a commit happens on a previously blank slate.