### PR TITLE
Clear pending destroy on createPage (a known safepoint).

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -216,6 +216,10 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
 // the pointer on Frame is just returned as a convenience
 pub fn createPage(self: *Session) !*Frame {
     lp.assert(self._active == null, "Session.createPage - page not null", .{});
+
+    // Drain any pending Page deinits now, while we're at a known-safe point
+    self.processQueuedDestroyed();
+
     if (comptime IS_DEBUG) {
         log.debug(.browser, "create page", .{});
     }


### PR DESCRIPTION
This allows pending destroys that have been accumulated to be cleaned up. In normal operations, this likely isn't going to happen. But we see a some unit tests create _many_ pages that never have the change to be cleaned up. The result is that the next "normal" unit test, which actually runs enough through Runner to trigger the cleanup, pays a huge cleanup price.

Arguably, for a test-only solution, we could create a session per test, or have explicit cleanup in the test. But having 1 long-lasting session is useful as it can show us these potential pitfalls AND, it isn't impossible that a real-world case runs into similar issues.