### PR TITLE
On HTTP request, only issue perform, don't drain messages

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -611,7 +611,15 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
             return err;
         };
     }
-    _ = try self.perform(0);
+
+    // Start the request (and move along any other request). This used to call
+    // self.perform(0) but that can also execute callbacks. Normally, that
+    // wouldn't be so bad. But curl can synchronously fire callbacks for the
+    // request we JUST added, which we do not want (it results in incorrect
+    // execution).
+    self.performing = true;
+    defer self.performing = false;
+    _ = try self.handles.perform();
 }
 
 pub const PerformStatus = enum {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -339,7 +339,7 @@ pub var test_session: *Session = undefined;
 
 const WEB_API_TEST_ROOT = "src/browser/tests/";
 const HtmlRunnerOpts = struct {
-    timeout_ms: u32 = 2000,
+    timeout_ms: u32 = 10000,
     inject_script: ?[]const u8 = null,
 };
 


### PR DESCRIPTION
This prevents callbacks from happening synchronously (doesn't help when the cache is used). Might not be needed when common libcurl lands. And, this only works because we now buffer the response, which isn't ideal but that's another issue.