### PR TITLE
Adds `Network.requestServedFromCache`

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -82,6 +82,7 @@ const EventListeners = struct {
     http_request_intercept: List = .{},
     http_request_done: List = .{},
     http_request_auth_required: List = .{},
+    http_request_served_from_cache: List = .{},
     http_response_data: List = .{},
     http_response_header_done: List = .{},
     javascript_dialog_opening: List = .{},
@@ -103,6 +104,7 @@ const Events = union(enum) {
     http_request_start: *const RequestStart,
     http_request_intercept: *const RequestIntercept,
     http_request_auth_required: *const RequestAuthRequired,
+    http_request_served_from_cache: *const RequestServedFromCache,
     http_request_done: *const RequestDone,
     http_response_data: *const ResponseData,
     http_response_header_done: *const ResponseHeaderDone,
@@ -204,6 +206,10 @@ pub const RequestDone = struct {
 pub const RequestFail = struct {
     transfer: *Transfer,
     err: anyerror,
+};
+
+pub const RequestServedFromCache = struct {
+    transfer: *Transfer,
 };
 
 pub const JavascriptDialogOpening = struct {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -677,6 +677,7 @@ pub const BrowserContext = struct {
         try self.notification.register(.http_request_done, self, onHttpRequestDone);
         try self.notification.register(.http_response_data, self, onHttpResponseData);
         try self.notification.register(.http_response_header_done, self, onHttpResponseHeadersDone);
+        try self.notification.register(.http_request_served_from_cache, self, onHttpRequestServedFromCache);
     }
 
     pub fn networkDisable(self: *BrowserContext) void {
@@ -685,6 +686,7 @@ pub const BrowserContext = struct {
         self.notification.unregister(.http_request_done, self);
         self.notification.unregister(.http_response_data, self);
         self.notification.unregister(.http_response_header_done, self);
+        self.notification.unregister(.http_request_served_from_cache, self);
     }
 
     pub fn fetchEnable(self: *BrowserContext, authRequests: bool) !void {
@@ -854,6 +856,11 @@ pub const BrowserContext = struct {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         defer self.resetNotificationArena();
         try @import("domains/fetch.zig").requestAuthRequired(self, data);
+    }
+
+    pub fn onHttpRequestServedFromCache(ctx: *anyopaque, msg: *const Notification.RequestServedFromCache) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/network.zig").httpServedFromCache(self, msg);
     }
 
     pub fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -328,6 +328,15 @@ pub fn httpRequestDone(bc: *CDP.BrowserContext, msg: *const Notification.Request
     }, .{ .session_id = session_id });
 }
 
+pub fn httpServedFromCache(bc: *CDP.BrowserContext, msg: *const Notification.RequestServedFromCache) !void {
+    const session_id = bc.session_id orelse return;
+    const transfer = msg.transfer;
+
+    try bc.cdp.sendEvent("Network.requestServedFromCache", .{
+        .requestId = &id.toRequestId(transfer),
+    }, .{ .session_id = session_id });
+}
+
 pub const RequestWriter = struct {
     transfer: *Transfer,
 

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -64,6 +64,12 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
         .timestamp = std.time.timestamp(),
         .request_headers = req_header_list.items,
     })) |cached| {
+        // Dispatch that the Request was served from the Cache.
+        transfer.req.params.notification.dispatch(
+            .http_request_served_from_cache,
+            &.{ .transfer = transfer },
+        );
+
         // Cache hit: serve synchronously from the original callbacks, then
         // tear down. On error, the transfer is still alive and Client.request's
         // errdefer will handle cleanup (loop_owned is still false).


### PR DESCRIPTION
This adds the proper dispatching of the `Network.requestServedFromCache` that is expected when we resolve a request from our cache instead of going to the network.