### PR TITLE
Add LP.configureLoading worker + --disable-workers opt-out for Web Worker loading

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -99,6 +99,7 @@ const CommonOptions = .{
     .{ .name = "storage_engine", .type = ?Storage.EngineType },
     .{ .name = "storage_sqlite_path", .type = ?[:0]const u8 },
     .{ .name = "disable_subframes", .type = bool },
+    .{ .name = "disable_workers", .type = bool },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -243,6 +244,13 @@ pub fn obeyRobots(self: *const Config) bool {
 pub fn disableSubframes(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| opts.disable_subframes,
+        else => unreachable,
+    };
+}
+
+pub fn disableWorkers(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp => |opts| opts.disable_workers,
         else => unreachable,
     };
 }
@@ -543,6 +551,18 @@ pub fn printUsageAndExit(self: *const Config, success: bool) void {
         \\                executionContextIds (lightpanda-io/browser#2400). On the CDP
         \\                serve path, drivers can also toggle this per-session via the
         \\                LP.configureLoading method.
+        \\                Defaults to false.
+        \\
+        \\--disable-workers
+        \\                Skip loading dedicated Web Workers. The Worker constructor
+        \\                still returns a Worker object so calling pages do not throw,
+        \\                but no script fetch is initiated and the worker scope's
+        \\                eval never runs (postMessage from the page to the worker is
+        \\                queued indefinitely). Sidesteps a v8 entered-context
+        \\                corruption that crashes the process when an in-page Worker
+        \\                completes its script fetch under specific HTTP-proxy timing
+        \\                conditions on Shopify storefront pages. Drivers can also
+        \\                toggle this per-session via the LP.configureLoading method.
         \\                Defaults to false.
         \\
         \\--block-private-networks

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -83,6 +83,12 @@ loader_id_gen: u32 = 0,
 // configuration (or CDP command) to disable iframe loading
 subframe_loading_enabled: bool = true,
 
+// configuration (or CDP command) to disable Web Worker loading. When false,
+// `new Worker(url)` returns a Worker object whose script is never fetched
+// and never evaluated. Set from the `--disable-workers` CLI flag at
+// session init; the LP.configureLoading CDP method can flip it per-session.
+worker_loading_enabled: bool = true,
+
 pub fn init(self: *Session, browser: *Browser, notification: *Notification) !void {
     const allocator = browser.app.allocator;
     const arena_pool = browser.arena_pool;
@@ -101,8 +107,9 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         .notification = notification,
         .fc_identity_pool = .init(allocator),
         .cookie_jar = storage.Cookie.Jar.init(allocator),
-        // CLI default; LP.configureLoading can flip this per-session.
+        // CLI defaults; LP.configureLoading can flip these per-session.
         .subframe_loading_enabled = !browser.app.config.disableSubframes(),
+        .worker_loading_enabled = !browser.app.config.disableWorkers(),
     };
 }
 

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -78,6 +78,17 @@ pub fn init(url: []const u8, frame: *Frame) !*Worker {
     errdefer self._worker_scope.deinit();
     try frame.trackWorker(self);
 
+    // `--disable-workers` (or `LP.configureLoading { worker: false }`):
+    // skip the script fetch and eval. The Worker object is still
+    // constructed so JS `new Worker(url)` does not throw, but the
+    // worker's eval never runs (postMessage from the page is queued
+    // indefinitely with no handler to drain it). Mirrors the
+    // `subframe_loading_enabled` pattern for iframes.
+    if (!session.worker_loading_enabled) {
+        log.debug(.browser, "worker disabled", .{ .url = resolved_url });
+        return self;
+    }
+
     if (std.mem.startsWith(u8, url, "blob:")) {
         errdefer frame.removeWorker(self);
         const blob: *Blob = frame.lookupBlobUrl(url) orelse {

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -62,12 +62,17 @@ pub fn processMessage(cmd: *CDP.Command) !void {
 }
 
 fn configureLoading(cmd: *CDP.Command) !void {
+    // Each field is optional so callers can flip one without resetting
+    // the other to its default. Backwards-compatible: existing callers
+    // that pass only `{ subFrame: bool }` are unchanged.
     const params = (try cmd.params(struct {
-        subFrame: bool = true,
+        subFrame: ?bool = null,
+        worker: ?bool = null,
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    bc.session.subframe_loading_enabled = params.subFrame;
+    if (params.subFrame) |v| bc.session.subframe_loading_enabled = v;
+    if (params.worker) |v| bc.session.worker_loading_enabled = v;
     return cmd.sendResult(null, .{});
 }
 
@@ -640,4 +645,46 @@ test "cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values
     // the response doesn't leak across dialogs.
     const c_after_alert = try ls.local.exec("confirm('leak?')", null);
     try testing.expectEqual(false, c_after_alert.toBool());
+}
+
+test "cdp.lp: configureLoading toggles subFrame and worker independently" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    _ = try bc.session.createPage();
+
+    // Defaults: both loading types enabled.
+    try testing.expectEqual(true, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(true, bc.session.worker_loading_enabled);
+
+    // subFrame-only: leaves worker untouched.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "LP.configureLoading",
+        .params = .{ .subFrame = false },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+    try testing.expectEqual(false, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(true, bc.session.worker_loading_enabled);
+
+    // worker-only: leaves subFrame untouched.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "LP.configureLoading",
+        .params = .{ .worker = false },
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+    try testing.expectEqual(false, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(false, bc.session.worker_loading_enabled);
+
+    // Both at once.
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "LP.configureLoading",
+        .params = .{ .subFrame = true, .worker = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 3 });
+    try testing.expectEqual(true, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(true, bc.session.worker_loading_enabled);
 }


### PR DESCRIPTION
## Summary

Adds two ways to opt out of dedicated Web Worker loading entirely. The Worker constructor still returns a Worker object so calling pages don't throw, but no script fetch is initiated and the worker scope's eval never runs.

* **CDP method `LP.configureLoading { worker: bool }`** — per-session toggleable at runtime, alongside the existing `{ subFrame: bool }`. Both fields are now optional so callers can flip one without resetting the other to its default. Backwards-compatible with existing `subFrame`-only callers.
* **CLI flag `--disable-workers`** — process-wide default applying to every session and to the `fetch` subcommand. Operators can flip it on without any driver changes. Mirrors `--disable-subframes` (#2401) exactly.

## Motivation

Reliably-reproducible SIGABRT in `Worker.loadInitialScript` whenever a page constructs a Web Worker AND lightpanda is launched with `--http_proxy`. Crash signature:

```
$msg="V8 fatal callback" location=v8::Context::Exit() message="Cannot exit non-entered context"

reason: Fatal V8 Error
mode: ReleaseFast
location: v8::Context::Exit()
message: Cannot exit non-entered context

Stack:
  _browser.webapi.Worker.loadInitialScript
  _browser.webapi.Worker.httpDoneCallback
  _network.layer.InterceptionLayer.InterceptContext.doneCallback
  _browser.HttpClient.processMessages
  _browser.HttpClient.perform
  _browser.HttpClient.tick
  _Server.handleConnection
```

The Zig-side Enter/Exit pair around the worker's eval doesn't match v8's `entered_contexts` stack invariant under that timing — something upstream of the `loadInitialScript` Exit leaves an extra Enter on the stack, so v8's `Utils::ApiCheck` (`isolate->context() == *env`) fires and the process aborts.

Reproducible against a Shopify storefront (e.g. `https://www.allbirds.com/products/mens-wool-runners`) when served through any HTTP proxy — the proxy just adds enough latency to surface the race; the same code path runs without `--http_proxy` but the timing window is too tight to reliably hit. The Allbirds trigger is the Shopify `web-pixel-extension` worker, but ANY Worker the page constructs hits the same code path.

The proper fix needs the v8 entered-contexts invariant to be restored end-to-end through the worker eval. That's a deeper dig into how `Worker.loadInitialScript` / `WorkerGlobalScope.importScript` / `ls.local.runMacrotasks` compose with v8's microtask queues across multiple contexts. I tried three intermediate fixes (deferring `loadInitialScript` via the frame scheduler when other scripts are mid-eval, replacing the post-eval cross-context `runMacrotasks` with worker-only `PerformCheckpoint`, and removing `runMacrotasks` entirely) and none stopped the crash. The bug fires from inside the synchronous tick path before the post-eval microtask handling runs, which means the leak happens during `Script::Run` itself and needs more targeted investigation than I was able to do in one sitting.

This PR is the workaround so users hitting the SIGABRT on storefront / analytics-heavy pages have a clean opt-in escape today. For our use case, disabling them removes a fragile code path with no downside on our side.

## Implementation

`Session.worker_loading_enabled: bool = true` — default matches existing behavior.

`Worker.init` short-circuits **after** constructing the Worker / `WorkerGlobalScope` / arena bookkeeping (so the JS `new Worker(url)` expression doesn't throw):

```zig
if (!session.worker_loading_enabled) {
    log.debug(.browser, "worker disabled", .{ .url = resolved_url });
    return self;
}
```

Two ways to flip the flag, mirroring the `--disable-subframes` pattern:

1. **`LP.configureLoading { worker }`** (`src/cdp/domains/lp.zig`) — both `subFrame` and `worker` are now optional fields in the params struct, so existing callers passing only `{ subFrame }` continue to work unchanged. Sets `bc.session.worker_loading_enabled`.

2. **`--disable-workers` CLI flag** (`src/Config.zig`) — added to `CommonOptions` (so it applies to `serve`, `fetch`, `mcp`). New `Config.disableWorkers()` getter; `Session.init` reads it as the initial value. The CDP method can override per-session at runtime regardless of the CLI default.

Total diff: +88 / -3 across 4 files (`src/Config.zig`, `src/browser/Session.zig`, `src/browser/webapi/Worker.zig`, `src/cdp/domains/lp.zig`).

## Verification

Reproducer pattern (puppeteer-core 24.42.0 + tiny CONNECT-tunnel proxy on `127.0.0.1:9999`, scripts in `cdp-repros/`):

```sh
# baseline (crashes):
serve --host 127.0.0.1 --port 9222 --http_proxy http://127.0.0.1:9999

# fixed:
serve --host 127.0.0.1 --port 9222 --http_proxy http://127.0.0.1:9999 --disable-workers
```

Driving `https://www.allbirds.com/products/mens-wool-runners`:

* **baseline (no `--disable-workers`):** 5/5 SIGABRT in `Worker.loadInitialScript` with the v8 fatal callback above.
* **with `--disable-workers`:** 10/10 successful, returns full HTML (~1 MB), no crash.

Test suite:

```
make test
  -> 637 of 637 tests passed
     (was 636/636 + new "cdp.lp: configureLoading toggles subFrame
      and worker independently" regression test)

zig fmt --check ./*.zig ./**/*.zig
  -> clean
```

## Notes

* The CDP method is the **same domain (`LP.configureLoading`) and same shape** as `--disable-subframes`' driver-side opt-in, so existing Playwright / puppeteer integrations that already toggle subframes don't need a separate code path — one CDP call can flip both.

* `worker_loading_enabled = false` does NOT remove `Worker` from the global namespace (so feature-detection like `if (typeof Worker !== 'undefined')` still reports true). It just makes constructed workers no-op. Pages that `postMessage` to a worker and wait for a response will hang on that promise forever (or until the page is torn down). For our extraction use case that's fine — we control the worklist timeout anyway — but it's worth noting if upstream wants to surface the disabled state more strongly (e.g. throw from `postMessage`, or remove the global entirely behind an even-stricter flag).

* Once the underlying v8 entered-contexts invariant is restored in `Worker.loadInitialScript`, this flag becomes a perf / sandboxing tool rather than a correctness workaround. Worth keeping anyway: blocking analytics / pixel workers is a reasonable thing to want.

## Related

* #2400 — the iframe analog to this issue (subframe nav invalidates `executionContextId`); same workaround pattern.
* #2401 — introduced `--disable-subframes` / `LP.configureLoading { subFrame }` that this PR mirrors exactly for workers.
