### PR TITLE
js: emit `null` when JSON-stringifying unserializable values

### DIFF
--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -304,6 +304,17 @@ pub fn toJson(self: Value, allocator: Allocator) ![]u8 {
 pub fn jsonStringify(self: Value, jws: anytype) !void {
     const local = self.local;
     const v = self.toJson(local.call_arena) catch return error.WriteFailed;
+    // V8's JSON::Stringify finishes by calling Object::ToString on whatever
+    // i::JsonStringify returns. For values that JSON.stringify treats as
+    // non-serializable at the top level (undefined, functions, symbols),
+    // i::JsonStringify yields the undefined sentinel, and ToString coerces
+    // it to the JS string "undefined". Writing those 9 bytes raw embeds a
+    // bare `undefined` token into the JSON stream — invalid per RFC 8259.
+    // Map that case to `null`, matching what JSON.stringify emits when an
+    // unserializable value sits in an array slot.
+    if (std.mem.eql(u8, v, "undefined")) {
+        return jws.write(null);
+    }
     jws.beginWriteRaw() catch return error.WriteFailed;
     jws.writer.writeAll(v) catch return error.WriteFailed;
     jws.endWriteRaw();
@@ -490,4 +501,61 @@ fn G(comptime global_type: GlobalType) type {
             }
         }
     };
+}
+
+const testing = @import("../../testing.zig");
+test "Value: jsonStringify maps unserializable JS values to null" {
+    const session = testing.test_session;
+    const frame = try session.createPage();
+    defer session.removePage();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    // V8::JSON::Stringify finishes with Object::ToString on whatever
+    // i::JsonStringify returns. For values JSON.stringify treats as
+    // non-serializable at the top level (undefined, functions, symbols),
+    // i::JsonStringify yields the undefined sentinel, and ToString coerces
+    // it to the JS string "undefined". Without the jsonStringify fix, those
+    // 9 bytes get written raw and the produced JSON is invalid.
+    const Wrapper = struct { v: Value };
+    const cases = .{
+        .{ .name = "undefined", .expr = "undefined" },
+        .{ .name = "function", .expr = "(function(){})" },
+        .{ .name = "symbol", .expr = "Symbol('s')" },
+    };
+    inline for (cases) |case| {
+        const value = try ls.local.exec(case.expr, null);
+        const out = try std.json.Stringify.valueAlloc(
+            testing.allocator,
+            Wrapper{ .v = value },
+            .{},
+        );
+        defer testing.allocator.free(out);
+        try testing.expectEqualSlices(u8, "{\"v\":null}", out);
+    }
+
+    // Values that DO serialize must pass through unchanged.
+    const ok_cases = .{
+        .{ .expr = "null", .expected = "{\"v\":null}" },
+        .{ .expr = "42", .expected = "{\"v\":42}" },
+        .{ .expr = "'hi'", .expected = "{\"v\":\"hi\"}" },
+        .{ .expr = "true", .expected = "{\"v\":true}" },
+        .{ .expr = "({a:1})", .expected = "{\"v\":{\"a\":1}}" },
+        .{ .expr = "[undefined]", .expected = "{\"v\":[null]}" },
+        .{ .expr = "({x:undefined})", .expected = "{\"v\":{}}" },
+        // A string literally equal to "undefined" must keep its quotes.
+        .{ .expr = "'undefined'", .expected = "{\"v\":\"undefined\"}" },
+    };
+    inline for (ok_cases) |case| {
+        const value = try ls.local.exec(case.expr, null);
+        const out = try std.json.Stringify.valueAlloc(
+            testing.allocator,
+            Wrapper{ .v = value },
+            .{},
+        );
+        defer testing.allocator.free(out);
+        try testing.expectEqualSlices(u8, case.expected, out);
+    }
 }


### PR DESCRIPTION
## What

`Value.jsonStringify` (used wherever the JSON encoder writes a `js.Value` field — `Runtime.consoleAPICalled` arguments, history `state` payloads, etc.) was emitting the bare token `undefined` for any JS value that `JSON.stringify` treats as non-serializable at the top level: `undefined`, functions, symbols. The resulting wire bytes are invalid per [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) and break strict-JSON CDP clients (Playwright, Puppeteer, anything calling `JSON.parse` on the frame).

Closes #2473.

## Root cause

`v8::JSON::Stringify` finishes by calling `i::Object::ToString` on whatever `i::JsonStringify` returns. For unserializable top-level values, `i::JsonStringify` yields the JS `undefined` sentinel and `ToString` coerces it to the JS string `"undefined"` (9 bytes). The previous implementation handed that slice straight to `writer.writeAll`, so those 9 bytes landed in the JSON stream as a bare token.

```mermaid
flowchart LR
    A[Value.jsonStringify] --> B[v8.JSON.Stringify undefined]
    B --> C[Local of String 'undefined']
    C --> D[writer.writeAll]
    D --> E[bare undefined in JSON stream]
    style C fill:#fdd
    style D fill:#fdd
    style E fill:#fdd
```

## Fix

- `src/browser/js/Value.zig` — `jsonStringify`: after `toJson`, check whether the returned slice equals exactly `"undefined"` (the bare 9-byte token V8 produces from `Object::ToString` on the undefined sentinel). If so, write JSON `null` via `jws.write(null)` instead of raw bytes. Other values pass through `beginWriteRaw` / `writeAll` / `endWriteRaw` unchanged. A JS string whose contents are literally `"undefined"` is unaffected — V8 quotes it as `"\"undefined\""` (11 bytes) so the equality check misses.

```mermaid
flowchart LR
    A[Value.jsonStringify] --> B[v8.JSON.Stringify undefined]
    B --> C[Local of String 'undefined']
    C --> D{slice == 'undefined'?}
    D -->|yes| E[jws.write null]
    D -->|no| F[writeAll raw bytes]
    E --> G[valid JSON null]
    F --> H[valid JSON]
    style D fill:#dfd
    style E fill:#dfd
    style G fill:#dfd
```

## Test

- **Unit test**: `Value: jsonStringify maps unserializable JS values to null` in `src/browser/js/Value.zig`. Constructs `js.Value` instances for `undefined`, an anonymous function, and a `Symbol`, serializes a wrapper struct via `std.json.Stringify.valueAlloc`, and asserts the output is `{"v":null}`. Also covers the unchanged paths: `null` / numbers / strings / booleans / objects / `[undefined]` → `[null]` / `({x: undefined})` → `{}` / a literal `"undefined"` string keeps its quotes.
- **Toggle-off check**: reverting the `if (std.mem.eql(u8, v, "undefined"))` block makes the targeted test fail with `expectEqual: "{\"v\":null}" != "{\"v\":undefined}"`. Restoring the fix returns it to green. Full `mise exec -- zig build test $V8` passes 653/653.
- **Reproducer**: the harness in #2473 (raw `ws` CDP probe that runs `console.log(undefined)` under `Runtime.enable` and scans inbound frames for `[:,]undefined[,}\]]`) exits `1` against `main` and `0` against this branch. Same harness scanned 11 frames clean on the fixed binary.

## Notes

- Narrow fix at the `js.Value` layer, on purpose: every existing CDP payload that embeds a `js.Value` benefits without changes to the CDP domain code. A spec-perfect fix for `Runtime.RemoteObject` would omit the `value` key entirely when the JS value is `undefined` (matching Chrome's wire shape), but that requires making `value: ?js.Value` and threading the optionality into every consumer — out of scope here. `"value": null` is the JSON spec answer for the same situation in an array slot (`JSON.stringify([undefined])` → `"[null]"`) and CDP clients accept it interchangeably.
- `Value.toJson` (used by `History.zig` / `Navigation.zig` for `state` payloads) is intentionally untouched — those callers store the resulting bytes and may want to preserve the existing `error.DataClone` behavior for unserializable inputs. The fix is scoped to the `jsonStringify` path that feeds `std.json.Stringify`.
