### PR TITLE
dom: implement HTMLDialogElement.{show, showModal, close}

### DIFF
--- a/src/browser/tests/element/html/dialog.html
+++ b/src/browser/tests/element/html/dialog.html
@@ -76,3 +76,125 @@
     testing.expectTrue(dialog instanceof HTMLDialogElement)
   }
 </script>
+
+<script id="show_sets_open">
+  {
+    const dialog = document.createElement('dialog')
+    testing.expectEqual(false, dialog.open)
+
+    dialog.show()
+    testing.expectEqual(true, dialog.open)
+    testing.expectEqual('', dialog.getAttribute('open'))
+  }
+</script>
+
+<script id="show_noop_when_already_open">
+  {
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('open', '')
+    testing.expectEqual(true, dialog.open)
+
+    dialog.show()
+    testing.expectEqual(true, dialog.open)
+  }
+</script>
+
+<script id="showModal_sets_open">
+  {
+    const dialog = document.createElement('dialog')
+    testing.expectEqual(false, dialog.open)
+
+    dialog.showModal()
+    testing.expectEqual(true, dialog.open)
+    testing.expectEqual('', dialog.getAttribute('open'))
+  }
+</script>
+
+<script id="showModal_throws_when_already_open">
+  {
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('open', '')
+
+    testing.expectError('InvalidStateError', () => dialog.showModal())
+    testing.expectEqual(true, dialog.open)
+  }
+</script>
+
+<script id="close_removes_open">
+  {
+    const dialog = document.createElement('dialog')
+    dialog.show()
+    testing.expectEqual(true, dialog.open)
+
+    dialog.close()
+    testing.expectEqual(false, dialog.open)
+    testing.expectEqual(null, dialog.getAttribute('open'))
+  }
+</script>
+
+<script id="close_noop_when_not_open">
+  {
+    const dialog = document.createElement('dialog')
+    testing.expectEqual(false, dialog.open)
+
+    dialog.close()
+    testing.expectEqual(false, dialog.open)
+  }
+</script>
+
+<script id="close_sets_returnValue_when_arg_given">
+  {
+    const dialog = document.createElement('dialog')
+    dialog.show()
+
+    dialog.close('confirmed')
+    testing.expectEqual('confirmed', dialog.returnValue)
+    testing.expectEqual('confirmed', dialog.getAttribute('returnvalue'))
+  }
+</script>
+
+<script id="close_preserves_returnValue_when_no_arg">
+  {
+    const dialog = document.createElement('dialog')
+    dialog.returnValue = 'preset'
+    dialog.show()
+
+    dialog.close()
+    testing.expectEqual('preset', dialog.returnValue)
+  }
+</script>
+
+<script id="close_fires_close_event">
+  {
+    const dialog = document.createElement('dialog')
+    document.body.appendChild(dialog)
+    dialog.show()
+
+    let fired = 0
+    let bubbled = false
+    let cancelable = null
+    dialog.addEventListener('close', (e) => {
+      fired++
+      cancelable = e.cancelable
+    })
+    document.addEventListener('close', () => { bubbled = true })
+
+    dialog.close('done')
+    testing.expectEqual(1, fired)
+    testing.expectEqual(false, bubbled)
+    testing.expectEqual(false, cancelable)
+  }
+</script>
+
+<script id="close_does_not_fire_event_when_not_open">
+  {
+    const dialog = document.createElement('dialog')
+    document.body.appendChild(dialog)
+
+    let fired = 0
+    dialog.addEventListener('close', () => fired++)
+
+    dialog.close()
+    testing.expectEqual(0, fired)
+  }
+</script>

--- a/src/browser/webapi/element/html/Dialog.zig
+++ b/src/browser/webapi/element/html/Dialog.zig
@@ -1,6 +1,7 @@
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
 
+const Event = @import("../../Event.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
@@ -39,6 +40,37 @@ pub fn setReturnValue(self: *Dialog, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("returnvalue"), .wrap(value), frame);
 }
 
+/// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show
+/// If the open attribute is set, return; otherwise set it to the empty string.
+/// Focus / inert / top-layer steps are no-ops here — no rendering pipeline.
+pub fn show(self: *Dialog, frame: *Frame) !void {
+    if (self.getOpen()) return;
+    try self.asElement().setAttributeSafe(comptime .wrap("open"), .wrap(""), frame);
+}
+
+/// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal
+/// Throws InvalidStateError if [open] is already set. Sets [open] otherwise.
+/// Focus trap, backdrop, and top-layer placement are no-ops — Lightpanda has
+/// no layout/compositor; [open] reflecting through to selectors is what
+/// downstream consumers rely on.
+pub fn showModal(self: *Dialog, frame: *Frame) !void {
+    if (self.getOpen()) return error.InvalidStateError;
+    try self.asElement().setAttributeSafe(comptime .wrap("open"), .wrap(""), frame);
+}
+
+/// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-close
+/// If [open] is unset, return. Otherwise remove [open], optionally update
+/// returnValue, and fire a `close` event (non-bubbling, non-cancelable).
+pub fn close(self: *Dialog, return_value: ?[]const u8, frame: *Frame) !void {
+    if (!self.getOpen()) return;
+    try self.asElement().removeAttribute(comptime .wrap("open"), frame);
+    if (return_value) |v| {
+        try self.asElement().setAttributeSafe(comptime .wrap("returnvalue"), .wrap(v), frame);
+    }
+    const event = try Event.init("close", .{ .bubbles = false, .cancelable = false }, frame._page);
+    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Dialog);
 
@@ -50,6 +82,10 @@ pub const JsApi = struct {
 
     pub const open = bridge.accessor(Dialog.getOpen, Dialog.setOpen, .{});
     pub const returnValue = bridge.accessor(Dialog.getReturnValue, Dialog.setReturnValue, .{});
+
+    pub const show = bridge.function(Dialog.show, .{});
+    pub const showModal = bridge.function(Dialog.showModal, .{ .dom_exception = true });
+    pub const close = bridge.function(Dialog.close, .{});
 };
 
 const testing = @import("../../../../testing.zig");


### PR DESCRIPTION
## What

`HTMLDialogElement` exposes the `open` and `returnValue` IDL accessors but not the three instance methods that drive the open/close state. Page scripts (and CDP-driven clients) that touch the native `<dialog>` UI throw `TypeError: d.showModal is not a function` on first use. This PR implements `show()`, `showModal()`, and `close([returnValue])` on `HTMLDialogElement.prototype` per [HTML §4.11.4 The dialog element](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element).

Closes #2434.

## Root cause

`src/browser/webapi/element/html/Dialog.zig` registered the constructor and the two attribute reflectors but never bound the three state-change methods on the `JsApi` struct. The methods themselves were never written.

<img width="823" height="117" alt="pr-1-broken-path" src="https://github.com/user-attachments/assets/000c7e8b-c679-4936-96e6-5894f9e6024e" />

## Fix

- `src/browser/webapi/element/html/Dialog.zig` — new methods:
  - `show(self, frame)`: early-return when `[open]` is already set, otherwise set it to the empty string.
  - `showModal(self, frame)`: throw `error.InvalidStateError` when `[open]` is already set, otherwise set it. Bound with `.{ .dom_exception = true }` so the error surfaces as a `DOMException` named `InvalidStateError` (mirrors `HTMLFormElement.prototype.requestSubmit` from #2253).
  - `close(self, return_value, frame)`: early-return when `[open]` is absent, otherwise remove `[open]`, optionally write `returnvalue`, and dispatch an `Event("close", { bubbles: false, cancelable: false })` via `frame._event_manager.dispatch(...)`.
- `src/browser/tests/element/html/dialog.html` — ten new test blocks covering: `show` sets `[open]`; `show` is a no-op when already open; `showModal` sets `[open]`; `showModal` throws `InvalidStateError` when already open; `close` removes `[open]`; `close` is a no-op when not open; `close(arg)` updates `returnValue`; `close()` preserves a pre-set `returnValue`; `close` dispatches a non-bubbling `close` event exactly once; `close` does not dispatch when not open.

The non-rendering parts of the spec (focus trap, backdrop, top-layer placement on `showModal`) are intentional no-ops — Lightpanda has no layout/compositor. `[open]` reflecting through to selectors and the `close` event firing are what downstream consumers depend on.

<img width="1188" height="251" alt="pr-2-fix-path" src="https://github.com/user-attachments/assets/b937868d-62f2-4a04-be88-583e84db3413" />

## Test

- **Unit test**: `WebApi: HTML.Dialog` (in `src/browser/webapi/element/html/Dialog.zig`, runs `src/browser/tests/element/html/dialog.html`). Fails on `main` (the new `show_sets_open` block fails first), passes with this commit. Full suite `zig build test` is green (636/636).
- **Reproducer**: a self-contained CDP probe (Lightpanda + `python3 -m http.server` + Node with raw `ws`, ~80 lines of shell + 50 lines of JS) exits 1 against current nightly (`1.0.0-nightly.6167+235f1cd9`) — all eight assertions fail because the three methods are `undefined` — and exits 0 against this branch with all `PASS` lines. Full output in the linked issue's reproducer section.

## Notes

The `cancel` event on Escape and the auto-focus behavior of `showModal` are out of scope: both require a keyboard input pipeline / focus management that Lightpanda doesn't have. Bringing them up if a follow-up issue lands.
