### PR TITLE
add `Network.clearBrowserCache` and `Network.canClearBrowserCache`

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -43,6 +43,8 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         setUserAgentOverride,
         deleteCookies,
         clearBrowserCookies,
+        clearBrowserCache,
+        canClearBrowserCache,
         setCookie,
         setCookies,
         getCookies,
@@ -58,6 +60,8 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .setExtraHTTPHeaders => return setExtraHTTPHeaders(cmd),
         .deleteCookies => return deleteCookies(cmd),
         .clearBrowserCookies => return clearBrowserCookies(cmd),
+        .clearBrowserCache => return clearBrowserCache(cmd),
+        .canClearBrowserCache => return canClearBrowserCache(cmd),
         .setCookie => return setCookie(cmd),
         .setCookies => return setCookies(cmd),
         .getCookies => return getCookies(cmd),
@@ -149,6 +153,23 @@ fn deleteCookies(cmd: *CDP.Command) !void {
         }
     }
     return cmd.sendResult(null, .{});
+}
+
+fn clearBrowserCache(cmd: *CDP.Command) !void {
+    // Network.clearBrowserCache takes no parameters per the CDP spec, but most
+    // CDP clients (chrome-remote-interface, chromedp, custom websocket clients)
+    // include an empty `"params":{}` object on every command for ergonomics.
+    // Chrome accepts that and clears the jar; reject only on truly malformed JSON.
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const network = bc.cdp.browser.http_client.network;
+    if (network.cache) |*c| try c.clear();
+    return cmd.sendResult(null, .{});
+}
+
+fn canClearBrowserCache(cmd: *CDP.Command) !void {
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const network = bc.cdp.browser.http_client.network;
+    return cmd.sendResult(.{ .result = network.cache != null }, .{});
 }
 
 fn clearBrowserCookies(cmd: *CDP.Command) !void {
@@ -662,4 +683,40 @@ test "cdp.Network: getAllCookies returns whole jar regardless of current origin"
             .{ .name = "b", .value = "2", .domain = "other.test", .path = "/", .size = 2, .secure = true },
         },
     }, .{ .id = 3 });
+}
+
+test "cdp.Network: clearBrowserCache succeeds" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.clearBrowserCache",
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+}
+
+test "cdp.Network: clearBrowserCache accepts empty params object" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC2" });
+
+    try ctx.processMessage(
+        \\{"id":1,"method":"Network.clearBrowserCache","params":{}}
+    );
+    try ctx.expectSentResult(null, .{ .id = 1 });
+}
+
+test "cdp.Network: canClearBrowserCache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CC3" });
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.canClearBrowserCache",
+    });
+
+    // Cache is disabled in standard tests for now.
+    try ctx.expectSentResult(.{ .result = false }, .{ .id = 1 });
 }


### PR DESCRIPTION
This adds two CDP methods, `Network.clearBrowserCache` and `Network.canClearBrowserCache`. The former clears the browser cache using the `clear()` method that was recently added. The latter informs us if the browser cache is clearable, acting mostly as a proxy for telling us if the cache is enabled or not at the call time.