### PR TITLE
Add AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Tests
+
+```bash
+make test                                       # Run all tests
+make test F="server"                            # Filter by substring
+TEST_FILTER="WebApi: #selector_all" make test   # Filter main + subtest (separator: #)
+TEST_VERBOSE=true make test
+TEST_FAIL_FIRST=true make test
+METRICS=true make test                          # Capture allocation/duration metrics as JSON
+```
+
+The custom test runner (`src/test_runner.zig`) detects memory leaks in debug builds. **A test that allocates without freeing fails** — not just lints.
+
+## Formatting
+
+```bash
+zig fmt --check ./*.zig ./**/*.zig    # Exact command CI runs
+```
+
+`zig build` depends on the fmt step, so a local build catches drift too.
+
+## Conventions
+
+Mirror the patterns in neighboring files. In particular:
+
+- `@import` alias case follows the imported file's basename (`const Frame = @import("Frame.zig")`, `const ast = @import("ast.zig")`).
+- Prefer struct-init type inference (`.{ ... }`) where the expected type is known from the function signature or variable annotation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to open a pull request (CLA, dev setup, pre-PR checks).
+
 ## Tests
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 Lightpanda accepts pull requests through GitHub.
 
+## Development
+
+- Run the tests: `make test`
+- Check formatting: `zig fmt --check ./*.zig ./**/*.zig`
+
+See [AGENTS.md](AGENTS.md) for the full set of test, formatting, and code conventions (test filters, the leak-detection invariant, `@import` alias case, struct-init inference).
+
+## Before opening a PR
+
+- [ ] Tests pass (`make test`).
+- [ ] Formatting is clean (`zig fmt --check ./*.zig ./**/*.zig`).
+- [ ] CLA signed (see below).
+
+## CLA
+
 You have to sign our [CLA](CLA.md) during your first pull request process
 otherwise we're not able to accept your contributions.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ See [#1279](https://github.com/lightpanda-io/browser/pull/1279) for more details
 
 You can test Lightpanda by running `make test`.
 
+```bash
+make test                                       # Run all tests
+make test F="server"                            # Filter by substring
+TEST_FILTER="WebApi: #selector_all" make test   # Filter main + subtest (separator: #)
+TEST_VERBOSE=true make test
+TEST_FAIL_FIRST=true make test
+METRICS=true make test                          # Capture allocation/duration metrics as JSON
+```
+
 ### End to end tests
 
 To run end to end tests, you need to clone the [demo


### PR DESCRIPTION
Adds a minimal `AGENTS.md` covering the project-specific bits that aren't already in the README or derivable from reading the code:

- Test filter / env var flags (`F=`, `TEST_FILTER`, `TEST_VERBOSE`, `TEST_FAIL_FIRST`, `METRICS`).
- The custom test runner's leak-detection invariant — a test that allocates without freeing fails outright.
- The exact `zig fmt --check` command CI runs.
- A short pointer at the existing `@import` alias-case and struct-init-inference patterns to mirror.

`CLAUDE.md` is a one-line `@AGENTS.md` import so Claude Code (which doesn't read AGENTS.md natively) picks up the same content without any duplication.

Deliberately out of scope:
- No `docs/` directory or architecture map — drifts easily, and humans/agents can read the code.
- No `.gitignore` changes for agent tooling — kept locally.
- No tool-specific rule files (`.cursorrules`, `.codex/...`) — AGENTS.md is the single source of truth.