### PR TITLE
On error, don't free headers

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -233,7 +233,6 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
         defer self.base.is_evaluating = was_evaluating;
 
         const headers = try self.getHeaders();
-        errdefer headers.deinit();
 
         if (is_blocking) {
             const response = try self.base.client.syncRequest(arena, .{

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -181,7 +181,7 @@ fn getThis(self: *const Function) js.Object {
 }
 
 pub fn src(self: *const Function) ![]const u8 {
-    return self.local.valueToString(.{ .local = self.local, .handle = @ptrCast(self.handle) }, .{});
+    return js.Value.toStringSlice(.{ .local = self.local, .handle = @ptrCast(self.handle) });
 }
 
 pub fn getPropertyValue(self: *const Function, name: []const u8) !?js.Value {


### PR DESCRIPTION
There's ambiguity in the http_client.request() call on whether or not the caller is responsible for freeing the header. It depends how request() fails, and it's impossible for the caller to know. This needs a fundamental fix, but, in the meantime, we get to pick between: a possible leak or a double free.

This commit opts for a possible leak. Why? Because overwhelmingly, if request fails, it'll fail at a point where it will handle the free. In those cases where it doesn't then the system is probably in trouble anyways (OOM).

(Also, as I was debugging, I noticed that the function.src() debug helper wasn't working, so I fixed it).