### PR TITLE
network: implement Network.emulateNetworkConditions

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -118,6 +118,11 @@ use_proxy: bool,
 // Current TLS verification state, applied per-connection in makeRequest.
 tls_verify: bool = true,
 
+// When true, every new HTTP request fails immediately with
+// error.InternetDisconnected before reaching curl. Toggled by
+// Network.emulateNetworkConditions ({"offline": true|false}).
+offline: bool = false,
+
 obey_robots: bool,
 
 // User agent override set via CDP Emulation.setUserAgentOverride.
@@ -461,6 +466,16 @@ pub fn request(self: *Client, req: Request, owner: ?*Owner) !void {
     // layer chain fails before any layer commits the transfer to an external
     // owner (queue / multi handle / pending interception), we clean up here
     // via transfer.abort which fires error_callback and deinits.
+    //
+    // Network.emulateNetworkConditions({"offline": true}) short-circuits here:
+    // every transfer is aborted with InternetDisconnected and surfaced to the
+    // client through the same RequestFail path libcurl uses on real connection
+    // failures (i.e. Network.loadingFailed with errorText set).
+    if (self.offline) {
+        transfer.abort(error.InternetDisconnected);
+        return error.InternetDisconnected;
+    }
+
     self.entry_layer.request(transfer) catch |err| {
         if (!transfer.loop_owned) {
             transfer.abort(err);

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -45,6 +45,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         clearBrowserCookies,
         clearBrowserCache,
         canClearBrowserCache,
+        emulateNetworkConditions,
         setCookie,
         setCookies,
         getCookies,
@@ -62,6 +63,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .clearBrowserCookies => return clearBrowserCookies(cmd),
         .clearBrowserCache => return clearBrowserCache(cmd),
         .canClearBrowserCache => return canClearBrowserCache(cmd),
+        .emulateNetworkConditions => return emulateNetworkConditions(cmd),
         .setCookie => return setCookie(cmd),
         .setCookies => return setCookies(cmd),
         .getCookies => return getCookies(cmd),
@@ -90,6 +92,43 @@ fn setCacheDisabled(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const client = &bc.cdp.browser.http_client;
     client.cache_layer.disabled = params.cacheDisabled;
+    return cmd.sendResult(null, .{});
+}
+
+// Network.emulateNetworkConditions
+// https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-emulateNetworkConditions
+//
+// `offline` is honored: every subsequent HTTP transfer fails with
+// InternetDisconnected before reaching curl, and surfaces to the client as
+// Network.loadingFailed (matching Chrome's offline emulation). Bandwidth /
+// latency / connectionType parameters are accepted for protocol compatibility
+// but not enforced — Lightpanda has no rendering or compositor pipeline that
+// would observe wall-clock latency, and no per-transfer bandwidth limiter.
+fn emulateNetworkConditions(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        offline: bool,
+        latency: ?f64 = null,
+        downloadThroughput: ?f64 = null,
+        uploadThroughput: ?f64 = null,
+        connectionType: ?[]const u8 = null,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const client = &bc.cdp.browser.http_client;
+    client.offline = params.offline;
+
+    if ((params.latency orelse 0) > 0 or
+        (params.downloadThroughput orelse 0) > 0 or
+        (params.uploadThroughput orelse 0) > 0)
+    {
+        log.warn(.not_implemented, "network throttling", .{
+            .latency = params.latency,
+            .downloadThroughput = params.downloadThroughput,
+            .uploadThroughput = params.uploadThroughput,
+        });
+    }
+    _ = params.connectionType;
+
     return cmd.sendResult(null, .{});
 }
 
@@ -783,4 +822,77 @@ test "cdp.Network: setCacheDisabled re-enables cache" {
 
     const client = ctx.cdp().browser.http_client;
     try testing.expectEqual(false, client.cache_layer.disabled);
+}
+
+test "cdp.Network: emulateNetworkConditions toggles offline" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-EN1" });
+
+    // Default: client starts online.
+    {
+        const client = ctx.cdp().browser.http_client;
+        try testing.expectEqual(false, client.offline);
+    }
+
+    // Go offline.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.emulateNetworkConditions",
+        .params = .{
+            .offline = true,
+            .latency = 0,
+            .downloadThroughput = -1,
+            .uploadThroughput = -1,
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+    {
+        const client = ctx.cdp().browser.http_client;
+        try testing.expectEqual(true, client.offline);
+    }
+
+    // Back online.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Network.emulateNetworkConditions",
+        .params = .{
+            .offline = false,
+            .latency = 0,
+            .downloadThroughput = -1,
+            .uploadThroughput = -1,
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+    {
+        const client = ctx.cdp().browser.http_client;
+        try testing.expectEqual(false, client.offline);
+    }
+}
+
+test "cdp.Network: emulateNetworkConditions accepts connectionType + throttling params" {
+    // Bandwidth / latency / connectionType parameters are accepted for protocol
+    // compatibility but currently no-op (logged via .not_implemented). Clients
+    // built against Chrome's CDP (Puppeteer, chrome-remote-interface, Selenium's
+    // execute_cdp) always pass the full 4-tuple, so a strict struct schema would
+    // reject every real call.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-EN2" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Network.emulateNetworkConditions",
+        .params = .{
+            .offline = false,
+            .latency = 150,
+            .downloadThroughput = 750000,
+            .uploadThroughput = 250000,
+            .connectionType = "cellular3g",
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+
+    const client = ctx.cdp().browser.http_client;
+    try testing.expectEqual(false, client.offline);
 }


### PR DESCRIPTION
## What

`Network.emulateNetworkConditions` is the standard CDP method for taking a target offline (and applying optional latency / bandwidth / connectionType hints). Before this change the method wasn't in the `Network` domain's action enum, so every call rejected with `-31998 UnknownMethod`. This PR wires up the dispatch + an `offline` toggle that short-circuits the HTTP layer chain, matching the contract of [Chrome's CDP behavior](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-emulateNetworkConditions).

Closes #2470.

## Root cause

The action enum in `processMessage` (`src/cdp/domains/network.zig`) didn't list `emulateNetworkConditions`, so `std.meta.stringToEnum` returned null and the dispatcher rejected the method as unknown. There was also no plumbing on `HttpClient` to express "every subsequent transfer must fail as if the network were unreachable" — `cache_layer.disabled` was the closest analogue but only suppresses cache reads, not transfers.

```mermaid
flowchart LR
    A[CDP Network.emulateNetworkConditions] --> B[processMessage enum]
    B --> C[no match, return UnknownMethod]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/cdp/domains/network.zig` — add `emulateNetworkConditions` to the action enum and an `emulateNetworkConditions` handler that flips `client.offline`. Latency / throughput / connectionType parameters are accepted for protocol compatibility and logged via `.not_implemented` until a real implementation lands.
- `src/browser/HttpClient.zig` — new `offline: bool = false` field on `Client`. `Client.request` short-circuits when `offline` is true: the transfer is created and immediately routed through `transfer.abort(error.InternetDisconnected)`, which fires the standard error_callback / `Network.loadingFailed` path. The in-page `fetch` / XHR observes a rejected promise / TypeError, matching Chrome.

```mermaid
flowchart LR
    A[CDP Network.emulateNetworkConditions] --> B[processMessage emulateNetworkConditions]
    B --> C[client.offline = params.offline]
    C --> D[next HTTP request short-circuits]
    D --> E[transfer.abort error.InternetDisconnected]
    E --> F[Network.loadingFailed and JS TypeError]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
    style F fill:#dfd
```

## Test

- **Unit tests** in `src/cdp/domains/network.zig`:
  - `cdp.Network: emulateNetworkConditions toggles offline` — sets `offline: true`, verifies `http_client.offline == true`; flips back and re-verifies.
  - `cdp.Network: emulateNetworkConditions accepts connectionType + throttling params` — calls with the full Chrome-style payload (`latency`, `downloadThroughput`, `uploadThroughput`, `connectionType`) to confirm the schema accepts what real CDP clients (chrome-remote-interface, Puppeteer, Selenium `execute_cdp`) actually send. Throttling logs the `.not_implemented` warn.
  - Both fail when the dispatch case is reverted to `error.UnknownMethod`, confirming the tests exercise this PR's wiring.
- **Reproducer** from #2470: `repro.sh` exits 1 against stock `main` (the probe rejects with `-31998: UnknownMethod`) and exits 0 against this branch (baseline fetch succeeds, fetch fails while `offline=true` with `TypeError: fetch error`, fetch recovers after `offline=false`).
- Full `mise exec -- zig build test $V8` passes locally (654/654).

## Notes

- Throttling (latency, downloadThroughput, uploadThroughput) and `connectionType` are accepted but not enforced. Implementing real bandwidth shaping needs per-transfer throttling at the curl layer and per-engine wall-clock latency injection, which is a much larger change. The protocol-compatible no-op (with `.not_implemented` warn) preserves the option of layering that on later without breaking clients today.
- The offline flag lives on `HttpClient` (client-wide), mirroring the existing `setCacheDisabled` / `setUserAgentOverride` / TLS-verify scoping. If a future multi-context use case needs per-target offline state, it can move onto `BrowserContext` alongside `extra_headers`.
- Per-request short-circuit happens at the top of `Client.request`, before the layer chain. Aborting via `transfer.abort(error.InternetDisconnected)` reuses the existing `RequestFail` notification pipeline, so consumers of `Network.loadingFailed` (and the in-page `fetch` / XHR error path) get the same surface they'd get from a real connection failure.
