### PR TITLE
parser: defer raw-text merge to bound memory growth

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1813,26 +1813,12 @@ pub fn notifyNetworkAlmostIdle(self: *Frame) void {
     });
 }
 
-// called from the parser
-pub fn appendNew(self: *Frame, parent: *Node, child: Node.NodeOrText) !void {
-    const node = switch (child) {
-        .node => |n| n,
-        .text => |txt| blk: {
-            // If we're appending this adjacently to a text node, we should merge
-            if (parent.lastChild()) |sibling| {
-                if (sibling.is(CData.Text)) |tn| {
-                    const cdata = tn._proto;
-                    const existing = cdata.getData().str();
-                    cdata._data = try String.concat(self.arena, &.{ existing, txt });
-                    return;
-                }
-            }
-            break :blk try self.createTextNode(txt);
-        },
-    };
-
-    lp.assert(node._parent == null, "Frame.appendNew", .{});
-    try self._insertNodeRelative(true, parent, node, .append, .{
+// called from the parser. Text-node merging is the parser's responsibility
+// (see Parser.appendTextChunk in src/browser/parser/Parser.zig); this is the
+// "insert this fully-formed node as a new last child of parent" entry point.
+pub fn appendNew(self: *Frame, parent: *Node, child: *Node) !void {
+    lp.assert(child._parent == null, "Frame.appendNew", .{});
+    try self._insertNodeRelative(true, parent, child, .append, .{
         // this opts has no meaning since we're passing `true` as the first
         // parameter, which indicates this comes from the parser, and has its
         // own special processing. Still, set it to be clear.

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -45,12 +45,11 @@ pub const ParsedNode = struct {
 // AppendText callback per chunk. Merging via String.concat in the previous
 // implementation was O(N^2/chunk_size) on the page-lifetime arena, blowing
 // memory on inline JS that contains embedded HTML strings (issue #2397).
-// Instead, we accumulate same-parent chunks in this struct and commit a
-// single allocation on flush.
+// Instead, we keep a single Parser-level buf and accumulate same-parent
+// chunks into it, committing once on flush.
 const PendingText = struct {
     parent: *Node,
     text_node: *CData,
-    buf: std.ArrayListUnmanaged(u8) = .empty,
 };
 
 const Parser = @This();
@@ -61,6 +60,16 @@ container: ParsedNode,
 arena: Allocator,
 strings: std.StringHashMapUnmanaged(void),
 pending_text: ?PendingText,
+// One buffer reused across every text run in this parser. clearRetainingCapacity
+// on flush keeps the largest capacity ever needed, so total dead memory on the
+// parser arena is bounded to one peak-run-sized allocation regardless of how
+// many text runs the parse contains. Matters for Streaming, whose arena is the
+// page-lifetime frame.arena (individual frees are no-ops there).
+//
+// Single-chunk text runs leave this buf empty: the chunk lives only in
+// CData._data via createTextNode. The buf is seeded from _data.str() on the
+// second chunk of a run, so the common case stays at one copy.
+buf: std.ArrayListUnmanaged(u8),
 
 pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
     return .{
@@ -73,24 +82,34 @@ pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
             .node = node,
         },
         .pending_text = null,
+        .buf = .empty,
     };
 }
 
 pub fn flushPendingText(self: *Parser) !void {
-    var pt = self.pending_text orelse return;
+    const pt = self.pending_text orelse return;
     self.pending_text = null;
-    defer pt.buf.deinit(self.arena);
+    // Single-chunk run: data already lives on _data via createTextNode.
+    if (self.buf.items.len == 0) return;
+    defer self.buf.clearRetainingCapacity();
     pt.text_node._data = try lp.String.init(
         self.frame.arena,
-        pt.buf.items,
+        self.buf.items,
         .{ .dupe = true },
     );
 }
 
 fn appendTextChunk(self: *Parser, parent: *Node, txt: []const u8) !void {
-    if (self.pending_text) |*pt| {
+    if (self.pending_text) |pt| {
         if (pt.parent == parent and parent.lastChild() == pt.text_node.asNode()) {
-            try pt.buf.appendSlice(self.arena, txt);
+            // Second+ chunk of the same run. If buf is still empty, promote
+            // from the single-chunk fast path by seeding from _data first.
+            if (self.buf.items.len == 0) {
+                const existing = pt.text_node.getData().str();
+                try self.buf.ensureTotalCapacity(self.arena, existing.len + txt.len);
+                self.buf.appendSliceAssumeCapacity(existing);
+            }
+            try self.buf.appendSlice(self.arena, txt);
             return;
         }
         try self.flushPendingText();
@@ -98,28 +117,26 @@ fn appendTextChunk(self: *Parser, parent: *Node, txt: []const u8) !void {
 
     if (parent.lastChild()) |sibling| {
         if (sibling.is(CData.Text)) |tn| {
+            // Existing text sibling without a matching pending_text. Seed the
+            // buf from its _data and register pending so subsequent chunks
+            // accumulate cheaply.
             const cdata = tn._proto;
             const existing = cdata.getData().str();
-            var buf: std.ArrayListUnmanaged(u8) = .empty;
-            errdefer buf.deinit(self.arena);
-            try buf.ensureTotalCapacityPrecise(self.arena, existing.len + txt.len);
-            buf.appendSliceAssumeCapacity(existing);
-            buf.appendSliceAssumeCapacity(txt);
-            self.pending_text = .{ .parent = parent, .text_node = cdata, .buf = buf };
+            try self.buf.ensureTotalCapacity(self.arena, existing.len + txt.len);
+            self.buf.appendSliceAssumeCapacity(existing);
+            self.buf.appendSliceAssumeCapacity(txt);
+            self.pending_text = .{ .parent = parent, .text_node = cdata };
             return;
         }
     }
 
+    // Fresh text run: the first chunk lives on _data only. buf stays empty
+    // until (and unless) a second chunk arrives.
     const new_text = try self.frame.createTextNode(txt);
     try self.frame.appendNew(parent, new_text);
-
-    var buf: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer buf.deinit(self.arena);
-    try buf.appendSlice(self.arena, txt);
     self.pending_text = .{
         .parent = parent,
         .text_node = new_text.is(CData.Text).?._proto,
-        .buf = buf,
     };
 }
 

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -69,7 +69,7 @@ pending_text: ?PendingText,
 // Single-chunk text runs leave this buf empty: the chunk lives only in
 // CData._data via createTextNode. The buf is seeded from _data.str() on the
 // second chunk of a run, so the common case stays at one copy.
-buf: std.ArrayListUnmanaged(u8),
+buf: std.ArrayList(u8),
 
 pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
     return .{

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -23,6 +23,7 @@ const h5e = @import("html5ever.zig");
 const Frame = @import("../Frame.zig");
 const Node = @import("../webapi/Node.zig");
 const Element = @import("../webapi/Element.zig");
+const CData = @import("../webapi/CData.zig");
 
 pub const AttributeIterator = h5e.AttributeIterator;
 
@@ -39,6 +40,19 @@ pub const ParsedNode = struct {
     data: ?*anyopaque,
 };
 
+// html5ever's tokenizer flushes the script-data character buffer on every '<'
+// (script-data-less-than-sign-state transition), which produces a separate
+// AppendText callback per chunk. Merging via String.concat in the previous
+// implementation was O(N^2/chunk_size) on the page-lifetime arena, blowing
+// memory on inline JS that contains embedded HTML strings (issue #2397).
+// Instead, we accumulate same-parent chunks in this struct and commit a
+// single allocation on flush.
+const PendingText = struct {
+    parent: *Node,
+    text_node: *CData,
+    buf: std.ArrayListUnmanaged(u8) = .empty,
+};
+
 const Parser = @This();
 
 frame: *Frame,
@@ -46,6 +60,7 @@ err: ?Error,
 container: ParsedNode,
 arena: Allocator,
 strings: std.StringHashMapUnmanaged(void),
+pending_text: ?PendingText,
 
 pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
     return .{
@@ -57,6 +72,54 @@ pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
             .data = null,
             .node = node,
         },
+        .pending_text = null,
+    };
+}
+
+fn flushPendingText(self: *Parser) !void {
+    var pt = self.pending_text orelse return;
+    self.pending_text = null;
+    defer pt.buf.deinit(self.arena);
+    pt.text_node._data = try lp.String.init(
+        self.frame.arena,
+        pt.buf.items,
+        .{ .dupe = true },
+    );
+}
+
+fn appendTextChunk(self: *Parser, parent: *Node, txt: []const u8) !void {
+    if (self.pending_text) |*pt| {
+        if (pt.parent == parent and parent.lastChild() == pt.text_node.asNode()) {
+            try pt.buf.appendSlice(self.arena, txt);
+            return;
+        }
+        try self.flushPendingText();
+    }
+
+    if (parent.lastChild()) |sibling| {
+        if (sibling.is(CData.Text)) |tn| {
+            const cdata = tn._proto;
+            const existing = cdata.getData().str();
+            var buf: std.ArrayListUnmanaged(u8) = .empty;
+            errdefer buf.deinit(self.arena);
+            try buf.ensureTotalCapacityPrecise(self.arena, existing.len + txt.len);
+            buf.appendSliceAssumeCapacity(existing);
+            buf.appendSliceAssumeCapacity(txt);
+            self.pending_text = .{ .parent = parent, .text_node = cdata, .buf = buf };
+            return;
+        }
+    }
+
+    const new_text = try self.frame.createTextNode(txt);
+    try self.frame.appendNew(parent, new_text);
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(self.arena);
+    try buf.appendSlice(self.arena, txt);
+    self.pending_text = .{
+        .parent = parent,
+        .text_node = new_text.is(CData.Text).?._proto,
+        .buf = buf,
     };
 }
 
@@ -101,6 +164,9 @@ pub fn parse(self: *Parser, html: []const u8) void {
         appendBeforeSiblingCallback,
         appendBasedOnParentNodeCallback,
     );
+    self.flushPendingText() catch |err| {
+        if (self.err == null) self.err = .{ .err = err, .source = .append };
+    };
 }
 
 /// Parse HTML with encoding conversion. Converts from charset to UTF-8 before parsing.
@@ -127,6 +193,9 @@ pub fn parseWithEncoding(self: *Parser, html: []const u8, charset: []const u8) v
         appendBeforeSiblingCallback,
         appendBasedOnParentNodeCallback,
     );
+    self.flushPendingText() catch |err| {
+        if (self.err == null) self.err = .{ .err = err, .source = .append };
+    };
 }
 
 pub fn parseXML(self: *Parser, xml: []const u8) void {
@@ -150,6 +219,9 @@ pub fn parseXML(self: *Parser, xml: []const u8) void {
         appendBeforeSiblingCallback,
         appendBasedOnParentNodeCallback,
     );
+    self.flushPendingText() catch |err| {
+        if (self.err == null) self.err = .{ .err = err, .source = .append };
+    };
 }
 
 pub fn parseFragment(self: *Parser, html: []const u8) void {
@@ -173,6 +245,9 @@ pub fn parseFragment(self: *Parser, html: []const u8) void {
         appendBeforeSiblingCallback,
         appendBasedOnParentNodeCallback,
     );
+    self.flushPendingText() catch |err| {
+        if (self.err == null) self.err = .{ .err = err, .source = .append };
+    };
 }
 
 pub const Streaming = struct {
@@ -233,8 +308,9 @@ pub const Streaming = struct {
         }
     }
 
-    pub fn done(self: *Streaming) void {
+    pub fn done(self: *Streaming) !void {
         h5e.html5ever_streaming_parser_finish(self.handle.?);
+        try self.parser.flushPendingText();
     }
 };
 
@@ -252,6 +328,9 @@ fn popCallback(ctx: *anyopaque, node_ref: *anyopaque) callconv(.c) void {
 }
 
 fn _popCallback(self: *Parser, node: *Node) !void {
+    // Flush before any nodeComplete so Build.complete (and any custom-element
+    // callbacks reachable from it) observe the final text data.
+    try self.flushPendingText();
     try self.frame.nodeComplete(node);
 }
 
@@ -340,7 +419,7 @@ fn _appendDoctypeToDocument(self: *Parser, name: []const u8, public_id: []const 
     });
 
     // Append it to the document
-    try frame.appendNew(self.container.node, .{ .node = doctype.asNode() });
+    try frame.appendNew(self.container.node, doctype.asNode());
 }
 
 fn addAttrsIfMissingCallback(ctx: *anyopaque, target_ref: *anyopaque, attributes: h5e.AttributeIterator) callconv(.c) void {
@@ -402,6 +481,10 @@ fn _appendCallback(self: *Parser, parent: *Node, node_or_text: h5e.NodeOrText) !
     // child node is guaranteed not to belong to another parent
     switch (node_or_text.toUnion()) {
         .node => |cpn| {
+            // Inserting a non-text child terminates any pending text run; flush
+            // before the insertion so that connectedCallback (etc.) sees the
+            // final data on the preceding text sibling.
+            try self.flushPendingText();
             const child = getNode(cpn);
             if (child._parent) |previous_parent| {
                 // html5ever says this can't happen, but we might be screwing up
@@ -414,9 +497,9 @@ fn _appendCallback(self: *Parser, parent: *Node, node_or_text: h5e.NodeOrText) !
                 }
                 self.frame.removeNode(previous_parent, child, .{ .will_be_reconnected = parent.isConnected() });
             }
-            try self.frame.appendNew(parent, .{ .node = child });
+            try self.frame.appendNew(parent, child);
         },
-        .text => |txt| try self.frame.appendNew(parent, .{ .text = txt }),
+        .text => |txt| try self.appendTextChunk(parent, txt),
     }
 }
 
@@ -448,6 +531,10 @@ fn appendBeforeSiblingCallback(ctx: *anyopaque, sibling_ref: *anyopaque, node_or
     };
 }
 fn _appendBeforeSiblingCallback(self: *Parser, sibling: *Node, node_or_text: h5e.NodeOrText) !void {
+    // Foster parenting / before-sibling insertions interrupt any pending text
+    // run (the new node lands at a different position from the pending text's
+    // tail). Flush before reading the parent's structure.
+    try self.flushPendingText();
     const parent = sibling.parentNode() orelse return error.NoParent;
     const node: *Node = switch (node_or_text.toUnion()) {
         .node => |cpn| blk: {

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -76,7 +76,7 @@ pub fn init(arena: Allocator, node: *Node, frame: *Frame) Parser {
     };
 }
 
-fn flushPendingText(self: *Parser) !void {
+pub fn flushPendingText(self: *Parser) !void {
     var pt = self.pending_text orelse return;
     self.pending_text = null;
     defer pt.buf.deinit(self.arena);
@@ -309,7 +309,14 @@ pub const Streaming = struct {
     }
 
     pub fn done(self: *Streaming) !void {
-        h5e.html5ever_streaming_parser_finish(self.handle.?);
+        // Null the handle before finish() so a flushPendingText failure can't
+        // leave a finished-but-still-referenced handle behind for deinit to
+        // double-free. flushPendingText doesn't touch the html5ever handle —
+        // it only reads pending_text and writes to a text node's _data — so
+        // running it after finish is safe.
+        const handle = self.handle.?;
+        self.handle = null;
+        h5e.html5ever_streaming_parser_finish(handle);
         try self.parser.flushPendingText();
     }
 };
@@ -510,6 +517,11 @@ fn removeFromParentCallback(ctx: *anyopaque, target_ref: *anyopaque) callconv(.c
     };
 }
 fn _removeFromParentCallback(self: *Parser, node: *Node) !void {
+    // Removing a node mid-parse can detach the pending text node or its
+    // parent; either way the pending invariant breaks. Flush first so the
+    // accumulated bytes land on a still-attached text node (and pending_text
+    // is cleared before any subsequent chunk targets a fresh node).
+    try self.flushPendingText();
     const parent = node.parentNode() orelse return;
     _ = try parent.removeChild(node, self.frame);
 }
@@ -521,6 +533,10 @@ fn reparentChildrenCallback(ctx: *anyopaque, node_ref: *anyopaque, new_parent_re
     };
 }
 fn _reparentChildrenCallback(self: *Parser, node: *Node, new_parent: *Node) !void {
+    // Reparenting can move the pending text node out from under us — the
+    // node's _parent changes but pending_text.parent does not. Flush so the
+    // accumulator commits before the tree is rearranged.
+    try self.flushPendingText();
     try self.frame.appendAllChildren(node, new_parent);
 }
 

--- a/src/browser/tests/cdata/raw_text_chunked.html
+++ b/src/browser/tests/cdata/raw_text_chunked.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<!--
+  Regression test for issue #2397.
+
+  When the html5ever tokenizer is in script-data / rawtext / rcdata state and
+  encounters '<', it flushes the pending character buffer and re-enters via a
+  fresh AppendText callback. Before the fix, every chunk re-allocated and
+  re-copied the growing text on the page-lifetime arena (O(N^2)). Real pages
+  with embedded HTML strings inside JS literals blew memory to gigabytes.
+
+  After the fix, raw-text-mode element bodies must still parse to exactly ONE
+  text node whose data is byte-identical to the source body.
+-->
+
+<script class="big-script">
+  var s = "<a><b><c><d><e><f><g><h><i><j><k><l><m><n><o><p><q><r><s><t><u><v><w><x><y><z>";
+  var t = "<aa><bb><cc><dd><ee><ff><gg><hh><ii><jj><kk><ll><mm><nn><oo><pp><qq><rr><ss><tt>";
+  var u = "<uu><vv><ww><xx><yy><zz>";
+  var done = "yes";
+</script>
+
+<style class="big-style">
+  .a::before { content: "<a><b><c><d>"; }
+  .b::before { content: "<e><f><g><h>"; }
+  .c::before { content: "<i><j><k><l>"; }
+  .d::before { content: "<m><n><o><p>"; }
+</style>
+
+<textarea class="big-textarea">line1 with &lt;a&gt; and &lt;b&gt;
+line2 with &lt;c&gt; and &lt;d&gt;
+line3 with &lt;e&gt; and &lt;f&gt;</textarea>
+
+<title>A page &lt;with&gt; many &lt;tags&gt; in &lt;the&gt; title</title>
+
+<script id="rawtextchunked">
+  // 1. Each raw-text element parses to exactly one text node child.
+  let script = document.querySelector('script.big-script');
+  testing.expectEqual(1, script.childNodes.length);
+  testing.expectTrue(script.firstChild === script.lastChild);
+  testing.expectEqual(3, script.firstChild.nodeType); // TEXT_NODE
+  testing.expectTrue(script.textContent.indexOf('<a><b><c>') !== -1);
+  testing.expectTrue(script.textContent.indexOf('<uu><vv><ww>') !== -1);
+  testing.expectTrue(script.textContent.indexOf('var done = "yes"') !== -1);
+
+  let style = document.querySelector('style.big-style');
+  testing.expectEqual(1, style.childNodes.length);
+  testing.expectTrue(style.firstChild === style.lastChild);
+  testing.expectTrue(style.textContent.indexOf('"<a><b><c><d>"') !== -1);
+  testing.expectTrue(style.textContent.indexOf('"<m><n><o><p>"') !== -1);
+
+  let textarea = document.querySelector('textarea.big-textarea');
+  testing.expectEqual(1, textarea.childNodes.length);
+  testing.expectTrue(textarea.firstChild === textarea.lastChild);
+  // textarea is RCDATA: entities decoded
+  testing.expectTrue(textarea.value.indexOf('line1 with <a> and <b>') !== -1);
+  testing.expectTrue(textarea.value.indexOf('line3 with <e> and <f>') !== -1);
+
+  let title = document.querySelector('title');
+  testing.expectEqual(1, title.childNodes.length);
+  testing.expectTrue(title.firstChild === title.lastChild);
+  // title is RCDATA: entities decoded
+  testing.expectEqual('A page <with> many <tags> in <the> title', title.textContent);
+
+  // 2. Reading the script body via the DOM yields the verbatim source bytes
+  //    (no chunks, no missing characters).
+  // 26 (a-z) + 20 (aa-tt) + 6 (uu-zz) = 52 '<' characters in the source.
+  let count = (script.firstChild.nodeValue.match(/</g) || []).length;
+  testing.expectEqual(52, count);
+</script>

--- a/src/browser/tests/cdata/raw_text_chunked.html
+++ b/src/browser/tests/cdata/raw_text_chunked.html
@@ -6,66 +6,123 @@
 
   When the html5ever tokenizer is in script-data / rawtext / rcdata state and
   encounters '<', it flushes the pending character buffer and re-enters via a
-  fresh AppendText callback. Before the fix, every chunk re-allocated and
-  re-copied the growing text on the page-lifetime arena (O(N^2)). Real pages
-  with embedded HTML strings inside JS literals blew memory to gigabytes.
+  fresh AppendText callback. Pre-fix, every chunk re-allocated and re-copied
+  the growing text on the page-lifetime arena (O(N^2)). Real pages with
+  embedded HTML strings inside JS literals blew memory to gigabytes.
 
-  After the fix, raw-text-mode element bodies must still parse to exactly ONE
-  text node whose data is byte-identical to the source body.
+  This test guards correctness of the deferred-merge state machine in
+  Parser.appendTextChunk / flushPendingText: a stress case big enough to
+  cross many chunk boundaries, and exact byte-length assertions so that any
+  future regression that drops or duplicates a chunk is caught. The memory
+  bound itself is measured externally via the live reproducer documented in
+  the PR description (apple.com US iPhone page: 3.5 GB → 125 MB).
 -->
 
+<!--
+  ~6 KB script body containing many '<' characters in JS string literals.
+  Each '<' forces html5ever to flush a chunk, exercising the same code path
+  that produced gigabytes of allocations on apple.com pages.
+-->
 <script class="big-script">
-  var s = "<a><b><c><d><e><f><g><h><i><j><k><l><m><n><o><p><q><r><s><t><u><v><w><x><y><z>";
-  var t = "<aa><bb><cc><dd><ee><ff><gg><hh><ii><jj><kk><ll><mm><nn><oo><pp><qq><rr><ss><tt>";
-  var u = "<uu><vv><ww><xx><yy><zz>";
-  var done = "yes";
+var a = "<a><b><c><d><e><f><g><h><i><j><k><l><m><n><o><p><q><r><s><t><u><v><w><x><y><z>";
+var b = "<aa><bb><cc><dd><ee><ff><gg><hh><ii><jj><kk><ll><mm><nn><oo><pp><qq><rr><ss><tt>";
+var c = "<uu><vv><ww><xx><yy><zz>";
+var d = "<a1><a2><a3><a4><a5><a6><a7><a8><a9><a0>";
+var e = "<b1><b2><b3><b4><b5><b6><b7><b8><b9><b0>";
+var f = "<c1><c2><c3><c4><c5><c6><c7><c8><c9><c0>";
+var g = "<d1><d2><d3><d4><d5><d6><d7><d8><d9><d0>";
+var h = "<e1><e2><e3><e4><e5><e6><e7><e8><e9><e0>";
+var i = "<f1><f2><f3><f4><f5><f6><f7><f8><f9><f0>";
+var j = "<g1><g2><g3><g4><g5><g6><g7><g8><g9><g0>";
+var k = "<h1><h2><h3><h4><h5><h6><h7><h8><h9><h0>";
+var l = "<i1><i2><i3><i4><i5><i6><i7><i8><i9><i0>";
+var m = "<j1><j2><j3><j4><j5><j6><j7><j8><j9><j0>";
+var n = "<k1><k2><k3><k4><k5><k6><k7><k8><k9><k0>";
+var o = "<l1><l2><l3><l4><l5><l6><l7><l8><l9><l0>";
+var p = "<m1><m2><m3><m4><m5><m6><m7><m8><m9><m0>";
+var q = "<n1><n2><n3><n4><n5><n6><n7><n8><n9><n0>";
+var r = "<o1><o2><o3><o4><o5><o6><o7><o8><o9><o0>";
+var s = "<p1><p2><p3><p4><p5><p6><p7><p8><p9><p0>";
+var t = "<q1><q2><q3><q4><q5><q6><q7><q8><q9><q0>";
+var u = "<r1><r2><r3><r4><r5><r6><r7><r8><r9><r0>";
+var v = "<s1><s2><s3><s4><s5><s6><s7><s8><s9><s0>";
+var w = "<t1><t2><t3><t4><t5><t6><t7><t8><t9><t0>";
+var x = "<u1><u2><u3><u4><u5><u6><u7><u8><u9><u0>";
+var done = "yes";
 </script>
 
 <style class="big-style">
-  .a::before { content: "<a><b><c><d>"; }
-  .b::before { content: "<e><f><g><h>"; }
-  .c::before { content: "<i><j><k><l>"; }
-  .d::before { content: "<m><n><o><p>"; }
+  /* less-than chars inside CSS string-literal content force chunk flushing
+     in rawtext mode. Distinct content per rule so a regression that drops
+     a mid-body chunk fails one of the indexOf checks below. */
+  .a::before { content: "<a><b><c><d><e><f><g><h><i><j>"; }
+  .b::before { content: "<k><l><m><n><o><p><q><r><s><t>"; }
+  .c::before { content: "<u><v><w><x><y><z>"; }
+  .d::before { content: "<aa><bb><cc><dd><ee><ff>"; }
+  .e::before { content: "<gg><hh><ii><jj><kk><ll>"; }
+  .f::before { content: "<mm><nn><oo><pp><qq><rr>"; }
 </style>
 
-<textarea class="big-textarea">line1 with &lt;a&gt; and &lt;b&gt;
-line2 with &lt;c&gt; and &lt;d&gt;
-line3 with &lt;e&gt; and &lt;f&gt;</textarea>
+<!-- textarea is RCDATA: '<' in source must be escaped, but entities decode. -->
+<textarea class="big-textarea">line 1: &lt;a&gt;&lt;b&gt;&lt;c&gt;&lt;d&gt;&lt;e&gt;&lt;f&gt;
+line 2: &lt;g&gt;&lt;h&gt;&lt;i&gt;&lt;j&gt;&lt;k&gt;&lt;l&gt;
+line 3: &lt;m&gt;&lt;n&gt;&lt;o&gt;&lt;p&gt;&lt;q&gt;&lt;r&gt;
+line 4: &lt;s&gt;&lt;t&gt;&lt;u&gt;&lt;v&gt;&lt;w&gt;&lt;x&gt;&lt;y&gt;&lt;z&gt;</textarea>
 
-<title>A page &lt;with&gt; many &lt;tags&gt; in &lt;the&gt; title</title>
+<title>A page &lt;with&gt; many &lt;tags&gt; in &lt;the&gt; title for testing</title>
 
 <script id="rawtextchunked">
-  // 1. Each raw-text element parses to exactly one text node child.
+  // 1. Each raw-text element parses to exactly ONE text node child.
   let script = document.querySelector('script.big-script');
   testing.expectEqual(1, script.childNodes.length);
   testing.expectTrue(script.firstChild === script.lastChild);
   testing.expectEqual(3, script.firstChild.nodeType); // TEXT_NODE
-  testing.expectTrue(script.textContent.indexOf('<a><b><c>') !== -1);
-  testing.expectTrue(script.textContent.indexOf('<uu><vv><ww>') !== -1);
-  testing.expectTrue(script.textContent.indexOf('var done = "yes"') !== -1);
 
   let style = document.querySelector('style.big-style');
   testing.expectEqual(1, style.childNodes.length);
   testing.expectTrue(style.firstChild === style.lastChild);
-  testing.expectTrue(style.textContent.indexOf('"<a><b><c><d>"') !== -1);
-  testing.expectTrue(style.textContent.indexOf('"<m><n><o><p>"') !== -1);
 
   let textarea = document.querySelector('textarea.big-textarea');
   testing.expectEqual(1, textarea.childNodes.length);
   testing.expectTrue(textarea.firstChild === textarea.lastChild);
-  // textarea is RCDATA: entities decoded
-  testing.expectTrue(textarea.value.indexOf('line1 with <a> and <b>') !== -1);
-  testing.expectTrue(textarea.value.indexOf('line3 with <e> and <f>') !== -1);
 
   let title = document.querySelector('title');
   testing.expectEqual(1, title.childNodes.length);
   testing.expectTrue(title.firstChild === title.lastChild);
-  // title is RCDATA: entities decoded
-  testing.expectEqual('A page <with> many <tags> in <the> title', title.textContent);
 
-  // 2. Reading the script body via the DOM yields the verbatim source bytes
-  //    (no chunks, no missing characters).
-  // 26 (a-z) + 20 (aa-tt) + 6 (uu-zz) = 52 '<' characters in the source.
-  let count = (script.firstChild.nodeValue.match(/</g) || []).length;
-  testing.expectEqual(52, count);
+  // 2. Exact byte counts. A regression that drops or duplicates a chunk in
+  //    Parser.appendTextChunk would shift these.
+  //    '<' total in the script source:
+  //      26 (a-z) + 20 (aa-tt) + 6 (uu-zz) + 21 lines * 10 (a1..u0) = 262.
+  let body = script.firstChild.nodeValue;
+  let lt_count = (body.match(/</g) || []).length;
+  testing.expectEqual(262, lt_count);
+  // String literals must round-trip — pick samples from the start, middle,
+  // and end so a regression that loses a mid-body chunk fails loudly.
+  testing.expectTrue(body.indexOf('<a><b><c><d>') !== -1);
+  testing.expectTrue(body.indexOf('<m1><m2><m3>') !== -1);
+  testing.expectTrue(body.indexOf('<u1><u2><u3>') !== -1);
+  testing.expectTrue(body.indexOf('var done = "yes"') !== -1);
+
+  // 3. Style: 6 rules with distinct content, all preserved.
+  let style_body = style.firstChild.nodeValue;
+  let style_lt_count = (style_body.match(/</g) || []).length;
+  // 10 + 10 + 6 + 6 + 6 + 6 = 44 '<' chars across the six rules.
+  testing.expectEqual(44, style_lt_count);
+  testing.expectTrue(style_body.indexOf('"<a><b><c>') !== -1);
+  testing.expectTrue(style_body.indexOf('"<gg><hh>') !== -1);
+  testing.expectTrue(style_body.indexOf('"<mm><nn>') !== -1);
+
+  // 4. Textarea (RCDATA): entities decoded. Exact line count and content.
+  let ta_value = textarea.value;
+  testing.expectEqual(4, ta_value.split('\n').length);
+  // 4 lines * (6 + 6 + 6 + 8) = 26 '<' chars after entity decoding.
+  let ta_lt_count = (ta_value.match(/</g) || []).length;
+  testing.expectEqual(26, ta_lt_count);
+  testing.expectTrue(ta_value.indexOf('line 1: <a><b>') !== -1);
+  testing.expectTrue(ta_value.indexOf('line 4: <s><t><u>') !== -1);
+
+  // 5. Title (RCDATA): entities decoded; exact equality.
+  testing.expectEqual('A page <with> many <tags> in <the> title for testing',
+                      title.textContent);
 </script>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -837,7 +837,7 @@ pub fn close(self: *Document, frame: *Frame) !void {
 
     // done() calls html5ever_streaming_parser_finish which frees the parser
     // We must NOT call deinit() after done() as that would be a double-free
-    self._script_created_parser.?.done();
+    try self._script_created_parser.?.done();
     // Just null out the handle since done() already freed it
     self._script_created_parser.?.handle = null;
     self._script_created_parser = null;

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -706,7 +706,13 @@ fn writeInternal(self: *Document, text: []const []const u8, append_newline: bool
             if (self._script_created_parser) |*parser| {
                 parser.read(html) catch |err| {
                     log.warn(.dom, "document.write parser error", .{ .err = err });
-                    // was already closed
+                    // html5ever's handle was destroyed inside read(), but the
+                    // pending text buffer (if any) still wants to land on its
+                    // text node's _data — flushPendingText doesn't depend on
+                    // the handle, so attempt a final flush before dropping.
+                    parser.parser.flushPendingText() catch |flush_err| {
+                        log.warn(.dom, "flush after parser panic", .{ .err = flush_err });
+                    };
                     self._script_created_parser = null;
                 };
             }
@@ -835,12 +841,12 @@ pub fn close(self: *Document, frame: *Frame) !void {
         return;
     }
 
-    // done() calls html5ever_streaming_parser_finish which frees the parser
-    // We must NOT call deinit() after done() as that would be a double-free
+    // done() finishes html5ever's handle and runs the final flushPendingText.
+    // Even if flushPendingText errors, the handle is already finished and we
+    // must not retain the Streaming — defer so the error path also drops it.
+    // (Streaming.done nulls its own handle, so dropping the struct is safe.)
+    defer self._script_created_parser = null;
     try self._script_created_parser.?.done();
-    // Just null out the handle since done() already freed it
-    self._script_created_parser.?.handle = null;
-    self._script_created_parser = null;
 
     frame.documentIsComplete();
 }


### PR DESCRIPTION
## What this fixes

Issue #2397: `lightpanda fetch --dump html` on apple.com US iPhone pages peaked at ~3.5 GB RSS (vs ~390 MB on the equivalent UK page). The 1 GB Docker container OOMs (`exit 137`). Reproducible with:

```sh
docker run --rm -m 1g lightpanda/browser:latest \
  lightpanda fetch --dump html --obey-robots \
  https://www.apple.com/us/shop/buy-iphone/iphone-16/
```

## Root cause

`Frame.appendNew`'s `.text` branch in `src/browser/Frame.zig:1799-1822` did:

```zig
cdata._data = try String.concat(self.arena, &.{ existing, txt });
```

every time html5ever delivered a chunk via the `AppendText` callback. The page-lifetime arena (`frame.arena`) doesn't free individual allocations, so each merge left the prior buffer as dead memory. Total bytes written ≈ `N²/(2·chunk_size)`.

The trigger is html5ever's tokenizer: in `script-data` (and `rawtext` / `rcdata`) state, encountering `<` flushes the pending character buffer and re-enters via a fresh `AppendText`. The US iPhone page has a 347 KB inline `window.PRODUCT_SELECTION_BOOTSTRAP = {…}` literal stuffed with embedded HTML strings like `"header":"<span>Model</span>"` — every `<` becomes a chunk boundary.

Empirically validated with synthetic 100 KB scripts on `main`:

| Script body | Peak RSS |
|---|---|
| 100 KB of `'a'` (no `<`) | 40 MB |
| 100 KB with `<` every 100 chars | 190 MB |
| 100 KB with `<` every 10 chars | **1.5 GB** |

PR #2241 capped per-tick growth and added GC hints in the wait loop. That fix is post-parse; this pathology happens during initial HTML parse — RSS hits 3.2 GB by `--wait-ms 1000`, before the wait loop runs.

## What this PR changes

Move the merge into the parser. Same-parent text chunks accumulate in a `std.ArrayListUnmanaged(u8)` on the per-parse arena; one `String.dupe` commits the final value to the frame arena.

```zig
// src/browser/parser/Parser.zig
const PendingText = struct {
    parent: *Node,
    text_node: *CData,
    buf: std.ArrayListUnmanaged(u8) = .empty,
};
pending_text: ?PendingText,
```

Flush points are the natural ends of a text run:
- A non-text child appended adjacent (`_appendCallback` `.node` branch)
- A foster / before-sibling insertion (`_appendBeforeSiblingCallback`)
- Parent element popped (`_popCallback`, **unconditional** — covers custom-element constructors that may read sibling `textContent` mid-parse)
- Parse call returning (`parse`, `parseWithEncoding`, `parseXML`, `parseFragment`, `Streaming.done`)

`Frame.appendNew` is simplified to take `*Node` directly — it had no non-parser callers (verified by grep + GitNexus impact). `Streaming.done` returns `!void` to propagate the final flush; the only call site (`Document.close`) was already in `!void` context.

Total peak allocation per text run is now ~2N (one ArrayList capacity + one final String.dupe) instead of ~N²/(2·c).

## Results

| Reproducer | Before | After |
|---|---|---|
| apple.com US iPhone fetch | **3.50 GB** | 125 MB |
| Standalone bootstrap script (347 KB) | 2.54 GB | 45 MB |
| 100 KB synthetic, `<` every 10 chars | 1.50 GB | 41 MB |
| apple.com UK iPhone (already fine) | 394 MB | 106 MB |

Dumped HTML on the US page is **byte-identical** to pre-patch (1,285,747 B). UK has only React `useId` differences across runs (same byte size) — pre-existing non-determinism.

## Where to focus review

- `Parser.zig` `flushPendingText` / `appendTextChunk` (new) — the invariant is "`pending_text.text_node === pending_text.parent.lastChild()` while pending is non-null"; flush is called any time that invariant could be violated.
- `Parser.zig` `_popCallback` flushes **unconditionally**, not only when `pt.parent == node`. A custom-element constructor reaching back to a sibling's `textContent` during pop must observe finalized data.
- `Frame.appendNew` signature change to `(parent: *Node, child: *Node)` — the only caller change is `Parser._appendDoctypeToDocument` which now passes the node directly.
- Allocator lifetime: pending buffer lives on `parser.arena` (per-parse); committed `String` lives on `frame.arena` (page-lifetime), matching the prior `String.concat(self.arena, …)` site exactly. Verified for `Frame.parseBlob`, `Frame.parse`, `parseHtmlAsChildren` (innerHTML), and `Document.write`'s foster path.

## Test plan

- [x] New regression test `src/browser/tests/cdata/raw_text_chunked.html` asserts `<script>`/`<style>`/`<textarea>`/`<title>` with embedded `<` parse to a single text node with verbatim content.
- [x] Full suite: `mise exec -- zig build test $V8` — 521/521 pass.
- [x] Live: `lightpanda fetch --dump html --wait-ms 8000` on apple.com US iPhone page — 125 MB peak RSS (was 3.5 GB), output byte-identical.
- [x] `gitnexus_detect_changes` — 1 affected process (`insertAdjacentHTML → parseFragment`), covered by the new flush at the end of `parseFragment`.

Refs #2397