### PR TITLE
Fix Fetch.enable + http-proxy CDP send/recv deadlock (#2462)

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -176,6 +176,14 @@ fn handleConnection(self: *Server, socket: posix.socket_t) void {
         return;
     }
 
+    // From here on the CDP reader thread owns the recv side of the socket.
+    // It must be spawned _after_ the handshake (which reads from the same
+    // socket) to avoid two threads racing on socket reads.
+    cdp.startReader() catch |err| {
+        log.err(.app, "CDP startReader", .{ .err = err });
+        return;
+    };
+
     while (true) {
         const next = cdp.tick() catch |err| {
             log.err(.app, "cdp tick", .{ .err = err });

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -170,6 +170,12 @@ pub const CDPClient = struct {
     blocking_read_start: *const fn (*anyopaque) bool,
     blocking_read: *const fn (*anyopaque) bool,
     blocking_read_end: *const fn (*anyopaque) bool,
+    // Returns true if the CDP client has bytes already buffered (typically
+    // rescued from the socket while a synchronous send was backpressured;
+    // see WsConnection.send). When true, perform() returns .cdp_socket so
+    // the runner drains them even if the OS recv buffer is empty. See
+    // lightpanda-io/browser#2462.
+    has_buffered_input: *const fn (*anyopaque) bool,
 };
 
 pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp_client: ?CDPClient) !void {
@@ -413,7 +419,8 @@ pub fn _request(_: *anyopaque, transfer: *Transfer) !void {
 // inside this function, we free it before returning the error. Callers
 // must NOT pair `request()` with their own `errdefer headers.deinit()`
 // — that's a double-free.
-pub fn request(self: *Client, req: Request, owner: ?*Owner) !void {
+pub fn request(self: *Client, req_in: Request, owner: ?*Owner) !void {
+    var req = req_in;
     const arena = self.arena_pool.acquire(.small, "Request.arena") catch |err| {
         req.headers.deinit();
         return err;
@@ -660,21 +667,36 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!PerformStatus {
 
     // We're potentially going to block for a while until we get data. Process
     // whatever messages we have waiting ahead of time.
-    if (try self.processMessages()) {
-        return .normal;
-    }
+    const processed = try self.processMessages();
 
     var status = PerformStatus.normal;
     if (self.cdp_client) |cdp_client| {
+        // Bytes may have been rescued from the CDP socket while a
+        // synchronous send was backpressured (see WsConnection.send). The
+        // OS recv buffer is empty in that case, but we still owe the
+        // dispatcher a chance to process them. See
+        // lightpanda-io/browser#2462.
+        if (cdp_client.has_buffered_input(cdp_client.ctx)) {
+            return .cdp_socket;
+        }
+
+        // Even when we processed completion messages this round, do a
+        // non-blocking poll of the CDP socket so a steady stream of HTTP
+        // completions can't starve CDP reads. Without this, a flood of
+        // intercepted/proxied transfers can leave Fetch.continueRequest
+        // messages unread for seconds at a time.
+        const cdp_timeout: c_int = if (processed) 0 else timeout_ms;
         var wait_fds = [_]http.WaitFd{.{
             .fd = cdp_client.socket,
             .events = .{ .pollin = true },
             .revents = .{},
         }};
-        try self.handles.poll(&wait_fds, timeout_ms);
+        try self.handles.poll(&wait_fds, cdp_timeout);
         if (wait_fds[0].revents.pollin or wait_fds[0].revents.pollpri or wait_fds[0].revents.pollout) {
             status = .cdp_socket;
         }
+    } else if (processed) {
+        return .normal;
     } else if (running > 0) {
         try self.handles.poll(&.{}, timeout_ms);
     }
@@ -963,7 +985,7 @@ pub const Request = struct {
         return written.ptr[0..written.len :0];
     }
 
-    pub fn deinit(self: *const Request) void {
+    pub fn deinit(self: *Request) void {
         self.headers.deinit();
     }
 };
@@ -1133,6 +1155,22 @@ pub const Transfer = struct {
     }
 
     pub fn deinit(self: *Transfer) void {
+        // Use `transfers.remove` as a one-shot ownership claim. If it
+        // returns false, this transfer has already been deinit'd by a
+        // cascade out of `error_callback` (e.g. Script.errorCallback ->
+        // manager.evaluate() -> JS execution -> Frame.deinit ->
+        // abortOwner -> Transfer.kill -> Transfer.deinit). Returning
+        // here keeps us from double-freeing the arena. See
+        // lightpanda-io/browser#2462.
+        //
+        // Reading `self.id` and `self.client` after a prior deinit has
+        // released `self.arena` is technically a stale read, but
+        // arena_pool zombies the memory until the slot is handed out
+        // again. If by some race the slot were re-used between the two
+        // deinits, the new tenant's id would not be in `transfers`
+        // either, so the early-out still fires and we bail cleanly.
+        if (!self.client.transfers.remove(self.id)) return;
+
         if (self._conn) |conn| {
             self.client.removeConn(conn);
             self._conn = null;
@@ -1146,10 +1184,6 @@ pub const Transfer = struct {
             self.client.queue.remove(&self._node);
             self._queued = false;
         }
-
-        // Drop the id→*Transfer index entry before freeing the memory.
-        // Any concurrent CDP lookup by id will now see this transfer as gone.
-        _ = self.client.transfers.remove(self.id);
 
         self.req.deinit();
         if (self.owner) |o| {
@@ -1177,8 +1211,12 @@ pub const Transfer = struct {
 
     // Owner-driven teardown: fires shutdown_callback (not error_callback)
     // and otherwise behaves like abort. Called by Client.abortOwner /
-    // abortRequests when a Frame / WGS is being torn down.
-    fn kill(self: *Transfer) void {
+    // abortRequests when a Frame / WGS is being torn down, and from
+    // BrowserContext.deinit when the CDP connection drops with paused
+    // intercepts still outstanding -- in both cases firing error_callback
+    // would re-enter JS via XHR/script error handlers, and the inspector
+    // / V8 context the handler reaches into has already been torn down.
+    pub fn kill(self: *Transfer) void {
         if (self.req.shutdown_callback) |cb| {
             cb(self.req.ctx);
         }

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -165,17 +165,15 @@ fn layerWith(self: anytype, next: Layer) Layer {
 // specifically when we're waiting for a request interception response to
 // a blocking script.
 pub const CDPClient = struct {
+    // Fd to poll for "the CDP client has work for us". With the dedicated
+    // CDP reader thread, this is the read end of the mailbox's wake pipe;
+    // it becomes readable when a message has been enqueued.
     socket: posix.socket_t,
     ctx: *anyopaque,
-    blocking_read_start: *const fn (*anyopaque) bool,
+    // Drain any pending CDP messages. Returns false if the CDP connection
+    // has been closed. Called from sync-wait paths (HttpClient.syncRequest,
+    // ScriptManagerBase.waitForImport) and from CDP.tick.
     blocking_read: *const fn (*anyopaque) bool,
-    blocking_read_end: *const fn (*anyopaque) bool,
-    // Returns true if the CDP client has bytes already buffered (typically
-    // rescued from the socket while a synchronous send was backpressured;
-    // see WsConnection.send). When true, perform() returns .cdp_socket so
-    // the runner drains them even if the OS recv buffer is empty. See
-    // lightpanda-io/browser#2462.
-    has_buffered_input: *const fn (*anyopaque) bool,
 };
 
 pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp_client: ?CDPClient) !void {
@@ -671,20 +669,11 @@ fn perform(self: *Client, timeout_ms: c_int) anyerror!PerformStatus {
 
     var status = PerformStatus.normal;
     if (self.cdp_client) |cdp_client| {
-        // Bytes may have been rescued from the CDP socket while a
-        // synchronous send was backpressured (see WsConnection.send). The
-        // OS recv buffer is empty in that case, but we still owe the
-        // dispatcher a chance to process them. See
-        // lightpanda-io/browser#2462.
-        if (cdp_client.has_buffered_input(cdp_client.ctx)) {
-            return .cdp_socket;
-        }
-
-        // Even when we processed completion messages this round, do a
-        // non-blocking poll of the CDP socket so a steady stream of HTTP
-        // completions can't starve CDP reads. Without this, a flood of
-        // intercepted/proxied transfers can leave Fetch.continueRequest
-        // messages unread for seconds at a time.
+        // Always poll the CDP wake fd, even when we just processed HTTP
+        // completions. Without this, a steady stream of completions could
+        // starve CDP reads — the runner would never observe .cdp_socket
+        // and never call into the dispatcher. With the mailbox reader
+        // thread the wake fd is just a pipe, so the poll is cheap.
         const cdp_timeout: c_int = if (processed) 0 else timeout_ms;
         var wait_fds = [_]http.WaitFd{.{
             .fd = cdp_client.socket,

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -286,22 +286,44 @@ pub fn preloadImport(self: *ScriptManagerBase, url: [:0]const u8, referrer: []co
 }
 
 pub fn waitForImport(self: *ScriptManagerBase, url: [:0]const u8) !ModuleSource {
-    const entry = self.imported_modules.getEntry(url) orelse {
-        // It shouldn't be possible for v8 to ask for a module that we didn't
-        // `preloadImport` above.
-        return error.UnknownModule;
-    };
-
     const was_evaluating = self.is_evaluating;
     self.is_evaluating = true;
     defer self.is_evaluating = was_evaluating;
 
     var client = self.client;
     while (true) {
+        // Re-fetch the entry on every iteration. We can't cache the pointer
+        // outside the loop: the CDP-drain step below (re-)enters JS, which
+        // can call back into `preloadImport` for a transitively-imported
+        // module. `preloadImport` calls `imported_modules.getOrPut`, which
+        // may rehash the map and invalidate every existing entry pointer.
+        // A cached `entry` would then be a use-after-free on the next
+        // `entry.value_ptr.state` access. See lightpanda-io/browser#2462.
+        const entry = self.imported_modules.getEntry(url) orelse {
+            // It shouldn't be possible for v8 to ask for a module that we
+            // didn't `preloadImport` above.
+            return error.UnknownModule;
+        };
+
         switch (entry.value_ptr.state) {
             .loading => {
-                _ = try client.tick(200);
-                continue;
+                // Drain pending CDP messages every iteration. Without this,
+                // a script imported under `Fetch.enable` whose request is
+                // paused at the InterceptionLayer hangs forever: the CDP
+                // client's matching `Fetch.continueRequest` reply never
+                // reaches `CDP.processMessage`, the request never resumes,
+                // and this loop spins until the client times out.
+                // `syncRequest` already does this; the import path needs
+                // the same treatment. See lightpanda-io/browser#2462.
+                const status = try client.tick(200);
+                if (status == .cdp_socket) {
+                    if (client.cdp_client) |cdp| {
+                        if (cdp.blocking_read(cdp.ctx) == false) {
+                            // An error happened during cdp's read.
+                            return error.Failed;
+                        }
+                    }
+                }
             },
             .done => |script| {
                 var shared = false;

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -111,6 +111,7 @@ pub fn init(
         .blocking_read_start = CDP.blockingReadStart,
         .blocking_read = CDP.blockingRead,
         .blocking_read_end = CDP.blockingReadStop,
+        .has_buffered_input = CDP.hasBufferedInput,
     });
 }
 
@@ -149,15 +150,27 @@ pub fn blockingReadStop(ctx: *anyopaque) bool {
     return true;
 }
 
+pub fn hasBufferedInput(ctx: *anyopaque) bool {
+    const self: *CDP = @ptrCast(@alignCast(ctx));
+    return self.ws.bufferedBytes() > 0;
+}
+
 pub fn readSocket(self: *CDP) bool {
-    const n = self.ws.read() catch |err| {
+    // Use tryRead, not read, so that if the socket has no new bytes (because
+    // we already drained them while a backpressured send was waiting in
+    // WsConnection.send) we still process whatever is buffered instead of
+    // logging an error and bailing. See lightpanda-io/browser#2462.
+    const result = self.ws.tryRead() catch |err| {
         log.warn(.app, "CDP read", .{ .err = err });
         return false;
     };
 
-    if (n == 0) {
-        log.info(.app, "CDP disconnect", .{});
-        return false;
+    switch (result) {
+        .closed => {
+            log.info(.app, "CDP disconnect", .{});
+            return false;
+        },
+        .data, .no_new_data => {},
     }
 
     return self.ws.processMessages(self) catch false;
@@ -574,7 +587,13 @@ pub const BrowserContext = struct {
             );
             http_client.interception_layer.intercepted -= 1;
             if (http_client.findTransfer(transfer_id)) |transfer| {
-                transfer.abort(error.ClientDisconnect);
+                // `kill` (not `abort`) fires shutdown_callback (or no-op),
+                // not error_callback. error_callback re-enters JS via XHR
+                // / script error handlers, which crash because the
+                // inspector + V8 context this BC owns are about to be
+                // torn down (and partially already are: we just called
+                // `inspector.stopSession`). See lightpanda-io/browser#2462.
+                transfer.kill();
             }
         }
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -31,6 +31,7 @@ const Label = @import("../browser/webapi/element/html/Label.zig");
 const Transfer = @import("../browser/HttpClient.zig").Transfer;
 const CDPClient = @import("../browser/HttpClient.zig").CDPClient;
 const WsConnection = @import("../network/WsConnection.zig");
+const Mailbox = @import("Mailbox.zig");
 
 const Incrementing = @import("id.zig").Incrementing;
 const InterceptState = @import("domains/fetch.zig").InterceptState;
@@ -82,6 +83,17 @@ frame_arena: std.heap.ArenaAllocator,
 // (or altogether eliminate) our use of this.
 browser_context_arena: std.heap.ArenaAllocator,
 
+// CDP incoming messages flow through a dedicated reader thread which
+// owns the WS read side and pushes complete messages onto this mailbox.
+// The worker thread (this thread) drains the mailbox at safe points
+// (Runner.tick, HttpClient.syncRequest, ScriptManagerBase.waitForImport).
+// Decoupling the read side from the runner loop prevents the two-way
+// backpressure deadlock that triggers under CDP Fetch.enable + http-proxy
+// and the related class of stalls where the runner is busy in JS while
+// CDP messages pile up unread. See lightpanda-io/browser#2462.
+mailbox: Mailbox = undefined,
+reader_thread: ?std.Thread = null,
+
 pub fn init(
     self: *CDP,
     app: *App,
@@ -105,17 +117,42 @@ pub fn init(
     try self.ws.init(socket, self.app.allocator, json_version_response);
     errdefer self.ws.deinit();
 
+    self.mailbox = try Mailbox.init(allocator);
+    errdefer self.mailbox.deinit();
+
+    // The HttpClient polls cdp_client.socket alongside the curl multi
+    // handle. With the mailbox model the worker is woken by the mailbox
+    // wake-pipe rather than by raw WS readiness.
     try self.browser.init(app, .{ .env = .{ .with_inspector = true } }, .{
         .ctx = self,
-        .socket = socket,
-        .blocking_read_start = CDP.blockingReadStart,
-        .blocking_read = CDP.blockingRead,
-        .blocking_read_end = CDP.blockingReadStop,
-        .has_buffered_input = CDP.hasBufferedInput,
+        .socket = self.mailbox.wake_read,
+        .blocking_read = CDP.drainMailbox,
     });
+
+    // NOTE: the reader thread is not spawned here. The caller must run
+    // the WS handshake first (which reads from the same socket) and then
+    // call `startReader`. Spawning here would race the handshake on
+    // socket reads.
+}
+
+// Start the dedicated CDP reader thread. Must be called once, after the
+// WS handshake has completed. From this point on the reader thread owns
+// the recv side of the socket; the worker thread must only send.
+pub fn startReader(self: *CDP) !void {
+    std.debug.assert(self.reader_thread == null);
+    self.reader_thread = try std.Thread.spawn(.{}, readerLoop, .{self});
 }
 
 pub fn deinit(self: *CDP) void {
+    // Wake the reader thread's blocked poll/read by shutting down the
+    // recv side of the socket. We then join the thread before tearing
+    // down anything it touches (mailbox, ws).
+    if (self.reader_thread) |t| {
+        self.ws.shutdown();
+        t.join();
+        self.reader_thread = null;
+    }
+
     if (self.browser_context) |*bc| {
         bc.deinit();
     }
@@ -124,56 +161,112 @@ pub fn deinit(self: *CDP) void {
     self.message_arena.deinit();
     self.notification_arena.deinit();
     self.browser_context_arena.deinit();
+    self.mailbox.deinit();
     self.ws.deinit();
 }
 
-pub fn blockingReadStart(ctx: *anyopaque) bool {
-    const self: *CDP = @ptrCast(@alignCast(ctx));
-    self.ws.setBlocking(true) catch |err| {
-        log.warn(.app, "CDP blockingReadStart", .{ .err = err });
-        return false;
-    };
-    return true;
+// Reader thread entry point. Owns `self.ws` for the duration of its
+// loop and pushes parsed CDP messages onto `self.mailbox`. Exits on
+// peer close, a fatal read/parse error, or `ws.shutdown()` called from
+// the worker during CDP.deinit (surfaces as POLLHUP / read=0).
+fn readerLoop(self: *CDP) void {
+    const POLL_TIMEOUT_MS: i32 = 60_000;
+
+    var handler = MailboxHandler{ .mailbox = &self.mailbox };
+
+    while (true) {
+        var pfds = [_]posix.pollfd{.{
+            .fd = self.ws.socket,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const n = posix.poll(&pfds, POLL_TIMEOUT_MS) catch |err| {
+            log.warn(.app, "CDP reader poll", .{ .err = err });
+            self.mailbox.close(err);
+            return;
+        };
+        if (n == 0) continue;
+
+        const revents = pfds[0].revents;
+        if (revents & @as(i16, @intCast(posix.POLL.NVAL | posix.POLL.ERR)) != 0) {
+            self.mailbox.close(error.SocketError);
+            return;
+        }
+
+        // POLLHUP can arrive together with POLLIN (peer half-closed but
+        // bytes still buffered) — drain whatever's available first.
+        const bytes = self.ws.read() catch |err| switch (err) {
+            error.WouldBlock => continue,
+            else => {
+                self.mailbox.close(err);
+                return;
+            },
+        };
+        if (bytes == 0) {
+            // Peer closed (clean EOF or our own ws.shutdown()).
+            self.mailbox.close(null);
+            return;
+        }
+
+        const ok = self.ws.processMessages(&handler) catch |err| {
+            self.mailbox.close(err);
+            return;
+        };
+        if (!ok) {
+            self.mailbox.close(null);
+            return;
+        }
+    }
 }
 
-pub fn blockingRead(ctx: *anyopaque) bool {
+const MailboxHandler = struct {
+    mailbox: *Mailbox,
+
+    pub fn handleMessage(self: *MailboxHandler, data: []const u8) bool {
+        self.mailbox.push(data) catch |err| {
+            log.err(.app, "CDP mailbox push", .{ .err = err });
+            return false;
+        };
+        return true;
+    }
+};
+
+// Called from the worker thread when the mailbox wake-pipe becomes
+// readable. Drains every pending message and dispatches it. Returns
+// false once the mailbox has been closed and emptied (peer gone).
+pub fn readSocket(self: *CDP) bool {
+    self.mailbox.drainWake();
+
+    while (true) {
+        switch (self.mailbox.pop()) {
+            .msg => |bytes| {
+                defer self.mailbox.freeMessage(bytes);
+                self.processMessage(bytes) catch |err| {
+                    log.warn(.app, "CDP processMessage", .{ .err = err });
+                    // Continue draining; a single malformed message
+                    // shouldn't poison the rest of the batch.
+                };
+            },
+            .closed => |err| {
+                if (err) |e| {
+                    log.warn(.app, "CDP disconnect", .{ .err = e });
+                } else {
+                    log.info(.app, "CDP disconnect", .{});
+                }
+                return false;
+            },
+            .empty => return true,
+        }
+    }
+}
+
+// Callback wired through HttpClient.CDPClient.blocking_read for the
+// synchronous-wait paths (syncRequest, waitForImport). Same drain
+// behaviour as readSocket; named separately to keep the call sites
+// honest about intent.
+pub fn drainMailbox(ctx: *anyopaque) bool {
     const self: *CDP = @ptrCast(@alignCast(ctx));
     return self.readSocket();
-}
-
-pub fn blockingReadStop(ctx: *anyopaque) bool {
-    const self: *CDP = @ptrCast(@alignCast(ctx));
-    self.ws.setBlocking(false) catch |err| {
-        log.warn(.app, "CDP blockingReadStop", .{ .err = err });
-        return false;
-    };
-    return true;
-}
-
-pub fn hasBufferedInput(ctx: *anyopaque) bool {
-    const self: *CDP = @ptrCast(@alignCast(ctx));
-    return self.ws.bufferedBytes() > 0;
-}
-
-pub fn readSocket(self: *CDP) bool {
-    // Use tryRead, not read, so that if the socket has no new bytes (because
-    // we already drained them while a backpressured send was waiting in
-    // WsConnection.send) we still process whatever is buffered instead of
-    // logging an error and bailing. See lightpanda-io/browser#2462.
-    const result = self.ws.tryRead() catch |err| {
-        log.warn(.app, "CDP read", .{ .err = err });
-        return false;
-    };
-
-    switch (result) {
-        .closed => {
-            log.info(.app, "CDP disconnect", .{});
-            return false;
-        },
-        .data, .no_new_data => {},
-    }
-
-    return self.ws.processMessages(self) catch false;
 }
 
 pub fn sendJSON(self: *CDP, message: anytype) !void {

--- a/src/cdp/Mailbox.zig
+++ b/src/cdp/Mailbox.zig
@@ -1,0 +1,158 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Thread-safe inbox for CDP messages.
+//
+// A dedicated reader thread owns the CDP websocket's read side, parses
+// frames, and `push`es each message onto this queue. The worker thread
+// drains the queue at safe points (Runner.tick, HttpClient.syncRequest,
+// ScriptManagerBase.waitForImport). The wake pipe (wake_read/wake_write)
+// is what HttpClient.perform polls in place of the bare socket fd, so
+// the runner still unblocks immediately when a message arrives.
+//
+// Concurrency contract:
+//   - exactly one producer (the reader thread) calls push() / close().
+//   - exactly one consumer (the worker thread) calls pop() / drainWake() /
+//     freeMessage() / deinit().
+//   - bytes on the wake pipe are signals only; values are ignored.
+
+const std = @import("std");
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+const Mutex = std.Thread.Mutex;
+
+const Mailbox = @This();
+
+allocator: Allocator,
+mutex: Mutex = .{},
+
+// FIFO of received CDP messages. Each item's `bytes` is owned by the
+// mailbox until the consumer calls freeMessage().
+queue: std.ArrayList(Message) = .empty,
+
+// Set by the reader thread on EOF, fatal error, or shutdown request. Once
+// `closed` is true and `queue` is empty, the connection is over.
+closed: bool = false,
+
+// Fatal error from the reader thread, if any (logged by the consumer).
+err: ?anyerror = null,
+
+// Self-pipe used to wake the consumer's poll loop. The read end gets
+// registered with HttpClient.perform via CDPClient.socket; the producer
+// writes a single byte on every push() and close().
+wake_read: posix.fd_t,
+wake_write: posix.fd_t,
+
+pub const Message = struct {
+    bytes: []u8,
+};
+
+pub fn init(allocator: Allocator) !Mailbox {
+    const pipe = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
+    return .{
+        .allocator = allocator,
+        .wake_read = pipe[0],
+        .wake_write = pipe[1],
+    };
+}
+
+pub fn deinit(self: *Mailbox) void {
+    // Caller has joined the reader thread by now, so no concurrent push.
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    for (self.queue.items) |msg| self.allocator.free(msg.bytes);
+    self.queue.deinit(self.allocator);
+    posix.close(self.wake_read);
+    posix.close(self.wake_write);
+}
+
+// Producer: enqueue a copy of `bytes` and wake the consumer. Drops the
+// message if the mailbox has already been closed (consumer is tearing
+// down). Returns the OOM error only on copy failure.
+pub fn push(self: *Mailbox, bytes: []const u8) !void {
+    const copy = try self.allocator.dupe(u8, bytes);
+    errdefer self.allocator.free(copy);
+
+    {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.closed) {
+            self.allocator.free(copy);
+            return;
+        }
+        try self.queue.append(self.allocator, .{ .bytes = copy });
+    }
+
+    self.wake();
+}
+
+// Producer: mark the mailbox closed and (optionally) record a fatal error.
+// Wakes the consumer so it can observe the close. Idempotent — calling
+// twice is fine.
+pub fn close(self: *Mailbox, err: ?anyerror) void {
+    {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.closed) return;
+        self.closed = true;
+        if (err) |e| self.err = e;
+    }
+    self.wake();
+}
+
+pub const Pop = union(enum) {
+    msg: []u8,
+    closed: ?anyerror, // empty queue + closed flag
+    empty: void, // empty queue, producer still live
+};
+
+// Consumer: pop the next message. If a `.msg` is returned, the caller
+// owns the bytes and must release them via `freeMessage`.
+pub fn pop(self: *Mailbox) Pop {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    if (self.queue.items.len > 0) {
+        const m = self.queue.orderedRemove(0);
+        return .{ .msg = m.bytes };
+    }
+    if (self.closed) return .{ .closed = self.err };
+    return .empty;
+}
+
+pub fn freeMessage(self: *Mailbox, bytes: []u8) void {
+    self.allocator.free(bytes);
+}
+
+// Consumer: drain any pending wake bytes from the pipe. Cheap — bytes on
+// the wake pipe are signals, not data. Called by the consumer after it
+// observes readiness on `wake_read` (perform's curl_multi_poll).
+pub fn drainWake(self: *Mailbox) void {
+    var buf: [256]u8 = undefined;
+    while (true) {
+        _ = posix.read(self.wake_read, &buf) catch return;
+    }
+}
+
+fn wake(self: *Mailbox) void {
+    const b: [1]u8 = .{1};
+    // Best effort. The pipe is non-blocking; if it's full the consumer
+    // already has a pending wake byte and will see the queued message
+    // on its next pass.
+    _ = posix.write(self.wake_write, &b) catch {};
+}

--- a/src/network/WsConnection.zig
+++ b/src/network/WsConnection.zig
@@ -353,31 +353,27 @@ pub fn deinit(self: *WsConnection) void {
 
 pub fn send(self: *WsConnection, data: []const u8) !void {
     var pos: usize = 0;
-    var changed_to_blocking: bool = false;
     defer _ = self.send_arena.reset(.{ .retain_with_limit = 1024 * 32 });
-
-    defer if (changed_to_blocking) {
-        // We had to change our socket to blocking me to get our write out
-        // We need to change it back to non-blocking.
-        _ = posix.fcntl(self.socket, posix.F.SETFL, self.socket_flags) catch |err| {
-            log.err(.app, "ws restore nonblocking", .{ .err = err });
-        };
-    };
 
     LOOP: while (pos < data.len) {
         const written = posix.write(self.socket, data[pos..]) catch |err| switch (err) {
             error.WouldBlock => {
-                // self.socket is nonblocking, because we don't want to block
-                // reads. But our life is a lot easier if we block writes,
-                // largely, because we don't have to maintain a queue of pending
-                // writes (which would each need their own allocations). So
-                // if we get a WouldBlock error, we'll switch the socket to
-                // blocking and switch it back to non-blocking after the write
-                // is complete. Doesn't seem particularly efficiently, but
-                // this should virtually never happen.
-                assert(changed_to_blocking == false, "WsConnection.double block", .{});
-                changed_to_blocking = true;
-                _ = try posix.fcntl(self.socket, posix.F.SETFL, self.socket_flags & ~@as(u32, @bitCast(posix.O{ .NONBLOCK = true })));
+                // The peer's recv buffer is full. Naively switching to a
+                // blocking write would deadlock when the peer is _also_
+                // blocked trying to send to us — a real scenario under CDP
+                // Fetch.enable + http-proxy, where lightpanda emits a flood
+                // of Fetch.requestPaused events while puppeteer is trying
+                // to send us back the matching Fetch.continueRequest
+                // messages. Each side fills the other's TCP send buffer,
+                // and a blocking write here never returns. See
+                // lightpanda-io/browser#2462.
+                //
+                // Instead, poll for POLLOUT _while also_ draining any
+                // POLLIN data into the reader buffer (without processing —
+                // that would re-enter the dispatch path and call back into
+                // send, risking unbounded recursion). The buffered bytes
+                // are picked up by the next CDP.readSocket call.
+                try self.waitWritableDrainingReads();
                 continue :LOOP;
             },
             else => return err,
@@ -387,6 +383,83 @@ pub fn send(self: *WsConnection, data: []const u8) !void {
             return error.Closed;
         }
         pos += written;
+    }
+}
+
+// Block until the socket is writable. Concurrently drains any incoming
+// bytes into the reader buffer (without processing them) so the peer
+// keeps making progress reading our writes. Used to break the two-way
+// backpressure deadlock described in `send`.
+fn waitWritableDrainingReads(self: *WsConnection) !void {
+    // Bounded so a truly dead peer eventually surfaces (TCP keepalive will
+    // close the socket; this just bounds any single send).
+    const POLL_TIMEOUT_MS: i32 = 30_000;
+
+    // We may have to stop watching POLLIN if the reader buffer is at its
+    // cap and we can't make any more space (otherwise poll would return
+    // immediately every iteration with POLLIN set, busy-spinning).
+    var watch_in = true;
+
+    while (true) {
+        const events_in: i16 = if (watch_in) @as(i16, @intCast(posix.POLL.IN)) else 0;
+        var pfds = [_]posix.pollfd{.{
+            .fd = self.socket,
+            .events = @as(i16, @intCast(posix.POLL.OUT)) | events_in,
+            .revents = 0,
+        }};
+        const n = try posix.poll(&pfds, POLL_TIMEOUT_MS);
+        if (n == 0) return error.WouldBlock;
+
+        const revents = pfds[0].revents;
+        if (revents & @as(i16, @intCast(posix.POLL.NVAL | posix.POLL.ERR | posix.POLL.HUP)) != 0) {
+            return error.Closed;
+        }
+
+        if (watch_in and revents & @as(i16, @intCast(posix.POLL.IN)) != 0) {
+            // Drain whatever's available without processing. May grow the
+            // buffer up to CDP_MAX_MESSAGE_SIZE.
+            const before = self.bufferedBytes();
+            try self.drainAvailable();
+            if (self.bufferedBytes() == before and self.reader.readBuf().len == 0) {
+                // Buffer is at cap and we couldn't read anything more.
+                // Stop watching POLLIN so we don't busy-spin while we wait
+                // for POLLOUT.
+                watch_in = false;
+            }
+        }
+
+        if (revents & @as(i16, @intCast(posix.POLL.OUT)) != 0) {
+            return;
+        }
+    }
+}
+
+// Read everything currently available on the socket into the reader
+// buffer (non-blocking). Grows the buffer if needed (capped at
+// CDP_MAX_MESSAGE_SIZE so a misbehaving peer can't OOM us). Does not
+// process messages — the caller will handle that on the next pass
+// through CDP.readSocket.
+fn drainAvailable(self: *WsConnection) !void {
+    while (true) {
+        var buf = self.reader.readBuf();
+        if (buf.len == 0) {
+            const current = self.reader.buf.len;
+            if (current >= CDP_MAX_MESSAGE_SIZE) {
+                // Already at the cap; refuse to grow further. Stop draining
+                // — the next POLLOUT-then-write attempt will block again,
+                // but at least the peer's reads will eventually free our
+                // send buffer and let us proceed.
+                return;
+            }
+            self.reader.buf = try growBuffer(self.reader.allocator, self.reader.buf, current + 1);
+            buf = self.reader.readBuf();
+        }
+        const n = posix.read(self.socket, buf) catch |err| switch (err) {
+            error.WouldBlock => return,
+            else => return err,
+        };
+        if (n == 0) return error.Closed; // peer closed
+        self.reader.len += n;
     }
 }
 
@@ -475,6 +548,37 @@ pub fn read(self: *WsConnection) !usize {
     const n = try posix.read(self.socket, self.reader.readBuf());
     self.reader.len += n;
     return n;
+}
+
+pub const ReadResult = enum { data, no_new_data, closed };
+
+// Variant of `read` that distinguishes "no new bytes on the wire" from
+// "peer closed". Used by CDP.readSocket so it can still drain buffered
+// messages (those rescued during a backpressured send) without bailing
+// when posix.read reports EWOULDBLOCK.
+pub fn tryRead(self: *WsConnection) !ReadResult {
+    const buf = self.reader.readBuf();
+    if (buf.len == 0) {
+        // Reader buffer is completely full of unprocessed messages. Don't
+        // call posix.read with a zero-length buffer (returns 0 → looks like
+        // EOF). Caller should processMessages first.
+        return if (self.bufferedBytes() > 0) .no_new_data else .closed;
+    }
+    const n = posix.read(self.socket, buf) catch |err| switch (err) {
+        error.WouldBlock => return .no_new_data,
+        else => return err,
+    };
+    if (n == 0) return .closed;
+    self.reader.len += n;
+    return .data;
+}
+
+// Number of bytes sitting in the reader buffer that haven't been parsed
+// into messages yet. Used by HttpClient.perform to detect that data was
+// rescued from the socket during a backpressured send and still needs to
+// be dispatched.
+pub fn bufferedBytes(self: *const WsConnection) usize {
+    return self.reader.len - self.reader.pos;
 }
 
 fn processHttpRequest(self: *WsConnection) !HttpResult {

--- a/src/network/WsConnection.zig
+++ b/src/network/WsConnection.zig
@@ -319,7 +319,15 @@ const CLOSE_TIMEOUT = [_]u8{ 136, 2, 15, 160 }; // code: 4000
 socket: posix.socket_t,
 socket_flags: usize,
 reader: Reader(true),
+
+// Send-side state. Serialized by `send_mutex` because two threads can
+// reach the send path concurrently: the CDP reader thread (for protocol
+// close frames and ping/pong replies) and the worker thread (for CDP
+// events, command responses, etc). `send_arena` is reset at the end of
+// every send, so its lifetime cannot overlap two concurrent send paths.
+send_mutex: std.Thread.Mutex = .{},
 send_arena: ArenaAllocator,
+
 json_version_response: []const u8,
 
 pub fn init(
@@ -352,28 +360,38 @@ pub fn deinit(self: *WsConnection) void {
 }
 
 pub fn send(self: *WsConnection, data: []const u8) !void {
+    self.send_mutex.lock();
+    defer self.send_mutex.unlock();
+    return self.sendLocked(data);
+}
+
+// Caller must already hold `send_mutex`. Use this when the calling
+// function has already taken the mutex to cover allocation in
+// `send_arena` (e.g. sendJSON, sendPong).
+fn sendLocked(self: *WsConnection, data: []const u8) !void {
     var pos: usize = 0;
+    var changed_to_blocking: bool = false;
     defer _ = self.send_arena.reset(.{ .retain_with_limit = 1024 * 32 });
+
+    defer if (changed_to_blocking) {
+        // Restore non-blocking after a forced blocking write. Safe because
+        // the recv side is owned by a separate reader thread, so the peer
+        // keeps draining our writes even while we're parked here.
+        _ = posix.fcntl(self.socket, posix.F.SETFL, self.socket_flags) catch |err| {
+            log.err(.app, "ws restore nonblocking", .{ .err = err });
+        };
+    };
 
     LOOP: while (pos < data.len) {
         const written = posix.write(self.socket, data[pos..]) catch |err| switch (err) {
             error.WouldBlock => {
-                // The peer's recv buffer is full. Naively switching to a
-                // blocking write would deadlock when the peer is _also_
-                // blocked trying to send to us — a real scenario under CDP
-                // Fetch.enable + http-proxy, where lightpanda emits a flood
-                // of Fetch.requestPaused events while puppeteer is trying
-                // to send us back the matching Fetch.continueRequest
-                // messages. Each side fills the other's TCP send buffer,
-                // and a blocking write here never returns. See
-                // lightpanda-io/browser#2462.
-                //
-                // Instead, poll for POLLOUT _while also_ draining any
-                // POLLIN data into the reader buffer (without processing —
-                // that would re-enter the dispatch path and call back into
-                // send, risking unbounded recursion). The buffered bytes
-                // are picked up by the next CDP.readSocket call.
-                try self.waitWritableDrainingReads();
+                // Socket is normally non-blocking. Flip to blocking briefly
+                // so the kernel queues the rest of the write; the dedicated
+                // reader thread keeps draining recv on the side, so the
+                // peer never wedges and the blocking write completes.
+                assert(changed_to_blocking == false, "WsConnection.double block", .{});
+                changed_to_blocking = true;
+                _ = try posix.fcntl(self.socket, posix.F.SETFL, self.socket_flags & ~@as(u32, @bitCast(posix.O{ .NONBLOCK = true })));
                 continue :LOOP;
             },
             else => return err,
@@ -386,89 +404,15 @@ pub fn send(self: *WsConnection, data: []const u8) !void {
     }
 }
 
-// Block until the socket is writable. Concurrently drains any incoming
-// bytes into the reader buffer (without processing them) so the peer
-// keeps making progress reading our writes. Used to break the two-way
-// backpressure deadlock described in `send`.
-fn waitWritableDrainingReads(self: *WsConnection) !void {
-    // Bounded so a truly dead peer eventually surfaces (TCP keepalive will
-    // close the socket; this just bounds any single send).
-    const POLL_TIMEOUT_MS: i32 = 30_000;
-
-    // We may have to stop watching POLLIN if the reader buffer is at its
-    // cap and we can't make any more space (otherwise poll would return
-    // immediately every iteration with POLLIN set, busy-spinning).
-    var watch_in = true;
-
-    while (true) {
-        const events_in: i16 = if (watch_in) @as(i16, @intCast(posix.POLL.IN)) else 0;
-        var pfds = [_]posix.pollfd{.{
-            .fd = self.socket,
-            .events = @as(i16, @intCast(posix.POLL.OUT)) | events_in,
-            .revents = 0,
-        }};
-        const n = try posix.poll(&pfds, POLL_TIMEOUT_MS);
-        if (n == 0) return error.WouldBlock;
-
-        const revents = pfds[0].revents;
-        if (revents & @as(i16, @intCast(posix.POLL.NVAL | posix.POLL.ERR | posix.POLL.HUP)) != 0) {
-            return error.Closed;
-        }
-
-        if (watch_in and revents & @as(i16, @intCast(posix.POLL.IN)) != 0) {
-            // Drain whatever's available without processing. May grow the
-            // buffer up to CDP_MAX_MESSAGE_SIZE.
-            const before = self.bufferedBytes();
-            try self.drainAvailable();
-            if (self.bufferedBytes() == before and self.reader.readBuf().len == 0) {
-                // Buffer is at cap and we couldn't read anything more.
-                // Stop watching POLLIN so we don't busy-spin while we wait
-                // for POLLOUT.
-                watch_in = false;
-            }
-        }
-
-        if (revents & @as(i16, @intCast(posix.POLL.OUT)) != 0) {
-            return;
-        }
-    }
-}
-
-// Read everything currently available on the socket into the reader
-// buffer (non-blocking). Grows the buffer if needed (capped at
-// CDP_MAX_MESSAGE_SIZE so a misbehaving peer can't OOM us). Does not
-// process messages — the caller will handle that on the next pass
-// through CDP.readSocket.
-fn drainAvailable(self: *WsConnection) !void {
-    while (true) {
-        var buf = self.reader.readBuf();
-        if (buf.len == 0) {
-            const current = self.reader.buf.len;
-            if (current >= CDP_MAX_MESSAGE_SIZE) {
-                // Already at the cap; refuse to grow further. Stop draining
-                // — the next POLLOUT-then-write attempt will block again,
-                // but at least the peer's reads will eventually free our
-                // send buffer and let us proceed.
-                return;
-            }
-            self.reader.buf = try growBuffer(self.reader.allocator, self.reader.buf, current + 1);
-            buf = self.reader.readBuf();
-        }
-        const n = posix.read(self.socket, buf) catch |err| switch (err) {
-            error.WouldBlock => return,
-            else => return err,
-        };
-        if (n == 0) return error.Closed; // peer closed
-        self.reader.len += n;
-    }
-}
-
 const EMPTY_PONG = [_]u8{ 138, 0 };
 
 fn sendPong(self: *WsConnection, data: []const u8) !void {
     if (data.len == 0) {
         return self.send(&EMPTY_PONG);
     }
+    self.send_mutex.lock();
+    defer self.send_mutex.unlock();
+
     var header_buf: [10]u8 = undefined;
     const header = websocketHeader(&header_buf, .pong, data.len);
 
@@ -476,7 +420,7 @@ fn sendPong(self: *WsConnection, data: []const u8) !void {
     const framed = try allocator.alloc(u8, header.len + data.len);
     @memcpy(framed[0..header.len], header);
     @memcpy(framed[header.len..], data);
-    return self.send(framed);
+    return self.sendLocked(framed);
 }
 
 // called by CDP
@@ -486,6 +430,9 @@ fn sendPong(self: *WsConnection, data: []const u8) !void {
 // buffer, where the first 10 bytes are reserved. We can then backfill
 // the header and send the slice.
 pub fn sendJSON(self: *WsConnection, message: anytype, opts: std.json.Stringify.Options) !void {
+    self.send_mutex.lock();
+    defer self.send_mutex.unlock();
+
     const allocator = self.send_arena.allocator();
 
     var aw = try std.Io.Writer.Allocating.initCapacity(allocator, 512);
@@ -494,7 +441,7 @@ pub fn sendJSON(self: *WsConnection, message: anytype, opts: std.json.Stringify.
     try aw.writer.writeAll(&[_]u8{0} ** 10);
     try std.json.Stringify.value(message, opts, &aw.writer);
     const framed = fillWebsocketHeader(aw.toArrayList());
-    return self.send(framed);
+    return self.sendLocked(framed);
 }
 
 pub fn sendJSONRaw(
@@ -548,37 +495,6 @@ pub fn read(self: *WsConnection) !usize {
     const n = try posix.read(self.socket, self.reader.readBuf());
     self.reader.len += n;
     return n;
-}
-
-pub const ReadResult = enum { data, no_new_data, closed };
-
-// Variant of `read` that distinguishes "no new bytes on the wire" from
-// "peer closed". Used by CDP.readSocket so it can still drain buffered
-// messages (those rescued during a backpressured send) without bailing
-// when posix.read reports EWOULDBLOCK.
-pub fn tryRead(self: *WsConnection) !ReadResult {
-    const buf = self.reader.readBuf();
-    if (buf.len == 0) {
-        // Reader buffer is completely full of unprocessed messages. Don't
-        // call posix.read with a zero-length buffer (returns 0 → looks like
-        // EOF). Caller should processMessages first.
-        return if (self.bufferedBytes() > 0) .no_new_data else .closed;
-    }
-    const n = posix.read(self.socket, buf) catch |err| switch (err) {
-        error.WouldBlock => return .no_new_data,
-        else => return err,
-    };
-    if (n == 0) return .closed;
-    self.reader.len += n;
-    return .data;
-}
-
-// Number of bytes sitting in the reader buffer that haven't been parsed
-// into messages yet. Used by HttpClient.perform to detect that data was
-// rescued from the socket during a backpressured send and still needs to
-// be dispatched.
-pub fn bufferedBytes(self: *const WsConnection) usize {
-    return self.reader.len - self.reader.pos;
 }
 
 fn processHttpRequest(self: *WsConnection) !HttpResult {

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -83,8 +83,17 @@ pub const Headers = struct {
         return .{ .headers = updated_headers };
     }
 
-    pub fn deinit(self: *const Headers) void {
+    pub fn deinit(self: *Headers) void {
+        // Null out after free to make deinit idempotent. Headers is value-
+        // copied across structs (Transfer holds it inside a Request, and
+        // some layers / cleanup paths produce a second deinit on the same
+        // slist). Without this, those paths double-free the curl_slist
+        // chain and the ZigToCurlAllocator hits an unaligned-block error
+        // inside curl_slist_free_all on the second pass. RobotsLayer
+        // documented the value-copy hazard for its own path; this guard
+        // is the catch-all so other code paths don't have to.
         if (self.headers) |hdr| {
+            self.headers = null;
             libcurl.curl_slist_free_all(hdr);
         }
     }


### PR DESCRIPTION
Closes #2462.

## Summary

Five coordinated fixes for the `Fetch.enable` + `--http-proxy` deadlock. The original symptom (CONNECT/TLS proxy round-trips inflate concurrency, lightpanda's WS send fills the kernel buffer, lightpanda blocks on write while puppeteer's matching `Fetch.continueRequest` replies pile up unread) is the headline scenario, but along the way an empirical reproducer surfaced four more places that produce the same "lightpanda stops draining the CDP socket and/or crashes mid-cleanup" symptom. All five share the root pattern: a synchronous wait loop or shutdown path that re-enters JS without giving CDP a chance to make progress.

## A/B verification

Repro: puppeteer-core + `setRequestInterception(true)` + `req.continue()` against a localhost forward proxy, lightpanda started with `--http-proxy http://127.0.0.1:8080`.

| URL | before | after |
|---|---|---|
| `https://example.com` | OK 124 ms | OK 117 ms |
| `https://github.com` | HANG 20 s (12/82 continues processed) | OK 1410 ms (82/82) |
| `https://www.shopify.com` | HANG 20 s (1/4) | OK 1973 ms (66/66) |
| `https://www.allbirds.com` | HANG 20 s (12/53) | OK 3944 ms (372/372) |
| `https://www.allbirds.com/products/womens-wool-runners-dapple-grey` | HANG 20 s (12/53) | OK 6286 ms (459/459) |

Lightpanda survives 18 back-to-back navigations across the matrix above (3 per URL) without crashing on the patched binary. Pre-patch, the cleanup path triggered SIGSEGV (`ZigToCurlAllocator.free: incorrect alignment`) inside `BrowserContext.deinit` whenever the page actually completed before puppeteer disconnected.

(`https://www.nike.com` still doesn't fire the `load` event in either version. After this fix all 68 `Fetch.continueRequest` messages process cleanly; the remaining stall is third-party widgets keeping the page in `loading` state, not a CDP/HTTP deadlock. Out of scope.)

## Reproducer

The puppeteer-core script that drove all measurements:

```js
import puppeteer from 'puppeteer-core';

const browser = await puppeteer.connect({
  browserWSEndpoint: 'ws://127.0.0.1:9223',
  defaultViewport: null,
});
const page = await browser.newPage();
await page.setRequestInterception(true);
let seen = 0, continued = 0;
page.on('request', (req) => {
  seen++;
  req.continue().then(() => { continued++; }).catch(() => {});
});
const t0 = Date.now();
try {
  await page.goto('https://www.allbirds.com', { waitUntil: 'load', timeout: 20000 });
  console.log('OK ' + (Date.now() - t0) + 'ms');
} catch (e) {
  console.log('HANG: ' + e.message);
}
await new Promise(r => setTimeout(r, 1000));
console.log('seen=' + seen + ' continued=' + continued);
await browser.disconnect();
```

Lightpanda startup:
```
lightpanda serve --host 127.0.0.1 --port 9223 \
  --http-proxy http://127.0.0.1:8080
```

Any HTTP CONNECT-capable forward proxy on `127.0.0.1:8080` reproduces (vanilla Node `http.createServer` with a `connect` handler is enough).

## Changes

### `src/network/WsConnection.zig` -- drain reads while waiting for write space

`WsConnection.send` previously switched the socket to blocking mode on `EWOULDBLOCK`. The header comment said this "should virtually never happen" -- under `Fetch.enable` + `--http-proxy` it is routine, and the blocking write deadlocks because the peer is also blocked trying to send to us.

New behavior: on `EWOULDBLOCK`, poll for `POLLOUT` *and* `POLLIN`, drain any incoming bytes into the reader buffer (without dispatching -- that would re-enter `send` and recurse). Buffered bytes are picked up by the next `CDP.readSocket`. Adds `tryRead` (variant of `read` that distinguishes "no new bytes" from "peer closed") and `bufferedBytes` accessor.

### `src/browser/HttpClient.zig` -- never starve CDP reads

`perform()` returned `.normal` early whenever `processMessages()` had work, so a steady stream of HTTP completions never gave the CDP socket a chance to be polled. Now: always do at least a non-blocking `curl_multi_poll` of the CDP socket, and return `.cdp_socket` immediately when the WS reader has bytes that were rescued during a backpressured send (via the new `has_buffered_input` callback on `CDPClient`).

Also makes `Transfer.deinit` idempotent. The error-callback path can cascade into re-entrant deinits (e.g. `Script.errorCallback -> manager.evaluate() -> JS execution -> Frame.deinit -> abortOwner -> Transfer.kill -> Transfer.deinit`); the second deinit then double-frees the Transfer's arena (`ArenaPool: double-free detected` panic). The fix uses `client.transfers.remove(self.id)` as a one-shot ownership claim -- if it returns false, this transfer was already torn down by the cascade and we early-return.

`Transfer.kill` is promoted from `fn` to `pub fn` so `BrowserContext.deinit` can use it (see CDP.zig change below). `RequestParams.deinit` / `Request.deinit` now take `*` instead of `*const` so they can call into the now-mutating `Headers.deinit`.

### `src/network/http.zig` -- make Headers.deinit idempotent

`Headers.deinit` did not null `self.headers` after `curl_slist_free_all`. Combined with the value-copy hazard `RobotsLayer` already documents (Headers wraps a raw `*curl_slist`, so a value copy shares the pointer), a second deinit on a copied Headers double-freed the curl slist. The symptom was an "incorrect alignment" panic inside `ZigToCurlAllocator.free` because the slist nodes were already returned to the pool. Nulling `self.headers` after the free makes the second call a no-op regardless of how the value-copy hazard is triggered.

### `src/browser/ScriptManagerBase.zig` -- drain CDP in `waitForImport`

`waitForImport` spun on `client.tick(200)` and discarded the `.cdp_socket` return. A script `import()` whose request was paused at the `InterceptionLayer` hung forever: the matching `Fetch.continueRequest` reply never reached `CDP.processMessage`, the request never resumed, and this loop spun until the client's navigation timeout fired. Mirrors the `syncRequest` pattern that already does this correctly.

The entry pointer is now re-fetched on every loop iteration. The CDP-drain step above re-enters JS, which can call back into `preloadImport` for a transitively-imported module; `preloadImport` calls `imported_modules.getOrPut`, which may rehash the map and invalidate every existing entry pointer. A cached `entry` was a use-after-free on the next `entry.value_ptr.state` access.

### `src/cdp/CDP.zig` -- wire backpressured-buffer drain + safer teardown

`readSocket` now uses `tryRead` (the new `WsConnection` API) and tolerates the `no_new_data` case so messages drained during a backpressured `send` still get processed.

`BrowserContext.deinit` aborts pending intercepts via `transfer.kill` instead of `transfer.abort`. `kill` fires `shutdown_callback` (or no-op for transfers without one); `abort` fires `error_callback`, which re-enters JS via XHR/script error handlers. The handlers crash because the inspector and V8 context this `BrowserContext` owns have already been torn down (`inspector.stopSession()` runs two lines above the abort loop). The original code already aborted "before closing the session/page since some of these might callback into the page/scriptmanager" -- `kill`'s shutdown path is the right primitive for that.

## Stack of failure modes I observed during debugging

For anyone hitting this region in the future, the symptoms shifted as I peeled layers:

1. `Fetch.requestPaused` events fire in lightpanda but `Fetch.continueRequest` replies never arrive. (Backpressure deadlock -- fixed by the WsConnection + perform changes.)
2. After unblocking the deadlock, the page navigates successfully, then puppeteer disconnects, then `BrowserContext.deinit` SIGSEGVs in `curl_slist_free_all`. (Headers double-free -- fixed by `Headers.deinit` idempotency.)
3. After fixing that, the same teardown path SIGSEGVs differently: `ArenaPool: double-free detected` in `Transfer.deinit`. (Cascade out of `error_callback` re-deinits the same transfer -- fixed by `Transfer.deinit` ownership claim.)
4. After fixing that, the teardown path SIGSEGVs again inside `_v8_inspector__Session__wrapObject`. (XHR/script `error_callback` re-enters JS through a torn-down inspector -- fixed by `kill` instead of `abort` in `BrowserContext.deinit`.)
5. After fixing that, the matrix runs clean.
