### PR TITLE
Defer page teardown while worker scripts are evaluating

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1244,6 +1244,24 @@ pub fn isGoingAway(self: *const Frame) bool {
     return parent.isGoingAway();
 }
 
+// True if this frame, any descendant frame, or any worker owned by any
+// of those frames is currently inside script evaluation. Used as a
+// reentrancy guard before tearing down a page from a CDP message that
+// may have been drained while a Zig->JS->Zig stack (e.g. Worker
+// importScripts -> syncRequest -> blocking_read) is mid-flight.
+// Recursive over child frames so an evaluating subframe also defers
+// parent teardown.
+pub fn anyScriptEvaluating(self: *const Frame) bool {
+    if (self._script_manager.base.is_evaluating) return true;
+    for (self.workers.items) |worker| {
+        if (worker._worker_scope._script_manager.is_evaluating) return true;
+    }
+    for (self.child_frames.items) |child| {
+        if (child.anyScriptEvaluating()) return true;
+    }
+    return false;
+}
+
 pub fn scriptAddedCallback(self: *Frame, comptime from_parser: bool, script: *Element.Html.Script) !void {
     if (self.isGoingAway()) {
         // if we're planning on navigating to another frame, don't run this script

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -200,8 +200,12 @@ pub fn removePage(self: *Session) void {
         lp.assert(false, "Session.removePage - page is null", .{});
     };
 
-    if (page.frame._script_manager.base.is_evaluating) {
+    if (page.frame.anyScriptEvaluating()) {
         // Reentrant teardown from a CDP message drained inside syncRequest;
+        // either the page's own script (frame ScriptManager.is_evaluating)
+        // or a Worker eval (Worker.loadInitialScript marks its
+        // _worker_scope._script_manager.is_evaluating). Tearing down here
+        // would free the arena/identity_map underneath the active eval.
         // Session.deinit reclaims the page when the connection closes.
         return;
     }

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -187,6 +187,21 @@ fn loadInitialScript(self: *Worker, script: []const u8) !void {
     try_catch.init(&ls.local);
     defer try_catch.deinit();
 
+    // Mark this worker's ScriptManager as evaluating for the lifetime of
+    // the eval. Worker scripts can call importScripts() which performs a
+    // synchronous HTTP request that pumps the CDP socket while waiting
+    // (HttpClient.syncRequest -> cdp.blocking_read). A CDP message such
+    // as Target.closeTarget arriving on that socket would otherwise tear
+    // down the page (Session.removePage -> Page.deinit -> Frame.deinit ->
+    // Worker.deinit) while this eval is mid-flight, freeing the worker's
+    // arena and identity_map underneath us. Session.removePage walks
+    // every frame's workers and bails out when any is_evaluating, so the
+    // teardown is deferred until the eval unwinds.
+    const sm = &self._worker_scope._script_manager;
+    const was_evaluating = sm.is_evaluating;
+    sm.is_evaluating = true;
+    defer sm.is_evaluating = was_evaluating;
+
     _ = ls.local.eval(script, self._url) catch |err| {
         const caught = try_catch.caughtOrError(self._arena, err);
         log.err(.browser, "worker script error", .{ .url = self._url, .caught = caught });

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -374,6 +374,26 @@ fn importScript(self: *WorkerGlobalScope, arena: Allocator, url: [:0]const u8) !
     var headers = try http_client.newHeaders();
     try self.headersForRequest(&headers);
 
+    // Mark the worker's ScriptManager as evaluating for the duration of
+    // the synchronous fetch. syncRequest pumps the CDP socket while
+    // waiting (HttpClient.syncRequest -> cdp.blocking_read). A CDP
+    // message such as Target.closeTarget arriving on that socket would
+    // otherwise tear down the page (Session.removePage -> Page.deinit ->
+    // Frame.deinit -> Worker.deinit) while we're mid-fetch, freeing the
+    // worker's arena and identity_map underneath us. Frame.anyScriptEvaluating
+    // walks every frame's workers, so the teardown is deferred until the
+    // outer call unwinds.
+    //
+    // The typical caller (Worker.loadInitialScript) already sets this
+    // around its own eval, so this is a defense-in-depth nesting: a worker
+    // script that calls importScripts() from a setTimeout callback or a
+    // microtask wouldn't have the outer guard, but would still be safe
+    // because of this one.
+    const sm = &self._script_manager;
+    const was_evaluating = sm.is_evaluating;
+    sm.is_evaluating = true;
+    defer sm.is_evaluating = was_evaluating;
+
     const response = http_client.syncRequest(arena, .{
         .url = resolved_url,
         .method = .GET,

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -371,7 +371,7 @@ pub fn disposeBrowserContext(self: *CDP, browser_context_id: []const u8) bool {
     // (see Session.removePage's matching guard). Defer cleanup to
     // CDP.deinit at connection close, by which time eval has unwound.
     if (bc.session.currentPage()) |page| {
-        if (page.frame._script_manager.base.is_evaluating) {
+        if (page.frame.anyScriptEvaluating()) {
             return true;
         }
     }


### PR DESCRIPTION
## Summary

Fixes a use-after-free segfault in worker script evaluation when a CDP message arrives mid-fetch during `importScripts()`.

## Reproduction

Drive `lightpanda serve` with `puppeteer-core`'s `puppeteer.connect({ browserWSEndpoint })` against any URL that loads dedicated workers calling `importScripts()` during initial eval. The Allbirds product page (`https://www.allbirds.com/products/mens-wool-runners`) loads ~8 web-pixel workers each calling `importScripts()`, and reliably triggered the crash within 1–10 sequential connections to the same server.

Stack signature (truncated):

```
Segmentation fault at address 0x...
std/hash_map.zig:798:33 in capacity            ← self.metadata.? - 1 dereferences freed page
std/hash_map.zig:1148:39 in getOrPutAssumeCapacityAdapted
src/browser/js/Context.zig:276 in addIdentity   ← identity_map.getOrPut on a freed Identity
src/browser/js/Local.zig:229    in mapZigInstanceToJs
src/browser/js/Caller.zig:382   in handleError  ← mapping a Zig error to a JS exception
src/browser/js/bridge.zig:161   in wrap         ← V8 callback into Zig
... v8 frames ...
src/browser/js/Local.zig:194    in compileAndRun
src/browser/webapi/Worker.zig:190 in loadInitialScript
src/browser/webapi/Worker.zig:178 in httpDoneCallback
```

## Root cause

`WorkerGlobalScope.importScripts` performs a synchronous HTTP request via `HttpClient.syncRequest`. To stay responsive during a long fetch, `syncRequest` pumps the CDP socket via `cdp.blocking_read` while waiting for the HTTP response. If a CDP message such as `Target.closeTarget` arrives on that socket mid-fetch, the dispatcher synchronously tore down the page:

```
Worker JS → importScripts → syncRequest → blocking_read
  → CDP dispatch → Target.closeTarget
  → Session.removePage → Page.deinit → Frame.deinit
  → Worker.deinit (frees worker arena + identity_map)
```

When control unwound back into the worker's eval, the next `addIdentity` call dereferenced the freed identity_map metadata pointer and segfaulted (sometimes immediately on the same connection, sometimes a few connections later as the arena pool recycled the freed memory and a different worker's identity got positioned over the old one).

`Session.removePage` already had a guard for this exact reentrancy pattern via `frame._script_manager.base.is_evaluating`, but it never tripped in the worker case because worker scripts don't go through the *frame's* `ScriptManager` — they have their own `_script_manager` on `WorkerGlobalScope`.

## Fix

Two small changes:

1. `Worker.loadInitialScript` now flips `_worker_scope._script_manager.is_evaluating` around the `eval`, with `was_evaluating` save/restore so nested worker evals (e.g. one worker's `importScripts` synchronously triggering another worker's done-callback via the curl pump) compose correctly.

2. New helper `Session.anyScriptEvaluating(frame)` recursively walks the frame tree (the frame's own `ScriptManager` + every owned worker's `ScriptManager` + child frames) and returns `true` if any is mid-eval. `Session.removePage` and `CDP.disposeBrowserContext` use this in place of the frame-only check, so teardown is deferred whenever any script — frame, worker, or subframe — is on the call stack. Final cleanup happens at `CDP.deinit` on connection close, matching the existing deferred-teardown contract documented in `Session.removePage`.

Diff is +38 / -2 across three files: `src/browser/Session.zig`, `src/browser/webapi/Worker.zig`, `src/cdp/CDP.zig`.

## Verification

- **Repro fixed:** 25 consecutive `puppeteer-core` `connect()` runs against the Allbirds URL on the same `lightpanda serve` process. All returned `status=200` with the expected `<title>` and ~922 KB body, server alive throughout. Pre-fix this crashed within 1–10 runs.
- **Mixed clients:** interleaved Puppeteer and Playwright `connectOverCDP` runs against the same server, no crashes (Playwright still times out on `page.goto` due to a separate, unrelated bug in the synthetic `STARTUP` session — out of scope here).
- **Unit tests:** 521/521 pass (`make test`).

## Notes / out of scope

While reproducing this I noticed that Playwright's `chromium.connectOverCDP` cannot navigate against `lightpanda serve` at all: it auto-attaches to the synthetic `STARTUP` target Lightpanda advertises, sends `Page.navigate` on that session, and Lightpanda's `dispatchStartupCommand` blindly replies `{}` and drops the message — Playwright then waits forever for `Page.frameNavigated`. Puppeteer's flow (`createBrowserContext` → `createTarget` → real session) is unaffected. That's a separate fix; happy to follow up with another PR if useful.
