### PR TITLE
Bound CDP macrotask drains so commands aren't queued behind page work

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -93,11 +93,16 @@ pub fn runMicrotasks(self: *Browser) void {
     self.env.runMicrotasks();
 }
 
-pub fn runMacrotasks(self: *Browser) !void {
+// `deadline_ms` is an optional monotonic-clock deadline. When non-null, the
+// macrotask drain yields back to the caller as soon as the deadline elapses,
+// leaving any remaining ready tasks in the queue. Used by Runner._tick in
+// CDP mode to bound how long we go between WebSocket polls (issue #2402).
+// Pass null for unbounded drains (e.g. fetch-mode wait, shutdown).
+pub fn runMacrotasks(self: *Browser, deadline_ms: ?u64) !void {
     const env = &self.env;
 
-    try self.env.runMacrotasks();
-    env.pumpMessageLoop();
+    try self.env.runMacrotasks(deadline_ms);
+    env.pumpMessageLoop(deadline_ms);
 
     // either of the above could have queued more microtasks
     env.runMicrotasks();

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -27,9 +27,17 @@ const HttpClient = @import("HttpClient.zig");
 
 const Node = @import("webapi/Node.zig");
 const Selector = @import("webapi/selector/Selector.zig");
+const milliTimestamp = @import("../datetime.zig").milliTimestamp;
 
 const log = lp.log;
 const IS_DEBUG = builtin.mode == .Debug;
+
+// In CDP mode, cap each macrotask drain at this many milliseconds so the
+// outer tick can poll the WebSocket between drain rounds. Without this,
+// pages with sustained JS activity (e.g. Angular RAF chains) hold the V8
+// thread for many seconds at a time and queued CDP commands stall behind
+// them — see lightpanda-io/browser#2402.
+const CDP_MACROTASK_BUDGET_MS: u64 = 50;
 
 const Runner = @This();
 
@@ -181,10 +189,19 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !CDPTickResult {
             // The HTML page was parsed. We now either have JS scripts to
             // download, or scheduled tasks to execute, or both.
 
+            // In CDP mode, bound the drain so a long Angular-style macrotask
+            // chain doesn't block us from polling the WebSocket below. In
+            // non-CDP mode (fetch), let the drain run to completion — there
+            // is no socket to service and `wait_ms` already caps wall time.
+            const macrotask_deadline: ?u64 = if (comptime is_cdp)
+                milliTimestamp(.monotonic) + CDP_MACROTASK_BUDGET_MS
+            else
+                null;
+
             // scheduler.run could trigger new http transfers, so do not
             // store http_client.http_active BEFORE this call and then use
             // it AFTER.
-            try browser.runMacrotasks();
+            try browser.runMacrotasks(macrotask_deadline);
 
             const http_active = http_client.http_active;
             const total_network_activity = http_active + http_client.interception_layer.intercepted;

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -768,7 +768,7 @@ pub const Script = struct {
 
         defer {
             local.runMacrotasks(); // also runs microtasks
-            _ = frame.js.scheduler.run() catch |err| {
+            _ = frame.js.scheduler.run(null) catch |err| {
                 log.err(.frame, "scheduler", .{ .err = err });
             };
         }

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -226,7 +226,7 @@ pub fn deinit(self: *Context) void {
     env.isolate.notifyContextDisposed();
     // There can be other tasks associated with this context that we need to
     // purge while the context is still alive.
-    _ = env.pumpMessageLoop();
+    _ = env.pumpMessageLoop(null);
     v8.v8__MicrotaskQueue__DELETE(self.microtask_queue);
 }
 

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -31,6 +31,7 @@ const App = @import("../../App.zig");
 const Frame = @import("../Frame.zig");
 const Window = @import("../webapi/Window.zig");
 const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
+const milliTimestamp = @import("../../datetime.zig").milliTimestamp;
 
 const v8 = js.v8;
 const log = lp.log;
@@ -385,7 +386,11 @@ pub fn runMicrotasks(self: *Env) void {
     }
 }
 
-pub fn runMacrotasks(self: *Env) !void {
+// `deadline_ms` is an optional monotonic-clock deadline. When non-null, this
+// returns as soon as the clock reaches the deadline so the caller can yield
+// to socket I/O (see Runner._tick). Pass null when running to completion is
+// required (e.g. shutdown drains).
+pub fn runMacrotasks(self: *Env, deadline_ms: ?u64) !void {
     if (v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle)) {
         return;
     }
@@ -404,7 +409,8 @@ pub fn runMacrotasks(self: *Env) !void {
         var hs: js.HandleScope = undefined;
         const entered = ctx.enter(&hs);
         defer entered.exit();
-        try ctx.scheduler.run();
+        try ctx.scheduler.run(deadline_ms);
+        if (deadlineElapsed(deadline_ms)) return;
     }
 }
 
@@ -417,14 +423,23 @@ pub fn msToNextMacrotask(self: *Env) ?u64 {
     return if (next_task == std.math.maxInt(u64)) null else next_task;
 }
 
-pub fn pumpMessageLoop(self: *const Env) void {
+// `deadline_ms`: see runMacrotasks. Existing callers that need an unbounded
+// drain pass null.
+pub fn pumpMessageLoop(self: *const Env, deadline_ms: ?u64) void {
     var hs: v8.HandleScope = undefined;
     v8.v8__HandleScope__CONSTRUCT(&hs, self.isolate.handle);
     defer v8.v8__HandleScope__DESTRUCT(&hs);
 
     const isolate = self.isolate.handle;
     const platform = self.platform.handle;
-    while (v8.v8__Platform__PumpMessageLoop(platform, isolate, false)) {}
+    while (v8.v8__Platform__PumpMessageLoop(platform, isolate, false)) {
+        if (deadlineElapsed(deadline_ms)) return;
+    }
+}
+
+inline fn deadlineElapsed(deadline_ms: ?u64) bool {
+    const d = deadline_ms orelse return false;
+    return milliTimestamp(.monotonic) >= d;
 }
 
 pub fn hasBackgroundTasks(self: *const Env) bool {

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -109,7 +109,7 @@ pub fn newCallback(
 
 pub fn runMacrotasks(self: *const Local) void {
     const env = self.ctx.env;
-    env.pumpMessageLoop();
+    env.pumpMessageLoop(null);
     env.runMicrotasks(); // macrotasks can cause microtasks to queue
 }
 

--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -79,10 +79,16 @@ pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts
     });
 }
 
-pub fn run(self: *Scheduler) !void {
+// `deadline_ms` is an optional monotonic-clock deadline. When non-null, the
+// scheduler returns after the currently-running task finishes if the clock
+// has reached the deadline, leaving any still-ready tasks queued. The outer
+// tick uses this to bound CDP message-handling latency on busy pages — see
+// `Runner._tick` and the GitHub issue at lightpanda-io/browser#2402.
+pub fn run(self: *Scheduler, deadline_ms: ?u64) !void {
     const now = milliTimestamp(.monotonic);
-    try self.runQueue(&self.low_priority, now);
-    try self.runQueue(&self.high_priority, now);
+    try self.runQueue(&self.low_priority, now, deadline_ms);
+    if (deadlineElapsed(deadline_ms)) return;
+    try self.runQueue(&self.high_priority, now, deadline_ms);
 }
 
 pub fn hasReadyTasks(self: *Scheduler) bool {
@@ -99,7 +105,7 @@ pub fn msToNextHigh(self: *Scheduler) ?u64 {
     return @intCast(task.run_at - now);
 }
 
-fn runQueue(self: *Scheduler, queue: *Queue, now: u64) !void {
+fn runQueue(self: *Scheduler, queue: *Queue, now: u64, deadline_ms: ?u64) !void {
     if (queue.count() == 0) {
         return;
     }
@@ -126,8 +132,15 @@ fn runQueue(self: *Scheduler, queue: *Queue, now: u64) !void {
             task.run_at = now + ms;
             try self.low_priority.add(task);
         }
+
+        if (deadlineElapsed(deadline_ms)) return;
     }
     return;
+}
+
+inline fn deadlineElapsed(deadline_ms: ?u64) bool {
+    const d = deadline_ms orelse return false;
+    return milliTimestamp(.monotonic) >= d;
 }
 
 fn queueHasReadyTask(queue: *Queue, now: u64) bool {
@@ -155,3 +168,58 @@ const Task = struct {
 
 const Callback = *const fn (ctx: *anyopaque) anyerror!?u32;
 const Finalizer = *const fn (ctx: *anyopaque) void;
+
+const Counter = struct {
+    n: u32 = 0,
+    fn cb(ctx: *anyopaque) anyerror!?u32 {
+        const self: *Counter = @ptrCast(@alignCast(ctx));
+        self.n += 1;
+        return null;
+    }
+};
+
+test "Scheduler.run with no deadline drains all ready tasks" {
+    // Scheduler.deinit doesn't free the underlying PriorityQueue storage
+    // (the production code relies on an arena allocator), so use an arena
+    // here too to avoid noise from the testing allocator's leak detector.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var sched = Scheduler.init(arena.allocator());
+    defer sched.deinit();
+
+    var counter: Counter = .{};
+    for (0..50) |_| {
+        try sched.add(&counter, Counter.cb, 0, .{});
+    }
+
+    try sched.run(null);
+    try std.testing.expectEqual(@as(u32, 50), counter.n);
+}
+
+test "Scheduler.run with already-elapsed deadline yields after first task" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var sched = Scheduler.init(arena.allocator());
+    defer sched.deinit();
+
+    var counter: Counter = .{};
+    // Add to the queue Scheduler.run drains first so the inner loop has
+    // something to do before the outer deadline check kicks in.
+    for (0..50) |_| {
+        try sched.add(&counter, Counter.cb, 0, .{ .low_priority = true });
+    }
+
+    // A deadline of 1 is in the past relative to the monotonic clock, so the
+    // loop runs exactly one task (the post-callback check yields) and the
+    // outer between-queues check then prevents the high_priority queue from
+    // running.
+    try sched.run(1);
+    try std.testing.expectEqual(@as(u32, 1), counter.n);
+
+    // Remaining tasks are still queued — re-running drains them when no
+    // deadline is set.
+    try sched.run(null);
+    try std.testing.expectEqual(@as(u32, 50), counter.n);
+}


### PR DESCRIPTION
## What this fixes

On pages with sustained JS activity (Angular SPAs in change-detection / `requestAnimationFrame` chains), every session-scoped CDP command — `Runtime.evaluate`, `DOM.getDocument`, `DOM.getOuterHTML` — stalls for 14–20 seconds in `serve` mode. `fetch --dump html` of the same page works fine because `--wait-ms` caps it; CDP has no equivalent ceiling.

The cleanest signal in the issue's reproducer is that `Runtime.evaluate('1+1')` — a zero-cost roundtrip — takes **14.7 seconds**. Whatever the command is, it isn't slow because of what it does; it's slow because it can't be read off the WebSocket. See #2402 for the full trace.

## Root cause

`Runner._tick` (CDP mode, `.html` / `.complete` branch) calls `browser.runMacrotasks()` *before* yielding to socket I/O via `http_client.tick(...)`. `Browser.runMacrotasks` drains three loops back-to-back, none of which yield:

1. `env.runMacrotasks()` → `Scheduler.runQueue`'s `while (queue.peek())` — every ready user-scheduled task (timers, `setTimeout`, `requestAnimationFrame`, …)
2. `env.pumpMessageLoop()` → `while (v8__Platform__PumpMessageLoop(...)) {}` — every V8 platform task
3. `env.runMicrotasks()` — every queued microtask

On the OPSWAT page this drain runs for 14–20 s before returning. CDP commands sent during that window sit in the kernel WebSocket buffer the whole time. Once the drain finishes, the very next `http_client.tick(0)` reads them and they execute in ~0 ms — confirming the bottleneck is the drain, not the command.

## What this PR changes

Threads an optional monotonic-clock **deadline** through the drain chain. Inner loops check it between tasks and yield to the caller when it has elapsed, leaving still-ready tasks queued for the next pass.

The hot edit is in `Runner.zig`:

```zig
// In CDP mode, bound the drain so a long Angular-style macrotask
// chain doesn't block us from polling the WebSocket below. In
// non-CDP mode (fetch), let the drain run to completion — there
// is no socket to service and `wait_ms` already caps wall time.
const macrotask_deadline: ?u64 = if (comptime is_cdp)
    milliTimestamp(.monotonic) + CDP_MACROTASK_BUDGET_MS
else
    null;

try browser.runMacrotasks(macrotask_deadline);
```

The deadline is plumbed through `Browser.runMacrotasks` → `Env.runMacrotasks` / `Env.pumpMessageLoop` → `Scheduler.run` / `Scheduler.runQueue` as `deadline_ms: ?u64`. All five gain the parameter. `null` preserves the existing unbounded behavior — that's what every non-CDP caller passes (worker `Local.runMacrotasks`, `Context.deinit`, the direct `scheduler.run` in `ScriptManagerBase`, and `Runner._tick` in fetch mode).

## Why 50 ms

It's a trade-off between page progress and CDP responsiveness. The deadline is checked *between* tasks, so:

- Smaller (e.g. 5 ms) → finer-grained yielding, more time spent re-entering the tick loop than running JS.
- Larger (e.g. 500 ms) → coarser yielding; on a page where individual callbacks are short, you'd see CDP commands wait that long behind the next batch.
- 50 ms → reasonable middle ground. On a page with short callbacks, CDP commands are picked up within ~50 ms. On a page with long single callbacks (like OPSWAT, see verification below), the per-command floor is set by the longest individual callback, not the budget — sub-second response on those pages needs ask #3.

Hard-coded as `CDP_MACROTASK_BUDGET_MS` in `Runner.zig`. Could be exposed as a `serve` flag later — the issue reporter is comfortable with anything well under 1 s, so a follow-up is fine.

## Caveats

- **A single long synchronous callback still blocks for its full duration.** The deadline is checked *between* tasks, not inside one. On the OPSWAT page in #2402, individual change-detection callbacks run ~2.75 s, so the per-command latency floor lands there even with the budget. Driving sub-second response on those pages needs V8 `RequestInterrupt` (ask #3 in the issue), which is the right long-term answer.
- **Microtasks (`env.runMicrotasks`) are not bounded.** Bounding them requires `RequestInterrupt`. They're typically cheap.
- **This is ask #1 only.** Asks #2 (CDP `Lightpanda.stopJs` / `--terminate-ms` equivalent), #3 (V8 `RequestInterrupt`), #4 (`msToNextMacrotask` exposure) are separate features and not addressed here.

## Where to focus review

The new parameter on `Browser.runMacrotasks` / `Env.runMacrotasks` / `Scheduler.run` / `Scheduler.runQueue` is mechanical — each had exactly one caller before this PR.

`Env.pumpMessageLoop` had three callers, and the two non-`Browser` ones run in different lifecycles. They both pass `null` (i.e. no behavior change), but I'd appreciate a second read on:

- `src/browser/js/Local.zig:111` — worker context, called from `ScriptManagerBase`, `WorkerGlobalScope`, `Worker`
- `src/browser/js/Context.zig:229` — context deinit, drains residual platform tasks before `MicrotaskQueue` deletion

Both should be unchanged. But worker / shutdown paths are exactly the kind of edge case where it would be easy to miss something.

## Test plan

- [x] `make test` — 523/523 pass, including two new `Scheduler.run` unit tests
- [x] `Scheduler.run(null)` drains all 50 queued tasks
- [x] `Scheduler.run(1)` (deadline already in the past) runs exactly 1 task, leaves the rest queued; a follow-up `Scheduler.run(null)` drains them
- [x] Manual verification against the OPSWAT reproducer in #2402 — every session-scoped command moves from "TIMEOUT 20 s" (current `main`) to ~2.75 s (this PR). See the verification comment below for the side-by-side probe output.

Refs #2402
