### PR TITLE
Send `Accept` header when navigating

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -488,6 +488,9 @@ pub const HttpHeaders = struct {
     // normal client.
     pub const accept_language: [:0]const u8 = "Accept-Language: en-US,en;q=0.9";
 
+    // Document-navigation Accept value Chrome sends.
+    pub const navigation_accept: [:0]const u8 = "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+
     user_agent: [:0]const u8, // User agent value (e.g. "Lightpanda/1.0")
     user_agent_header: [:0]const u8,
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -621,6 +621,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     };
 
     var headers = try http_client.newHeaders();
+    try headers.add(lp.Config.HttpHeaders.navigation_accept);
     if (opts.header) |hdr| {
         try headers.add(hdr);
     }


### PR DESCRIPTION
Prefers Firefox's `Accept` header value, WAF challenges seem to require this. Only affects navigation requests.