### PR TITLE
Silence test warnings

### DIFF
--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -203,6 +203,9 @@ pub const JsApi = struct {
 
 const testing = @import("../../testing.zig");
 test "WebApi: EventTarget" {
+    const filter: testing.LogFilter = .init(&.{.js, .event});
+    defer filter.deinit();
+
     // we create thousands of these per frame. Nothing should bloat it.
     try testing.expectEqual(16, @sizeOf(EventTarget));
     try testing.htmlRunner("events.html", .{});


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/2368  added more warnings on JS callback failure. The test for these naturally trigger the logging. Silence them during testing.