### PR TITLE
Fix the XHR teardown order

### DIFF
--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -145,8 +145,8 @@ fn releaseSelfRef(self: *XMLHttpRequest) void {
     if (self._active_request == false) {
         return;
     }
-    self.releaseRef(self._exec.context.page);
     self._active_request = false;
+    self.releaseRef(self._exec.context.page);
 }
 
 pub fn releaseRef(self: *XMLHttpRequest, page: *Page) void {


### PR DESCRIPTION
`releaseRef` can free the XHR instance, so anything we want to set, has to happen before then. (It might seem like the set is meaningful if we're just going to destroy the instance, but `releaseRef` might also _not_ destroy the instance, and the guard is for those cases).