### PR TITLE
Enable ImageData and OffscreenCanvasRenderingContext2D on Worker

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -978,9 +978,11 @@ pub const WorkerJsApis = flattenTypes(&.{
     @import("../webapi/AbortController.zig"),
     @import("../webapi/URL.zig"),
     @import("../webapi/canvas/OffscreenCanvas.zig"),
+    @import("../webapi/canvas/OffscreenCanvasRenderingContext2D.zig"),
     @import("../webapi/net/XMLHttpRequest.zig"),
     @import("../webapi/net/XMLHttpRequestEventTarget.zig"),
     @import("../webapi/FileReader.zig"),
+    @import("../webapi/ImageData.zig"),
     // @import("../webapi/Performance.zig"),
 });
 

--- a/src/browser/webapi/ImageData.zig
+++ b/src/browser/webapi/ImageData.zig
@@ -20,9 +20,9 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const Frame = @import("../Frame.zig");
 
 const String = lp.String;
+const Execution = js.Execution;
 
 /// https://developer.mozilla.org/en-US/docs/Web/API/ImageData/ImageData
 const ImageData = @This();
@@ -55,7 +55,7 @@ pub fn init(
     width: u32,
     height: u32,
     maybe_settings: ?ConstructorSettings,
-    frame: *Frame,
+    exec: *Execution,
 ) !*ImageData {
     // Though arguments are unsigned long, these are capped to max. i32 on Chrome.
     // https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/html/canvas/image_data.cc#L61
@@ -77,10 +77,10 @@ pub fn init(
     size, overflown = @mulWithOverflow(size, 4);
     if (overflown == 1) return error.IndexSizeError;
 
-    return frame._factory.create(ImageData{
+    return exec._factory.create(ImageData{
         ._width = width,
         ._height = height,
-        ._data = try frame.js.local.?.createTypedArray(.uint8_clamped, size).persist(),
+        ._data = try exec.context.local.?.createTypedArray(.uint8_clamped, size).persist(),
     });
 }
 

--- a/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
@@ -21,10 +21,11 @@ const std = @import("std");
 const js = @import("../../js/js.zig");
 
 const color = @import("../../color.zig");
-const Frame = @import("../../Frame.zig");
 
 const Canvas = @import("../element/html/Canvas.zig");
 const ImageData = @import("../ImageData.zig");
+
+const Execution = js.Execution;
 
 /// This class doesn't implement a `constructor`.
 /// It can be obtained with a call to `HTMLCanvasElement#getContext`.
@@ -41,8 +42,8 @@ pub fn getCanvas(self: *const CanvasRenderingContext2D) *Canvas {
     return self._canvas;
 }
 
-pub fn getFillStyle(self: *const CanvasRenderingContext2D, frame: *Frame) ![]const u8 {
-    var w = std.Io.Writer.Allocating.init(frame.call_arena);
+pub fn getFillStyle(self: *const CanvasRenderingContext2D, exec: *Execution) ![]const u8 {
+    var w = std.Io.Writer.Allocating.init(exec.call_arena);
     try self._fill_style.format(&w.writer);
     return w.written();
 }
@@ -67,15 +68,15 @@ pub fn createImageData(
     maybe_height: ?u32,
     /// Can be used if width and height provided.
     maybe_settings: ?ImageData.ConstructorSettings,
-    frame: *Frame,
+    exec: *Execution,
 ) !*ImageData {
     switch (width_or_image_data) {
         .width => |width| {
             const height = maybe_height orelse return error.TypeError;
-            return ImageData.init(width, height, maybe_settings, frame);
+            return ImageData.init(width, height, maybe_settings, exec);
         },
         .image_data => |image_data| {
-            return ImageData.init(image_data._width, image_data._height, null, frame);
+            return ImageData.init(image_data._width, image_data._height, null, exec);
         },
     }
 }
@@ -88,12 +89,12 @@ pub fn getImageData(
     _: i32, // sy
     sw: i32,
     sh: i32,
-    frame: *Frame,
+    exec: *Execution,
 ) !*ImageData {
     if (sw <= 0 or sh <= 0) {
         return error.IndexSizeError;
     }
-    return ImageData.init(@intCast(sw), @intCast(sh), null, frame);
+    return ImageData.init(@intCast(sw), @intCast(sh), null, exec);
 }
 
 pub fn save(_: *CanvasRenderingContext2D) void {}

--- a/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
@@ -20,9 +20,10 @@ const std = @import("std");
 
 const js = @import("../../js/js.zig");
 const color = @import("../../color.zig");
-const Frame = @import("../../Frame.zig");
 
 const ImageData = @import("../ImageData.zig");
+
+const Execution = js.Execution;
 
 /// This class doesn't implement a `constructor`.
 /// It can be obtained with a call to `OffscreenCanvas#getContext`.
@@ -32,8 +33,8 @@ const OffscreenCanvasRenderingContext2D = @This();
 /// TODO: Add support for `CanvasGradient` and `CanvasPattern`.
 _fill_style: color.RGBA = color.RGBA.Named.black,
 
-pub fn getFillStyle(self: *const OffscreenCanvasRenderingContext2D, frame: *Frame) ![]const u8 {
-    var w = std.Io.Writer.Allocating.init(frame.call_arena);
+pub fn getFillStyle(self: *const OffscreenCanvasRenderingContext2D, exec: *Execution) ![]const u8 {
+    var w = std.Io.Writer.Allocating.init(exec.call_arena);
     try self._fill_style.format(&w.writer);
     return w.written();
 }
@@ -58,15 +59,15 @@ pub fn createImageData(
     maybe_height: ?u32,
     /// Can be used if width and height provided.
     maybe_settings: ?ImageData.ConstructorSettings,
-    frame: *Frame,
+    exec: *Execution,
 ) !*ImageData {
     switch (width_or_image_data) {
         .width => |width| {
             const height = maybe_height orelse return error.TypeError;
-            return ImageData.init(width, height, maybe_settings, frame);
+            return ImageData.init(width, height, maybe_settings, exec);
         },
         .image_data => |image_data| {
-            return ImageData.init(image_data._width, image_data._height, null, frame);
+            return ImageData.init(image_data._width, image_data._height, null, exec);
         },
     }
 }
@@ -79,12 +80,12 @@ pub fn getImageData(
     _: i32, // sy
     sw: i32,
     sh: i32,
-    frame: *Frame,
+    exec: *Execution,
 ) !*ImageData {
     if (sw <= 0 or sh <= 0) {
         return error.IndexSizeError;
     }
-    return ImageData.init(@intCast(sw), @intCast(sh), null, frame);
+    return ImageData.init(@intCast(sw), @intCast(sh), null, exec);
 }
 
 pub fn save(_: *OffscreenCanvasRenderingContext2D) void {}


### PR DESCRIPTION
These are currently reachable in Worker via the OffscreenCanvas, so when used they crash. WPT /html/canvas/offscreen/2d.conformance.requirements.basics.worker.html