### PR TITLE
Fix #2472: scope frame ID generator to Browser, not Session

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -45,9 +45,29 @@ http_client: HttpClient,
 // used by sessions to allocate pages.
 page_pool: std.heap.MemoryPool(Page),
 
+// Monotonic frame-ID generator scoped to this Browser (one per CDP
+// connection). Lives here, not on Session, because CDP target IDs
+// (encoded as `FID-{d:0>10}`) must be unique for the lifetime of the
+// connection -- a Session-scoped counter would re-issue the same
+// `FID-0000000001` for every fresh BrowserContext on the connection,
+// which Playwright rejects with `Duplicate target FID-...` (issue
+// #2472).
+frame_id_gen: u32 = 0,
+
 const InitOpts = struct {
     env: js.Env.InitOpts = .{},
 };
+
+// Allocate the next frame ID. Wrapping `+%` keeps this safe past 2^32
+// allocations on a single connection (which would take days of
+// continuous navigation; in practice we wrap the connection long
+// before that). Callers must format with `FID-{d:0>10}` to match the
+// existing CDP target-ID encoding (`src/cdp/id.zig`).
+pub fn nextFrameId(self: *Browser) u32 {
+    const id = self.frame_id_gen +% 1;
+    self.frame_id_gen = id;
+    return id;
+}
 
 pub fn init(self: *Browser, app: *App, opts: InitOpts, cdp_client: ?HttpClient.CDPClient) !void {
     const allocator = app.allocator;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -76,8 +76,10 @@ _pending: ?*Page = null,
 
 _queued_destroy: std.ArrayList(*Page) = .{},
 
-// IDs. Kept at Session level so IDs can remain unique across Page replacements.
-frame_id_gen: u32 = 0,
+// Loader IDs are scoped to the Session: each new BrowserContext gets a
+// fresh counter. Frame IDs (`frame_id_gen`) live on `Browser` instead so
+// CDP target IDs stay unique across BrowserContext lifecycle on a single
+// connection (see `Browser.frame_id_gen` and issue #2472).
 loader_id_gen: u32 = 0,
 
 // configuration (or CDP command) to disable iframe loading
@@ -165,10 +167,18 @@ fn destroyPage(self: *Session, page: *Page) void {
 
 // Tear down the currently-active Page. Dispatches `frame_remove` first
 // so CDP can clear inspector state while the OLD page is still walkable,
-// then frees the slot and notifies Navigation. Resets `frame_id_gen` to
-// match pre-pending-page behavior. Used by removePage and by the
-// synthetic-nav path (replaceRootImmediate). Does NOT touch any pending
-// page — callers handle that themselves.
+// then frees the slot and notifies Navigation. Used by removePage and
+// by the synthetic-nav path (replaceRootImmediate). Does NOT touch any
+// pending page — callers handle that themselves.
+//
+// Frame IDs are NOT reset here — the counter lives on `Browser` and is
+// monotonic for the lifetime of the CDP connection so target IDs stay
+// unique (issue #2472). The previous reset-to-zero behaviour was
+// invisible within a single Session/BrowserContext (the next
+// `installNewActivePage` was usually called with the old frame's
+// explicit `frame_id`, see `replaceRootImmediate`) but caused
+// `Duplicate target FID-...` collisions when a new BrowserContext
+// allocated its first page after dispose.
 //
 // NOT a substitute for the careful 5-step sequence in commitPendingPage,
 // which interleaves the OLD-page teardown with the pending-page promotion
@@ -186,7 +196,6 @@ fn tearDownActivePage(self: *Session) void {
     self.destroyPage(page);
     self._active = null;
     self.navigation.onRemoveFrame();
-    self.frame_id_gen = 0;
 }
 
 // Allocate a Page in a free slot, publish it as the active page, and
@@ -619,10 +628,11 @@ pub fn discardPendingPage(self: *Session) void {
     self.destroyPage(page);
 }
 
+// Frame IDs come from `Browser` (per-CDP-connection scope), not
+// `Session` (per-BrowserContext). Kept as a Session method so existing
+// callers (Frame, Worker) don't have to thread a Browser pointer.
 pub fn nextFrameId(self: *Session) u32 {
-    const id = self.frame_id_gen +% 1;
-    self.frame_id_gen = id;
-    return id;
+    return self.browser.nextFrameId();
 }
 
 pub fn nextLoaderId(self: *Session) u32 {

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -570,6 +570,47 @@ test "cdp.target: disposeBrowserContext" {
     }
 }
 
+// Issue #2472: CDP target IDs (`FID-{d:0>10}`) must stay unique for the
+// lifetime of a CDP connection. Before the fix, `Session.frame_id_gen`
+// reset to 0 on `tearDownActivePage` AND fresh sessions also started
+// from 0, so the second `Target.createTarget` after a dispose re-issued
+// the same `FID-0000000001` and Playwright clients tripped on
+// `Duplicate target FID-...`. The counter now lives on `Browser` and is
+// monotonic across BrowserContexts.
+test "cdp.target: createTarget assigns unique IDs across BrowserContexts (issue #2472)" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    // Cycle 1: create context + target, capture the assigned target_id.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Target.createTarget",
+        .params = .{ .url = "about:blank" },
+    });
+    const target_id_1 = ctx.cdp().browser_context.?.target_id.?;
+    const bc_id_1 = ctx.cdp().browser_context.?.id;
+
+    // Dispose the first context.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Target.disposeBrowserContext",
+        .params = .{ .browserContextId = bc_id_1 },
+    });
+    try testing.expectEqual(null, ctx.cdp().browser_context);
+
+    // Cycle 2: create another context + target. The new target_id must
+    // differ from cycle 1's -- duplicates here are exactly what Playwright
+    // asserts on with `Duplicate target FID-...`.
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Target.createTarget",
+        .params = .{ .url = "about:blank" },
+    });
+    const target_id_2 = ctx.cdp().browser_context.?.target_id.?;
+
+    try testing.expect(!std.mem.eql(u8, &target_id_1, &target_id_2));
+}
+
 test "cdp.target: createTarget" {
     {
         var ctx = try testing.context();


### PR DESCRIPTION
Fixes #2472.

## Summary

CDP target IDs (`FID-{d:0>10}`) must stay unique for the lifetime of the CDP connection. Playwright's `CRBrowser._onAttachedToTarget` records every attached target in an in-memory map and asserts on collision; the assertion is fatal and the connection is unusable afterwards.

Before this PR, `Session.frame_id_gen` reset to 0 in two places:

  1. `tearDownActivePage` explicitly reset to 0 after every page teardown. The reset was likely intended to mimic pre-pending-page numbering within a single Session, but invisible there because the immediately-following `installNewActivePage` typically reuses the old frame's explicit `frame_id` (see `replaceRootImmediate`).

  2. Fresh Sessions started from the field default of 0. Each `Target.createBrowserContext` calls `Browser.newSession`, which deinits the old Session and constructs a new one -- so even without (1), the next BrowserContext's first page would still get `FID-0000000001`.

(2) is the operative cause of the `Duplicate target FID-0000000001` collision in the issue: the second `browser.newContext()` on a connection allocates a fresh Session whose first page re-issues the same `FID-0000000001` as the first context's frame.

## Fix

Move `frame_id_gen` (and `nextFrameId`) from `Session` to `Browser`. `Browser` is per-CDP-connection (each `CDP` holds one `Browser`, each `Browser` holds one `Session` at a time), so the counter now spans the entire connection lifetime as the CDP spec / Chrome behaviour requires.

Existing callers (`Session.createPage`, `Frame.zig:1327`, `Frame.zig:1437`, `Worker.zig:74`) still go through `Session.nextFrameId` -- it's now a thin pass-through to `browser.nextFrameId()` -- so no call sites change. The explicit reset in `tearDownActivePage` is removed; it was redundant within a Session (root navigation reuses the old frame_id) and harmful across Sessions.

`loader_id_gen` stays on Session: Loader IDs (`LID-...`) are per-frame in CDP and Playwright doesn't track them in the target registry, so the per-Session reset is correct there.

## Verification

Repro from the issue (`playwright-core@1.58.2`):

```js
for (let i = 1; i <= 5; i++) {
  const ctx = await browser.newContext();
  await ctx.newPage();
  await ctx.close();
  console.log(`cycle ${i} ok`);
}
```

Before:
```
cycle 1 ok
Error: Duplicate target FID-0000000001
    at CRBrowser._onAttachedToTarget
```

After:
```
cycle 1 ok
cycle 2 ok
cycle 3 ok
cycle 4 ok
cycle 5 ok
ALL CYCLES OK
```

## Tests

`zig build test`: 653 / 653 pass (652 existing + 1 new).

Added `cdp.target: createTarget assigns unique IDs across BrowserContexts (issue #2472)` -- creates a target, disposes the context, creates another target, and asserts the two `target_id`s differ. Verified the regression test catches the bug:

```
$ git stash push src/browser/Browser.zig src/browser/Session.zig
$ zig build test
[31mcdp.target: createTarget assigns unique IDs across BrowserContexts (issue #2472) (51.05ms)
652 of 653 tests passed
```

Reverting the Browser.zig + Session.zig changes (keeping only the test) reproduces the failure.

## Notes

Independent of #2399 (Playwright connectOverCDP synthetic-STARTUP promotion) but interacts with it. #2399 makes the synthetic STARTUP target's `targetId` deterministically match the first real frame ID (`FID-0000000001`) so the synthetic-to-real handoff doesn't mismatch in Playwright's registry. That alignment now holds across BrowserContext lifecycle too -- the second context's first frame is `FID-0000000002`, not a duplicate of the synthetic.

The deferred-dispose path in `CDP.disposeBrowserContext` (`src/cdp/CDP.zig:383`) was a possibly-related second finding noted in the issue (script-eval reentrant teardown leaving `browser_context != null`, surfacing as `Cannot have more than one browser context at a time`). It's not addressed here -- I couldn't isolate it in a standalone repro and it may turn out to be the same root cause surfacing differently. Filing separately if it persists once this lands.
