### PR TITLE
properly disable cache on `Network.setCacheDisabled`

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -55,7 +55,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
     switch (action) {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
-        .setCacheDisabled => return cmd.sendResult(null, .{}),
+        .setCacheDisabled => return setCacheDisabled(cmd),
         .setUserAgentOverride => return @import("emulation.zig").setUserAgentOverride(cmd),
         .setExtraHTTPHeaders => return setExtraHTTPHeaders(cmd),
         .deleteCookies => return deleteCookies(cmd),
@@ -79,6 +79,17 @@ fn enable(cmd: *CDP.Command) !void {
 fn disable(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     bc.networkDisable();
+    return cmd.sendResult(null, .{});
+}
+
+fn setCacheDisabled(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        cacheDisabled: bool,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const client = &bc.cdp.browser.http_client;
+    client.cache_layer.disabled = params.cacheDisabled;
     return cmd.sendResult(null, .{});
 }
 
@@ -733,4 +744,43 @@ test "cdp.Network: canClearBrowserCache" {
 
     // Cache is disabled in standard tests for now.
     try ctx.expectSentResult(.{ .result = false }, .{ .id = 1 });
+}
+
+test "cdp.Network: setCacheDisabled disables cache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CD1" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(true, client.cache_layer.disabled);
+}
+
+test "cdp.Network: setCacheDisabled re-enables cache" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-CD2" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Network.setCacheDisabled",
+        .params = .{ .cacheDisabled = false },
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(false, client.cache_layer.disabled);
 }

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -36,6 +36,7 @@ const log = lp.log;
 const CacheLayer = @This();
 
 next: Layer = undefined,
+disabled: bool = false,
 
 pub fn layer(self: *CacheLayer) Layer {
     return .{
@@ -50,7 +51,7 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
     const self: *CacheLayer = @ptrCast(@alignCast(ptr));
     const req = &transfer.req;
 
-    if (req.params.method != .GET) {
+    if (self.disabled or req.params.method != .GET) {
         return self.next.request(transfer);
     }
 


### PR DESCRIPTION
This adds a `disabled` flag on the `CacheLayer` that is set by the CDP method `Network.setCacheDisabled`. This stops the requests from going through the CacheLayer callback chain (preventing gets and puts)