### PR TITLE
Add LP.setSubframeLoading + --disable-subframes opt-out for iframe loading

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -98,6 +98,7 @@ const CommonOptions = .{
     .{ .name = "cookie_jar", .type = ?[]const u8 },
     .{ .name = "storage_engine", .type = ?Storage.EngineType },
     .{ .name = "storage_sqlite_path", .type = ?[:0]const u8 },
+    .{ .name = "disable_subframes", .type = bool },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -210,6 +211,20 @@ pub fn obeyRobots(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| opts.obey_robots,
         else => unreachable,
+    };
+}
+
+// When true, the HTML parser silently skips loading <iframe> elements:
+// no child frame is created, no document fetch, no Page.frameAttached /
+// Page.frameNavigated / Runtime.executionContextCreated events emitted.
+// Useful for pages that load large numbers of analytics / pixel iframes
+// where each subframe navigation invalidates the driver's cached
+// executionContextIds (#2400). The CDP method LP.setSubframeLoading
+// can override this at runtime per-session.
+pub fn disableSubframes(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp => |opts| opts.disable_subframes,
+        else => false,
     };
 }
 
@@ -498,6 +513,17 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\--obey-robots
         \\                Fetches and obeys the robots.txt (if available) of the web pages
         \\                we make requests towards.
+        \\                Defaults to false.
+        \\
+        \\--disable-subframes
+        \\                Skip loading <iframe> elements. The HTML parser registers them
+        \\                in the DOM but no child frame, document fetch, or
+        \\                Page.frameAttached / Runtime.executionContextCreated events are
+        \\                produced. Useful for pages that load many analytics / pixel
+        \\                iframes where each subframe navigation invalidates driver-side
+        \\                executionContextIds (lightpanda-io/browser#2400). On the CDP
+        \\                serve path, drivers can also toggle this per-session via the
+        \\                LP.setSubframeLoading method.
         \\                Defaults to false.
         \\
         \\--block-private-networks

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1276,6 +1276,15 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
     if (iframe._executed) {
         return;
     }
+    if (!self._session.subframe_loading_enabled) {
+        // The CDP driver opted out of subframe loading via
+        // LP.setSubframeLoading. Mark the iframe as "executed" so the
+        // parser doesn't keep handing it back to us, but skip the child
+        // frame creation / navigation / notification entirely — no child
+        // Frame, no Page.frameAttached, no Runtime.executionContextCreated.
+        iframe._executed = true;
+        return;
+    }
 
     var src = iframe.asElement().getAttributeSafe(comptime .wrap("src")) orelse "";
     if (src.len == 0) {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -76,6 +76,17 @@ _pending: ?*Page = null,
 frame_id_gen: u32 = 0,
 loader_id_gen: u32 = 0,
 
+// When false, the HTML parser silently skips loading <iframe> elements
+// (no child frame is created, no document fetch, no Page.frameAttached /
+// Page.frameNavigated / Runtime.executionContextCreated events emitted).
+// Lets CDP drivers opt out of subframe processing for pages that load
+// large numbers of analytics / pixel iframes — useful as a workaround
+// for #2400 (child-iframe navigation churns the main frame's
+// executionContextId because IsolatedWorld is shared and CONTEXT_GROUP_ID
+// is per-BrowserContext rather than per-frame). Toggled via
+// LP.setSubframeLoading from CDP.
+subframe_loading_enabled: bool = true,
+
 pub fn init(self: *Session, browser: *Browser, notification: *Notification) !void {
     const allocator = browser.app.allocator;
     const arena_pool = browser.arena_pool;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -105,6 +105,8 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         .notification = notification,
         .fc_identity_pool = .init(allocator),
         .cookie_jar = storage.Cookie.Jar.init(allocator),
+        // CLI default; LP.setSubframeLoading can flip this per-session.
+        .subframe_loading_enabled = !browser.app.config.disableSubframes(),
     };
 }
 

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -42,6 +42,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         scrollNode,
         waitForSelector,
         handleJavaScriptDialog,
+        setSubframeLoading,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
@@ -56,7 +57,33 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .scrollNode => return scrollNode(cmd),
         .waitForSelector => return waitForSelector(cmd),
         .handleJavaScriptDialog => return handleJavaScriptDialog(cmd),
+        .setSubframeLoading => return setSubframeLoading(cmd),
     }
+}
+
+// LP.setSubframeLoading { enabled: bool }
+//
+// When called with enabled=false, the HTML parser silently skips loading
+// <iframe> elements: no child Frame is created, no document fetch, and
+// no Page.frameAttached / Page.frameNavigated / Runtime.executionContextCreated
+// events are emitted for the would-be subframe. Useful as an opt-in
+// workaround for pages that load large numbers of analytics / pixel
+// iframes (e.g. shopify storefronts) where each subframe navigation
+// re-registers the main frame's V8 contexts under the child's frameId
+// and invalidates the driver's cached executionContextIds (#2400).
+//
+// Default: enabled=true (current behaviour). Setting enabled=true again
+// re-enables loading for any iframes added to the DOM after the call;
+// already-skipped iframes stay skipped (the parser marks them as
+// _executed when bypassed).
+fn setSubframeLoading(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        enabled: bool,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.NoBrowserContext;
+    bc.session.subframe_loading_enabled = params.enabled;
+    return cmd.sendResult(null, .{});
 }
 
 fn getSemanticTree(cmd: anytype) !void {


### PR DESCRIPTION
## Summary

Adds two ways to opt out of subframe loading entirely -- useful as a workaround for #2400 (child-iframe navigation invalidates the main frame's `executionContextId`):

* **CDP method `LP.setSubframeLoading { enabled: bool }`** -- per-session opt-in toggleable at runtime by the driver.
* **CLI flag `--disable-subframes`** -- process-wide default, applies to every session and to the `fetch` subcommand. Operators can flip it on without any driver changes.

When subframe loading is off, the HTML parser registers `<iframe>` elements in the DOM (they're still in the tree if the driver inspects via `DOM.getDocument` or `LP.getMarkdown`) but skips child Frame creation, document fetch, and the corresponding `Page.frameAttached` / `Page.frameNavigated` / `Runtime.executionContextCreated` events. The driver only sees the main frame's lifecycle.

## Motivation

#2400 is the underlying issue: every child-iframe navigation in Lightpanda re-emits `Runtime.executionContextCreated` on the main frame's V8 contexts (because `IsolatedWorld` is shared per-`BrowserContext` and `CONTEXT_GROUP_ID` is a constant). V8's inspector treats that as a re-registration with a fresh `executionContextId`, invalidating the id the driver had pinned for the main frame's main world / utility world. Subsequent `Runtime.evaluate` fails with `-32000 "Cannot find context with specified id"`, which Playwright surfaces as `"Execution context was destroyed, most likely because of a navigation."` and Puppeteer surfaces as `IsolatedWorld.evaluate` hangs.

The proper fix needs per-frame V8 inspector context groups (or per-frame `IsolatedWorld`), discussed in #2400. That's a meaningful refactor. This PR is the workaround so users hitting `page.title()` / `page.evaluate(...)` failures on iframe-heavy pages (Shopify storefronts, ad-heavy news sites, anywhere with web-pixel sandboxes) have a clean opt-in escape today.

## Implementation

`Session.subframe_loading_enabled: bool = true` -- default matches existing behavior.

`Frame.iframeAddedCallback` short-circuits when the flag is false, marking the iframe `_executed = true` so the parser doesn't re-deliver it:

```zig
if (!self._session.subframe_loading_enabled) {
    iframe._executed = true;
    return;
}
```

Two ways to flip the flag:

1. `LP.setSubframeLoading { enabled }` (`src/cdp/domains/lp.zig`) -- CDP method on the existing `LP` domain. Sets `bc.session.subframe_loading_enabled`.

2. `--disable-subframes` CLI flag (`src/Config.zig`) -- added to `CommonOptions` (so it applies to `serve`, `fetch`, `mcp`). New `Config.disableSubframes()` getter; `Session.init` reads it as the initial value. The CDP method can override per-session at runtime regardless of the CLI default.

Total diff: +75 / 0 across 4 files (`src/Config.zig`, `src/browser/Session.zig`, `src/browser/Frame.zig`, `src/cdp/domains/lp.zig`).

## Verification

Reproducer: `puppeteer-core` 24.42.0 against `https://www.allbirds.com/products/mens-wool-runners` (page instantiates ~11 web-pixel iframes during initial render).

**Baseline (no fix)** -- page loads, but the worker re-entrancy bug from #2398 also bites and the server segfaults on disconnect; iframe `executionContextCreated` churn happens in the trace.

**With `LP.setSubframeLoading({ enabled: false })`:**

```
[opt-out] LP.setSubframeLoading reply: {}
[ok] goto status=200 elapsed=6166ms
[stats] frame_attached_events_seen=0
[ok] page.title() = "Allbirds Wool Runners, Men's | Reviews, SIzing Info | Casual Walking, Running Shoes"
[ok] evaluate(1+1) = 2
[ok] evaluate(document.title) = "Allbirds Wool Runners, Men's | Reviews, SIzing Info | Casual Walking, Running Shoes"
[ok] body.innerHTML.length = 923161
```

**With `--disable-subframes` CLI flag (no driver-side opt-in):**

```
serve --disable-subframes + plain puppeteer-core goto
  [ok] goto status=200 elapsed=6354ms frameAttached=0

fetch --disable-subframes --dump html https://www.allbirds.com/products/mens-wool-runners
  exit=0
  html bytes: 1021562
  title: <title>Allbirds Wool Runners, Men's | ...</title>
  iframe count in dumped html: 2  (still in DOM, just not loaded)
```

521/521 unit tests pass.

## Notes

* For `playwright-core` `chromium.connectOverCDP`, the CDP method path is awkward: both `BrowserContext.newCDPSession(page)` and `Browser.newBrowserCDPSession()` open a new `CRSession` that collides with #2399's STARTUP-session reuse and triggers Playwright's internal `assert(!object.id)` in `crConnection.js`. The `--disable-subframes` CLI flag is the recommended path for Playwright users for now.

* This intentionally doesn't prevent iframes from existing in the DOM -- `document.querySelectorAll('iframe')` still returns them, `LP.getMarkdown` and `LP.getSemanticTree` still see them -- it just stops their content from being fetched and processed. That preserves any selector / scraping logic that relies on inspecting the iframe tags themselves.

* Once #2400's underlying architectural fix lands (per-frame V8 inspector context groups or per-frame `IsolatedWorld`), this method becomes a niche performance / sandboxing tool rather than a correctness workaround. Worth keeping anyway: blocking analytics / pixel iframes is a reasonable thing to want to do.

## Related

* #2400 -- root-cause issue this works around.
* #2398 -- worker re-entrancy crash that also surfaces on the same Allbirds repro page; independent.
* #2399 -- Playwright `connectOverCDP` STARTUP session promotion; referenced for the Playwright-side CDP-method limitation noted above.
