### PR TITLE
Add timeslice to scheduler

### DIFF
--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -80,9 +80,8 @@ pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts
 }
 
 pub fn run(self: *Scheduler) !void {
-    const now = milliTimestamp(.monotonic);
-    try self.runQueue(&self.low_priority, now);
-    try self.runQueue(&self.high_priority, now);
+    try self.runQueue(&self.low_priority);
+    try self.runQueue(&self.high_priority);
 }
 
 pub fn hasReadyTasks(self: *Scheduler) bool {
@@ -99,10 +98,12 @@ pub fn msToNextHigh(self: *Scheduler) ?u64 {
     return @intCast(task.run_at - now);
 }
 
-fn runQueue(self: *Scheduler, queue: *Queue, now: u64) !void {
+fn runQueue(self: *Scheduler, queue: *Queue) !void {
     if (queue.count() == 0) {
         return;
     }
+    const start = milliTimestamp(.monotonic);
+    var now = start;
 
     while (queue.peek()) |*task_| {
         if (task_.run_at > now) {
@@ -125,6 +126,11 @@ fn runQueue(self: *Scheduler, queue: *Queue, now: u64) !void {
             }
             task.run_at = now + ms;
             try self.low_priority.add(task);
+        }
+
+        now = milliTimestamp(.monotonic);
+        if (now - start > 500) {
+            return;
         }
     }
     return;


### PR DESCRIPTION
Give scheduler a 500ms timeslice to run per queue (high/low priority).

A site can load hundreds of timeouts to all execute at the same time. These can be relatively expensive (e.g. lots of calls directly or indirectly to getBoundingClientRect). As-is, the scheduler drains its queue to completion and other timeouts, like --wait-ms can't do what they're meant to do. By adding timeslice, we prevent many tasks all scheduled for the same time to go unchecked.

I was initially planning on putting this higher in runMacrotasks, but that could lead to starvation, i.e. if the first context used up all the time. Having it per context is more fair, at the cost of running 500ms * context. But, (a) the number of context we allow is fixed and (b) the reality is that most sites have few contexts and normally only the first one is doing anything interesting.