### PR TITLE
Drain deferred disposeBrowserContext on next createBrowserContext (#2472 follow-up)

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -345,11 +345,40 @@ fn dispatchCommand(command: *Command, method: []const u8) !void {
 
 fn isValidSessionId(self: *const CDP, input_session_id: []const u8) bool {
     const browser_context = &(self.browser_context orelse return false);
+    // A pending-dispose bc is logically gone from the client's POV --
+    // commands on its session_id should reject like any other unknown
+    // session, not silently route into a half-alive context.
+    if (browser_context.pending_dispose) return false;
     const session_id = browser_context.session_id orelse return false;
     return std.mem.eql(u8, session_id, input_session_id);
 }
 
+// Finish a deferred `disposeBrowserContext` if one is pending and the
+// eval frame that blocked it has unwound. Returns true if the bc was
+// flushed (or there was none). Returns false if a pending dispose
+// remains (eval still on stack -- caller must surface that to the user).
+fn flushPendingDispose(self: *CDP) bool {
+    const bc = &(self.browser_context orelse return true);
+    if (!bc.pending_dispose) return true;
+    if (bc.session.currentPage()) |page| {
+        if (page.frame.anyScriptEvaluating()) return false;
+    }
+    bc.deinit();
+    self.browser.closeSession();
+    self.browser_context = null;
+    _ = self.browser_context_arena.reset(.{ .retain_with_limit = 1024 * 16 });
+    return true;
+}
+
 pub fn createBrowserContext(self: *CDP) ![]const u8 {
+    // Drain any deferred dispose first. Without this, a Playwright-style
+    // `ctx.close(); newContext()` sequence rejects with AlreadyExists
+    // forever once the original close hit the deferred branch in
+    // `disposeBrowserContext` -- the comment there says "deferred to
+    // CDP.deinit at connection close," but long-lived CDP connections
+    // (Playwright `connectOverCDP`) never close between contexts.
+    _ = self.flushPendingDispose();
+
     if (self.browser_context != null) {
         return error.AlreadyExists;
     }
@@ -370,10 +399,11 @@ pub fn disposeBrowserContext(self: *CDP, browser_context_id: []const u8) bool {
     // Reentrant teardown from a CDP message drained inside HttpClient.syncRequest.
     // Tearing down the browser context here would free Session/Page state
     // that the unwinding script-eval frame above us is about to dereference
-    // (see Session.removePage's matching guard). Defer cleanup to
-    // CDP.deinit at connection close, by which time eval has unwound.
+    // (see Session.removePage's matching guard). Mark the bc for deferred
+    // cleanup; the next `createBrowserContext` (or `deinit`) drains it.
     if (bc.session.currentPage()) |page| {
         if (page.frame.anyScriptEvaluating()) {
+            bc.pending_dispose = true;
             return true;
         }
     }
@@ -468,6 +498,13 @@ pub const BrowserContext = struct {
 
     http_proxy_changed: bool = false,
     user_agent_changed: bool = false,
+
+    // Set by `disposeBrowserContext` when teardown is deferred because
+    // a script eval is on the stack (`page.frame.anyScriptEvaluating()`).
+    // Drained on the next `createBrowserContext` (and treated as a
+    // hard "already-disposed" signal by `isValidSessionId` so commands
+    // on the old session_id reject instead of routing to a half-alive bc).
+    pending_dispose: bool = false,
 
     // Extra headers to add to all requests.
     extra_headers: std.ArrayList([*c]const u8) = .empty,

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -570,6 +570,61 @@ test "cdp.target: disposeBrowserContext" {
     }
 }
 
+// Issue #2472 follow-up: `disposeBrowserContext` may defer cleanup if
+// a script eval is on the stack (CDP-pump from `HttpClient.syncRequest`
+// drains a `Target.disposeBrowserContext` while is_evaluating == true).
+// Without `flushPendingDispose`, the next `Target.createBrowserContext`
+// rejects with `AlreadyExists` forever -- the original comment said
+// cleanup was "deferred to CDP.deinit at connection close," but
+// long-lived CDP connections (Playwright `connectOverCDP`) never close
+// between contexts. The fix flushes pending-dispose at the next
+// createBrowserContext call once eval has unwound.
+test "cdp.target: createBrowserContext flushes deferred dispose once eval unwinds" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    // Set up bc#1 with an active page (target_id, session, frame).
+    const bc1 = try ctx.loadBrowserContext(.{
+        .id = "BID-1",
+        .url = "hi.html",
+        .target_id = "FID-000000000X".*,
+    });
+    const bc1_id_copy = bc1.id;
+
+    // Simulate "CDP message arrived while script eval is on the stack":
+    // the page exists and we forcibly mark its script manager as
+    // evaluating, mirroring `HttpClient.syncRequest` pumping CDP messages
+    // mid-fetch (`ScriptManager.executeScript` sets `is_evaluating = true`
+    // around the syncRequest).
+    const page = bc1.session.currentPage().?;
+    page.frame._script_manager.base.is_evaluating = true;
+
+    // disposeBrowserContext returns success (true) but defers actual
+    // teardown -- bc remains on `cdp.browser_context`, marked
+    // `pending_dispose`.
+    try testing.expectEqual(true, ctx.cdp().disposeBrowserContext(bc1_id_copy));
+    try testing.expect(ctx.cdp().browser_context != null);
+    try testing.expect(ctx.cdp().browser_context.?.pending_dispose);
+
+    // While eval is still on the stack, createBrowserContext can't drain
+    // the pending dispose -- it must surface AlreadyExists rather than
+    // half-tearing-down a context whose Session/V8 state is still in use.
+    try testing.expectError(error.AlreadyExists, ctx.cdp().createBrowserContext());
+
+    // Eval finishes (HttpClient.syncRequest returns, ScriptManager pops
+    // its `defer is_evaluating = was_evaluating`). The next CDP message
+    // arrives -- `createBrowserContext` flushes the deferred dispose and
+    // proceeds normally.
+    page.frame._script_manager.base.is_evaluating = false;
+
+    const bc2_id = try ctx.cdp().createBrowserContext();
+    try testing.expect(ctx.cdp().browser_context != null);
+    try testing.expect(!ctx.cdp().browser_context.?.pending_dispose);
+    // The new bc must be a distinct allocation -- the deferred bc was
+    // freed by the flush, not reused.
+    try testing.expect(!std.mem.eql(u8, bc1_id_copy, bc2_id));
+}
+
 test "cdp.target: createTarget" {
     {
         var ctx = try testing.context();


### PR DESCRIPTION
Follow-up to #2472 / #2474. The frame-ID PR fixed the cross-BrowserContext target-ID collision. This one fixes a second `Cannot have more than one browser context at a time` failure that the same Playwright workload hits when the CDP connection is long-lived.

## Problem

`CDP.disposeBrowserContext` (`src/cdp/CDP.zig:378`) defers cleanup when a script eval is on the stack. The existing comment is right about why -- a CDP message drained inside `HttpClient.syncRequest` arrives mid-evaluate, and tearing down the bc here would free Session / V8 / inspector state the unwinding script frame is about to dereference. The comment also said cleanup was "deferred to `CDP.deinit` at connection close, by which time eval has unwound."

That assumption holds for short-lived CDP connections that close after each browser session. It breaks for long-lived ones. Playwright's `chromium.connectOverCDP` keeps the websocket open across many BrowserContexts: once a dispose hits the deferred branch, `browser_context` stays non-null, and the next `createBrowserContext` rejects with `error.AlreadyExists` -> `Cannot have more than one browser context at a time` for the rest of the connection. There is no path to recovery short of disconnecting and reconnecting, which defeats the point of pooling.

## Reproduction

Minimal Node + Playwright + a slow `<script src>` server:

```js
import { chromium } from "playwright-core";
import http from "node:http";
import { spawn } from "node:child_process";

// Slow script server: holds /slow.js open for 3 s so syncRequest is in flight.
const server = http.createServer((req, res) => {
  if (req.url === "/slow.js") {
    setTimeout(() => res.end("window.__loaded=true;"), 3_000);
    return;
  }
  res.writeHead(200, { "content-type": "text/html" });
  res.end(`<!doctype html><script src="/slow.js"></script>`);
});
await new Promise((r) => server.listen(0, "127.0.0.1", r));
const PAGE_URL = `http://127.0.0.1:${server.address().port}/`;

const lp = spawn("lightpanda", ["serve", "--host", "127.0.0.1", "--port", "9229"], { stdio: "inherit" });
await new Promise((r) => setTimeout(r, 1_500));
const browser = await chromium.connectOverCDP("ws://127.0.0.1:9229");

for (let i = 1; i <= 3; i++) {
  const ctx = await browser.newContext();
  const page = await ctx.newPage();
  page.goto(PAGE_URL).catch(() => {});           // start sync /slow.js fetch
  await new Promise((r) => setTimeout(r, 500));  // close mid-fetch
  await ctx.close();                             // -> deferred dispose
  await new Promise((r) => setTimeout(r, 4_000)); // wait long enough for eval to unwind
}
```

Before this PR (against `main`):

```
cycle 1 close() returned
FAILED: browser.newContext: Protocol error (Target.createBrowserContext):
  Cannot have more than one browser context at a time
```

After:

```
cycle 1 close() returned
cycle 2 close() returned
cycle 3 close() returned
ALL CYCLES OK
```

## Fix

Three small changes in `src/cdp/CDP.zig`:

  1. **New `pending_dispose: bool` flag on `BrowserContext`.** Set in the deferred branch of `disposeBrowserContext` instead of just returning. Marks the bc as logically gone but physically still alive while the eval frame above us unwinds.

  2. **New private `flushPendingDispose` helper.** Re-checks `anyScriptEvaluating()` and runs the same `bc.deinit` + `closeSession` + `browser_context = null` the non-deferred path would have if eval is now off the stack. Returns `false` if eval is still on the stack so the caller can surface that to the client.

  3. **`createBrowserContext` calls `flushPendingDispose` before checking `AlreadyExists`.** If the previous deferred dispose can be drained, the new context proceeds normally. If eval is still on the stack at the next create attempt (very tight cycle), the create still rejects with `AlreadyExists` -- waiting for eval to finish is the client's problem, but recovery now happens automatically once it does.

  4. **`isValidSessionId` treats `pending_dispose == true` as no bc.** Commands on the old session_id now reject with `Unknown sessionId` instead of silently routing into a half-alive context.

`Session.removePage` has the same deferred pattern but isn't in the client-visible recovery path (Playwright never calls page-level dispose, only context-level), so this PR doesn't touch it. Filing separately if it turns out to bite something.

## Tests

`zig build test`: 653 / 653 pass (652 existing + 1 new).

Added `cdp.target: createBrowserContext flushes deferred dispose once eval unwinds`:

  - Forces `is_evaluating = true` on the active page's frame.
  - Asserts `disposeBrowserContext` returns success and flips `pending_dispose`.
  - Asserts `createBrowserContext` rejects with `AlreadyExists` while eval is still on the stack.
  - Drops `is_evaluating = false` (eval has unwound).
  - Asserts the next `createBrowserContext` flushes the pending dispose and returns a distinct bc.

Verified the test catches the bug: reverting the CDP.zig changes (keeping only the test) produces a single-test failure, the rest of the suite still passes.

## Relationship to other PRs

  - #2399: Playwright `connectOverCDP` STARTUP-session promotion. Lets Playwright clients connect at all.
  - #2474 (#2472): Frame ID generator scoped to Browser. Lets Playwright clients open a second BrowserContext on the same connection without `Duplicate target FID-...`.
  - **This PR**: lets Playwright clients keep doing that even after a context-close lands during a sync script fetch.

Independent of both -- can land in any order. With all three, Playwright `connectOverCDP` becomes safe to use as a long-lived pooled connection.
