### PR TITLE
Don't process scripts that failed to load

### DIFF
--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -284,8 +284,9 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
         return;
     }
 
-    if (script.status == 0) {
-        // an error (that we already logged)
+    if (script.status < 200 or script.status > 299) {
+        log.info(.http, "script load error", .{ .status = script.status });
+        script.executeCallback(comptime .wrap("error"));
         script.deinit();
         return;
     }

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -687,7 +687,7 @@ pub const Script = struct {
                 const entry = manager.imported_modules.getPtr(self.url).?;
                 entry.state = .err;
             },
-            .frame => {},
+            .frame => self.executeCallback(comptime .wrap("error")),
         }
         self.deinit();
         manager.evaluate();
@@ -792,7 +792,7 @@ pub const Script = struct {
         self.executeCallback(comptime .wrap("error"));
     }
 
-    fn executeCallback(self: *const Script, typ: String) void {
+    pub fn executeCallback(self: *const Script, typ: String) void {
         const fe = self.extra.frame;
         const frame = fe.frame;
         const Event = @import("webapi/Event.zig");

--- a/src/browser/tests/page/meta.html
+++ b/src/browser/tests/page/meta.html
@@ -44,3 +44,19 @@
 
 <!-- Leave it, it used to crash -->
 <script src='empty.js?x=["violated-directive=worker-src","TEST COMPLETE"]'></script>
+
+<!--
+  A blocking <script src> whose fetch returns a non-2xx status must:
+    - NOT execute the response body as JavaScript
+    - Fire an `error` event on the element (and NOT `load`)
+  /404.js returns valid JS (`window.__404_body_executed = true;`) with a
+  404 status, so the regression where we eval'd 4xx bodies would flip
+  __404_body_executed to true.
+-->
+<script>window.__bad404 = { error: false, load: false };</script>
+<script src="404.js" onerror="window.__bad404.error = true" onload="window.__bad404.load = true"></script>
+<script>
+  testing.expectEqual(true, window.__bad404.error);
+  testing.expectEqual(false, window.__bad404.load);
+  testing.expectEqual('undefined', typeof window.__404_body_executed);
+</script>

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -649,6 +649,18 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/404.js")) {
+        // Valid JS body served with a 404 status. Used to assert that
+        // ScriptManager does NOT execute the body of a failed script
+        // fetch — if it did, window.__404_body_executed would be set.
+        return req.respond("window.__404_body_executed = true;", .{
+            .status = .not_found,
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "application/javascript" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/xhr/500")) {
         return req.respond("Internal Server Error", .{
             .status = .internal_server_error,


### PR DESCRIPTION
At some point recently, we started to process scripts that fail to load (e.g. 404). This stops such scripts from [trying] to be evaluated, and executes the onerror handler in all script loading paths.