### PR TITLE
`HTMLLinkElement`: `crossOrigin` -> `crossorigin` for attributes

### DIFF
--- a/src/browser/tests/element/html/link.html
+++ b/src/browser/tests/element/html/link.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../../testing.js"></script>
 
-<link id="lh1" rel="stylesheet" href="/styles/main.css" media="screen" as="style">
+<link id="lh1" rel="stylesheet" href="/styles/main.css" media="screen" as="style" crossorigin="anonymous">
 <link id="lh2">
 
 <script id="link-from-html">
@@ -12,6 +12,7 @@
     testing.expectEqual(testing.ORIGIN + '/styles/main.css', lh1.href);
     testing.expectEqual('screen', lh1.media);
     testing.expectEqual('style', lh1.as);
+    testing.expectEqual('anonymous', lh1.crossOrigin);
 
     lh1.rel = 'preload';
     testing.expectEqual('preload', lh1.rel);

--- a/src/browser/tests/element/html/link.html
+++ b/src/browser/tests/element/html/link.html
@@ -1,6 +1,31 @@
 <!DOCTYPE html>
 <script src="../../testing.js"></script>
 
+<link id="lh1" rel="stylesheet" href="/styles/main.css" media="screen" as="style">
+<link id="lh2">
+
+<script id="link-from-html">
+  {
+    const lh1 = document.getElementById('lh1');
+    testing.expectEqual('HTMLLinkElement', lh1.constructor.name);
+    testing.expectEqual('stylesheet', lh1.rel);
+    testing.expectEqual(testing.ORIGIN + '/styles/main.css', lh1.href);
+    testing.expectEqual('screen', lh1.media);
+    testing.expectEqual('style', lh1.as);
+
+    lh1.rel = 'preload';
+    testing.expectEqual('preload', lh1.rel);
+    lh1.media = 'print';
+    testing.expectEqual('print', lh1.media);
+
+    const lh2 = document.getElementById('lh2');
+    testing.expectEqual('', lh2.rel);
+    testing.expectEqual('', lh2.href);
+    testing.expectEqual('', lh2.media);
+    testing.expectEqual('', lh2.as);
+  }
+</script>
+
 <script id=link>
   let l2 = document.createElement('link');
   testing.expectEqual('', l2.href);
@@ -18,6 +43,12 @@
 
   l2.crossOrigin = '';
   testing.expectEqual('anonymous', l2.crossOrigin);
+
+  testing.expectEqual('', l2.media);
+  l2.media = 'screen and (max-width: 600px)';
+  testing.expectEqual('screen and (max-width: 600px)', l2.media);
+  l2.media = 'print';
+  testing.expectEqual('print', l2.media);
 </script>
 
 <script id="link-load-event">

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -71,6 +71,14 @@ pub fn setAs(self: *Link, value: []const u8, frame: *Frame) !void {
     return self.asElement().setAttributeSafe(comptime .wrap("as"), .wrap(value), frame);
 }
 
+pub fn getMedia(self: *Link) []const u8 {
+    return self.asElement().getAttributeSafe(comptime .wrap("media")) orelse return "";
+}
+
+pub fn setMedia(self: *Link, value: []const u8, frame: *Frame) !void {
+    return self.asElement().setAttributeSafe(comptime .wrap("media"), .wrap(value), frame);
+}
+
 pub fn getCrossOrigin(self: *const Link) ?[]const u8 {
     return self.asConstElement().getAttributeSafe(comptime .wrap("crossOrigin"));
 }
@@ -120,6 +128,7 @@ pub const JsApi = struct {
 
     pub const as = bridge.accessor(Link.getAs, Link.setAs, .{});
     pub const rel = bridge.accessor(Link.getRel, Link.setRel, .{});
+    pub const media = bridge.accessor(Link.getMedia, Link.setMedia, .{});
     pub const href = bridge.accessor(Link.getHref, Link.setHref, .{});
     pub const crossOrigin = bridge.accessor(Link.getCrossOrigin, Link.setCrossOrigin, .{});
     pub const relList = bridge.accessor(_getRelList, null, .{ .null_as_undefined = true });

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -80,7 +80,7 @@ pub fn setMedia(self: *Link, value: []const u8, frame: *Frame) !void {
 }
 
 pub fn getCrossOrigin(self: *const Link) ?[]const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("crossOrigin"));
+    return self.asConstElement().getAttributeSafe(comptime .wrap("crossorigin"));
 }
 
 pub fn setCrossOrigin(self: *Link, value: []const u8, frame: *Frame) !void {
@@ -88,7 +88,7 @@ pub fn setCrossOrigin(self: *Link, value: []const u8, frame: *Frame) !void {
     if (std.ascii.eqlIgnoreCase(value, "use-credentials")) {
         normalized = "use-credentials";
     }
-    return self.asElement().setAttributeSafe(comptime .wrap("crossOrigin"), .wrap(normalized), frame);
+    return self.asElement().setAttributeSafe(comptime .wrap("crossorigin"), .wrap(normalized), frame);
 }
 
 pub fn linkAddedCallback(self: *Link, frame: *Frame) !void {


### PR DESCRIPTION
Branch created on #2415, better be merged after that one.