### PR TITLE
Promote synthetic STARTUP session for Playwright connectOverCDP

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -62,6 +62,17 @@ browser: Browser,
 // when true, any target creation must be attached.
 target_auto_attach: bool = false,
 
+// Set when setAutoAttach has emitted the synthetic Target.attachedToTarget
+// event for the placeholder STARTUP session (no real BrowserContext yet).
+// The next doAttachtoTarget that would otherwise generate a fresh
+// session_id reuses the literal string "STARTUP" instead, so drivers that
+// already saw the synthetic attach (Puppeteer-style: setAutoAttach ->
+// silent STARTUP -> createBrowserContext + createTarget) end up driving
+// the real target via the same sessionId they already learned about,
+// rather than receiving a second attachedToTarget event for the same
+// targetId with a different sessionId. Cleared on first reuse.
+startup_session_advertised: bool = false,
+
 target_id_gen: TargetIdGen = .{},
 session_id_gen: SessionIdGen = .{},
 browser_context_id_gen: BrowserContextIdGen = .{},
@@ -264,16 +275,81 @@ pub fn dispatch(self: *CDP, arena: Allocator, sender: Command.Sender, str: []con
 // When messages are received with the "STARTUP" sessionId, we do
 // "special" handling - the bare minimum we need to do until the driver
 // switches to a real BrowserContext.
-// (I can imagine this logic will become driver-specific)
+//
+// Two driver styles reach this code:
+//
+//  * Puppeteer-style: setAutoAttach -> createBrowserContext ->
+//    createTarget. Subsequent commands carry a real session_id assigned
+//    by doAttachtoTarget. They never arrive here, since their
+//    sessionId isn't "STARTUP".
+//
+//  * Playwright-style (chromium.connectOverCDP): setAutoAttach ->
+//    immediately drives the synthetic STARTUP target with Page.enable,
+//    Page.navigate, etc. on sessionId="STARTUP". It never calls
+//    createBrowserContext / createTarget itself, so without help here
+//    every command but Page.getFrameTree would be silently {}-acked
+//    and Page.navigate would never fire any frame events. We lazily
+//    promote the synthetic STARTUP session into a real BrowserContext +
+//    Target + Session whose session_id is the literal string "STARTUP",
+//    then route the command through the normal dispatcher.
 fn dispatchStartupCommand(command: *Command, method: []const u8) !void {
-    // Stagehand parses the response and error if we don't return a
-    // correct one for Page.getFrameTree on startup call.
+    // Page.getFrameTree's handler already returns a synthetic placeholder
+    // when no real BrowserContext exists yet (Stagehand depends on this),
+    // so route it without forcing a promotion. If a previous STARTUP
+    // command already promoted, the handler returns the real frame tree.
     if (std.mem.eql(u8, method, "Page.getFrameTree")) {
-        // The Page.getFrameTree handles startup response gracefully.
         return dispatchCommand(command, method);
     }
 
-    return command.sendResult(null, .{});
+    // Some commands are safe to silently {}-ack on the synthetic STARTUP
+    // session without promoting it into a real BrowserContext. Notably:
+    //
+    //   * Target.* on STARTUP is session/target management that drivers
+    //     send opportunistically between connect() and their own
+    //     Target.createBrowserContext / Target.createTarget. Promoting
+    //     here would steal the bc from under them and make their
+    //     subsequent createBrowserContext error with "Cannot have more
+    //     than one browser context at a time" (puppeteer-core 24.x sends
+    //     Target.setAutoAttach with sessionId=STARTUP before its own
+    //     createBrowserContext).
+    //
+    //   * Runtime.runIfWaitingForDebugger is unconditionally sent during
+    //     connect by both Puppeteer and Playwright; it's a no-op for us.
+    //
+    // Anything else (Page.enable, Page.navigate, Network.enable,
+    // Runtime.enable, Log.enable, Emulation.*, etc.) is real work that
+    // requires a backing page, so promote and dispatch normally.
+    if (isStartupSilentNoop(method)) {
+        return command.sendResult(null, .{});
+    }
+
+    const cdp = command.cdp;
+    if (cdp.browser_context == null) {
+        // Lazy promote: create a real BrowserContext + Target whose
+        // session_id is the literal string "STARTUP". Subsequent STARTUP
+        // commands match via isValidSessionId and dispatch normally.
+        try @import("domains/target.zig").promoteStartupSession(command);
+        return dispatchCommand(command, method);
+    }
+
+    // bc exists. STARTUP is only meaningful as a sessionId if the bc was
+    // promoted into one (session_id == "STARTUP"). Otherwise the driver
+    // is sending the placeholder sessionId at the wrong time (e.g. after
+    // its own createBrowserContext + doAttachtoTarget assigned a real
+    // session_id) and we should reject it like any other stale id.
+    const bc_session_id = cdp.browser_context.?.session_id orelse {
+        return command.sendError(-32001, "Unknown sessionId", .{});
+    };
+    if (!std.mem.eql(u8, bc_session_id, "STARTUP")) {
+        return command.sendError(-32001, "Unknown sessionId", .{});
+    }
+    return dispatchCommand(command, method);
+}
+
+fn isStartupSilentNoop(method: []const u8) bool {
+    if (std.mem.startsWith(u8, method, "Target.")) return true;
+    if (std.mem.eql(u8, method, "Runtime.runIfWaitingForDebugger")) return true;
+    return false;
 }
 
 fn dispatchCommand(command: *Command, method: []const u8) !void {
@@ -1183,22 +1259,51 @@ test "cdp: STARTUP sessionId" {
     defer ctx.deinit();
 
     {
-        // we have no browser context
-        try ctx.processMessage(.{ .id = 2, .method = "Hi", .sessionId = "STARTUP" });
-        try ctx.expectSentResult(null, .{ .id = 2, .index = 0, .session_id = "STARTUP" });
+        // No browser_context: a STARTUP-tagged command lazily promotes
+        // into a real BrowserContext + Target whose session_id is the
+        // literal string "STARTUP", then dispatches normally. We use
+        // Page.getFrameTree because its handler is the one method that's
+        // routed without forcing promotion (Stagehand depends on this);
+        // it falls back to the synthetic placeholder when there's no bc,
+        // and after subsequent STARTUP-tagged commands promote it returns
+        // the real frame tree.
+        try testing.expectEqual(null, ctx.cdp().browser_context);
+        try ctx.processMessage(.{ .id = 1, .method = "Browser.getVersion", .sessionId = "STARTUP" });
+        const bc = &ctx.cdp().browser_context.?;
+        try testing.expectEqualSlices(u8, "STARTUP", bc.session_id.?);
+        try testing.expect(bc.target_id != null);
     }
 
     {
-        // we have a browser context but no session_id
-        _ = try ctx.loadBrowserContext(.{});
-        try ctx.processMessage(.{ .id = 3, .method = "Hi", .sessionId = "STARTUP" });
-        try ctx.expectSentResult(null, .{ .id = 3, .index = 1, .session_id = "STARTUP" });
+        // bc already promoted with session_id="STARTUP": subsequent
+        // STARTUP-tagged commands match isValidSessionId and dispatch
+        // through the normal command path.
+        try ctx.processMessage(.{ .id = 2, .method = "Browser.getVersion", .sessionId = "STARTUP" });
     }
+}
 
-    {
-        // we have a browser context with a different session_id
-        _ = try ctx.loadBrowserContext(.{ .session_id = "SESS-2" });
-        try ctx.processMessage(.{ .id = 4, .method = "Hi", .sessionId = "STARTUP" });
-        try ctx.expectSentResult(null, .{ .id = 4, .index = 2, .session_id = "STARTUP" });
-    }
+test "cdp: STARTUP sessionId rejected after non-STARTUP attach" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    // bc exists with a real session_id assigned by createTarget /
+    // doAttachtoTarget. The driver should be using that session_id, not
+    // the synthetic STARTUP placeholder. Reject so a stale STARTUP
+    // message can't smuggle commands into a real session.
+    _ = try ctx.loadBrowserContext(.{ .session_id = "SESS-2" });
+    try ctx.processMessage(.{ .id = 1, .method = "Browser.getVersion", .sessionId = "STARTUP" });
+    try ctx.expectSentError(-32001, "Unknown sessionId", .{ .id = 1 });
+}
+
+test "cdp: STARTUP sessionId rejected when bc has no session_id" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    // bc exists but no doAttachtoTarget has run yet (session_id == null).
+    // STARTUP is the placeholder sessionId from setAutoAttach; it's only
+    // valid when there's no bc at all (lazy promote) or when a previous
+    // promote bound it. Reject otherwise.
+    _ = try ctx.loadBrowserContext(.{});
+    try ctx.processMessage(.{ .id = 1, .method = "Browser.getVersion", .sessionId = "STARTUP" });
+    try ctx.expectSentError(-32001, "Unknown sessionId", .{ .id = 1 });
 }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -87,13 +87,18 @@ const CDPFrame = struct {
 };
 
 fn getFrameTree(cmd: *CDP.Command) !void {
-    // Stagehand parses the response and error if we don't return a
-    // correct one for this call when browser context or target id are missing.
+    // Stagehand parses the response and errors if we don't return a
+    // correct one for this call when no browser context / target id
+    // exists yet. The synthetic frameId / loaderId here deliberately
+    // match what the first real frame and loader will be assigned when
+    // a STARTUP session is later promoted (Session.nextFrameId / nextLoaderId
+    // both return 1 first), so drivers that bind to the synthetic ids
+    // reconcile cleanly with the post-promotion frame tree.
     const startup = .{
         .frameTree = .{
             .frame = .{
-                .id = "TID-STARTUP",
-                .loaderId = "LID-STARTUP",
+                .id = "FID-0000000001",
+                .loaderId = "LID-0000000001",
                 .securityOrigin = @import("../CDP.zig").URL_BASE,
                 .url = "about:blank",
                 .secureContextType = "Secure",
@@ -875,13 +880,15 @@ test "cdp.frame: getFrameTree" {
     defer ctx.deinit();
 
     {
-        // no browser context - should return TID-STARTUP
+        // no browser context - synthetic placeholder; ids deliberately
+        // match what the first promoted frame/loader will be assigned
+        // (Session.nextFrameId / nextLoaderId both return 1 first).
         try ctx.processMessage(.{ .id = 1, .method = "Page.getFrameTree", .sessionId = "STARTUP" });
         try ctx.expectSentResult(.{
             .frameTree = .{
                 .frame = .{
-                    .id = "TID-STARTUP",
-                    .loaderId = "LID-STARTUP",
+                    .id = "FID-0000000001",
+                    .loaderId = "LID-0000000001",
                     .url = "about:blank",
                     .secureContextType = "Secure",
                 },

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -144,6 +144,75 @@ fn disposeBrowserContext(cmd: *CDP.Command) !void {
     try cmd.sendResult(null, .{});
 }
 
+// Lazy promotion of the synthetic STARTUP session into a real
+// BrowserContext + Target + Session whose session_id is the literal
+// string "STARTUP". Used by CDP.dispatchStartupCommand when a driver
+// (notably Playwright's chromium.connectOverCDP) starts driving the
+// synthetic STARTUP target Lightpanda advertised in setAutoAttach
+// without ever calling Target.createBrowserContext / Target.createTarget.
+//
+// Mirrors the bootstrap portion of createTarget but deliberately omits
+// the Target.targetCreated and Target.attachedToTarget events:
+// setAutoAttach already sent Target.attachedToTarget for the synthetic
+// STARTUP target, and emitting another attached/created event for what
+// the driver considers the same target produces duplicate sessions in
+// Playwright.
+//
+// The synthetic Target.attachedToTarget event sent by setAutoAttach
+// already advertised this target with the same FID-0000000001 /
+// BID-1 strings the freshly-created BrowserContext + root frame are
+// assigned (Session.nextFrameId returns 1 first; the bc id generator
+// returns BID-1 first), so events emitted after promotion line up with
+// what the driver already recorded.
+// Puppeteer never reaches this path (it always issues
+// createBrowserContext + createTarget without sessionId before sending
+// any STARTUP-tagged command).
+pub fn promoteStartupSession(cmd: *CDP.Command) !void {
+    lp.assert(cmd.browser_context == null, "promoteStartupSession with existing bc", .{});
+
+    const bc = cmd.createBrowserContext() catch |err| switch (err) {
+        error.AlreadyExists => unreachable,
+        else => return err,
+    };
+
+    lp.assert(!bc.session.hasPage(), "promoteStartupSession with existing page", .{});
+    lp.assert(bc.session_id == null, "promoteStartupSession with existing session_id", .{});
+
+    const frame = try bc.session.createPage();
+
+    // target_id == frame_id of the root frame, matching createTarget.
+    const frame_id = id.toFrameId(frame._frame_id);
+    bc.target_id = frame_id;
+    const target_id = &bc.target_id.?;
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+
+        const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":true,\"type\":\"default\",\"frameId\":\"{s}\"}}", .{target_id});
+        bc.inspector_session.inspector.contextCreated(
+            &ls.local,
+            "",
+            "", // @ZIGDOM
+            aux_data,
+            true,
+        );
+    }
+
+    bc.security_origin = "://";
+    bc.secure_context_type = "InsecureScheme";
+
+    // Bind the existing "STARTUP" sessionId to this bc so the dispatcher's
+    // isValidSessionId check passes for subsequent commands. Mirror
+    // doAttachtoTarget's first-attach extra-headers reset.
+    bc.extra_headers.clearRetainingCapacity();
+    bc.session_id = "STARTUP";
+    // The synthetic advertisement is now backed by a real bc/target; no
+    // future doAttachtoTarget should reuse the literal "STARTUP" string.
+    cmd.cdp.startup_session_advertised = false;
+}
+
 fn createTarget(cmd: *CDP.Command) !void {
     const params = (try cmd.params(struct {
         url: [:0]const u8 = "about:blank",
@@ -444,28 +513,58 @@ fn setAutoAttach(cmd: *CDP.Command) !void {
     // there.
     // This hack requires the main cdp dispatch handler to special case
     // messages from this "STARTUP" session.
+    //
+    // The synthetic targetId / browserContextId here are deliberately the
+    // same strings the first real frame and BrowserContext will be assigned
+    // when promoted (Session.nextFrameId starts at 0 and returns 1 first;
+    // CDP.browser_context_id_gen returns BID-1 first). Drivers that bind
+    // the page to whatever targetId we advertise here (Playwright's
+    // chromium.connectOverCDP, in particular) reconcile cleanly with the
+    // events emitted after promotion. Puppeteer-style drivers ignore this
+    // synthetic event entirely.
     try cmd.sendEvent("Target.attachedToTarget", AttachToTarget{
         .sessionId = "STARTUP",
         .targetInfo = TargetInfo{
             .type = "page",
-            .targetId = "TID-STARTUP",
+            .targetId = "FID-0000000001",
             .title = "",
             .url = "about:blank",
-            .browserContextId = "BID-STARTUP",
+            .browserContextId = "BID-1",
         },
     }, .{});
+    cmd.cdp.startup_session_advertised = true;
 
     try cmd.sendResult(null, .{});
 }
 
 fn doAttachtoTarget(cmd: *CDP.Command, target_id: []const u8) !void {
     const bc = cmd.browser_context.?;
-    const session_id = bc.session_id orelse cmd.cdp.session_id_gen.next();
+    const cdp = cmd.cdp;
+
+    // If setAutoAttach already advertised the synthetic STARTUP session
+    // for this connection (Puppeteer-style flow: setAutoAttach -> silent
+    // STARTUP commands -> createBrowserContext + createTarget), reuse
+    // "STARTUP" as the session_id so the driver sees a single coherent
+    // session for the target it already knows about, rather than receiving
+    // a second Target.attachedToTarget event with a different sessionId
+    // for the same targetId (which would make the driver try to drive two
+    // separate Page-init flows over the same target).
+    const reuse_startup = cdp.startup_session_advertised and bc.session_id == null;
+    const session_id: []const u8 = if (reuse_startup) "STARTUP" else (bc.session_id orelse cdp.session_id_gen.next());
 
     if (bc.session_id == null) {
         // extra_headers should not be kept on a new frame or tab,
         // currently we have only 1 frame, we clear it just in case
         bc.extra_headers.clearRetainingCapacity();
+    }
+
+    if (reuse_startup) {
+        // The driver already received Target.attachedToTarget for this
+        // session in setAutoAttach; suppress the duplicate. Just bind
+        // bc.session_id so the dispatcher accepts STARTUP-tagged commands.
+        cdp.startup_session_advertised = false;
+        bc.session_id = session_id;
+        return;
     }
 
     try cmd.sendEvent("Target.attachedToTarget", AttachToTarget{


### PR DESCRIPTION
## Summary

Makes Lightpanda's CDP server work with `playwright-core`'s `chromium.connectOverCDP`. Previously, Playwright would auto-attach to the synthetic `STARTUP` target Lightpanda advertises in `Target.setAutoAttach`, drive it with `Page.enable` / `Page.navigate` / etc. on `sessionId="STARTUP"`, and time out forever waiting for `Page.frameNavigated` events that never came — the dispatcher silently `{}`-acked every STARTUP-tagged command except `Page.getFrameTree`.

## Reproduction

```js
import { chromium } from 'playwright-core';
const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
const ctx = browser.contexts()[0] ?? await browser.newContext();
const page = ctx.pages()[0] ?? await ctx.newPage();
await page.goto('https://www.allbirds.com/products/mens-wool-runners', { waitUntil: 'load' });
// → TimeoutError: page.goto: Timeout exceeded
```

`puppeteer-core` was unaffected because it uses a different protocol shape: `puppeteer.connect()` → `browser.createBrowserContext()` → `context.newPage()`, which sends `Target.createBrowserContext` + `Target.createTarget` (no sessionId) and then drives the new target on a real session_id assigned by `doAttachtoTarget`. It never sends a STARTUP-tagged work command.

## Root cause

Lightpanda's CDP server is built around the assumption "browser starts empty, driver creates everything." `Target.setAutoAttach` advertises a synthetic placeholder target with `sessionId="STARTUP"` so drivers don't block waiting for a real target to appear. The comment in `setAutoAttach` makes the assumption explicit: *"Hopefully, the first thing they'll do is create a real BrowserContext and progress from there."*

Playwright's `chromium.connectOverCDP` does the opposite. It assumes a real Chrome on the other end and auto-attaches to whatever target is advertised, then immediately drives that target. The dispatcher's `dispatchStartupCommand`:

```zig
fn dispatchStartupCommand(command: *Command, method: []const u8) !void {
    if (std.mem.eql(u8, method, "Page.getFrameTree")) {
        return dispatchCommand(command, method);
    }
    return command.sendResult(null, .{});  // ← {}-acks EVERYTHING else
}
```

silently drops `Page.enable`, `Page.navigate`, `Network.enable`, `Runtime.enable`, `Page.setLifecycleEventsEnabled`, `Page.addScriptToEvaluateOnNewDocument`, `Emulation.*`, etc. After `Page.navigate`, no `Page.frameNavigated` / `lifecycleEvent` / `loadEventFired` events ever fire and `page.goto` times out.

## Fix

Three coordinated changes:

**1. Lazy-promote on first STARTUP work command.** `dispatchStartupCommand` now creates a real `BrowserContext` + `Target` whose `session_id` is the literal string `"STARTUP"` the first time a STARTUP-tagged command needs real page state, then routes through the normal dispatcher. After promotion, `isValidSessionId` accepts `"STARTUP"` and every subsequent command flows through the standard handlers.

`Target.*` and `Runtime.runIfWaitingForDebugger` are explicitly held out: Puppeteer sends `Target.setAutoAttach` and `Runtime.runIfWaitingForDebugger` with `sessionId="STARTUP"` *between* `puppeteer.connect()` and its own `Target.createBrowserContext`. Promoting on those would steal the bc out from under Puppeteer's `createBrowserContext` (which would then error with `"Cannot have more than one browser context at a time"`). Silently `{}`-acking them, as before, keeps Puppeteer's flow intact.

Once a bc exists with `session_id != "STARTUP"` (i.e. a real session_id was assigned by `createTarget` + `doAttachtoTarget`), further STARTUP-tagged commands are rejected with `-32001 "Unknown sessionId"` rather than silently no-oped, since they're now stale.

**2. Synthetic IDs match the real first frame / context.** The synthetic `targetId` / `browserContextId` in `setAutoAttach` were `"TID-STARTUP"` / `"BID-STARTUP"`. They are now `"FID-0000000001"` / `"BID-1"` — the same strings the first real Target / BrowserContext will be assigned (`Session.nextFrameId` returns 1 first; the bc id generator returns `BID-1` first). After promotion, every event Lightpanda emits (`Page.frameNavigated`, `Runtime.executionContextCreated`, etc.) carries IDs that line up with what the driver already recorded from the synthetic event. `Page.getFrameTree`'s synthetic placeholder was updated to match (`LID-STARTUP` → `LID-0000000001`). Without this, Playwright's first `getFrameTree` response carried a different `frame.id` than the `targetId` it had just learned from `Target.attachedToTarget`, and Playwright marked the original main frame as detached — `page.goto` then errored synchronously with `"Frame has been detached. (after 1ms)"`.

**3. `doAttachtoTarget` reuses the literal `"STARTUP"` session_id when the synthetic STARTUP session was already advertised.** A new flag `cdp.startup_session_advertised` is set when `setAutoAttach` emits the synthetic event, and consumed by `doAttachtoTarget` the next time it would otherwise generate a fresh session_id. Without this, Puppeteer's flow ended up with two `Target.attachedToTarget` events for the same `targetId` (one with `sessionId="STARTUP"`, then another with `sessionId="SID-1"` after `createTarget` ran). Puppeteer treats those as two separate sessions and tries to initialize a Page over each; the STARTUP one then fails every command with `"Unknown sessionId"` because `bc.session_id` had been overwritten to `SID-1`.

A new helper `promoteStartupSession` in `domains/target.zig` mirrors the bootstrap portion of `createTarget` but skips the `Target.targetCreated` / `Target.attachedToTarget` events (the driver already received `Target.attachedToTarget` in `setAutoAttach` and a duplicate would re-trigger Playwright's confusion).

## Verification

- `playwright-core` 1.59.1 `chromium.connectOverCDP` + `page.goto` on `https://www.allbirds.com/products/mens-wool-runners` now returns `status=200` and fires `framenavigated` / `domcontentloaded` / `load` events. Server stays alive across 10 sequential runs.
- `puppeteer-core` 24.42.0 `puppeteer.connect()` + `createBrowserContext` + `newPage().goto()` still works end-to-end and extracts the expected `<title>` and ~922 KB body.
- 523/523 unit tests pass. The existing `cdp: STARTUP sessionId` test was rewritten to assert the new lazy-promote behavior, and two new tests cover the rejection paths (bc with non-STARTUP session_id, bc with no session_id at all).
- Combined with #2398 (the worker re-entrancy crash fix), 10 sequential mixed Puppeteer / Playwright runs against the same `lightpanda serve` process: 9 successful (`status=200`), 1 Playwright timeout (network flake on the 10th run), server stayed alive throughout.

## Notes / out of scope

Playwright now navigates successfully but `page.title()` returns `""` and `page.evaluate(() => document.title)` errors with `"Execution context was destroyed, most likely because of a navigation."` That's Lightpanda's `Page.createIsolatedWorld` / `Runtime.executionContextCreated` flow not re-binding Playwright's utility-world context after navigation — a separate gap, not fixed here. The user-facing `page.goto` path works.

Independent of #2398. Either order of landing is fine.
