### PR TITLE
Give setters an arity of 1

### DIFF
--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -633,6 +633,7 @@ fn attachClass(comptime JsApi: type, isolate: *v8.Isolate, template: *const v8.F
                     const cb = v8.v8__FunctionTemplate__New__Config(isolate, &.{
                         .callback = setter,
                         .signature = getter_signature,
+                        .length = 1,
                     }).?;
                     const setter_name_str = "set " ++ name;
                     const setter_name_v8 = v8.v8__String__NewFromUtf8(isolate, setter_name_str.ptr, v8.kNormal, @intCast(setter_name_str.len));

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -153,7 +153,9 @@ pub const Function = struct {
             .cache = opts.cache,
             .static = opts.static,
             .wpt_only = opts.wpt_only,
-            .arity = getArity(@TypeOf(func), 1),
+            // Non-static methods receive `self` as their first param; static
+            // methods don't, so don't skip the first param for them.
+            .arity = getArity(@TypeOf(func), if (opts.static) 0 else 1),
             .func = if (opts.noop) noopFunction else struct {
                 fn wrap(handle: ?*const v8.FunctionCallbackInfo) callconv(.c) void {
                     Caller.Function.call(T, handle.?, func, opts);


### PR DESCRIPTION
Static functions don't take a 'self' so their arity isn't + 1.

Fixes a handful of IDL test cases.