### PR TITLE
Add `fromDiskCache` field to `Network.Response`

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -434,6 +434,11 @@ const ResponseWriter = struct {
         }
 
         {
+            try jws.objectField("fromDiskCache");
+            try jws.write(response.inner == .cached);
+        }
+
+        {
             try jws.objectField("timing");
             try jws.write(.{
                 // TODO: fix


### PR DESCRIPTION
This adds the `fromDiskCache` field in the `Network.Response` type that we return from various CDP locations. This is meant to signify if the CDP Response was served from the cache or not.