### PR TITLE
Fix fetch cleanup after context teardown

### DIFF
--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -27,6 +27,15 @@
   }
 </script>
 
+<script id=fetch_teardown_with_pending_request type=module>
+  {
+    // Regression for https://github.com/lightpanda-io/browser/issues/2373:
+    // page teardown aborts in-flight fetches after the JS context is destroyed.
+    fetch('http://127.0.0.1:9582/slow_fetch').catch(() => {});
+    testing.expectEqual(true, true);
+  }
+</script>
+
 <script id=fetch_json type=module>
   {
     const state = await testing.async();

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -37,6 +37,7 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 const Fetch = @This();
 
 _exec: *const Execution,
+_page: *Page,
 _url: []const u8,
 _buf: std.ArrayList(u8),
 _response: *Response,
@@ -68,6 +69,7 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
     const fetch = try response._arena.create(Fetch);
     fetch.* = .{
         ._exec = exec,
+        ._page = exec.context.page,
         ._buf = .empty,
         ._url = try response._arena.dupe(u8, request._url),
         ._resolver = try resolver.persist(),
@@ -260,7 +262,7 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     // clear this. (defer since `self is in the response's arena).
 
     defer if (owns_response) {
-        response.deinit(self._exec.context.page);
+        response.deinit(self._page);
     };
 
     var ls: js.Local.Scope = undefined;
@@ -277,7 +279,7 @@ fn httpShutdownCallback(ctx: *anyopaque) void {
     if (self._owns_response) {
         var response = self._response;
         response._http_response = null;
-        response.deinit(self._exec.context.page);
+        response.deinit(self._page);
         // Do not access `self` after this point: the Fetch struct was
         // allocated from response._arena which has been released.
     }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -657,6 +657,15 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/slow_fetch")) {
+        std.Thread.sleep(100 * std.time.ns_per_ms);
+        return req.respond("slow", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/plain" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/echo_referer")) {
         // Echo the request's Referer header back as HTML so tests can assert
         // what Referer the navigation sent. Used by the cross-page Referer test.


### PR DESCRIPTION
## Summary
- Store the owning `Page` on in-flight `fetch()` requests so shutdown/error cleanup does not dereference `Execution.context` after the V8 context has been destroyed.
- Use that stored page when releasing an unclaimed `Response` arena during fetch shutdown/error paths.
- Add a regression test that starts a pending fetch and lets page teardown abort it.

Fixes https://github.com/lightpanda-io/browser/issues/2373

## Root cause
`Frame.deinit()` destroys the JS/V8 context before aborting in-flight frame HTTP requests. `Fetch.httpShutdownCallback()` was doing cleanup through `self._exec.context.page`; during teardown that context can already be detached/destroyed, leading to `EXC_BAD_ACCESS` / `Segmentation fault: 11` after `fetch --dump html` has written output.

## Verification
- Reproduced the issue on exact reported commit `61364437`: 1/3 plain runs crashed with `exit=139`.
- `lldb` on the same commit stopped at `browser.webapi.net.Fetch.httpShutdownCallback`, dereferencing `self._exec.context.page`.
- Applied this fix to that exact commit and reran the reported URL 10 times: 10/10 exited `0`.
- Ran the focused fetch test.
  `make test F="fetch"`
- Rebuilt the binary.
  `make build`
- Re-ran the reported command.
  `./zig-out/bin/lightpanda fetch --dump html https://docs.infoworks.io/infoworks-6.2.1/getting-started/infoworks-installation-on-aks`

## Notes
For local reproduction I used the repo's pinned Zig/V8 setup (`mise exec --`, explicit prebuilt V8 path), but the commands above are the maintainer-facing equivalents.
