### PR TITLE
Fix double-free in fetch when http_client.request fails synchronously

### DIFF
--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -94,7 +94,12 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         .@"same-origin" => if (exec.isSameOrigin(request._url)) &session.cookie_jar else null,
     };
 
-    try http_client.request(.{
+    // Synchronous failures from request layers (e.g. RobotsLayer returning
+    // RobotsBlocked when robots.txt is already cached) are dispatched to
+    // httpErrorCallback by Client.request, which rejects the promise and
+    // releases response._arena. Propagating the error from here would also
+    // fire the `errdefer response.deinit` above and double-free the arena.
+    http_client.request(.{
         .ctx = fetch,
         .params = .{
             .url = request._url,
@@ -114,7 +119,7 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         .done_callback = httpDoneCallback,
         .error_callback = httpErrorCallback,
         .shutdown_callback = httpShutdownCallback,
-    });
+    }) catch {};
     return resolver.promise();
 }
 


### PR DESCRIPTION
## Summary

Fixes #2403 — `lightpanda fetch --obey-robots https://bbc.co.uk/sport` aborts with `malloc: pointer being freed was not allocated` (release builds) or panics with `ArenaPool: double-free detected` (debug builds).

`Fetch.init` (`src/browser/webapi/net/Fetch.zig`) holds two cleanup paths for the response arena:

1. `errdefer response.deinit(page)` (line 66), set up before `http_client.request`.
2. `httpErrorCallback`'s `defer response.deinit(page)` (line 262), invoked by `Client.request` when the request fails.

When a request layer fails synchronously — e.g. `RobotsLayer` returning `RobotsBlocked` because the cached `robots.txt` already disallows the URL — `Client.request`'s catch block dispatches `httpErrorCallback` (which deinits the response and rejects the promise) and then returns the error. The `try` in `Fetch.init` then propagates that error, firing the `errdefer` and calling `response.deinit` a second time on the same arena. The arena pool's free list ends up with the same entry twice; the abort surfaces later when an unrelated arena release detects the corruption.

This blew up specifically with `--obey-robots` because `RobotsLayer` is the only layer that returns errors synchronously up the stack. Without the flag the bug never surfaces.

## Fix

Replace `try http_client.request(...)` with `http_client.request(...) catch {}`. `httpErrorCallback` already rejects the promise, which is the spec-correct outcome of `fetch()` on a network error. Swallowing the propagated error keeps the `errdefer` from firing and avoids the double-deinit.

The `_owns_response` flag introduced by 8ee644d9 ("Protect against response double-free") handles the inverse case (microtask-triggered nested teardown after the resolver is rejected). This commit is the symmetric fix for the *outer* errdefer.

```mermaid
sequenceDiagram
    participant F as Fetch.init
    participant C as Client.request
    participant R as RobotsLayer
    participant E as httpErrorCallback

    Note over F: errdefer response.deinit set
    F->>C: http_client.request
    C->>R: entry_layer.request
    R-->>C: error.RobotsBlocked
    C->>E: error_callback(ctx, err)
    Note over E: defer fires release 1
    E-->>C: returns
    C->>C: deinitRequest (request arena, separate)
    C-->>F: returns err
    Note over F: BEFORE try propagates errdefer fires release 2 DOUBLE FREE
    Note over F: AFTER catch swallows promise stays rejected
```

## Verification

- Reproducer from the issue: `lightpanda fetch --obey-robots https://bbc.co.uk/sport` — debug build now exits 0 (was: `ArenaPool: double-free detected name=Response`); release build also exits 0.
- Same command without `--obey-robots`: still exits 0 (no regression).
- `zig build test`: 521/521 tests pass.

## Other callers of `Client.request`

Audited and none have the same conflict between an outer `errdefer` and the `error_callback`'s cleanup:

- `Frame.navigate` (`Frame.zig:678`): `catch |err| { log; return err; }` — no errdefer fights `frameErrorCallback`.
- `Worker.init` (`Worker.zig:113`): `httpErrorCallback` only fires an error event, doesn't free the Worker.
- `XMLHttpRequest.send` (`XMLHttpRequest.zig:295`): refcount-managed, no extra cleanup path.
- `ScriptManager.zig:259`: explicit `handover` flag pattern.

## Test plan

- [x] Reproduce the panic on `main` with debug build (`ArenaPool: double-free detected`)
- [x] Reproduce the abort on `main` with release build (`malloc: pointer being freed was not allocated`)
- [x] Apply patch; reproducer exits 0 in both build modes
- [x] Confirm `--obey-robots` still blocks disallowed URLs (`blocked by robots` warn fires; rejection delivered to JS)
- [x] `zig build test` — 521/521 pass
- [x] Diff against the existing `_owns_response` ownership protocol; this fix complements 8ee644d9

> [!NOTE]
> The OOM path in `Client.request` (where `arena_pool.acquire(.small, ...)` fails before `entry_layer.request` is reached) does not invoke `error_callback`. Under that path this commit silently leaks the response arena until session teardown — consistent with the leak-over-double-free policy from a74c5cc5. Fully fixing it requires a broader rework of `Client.request`'s error contract and is out of scope here.