### PR TITLE
css: evaluate @media and matchMedia against viewport

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -22,6 +22,7 @@ const lp = @import("lightpanda");
 const Frame = @import("Frame.zig");
 
 const CssParser = @import("css/Parser.zig");
+const MediaQuery = @import("css/MediaQuery.zig");
 const Element = @import("webapi/Element.zig");
 
 const Selector = @import("webapi/selector/Selector.zig");
@@ -78,8 +79,14 @@ pub fn deinit(self: *StyleManager) void {
 fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
     if (sheet._css_rules) |css_rules| {
         for (css_rules._rules.items) |rule| {
-            const style_rule = rule.is(CSSStyleRule) orelse continue;
-            try self.addRule(style_rule);
+            switch (rule._type) {
+                .style => |sr| try self.addRule(sr),
+                // Re-parse the stored source so an `@media` rule inserted via
+                // `insertRule` / `replaceSync` participates in the cascade
+                // when its query matches the viewport.
+                .media => try self.applyMediaAtRule(rule._text),
+                else => {},
+            }
         }
         return;
     }
@@ -89,13 +96,52 @@ fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
         const text = try style.asNode().getTextContentAlloc(self.arena);
         var it = CssParser.parseStylesheet(text);
         while (it.next()) |parsed_rule| {
-            // StyleManager only filters on regular style rules (display,
-            // visibility, opacity). At-rules don't carry top-level
-            // declarations relevant here -- skip them.
             switch (parsed_rule) {
                 .style => |s| try self.addRawRule(s.selector, s.block),
-                .at_rule => {},
+                .at_rule => |a| {
+                    // Only `@media` participates in the cascade here. Other
+                    // at-rules (`@keyframes`, `@supports`, `@font-face`, …)
+                    // don't carry top-level declarations relevant to the
+                    // visibility filter and stay skipped as before.
+                    if (std.ascii.eqlIgnoreCase(a.keyword, "media")) {
+                        try self.applyMediaAtRule(a.text);
+                    }
+                },
             }
+        }
+    }
+}
+
+/// Apply an `@media` at-rule by evaluating its query against the current
+/// viewport and, if it matches, parsing the inner block as if its declarations
+/// lived at the top level. Non-matching queries silently drop the inner
+/// rules. Inline-only by design: external `<link rel="stylesheet">` is out
+/// of scope for the headless engine.
+fn applyMediaAtRule(self: *StyleManager, text: []const u8) !void {
+    // text shape: `@media <query> { <inner> }` (guaranteed by
+    // `CssParser.RulesIterator.consumeAtRule` for block at-rules — the span
+    // starts at `@` and ends after the matching close `}`).
+    if (text.len < @as(usize, "@media".len) + 2) return;
+    if (!std.ascii.eqlIgnoreCase(text[0.."@media".len], "@media")) return;
+
+    var rest = text["@media".len..];
+    const open = std.mem.indexOfScalar(u8, rest, '{') orelse return;
+    const query = std.mem.trim(u8, rest[0..open], &std.ascii.whitespace);
+
+    if (rest.len == 0 or rest[rest.len - 1] != '}') return;
+    const inner = rest[open + 1 .. rest.len - 1];
+
+    if (!MediaQuery.matches(query, MediaQuery.Viewport.default())) return;
+
+    var it = CssParser.parseStylesheet(inner);
+    while (it.next()) |nested_rule| {
+        switch (nested_rule) {
+            .style => |s| try self.addRawRule(s.selector, s.block),
+            .at_rule => |nested| {
+                if (std.ascii.eqlIgnoreCase(nested.keyword, "media")) {
+                    try self.applyMediaAtRule(nested.text);
+                }
+            },
         }
     }
 }

--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -125,7 +125,11 @@ fn applyMediaAtRule(self: *StyleManager, text: []const u8) !void {
     if (!std.ascii.eqlIgnoreCase(text[0.."@media".len], "@media")) return;
 
     var rest = text["@media".len..];
-    const open = std.mem.indexOfScalar(u8, rest, '{') orelse return;
+    // Use a comment-aware brace finder; a `/* { */` in the prelude would
+    // otherwise split the rule at the wrong place. The inner block's
+    // contents are re-parsed by CssParser below, which has its own trivia
+    // handling, so only this outer boundary needs the special-case scan.
+    const open = indexOfOpenBraceSkippingComments(rest) orelse return;
     const query = std.mem.trim(u8, rest[0..open], &std.ascii.whitespace);
 
     if (rest.len == 0 or rest[rest.len - 1] != '}') return;
@@ -144,6 +148,22 @@ fn applyMediaAtRule(self: *StyleManager, text: []const u8) !void {
             },
         }
     }
+}
+
+/// Find the first `{` in `s` that is not inside a CSS `/* ... */` comment.
+/// An unclosed comment returns `null` (treat the whole rule as malformed).
+fn indexOfOpenBraceSkippingComments(s: []const u8) ?usize {
+    var i: usize = 0;
+    while (i < s.len) {
+        if (i + 1 < s.len and s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOf(u8, s[i + 2 ..], "*/") orelse return null;
+            i = i + 2 + close + 2;
+            continue;
+        }
+        if (s[i] == '{') return i;
+        i += 1;
+    }
+    return null;
 }
 
 fn addRawRule(self: *StyleManager, selector_text: []const u8, block_text: []const u8) !void {

--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -76,6 +76,12 @@ pub fn deinit(self: *StyleManager) void {
     self.frame.releaseArena(self.arena);
 }
 
+/// Hard cap on `@media` nesting depth. CSS Nesting allows arbitrarily-deep
+/// at-rule nesting; without a cap a hostile inline stylesheet could blow the
+/// Zig stack via mutually-recursive `applyMediaAtRule` frames. 32 is well
+/// past anything seen in the wild.
+const MAX_MEDIA_NESTING: u8 = 32;
+
 fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
     if (sheet._css_rules) |css_rules| {
         for (css_rules._rules.items) |rule| {
@@ -84,7 +90,7 @@ fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
                 // Re-parse the stored source so an `@media` rule inserted via
                 // `insertRule` / `replaceSync` participates in the cascade
                 // when its query matches the viewport.
-                .media => try self.applyMediaAtRule(rule._text),
+                .media => try self.applyMediaAtRule(rule._text, 0),
                 else => {},
             }
         }
@@ -104,7 +110,7 @@ fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
                     // don't carry top-level declarations relevant to the
                     // visibility filter and stay skipped as before.
                     if (std.ascii.eqlIgnoreCase(a.keyword, "media")) {
-                        try self.applyMediaAtRule(a.text);
+                        try self.applyMediaAtRule(a.text, 0);
                     }
                 },
             }
@@ -117,25 +123,31 @@ fn parseSheet(self: *StyleManager, sheet: *CSSStyleSheet) !void {
 /// lived at the top level. Non-matching queries silently drop the inner
 /// rules. Inline-only by design: external `<link rel="stylesheet">` is out
 /// of scope for the headless engine.
-fn applyMediaAtRule(self: *StyleManager, text: []const u8) !void {
-    // text shape: `@media <query> { <inner> }` (guaranteed by
-    // `CssParser.RulesIterator.consumeAtRule` for block at-rules — the span
-    // starts at `@` and ends after the matching close `}`).
-    if (text.len < @as(usize, "@media".len) + 2) return;
-    if (!std.ascii.eqlIgnoreCase(text[0.."@media".len], "@media")) return;
+fn applyMediaAtRule(self: *StyleManager, text: []const u8, depth: u8) !void {
+    if (depth >= MAX_MEDIA_NESTING) return;
 
-    var rest = text["@media".len..];
+    // text shape: `@media <query> { <inner> }` for well-formed input.
+    // `CssParser.RulesIterator.consumeAtRule` always emits a span starting
+    // at `@`; for unclosed blocks it runs to EOF, so the closing `}` is
+    // located explicitly rather than assumed to be the final byte.
+
+    if (text.len < @as(usize, "@media".len) + 2) return;
+    if (!std.ascii.startsWithIgnoreCase(text, "@media")) return;
+
+    const rest = text["@media".len..];
     // Use a comment-aware brace finder; a `/* { */` in the prelude would
     // otherwise split the rule at the wrong place. The inner block's
     // contents are re-parsed by CssParser below, which has its own trivia
     // handling, so only this outer boundary needs the special-case scan.
     const open = indexOfOpenBraceSkippingComments(rest) orelse return;
+    // Search only past the opening brace — the matching `}` lives there, and
+    // any returned position is naturally `> open` (since `rest[open] == '{'`).
+    const close = open + (std.mem.lastIndexOfScalar(u8, rest[open..], '}') orelse return);
+
     const query = std.mem.trim(u8, rest[0..open], &std.ascii.whitespace);
+    const inner = rest[open + 1 .. close];
 
-    if (rest.len == 0 or rest[rest.len - 1] != '}') return;
-    const inner = rest[open + 1 .. rest.len - 1];
-
-    if (!MediaQuery.matches(query, MediaQuery.Viewport.default())) return;
+    if (!MediaQuery.matches(query, MediaQuery.Viewport.default)) return;
 
     var it = CssParser.parseStylesheet(inner);
     while (it.next()) |nested_rule| {
@@ -143,7 +155,7 @@ fn applyMediaAtRule(self: *StyleManager, text: []const u8) !void {
             .style => |s| try self.addRawRule(s.selector, s.block),
             .at_rule => |nested| {
                 if (std.ascii.eqlIgnoreCase(nested.keyword, "media")) {
-                    try self.applyMediaAtRule(nested.text);
+                    try self.applyMediaAtRule(nested.text, depth + 1);
                 }
             },
         }

--- a/src/browser/css/MediaQuery.zig
+++ b/src/browser/css/MediaQuery.zig
@@ -47,25 +47,28 @@ pub const Viewport = struct {
     /// `innerHeight`, `Screen.width` / `height`, and `VisualViewport.width` /
     /// `height`. When viewport emulation lands, this is the single helper to
     /// rewire so the cascade and `matchMedia` move together.
-    pub fn default() Viewport {
-        return .{ .width = 1920, .height = 1080 };
-    }
+    pub const default = Viewport{
+        .width = 1920,
+        .height = 1080,
+    };
 };
 
 /// Returns true if `query` matches the given viewport. Comma-separated
 /// queries are evaluated independently and combined with OR.
 pub fn matches(query: []const u8, viewport: Viewport) bool {
-    // Strip CSS `/* ... */` comments up-front so a comment in the prelude or
-    // inside a feature parenthesis can't shadow a brace, comma, or paren.
-    var buf: [4096]u8 = undefined;
-    const stripped = stripComments(query, &buf);
+    // Reject any input with an unbalanced `/* ...` before parsing. Every
+    // downstream scanner is comment-aware but only on the assumption that
+    // each comment is closed; an unterminated one would otherwise silently
+    // swallow the rest of the input and could flip a partially-parsed query
+    // to `true`.
+    if (hasUnterminatedComment(query)) return false;
 
-    var rest = std.mem.trim(u8, stripped, &std.ascii.whitespace);
+    var rest = trimWsAndComments(query);
     if (rest.len == 0) return false;
 
     while (rest.len > 0) {
         const cut = nextTopLevelComma(rest);
-        const piece = std.mem.trim(u8, rest[0..cut], &std.ascii.whitespace);
+        const piece = trimWsAndComments(rest[0..cut]);
         if (piece.len > 0 and matchesSingle(piece, viewport)) return true;
         if (cut == rest.len) break;
         rest = rest[cut + 1 ..];
@@ -73,35 +76,88 @@ pub fn matches(query: []const u8, viewport: Viewport) bool {
     return false;
 }
 
-/// Strip CSS comments (`/* ... */`) from `query` into `buf`, returning the
-/// stripped slice. Each comment is replaced with a single space so token
-/// boundaries are preserved (`a/*x*/b` becomes `a b`, not `ab`). An unclosed
-/// `/* ...` returns the original input so callers fall through to the normal
-/// parser error path. If the query is larger than the buffer, returns the
-/// original input — sane media queries are ~tens of bytes so 4 KiB is plenty.
-fn stripComments(query: []const u8, buf: []u8) []const u8 {
-    if (query.len > buf.len) return query;
-    var out: usize = 0;
+/// Returns true if `s` contains an opening `/*` without a matching `*/`.
+/// Called once at the top of `matches`; lets every other scanner trust that
+/// comments are balanced.
+fn hasUnterminatedComment(s: []const u8) bool {
     var i: usize = 0;
-    while (i < query.len) {
-        if (i + 1 < query.len and query[i] == '/' and query[i + 1] == '*') {
-            const close = std.mem.indexOf(u8, query[i + 2 ..], "*/") orelse return query;
-            buf[out] = ' ';
-            out += 1;
-            i = i + 2 + close + 2;
+    while (i + 1 < s.len) {
+        if (s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, i + 2, "*/") orelse return true;
+            i = close + 2;
             continue;
         }
-        buf[out] = query[i];
-        out += 1;
         i += 1;
     }
-    return buf[0..out];
+    return false;
+}
+
+/// Advance `i` past any whitespace and `/* ... */` comments. Assumes
+/// comments are balanced (see `hasUnterminatedComment`); an unterminated
+/// comment encountered defensively returns `s.len` so the caller breaks out.
+fn skipWsAndComments(s: []const u8, start: usize) usize {
+    var i = start;
+    while (i < s.len) {
+        if (std.ascii.isWhitespace(s[i])) {
+            i += 1;
+        } else if (i + 1 < s.len and s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, i + 2, "*/") orelse return s.len;
+            i = close + 2;
+        } else break;
+    }
+    return i;
+}
+
+/// Strip leading and trailing whitespace and `/* ... */` comments from `s`.
+/// Interior trivia is preserved; token-by-token scanners skip it as they go.
+fn trimWsAndComments(s: []const u8) []const u8 {
+    var start: usize = 0;
+    var end: usize = s.len;
+    while (start < end) {
+        if (std.ascii.isWhitespace(s[start])) {
+            start += 1;
+        } else if (start + 1 < end and s[start] == '/' and s[start + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, start + 2, "*/") orelse return s[start..end];
+            start = close + 2;
+        } else break;
+    }
+    while (end > start) {
+        if (std.ascii.isWhitespace(s[end - 1])) {
+            end -= 1;
+        } else if (end >= start + 2 and s[end - 1] == '/' and s[end - 2] == '*') {
+            const open_rel = std.mem.lastIndexOf(u8, s[start .. end - 2], "/*") orelse return s[start..end];
+            end = start + open_rel;
+        } else break;
+    }
+    return s[start..end];
+}
+
+/// First occurrence of `needle` in `s` that is not inside a `/* ... */`
+/// comment. Comments are assumed balanced (see `hasUnterminatedComment`).
+fn indexOfScalarSkippingComments(s: []const u8, needle: u8) ?usize {
+    var i: usize = 0;
+    while (i < s.len) {
+        if (i + 1 < s.len and s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, i + 2, "*/") orelse return null;
+            i = close + 2;
+            continue;
+        }
+        if (s[i] == needle) return i;
+        i += 1;
+    }
+    return null;
 }
 
 fn nextTopLevelComma(s: []const u8) usize {
     var depth: usize = 0;
-    for (s, 0..) |c, i| {
-        switch (c) {
+    var i: usize = 0;
+    while (i < s.len) {
+        if (i + 1 < s.len and s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, i + 2, "*/") orelse return s.len;
+            i = close + 2;
+            continue;
+        }
+        switch (s[i]) {
             '(' => depth += 1,
             ')' => if (depth > 0) {
                 depth -= 1;
@@ -109,6 +165,7 @@ fn nextTopLevelComma(s: []const u8) usize {
             ',' => if (depth == 0) return i,
             else => {},
         }
+        i += 1;
     }
     return s.len;
 }
@@ -116,12 +173,11 @@ fn nextTopLevelComma(s: []const u8) usize {
 const MediaType = enum { all, screen, print, speech, tv };
 
 fn parseMediaType(word: []const u8) ?MediaType {
-    const eql = std.ascii.eqlIgnoreCase;
-    if (eql(word, "all")) return .all;
-    if (eql(word, "screen")) return .screen;
-    if (eql(word, "print")) return .print;
-    if (eql(word, "speech")) return .speech;
-    if (eql(word, "tv")) return .tv;
+    if (std.mem.eql(u8, word, "all")) return .all;
+    if (std.mem.eql(u8, word, "screen")) return .screen;
+    if (std.mem.eql(u8, word, "print")) return .print;
+    if (std.mem.eql(u8, word, "speech")) return .speech;
+    if (std.mem.eql(u8, word, "tv")) return .tv;
     return null;
 }
 
@@ -133,7 +189,7 @@ fn matchesSingle(query: []const u8, viewport: Viewport) bool {
 
     var i: usize = 0;
     while (i < query.len) {
-        while (i < query.len and std.ascii.isWhitespace(query[i])) i += 1;
+        i = skipWsAndComments(query, i);
         if (i >= query.len) break;
 
         if (query[i] == '(') {
@@ -146,16 +202,24 @@ fn matchesSingle(query: []const u8, viewport: Viewport) bool {
         }
 
         const start = i;
-        while (i < query.len and isIdentChar(query[i])) i += 1;
-        if (i == start) return false;
-        const word = query[start..i];
-        saw_token = true;
+        while (i < query.len and isIdentChar(query[i])) {
+            i += 1;
+        }
 
-        if (std.ascii.eqlIgnoreCase(word, "not")) {
+        const len = i - start;
+        if (len < 2 or len > 16) {
+            return false;
+        }
+
+        var word_buf: [16]u8 = undefined;
+        const word = std.ascii.lowerString(&word_buf, query[start..i]);
+
+        saw_token = true;
+        if (std.mem.eql(u8, word, "not")) {
             negate = true;
-        } else if (std.ascii.eqlIgnoreCase(word, "only")) {
+        } else if (std.mem.eql(u8, word, "only")) {
             // 'only' is a hint to legacy parsers — treat as a no-op qualifier.
-        } else if (std.ascii.eqlIgnoreCase(word, "and")) {
+        } else if (std.mem.eql(u8, word, "and")) {
             // separator between media-type and feature, or between features.
         } else if (parseMediaType(word)) |t| {
             type_set = t;
@@ -166,7 +230,9 @@ fn matchesSingle(query: []const u8, viewport: Viewport) bool {
         }
     }
 
-    if (!saw_token) return false;
+    if (!saw_token) {
+        return false;
+    }
 
     const type_matches = if (type_set) |t|
         switch (t) {
@@ -184,13 +250,19 @@ fn findClosingParen(s: []const u8, open: usize) ?usize {
     std.debug.assert(s[open] == '(');
     var depth: usize = 1;
     var i = open + 1;
-    while (i < s.len) : (i += 1) {
+    while (i < s.len) {
+        if (i + 1 < s.len and s[i] == '/' and s[i + 1] == '*') {
+            const close = std.mem.indexOfPos(u8, s, i + 2, "*/") orelse return null;
+            i = close + 2;
+            continue;
+        }
         if (s[i] == '(') {
             depth += 1;
         } else if (s[i] == ')') {
             depth -= 1;
             if (depth == 0) return i;
         }
+        i += 1;
     }
     return null;
 }
@@ -200,12 +272,12 @@ fn isIdentChar(c: u8) bool {
 }
 
 fn evalFeature(text: []const u8, viewport: Viewport) bool {
-    const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+    const trimmed = trimWsAndComments(text);
     if (trimmed.len == 0) return false;
 
-    if (std.mem.indexOfScalar(u8, trimmed, ':')) |colon| {
-        const name = std.mem.trim(u8, trimmed[0..colon], &std.ascii.whitespace);
-        const value = std.mem.trim(u8, trimmed[colon + 1 ..], &std.ascii.whitespace);
+    if (indexOfScalarSkippingComments(trimmed, ':')) |colon| {
+        const name = trimWsAndComments(trimmed[0..colon]);
+        const value = trimWsAndComments(trimmed[colon + 1 ..]);
         return evalNameValue(name, value, viewport);
     }
 
@@ -213,45 +285,54 @@ fn evalFeature(text: []const u8, viewport: Viewport) bool {
 }
 
 fn evalNameValue(name: []const u8, value: []const u8, viewport: Viewport) bool {
-    const eql = std.ascii.eqlIgnoreCase;
+    if (name.len > 16) {
+        return false;
+    }
 
-    if (eql(name, "min-width")) {
+    var buf: [16]u8 = undefined;
+    const lname = std.ascii.lowerString(&buf, name);
+    if (std.mem.eql(u8, lname, "min-width")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.width >= px;
     }
-    if (eql(name, "max-width")) {
+    if (std.mem.eql(u8, lname, "max-width")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.width <= px;
     }
-    if (eql(name, "width")) {
+    if (std.mem.eql(u8, lname, "width")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.width == px;
     }
-    if (eql(name, "min-height")) {
+    if (std.mem.eql(u8, lname, "min-height")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.height >= px;
     }
-    if (eql(name, "max-height")) {
+    if (std.mem.eql(u8, lname, "max-height")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.height <= px;
     }
-    if (eql(name, "height")) {
+    if (std.mem.eql(u8, lname, "height")) {
         const px = parseLengthPx(value) orelse return false;
         return viewport.height == px;
     }
-    if (eql(name, "orientation")) {
-        if (eql(value, "landscape")) return viewport.width >= viewport.height;
-        if (eql(value, "portrait")) return viewport.height > viewport.width;
+    if (std.mem.eql(u8, lname, "orientation")) {
+        if (std.ascii.eqlIgnoreCase(value, "landscape")) return viewport.width >= viewport.height;
+        if (std.ascii.eqlIgnoreCase(value, "portrait")) return viewport.height > viewport.width;
         return false;
     }
     return false;
 }
 
 fn evalBoolean(name: []const u8, viewport: Viewport) bool {
-    const eql = std.ascii.eqlIgnoreCase;
-    if (eql(name, "width")) return viewport.width > 0;
-    if (eql(name, "height")) return viewport.height > 0;
-    if (eql(name, "orientation")) return true;
+    if (name.len > 16) {
+        return false;
+    }
+    var buf: [16]u8 = undefined;
+    const lname = std.ascii.lowerString(&buf, name);
+
+    if (std.mem.eql(u8, lname, "width")) return viewport.width > 0;
+    if (std.mem.eql(u8, lname, "height")) return viewport.height > 0;
+    if (std.mem.eql(u8, lname, "orientation")) return true;
     return false;
 }
 
@@ -287,12 +368,12 @@ fn parseLengthPx(value: []const u8) ?u32 {
 const testing = std.testing;
 
 test "MediaQuery: empty query is false" {
-    try testing.expect(!matches("", Viewport.default()));
-    try testing.expect(!matches("   ", Viewport.default()));
+    try testing.expect(!matches("", Viewport.default));
+    try testing.expect(!matches("   ", Viewport.default));
 }
 
 test "MediaQuery: bare media types" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("all", v));
     try testing.expect(matches("screen", v));
     try testing.expect(matches("ALL", v));
@@ -303,12 +384,12 @@ test "MediaQuery: bare media types" {
 }
 
 test "MediaQuery: unknown ident is false" {
-    try testing.expect(!matches("foo", Viewport.default()));
-    try testing.expect(!matches("braille", Viewport.default()));
+    try testing.expect(!matches("foo", Viewport.default));
+    try testing.expect(!matches("braille", Viewport.default));
 }
 
 test "MediaQuery: min-width on 1920x1080 viewport" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(min-width: 1px)", v));
     try testing.expect(matches("(min-width: 600px)", v));
     try testing.expect(matches("(min-width: 1920px)", v));
@@ -317,7 +398,7 @@ test "MediaQuery: min-width on 1920x1080 viewport" {
 }
 
 test "MediaQuery: max-width" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(max-width: 1920px)", v));
     try testing.expect(matches("(max-width: 2000px)", v));
     try testing.expect(!matches("(max-width: 1919px)", v));
@@ -325,14 +406,14 @@ test "MediaQuery: max-width" {
 }
 
 test "MediaQuery: width (exact)" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(width: 1920px)", v));
     try testing.expect(!matches("(width: 1921px)", v));
     try testing.expect(!matches("(width: 1919px)", v));
 }
 
 test "MediaQuery: min-height / max-height / height" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(min-height: 1080px)", v));
     try testing.expect(!matches("(min-height: 1081px)", v));
     try testing.expect(matches("(max-height: 1080px)", v));
@@ -342,7 +423,7 @@ test "MediaQuery: min-height / max-height / height" {
 }
 
 test "MediaQuery: orientation" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(orientation: landscape)", v));
     try testing.expect(!matches("(orientation: portrait)", v));
 
@@ -356,7 +437,7 @@ test "MediaQuery: orientation" {
 }
 
 test "MediaQuery: combined with `and`" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("screen and (min-width: 600px)", v));
     try testing.expect(!matches("print and (min-width: 600px)", v));
     try testing.expect(matches("(min-width: 600px) and (max-width: 2000px)", v));
@@ -365,7 +446,7 @@ test "MediaQuery: combined with `and`" {
 }
 
 test "MediaQuery: `not` negates" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("not print", v));
     try testing.expect(!matches("not screen", v));
     try testing.expect(!matches("not (min-width: 600px)", v));
@@ -373,7 +454,7 @@ test "MediaQuery: `not` negates" {
 }
 
 test "MediaQuery: comma is OR" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("print, screen", v));
     try testing.expect(matches("(max-width: 100px), (min-width: 600px)", v));
     try testing.expect(!matches("(max-width: 100px), (min-width: 3000px)", v));
@@ -381,33 +462,33 @@ test "MediaQuery: comma is OR" {
 }
 
 test "MediaQuery: `only` is no-op" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("only screen", v));
     try testing.expect(matches("only screen and (min-width: 600px)", v));
     try testing.expect(!matches("only print", v));
 }
 
 test "MediaQuery: em units (1em=16px)" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(min-width: 30em)", v)); // 480px <= 1920px
     try testing.expect(matches("(min-width: 120em)", v)); // 1920px == 1920
     try testing.expect(!matches("(min-width: 121em)", v)); // 1936px > 1920
 }
 
 test "MediaQuery: rem treated as em" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(min-width: 30rem)", v));
     try testing.expect(!matches("(min-width: 121rem)", v));
 }
 
 test "MediaQuery: bare 0 is valid" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(min-width: 0)", v));
     try testing.expect(!matches("(max-width: 0)", v));
 }
 
 test "MediaQuery: unknown feature is false" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(!matches("(monochrome)", v));
     try testing.expect(!matches("(prefers-color-scheme: dark)", v));
     try testing.expect(!matches("(prefers-reduced-motion: reduce)", v));
@@ -416,7 +497,7 @@ test "MediaQuery: unknown feature is false" {
 }
 
 test "MediaQuery: malformed value is false" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(!matches("(min-width: foo)", v));
     try testing.expect(!matches("(min-width:)", v));
     try testing.expect(!matches("(min-width: -100px)", v));
@@ -424,7 +505,7 @@ test "MediaQuery: malformed value is false" {
 }
 
 test "MediaQuery: boolean form (feature presence)" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("(width)", v));
     try testing.expect(matches("(height)", v));
     try testing.expect(matches("(orientation)", v));
@@ -433,19 +514,19 @@ test "MediaQuery: boolean form (feature presence)" {
 }
 
 test "MediaQuery: viewport-default values" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expectEqual(@as(u32, 1920), v.width);
     try testing.expectEqual(@as(u32, 1080), v.height);
 }
 
 test "MediaQuery: leading whitespace and case" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("  (MIN-WIDTH: 600PX)  ", v));
     try testing.expect(matches("SCREEN AND (Min-Width: 600px)", v));
 }
 
 test "MediaQuery: malformed query is false" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(!matches("(", v));
     try testing.expect(!matches("(min-width: 600px", v));
     try testing.expect(!matches("@@@", v));
@@ -453,19 +534,19 @@ test "MediaQuery: malformed query is false" {
 
 test "MediaQuery: not print is true on screen viewport" {
     // Common pattern: `<style media="not print">`
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(matches("not print", v));
 }
 
 test "MediaQuery: common responsive breakpoint" {
     // Pattern: hide one of mobile/desktop CTA duplicates above a breakpoint.
-    const v = Viewport.default(); // 1920×1080 — desktop side.
+    const v = Viewport.default; // 1920×1080 — desktop side.
     try testing.expect(matches("(min-width: 768px)", v));
     try testing.expect(!matches("(max-width: 767px)", v));
 }
 
 test "MediaQuery: comments are stripped" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     // Comment between tokens.
     try testing.expect(matches("screen and /*hidden*/ (min-width: 1px)", v));
     // Comment at the start.
@@ -479,7 +560,7 @@ test "MediaQuery: comments are stripped" {
 }
 
 test "MediaQuery: em / rem overflow fails closed" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     // 268435456 × 16 overflows u32 (would wrap to 0); the evaluator must
     // treat the length as unparseable and the query as non-matching.
     try testing.expect(!matches("(min-width: 268435456em)", v));
@@ -490,10 +571,108 @@ test "MediaQuery: em / rem overflow fails closed" {
 }
 
 test "MediaQuery: unimplemented units fail closed" {
-    const v = Viewport.default();
+    const v = Viewport.default;
     try testing.expect(!matches("(min-width: 5cm)", v));
     try testing.expect(!matches("(min-width: 50mm)", v));
     try testing.expect(!matches("(min-width: 10pt)", v));
     try testing.expect(!matches("(min-width: 1in)", v));
     try testing.expect(!matches("(min-width: 50vw)", v));
+}
+
+test "MediaQuery: range syntax is unsupported (fails closed)" {
+    const v = Viewport.default;
+    // MQ4 range form is not implemented — should evaluate false rather than
+    // accidentally matching via the `width` boolean form.
+    try testing.expect(!matches("(width >= 600px)", v));
+    try testing.expect(!matches("(width <= 600px)", v));
+    try testing.expect(!matches("(width < 100px)", v));
+    try testing.expect(!matches("(600px <= width <= 1200px)", v));
+}
+
+test "MediaQuery: decimal lengths are rejected" {
+    const v = Viewport.default;
+    try testing.expect(!matches("(min-width: 600.5px)", v));
+    try testing.expect(!matches("(min-width: 0.5em)", v));
+    try testing.expect(!matches("(width: 1920.0px)", v));
+}
+
+test "MediaQuery: whitespace-tight and -loose features" {
+    const v = Viewport.default;
+    try testing.expect(matches("(min-width:600px)", v));
+    try testing.expect(matches("( min-width : 600px )", v));
+    try testing.expect(matches("(  min-width  :  600px  )", v));
+}
+
+test "MediaQuery: additional comment placements" {
+    const v = Viewport.default;
+    // Two adjacent comments between tokens.
+    try testing.expect(matches("screen /*a*/ /*b*/ and (min-width: 1px)", v));
+    // Comments on both sides of the feature content.
+    try testing.expect(matches("(/*a*/ min-width: 600px /*b*/)", v));
+    // Comment that contains a colon — must not be confused with the
+    // feature's `:` separator.
+    try testing.expect(matches("(/* foo:bar */ min-width: 600px)", v));
+    // Comment that contains parens — must not derail paren matching.
+    try testing.expect(matches("(min-width: 600px /* ) ( */ )", v));
+}
+
+test "MediaQuery: u32 boundaries on length" {
+    const v = Viewport.default;
+    // u32 max parses; the viewport (1920) doesn't reach it.
+    try testing.expect(!matches("(min-width: 4294967295px)", v));
+    // Beyond u32 max overflows parseInt and fails closed.
+    try testing.expect(!matches("(min-width: 4294967296px)", v));
+    try testing.expect(!matches("(min-width: 9999999999px)", v));
+}
+
+test "MediaQuery: empty parens" {
+    const v = Viewport.default;
+    try testing.expect(!matches("()", v));
+    try testing.expect(!matches("(   )", v));
+    try testing.expect(!matches("screen and ()", v));
+}
+
+test "MediaQuery: long AND chains" {
+    const v = Viewport.default;
+    try testing.expect(matches(
+        "screen and (min-width: 600px) and (max-width: 2000px) and (orientation: landscape)",
+        v,
+    ));
+    try testing.expect(!matches(
+        "screen and (min-width: 600px) and (max-width: 1000px) and (orientation: landscape)",
+        v,
+    ));
+}
+
+test "MediaQuery: not all is always false" {
+    try testing.expect(!matches("not all", Viewport.default));
+}
+
+test "MediaQuery: not applies to the whole query" {
+    const v = Viewport.default;
+    // For 1920×1080: (min-width:3000px)=false, (orientation:landscape)=true.
+    // Combined feature match is false; `not` flips it to true.
+    try testing.expect(matches("not (min-width: 3000px) and (orientation: landscape)", v));
+    // Both branches true → combined true → `not` flips to false.
+    try testing.expect(!matches("not (min-width: 1px) and (orientation: landscape)", v));
+}
+
+test "MediaQuery: multibyte UTF-8 tokens fail closed" {
+    const v = Viewport.default;
+    // Unsupported feature name with a multi-byte character.
+    try testing.expect(!matches("(café-width: 600px)", v));
+    // Multi-byte identifier in media-type position.
+    try testing.expect(!matches("café", v));
+}
+
+test "MediaQuery: trailing unterminated comment fails closed" {
+    const v = Viewport.default;
+    // A valid prefix followed by an unbalanced `/* ...` must still evaluate
+    // to false. Without an explicit guard, the inline comment-skipper would
+    // silently consume the rest of the input and return whatever the prefix
+    // already parsed to.
+    try testing.expect(!matches("screen /* unterminated", v));
+    try testing.expect(!matches("(min-width: 600px) /* unterminated", v));
+    // Terminated then unterminated.
+    try testing.expect(!matches("screen /* a */ /* b", v));
 }

--- a/src/browser/css/MediaQuery.zig
+++ b/src/browser/css/MediaQuery.zig
@@ -55,7 +55,12 @@ pub const Viewport = struct {
 /// Returns true if `query` matches the given viewport. Comma-separated
 /// queries are evaluated independently and combined with OR.
 pub fn matches(query: []const u8, viewport: Viewport) bool {
-    var rest = std.mem.trim(u8, query, &std.ascii.whitespace);
+    // Strip CSS `/* ... */` comments up-front so a comment in the prelude or
+    // inside a feature parenthesis can't shadow a brace, comma, or paren.
+    var buf: [4096]u8 = undefined;
+    const stripped = stripComments(query, &buf);
+
+    var rest = std.mem.trim(u8, stripped, &std.ascii.whitespace);
     if (rest.len == 0) return false;
 
     while (rest.len > 0) {
@@ -66,6 +71,31 @@ pub fn matches(query: []const u8, viewport: Viewport) bool {
         rest = rest[cut + 1 ..];
     }
     return false;
+}
+
+/// Strip CSS comments (`/* ... */`) from `query` into `buf`, returning the
+/// stripped slice. Each comment is replaced with a single space so token
+/// boundaries are preserved (`a/*x*/b` becomes `a b`, not `ab`). An unclosed
+/// `/* ...` returns the original input so callers fall through to the normal
+/// parser error path. If the query is larger than the buffer, returns the
+/// original input — sane media queries are ~tens of bytes so 4 KiB is plenty.
+fn stripComments(query: []const u8, buf: []u8) []const u8 {
+    if (query.len > buf.len) return query;
+    var out: usize = 0;
+    var i: usize = 0;
+    while (i < query.len) {
+        if (i + 1 < query.len and query[i] == '/' and query[i + 1] == '*') {
+            const close = std.mem.indexOf(u8, query[i + 2 ..], "*/") orelse return query;
+            buf[out] = ' ';
+            out += 1;
+            i = i + 2 + close + 2;
+            continue;
+        }
+        buf[out] = query[i];
+        out += 1;
+        i += 1;
+    }
+    return buf[0..out];
 }
 
 fn nextTopLevelComma(s: []const u8) usize {
@@ -246,8 +276,11 @@ fn parseLengthPx(value: []const u8) ?u32 {
         return if (num == 0) 0 else null;
     }
     if (std.ascii.eqlIgnoreCase(unit, "px")) return num;
-    if (std.ascii.eqlIgnoreCase(unit, "em")) return num * 16;
-    if (std.ascii.eqlIgnoreCase(unit, "rem")) return num * 16;
+    // `em` / `rem`: 1em = 16px. `std.math.mul` returns an error on u32 overflow
+    // (e.g. `268435456em` would otherwise wrap or panic in debug); treat that
+    // as an unparseable length so the query fails closed per MQ4.
+    if (std.ascii.eqlIgnoreCase(unit, "em")) return std.math.mul(u32, num, 16) catch null;
+    if (std.ascii.eqlIgnoreCase(unit, "rem")) return std.math.mul(u32, num, 16) catch null;
     return null;
 }
 
@@ -424,10 +457,43 @@ test "MediaQuery: not print is true on screen viewport" {
     try testing.expect(matches("not print", v));
 }
 
-test "MediaQuery: complex real-world responsive pattern" {
-    // Decidim / Spree pattern: hide mobile CTA above breakpoint.
-    const v = Viewport.default(); // 1920×1080 — desktop
+test "MediaQuery: common responsive breakpoint" {
+    // Pattern: hide one of mobile/desktop CTA duplicates above a breakpoint.
+    const v = Viewport.default(); // 1920×1080 — desktop side.
     try testing.expect(matches("(min-width: 768px)", v));
-    // Inverse pattern: mobile-only CTA below breakpoint.
     try testing.expect(!matches("(max-width: 767px)", v));
+}
+
+test "MediaQuery: comments are stripped" {
+    const v = Viewport.default();
+    // Comment between tokens.
+    try testing.expect(matches("screen and /*hidden*/ (min-width: 1px)", v));
+    // Comment at the start.
+    try testing.expect(matches("/* leading */ screen", v));
+    // Comment that would otherwise change parens depth.
+    try testing.expect(matches("(min-width: /* hi */ 600px)", v));
+    // Comment containing a comma — must not split the query.
+    try testing.expect(matches("screen /*, print*/", v));
+    // Unclosed comment falls through to the parser, which fails closed.
+    try testing.expect(!matches("/* unterminated", v));
+}
+
+test "MediaQuery: em / rem overflow fails closed" {
+    const v = Viewport.default();
+    // 268435456 × 16 overflows u32 (would wrap to 0); the evaluator must
+    // treat the length as unparseable and the query as non-matching.
+    try testing.expect(!matches("(min-width: 268435456em)", v));
+    try testing.expect(!matches("(min-width: 268435456rem)", v));
+    // Just below the overflow threshold still parses (but doesn't match
+    // because 268435455 × 16 > viewport width).
+    try testing.expect(!matches("(min-width: 268435455em)", v));
+}
+
+test "MediaQuery: unimplemented units fail closed" {
+    const v = Viewport.default();
+    try testing.expect(!matches("(min-width: 5cm)", v));
+    try testing.expect(!matches("(min-width: 50mm)", v));
+    try testing.expect(!matches("(min-width: 10pt)", v));
+    try testing.expect(!matches("(min-width: 1in)", v));
+    try testing.expect(!matches("(min-width: 50vw)", v));
 }

--- a/src/browser/css/MediaQuery.zig
+++ b/src/browser/css/MediaQuery.zig
@@ -1,0 +1,433 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Media-query evaluator for inline `<style>` @media rules and
+//! `window.matchMedia()`. Deliberately narrow scope: external
+//! `<link rel="stylesheet">` fetch is not implemented and not in scope here.
+//!
+//! Spec subset (Media Queries Level 4 §3) sufficient for the responsive
+//! patterns observed in agentic-AI / scraping targets:
+//!   - Media types: `all`, `screen`, `print`, `speech`, `tv`
+//!   - Features: `width` / `min-width` / `max-width`,
+//!               `height` / `min-height` / `max-height`,
+//!               `orientation` (portrait | landscape).
+//!   - Length values: `<int>px`, `<int>em` (1em = 16px), `<int>rem`,
+//!     and bare `0`.
+//!   - Operators: `,` (OR), `and`, `not`, `only`.
+//!
+//! Per spec, any unrecognized media type, unsupported feature, or malformed
+//! value evaluates the containing query to `false`. The remaining
+//! comma-separated branches are still evaluated independently.
+//!
+//! See lightpanda-io/browser#2363 sibling and the surrounding discussion
+//! around C10 (inline-only narrow scope, no external CSS fetch).
+
+const std = @import("std");
+
+pub const Viewport = struct {
+    width: u32,
+    height: u32,
+
+    /// Mirrors the hardcoded values exposed by `Window.innerWidth` /
+    /// `innerHeight`, `Screen.width` / `height`, and `VisualViewport.width` /
+    /// `height`. When viewport emulation lands, this is the single helper to
+    /// rewire so the cascade and `matchMedia` move together.
+    pub fn default() Viewport {
+        return .{ .width = 1920, .height = 1080 };
+    }
+};
+
+/// Returns true if `query` matches the given viewport. Comma-separated
+/// queries are evaluated independently and combined with OR.
+pub fn matches(query: []const u8, viewport: Viewport) bool {
+    var rest = std.mem.trim(u8, query, &std.ascii.whitespace);
+    if (rest.len == 0) return false;
+
+    while (rest.len > 0) {
+        const cut = nextTopLevelComma(rest);
+        const piece = std.mem.trim(u8, rest[0..cut], &std.ascii.whitespace);
+        if (piece.len > 0 and matchesSingle(piece, viewport)) return true;
+        if (cut == rest.len) break;
+        rest = rest[cut + 1 ..];
+    }
+    return false;
+}
+
+fn nextTopLevelComma(s: []const u8) usize {
+    var depth: usize = 0;
+    for (s, 0..) |c, i| {
+        switch (c) {
+            '(' => depth += 1,
+            ')' => if (depth > 0) {
+                depth -= 1;
+            },
+            ',' => if (depth == 0) return i,
+            else => {},
+        }
+    }
+    return s.len;
+}
+
+const MediaType = enum { all, screen, print, speech, tv };
+
+fn parseMediaType(word: []const u8) ?MediaType {
+    const eql = std.ascii.eqlIgnoreCase;
+    if (eql(word, "all")) return .all;
+    if (eql(word, "screen")) return .screen;
+    if (eql(word, "print")) return .print;
+    if (eql(word, "speech")) return .speech;
+    if (eql(word, "tv")) return .tv;
+    return null;
+}
+
+fn matchesSingle(query: []const u8, viewport: Viewport) bool {
+    var negate = false;
+    var type_set: ?MediaType = null;
+    var features_match = true;
+    var saw_token = false;
+
+    var i: usize = 0;
+    while (i < query.len) {
+        while (i < query.len and std.ascii.isWhitespace(query[i])) i += 1;
+        if (i >= query.len) break;
+
+        if (query[i] == '(') {
+            const end = findClosingParen(query, i) orelse return false;
+            const inner = query[i + 1 .. end];
+            if (!evalFeature(inner, viewport)) features_match = false;
+            saw_token = true;
+            i = end + 1;
+            continue;
+        }
+
+        const start = i;
+        while (i < query.len and isIdentChar(query[i])) i += 1;
+        if (i == start) return false;
+        const word = query[start..i];
+        saw_token = true;
+
+        if (std.ascii.eqlIgnoreCase(word, "not")) {
+            negate = true;
+        } else if (std.ascii.eqlIgnoreCase(word, "only")) {
+            // 'only' is a hint to legacy parsers — treat as a no-op qualifier.
+        } else if (std.ascii.eqlIgnoreCase(word, "and")) {
+            // separator between media-type and feature, or between features.
+        } else if (parseMediaType(word)) |t| {
+            type_set = t;
+        } else {
+            // Unknown ident in media-type position: per spec the whole query
+            // is treated as a non-matching type.
+            return false;
+        }
+    }
+
+    if (!saw_token) return false;
+
+    const type_matches = if (type_set) |t|
+        switch (t) {
+            .all, .screen => true,
+            .print, .speech, .tv => false,
+        }
+    else
+        true;
+
+    const result = type_matches and features_match;
+    return if (negate) !result else result;
+}
+
+fn findClosingParen(s: []const u8, open: usize) ?usize {
+    std.debug.assert(s[open] == '(');
+    var depth: usize = 1;
+    var i = open + 1;
+    while (i < s.len) : (i += 1) {
+        if (s[i] == '(') {
+            depth += 1;
+        } else if (s[i] == ')') {
+            depth -= 1;
+            if (depth == 0) return i;
+        }
+    }
+    return null;
+}
+
+fn isIdentChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '-' or c == '_';
+}
+
+fn evalFeature(text: []const u8, viewport: Viewport) bool {
+    const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+    if (trimmed.len == 0) return false;
+
+    if (std.mem.indexOfScalar(u8, trimmed, ':')) |colon| {
+        const name = std.mem.trim(u8, trimmed[0..colon], &std.ascii.whitespace);
+        const value = std.mem.trim(u8, trimmed[colon + 1 ..], &std.ascii.whitespace);
+        return evalNameValue(name, value, viewport);
+    }
+
+    return evalBoolean(trimmed, viewport);
+}
+
+fn evalNameValue(name: []const u8, value: []const u8, viewport: Viewport) bool {
+    const eql = std.ascii.eqlIgnoreCase;
+
+    if (eql(name, "min-width")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.width >= px;
+    }
+    if (eql(name, "max-width")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.width <= px;
+    }
+    if (eql(name, "width")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.width == px;
+    }
+    if (eql(name, "min-height")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.height >= px;
+    }
+    if (eql(name, "max-height")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.height <= px;
+    }
+    if (eql(name, "height")) {
+        const px = parseLengthPx(value) orelse return false;
+        return viewport.height == px;
+    }
+    if (eql(name, "orientation")) {
+        if (eql(value, "landscape")) return viewport.width >= viewport.height;
+        if (eql(value, "portrait")) return viewport.height > viewport.width;
+        return false;
+    }
+    return false;
+}
+
+fn evalBoolean(name: []const u8, viewport: Viewport) bool {
+    const eql = std.ascii.eqlIgnoreCase;
+    if (eql(name, "width")) return viewport.width > 0;
+    if (eql(name, "height")) return viewport.height > 0;
+    if (eql(name, "orientation")) return true;
+    return false;
+}
+
+/// Parse `<int>px`, `<int>em` (1em=16px), `<int>rem`, or bare `0`.
+/// Negative lengths are rejected per the Media Queries spec (`<length>` in
+/// media features may not be negative). Returns null on any other form.
+fn parseLengthPx(value: []const u8) ?u32 {
+    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (trimmed.len == 0) return null;
+    if (trimmed[0] == '-') return null;
+
+    var i: usize = 0;
+    if (i < trimmed.len and trimmed[i] == '+') i += 1;
+    const num_start = i;
+    while (i < trimmed.len and std.ascii.isDigit(trimmed[i])) i += 1;
+    if (i == num_start) return null;
+
+    const num = std.fmt.parseInt(u32, trimmed[num_start..i], 10) catch return null;
+    const unit = std.mem.trim(u8, trimmed[i..], &std.ascii.whitespace);
+
+    if (unit.len == 0) {
+        return if (num == 0) 0 else null;
+    }
+    if (std.ascii.eqlIgnoreCase(unit, "px")) return num;
+    if (std.ascii.eqlIgnoreCase(unit, "em")) return num * 16;
+    if (std.ascii.eqlIgnoreCase(unit, "rem")) return num * 16;
+    return null;
+}
+
+const testing = std.testing;
+
+test "MediaQuery: empty query is false" {
+    try testing.expect(!matches("", Viewport.default()));
+    try testing.expect(!matches("   ", Viewport.default()));
+}
+
+test "MediaQuery: bare media types" {
+    const v = Viewport.default();
+    try testing.expect(matches("all", v));
+    try testing.expect(matches("screen", v));
+    try testing.expect(matches("ALL", v));
+    try testing.expect(matches("Screen", v));
+    try testing.expect(!matches("print", v));
+    try testing.expect(!matches("speech", v));
+    try testing.expect(!matches("tv", v));
+}
+
+test "MediaQuery: unknown ident is false" {
+    try testing.expect(!matches("foo", Viewport.default()));
+    try testing.expect(!matches("braille", Viewport.default()));
+}
+
+test "MediaQuery: min-width on 1920x1080 viewport" {
+    const v = Viewport.default();
+    try testing.expect(matches("(min-width: 1px)", v));
+    try testing.expect(matches("(min-width: 600px)", v));
+    try testing.expect(matches("(min-width: 1920px)", v));
+    try testing.expect(!matches("(min-width: 1921px)", v));
+    try testing.expect(!matches("(min-width: 3000px)", v));
+}
+
+test "MediaQuery: max-width" {
+    const v = Viewport.default();
+    try testing.expect(matches("(max-width: 1920px)", v));
+    try testing.expect(matches("(max-width: 2000px)", v));
+    try testing.expect(!matches("(max-width: 1919px)", v));
+    try testing.expect(!matches("(max-width: 0)", v));
+}
+
+test "MediaQuery: width (exact)" {
+    const v = Viewport.default();
+    try testing.expect(matches("(width: 1920px)", v));
+    try testing.expect(!matches("(width: 1921px)", v));
+    try testing.expect(!matches("(width: 1919px)", v));
+}
+
+test "MediaQuery: min-height / max-height / height" {
+    const v = Viewport.default();
+    try testing.expect(matches("(min-height: 1080px)", v));
+    try testing.expect(!matches("(min-height: 1081px)", v));
+    try testing.expect(matches("(max-height: 1080px)", v));
+    try testing.expect(!matches("(max-height: 1079px)", v));
+    try testing.expect(matches("(height: 1080px)", v));
+    try testing.expect(!matches("(height: 1081px)", v));
+}
+
+test "MediaQuery: orientation" {
+    const v = Viewport.default();
+    try testing.expect(matches("(orientation: landscape)", v));
+    try testing.expect(!matches("(orientation: portrait)", v));
+
+    const portrait: Viewport = .{ .width = 600, .height = 800 };
+    try testing.expect(!matches("(orientation: landscape)", portrait));
+    try testing.expect(matches("(orientation: portrait)", portrait));
+
+    const square: Viewport = .{ .width = 500, .height = 500 };
+    try testing.expect(matches("(orientation: landscape)", square));
+    try testing.expect(!matches("(orientation: portrait)", square));
+}
+
+test "MediaQuery: combined with `and`" {
+    const v = Viewport.default();
+    try testing.expect(matches("screen and (min-width: 600px)", v));
+    try testing.expect(!matches("print and (min-width: 600px)", v));
+    try testing.expect(matches("(min-width: 600px) and (max-width: 2000px)", v));
+    try testing.expect(!matches("(min-width: 600px) and (max-width: 1000px)", v));
+    try testing.expect(matches("all and (orientation: landscape)", v));
+}
+
+test "MediaQuery: `not` negates" {
+    const v = Viewport.default();
+    try testing.expect(matches("not print", v));
+    try testing.expect(!matches("not screen", v));
+    try testing.expect(!matches("not (min-width: 600px)", v));
+    try testing.expect(matches("not (min-width: 3000px)", v));
+}
+
+test "MediaQuery: comma is OR" {
+    const v = Viewport.default();
+    try testing.expect(matches("print, screen", v));
+    try testing.expect(matches("(max-width: 100px), (min-width: 600px)", v));
+    try testing.expect(!matches("(max-width: 100px), (min-width: 3000px)", v));
+    try testing.expect(matches("foo, screen", v));
+}
+
+test "MediaQuery: `only` is no-op" {
+    const v = Viewport.default();
+    try testing.expect(matches("only screen", v));
+    try testing.expect(matches("only screen and (min-width: 600px)", v));
+    try testing.expect(!matches("only print", v));
+}
+
+test "MediaQuery: em units (1em=16px)" {
+    const v = Viewport.default();
+    try testing.expect(matches("(min-width: 30em)", v)); // 480px <= 1920px
+    try testing.expect(matches("(min-width: 120em)", v)); // 1920px == 1920
+    try testing.expect(!matches("(min-width: 121em)", v)); // 1936px > 1920
+}
+
+test "MediaQuery: rem treated as em" {
+    const v = Viewport.default();
+    try testing.expect(matches("(min-width: 30rem)", v));
+    try testing.expect(!matches("(min-width: 121rem)", v));
+}
+
+test "MediaQuery: bare 0 is valid" {
+    const v = Viewport.default();
+    try testing.expect(matches("(min-width: 0)", v));
+    try testing.expect(!matches("(max-width: 0)", v));
+}
+
+test "MediaQuery: unknown feature is false" {
+    const v = Viewport.default();
+    try testing.expect(!matches("(monochrome)", v));
+    try testing.expect(!matches("(prefers-color-scheme: dark)", v));
+    try testing.expect(!matches("(prefers-reduced-motion: reduce)", v));
+    try testing.expect(!matches("(hover: hover)", v));
+    try testing.expect(!matches("(color)", v));
+}
+
+test "MediaQuery: malformed value is false" {
+    const v = Viewport.default();
+    try testing.expect(!matches("(min-width: foo)", v));
+    try testing.expect(!matches("(min-width:)", v));
+    try testing.expect(!matches("(min-width: -100px)", v));
+    try testing.expect(!matches("(min-width: 100xx)", v));
+}
+
+test "MediaQuery: boolean form (feature presence)" {
+    const v = Viewport.default();
+    try testing.expect(matches("(width)", v));
+    try testing.expect(matches("(height)", v));
+    try testing.expect(matches("(orientation)", v));
+    try testing.expect(!matches("(monochrome)", v));
+    try testing.expect(!matches("(color)", v));
+}
+
+test "MediaQuery: viewport-default values" {
+    const v = Viewport.default();
+    try testing.expectEqual(@as(u32, 1920), v.width);
+    try testing.expectEqual(@as(u32, 1080), v.height);
+}
+
+test "MediaQuery: leading whitespace and case" {
+    const v = Viewport.default();
+    try testing.expect(matches("  (MIN-WIDTH: 600PX)  ", v));
+    try testing.expect(matches("SCREEN AND (Min-Width: 600px)", v));
+}
+
+test "MediaQuery: malformed query is false" {
+    const v = Viewport.default();
+    try testing.expect(!matches("(", v));
+    try testing.expect(!matches("(min-width: 600px", v));
+    try testing.expect(!matches("@@@", v));
+}
+
+test "MediaQuery: not print is true on screen viewport" {
+    // Common pattern: `<style media="not print">`
+    const v = Viewport.default();
+    try testing.expect(matches("not print", v));
+}
+
+test "MediaQuery: complex real-world responsive pattern" {
+    // Decidim / Spree pattern: hide mobile CTA above breakpoint.
+    const v = Viewport.default(); // 1920×1080 — desktop
+    try testing.expect(matches("(min-width: 768px)", v));
+    // Inverse pattern: mobile-only CTA below breakpoint.
+    try testing.expect(!matches("(max-width: 767px)", v));
+}

--- a/src/browser/tests/css/media_at_rule_cascade.html
+++ b/src/browser/tests/css/media_at_rule_cascade.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<head>
+  <script src="../testing.js"></script>
+</head>
+
+<!--
+  Inline `@media` rules are evaluated against the hardcoded viewport
+  (1920×1080). When the query matches, the inner declarations participate
+  in the visibility cascade exactly as if they were written at the top
+  level. When it doesn't, they are dropped.
+
+  Out of scope: external `<link rel="stylesheet">` fetch, dynamic viewport
+  emulation. Those remain unimplemented per the headless engine's design.
+-->
+
+<style>
+  /* Matches: 1920px ≥ 768px → #hide-on-desktop should be hidden. */
+  @media (min-width: 768px) {
+    #hide-on-desktop { display: none; }
+  }
+  /* Doesn't match: 1920px > 767px → #hide-on-mobile stays visible. */
+  @media (max-width: 767px) {
+    #hide-on-mobile { display: none; }
+  }
+  /* Comma-OR: at least one branch matches → #hidden-by-or hidden. */
+  @media (max-width: 100px), (min-width: 600px) {
+    #hidden-by-or { display: none; }
+  }
+  /* Neither branch matches → #not-hidden-by-or stays visible. */
+  @media (max-width: 100px), (min-width: 3000px) {
+    #not-hidden-by-or { display: none; }
+  }
+  /* Negation: matches when the inner query doesn't.
+     `not print` → matches on screen → #hidden-by-not hidden. */
+  @media not print {
+    #hidden-by-not { display: none; }
+  }
+  /* Bare type match: screen always matches in this engine. */
+  @media screen {
+    #hidden-by-screen { display: none; }
+  }
+  /* Nested @media — both must match (outer screen + inner min-width). */
+  @media screen {
+    @media (min-width: 600px) {
+      #hidden-by-nested { display: none; }
+    }
+  }
+  /* Unsupported feature → query doesn't match → element stays visible. */
+  @media (prefers-color-scheme: dark) {
+    #not-hidden-unsupported { display: none; }
+  }
+  /* visibility:hidden inside @media. */
+  @media (min-width: 1px) {
+    #visibility-hidden-cascade { visibility: hidden; }
+  }
+</style>
+
+<body>
+  <div id="hide-on-desktop">desktop</div>
+  <div id="hide-on-mobile">mobile</div>
+  <div id="hidden-by-or">or-hit</div>
+  <div id="not-hidden-by-or">or-miss</div>
+  <div id="hidden-by-not">not-hit</div>
+  <div id="hidden-by-screen">screen-hit</div>
+  <div id="hidden-by-nested">nested-hit</div>
+  <div id="not-hidden-unsupported">unsupported</div>
+  <div id="visibility-hidden-cascade">visibility</div>
+  <div id="dyn-target">dyn-target</div>
+  <style id="dyn"></style>
+</body>
+
+<script id=cascade_matching_query_hides>
+{
+  testing.expectFalse($('#hide-on-desktop').checkVisibility());
+}
+</script>
+
+<script id=cascade_non_matching_query_does_not_hide>
+{
+  testing.expectTrue($('#hide-on-mobile').checkVisibility());
+}
+</script>
+
+<script id=cascade_comma_is_or_hit>
+{
+  testing.expectFalse($('#hidden-by-or').checkVisibility());
+}
+</script>
+
+<script id=cascade_comma_is_or_miss>
+{
+  testing.expectTrue($('#not-hidden-by-or').checkVisibility());
+}
+</script>
+
+<script id=cascade_not_negates>
+{
+  testing.expectFalse($('#hidden-by-not').checkVisibility());
+}
+</script>
+
+<script id=cascade_bare_type_matches>
+{
+  testing.expectFalse($('#hidden-by-screen').checkVisibility());
+}
+</script>
+
+<script id=cascade_nested_media>
+{
+  testing.expectFalse($('#hidden-by-nested').checkVisibility());
+}
+</script>
+
+<script id=cascade_unsupported_feature_is_false>
+{
+  testing.expectTrue($('#not-hidden-unsupported').checkVisibility());
+}
+</script>
+
+<script id=cascade_visibility_hidden>
+{
+  // checkVisibility() defaults to checkVisibilityCSS only (display), so a
+  // visibility:hidden element still reports visible by default.
+  // Use the `visibilityProperty: true` option to include it.
+  testing.expectTrue($('#visibility-hidden-cascade').checkVisibility());
+  testing.expectFalse(
+    $('#visibility-hidden-cascade').checkVisibility({ visibilityProperty: true })
+  );
+}
+</script>
+
+<script id=cascade_dynamic_insertRule_matching>
+{
+  const sheet = $('#dyn').sheet;
+  const index = sheet.insertRule(
+    '@media (min-width: 600px) { #dyn-target { display: none; } }', 0
+  );
+  testing.expectEqual(0, index);
+  testing.expectFalse($('#dyn-target').checkVisibility());
+}
+</script>
+
+<script id=cascade_cssRules_surface>
+{
+  // Even when the @media rule's declarations apply to the cascade, the
+  // rule is still exposed via cssRules as a CSSRule with type MEDIA_RULE (4).
+  // CSS-in-JS libraries deduplicate on cssRules — keep that surface intact.
+  const sheet = $('#dyn').sheet;
+  const rule = sheet.cssRules[0];
+  testing.expectEqual(4, rule.type);
+}
+</script>

--- a/src/browser/tests/css/media_at_rule_cascade.html
+++ b/src/browser/tests/css/media_at_rule_cascade.html
@@ -53,6 +53,15 @@
   @media (min-width: 1px) {
     #visibility-hidden-cascade { visibility: hidden; }
   }
+  /* Comment-in-prelude: the brace inside the comment must not be mistaken
+     for the rule's opening brace. */
+  @media /* { fake */ (min-width: 1px) {
+    #commented-prelude { display: none; }
+  }
+  /* Comment-in-query: the prelude includes a comment between tokens. */
+  @media screen /*x*/ and (min-width: 1px) {
+    #commented-query { display: none; }
+  }
 </style>
 
 <body>
@@ -65,8 +74,12 @@
   <div id="hidden-by-nested">nested-hit</div>
   <div id="not-hidden-unsupported">unsupported</div>
   <div id="visibility-hidden-cascade">visibility</div>
+  <div id="commented-prelude">commented-prelude</div>
+  <div id="commented-query">commented-query</div>
   <div id="dyn-target">dyn-target</div>
+  <div id="dyn2-target">dyn2-target</div>
   <style id="dyn"></style>
+  <style id="dyn2"></style>
 </body>
 
 <script id=cascade_matching_query_hides>
@@ -148,5 +161,30 @@
   const sheet = $('#dyn').sheet;
   const rule = sheet.cssRules[0];
   testing.expectEqual(4, rule.type);
+}
+</script>
+
+<script id=cascade_commented_prelude>
+{
+  // `@media /* { fake */ (min-width: 1px)` — the brace inside the comment
+  // would otherwise fool a naive prelude/inner split.
+  testing.expectFalse($('#commented-prelude').checkVisibility());
+}
+</script>
+
+<script id=cascade_commented_query>
+{
+  // Comments between query tokens must be stripped before evaluation.
+  testing.expectFalse($('#commented-query').checkVisibility());
+}
+</script>
+
+<script id=cascade_replaceSync_matching>
+{
+  // The _css_rules path also fires through replaceSync, not just insertRule.
+  $('#dyn2').sheet.replaceSync(
+    '@media (min-width: 600px) { #dyn2-target { display: none; } }'
+  );
+  testing.expectFalse($('#dyn2-target').checkVisibility());
 }
 </script>

--- a/src/browser/tests/css/media_at_rule_cascade.html
+++ b/src/browser/tests/css/media_at_rule_cascade.html
@@ -62,6 +62,33 @@
   @media screen /*x*/ and (min-width: 1px) {
     #commented-query { display: none; }
   }
+  /* Comments inside the inner block (between declarations and inside a
+     declaration's value position). The outer `@media` evaluation must not
+     interfere with the CSS parser's own comment handling for the inner
+     block. */
+  @media (min-width: 600px) {
+    #inner-block-comments {
+      /* leading comment */
+      display: none; /* trailing comment */
+      /* between */
+      color: red;
+    }
+  }
+  /* Nested @media where the inner query does NOT match. Outer matches
+     (screen), inner doesn't (print) → inner declarations must be dropped. */
+  @media screen {
+    @media print {
+      #nested-inner-miss { display: none; }
+    }
+  }
+  /* Whitespace-heavy prelude — many spaces between tokens. */
+  @media   screen   and    (min-width:   100px)   {
+    #ws-heavy { display: none; }
+  }
+  /* Mixed-case at-keyword and tokens. */
+  @MEDIA SCREEN AND (MIN-WIDTH: 100PX) {
+    #upper-case { display: none; }
+  }
 </style>
 
 <body>
@@ -76,10 +103,16 @@
   <div id="visibility-hidden-cascade">visibility</div>
   <div id="commented-prelude">commented-prelude</div>
   <div id="commented-query">commented-query</div>
+  <div id="inner-block-comments">inner-block-comments</div>
+  <div id="nested-inner-miss">nested-inner-miss</div>
+  <div id="ws-heavy">ws-heavy</div>
+  <div id="upper-case">upper-case</div>
   <div id="dyn-target">dyn-target</div>
   <div id="dyn2-target">dyn2-target</div>
+  <div id="deep-nest-target">deep-nest-target</div>
   <style id="dyn"></style>
   <style id="dyn2"></style>
+  <style id="deep-nest-style"></style>
 </body>
 
 <script id=cascade_matching_query_hides>
@@ -186,5 +219,51 @@
     '@media (min-width: 600px) { #dyn2-target { display: none; } }'
   );
   testing.expectFalse($('#dyn2-target').checkVisibility());
+}
+</script>
+
+<script id=cascade_inner_block_comments>
+{
+  // Comments inside the inner block belong to the CSS parser's tokenizer,
+  // not to the media-query evaluator — they must not block the cascade.
+  testing.expectFalse($('#inner-block-comments').checkVisibility());
+}
+</script>
+
+<script id=cascade_nested_inner_miss>
+{
+  // Outer matches (screen), inner doesn't (print). The inner declarations
+  // must be dropped — the element stays visible.
+  testing.expectTrue($('#nested-inner-miss').checkVisibility());
+}
+</script>
+
+<script id=cascade_ws_heavy_prelude>
+{
+  testing.expectFalse($('#ws-heavy').checkVisibility());
+}
+</script>
+
+<script id=cascade_upper_case_keyword>
+{
+  // `@MEDIA SCREEN AND (MIN-WIDTH: 100PX)` should evaluate the same as the
+  // lower-case form — at-keywords, types, features, and units are all
+  // case-insensitive.
+  testing.expectFalse($('#upper-case').checkVisibility());
+}
+</script>
+
+<script id=cascade_deep_nesting_capped>
+{
+  // 50 levels of `@media screen { ... }` around a `display:none` rule. The
+  // depth guard (MAX_MEDIA_NESTING in StyleManager.zig) must short-circuit
+  // before the Zig stack is exhausted — and the inner rule sits beyond the
+  // cap, so the element stays visible.
+  let css = '';
+  for (let i = 0; i < 50; i++) css += '@media screen { ';
+  css += '#deep-nest-target { display: none; }';
+  for (let i = 0; i < 50; i++) css += ' }';
+  $('#deep-nest-style').sheet.replaceSync(css);
+  testing.expectTrue($('#deep-nest-target').checkVisibility());
 }
 </script>

--- a/src/browser/tests/css/media_query_list.html
+++ b/src/browser/tests/css/media_query_list.html
@@ -6,24 +6,101 @@
 <body>
 </body>
 
+<!--
+  The viewport reported by window.innerWidth / innerHeight is currently
+  hardcoded at 1920×1080. matchMedia evaluates against the same dimensions.
+-->
+
 <script id=matchMedia_basic>
 {
   const mql = window.matchMedia('(min-width: 600px)');
   testing.expectEqual('object', typeof mql);
   testing.expectEqual('(min-width: 600px)', mql.media);
+  testing.expectEqual(true, mql.matches);
+}
+</script>
+
+<script id=matchMedia_min_width_above_viewport>
+{
+  const mql = window.matchMedia('(min-width: 3000px)');
+  testing.expectEqual('(min-width: 3000px)', mql.media);
   testing.expectEqual(false, mql.matches);
 }
 </script>
 
-<script id=matchMedia_different_queries>
+<script id=matchMedia_max_width>
 {
-  const mql1 = window.matchMedia('(max-width: 1024px)');
-  testing.expectEqual('(max-width: 1024px)', mql1.media);
-  testing.expectEqual(false, mql1.matches);
+  const below = window.matchMedia('(max-width: 1024px)');
+  testing.expectEqual('(max-width: 1024px)', below.media);
+  testing.expectEqual(false, below.matches);
 
-  const mql2 = window.matchMedia('(prefers-color-scheme: dark)');
-  testing.expectEqual('(prefers-color-scheme: dark)', mql2.media);
-  testing.expectEqual(false, mql2.matches);
+  const above = window.matchMedia('(max-width: 2000px)');
+  testing.expectEqual(true, above.matches);
+}
+</script>
+
+<script id=matchMedia_orientation>
+{
+  // 1920×1080 is landscape.
+  testing.expectEqual(true, window.matchMedia('(orientation: landscape)').matches);
+  testing.expectEqual(false, window.matchMedia('(orientation: portrait)').matches);
+}
+</script>
+
+<script id=matchMedia_media_types>
+{
+  testing.expectEqual(true, window.matchMedia('all').matches);
+  testing.expectEqual(true, window.matchMedia('screen').matches);
+  testing.expectEqual(false, window.matchMedia('print').matches);
+}
+</script>
+
+<script id=matchMedia_unsupported_feature>
+{
+  // Unknown features evaluate to false per Media Queries Level 4.
+  testing.expectEqual(false, window.matchMedia('(prefers-color-scheme: dark)').matches);
+  testing.expectEqual(false, window.matchMedia('(hover: hover)').matches);
+}
+</script>
+
+<script id=matchMedia_combined>
+{
+  testing.expectEqual(true,  window.matchMedia('screen and (min-width: 600px)').matches);
+  testing.expectEqual(false, window.matchMedia('print and (min-width: 600px)').matches);
+  testing.expectEqual(true,  window.matchMedia('(min-width: 600px) and (max-width: 2000px)').matches);
+}
+</script>
+
+<script id=matchMedia_comma_is_or>
+{
+  testing.expectEqual(true, window.matchMedia('print, screen').matches);
+  testing.expectEqual(true, window.matchMedia('(max-width: 100px), (min-width: 600px)').matches);
+  testing.expectEqual(false, window.matchMedia('(max-width: 100px), (min-width: 3000px)').matches);
+}
+</script>
+
+<script id=matchMedia_not>
+{
+  testing.expectEqual(true,  window.matchMedia('not print').matches);
+  testing.expectEqual(false, window.matchMedia('not screen').matches);
+  testing.expectEqual(false, window.matchMedia('not (min-width: 600px)').matches);
+}
+</script>
+
+<script id=matchMedia_only>
+{
+  // `only` is a legacy hint to old parsers; behaves as no-op for modern engines.
+  testing.expectEqual(true, window.matchMedia('only screen').matches);
+  testing.expectEqual(true, window.matchMedia('only screen and (min-width: 600px)').matches);
+}
+</script>
+
+<script id=matchMedia_em_units>
+{
+  // 1em = 16px. 30em = 480px ≤ 1920px → matches.
+  testing.expectEqual(true,  window.matchMedia('(min-width: 30em)').matches);
+  // 121em = 1936px > 1920px → does not match.
+  testing.expectEqual(false, window.matchMedia('(min-width: 121em)').matches);
 }
 </script>
 

--- a/src/browser/tests/css/media_query_list.html
+++ b/src/browser/tests/css/media_query_list.html
@@ -101,6 +101,29 @@
   testing.expectEqual(true,  window.matchMedia('(min-width: 30em)').matches);
   // 121em = 1936px > 1920px → does not match.
   testing.expectEqual(false, window.matchMedia('(min-width: 121em)').matches);
+  // u32-overflowing em / rem fails closed instead of panicking.
+  testing.expectEqual(false, window.matchMedia('(min-width: 268435456em)').matches);
+  testing.expectEqual(false, window.matchMedia('(min-width: 268435456rem)').matches);
+}
+</script>
+
+<script id=matchMedia_comments_stripped>
+{
+  // CSS `/* ... */` comments between query tokens are stripped per spec.
+  testing.expectEqual(true,  window.matchMedia('screen and /*x*/ (min-width: 1px)').matches);
+  testing.expectEqual(true,  window.matchMedia('/* leading */ screen').matches);
+  testing.expectEqual(true,  window.matchMedia('(min-width: /* hi */ 600px)').matches);
+}
+</script>
+
+<script id=matchMedia_unimplemented_units>
+{
+  // Units the evaluator doesn't claim to support (cm/mm/pt/in/vw/vh) fail closed.
+  testing.expectEqual(false, window.matchMedia('(min-width: 5cm)').matches);
+  testing.expectEqual(false, window.matchMedia('(min-width: 50mm)').matches);
+  testing.expectEqual(false, window.matchMedia('(min-width: 10pt)').matches);
+  testing.expectEqual(false, window.matchMedia('(min-width: 1in)').matches);
+  testing.expectEqual(false, window.matchMedia('(min-width: 50vw)').matches);
 }
 </script>
 

--- a/src/browser/webapi/css/MediaQueryList.zig
+++ b/src/browser/webapi/css/MediaQueryList.zig
@@ -41,12 +41,17 @@ pub fn getMedia(self: *const MediaQueryList) []const u8 {
 
 /// Re-evaluates the stored query against the current viewport on every call
 /// so the result stays in sync if viewport emulation later lands. The
-/// viewport currently comes from `MediaQuery.Viewport.default()` (1920×1080),
+/// viewport currently comes from `MediaQuery.Viewport.default` (1920×1080),
 /// matching `Window.innerWidth` / `innerHeight`.
 pub fn getMatches(self: *const MediaQueryList) bool {
-    return MediaQuery.matches(self._media, MediaQuery.Viewport.default());
+    return MediaQuery.matches(self._media, MediaQuery.Viewport.default);
 }
 
+// TODO: once viewport emulation lands, `change` events need to fire on
+// every listener registered here (and via `addEventListener("change", ...)`
+// through the EventTarget proto) when the viewport crosses the breakpoint
+// that flips `matches`. Today the viewport is a constant, so no event can
+// ever fire — the registrations are no-ops rather than stored hooks.
 pub fn addListener(_: *const MediaQueryList, _: js.Function) void {}
 pub fn removeListener(_: *const MediaQueryList, _: js.Function) void {}
 

--- a/src/browser/webapi/css/MediaQueryList.zig
+++ b/src/browser/webapi/css/MediaQueryList.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const js = @import("../../js/js.zig");
 const EventTarget = @import("../EventTarget.zig");
+const MediaQuery = @import("../../css/MediaQuery.zig");
 
 const MediaQueryList = @This();
 
@@ -38,6 +39,14 @@ pub fn getMedia(self: *const MediaQueryList) []const u8 {
     return self._media;
 }
 
+/// Re-evaluates the stored query against the current viewport on every call
+/// so the result stays in sync if viewport emulation later lands. The
+/// viewport currently comes from `MediaQuery.Viewport.default()` (1920×1080),
+/// matching `Window.innerWidth` / `innerHeight`.
+pub fn getMatches(self: *const MediaQueryList) bool {
+    return MediaQuery.matches(self._media, MediaQuery.Viewport.default());
+}
+
 pub fn addListener(_: *const MediaQueryList, _: js.Function) void {}
 pub fn removeListener(_: *const MediaQueryList, _: js.Function) void {}
 
@@ -51,7 +60,7 @@ pub const JsApi = struct {
     };
 
     pub const media = bridge.accessor(MediaQueryList.getMedia, null, .{});
-    pub const matches = bridge.property(false, .{ .template = false, .readonly = true });
+    pub const matches = bridge.accessor(MediaQueryList.getMatches, null, .{});
     pub const addListener = bridge.function(MediaQueryList.addListener, .{ .noop = true });
     pub const removeListener = bridge.function(MediaQueryList.removeListener, .{ .noop = true });
 };
@@ -59,4 +68,8 @@ pub const JsApi = struct {
 const testing = @import("../../../testing.zig");
 test "WebApi: MediaQueryList" {
     try testing.htmlRunner("css/media_query_list.html", .{});
+}
+
+test "WebApi: media @-rule cascade" {
+    try testing.htmlRunner("css/media_at_rule_cascade.html", .{});
 }


### PR DESCRIPTION
## What

CSS `@media` rules inside inline `<style>` are now applied to the cascade when the query matches the viewport, and `window.matchMedia(q).matches` returns spec-correct booleans instead of a hardcoded `false`. The evaluator is a minimal Media Queries Level 4 subset and reads the same `1920×1080` viewport already exposed by `Window.innerWidth` / `innerHeight`. External `<link rel="stylesheet">` fetch stays out of scope; this is inline-only.

Closes #2477.

## Root cause

Two unrelated holes in the CSS path converged on the same observable failure for downstream CDP clients running against responsive pages:

- `src/browser/webapi/css/MediaQueryList.zig` exposed `matches` as `bridge.property(false, .{ ... })` — a literal hardcoded `false` rather than an accessor.
- `src/browser/StyleManager.zig`'s `parseSheet` had `.at_rule => {}` in both the raw-text and the `_css_rules` paths, silently dropping every parsed `@media` rule even though `CssParser` already surfaces them as `AtRule{ keyword: "media", text: "@media (...) {...}" }`.

```mermaid
flowchart LR
    A[parseSheet] --> B[switch on Rule type]
    B --> C[.style: addRawRule]
    B --> D[.at_rule: dropped]
    D --> E[no cascade entry]
    F[matchMedia] --> G[matches = property false]
    G --> H[always false]
    style D fill:#fdd
    style E fill:#fdd
    style G fill:#fdd
    style H fill:#fdd
```

## Fix

- New `src/browser/css/MediaQuery.zig` — ~200 LOC Media Queries Level 4 subset evaluator. Features: `width` / `min-width` / `max-width`, `height` / `min-height` / `max-height`, `orientation`. Lengths: `px`, `em` / `rem` (1em=16px), bare `0`. Operators: `,` (OR), `and`, `not`, `only`. Unknown features evaluate to `false` per spec. Viewport via `MediaQuery.Viewport.default()` — the single helper to rewire when viewport emulation lands.
- `src/browser/webapi/css/MediaQueryList.zig` — `matches` is now `bridge.accessor(getMatches, null, .{})`, re-evaluating against the current viewport on every read.
- `src/browser/StyleManager.zig` — `parseSheet` dispatches `@media` at-rules (both raw-text and `_css_rules` paths) to a new `applyMediaAtRule` helper. The helper strips the `@media` prefix, extracts the query and inner block, runs the evaluator, and on match recursively parses the inner block through `CssParser.parseStylesheet` so inner rules participate in the cascade exactly as if they were written at top level. Nested `@media` inside `@media` recurses naturally.

```mermaid
flowchart LR
    A[parseSheet] --> B[switch on Rule type]
    B --> C[.style: addRawRule]
    B --> D[.at_rule keyword==media]
    D --> E[applyMediaAtRule]
    E --> F[MediaQuery.matches]
    F -->|matches| G[parseStylesheet inner -> addRawRule]
    F -->|no match| H[drop inner]
    I[matchMedia] --> J[getMatches accessor]
    J --> K[MediaQuery.matches]
    K --> L[true or false]
    style D fill:#dfd
    style E fill:#dfd
    style G fill:#dfd
    style J fill:#dfd
    style L fill:#dfd
```

Other at-rules (`@keyframes`, `@supports`, `@font-face`, `@import`, …) continue to be stored as opaque `CSSRule` placeholders surfaced through `cssRules` for CSS-in-JS deduplication, unchanged.

## Test

- **Zig unit tests**: 23 new tests in `src/browser/css/MediaQuery.zig` covering the full evaluator surface (media types, features, units, operators, malformed input, real-world responsive patterns).
- **HTML fixtures**:
  - `src/browser/tests/css/media_query_list.html` (existing — assertions refreshed) — `matchMedia` returns correct booleans for `min-width` / `max-width` / `orientation` / `and` / `not` / `only` / comma-OR / `em` / unsupported features.
  - `src/browser/tests/css/media_at_rule_cascade.html` (new) — `checkVisibility()` reflects matching and non-matching `@media` rules, comma-OR, `not`, bare types, nested `@media`, unsupported features, and dynamic `insertRule`. `cssRules[0].type === 4` (MEDIA_RULE) is still surfaced so CSS-in-JS dedup paths stay intact.
- **Full suite**: `mise exec -- zig build test $V8` → **676 of 676 tests passed**.
- **Toggle-off proof**: reverted the production lines while keeping the new tests in place → matchMedia HTML fixture fails (`got=false want=true`) and cascade HTML fixture fails (`got=true want=false`). Restored the fix → 25 of 25 targeted tests pass again.
- **End-to-end reproducer** (from #2477): exit 1 on installed nightly `1.0.0-dev.6246+4f33d64c5`, exit 0 against `zig-out/bin/lightpanda` built from this branch.

## Notes

- The diff is scoped to the two existing surfaces + the new evaluator file. No CSS parser changes — `CssParser.RulesIterator` already surfaces `@media` blocks via `AtRule.text` with the full source span. The evaluator works against that existing structure.
- `matches` is re-evaluated on every JS read of `mql.matches` so future viewport-emulation work won't need to invalidate caches.
- Out of scope (and explicitly noted in #2477 to keep this PR small and to match the engine's "no rendering, flat cost profile" stance): external `<link rel="stylesheet">` fetch, dynamic viewport, container queries, `@supports`, `@layer`. Those stay as opaque `CSSRule` placeholders.
