### PR TITLE
terminal: replace linenoise with isocline

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,7 +88,7 @@ pub fn build(b: *Build) !void {
         try linkCurl(b, mod, enable_tsan);
         try linkHtml5Ever(b, mod);
         linkZenai(b, mod);
-        linkLinenoise(b, mod);
+        linkIsocline(b, mod);
 
         break :blk mod;
     };
@@ -1005,11 +1005,11 @@ fn linkZenai(b: *Build, mod: *Build.Module) void {
     mod.addImport("zenai", dep.module("zenai"));
 }
 
-fn linkLinenoise(b: *Build, mod: *Build.Module) void {
-    const dep = b.dependency("linenoise", .{});
-    mod.addIncludePath(dep.path(""));
+fn linkIsocline(b: *Build, mod: *Build.Module) void {
+    const dep = b.dependency("isocline", .{});
+    mod.addIncludePath(dep.path("include"));
     mod.addCSourceFile(.{
-        .file = dep.path("linenoise.c"),
+        .file = dep.path("src/isocline.c"),
     });
 }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,13 +34,13 @@
             .url = "https://github.com/allyourcodebase/sqlite3/archive/8f840560eae88ab66668c6827c64ffbd0d74ef37.tar.gz",
             .hash = "sqlite3-3.51.0-DMxLWssOAABZ8cAvU_LfBIbp0kZjm824PU8sSLXpEDdr",
         },
-        .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#fb7d356617dcf7559c2d47d56b73d9b082f81b9b",
-            .hash = "zenai-0.0.0-iOY_VOebAwA19L7IyQKx8CJRDbNwf75jN_nJ_F3OFD8m",
-        },
         .libidn2 = .{
             .url = "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz",
             .hash = "N-V-__8AABGOuAC_dhAN07kfoP4dycCFi8Bka4O-tuhriNH8",
+        },
+        .zenai = .{
+            .url = "git+https://github.com/lightpanda-io/zenai.git#fb7d356617dcf7559c2d47d56b73d9b082f81b9b",
+            .hash = "zenai-0.0.0-iOY_VOebAwA19L7IyQKx8CJRDbNwf75jN_nJ_F3OFD8m",
         },
         .isocline = .{
             .url = "https://github.com/daanx/isocline/archive/refs/tags/v1.1.0.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,10 +34,6 @@
             .url = "https://github.com/allyourcodebase/sqlite3/archive/8f840560eae88ab66668c6827c64ffbd0d74ef37.tar.gz",
             .hash = "sqlite3-3.51.0-DMxLWssOAABZ8cAvU_LfBIbp0kZjm824PU8sSLXpEDdr",
         },
-        .linenoise = .{
-            .url = "https://github.com/antirez/linenoise/archive/refs/tags/2.0.tar.gz",
-            .hash = "N-V-__8AAJ4HAgCX79UDBfNwhqAqUVoGC44ib6UYa18q6oa_",
-        },
         .zenai = .{
             .url = "git+https://github.com/lightpanda-io/zenai.git#fb7d356617dcf7559c2d47d56b73d9b082f81b9b",
             .hash = "zenai-0.0.0-iOY_VOebAwA19L7IyQKx8CJRDbNwf75jN_nJ_F3OFD8m",
@@ -45,6 +41,10 @@
         .libidn2 = .{
             .url = "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz",
             .hash = "N-V-__8AABGOuAC_dhAN07kfoP4dycCFi8Bka4O-tuhriNH8",
+        },
+        .isocline = .{
+            .url = "https://github.com/daanx/isocline/archive/refs/tags/v1.1.0.tar.gz",
+            .hash = "N-V-__8AAAO9EgA-gjVR9Uf87fpOT--TBHVEvafXa3yRa0HY",
         },
     },
     .paths = .{""},

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -312,6 +312,18 @@ fn runRepl(self: *Self) void {
 
         const cmd = Command.parse(line);
 
+        // Distinguish "you typed `TYPE` but forgot the args" from "this is
+        // natural language for the LLM". Both fall through to
+        // `.natural_language` in Command.parse, but the first should never
+        // hit the LLM-needed error path — it's a syntax mistake on a
+        // PandaScript command.
+        if (std.meta.activeTag(cmd) == .natural_language) {
+            if (Command.keywordSyntax(line)) |kc| {
+                self.terminal.printErrorFmt("Usage: {s} {s}", .{ kc.name, kc.args });
+                continue;
+            }
+        }
+
         if (cmd.needsLlm() and self.ai_client == null) {
             self.terminal.printError("This command needs an LLM. Set an API key or pass --provider (and drop --no-llm if you set it). PandaScript commands (GOTO, CLICK, EXTRACT, ...) work without one.");
             continue;

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -300,7 +300,7 @@ fn runRepl(self: *Self) void {
     }
 
     repl: while (true) {
-        const line = self.terminal.readLine("> ") orelse break;
+        const line = self.terminal.readLine("") orelse break;
         defer self.terminal.freeLine(line);
 
         if (line.len == 0) continue;

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -228,7 +228,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Self 
 
     self.cmd_executor = CommandExecutor.init(allocator, tool_executor, &self.terminal);
 
-    self.terminal.setSlashSchemas(slash_schemas);
+    self.terminal.attachCompleter(slash_schemas);
 
     return self;
 }
@@ -300,8 +300,8 @@ fn runRepl(self: *Self) void {
     }
 
     repl: while (true) {
-        const line = self.terminal.readLine("") orelse break;
-        defer self.terminal.freeLine(line);
+        const line = Terminal.readLine("") orelse break;
+        defer Terminal.freeLine(line);
 
         if (line.len == 0) continue;
 

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -355,9 +355,7 @@ fn handleSlash(self: *Self, body: []const u8) bool {
     const name = split.name;
     const rest = split.rest;
 
-    if (std.mem.eql(u8, name, "quit")) {
-        return true;
-    }
+    if (std.mem.eql(u8, name, "quit")) return true;
     if (std.mem.eql(u8, name, "help")) {
         self.printSlashHelp(rest);
         return false;

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -319,7 +319,7 @@ fn runRepl(self: *Self) void {
         // PandaScript command.
         if (std.meta.activeTag(cmd) == .natural_language) {
             if (Command.keywordSyntax(line)) |kc| {
-                self.terminal.printErrorFmt("Usage: {s} {s}", .{ kc.name, kc.args });
+                self.terminal.printErrorFmt("Usage: {s} {s}", .{ kc.name, kc.args.? });
                 continue;
             }
         }

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -228,7 +228,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Self 
 
     self.cmd_executor = CommandExecutor.init(allocator, tool_executor, &self.terminal);
 
-    Terminal.setSlashSchemas(slash_schemas);
+    self.terminal.setSlashSchemas(slash_schemas);
 
     return self;
 }

--- a/src/agent/Command.zig
+++ b/src/agent/Command.zig
@@ -217,6 +217,40 @@ pub fn parse(line: []const u8) Command {
     return .{ .natural_language = trimmed };
 }
 
+pub const KeywordSyntax = struct {
+    name: []const u8,
+    args: []const u8,
+};
+
+/// If the first word of `line` matches a recognized PandaScript keyword that
+/// takes arguments, returns its expected shape. Lets the REPL distinguish
+/// "you mistyped args for a known command" from "this is natural language" —
+/// the latter goes to the LLM, the former gets a syntax error. Argless
+/// commands (TREE, MARKDOWN, LOGIN, ACCEPT_COOKIES) are intentionally absent
+/// because they always parse successfully when typed alone, so they never
+/// fall through to natural_language.
+pub fn keywordSyntax(line: []const u8) ?KeywordSyntax {
+    const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
+    const end = std.mem.indexOfAny(u8, trimmed, &std.ascii.whitespace) orelse trimmed.len;
+    const word = trimmed[0..end];
+    const table = [_]KeywordSyntax{
+        .{ .name = "GOTO", .args = "<url>" },
+        .{ .name = "CLICK", .args = "'<selector>'" },
+        .{ .name = "TYPE", .args = "'<selector>' '<value>'" },
+        .{ .name = "WAIT", .args = "'<selector>'" },
+        .{ .name = "SCROLL", .args = "[x] [y]" },
+        .{ .name = "HOVER", .args = "'<selector>'" },
+        .{ .name = "SELECT", .args = "'<selector>' '<value>'" },
+        .{ .name = "CHECK", .args = "'<selector>' [true|false]" },
+        .{ .name = "EXTRACT", .args = "'<selector>'" },
+        .{ .name = "EVAL", .args = "'<script>'" },
+    };
+    for (table) |kc| {
+        if (std.mem.eql(u8, word, kc.name)) return kc;
+    }
+    return null;
+}
+
 /// Iterator for parsing a script file, handling multi-line EVAL """ ... """ blocks.
 pub const ScriptIterator = struct {
     allocator: std.mem.Allocator,

--- a/src/agent/Command.zig
+++ b/src/agent/Command.zig
@@ -219,13 +219,12 @@ pub fn parse(line: []const u8) Command {
 
 pub const KeywordSyntax = struct {
     name: []const u8,
-    /// Null for argless commands (TREE, MARKDOWN, LOGIN, ACCEPT_COOKIES).
+    /// Null for argless commands.
     args: ?[]const u8,
 };
 
 /// Single source of truth for PandaScript keyword names — consumed by the
-/// parser, the REPL highlighter, and Tab completion. Order is REPL-facing
-/// (action verbs first), so completions feel natural.
+/// parser, the REPL highlighter, and Tab completion.
 pub const keywords = [_]KeywordSyntax{
     .{ .name = "GOTO", .args = "<url>" },
     .{ .name = "CLICK", .args = "'<selector>'" },
@@ -243,12 +242,9 @@ pub const keywords = [_]KeywordSyntax{
     .{ .name = "ACCEPT_COOKIES", .args = null },
 };
 
-/// If the first word of `line` matches a recognized PandaScript keyword that
-/// takes arguments, returns its expected shape. Lets the REPL distinguish
-/// "you mistyped args for a known command" from "this is natural language" —
-/// the latter goes to the LLM, the former gets a syntax error. Argless
-/// commands return null because they always parse successfully when typed
-/// alone, so they never fall through to natural_language.
+/// If the first word of `line` is a PandaScript keyword that takes arguments,
+/// returns its expected shape. Argless keywords return null — they always
+/// parse successfully when typed alone, so they never need the syntax-error path.
 pub fn keywordSyntax(line: []const u8) ?KeywordSyntax {
     const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
     const end = std.mem.indexOfAny(u8, trimmed, &std.ascii.whitespace) orelse trimmed.len;

--- a/src/agent/Command.zig
+++ b/src/agent/Command.zig
@@ -219,34 +219,42 @@ pub fn parse(line: []const u8) Command {
 
 pub const KeywordSyntax = struct {
     name: []const u8,
-    args: []const u8,
+    /// Null for argless commands (TREE, MARKDOWN, LOGIN, ACCEPT_COOKIES).
+    args: ?[]const u8,
+};
+
+/// Single source of truth for PandaScript keyword names — consumed by the
+/// parser, the REPL highlighter, and Tab completion. Order is REPL-facing
+/// (action verbs first), so completions feel natural.
+pub const keywords = [_]KeywordSyntax{
+    .{ .name = "GOTO", .args = "<url>" },
+    .{ .name = "CLICK", .args = "'<selector>'" },
+    .{ .name = "TYPE", .args = "'<selector>' '<value>'" },
+    .{ .name = "WAIT", .args = "'<selector>'" },
+    .{ .name = "SCROLL", .args = "[x] [y]" },
+    .{ .name = "HOVER", .args = "'<selector>'" },
+    .{ .name = "SELECT", .args = "'<selector>' '<value>'" },
+    .{ .name = "CHECK", .args = "'<selector>' [true|false]" },
+    .{ .name = "TREE", .args = null },
+    .{ .name = "MARKDOWN", .args = null },
+    .{ .name = "EXTRACT", .args = "'<selector>'" },
+    .{ .name = "EVAL", .args = "'<script>'" },
+    .{ .name = "LOGIN", .args = null },
+    .{ .name = "ACCEPT_COOKIES", .args = null },
 };
 
 /// If the first word of `line` matches a recognized PandaScript keyword that
 /// takes arguments, returns its expected shape. Lets the REPL distinguish
 /// "you mistyped args for a known command" from "this is natural language" —
 /// the latter goes to the LLM, the former gets a syntax error. Argless
-/// commands (TREE, MARKDOWN, LOGIN, ACCEPT_COOKIES) are intentionally absent
-/// because they always parse successfully when typed alone, so they never
-/// fall through to natural_language.
+/// commands return null because they always parse successfully when typed
+/// alone, so they never fall through to natural_language.
 pub fn keywordSyntax(line: []const u8) ?KeywordSyntax {
     const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
     const end = std.mem.indexOfAny(u8, trimmed, &std.ascii.whitespace) orelse trimmed.len;
     const word = trimmed[0..end];
-    const table = [_]KeywordSyntax{
-        .{ .name = "GOTO", .args = "<url>" },
-        .{ .name = "CLICK", .args = "'<selector>'" },
-        .{ .name = "TYPE", .args = "'<selector>' '<value>'" },
-        .{ .name = "WAIT", .args = "'<selector>'" },
-        .{ .name = "SCROLL", .args = "[x] [y]" },
-        .{ .name = "HOVER", .args = "'<selector>'" },
-        .{ .name = "SELECT", .args = "'<selector>' '<value>'" },
-        .{ .name = "CHECK", .args = "'<selector>' [true|false]" },
-        .{ .name = "EXTRACT", .args = "'<selector>'" },
-        .{ .name = "EVAL", .args = "'<script>'" },
-    };
-    for (table) |kc| {
-        if (std.mem.eql(u8, word, kc.name)) return kc;
+    for (keywords) |kc| {
+        if (kc.args != null and std.mem.eql(u8, word, kc.name)) return kc;
     }
     return null;
 }

--- a/src/agent/Command.zig
+++ b/src/agent/Command.zig
@@ -620,6 +620,26 @@ test "parse GOTO missing url" {
     try std.testing.expect(cmd == .natural_language);
 }
 
+test "keywordSyntax: argful keyword without args returns its shape" {
+    const k = keywordSyntax("CLICK").?;
+    try std.testing.expectEqualStrings("CLICK", k.name);
+    try std.testing.expectEqualStrings("'<selector>'", k.args.?);
+}
+
+test "keywordSyntax: trailing whitespace tolerated" {
+    try std.testing.expect(keywordSyntax("  GOTO   ") != null);
+}
+
+test "keywordSyntax: argless keyword returns null" {
+    try std.testing.expect(keywordSyntax("LOGIN") == null);
+    try std.testing.expect(keywordSyntax("TREE") == null);
+}
+
+test "keywordSyntax: unknown word returns null" {
+    try std.testing.expect(keywordSyntax("FOOBAR") == null);
+    try std.testing.expect(keywordSyntax("click the button") == null);
+}
+
 test "parse CLICK quoted" {
     const cmd = parse("CLICK \"Login\"");
     try std.testing.expectEqualStrings("Login", cmd.click);

--- a/src/agent/SlashCommand.zig
+++ b/src/agent/SlashCommand.zig
@@ -29,8 +29,7 @@ pub const SchemaInfo = struct {
 };
 
 /// Meta slash commands handled directly by the agent (not by ToolExecutor).
-/// Only the names matter for completion; arg hints are not surfaced
-/// separately (the menu is enough).
+/// Kept in sync with `handleSlash` in Agent.zig.
 pub const meta_names = [_][:0]const u8{ "help", "quit" };
 
 pub const ParseError = error{

--- a/src/agent/SlashCommand.zig
+++ b/src/agent/SlashCommand.zig
@@ -28,6 +28,11 @@ pub const SchemaInfo = struct {
     hints: []const HintSlot,
 };
 
+/// Meta slash commands handled directly by the agent (not by ToolExecutor).
+/// Only the names matter for completion; arg hints are not surfaced
+/// separately (the menu is enough).
+pub const meta_names = [_][:0]const u8{ "help", "quit" };
+
 pub const ParseError = error{
     MissingName,
     UnknownTool,

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -5,11 +5,21 @@ const Config = lp.Config;
 const Command = @import("Command.zig");
 const SlashCommand = @import("SlashCommand.zig");
 const Spinner = @import("Spinner.zig");
+const string = @import("../string.zig");
 const c = @cImport({
     @cInclude("isocline.h");
 });
 
 const Self = @This();
+
+const style_cmd = "ps-cmd";
+const style_slash = "ps-slash";
+const style_string = "ps-string";
+const style_var = "ps-var";
+const style_url = "ps-url";
+const style_key = "ps-key";
+const style_num = "ps-num";
+const style_err = "ps-err";
 
 pub const ansi = struct {
     pub const reset = "\x1b[0m";
@@ -27,6 +37,7 @@ fn atLeast(level: Verbosity, min: Verbosity) bool {
     return @intFromEnum(level) >= @intFromEnum(min);
 }
 
+allocator: std.mem.Allocator,
 history_path: ?[:0]const u8,
 verbosity: Verbosity,
 /// Non-null in REPL mode. Doubles as scratch arena for the pretty-printer
@@ -39,17 +50,14 @@ spinner: Spinner,
 /// Schemas the completer uses to render `/slash` arg hints. Empty until
 /// `setSlashSchemas` is called.
 slash_schemas: []const SlashCommand.SchemaInfo = &.{},
-
-// Meta slash commands handled directly by the agent (not by ToolExecutor).
-// Kept in sync with `handleSlash` in `Agent.zig`. Only the names matter for
-// completion; arg hints are not surfaced separately (the menu is enough).
-const meta_slash_commands = [_][:0]const u8{ "help", "quit" };
+/// Cached LP_* environment variable names for completion.
+env_names: ?[]const []const u8 = null,
 
 // Flat name list for the "match any slash command" search/completion paths.
-const all_slash_names: [browser_tools.tool_defs.len + meta_slash_commands.len][]const u8 = blk: {
-    var names: [browser_tools.tool_defs.len + meta_slash_commands.len][]const u8 = undefined;
+const all_slash_names: [browser_tools.tool_defs.len + SlashCommand.meta_names.len][]const u8 = blk: {
+    var names: [browser_tools.tool_defs.len + SlashCommand.meta_names.len][]const u8 = undefined;
     for (browser_tools.tool_defs, 0..) |td, i| names[i] = td.name;
-    for (meta_slash_commands, 0..) |m, i| names[browser_tools.tool_defs.len + i] = m;
+    for (SlashCommand.meta_names, 0..) |m, i| names[browser_tools.tool_defs.len + i] = m;
     break :blk names;
 };
 
@@ -59,6 +67,7 @@ const all_slash_names: [browser_tools.tool_defs.len + meta_slash_commands.len][]
 pub fn setSlashSchemas(self: *Self, schemas: []const SlashCommand.SchemaInfo) void {
     self.slash_schemas = schemas;
     c.ic_set_default_completer(&completionCallback, self);
+    c.ic_set_default_highlighter(&highlighterCallback, null);
 }
 
 pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity: Verbosity, is_repl: bool) Self {
@@ -69,21 +78,21 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     _ = c.ic_set_hint_delay(0);
     _ = c.ic_enable_brace_insertion(true);
     // `ps-*` namespace avoids colliding with isocline's built-in `ic-*` styles.
-    c.ic_style_def("ps-cmd", "ansi-cyan bold");
-    c.ic_style_def("ps-slash", "ansi-magenta bold");
-    c.ic_style_def("ps-string", "ansi-green");
-    c.ic_style_def("ps-var", "ansi-yellow bold");
-    c.ic_style_def("ps-url", "ansi-blue underline");
-    c.ic_style_def("ps-key", "ansi-cyan");
-    c.ic_style_def("ps-num", "ansi-yellow");
-    c.ic_style_def("ps-err", "ansi-red");
+    c.ic_style_def(style_cmd, "ansi-cyan bold");
+    c.ic_style_def(style_slash, "ansi-magenta bold");
+    c.ic_style_def(style_string, "ansi-green");
+    c.ic_style_def(style_var, "ansi-yellow bold");
+    c.ic_style_def(style_url, "ansi-blue underline");
+    c.ic_style_def(style_key, "ansi-cyan");
+    c.ic_style_def(style_num, "ansi-yellow");
+    c.ic_style_def(style_err, "ansi-red");
     _ = c.ic_enable_highlight(true);
-    c.ic_set_default_highlighter(&highlighterCallback, null);
     if (history_path) |path| {
         c.ic_set_history(path.ptr, -1); // -1 → 200-entry default cap
     }
     const stderr_is_tty = std.posix.isatty(std.posix.STDERR_FILENO);
     return .{
+        .allocator = allocator,
         .history_path = history_path,
         .verbosity = verbosity,
         .repl_arena = if (is_repl) std.heap.ArenaAllocator.init(allocator) else null,
@@ -99,6 +108,7 @@ fn isRepl(self: *const Self) bool {
 pub fn deinit(self: *Self) void {
     self.spinner.deinit();
     if (self.repl_arena) |*a| a.deinit();
+    if (self.env_names) |names| self.allocator.free(names);
 }
 
 const bullet_line_fmt = "{s}●{s} {s}[tool: {s}]{s} {s}\n";
@@ -251,6 +261,7 @@ fn addPartialKeyCompletions(
 
 // Completes `$LP_*` against the live process environment.
 fn addEnvVarCompletions(
+    self: *Self,
     cenv: ?*c.ic_completion_env_t,
     buf: *[completion_buf_len:0]u8,
     input: []const u8,
@@ -261,10 +272,10 @@ fn addEnvVarCompletions(
         if (!std.ascii.isAlphanumeric(ch) and ch != '_') return;
     }
 
-    // Names are slices into std.os.environ; only pointer metadata is allocated.
-    var stack: [16 * 1024]u8 = undefined;
-    var fba: std.heap.FixedBufferAllocator = .init(&stack);
-    const names = browser_tools.lpEnvNames(fba.allocator()) catch return;
+    if (self.env_names == null) {
+        self.env_names = browser_tools.lpEnvNames(self.allocator) catch null;
+    }
+    const names = self.env_names orelse return;
 
     const head = input[0 .. dollar + 1];
     for (names) |name| {
@@ -314,7 +325,7 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
         }
     }
 
-    addEnvVarCompletions(cenv, &buf, input);
+    self.addEnvVarCompletions(cenv, &buf, input);
 }
 
 // Byte offsets to ic_highlight are not UTF-8 code points; safe because we
@@ -331,28 +342,20 @@ fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*a
     while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
     const cmd = text[cmd_start..i];
     if (cmd.len > 0 and cmd[0] == '/') {
-        const style = if (isKnownSlashName(cmd[1..])) "ps-slash" else "ps-err";
+        const style = if (isKnownSlashName(cmd[1..])) style_slash else style_err;
         c.ic_highlight(henv, @intCast(cmd_start), @intCast(cmd.len), style.ptr);
         highlightSlashArgs(henv, text, i);
     } else {
         // ALL CAPS but unknown → typo (red); lowercase/mixed → natural language (unstyled).
         const style: ?[*:0]const u8 = if (isKnownCommand(cmd))
-            "ps-cmd"
-        else if (isAllUpper(cmd))
-            "ps-err"
+            style_cmd
+        else if (string.isAllUpper(cmd))
+            style_err
         else
             null;
         if (style) |s| c.ic_highlight(henv, @intCast(cmd_start), @intCast(cmd.len), s);
         highlightPandaArgs(henv, text, i);
     }
-}
-
-fn isAllUpper(s: []const u8) bool {
-    if (s.len == 0) return false;
-    for (s) |ch| {
-        if (!std.ascii.isUpper(ch) and !std.ascii.isDigit(ch) and ch != '_') return false;
-    }
-    return true;
 }
 
 fn isKnownCommand(name: []const u8) bool {
@@ -373,11 +376,11 @@ fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
     if (start >= end) return;
     const tok = text[start..end];
     if (tok[0] == '$') {
-        c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-var".ptr);
+        c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_var.ptr);
         return;
     }
-    if (std.mem.startsWith(u8, tok, "http://") or std.mem.startsWith(u8, tok, "https://")) {
-        c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-url".ptr);
+    if (lp.URL.isCompleteHTTPUrl(tok)) {
+        c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_url.ptr);
         return;
     }
     if (std.ascii.isDigit(tok[0])) {
@@ -386,18 +389,16 @@ fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
             all_num = false;
             break;
         };
-        if (all_num) c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-num".ptr);
+        if (all_num) c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_num.ptr);
     }
 }
 
-// Backslash escapes are recognized just enough to skip `\'` inside a quoted string.
+// Note: Does not handle backslash escapes (matches SlashCommand.zig parser).
 fn scanQuoted(text: []const u8, start: usize) usize {
     if (start >= text.len) return start;
     const quote = text[start];
     var i = start + 1;
-    while (i < text.len and text[i] != quote) : (i += 1) {
-        if (text[i] == '\\' and i + 1 < text.len) i += 1;
-    }
+    while (i < text.len and text[i] != quote) : (i += 1) {}
     return if (i < text.len) i + 1 else i;
 }
 
@@ -410,7 +411,7 @@ fn highlightPandaArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
         if (text[i] == '\'' or text[i] == '"') {
             const tok_start = i;
             i = scanQuoted(text, i);
-            c.ic_highlight(henv, @intCast(tok_start), @intCast(i - tok_start), "ps-string".ptr);
+            c.ic_highlight(henv, @intCast(tok_start), @intCast(i - tok_start), style_string.ptr);
             continue;
         }
         const tok_start = i;
@@ -429,12 +430,12 @@ fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
         while (i < text.len and !std.ascii.isWhitespace(text[i]) and text[i] != '=') i += 1;
         const key_end = i;
         if (i < text.len and text[i] == '=') {
-            c.ic_highlight(henv, @intCast(tok_start), @intCast(key_end - tok_start), "ps-key".ptr);
+            c.ic_highlight(henv, @intCast(tok_start), @intCast(key_end - tok_start), style_key.ptr);
             i += 1;
             const val_start = i;
             if (i < text.len and (text[i] == '\'' or text[i] == '"')) {
                 i = scanQuoted(text, i);
-                c.ic_highlight(henv, @intCast(val_start), @intCast(i - val_start), "ps-string".ptr);
+                c.ic_highlight(henv, @intCast(val_start), @intCast(i - val_start), style_string.ptr);
             } else {
                 while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
                 highlightBareToken(henv, text, val_start, i);

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const browser_tools = lp.tools;
 const Config = lp.Config;
+const Command = @import("Command.zig");
 const SlashCommand = @import("SlashCommand.zig");
 const Spinner = @import("Spinner.zig");
 const c = @cImport({
@@ -39,25 +40,6 @@ spinner: Spinner,
 /// `setSlashSchemas` is called.
 slash_schemas: []const SlashCommand.SchemaInfo = &.{},
 
-const CommandInfo = struct { name: [:0]const u8 };
-
-const commands = [_]CommandInfo{
-    .{ .name = "GOTO" },
-    .{ .name = "CLICK" },
-    .{ .name = "TYPE" },
-    .{ .name = "WAIT" },
-    .{ .name = "SCROLL" },
-    .{ .name = "HOVER" },
-    .{ .name = "SELECT" },
-    .{ .name = "CHECK" },
-    .{ .name = "TREE" },
-    .{ .name = "MARKDOWN" },
-    .{ .name = "EXTRACT" },
-    .{ .name = "EVAL" },
-    .{ .name = "LOGIN" },
-    .{ .name = "ACCEPT_COOKIES" },
-};
-
 // Meta slash commands handled directly by the agent (not by ToolExecutor).
 // Kept in sync with `handleSlash` in `Agent.zig`. Only the names matter for
 // completion; arg hints are not surfaced separately (the menu is enough).
@@ -83,7 +65,7 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     _ = c.ic_enable_multiline(true);
     _ = c.ic_enable_hint(true);
     _ = c.ic_enable_inline_help(true);
-    // Match linenoise's instant ghost behavior; default is 400 ms.
+    // Show ghost completions instantly; isocline's default is 400 ms.
     _ = c.ic_set_hint_delay(0);
     _ = c.ic_enable_brace_insertion(true);
     // `ps-*` namespace avoids colliding with isocline's built-in `ic-*` styles.
@@ -119,8 +101,6 @@ pub fn deinit(self: *Self) void {
     if (self.repl_arena) |*a| a.deinit();
 }
 
-// Shared between the spinner-emit path (writes to an arena buffer) and the
-// non-spinner TTY path (writes to stderr via std.debug.print).
 const bullet_line_fmt = "{s}●{s} {s}[tool: {s}]{s} {s}\n";
 
 /// Called after the tool returns.
@@ -326,9 +306,9 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
     } else if (!has_space) {
         // Case-insensitive here so Tab also rewrites mistyped lowercase
         // (`goto` → `GOTO`); the highlighter stays case-sensitive.
-        for (commands) |cmd| {
-            if (std.ascii.startsWithIgnoreCase(cmd.name, input)) {
-                const text = std.fmt.bufPrintZ(&buf, "{s}", .{cmd.name}) catch continue;
+        for (Command.keywords) |kw| {
+            if (std.ascii.startsWithIgnoreCase(kw.name, input)) {
+                const text = std.fmt.bufPrintZ(&buf, "{s}", .{kw.name}) catch continue;
                 _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
             }
         }
@@ -368,16 +348,16 @@ fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*a
 }
 
 fn isAllUpper(s: []const u8) bool {
-    for (s) |ch| switch (ch) {
-        'A'...'Z', '_', '0'...'9' => {},
-        else => return false,
-    };
-    return s.len > 0;
+    if (s.len == 0) return false;
+    for (s) |ch| {
+        if (!std.ascii.isUpper(ch) and !std.ascii.isDigit(ch) and ch != '_') return false;
+    }
+    return true;
 }
 
 fn isKnownCommand(name: []const u8) bool {
-    for (commands) |cmd| {
-        if (std.mem.eql(u8, cmd.name, name)) return true;
+    for (Command.keywords) |kw| {
+        if (std.mem.eql(u8, kw.name, name)) return true;
     }
     return false;
 }

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -47,10 +47,7 @@ verbosity: Verbosity,
 repl_arena: ?std.heap.ArenaAllocator,
 stderr_is_tty: bool,
 spinner: Spinner,
-/// Schemas the completer uses to render `/slash` arg hints. Empty until
-/// `setSlashSchemas` is called.
 slash_schemas: []const SlashCommand.SchemaInfo = &.{},
-/// Cached LP_* environment variable names for completion.
 env_names: ?[]const []const u8 = null,
 
 // Flat name list for the "match any slash command" search/completion paths.
@@ -61,13 +58,12 @@ const all_slash_names: [browser_tools.tool_defs.len + SlashCommand.meta_names.le
     break :blk names;
 };
 
-/// Registers isocline's completer with `self` as user-data, so the C
-/// callback can reach `slash_schemas` via `ic_completion_arg`. Must run
-/// after the Terminal is in its final memory location.
-pub fn setSlashSchemas(self: *Self, schemas: []const SlashCommand.SchemaInfo) void {
+/// Wires the isocline completer to `self` so the C callback can reach
+/// `slash_schemas` via `ic_completion_arg`. Must run after the Terminal is
+/// in its final memory location.
+pub fn attachCompleter(self: *Self, schemas: []const SlashCommand.SchemaInfo) void {
     self.slash_schemas = schemas;
     c.ic_set_default_completer(&completionCallback, self);
-    c.ic_set_default_highlighter(&highlighterCallback, null);
 }
 
 pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity: Verbosity, is_repl: bool) Self {
@@ -86,6 +82,7 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     c.ic_style_def(style_key, "ansi-cyan");
     c.ic_style_def(style_num, "ansi-yellow");
     c.ic_style_def(style_err, "ansi-red");
+    c.ic_set_default_highlighter(&highlighterCallback, null);
     _ = c.ic_enable_highlight(true);
     if (history_path) |path| {
         c.ic_set_history(path.ptr, -1); // -1 → 200-entry default cap
@@ -273,16 +270,14 @@ fn addEnvVarCompletions(
     }
 
     if (self.env_names == null) {
-        self.env_names = browser_tools.lpEnvNames(self.allocator) catch null;
+        // On OOM, cache an empty slice so we don't retry every keystroke.
+        self.env_names = browser_tools.lpEnvNames(self.allocator) catch &.{};
     }
-    const names = self.env_names orelse return;
+    const names = self.env_names.?;
+    if (names.len == 0) return;
 
     const head = input[0 .. dollar + 1];
-    for (names) |name| {
-        if (!std.ascii.startsWithIgnoreCase(name, partial)) continue;
-        const text = std.fmt.bufPrintZ(buf, "{s}{s}", .{ head, name }) catch continue;
-        _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
-    }
+    for (names) |name| addPrefixedCompletion(cenv, buf, input, head, name, "", partial);
 }
 
 fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callconv(.c) void {
@@ -315,28 +310,26 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
             return;
         }
     } else if (!has_space) {
-        // Case-insensitive here so Tab also rewrites mistyped lowercase
-        // (`goto` → `GOTO`); the highlighter stays case-sensitive.
-        for (Command.keywords) |kw| {
-            if (std.ascii.startsWithIgnoreCase(kw.name, input)) {
-                const text = std.fmt.bufPrintZ(&buf, "{s}", .{kw.name}) catch continue;
-                _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
-            }
-        }
+        // Case-insensitive so Tab rewrites mistyped lowercase (`goto` → `GOTO`);
+        // the highlighter stays case-sensitive.
+        for (Command.keywords) |kw| addPrefixedCompletion(cenv, &buf, input, "", kw.name, "", input);
     }
 
     self.addEnvVarCompletions(cenv, &buf, input);
+}
+
+// Advances `i` past whitespace; returns true if more text remains.
+fn skipWs(text: []const u8, i: *usize) bool {
+    while (i.* < text.len and std.ascii.isWhitespace(text[i.*])) i.* += 1;
+    return i.* < text.len;
 }
 
 // Byte offsets to ic_highlight are not UTF-8 code points; safe because we
 // only tokenize on ASCII boundaries (whitespace, quotes, `=`, `$`).
 fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*anyopaque) callconv(.c) void {
     const text = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(input)), 0);
-    if (text.len == 0) return;
-
     var i: usize = 0;
-    while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
-    if (i >= text.len) return;
+    if (!skipWs(text, &i)) return;
 
     const cmd_start = i;
     while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
@@ -383,31 +376,22 @@ fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
         c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_url.ptr);
         return;
     }
-    if (std.ascii.isDigit(tok[0])) {
-        var all_num = true;
-        for (tok) |ch| if (!std.ascii.isDigit(ch) and ch != '.') {
-            all_num = false;
-            break;
-        };
-        if (all_num) c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_num.ptr);
-    }
+    if (std.fmt.parseFloat(f64, tok)) |_| {
+        c.ic_highlight(henv, @intCast(start), @intCast(end - start), style_num.ptr);
+    } else |_| {}
 }
 
-// Note: Does not handle backslash escapes (matches SlashCommand.zig parser).
+// Returns the index just past the matching closing quote, or `text.len` if
+// unterminated. Does not handle backslash escapes (matches SlashCommand.zig parser).
 fn scanQuoted(text: []const u8, start: usize) usize {
     if (start >= text.len) return start;
-    const quote = text[start];
-    var i = start + 1;
-    while (i < text.len and text[i] != quote) : (i += 1) {}
-    return if (i < text.len) i + 1 else i;
+    const close = std.mem.indexOfScalarPos(u8, text, start + 1, text[start]) orelse return text.len;
+    return close + 1;
 }
 
 fn highlightPandaArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize) void {
     var i = start;
-    while (i < text.len) {
-        while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
-        if (i >= text.len) break;
-
+    while (skipWs(text, &i)) {
         if (text[i] == '\'' or text[i] == '"') {
             const tok_start = i;
             i = scanQuoted(text, i);
@@ -422,10 +406,7 @@ fn highlightPandaArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
 
 fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize) void {
     var i = start;
-    while (i < text.len) {
-        while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
-        if (i >= text.len) break;
-
+    while (skipWs(text, &i)) {
         const tok_start = i;
         while (i < text.len and !std.ascii.isWhitespace(text[i]) and text[i] != '=') i += 1;
         const key_end = i;
@@ -444,13 +425,13 @@ fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
     }
 }
 
-pub fn readLine(_: *Self, prompt: [*:0]const u8) ?[]const u8 {
+pub fn readLine(prompt: [*:0]const u8) ?[]const u8 {
     // Isocline auto-appends the line to its (optionally-persisted) history.
     const line = c.ic_readline(prompt) orelse return null;
     return std.mem.sliceTo(line, 0);
 }
 
-pub fn freeLine(_: *Self, line: []const u8) void {
+pub fn freeLine(line: []const u8) void {
     c.ic_free(@ptrCast(@constCast(line.ptr)));
 }
 

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -95,6 +95,20 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     // to ic_readline renders verbatim; the agent already supplies its own
     // `> ` prefix.
     c.ic_set_prompt_marker("", "");
+    // PandaScript syntax highlighting. Names are namespaced `ps-*` so users
+    // (or a future theme system) can override via `ic_style_def` without
+    // colliding with isocline's built-in `ic-*` styles. Bold/underline are
+    // intentionally restrained — the prompt is meant to read, not glow.
+    c.ic_style_def("ps-cmd", "ansi-cyan bold");
+    c.ic_style_def("ps-slash", "ansi-magenta bold");
+    c.ic_style_def("ps-string", "ansi-green");
+    c.ic_style_def("ps-var", "ansi-yellow bold");
+    c.ic_style_def("ps-url", "ansi-blue underline");
+    c.ic_style_def("ps-key", "ansi-cyan");
+    c.ic_style_def("ps-num", "ansi-yellow");
+    c.ic_style_def("ps-err", "ansi-red");
+    _ = c.ic_enable_highlight(true);
+    c.ic_set_default_highlighter(&highlighterCallback, null);
     if (history_path) |path| {
         // -1 → default cap (200 entries). Passing a filename makes isocline
         // load existing entries and auto-persist additions.
@@ -276,6 +290,37 @@ fn addPartialKeyCompletions(
     }
 }
 
+// Offers `$LP_*` completions when the user is mid-typing a `$VAR` token.
+// Triggers wherever a `$` appears with only name characters following it, so
+// it works in PandaScript args (`TYPE '#u' $LP_`), slash values
+// (`/click value=$L`), and bare prefixes (`$L`). Names come from the same
+// source as the `getEnv` tool — `std.os.environ` filtered to LP_*.
+fn addEnvVarCompletions(
+    cenv: ?*c.ic_completion_env_t,
+    buf: *[completion_buf_len:0]u8,
+    input: []const u8,
+) void {
+    const dollar = std.mem.lastIndexOfScalar(u8, input, '$') orelse return;
+    const partial = input[dollar + 1 ..];
+    for (partial) |ch| {
+        if (!std.ascii.isAlphanumeric(ch) and ch != '_') return;
+    }
+
+    // Stack-only scratch for the env-name list. 16 KiB holds ~1000 names'
+    // worth of pointer metadata (names themselves point into std.os.environ
+    // and aren't copied) — far more than any realistic environment.
+    var stack: [16 * 1024]u8 = undefined;
+    var fba: std.heap.FixedBufferAllocator = .init(&stack);
+    const names = browser_tools.lpEnvNames(fba.allocator()) catch return;
+
+    const head = input[0 .. dollar + 1];
+    for (names) |name| {
+        if (!std.ascii.startsWithIgnoreCase(name, partial)) continue;
+        const text = std.fmt.bufPrintZ(buf, "{s}{s}", .{ head, name }) catch continue;
+        _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
+    }
+}
+
 fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callconv(.c) void {
     const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(prefix)), 0);
     const self_ptr = c.ic_completion_arg(cenv) orelse return;
@@ -285,6 +330,8 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
     // copies the string internally so reuse across candidates is fine.
     var buf: [completion_buf_len:0]u8 = undefined;
 
+    // `/help <name>` — the arg is itself a tool name, not a value, so env-var
+    // completion would be confusing here. Short-circuit.
     if (parseHelpArgPrefix(input)) |partial| {
         for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, help_arg_prefix, name, "", partial);
         return;
@@ -300,19 +347,165 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
                     addPartialKeyCompletions(cenv, input, parts.rest, schema, &buf);
                 }
             }
+            // Fall through so `value=$LP_` etc. picks up env completions.
+        } else {
+            const partial = input[1..];
+            for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, "/", name, "", partial);
             return;
         }
-        const partial = input[1..];
-        for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, "/", name, "", partial);
-        return;
+    } else if (!has_space) {
+        // Case-insensitive on the completion side so Tab also rewrites
+        // mistyped lowercase (`goto` → `GOTO`). The highlighter stays
+        // case-sensitive, so a lowercase-typed line reads as natural
+        // language until the user accepts the completion.
+        for (commands) |cmd| {
+            if (std.ascii.startsWithIgnoreCase(cmd.name, input)) {
+                const text = std.fmt.bufPrintZ(&buf, "{s}", .{cmd.name}) catch continue;
+                _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
+            }
+        }
     }
 
-    if (has_space) return;
+    addEnvVarCompletions(cenv, &buf, input);
+}
+
+// PandaScript syntax highlighter. Invoked by isocline on every input change;
+// keep it cheap. The `pos` and `count` passed to `ic_highlight` are byte
+// offsets/lengths into `input`, not UTF-8 code points — fine here because we
+// only tokenize on ASCII boundaries (whitespace, quotes, `=`, `$`).
+fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*anyopaque) callconv(.c) void {
+    const text = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(input)), 0);
+    if (text.len == 0) return;
+
+    var i: usize = 0;
+    while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
+    if (i >= text.len) return;
+
+    // First word: either `/slash` form or a bare PandaScript command name.
+    // Unknown leading tokens get highlighted as errors so typos are visible
+    // before the user hits Enter.
+    const cmd_start = i;
+    while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
+    const cmd = text[cmd_start..i];
+    if (cmd.len > 0 and cmd[0] == '/') {
+        const name = cmd[1..];
+        const style = if (isKnownSlashName(name)) "ps-slash" else "ps-err";
+        c.ic_highlight(henv, @intCast(cmd_start), @intCast(cmd.len), style.ptr);
+        highlightSlashArgs(henv, text, i);
+    } else {
+        // PandaScript commands are ALL CAPS. Known → keyword color. ALL CAPS
+        // but unknown → red (likely typo). Anything else → no highlight,
+        // it's a natural-language query for the LLM.
+        const style: ?[*:0]const u8 = if (isKnownCommand(cmd))
+            "ps-cmd"
+        else if (isAllUpper(cmd))
+            "ps-err"
+        else
+            null;
+        if (style) |s| c.ic_highlight(henv, @intCast(cmd_start), @intCast(cmd.len), s);
+        highlightPandaArgs(henv, text, i);
+    }
+}
+
+fn isAllUpper(s: []const u8) bool {
+    for (s) |ch| switch (ch) {
+        'A'...'Z', '_', '0'...'9' => {},
+        else => return false,
+    };
+    return s.len > 0;
+}
+
+fn isKnownCommand(name: []const u8) bool {
     for (commands) |cmd| {
-        if (std.ascii.startsWithIgnoreCase(cmd.name, input)) {
-            const text = std.fmt.bufPrintZ(&buf, "{s}", .{cmd.name}) catch continue;
-            _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
+        if (std.mem.eql(u8, cmd.name, name)) return true;
+    }
+    return false;
+}
+
+fn isKnownSlashName(name: []const u8) bool {
+    for (all_slash_names) |n| {
+        if (std.ascii.eqlIgnoreCase(n, name)) return true;
+    }
+    return false;
+}
+
+// Color a non-quoted token based on its leading character: `$` → variable,
+// `http(s)://` → URL, digits → number. Anything else falls through with no
+// highlight (lets the terminal's default foreground show through).
+fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize, end: usize) void {
+    if (start >= end) return;
+    const tok = text[start..end];
+    if (tok[0] == '$') {
+        c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-var".ptr);
+        return;
+    }
+    if (std.mem.startsWith(u8, tok, "http://") or std.mem.startsWith(u8, tok, "https://")) {
+        c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-url".ptr);
+        return;
+    }
+    if (std.ascii.isDigit(tok[0])) {
+        var all_num = true;
+        for (tok) |ch| if (!std.ascii.isDigit(ch) and ch != '.') {
+            all_num = false;
+            break;
+        };
+        if (all_num) c.ic_highlight(henv, @intCast(start), @intCast(end - start), "ps-num".ptr);
+    }
+}
+
+// Consume a quoted token (single or double) at `start`, returning the index
+// just past the closing quote. Handles backslash escapes minimally — enough
+// not to confuse `\'` inside a single-quoted string.
+fn scanQuoted(text: []const u8, start: usize) usize {
+    if (start >= text.len) return start;
+    const quote = text[start];
+    var i = start + 1;
+    while (i < text.len and text[i] != quote) : (i += 1) {
+        if (text[i] == '\\' and i + 1 < text.len) i += 1;
+    }
+    return if (i < text.len) i + 1 else i;
+}
+
+fn highlightPandaArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize) void {
+    var i = start;
+    while (i < text.len) {
+        while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
+        if (i >= text.len) break;
+
+        if (text[i] == '\'' or text[i] == '"') {
+            const tok_start = i;
+            i = scanQuoted(text, i);
+            c.ic_highlight(henv, @intCast(tok_start), @intCast(i - tok_start), "ps-string".ptr);
+            continue;
         }
+        const tok_start = i;
+        while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
+        highlightBareToken(henv, text, tok_start, i);
+    }
+}
+
+fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize) void {
+    var i = start;
+    while (i < text.len) {
+        while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
+        if (i >= text.len) break;
+
+        const tok_start = i;
+        while (i < text.len and !std.ascii.isWhitespace(text[i]) and text[i] != '=') i += 1;
+        const key_end = i;
+        if (i < text.len and text[i] == '=') {
+            c.ic_highlight(henv, @intCast(tok_start), @intCast(key_end - tok_start), "ps-key".ptr);
+            i += 1; // consume '='
+            const val_start = i;
+            if (i < text.len and (text[i] == '\'' or text[i] == '"')) {
+                i = scanQuoted(text, i);
+                c.ic_highlight(henv, @intCast(val_start), @intCast(i - val_start), "ps-string".ptr);
+            } else {
+                while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
+                highlightBareToken(henv, text, val_start, i);
+            }
+        }
+        // bare positional (no `=`) — leave unstyled.
     }
 }
 

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -5,7 +5,7 @@ const Config = lp.Config;
 const SlashCommand = @import("SlashCommand.zig");
 const Spinner = @import("Spinner.zig");
 const c = @cImport({
-    @cInclude("linenoise.h");
+    @cInclude("isocline.h");
 });
 
 const Self = @This();
@@ -35,62 +35,70 @@ verbosity: Verbosity,
 repl_arena: ?std.heap.ArenaAllocator,
 stderr_is_tty: bool,
 spinner: Spinner,
+/// Schemas the completer uses to render `/slash` arg hints. Empty until
+/// `setSlashSchemas` is called.
+slash_schemas: []const SlashCommand.SchemaInfo = &.{},
 
-const CommandInfo = struct { name: [:0]const u8, hint: [:0]const u8 };
+const CommandInfo = struct { name: [:0]const u8 };
 
 const commands = [_]CommandInfo{
-    .{ .name = "GOTO", .hint = " <url>" },
-    .{ .name = "CLICK", .hint = " '<selector>'" },
-    .{ .name = "TYPE", .hint = " '<selector>' '<value>'" },
-    .{ .name = "WAIT", .hint = " '<selector>'" },
-    .{ .name = "SCROLL", .hint = " [x] [y]" },
-    .{ .name = "HOVER", .hint = " '<selector>'" },
-    .{ .name = "SELECT", .hint = " '<selector>' '<value>'" },
-    .{ .name = "CHECK", .hint = " '<selector>' [true|false]" },
-    .{ .name = "TREE", .hint = "" },
-    .{ .name = "MARKDOWN", .hint = "" },
-    .{ .name = "EXTRACT", .hint = " '<selector>'" },
-    .{ .name = "EVAL", .hint = " '<script>'" },
-    .{ .name = "LOGIN", .hint = "" },
-    .{ .name = "ACCEPT_COOKIES", .hint = "" },
+    .{ .name = "GOTO" },
+    .{ .name = "CLICK" },
+    .{ .name = "TYPE" },
+    .{ .name = "WAIT" },
+    .{ .name = "SCROLL" },
+    .{ .name = "HOVER" },
+    .{ .name = "SELECT" },
+    .{ .name = "CHECK" },
+    .{ .name = "TREE" },
+    .{ .name = "MARKDOWN" },
+    .{ .name = "EXTRACT" },
+    .{ .name = "EVAL" },
+    .{ .name = "LOGIN" },
+    .{ .name = "ACCEPT_COOKIES" },
 };
 
 // Meta slash commands handled directly by the agent (not by ToolExecutor).
-// Kept in sync with `handleSlash` in `Agent.zig`. Meta args are positional
-// (no `key=value`), so the slot strings are pre-bracketed and can't reuse
-// `SchemaInfo.hints` which renders `[name=…]`.
-const MetaCommand = struct {
-    name: [:0]const u8,
-    hint_slots: []const []const u8,
-};
-
-const meta_slash_commands = [_]MetaCommand{
-    .{ .name = "help", .hint_slots = &.{"[tool_name]"} },
-    .{ .name = "quit", .hint_slots = &.{} },
-};
+// Kept in sync with `handleSlash` in `Agent.zig`. Only the names matter for
+// completion; arg hints are not surfaced separately (the menu is enough).
+const meta_slash_commands = [_][:0]const u8{ "help", "quit" };
 
 // Flat name list for the "match any slash command" search/completion paths.
 const all_slash_names: [browser_tools.tool_defs.len + meta_slash_commands.len][]const u8 = blk: {
     var names: [browser_tools.tool_defs.len + meta_slash_commands.len][]const u8 = undefined;
     for (browser_tools.tool_defs, 0..) |td, i| names[i] = td.name;
-    for (meta_slash_commands, 0..) |m, i| names[browser_tools.tool_defs.len + i] = m.name;
+    for (meta_slash_commands, 0..) |m, i| names[browser_tools.tool_defs.len + i] = m;
     break :blk names;
 };
 
-// File-scope because the linenoise hint callback is a C function pointer with
-// no user-data slot. Empty in non-REPL paths, which is harmless.
-var slash_schemas: []const SlashCommand.SchemaInfo = &.{};
-
-pub fn setSlashSchemas(schemas: []const SlashCommand.SchemaInfo) void {
-    slash_schemas = schemas;
+/// Stores the schemas on the Terminal and (re-)registers isocline's
+/// completer with `self` as user-data so the callback can reach them via
+/// `ic_completion_arg`. Called from Agent.zig after the Terminal is in its
+/// final memory location.
+pub fn setSlashSchemas(self: *Self, schemas: []const SlashCommand.SchemaInfo) void {
+    self.slash_schemas = schemas;
+    c.ic_set_default_completer(&completionCallback, self);
 }
 
 pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity: Verbosity, is_repl: bool) Self {
-    c.linenoiseSetMultiLine(1);
-    c.linenoiseSetCompletionCallback(&completionCallback);
-    c.linenoiseSetHintsCallback(&hintsCallback);
+    _ = c.ic_enable_multiline(true);
+    _ = c.ic_enable_hint(true);
+    _ = c.ic_enable_inline_help(true);
+    // Default is 400ms; match linenoise's instant ghost-suffix behavior so
+    // users see the inline preview as they type without a noticeable pause.
+    _ = c.ic_set_hint_delay(0);
+    // Disable automatic brace/quote insertion — selectors quoted with ' or "
+    // are common in PandaScript and auto-inserting closers gets in the user's
+    // way more than it helps.
+    _ = c.ic_enable_brace_insertion(false);
+    // Clear isocline's default `> ` prompt marker so the prompt text we pass
+    // to ic_readline renders verbatim; the agent already supplies its own
+    // `> ` prefix.
+    c.ic_set_prompt_marker("", "");
     if (history_path) |path| {
-        _ = c.linenoiseHistoryLoad(path.ptr);
+        // -1 → default cap (200 entries). Passing a filename makes isocline
+        // load existing entries and auto-persist additions.
+        c.ic_set_history(path.ptr, -1);
     }
     const stderr_is_tty = std.posix.isatty(std.posix.STDERR_FILENO);
     return .{
@@ -154,35 +162,25 @@ fn formatBulletLine(arena: std.mem.Allocator, name: []const u8, args: []const u8
     return aw.written();
 }
 
-const completion_buf_len = 256;
+// Bound on the largest single completion text we synthesize. The longest
+// real case is a multi-slot schema hint glued onto a 64-char input.
+const completion_buf_len = 512;
 
+// Synthesizes a completion that, when accepted, replaces the user's entire
+// current input (`input`) with `prefix ++ name ++ suffix`. The inline hint
+// shown before Tab is just the trailing portion past `input.len`.
 fn addPrefixedCompletion(
-    lc: [*c]c.linenoiseCompletions,
-    name_buf: *[completion_buf_len:0]u8,
+    cenv: ?*c.ic_completion_env_t,
+    buf: *[completion_buf_len:0]u8,
+    input: []const u8,
     prefix: []const u8,
     name: []const u8,
     suffix: []const u8,
     partial: []const u8,
 ) void {
     if (!std.ascii.startsWithIgnoreCase(name, partial)) return;
-    _ = std.fmt.bufPrintZ(name_buf, "{s}{s}{s}", .{ prefix, name, suffix }) catch return;
-    c.linenoiseAddCompletion(lc, name_buf);
-}
-
-fn slashHint(name: []const u8, partial: []const u8) ?[]const u8 {
-    if (name.len <= partial.len) return null;
-    if (!std.ascii.startsWithIgnoreCase(name, partial)) return null;
-    return name[partial.len..];
-}
-
-fn renderNameSuffixHint(partial: []const u8) [*c]u8 {
-    for (all_slash_names) |name| {
-        if (slashHint(name, partial)) |s| {
-            _ = std.fmt.bufPrintZ(&hint_buf, "{s}", .{s}) catch return null;
-            return @ptrCast(&hint_buf);
-        }
-    }
-    return null;
+    const text = std.fmt.bufPrintZ(buf, "{s}{s}{s}", .{ prefix, name, suffix }) catch return;
+    _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
 }
 
 fn parseSlashCommand(input: []const u8) ?SlashCommand.Split {
@@ -190,23 +188,6 @@ fn parseSlashCommand(input: []const u8) ?SlashCommand.Split {
     // accept "foo" as the name after trimming.
     if (input.len < 2 or input[0] != '/' or std.ascii.isWhitespace(input[1])) return null;
     return SlashCommand.splitNameRest(input[1..]);
-}
-
-fn findMetaSlots(name: []const u8) ?[]const []const u8 {
-    for (meta_slash_commands) |meta| {
-        if (std.ascii.eqlIgnoreCase(meta.name, name)) return meta.hint_slots;
-    }
-    return null;
-}
-
-// Appends `lead + formatted` to `hint_buf` at `pos`, advancing `pos`. Lead is
-// a single space except on the very first slot when the user's input already
-// ends in whitespace. Returns false if the buffer is full.
-fn appendHint(pos: *usize, ends_ws: bool, comptime fmt: []const u8, args: anytype) bool {
-    const lead: []const u8 = if (pos.* > 0 or !ends_ws) " " else "";
-    const written = std.fmt.bufPrint(hint_buf[pos.*..], "{s}" ++ fmt, .{lead} ++ args) catch return false;
-    pos.* += written.len;
-    return true;
 }
 
 // Cap on tokens we read out of the body. Real schemas and CLI inputs have far
@@ -263,58 +244,6 @@ fn analyzeBody(schema: *const SlashCommand.SchemaInfo, body: []const u8, ends_ws
     return a;
 }
 
-// Two modes:
-//   1. Trailing in-progress key prefix → render the matching field's name
-//      suffix + "=…" (e.g. `/click sel` → `ector=…`).
-//   2. Otherwise → render `<required>` and `[optional=…]` for each unused field.
-fn renderSchemaArgHint(
-    schema: *const SlashCommand.SchemaInfo,
-    body: []const u8,
-    ends_ws: bool,
-) ?[*c]u8 {
-    const a = analyzeBody(schema, body, ends_ws);
-
-    if (a.partial_key) |pk| {
-        for (schema.hints) |slot| {
-            if (a.isUsed(slot.name)) continue;
-            if (!std.ascii.startsWithIgnoreCase(slot.name, pk)) continue;
-            _ = std.fmt.bufPrintZ(&hint_buf, "{s}=…", .{slot.name[pk.len..]}) catch return null;
-            return @ptrCast(&hint_buf);
-        }
-    }
-
-    var pos: usize = 0;
-    for (schema.hints) |slot| {
-        if (a.isUsed(slot.name)) continue;
-        const ok = if (slot.required)
-            appendHint(&pos, ends_ws, "<{s}>", .{slot.name})
-        else
-            appendHint(&pos, ends_ws, "[{s}=…]", .{slot.name});
-        if (!ok) return null;
-    }
-
-    if (pos == 0) return null;
-    hint_buf[pos] = 0;
-    return @ptrCast(&hint_buf);
-}
-
-// Meta-command variant: positional slots, no `key=` form. Slot strings come
-// pre-bracketed (e.g. "[tool_name]") and are written verbatim.
-fn renderMetaArgHint(slots: []const []const u8, body: []const u8, ends_ws: bool) ?[*c]u8 {
-    var committed: usize = 0;
-    var it = std.mem.tokenizeAny(u8, body, &std.ascii.whitespace);
-    while (it.next()) |_| committed += 1;
-    if (committed >= slots.len) return null;
-
-    var pos: usize = 0;
-    for (slots[committed..]) |slot| {
-        if (!appendHint(&pos, ends_ws, "{s}", .{slot})) return null;
-    }
-    if (pos == 0) return null;
-    hint_buf[pos] = 0;
-    return @ptrCast(&hint_buf);
-}
-
 const help_arg_prefix = "/help ";
 
 // Returns the trailing argument when `input` is `/help <arg>` with no
@@ -327,11 +256,11 @@ fn parseHelpArgPrefix(input: []const u8) ?[]const u8 {
 }
 
 fn addPartialKeyCompletions(
+    cenv: ?*c.ic_completion_env_t,
     input: []const u8,
     body: []const u8,
     schema: *const SlashCommand.SchemaInfo,
-    lc: [*c]c.linenoiseCompletions,
-    name_buf: *[completion_buf_len:0]u8,
+    buf: *[completion_buf_len:0]u8,
 ) void {
     const ends_ws = input[input.len - 1] == ' ';
     const a = analyzeBody(schema, body, ends_ws);
@@ -343,25 +272,21 @@ fn addPartialKeyCompletions(
     const prefix = input[0 .. input.len - partial.len];
     for (schema.hints) |slot| {
         if (a.isUsed(slot.name)) continue;
-        addPrefixedCompletion(lc, name_buf, prefix, slot.name, "=", partial);
+        addPrefixedCompletion(cenv, buf, input, prefix, slot.name, "=", partial);
     }
 }
 
-fn completionCallback(buf: [*c]const u8, lc: [*c]c.linenoiseCompletions) callconv(.c) void {
-    const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(buf)), 0);
+fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callconv(.c) void {
+    const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(prefix)), 0);
+    const self_ptr = c.ic_completion_arg(cenv) orelse return;
+    const self: *Self = @ptrCast(@alignCast(self_ptr));
 
-    // linenoise strdup's the string, so a stack buffer reused per match is
-    // fine. 256 leaves room for partial-key completions where the prefix is
-    // the whole input minus the trailing partial token.
-    var name_buf: [completion_buf_len:0]u8 = undefined;
-
-    // If nothing matches, register the input itself so linenoise still enters
-    // completion mode. Otherwise it returns the Tab keypress to its edit loop,
-    // which inserts '\t' into the buffer and corrupts the line.
-    defer if (lc.*.len == 0) c.linenoiseAddCompletion(lc, buf);
+    // Per-call scratch buffer for synthesized completion strings. Isocline
+    // copies the string internally so reuse across candidates is fine.
+    var buf: [completion_buf_len:0]u8 = undefined;
 
     if (parseHelpArgPrefix(input)) |partial| {
-        for (all_slash_names) |name| addPrefixedCompletion(lc, &name_buf, help_arg_prefix, name, "", partial);
+        for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, help_arg_prefix, name, "", partial);
         return;
     }
 
@@ -371,86 +296,35 @@ fn completionCallback(buf: [*c]const u8, lc: [*c]c.linenoiseCompletions) callcon
     if (input[0] == '/') {
         if (has_space) {
             if (parseSlashCommand(input)) |parts| {
-                if (SlashCommand.findSchema(slash_schemas, parts.name)) |schema| {
-                    addPartialKeyCompletions(input, parts.rest, schema, lc, &name_buf);
+                if (SlashCommand.findSchema(self.slash_schemas, parts.name)) |schema| {
+                    addPartialKeyCompletions(cenv, input, parts.rest, schema, &buf);
                 }
             }
             return;
         }
         const partial = input[1..];
-        for (all_slash_names) |name| addPrefixedCompletion(lc, &name_buf, "/", name, "", partial);
+        for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, "/", name, "", partial);
         return;
     }
 
     if (has_space) return;
     for (commands) |cmd| {
         if (std.ascii.startsWithIgnoreCase(cmd.name, input)) {
-            c.linenoiseAddCompletion(lc, cmd.name.ptr);
+            const text = std.fmt.bufPrintZ(&buf, "{s}", .{cmd.name}) catch continue;
+            _ = c.ic_add_completion_prim(cenv, text.ptr, null, null, @intCast(input.len), 0);
         }
     }
 }
 
-// File-scope so the pointer survives the callback's stack frame; linenoise
-// reads the returned hint in refreshShowHints() *after* this function has
-// already returned, so a stack-local buffer would be UB. Sized for multi-slot
-// schema hints like `<sel> [timeout=…] [text=…] [waitFor=…]`.
-var hint_buf: [completion_buf_len:0]u8 = undefined;
-
-fn hintsCallback(buf: [*c]const u8, color: [*c]c_int, bold: [*c]c_int) callconv(.c) [*c]u8 {
-    const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(buf)), 0);
-    if (input.len == 0) return null;
-
-    color.* = 90;
-    bold.* = 0;
-
-    // /help <partial> — suggest a tool name (more useful than the slot hint
-    // because we can show concrete completions).
-    if (parseHelpArgPrefix(input)) |partial| {
-        return renderNameSuffixHint(partial);
-    }
-
-    if (parseSlashCommand(input)) |parts| {
-        const ends_ws = input[input.len - 1] == ' ';
-        if (SlashCommand.findSchema(slash_schemas, parts.name)) |schema| {
-            return renderSchemaArgHint(schema, parts.rest, ends_ws) orelse null;
-        }
-        if (findMetaSlots(parts.name)) |slots| {
-            return renderMetaArgHint(slots, parts.rest, ends_ws) orelse null;
-        }
-    }
-
-    if (std.mem.indexOfScalar(u8, input, ' ') != null) return null;
-
-    if (input[0] == '/') {
-        return renderNameSuffixHint(input[1..]);
-    }
-
-    for (commands) |cmd| {
-        if (std.ascii.eqlIgnoreCase(cmd.name, input)) {
-            if (cmd.hint.len == 0) return null;
-            return @ptrCast(@constCast(cmd.hint.ptr));
-        }
-        if (cmd.name.len > input.len and std.ascii.startsWithIgnoreCase(cmd.name, input)) {
-            return @ptrCast(@constCast(cmd.name.ptr + input.len));
-        }
-    }
-    return null;
-}
-
-pub fn readLine(self: *Self, prompt: [*:0]const u8) ?[]const u8 {
-    const line = c.linenoise(prompt) orelse return null;
-    const slice = std.mem.sliceTo(line, 0);
-    if (slice.len > 0) {
-        _ = c.linenoiseHistoryAdd(line);
-        if (self.history_path) |path| {
-            _ = c.linenoiseHistorySave(path.ptr);
-        }
-    }
-    return slice;
+pub fn readLine(_: *Self, prompt: [*:0]const u8) ?[]const u8 {
+    // Isocline auto-adds the returned line to history and auto-persists when
+    // a history file was set via `ic_set_history`.
+    const line = c.ic_readline(prompt) orelse return null;
+    return std.mem.sliceTo(line, 0);
 }
 
 pub fn freeLine(_: *Self, line: []const u8) void {
-    c.linenoiseFree(@ptrCast(@constCast(line.ptr)));
+    c.ic_free(@ptrCast(@constCast(line.ptr)));
 }
 
 pub fn printAssistant(_: *Self, text: []const u8) void {

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -71,10 +71,9 @@ const all_slash_names: [browser_tools.tool_defs.len + meta_slash_commands.len][]
     break :blk names;
 };
 
-/// Stores the schemas on the Terminal and (re-)registers isocline's
-/// completer with `self` as user-data so the callback can reach them via
-/// `ic_completion_arg`. Called from Agent.zig after the Terminal is in its
-/// final memory location.
+/// Registers isocline's completer with `self` as user-data, so the C
+/// callback can reach `slash_schemas` via `ic_completion_arg`. Must run
+/// after the Terminal is in its final memory location.
 pub fn setSlashSchemas(self: *Self, schemas: []const SlashCommand.SchemaInfo) void {
     self.slash_schemas = schemas;
     c.ic_set_default_completer(&completionCallback, self);
@@ -84,21 +83,10 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     _ = c.ic_enable_multiline(true);
     _ = c.ic_enable_hint(true);
     _ = c.ic_enable_inline_help(true);
-    // Default is 400ms; match linenoise's instant ghost-suffix behavior so
-    // users see the inline preview as they type without a noticeable pause.
+    // Match linenoise's instant ghost behavior; default is 400 ms.
     _ = c.ic_set_hint_delay(0);
-    // Disable automatic brace/quote insertion — selectors quoted with ' or "
-    // are common in PandaScript and auto-inserting closers gets in the user's
-    // way more than it helps.
-    _ = c.ic_enable_brace_insertion(false);
-    // Clear isocline's default `> ` prompt marker so the prompt text we pass
-    // to ic_readline renders verbatim; the agent already supplies its own
-    // `> ` prefix.
-    c.ic_set_prompt_marker("", "");
-    // PandaScript syntax highlighting. Names are namespaced `ps-*` so users
-    // (or a future theme system) can override via `ic_style_def` without
-    // colliding with isocline's built-in `ic-*` styles. Bold/underline are
-    // intentionally restrained — the prompt is meant to read, not glow.
+    _ = c.ic_enable_brace_insertion(true);
+    // `ps-*` namespace avoids colliding with isocline's built-in `ic-*` styles.
     c.ic_style_def("ps-cmd", "ansi-cyan bold");
     c.ic_style_def("ps-slash", "ansi-magenta bold");
     c.ic_style_def("ps-string", "ansi-green");
@@ -110,9 +98,7 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     _ = c.ic_enable_highlight(true);
     c.ic_set_default_highlighter(&highlighterCallback, null);
     if (history_path) |path| {
-        // -1 → default cap (200 entries). Passing a filename makes isocline
-        // load existing entries and auto-persist additions.
-        c.ic_set_history(path.ptr, -1);
+        c.ic_set_history(path.ptr, -1); // -1 → 200-entry default cap
     }
     const stderr_is_tty = std.posix.isatty(std.posix.STDERR_FILENO);
     return .{
@@ -176,13 +162,8 @@ fn formatBulletLine(arena: std.mem.Allocator, name: []const u8, args: []const u8
     return aw.written();
 }
 
-// Bound on the largest single completion text we synthesize. The longest
-// real case is a multi-slot schema hint glued onto a 64-char input.
 const completion_buf_len = 512;
 
-// Synthesizes a completion that, when accepted, replaces the user's entire
-// current input (`input`) with `prefix ++ name ++ suffix`. The inline hint
-// shown before Tab is just the trailing portion past `input.len`.
 fn addPrefixedCompletion(
     cenv: ?*c.ic_completion_env_t,
     buf: *[completion_buf_len:0]u8,
@@ -260,8 +241,6 @@ fn analyzeBody(schema: *const SlashCommand.SchemaInfo, body: []const u8, ends_ws
 
 const help_arg_prefix = "/help ";
 
-// Returns the trailing argument when `input` is `/help <arg>` with no
-// further whitespace; null otherwise (e.g. `/help foo bar`).
 fn parseHelpArgPrefix(input: []const u8) ?[]const u8 {
     if (!std.ascii.startsWithIgnoreCase(input, help_arg_prefix)) return null;
     const arg = std.mem.trimLeft(u8, input[help_arg_prefix.len..], " ");
@@ -290,11 +269,7 @@ fn addPartialKeyCompletions(
     }
 }
 
-// Offers `$LP_*` completions when the user is mid-typing a `$VAR` token.
-// Triggers wherever a `$` appears with only name characters following it, so
-// it works in PandaScript args (`TYPE '#u' $LP_`), slash values
-// (`/click value=$L`), and bare prefixes (`$L`). Names come from the same
-// source as the `getEnv` tool — `std.os.environ` filtered to LP_*.
+// Completes `$LP_*` against the live process environment.
 fn addEnvVarCompletions(
     cenv: ?*c.ic_completion_env_t,
     buf: *[completion_buf_len:0]u8,
@@ -306,9 +281,7 @@ fn addEnvVarCompletions(
         if (!std.ascii.isAlphanumeric(ch) and ch != '_') return;
     }
 
-    // Stack-only scratch for the env-name list. 16 KiB holds ~1000 names'
-    // worth of pointer metadata (names themselves point into std.os.environ
-    // and aren't copied) — far more than any realistic environment.
+    // Names are slices into std.os.environ; only pointer metadata is allocated.
     var stack: [16 * 1024]u8 = undefined;
     var fba: std.heap.FixedBufferAllocator = .init(&stack);
     const names = browser_tools.lpEnvNames(fba.allocator()) catch return;
@@ -326,12 +299,9 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
     const self_ptr = c.ic_completion_arg(cenv) orelse return;
     const self: *Self = @ptrCast(@alignCast(self_ptr));
 
-    // Per-call scratch buffer for synthesized completion strings. Isocline
-    // copies the string internally so reuse across candidates is fine.
     var buf: [completion_buf_len:0]u8 = undefined;
 
-    // `/help <name>` — the arg is itself a tool name, not a value, so env-var
-    // completion would be confusing here. Short-circuit.
+    // `/help <name>`: arg is a tool name, not a value — skip env-var fallthrough.
     if (parseHelpArgPrefix(input)) |partial| {
         for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, help_arg_prefix, name, "", partial);
         return;
@@ -347,17 +317,15 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
                     addPartialKeyCompletions(cenv, input, parts.rest, schema, &buf);
                 }
             }
-            // Fall through so `value=$LP_` etc. picks up env completions.
+            // Fall through so `value=$LP_` picks up env completions.
         } else {
             const partial = input[1..];
             for (all_slash_names) |name| addPrefixedCompletion(cenv, &buf, input, "/", name, "", partial);
             return;
         }
     } else if (!has_space) {
-        // Case-insensitive on the completion side so Tab also rewrites
-        // mistyped lowercase (`goto` → `GOTO`). The highlighter stays
-        // case-sensitive, so a lowercase-typed line reads as natural
-        // language until the user accepts the completion.
+        // Case-insensitive here so Tab also rewrites mistyped lowercase
+        // (`goto` → `GOTO`); the highlighter stays case-sensitive.
         for (commands) |cmd| {
             if (std.ascii.startsWithIgnoreCase(cmd.name, input)) {
                 const text = std.fmt.bufPrintZ(&buf, "{s}", .{cmd.name}) catch continue;
@@ -369,9 +337,7 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
     addEnvVarCompletions(cenv, &buf, input);
 }
 
-// PandaScript syntax highlighter. Invoked by isocline on every input change;
-// keep it cheap. The `pos` and `count` passed to `ic_highlight` are byte
-// offsets/lengths into `input`, not UTF-8 code points — fine here because we
+// Byte offsets to ic_highlight are not UTF-8 code points; safe because we
 // only tokenize on ASCII boundaries (whitespace, quotes, `=`, `$`).
 fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*anyopaque) callconv(.c) void {
     const text = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(input)), 0);
@@ -381,21 +347,15 @@ fn highlighterCallback(henv: ?*c.ic_highlight_env_t, input: [*c]const u8, _: ?*a
     while (i < text.len and std.ascii.isWhitespace(text[i])) i += 1;
     if (i >= text.len) return;
 
-    // First word: either `/slash` form or a bare PandaScript command name.
-    // Unknown leading tokens get highlighted as errors so typos are visible
-    // before the user hits Enter.
     const cmd_start = i;
     while (i < text.len and !std.ascii.isWhitespace(text[i])) i += 1;
     const cmd = text[cmd_start..i];
     if (cmd.len > 0 and cmd[0] == '/') {
-        const name = cmd[1..];
-        const style = if (isKnownSlashName(name)) "ps-slash" else "ps-err";
+        const style = if (isKnownSlashName(cmd[1..])) "ps-slash" else "ps-err";
         c.ic_highlight(henv, @intCast(cmd_start), @intCast(cmd.len), style.ptr);
         highlightSlashArgs(henv, text, i);
     } else {
-        // PandaScript commands are ALL CAPS. Known → keyword color. ALL CAPS
-        // but unknown → red (likely typo). Anything else → no highlight,
-        // it's a natural-language query for the LLM.
+        // ALL CAPS but unknown → typo (red); lowercase/mixed → natural language (unstyled).
         const style: ?[*:0]const u8 = if (isKnownCommand(cmd))
             "ps-cmd"
         else if (isAllUpper(cmd))
@@ -429,9 +389,6 @@ fn isKnownSlashName(name: []const u8) bool {
     return false;
 }
 
-// Color a non-quoted token based on its leading character: `$` → variable,
-// `http(s)://` → URL, digits → number. Anything else falls through with no
-// highlight (lets the terminal's default foreground show through).
 fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usize, end: usize) void {
     if (start >= end) return;
     const tok = text[start..end];
@@ -453,9 +410,7 @@ fn highlightBareToken(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
     }
 }
 
-// Consume a quoted token (single or double) at `start`, returning the index
-// just past the closing quote. Handles backslash escapes minimally — enough
-// not to confuse `\'` inside a single-quoted string.
+// Backslash escapes are recognized just enough to skip `\'` inside a quoted string.
 fn scanQuoted(text: []const u8, start: usize) usize {
     if (start >= text.len) return start;
     const quote = text[start];
@@ -495,7 +450,7 @@ fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
         const key_end = i;
         if (i < text.len and text[i] == '=') {
             c.ic_highlight(henv, @intCast(tok_start), @intCast(key_end - tok_start), "ps-key".ptr);
-            i += 1; // consume '='
+            i += 1;
             const val_start = i;
             if (i < text.len and (text[i] == '\'' or text[i] == '"')) {
                 i = scanQuoted(text, i);
@@ -505,13 +460,11 @@ fn highlightSlashArgs(henv: ?*c.ic_highlight_env_t, text: []const u8, start: usi
                 highlightBareToken(henv, text, val_start, i);
             }
         }
-        // bare positional (no `=`) — leave unstyled.
     }
 }
 
 pub fn readLine(_: *Self, prompt: [*:0]const u8) ?[]const u8 {
-    // Isocline auto-adds the returned line to history and auto-persists when
-    // a history file was set via `ic_set_history`.
+    // Isocline auto-appends the line to its (optionally-persisted) history.
     const line = c.ic_readline(prompt) orelse return null;
     return std.mem.sliceTo(line, 0);
 }

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -38,7 +38,6 @@ fn atLeast(level: Verbosity, min: Verbosity) bool {
 }
 
 allocator: std.mem.Allocator,
-history_path: ?[:0]const u8,
 verbosity: Verbosity,
 /// Non-null in REPL mode. Doubles as scratch arena for the pretty-printer
 /// (reset per `printToolResult`, so memory is bounded by the largest single
@@ -90,7 +89,6 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
     const stderr_is_tty = std.posix.isatty(std.posix.STDERR_FILENO);
     return .{
         .allocator = allocator,
-        .history_path = history_path,
         .verbosity = verbosity,
         .repl_arena = if (is_repl) std.heap.ArenaAllocator.init(allocator) else null,
         .stderr_is_tty = stderr_is_tty,

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -919,27 +919,26 @@ fn execGetEnv(arena: std.mem.Allocator, arguments: ?std.json.Value) ToolError![]
         if (lookupLpEnv(name)) |value| return value;
         return std.fmt.allocPrint(arena, "Environment variable '{s}' is not set", .{name}) catch ToolError.InternalError;
     }
-    return listLpEnvNames(arena);
+
+    const names = lpEnvNames(arena) catch return ToolError.InternalError;
+    return formatLpEnvNames(arena, names);
 }
 
-fn lpNameLessThan(_: void, a: []const u8, b: []const u8) bool {
-    return std.mem.lessThan(u8, a, b);
-}
-
-fn listLpEnvNames(arena: std.mem.Allocator) ToolError![]const u8 {
-    var lines: std.ArrayList([]const u8) = .empty;
-    lines.ensureTotalCapacity(arena, std.os.environ.len) catch return ToolError.InternalError;
-    for (std.os.environ) |entry| {
-        lines.appendAssumeCapacity(std.mem.span(entry));
+fn formatLpEnvNames(arena: std.mem.Allocator, names: []const []const u8) ToolError![]const u8 {
+    if (names.len == 0) return "No LP_* environment variables are set.";
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    aw.writer.print("LP_* environment variables ({d}):\n", .{names.len}) catch return ToolError.InternalError;
+    for (names) |n| {
+        aw.writer.print("  {s}\n", .{n}) catch return ToolError.InternalError;
     }
-    return formatLpEnvNames(arena, lines.items);
+    return aw.written();
 }
 
 /// Sorted `LP_*`-prefixed environment-variable names from the current
 /// process. Returned slices point into `std.os.environ`, which is stable for
 /// the process lifetime; the outer slice is allocated from `arena`. Used by
-/// the agent REPL completer to offer `$LP_*` Tab completions — same data
-/// source as the `getEnv` tool (no-name variant), just unformatted.
+/// the agent REPL completer to offer `$LP_*` Tab completions and by
+/// `execGetEnv` for the no-name variant.
 pub fn lpEnvNames(arena: std.mem.Allocator) error{OutOfMemory}![]const []const u8 {
     var names: std.ArrayList([]const u8) = .empty;
     try names.ensureTotalCapacity(arena, std.os.environ.len);
@@ -950,27 +949,12 @@ pub fn lpEnvNames(arena: std.mem.Allocator) error{OutOfMemory}![]const []const u
         if (!std.ascii.startsWithIgnoreCase(name, "LP_")) continue;
         names.appendAssumeCapacity(name);
     }
-    std.mem.sort([]const u8, names.items, {}, lpNameLessThan);
+    std.mem.sort([]const u8, names.items, {}, struct {
+        fn lt(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
     return names.items;
-}
-
-fn formatLpEnvNames(arena: std.mem.Allocator, env_lines: []const []const u8) ToolError![]const u8 {
-    var names: std.ArrayList([]const u8) = .empty;
-    for (env_lines) |line| {
-        const eq_idx = std.mem.indexOfScalar(u8, line, '=') orelse continue;
-        const name = line[0..eq_idx];
-        if (!std.ascii.startsWithIgnoreCase(name, "LP_")) continue;
-        names.append(arena, name) catch return ToolError.InternalError;
-    }
-    if (names.items.len == 0) return "No LP_* environment variables are set.";
-    std.mem.sort([]const u8, names.items, {}, lpNameLessThan);
-
-    var aw: std.Io.Writer.Allocating = .init(arena);
-    aw.writer.print("LP_* environment variables ({d}):\n", .{names.items.len}) catch return ToolError.InternalError;
-    for (names.items) |n| {
-        aw.writer.print("  {s}\n", .{n}) catch return ToolError.InternalError;
-    }
-    return aw.written();
 }
 
 /// Resolve an LP_-prefixed environment variable, or `null` for any other name.
@@ -1210,31 +1194,25 @@ test "execGetEnv hides non-LP_ values even when set" {
     );
 }
 
-test "formatLpEnvNames lists names without values" {
+test "formatLpEnvNames renders names without values" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const aa = arena.allocator();
 
-    const lines = [_][]const u8{
-        "LP_FOO=secret",
-        "HOME=/home/x",
-        "LP_BAR=other-secret",
-    };
-    const r = try formatLpEnvNames(aa, &lines);
+    const names = [_][]const u8{ "LP_BAR", "LP_FOO" };
+    const r = try formatLpEnvNames(aa, &names);
 
     try std.testing.expect(std.mem.indexOf(u8, r, "LP_FOO") != null);
     try std.testing.expect(std.mem.indexOf(u8, r, "LP_BAR") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r, "HOME") == null);
     try std.testing.expect(std.mem.indexOf(u8, r, "secret") == null);
 }
 
-test "formatLpEnvNames reports empty when no LP_* entries" {
+test "formatLpEnvNames reports empty when no names" {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const aa = arena.allocator();
 
-    const lines = [_][]const u8{"HOME=/home/x"};
-    const r = try formatLpEnvNames(aa, &lines);
+    const r = try formatLpEnvNames(aa, &.{});
     try std.testing.expectEqualStrings("No LP_* environment variables are set.", r);
 }
 

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -935,6 +935,24 @@ fn listLpEnvNames(arena: std.mem.Allocator) ToolError![]const u8 {
     return formatLpEnvNames(arena, lines.items);
 }
 
+/// Sorted `LP_*`-prefixed environment-variable names from the current
+/// process. Returned slices point into `std.os.environ`, which is stable for
+/// the process lifetime; the outer slice is allocated from `arena`. Used by
+/// the agent REPL completer to offer `$LP_*` Tab completions — same data
+/// source as the `getEnv` tool (no-name variant), just unformatted.
+pub fn lpEnvNames(arena: std.mem.Allocator) error{OutOfMemory}![]const []const u8 {
+    var names: std.ArrayList([]const u8) = .empty;
+    for (std.os.environ) |entry| {
+        const line = std.mem.span(entry);
+        const eq_idx = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const name = line[0..eq_idx];
+        if (!std.ascii.startsWithIgnoreCase(name, "LP_")) continue;
+        try names.append(arena, name);
+    }
+    std.mem.sort([]const u8, names.items, {}, lpNameLessThan);
+    return names.items;
+}
+
 fn formatLpEnvNames(arena: std.mem.Allocator, env_lines: []const []const u8) ToolError![]const u8 {
     var names: std.ArrayList([]const u8) = .empty;
     for (env_lines) |line| {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -942,12 +942,13 @@ fn listLpEnvNames(arena: std.mem.Allocator) ToolError![]const u8 {
 /// source as the `getEnv` tool (no-name variant), just unformatted.
 pub fn lpEnvNames(arena: std.mem.Allocator) error{OutOfMemory}![]const []const u8 {
     var names: std.ArrayList([]const u8) = .empty;
+    try names.ensureTotalCapacity(arena, std.os.environ.len);
     for (std.os.environ) |entry| {
         const line = std.mem.span(entry);
         const eq_idx = std.mem.indexOfScalar(u8, line, '=') orelse continue;
         const name = line[0..eq_idx];
         if (!std.ascii.startsWithIgnoreCase(name, "LP_")) continue;
-        try names.append(arena, name);
+        names.appendAssumeCapacity(name);
     }
     std.mem.sort([]const u8, names.items, {}, lpNameLessThan);
     return names.items;

--- a/src/string.zig
+++ b/src/string.zig
@@ -340,6 +340,18 @@ fn asUint(comptime string: anytype) std.meta.Int(
 }
 
 const testing = @import("testing.zig");
+
+test "isAllUpper" {
+    try testing.expectEqual(false, isAllUpper(""));
+    try testing.expectEqual(true, isAllUpper("GOTO"));
+    try testing.expectEqual(true, isAllUpper("ACCEPT_COOKIES"));
+    try testing.expectEqual(true, isAllUpper("X1"));
+    try testing.expectEqual(true, isAllUpper("_"));
+    try testing.expectEqual(false, isAllUpper("Goto"));
+    try testing.expectEqual(false, isAllUpper("goto"));
+    try testing.expectEqual(false, isAllUpper("GO TO"));
+}
+
 test "String" {
     const other_short = try String.init(undefined, "other_short", .{});
     const other_long = try String.init(testing.allocator, "other_long" ** 100, .{});

--- a/src/string.zig
+++ b/src/string.zig
@@ -311,6 +311,14 @@ pub fn isAllWhitespace(text: []const u8) bool {
     } else true;
 }
 
+pub fn isAllUpper(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |ch| {
+        if (!std.ascii.isUpper(ch) and !std.ascii.isDigit(ch) and ch != '_') return false;
+    }
+    return true;
+}
+
 // Discriminatory type that signals the bridge to use arena instead of call_arena
 // Use this for strings that need to persist beyond the current call
 // The caller can unwrap and store just the underlying .str field


### PR DESCRIPTION
Replaces the linenoise library with isocline for improved REPL
functionality. Updates build scripts and moves completion state from
global variables into the Terminal struct.