### PR TITLE
Implement Accessibility.queryAXTree CDP method (and fix latent frame-binding bug)

### DIFF
--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -634,6 +634,119 @@ pub const Writer = struct {
     }
 };
 
+// Backing writer for Accessibility.queryAXTree. Walks the DOM subtree rooted
+// at `root`, computes role + accessible name for every node (including those
+// that would be ignored in the AX tree, per the CDP spec), and emits a flat
+// JSON array of nodes whose role/name match the optional filters.
+//
+// Intentionally MVP: emits an empty `properties` array and empty `childIds`.
+// Clients that need full properties call Accessibility.getFullAXTree on a
+// matched nodeId.
+pub const QueryWriter = struct {
+    root: *const Node,
+    registry: *Node.Registry,
+    frame: *Frame,
+    visibility_cache: *DOMNode.Element.VisibilityCache,
+    label_index: *Label.LabelByForIndex,
+    temp_arena: std.mem.Allocator,
+    accessible_name: ?[]const u8,
+    role: ?[]const u8,
+
+    pub const Opts = struct {
+        accessible_name: ?[]const u8 = null,
+        role: ?[]const u8 = null,
+    };
+
+    pub fn jsonStringify(self: *const QueryWriter, w: anytype) error{WriteFailed}!void {
+        self.toJSON(w) catch |err| {
+            log.err(.cdp, "queryAXTree toJSON", .{ .err = err });
+            return error.WriteFailed;
+        };
+    }
+
+    fn toJSON(self: *const QueryWriter, w: anytype) !void {
+        try w.beginArray();
+        try self.walk(self.root.dom, false, w);
+        return w.endArray();
+    }
+
+    fn walk(self: *const QueryWriter, node: *DOMNode, in_aria_hidden: bool, w: anytype) !void {
+        const axn = AXNode.fromNode(node);
+        try self.maybeEmit(axn, in_aria_hidden, w);
+
+        // <head>, <script>, <style> never expose AX content — skip recursion.
+        if (axn.ignoreChildren()) return;
+
+        const child_in_aria_hidden = in_aria_hidden or blk: {
+            const parent_el = node.is(DOMNode.Element) orelse break :blk false;
+            break :blk hasAriaHiddenTrue(parent_el);
+        };
+
+        var it = node.childrenIterator();
+        while (it.next()) |child| {
+            switch (child._type) {
+                .element, .cdata => {},
+                else => continue,
+            }
+            try self.walk(child, child_in_aria_hidden, w);
+        }
+    }
+
+    fn maybeEmit(self: *const QueryWriter, axn: AXNode, in_aria_hidden: bool, w: anytype) !void {
+        const role_str = axn.getRole() catch return;
+        if (self.role) |needle| {
+            if (!std.mem.eql(u8, needle, role_str)) return;
+        }
+
+        const name = (try axn.getName(self.frame, self.temp_arena)) orelse "";
+        if (self.accessible_name) |needle| {
+            if (!std.mem.eql(u8, needle, name)) return;
+        }
+
+        const node = try self.registry.register(axn.dom);
+        const ignored = axn.isIgnore(self.frame, self.visibility_cache, in_aria_hidden);
+
+        try w.beginObject();
+
+        try w.objectField("nodeId");
+        var buf: [10]u8 = undefined;
+        const id_str = try std.fmt.bufPrint(&buf, "{d}", .{node.id});
+        try w.write(id_str);
+
+        try w.objectField("backendDOMNodeId");
+        try w.write(node.id);
+
+        try w.objectField("ignored");
+        try w.write(ignored);
+
+        try w.objectField("role");
+        try w.beginObject();
+        try w.objectField("type");
+        try w.write("role");
+        try w.objectField("value");
+        try w.write(role_str);
+        try w.endObject();
+
+        try w.objectField("name");
+        try w.beginObject();
+        try w.objectField("type");
+        try w.write("computedString");
+        try w.objectField("value");
+        try w.write(name);
+        try w.endObject();
+
+        try w.objectField("properties");
+        try w.beginArray();
+        try w.endArray();
+
+        try w.objectField("childIds");
+        try w.beginArray();
+        try w.endArray();
+
+        try w.endObject();
+    }
+};
+
 pub const AXRole = enum(u8) {
     // zig fmt: off
     none, article, banner, blockquote, button, caption, cell, checkbox, code, color,
@@ -1590,4 +1703,154 @@ test "AXNode: writer prunes hidden and resolves labels" {
         }
         try testing.expect(found);
     }
+}
+
+test "AXNode: QueryWriter filters by role" {
+    var registry = Node.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer frame._session.removePage();
+    var doc = frame.window._document;
+
+    const node = try registry.register(doc.asNode());
+    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
+    var label_index: Label.LabelByForIndex = .{};
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+        .root = node,
+        .registry = &registry,
+        .frame = frame,
+        .visibility_cache = &visibility_cache,
+        .label_index = &label_index,
+        .temp_arena = temp_arena,
+        .accessible_name = null,
+        .role = "heading",
+    }, .{});
+    defer testing.allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const nodes = parsed.value.array.items;
+    // Fixture has one <h1>Visible</h1>.
+    try testing.expectEqual(1, nodes.len);
+
+    const role_val = nodes[0].object.get("role").?.object.get("value").?.string;
+    try testing.expectEqual("heading", role_val);
+
+    const name_val = nodes[0].object.get("name").?.object.get("value").?.string;
+    try testing.expectEqual("Visible", name_val);
+}
+
+test "AXNode: QueryWriter filters by accessible name" {
+    var registry = Node.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer frame._session.removePage();
+    var doc = frame.window._document;
+
+    const node = try registry.register(doc.asNode());
+    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
+    var label_index: Label.LabelByForIndex = .{};
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+        .root = node,
+        .registry = &registry,
+        .frame = frame,
+        .visibility_cache = &visibility_cache,
+        .label_index = &label_index,
+        .temp_arena = temp_arena,
+        .accessible_name = "Search",
+        .role = null,
+    }, .{});
+    defer testing.allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const nodes = parsed.value.array.items;
+    // Fixture has <label for="search-input">Search</label> — its accessible
+    // name is "Search". The label itself plus the input it labels both
+    // surface as candidates; verify at least one match with the right name.
+    try testing.expect(nodes.len >= 1);
+    for (nodes) |n| {
+        const name_val = n.object.get("name").?.object.get("value").?.string;
+        try testing.expectEqual("Search", name_val);
+    }
+}
+
+test "AXNode: QueryWriter combined role and name filter" {
+    var registry = Node.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer frame._session.removePage();
+    var doc = frame.window._document;
+
+    const node = try registry.register(doc.asNode());
+    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
+    var label_index: Label.LabelByForIndex = .{};
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    // Fixture has a CSS-hidden checkbox whose label says "Enable feature".
+    // Filter by both — should pin to one match.
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+        .root = node,
+        .registry = &registry,
+        .frame = frame,
+        .visibility_cache = &visibility_cache,
+        .label_index = &label_index,
+        .temp_arena = temp_arena,
+        .accessible_name = "Enable feature",
+        .role = "checkbox",
+    }, .{});
+    defer testing.allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const nodes = parsed.value.array.items;
+    try testing.expectEqual(1, nodes.len);
+
+    const role_val = nodes[0].object.get("role").?.object.get("value").?.string;
+    try testing.expectEqual("checkbox", role_val);
+}
+
+test "AXNode: QueryWriter no match returns empty array" {
+    var registry = Node.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer frame._session.removePage();
+    var doc = frame.window._document;
+
+    const node = try registry.register(doc.asNode());
+    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
+    var label_index: Label.LabelByForIndex = .{};
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+        .root = node,
+        .registry = &registry,
+        .frame = frame,
+        .visibility_cache = &visibility_cache,
+        .label_index = &label_index,
+        .temp_arena = temp_arena,
+        .accessible_name = null,
+        .role = "marquee",
+    }, .{});
+    defer testing.allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    try testing.expectEqual(0, parsed.value.array.items.len);
 }

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -693,7 +693,19 @@ pub const QueryWriter = struct {
     }
 
     fn maybeEmit(self: *const QueryWriter, axn: AXNode, in_aria_hidden: bool, w: anytype) !void {
-        const role_str = axn.getRole() catch return;
+        // Mirror Writer.writeNode (line 488-499): if this is a <label> for a
+        // hidden checkbox/radio (toggle-switch / CSS-only radio pattern), emit
+        // the label with the input's role so clients searching by role land
+        // on the label's clickable backendDOMNodeId rather than the hidden,
+        // non-interactable input.
+        const promoted_input = labelPromotionTarget(axn, self.frame, self.visibility_cache);
+
+        const role_str = if (promoted_input) |input| switch (input._input_type) {
+            .checkbox => "checkbox",
+            .radio => "radio",
+            else => unreachable,
+        } else (axn.getRole() catch return);
+
         if (self.role) |needle| {
             if (!std.mem.eql(u8, needle, role_str)) return;
         }
@@ -1785,7 +1797,7 @@ test "AXNode: QueryWriter filters by accessible name" {
     }
 }
 
-test "AXNode: QueryWriter combined role and name filter" {
+test "AXNode: QueryWriter combined role and name filter promotes hidden-input labels" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -1799,8 +1811,12 @@ test "AXNode: QueryWriter combined role and name filter" {
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 
-    // Fixture has a CSS-hidden checkbox whose label says "Enable feature".
-    // Filter by both — should pin to one match.
+    // Fixture has a CSS-hidden checkbox `<input id="toggle-switch" ...>` plus
+    // `<label for="toggle-switch">Enable feature</label>`. Walking finds both:
+    //   - the label (role promoted to "checkbox", ignored=false, clickable)
+    //   - the hidden input (intrinsic role="checkbox", ignored=true)
+    // The label is the actionable target — a real client searching by role
+    // would act on the entry with ignored=false.
     const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
         .root = node,
         .registry = &registry,
@@ -1817,10 +1833,20 @@ test "AXNode: QueryWriter combined role and name filter" {
     defer parsed.deinit();
 
     const nodes = parsed.value.array.items;
-    try testing.expectEqual(1, nodes.len);
+    try testing.expect(nodes.len >= 1);
 
-    const role_val = nodes[0].object.get("role").?.object.get("value").?.string;
-    try testing.expectEqual("checkbox", role_val);
+    // Every match has the right role and name.
+    var actionable_match = false;
+    for (nodes) |n| {
+        const role_val = n.object.get("role").?.object.get("value").?.string;
+        const name_val = n.object.get("name").?.object.get("value").?.string;
+        try testing.expectEqual("checkbox", role_val);
+        try testing.expectEqual("Enable feature", name_val);
+        if (!n.object.get("ignored").?.bool) actionable_match = true;
+    }
+    // At least one match must be ignored=false. If the label wasn't promoted,
+    // only the hidden input would match (ignored=true) — a regression.
+    try testing.expect(actionable_match);
 }
 
 test "AXNode: QueryWriter no match returns empty array" {

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -45,11 +45,31 @@ pub const Writer = struct {
     visibility_cache: *DOMNode.Element.VisibilityCache,
     label_index: *Label.LabelByForIndex,
     temp_arena: std.mem.Allocator,
+    // When null, emit the full AX tree (getFullAXTree). When set, walk the
+    // subtree visiting all nodes (including AX-ignored ones, per the
+    // queryAXTree spec) and emit only nodes whose role + accessible name
+    // match the filter, in a flat shape.
+    filter: ?Filter = null,
 
-    pub const Opts = struct {};
+    pub const Filter = struct {
+        role: ?[]const u8 = null,
+        accessible_name: ?[]const u8 = null,
+    };
+
+    pub const Opts = struct {
+        filter: ?Filter = null,
+    };
+
+    const ResolvedRole = struct {
+        role: []const u8,
+        // Non-null when the current node is a <label> whose target control is
+        // a CSS-hidden checkbox/radio. Callers use this to emit the control's
+        // checked/disabled properties on the promoted label.
+        promoted_input: ?*DOMNode.Element.Html.Input,
+    };
 
     pub fn jsonStringify(self: *const Writer, w: anytype) error{WriteFailed}!void {
-        self.toJSON(self.root, w) catch |err| {
+        self.toJSON(w) catch |err| {
             // The only error our jsonStringify method can return is
             // @TypeOf(w).Error. In other words, our code can't return its own
             // error, we can only return a writer error. Kinda sucks.
@@ -58,13 +78,34 @@ pub const Writer = struct {
         };
     }
 
-    fn toJSON(self: *const Writer, node: *const Node, w: anytype) !void {
+    fn toJSON(self: *const Writer, w: anytype) !void {
         try w.beginArray();
-        const root = AXNode.fromNode(node.dom);
-        if (try self.writeNode(node.id, root, false, w)) {
-            try self.writeNodeChildren(root, false, w);
+        if (self.filter != null) {
+            try self.walkQuery(self.root.dom, false, w);
+        } else {
+            const root = AXNode.fromNode(self.root.dom);
+            if (try self.writeNode(self.root.id, root, false, w)) {
+                try self.writeNodeChildren(root, false, w);
+            }
         }
         return w.endArray();
+    }
+
+    // Resolve the displayed role for `axn`, accounting for label-promotion
+    // when a <label> targets a CSS-hidden checkbox/radio. Shared between the
+    // tree (writeNode) and query (emitMatch) paths so the two can't drift.
+    fn resolveRole(self: *const Writer, axn: AXNode) !ResolvedRole {
+        if (labelPromotionTarget(axn, self.frame, self.visibility_cache)) |input| {
+            return .{
+                .role = switch (input._input_type) {
+                    .checkbox => "checkbox",
+                    .radio => "radio",
+                    else => unreachable,
+                },
+                .promoted_input = input,
+            };
+        }
+        return .{ .role = try axn.getRole(), .promoted_input = null };
     }
 
     // CDP spec defines AXNodeId as a string, so nodeId/parentId/childIds must
@@ -485,18 +526,11 @@ pub const Writer = struct {
         try w.objectField("backendDOMNodeId");
         try w.write(id);
 
-        const promoted_input = labelPromotionTarget(axn, self.frame, self.visibility_cache);
+        const resolved = try self.resolveRole(axn);
+        const promoted_input = resolved.promoted_input;
 
         try w.objectField("role");
-        if (promoted_input) |input| {
-            try self.writeAXValue(.{ .role = switch (input._input_type) {
-                .checkbox => "checkbox",
-                .radio => "radio",
-                else => unreachable,
-            } }, w);
-        } else {
-            try self.writeAXValue(.{ .role = try axn.getRole() }, w);
-        }
+        try self.writeAXValue(.{ .role = resolved.role }, w);
 
         const ignore = axn.isIgnore(self.frame, self.visibility_cache, in_aria_hidden);
         try w.objectField("ignored");
@@ -632,47 +666,12 @@ pub const Writer = struct {
             try self.writeAXValue(.{ .string = val }, w);
         }
     }
-};
 
-// Backing writer for Accessibility.queryAXTree. Walks the DOM subtree rooted
-// at `root`, computes role + accessible name for every node (including those
-// that would be ignored in the AX tree, per the CDP spec), and emits a flat
-// JSON array of nodes whose role/name match the optional filters.
-//
-// Intentionally MVP: emits an empty `properties` array and empty `childIds`.
-// Clients that need full properties call Accessibility.getFullAXTree on a
-// matched nodeId.
-pub const QueryWriter = struct {
-    root: *const Node,
-    registry: *Node.Registry,
-    frame: *Frame,
-    visibility_cache: *DOMNode.Element.VisibilityCache,
-    label_index: *Label.LabelByForIndex,
-    temp_arena: std.mem.Allocator,
-    accessible_name: ?[]const u8,
-    role: ?[]const u8,
-
-    pub const Opts = struct {
-        accessible_name: ?[]const u8 = null,
-        role: ?[]const u8 = null,
-    };
-
-    pub fn jsonStringify(self: *const QueryWriter, w: anytype) error{WriteFailed}!void {
-        self.toJSON(w) catch |err| {
-            log.err(.cdp, "queryAXTree toJSON", .{ .err = err });
-            return error.WriteFailed;
-        };
-    }
-
-    fn toJSON(self: *const QueryWriter, w: anytype) !void {
-        try w.beginArray();
-        try self.walk(self.root.dom, false, w);
-        return w.endArray();
-    }
-
-    fn walk(self: *const QueryWriter, node: *DOMNode, in_aria_hidden: bool, w: anytype) !void {
+    // Query-mode walk. Visits every node under `root` (including AX-ignored
+    // ones, per the queryAXTree spec) and defers emission to emitMatch.
+    fn walkQuery(self: *const Writer, node: *DOMNode, in_aria_hidden: bool, w: anytype) !void {
         const axn = AXNode.fromNode(node);
-        try self.maybeEmit(axn, in_aria_hidden, w);
+        try self.emitMatch(axn, in_aria_hidden, w);
 
         // <head>, <script>, <style> never expose AX content — skip recursion.
         if (axn.ignoreChildren()) return;
@@ -688,30 +687,24 @@ pub const QueryWriter = struct {
                 .element, .cdata => {},
                 else => continue,
             }
-            try self.walk(child, child_in_aria_hidden, w);
+            try self.walkQuery(child, child_in_aria_hidden, w);
         }
     }
 
-    fn maybeEmit(self: *const QueryWriter, axn: AXNode, in_aria_hidden: bool, w: anytype) !void {
-        // Mirror Writer.writeNode (line 488-499): if this is a <label> for a
-        // hidden checkbox/radio (toggle-switch / CSS-only radio pattern), emit
-        // the label with the input's role so clients searching by role land
-        // on the label's clickable backendDOMNodeId rather than the hidden,
-        // non-interactable input.
-        const promoted_input = labelPromotionTarget(axn, self.frame, self.visibility_cache);
+    // Emit `axn` to `w` iff it satisfies the active filter. Output shape is
+    // the queryAXTree flat-match shape: nodeId, backendDOMNodeId, ignored,
+    // role, name, plus empty properties / childIds (clients fetch full
+    // properties via getFullAXTree on a matched nodeId).
+    fn emitMatch(self: *const Writer, axn: AXNode, in_aria_hidden: bool, w: anytype) !void {
+        const filter = self.filter.?;
+        const resolved = self.resolveRole(axn) catch return;
 
-        const role_str = if (promoted_input) |input| switch (input._input_type) {
-            .checkbox => "checkbox",
-            .radio => "radio",
-            else => unreachable,
-        } else (axn.getRole() catch return);
-
-        if (self.role) |needle| {
-            if (!std.mem.eql(u8, needle, role_str)) return;
+        if (filter.role) |needle| {
+            if (!std.mem.eql(u8, needle, resolved.role)) return;
         }
 
         const name = (try axn.getName(self.frame, self.temp_arena)) orelse "";
-        if (self.accessible_name) |needle| {
+        if (filter.accessible_name) |needle| {
             if (!std.mem.eql(u8, needle, name)) return;
         }
 
@@ -721,9 +714,7 @@ pub const QueryWriter = struct {
         try w.beginObject();
 
         try w.objectField("nodeId");
-        var buf: [10]u8 = undefined;
-        const id_str = try std.fmt.bufPrint(&buf, "{d}", .{node.id});
-        try w.write(id_str);
+        try writeIdString(node.id, w);
 
         try w.objectField("backendDOMNodeId");
         try w.write(node.id);
@@ -732,12 +723,7 @@ pub const QueryWriter = struct {
         try w.write(ignored);
 
         try w.objectField("role");
-        try w.beginObject();
-        try w.objectField("type");
-        try w.write("role");
-        try w.objectField("value");
-        try w.write(role_str);
-        try w.endObject();
+        try self.writeAXValue(.{ .role = resolved.role }, w);
 
         try w.objectField("name");
         try w.beginObject();
@@ -1717,7 +1703,7 @@ test "AXNode: writer prunes hidden and resolves labels" {
     }
 }
 
-test "AXNode: QueryWriter filters by role" {
+test "AXNode: Writer query filters by role" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -1731,15 +1717,14 @@ test "AXNode: QueryWriter filters by role" {
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 
-    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .frame = frame,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
-        .accessible_name = null,
-        .role = "heading",
+        .filter = .{ .role = "heading" },
     }, .{});
     defer testing.allocator.free(json);
 
@@ -1757,7 +1742,7 @@ test "AXNode: QueryWriter filters by role" {
     try testing.expectEqual("Visible", name_val);
 }
 
-test "AXNode: QueryWriter filters by accessible name" {
+test "AXNode: Writer query filters by accessible name" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -1771,15 +1756,14 @@ test "AXNode: QueryWriter filters by accessible name" {
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 
-    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .frame = frame,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
-        .accessible_name = "Search",
-        .role = null,
+        .filter = .{ .accessible_name = "Search" },
     }, .{});
     defer testing.allocator.free(json);
 
@@ -1797,7 +1781,7 @@ test "AXNode: QueryWriter filters by accessible name" {
     }
 }
 
-test "AXNode: QueryWriter combined role and name filter promotes hidden-input labels" {
+test "AXNode: Writer query combined role+name filter promotes hidden-input labels" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -1817,15 +1801,14 @@ test "AXNode: QueryWriter combined role and name filter promotes hidden-input la
     //   - the hidden input (intrinsic role="checkbox", ignored=true)
     // The label is the actionable target — a real client searching by role
     // would act on the entry with ignored=false.
-    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .frame = frame,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
-        .accessible_name = "Enable feature",
-        .role = "checkbox",
+        .filter = .{ .accessible_name = "Enable feature", .role = "checkbox" },
     }, .{});
     defer testing.allocator.free(json);
 
@@ -1849,7 +1832,7 @@ test "AXNode: QueryWriter combined role and name filter promotes hidden-input la
     try testing.expect(actionable_match);
 }
 
-test "AXNode: QueryWriter no match returns empty array" {
+test "AXNode: Writer query no match returns empty array" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
@@ -1863,15 +1846,14 @@ test "AXNode: QueryWriter no match returns empty array" {
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 
-    const json = try std.json.Stringify.valueAlloc(testing.allocator, QueryWriter{
+    const json = try std.json.Stringify.valueAlloc(testing.allocator, Writer{
         .root = node,
         .registry = &registry,
         .frame = frame,
         .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
-        .accessible_name = null,
-        .role = "marquee",
+        .filter = .{ .role = "marquee" },
     }, .{});
     defer testing.allocator.free(json);
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -654,7 +654,13 @@ pub const BrowserContext = struct {
     }
 
     pub fn axnodeWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.Writer.Opts) !AXNode.Writer {
-        const frame = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        // Bind the writer to the frame that owns the root node, not whatever
+        // happens to be `currentFrame`. Name resolution (`Label.findLabelByFor`
+        // against `ownerDocument`) and visibility checks (`frame._style_manager`)
+        // are per-frame; getting this wrong on cross-frame queries produces
+        // names/visibility from the wrong document.
+        const fallback = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        const frame = root.dom.ownerFrame(fallback);
         _ = opts;
         const cache = try frame.call_arena.create(Element.VisibilityCache);
         cache.* = .empty;
@@ -671,7 +677,9 @@ pub const BrowserContext = struct {
     }
 
     pub fn axnodeQueryWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.QueryWriter.Opts) !AXNode.QueryWriter {
-        const frame = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        // See axnodeWriter for the frame-binding rationale.
+        const fallback = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        const frame = root.dom.ownerFrame(fallback);
         const cache = try frame.call_arena.create(Element.VisibilityCache);
         cache.* = .empty;
         const label_index = try frame.call_arena.create(Label.LabelByForIndex);

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -670,6 +670,24 @@ pub const BrowserContext = struct {
         };
     }
 
+    pub fn axnodeQueryWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.QueryWriter.Opts) !AXNode.QueryWriter {
+        const frame = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        const cache = try frame.call_arena.create(Element.VisibilityCache);
+        cache.* = .empty;
+        const label_index = try frame.call_arena.create(Label.LabelByForIndex);
+        label_index.* = .{};
+        return .{
+            .root = root,
+            .registry = &self.node_registry,
+            .frame = frame,
+            .visibility_cache = cache,
+            .label_index = label_index,
+            .temp_arena = temp_arena,
+            .accessible_name = opts.accessible_name,
+            .role = opts.role,
+        };
+    }
+
     pub fn getURL(self: *const BrowserContext) ?[:0]const u8 {
         const frame = self.session.currentFrame() orelse return null;
         const url = frame.url;

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -661,7 +661,6 @@ pub const BrowserContext = struct {
         // names/visibility from the wrong document.
         const fallback = self.session.currentFrame() orelse return error.FrameNotLoaded;
         const frame = root.dom.ownerFrame(fallback);
-        _ = opts;
         const cache = try frame.call_arena.create(Element.VisibilityCache);
         cache.* = .empty;
         const label_index = try frame.call_arena.create(Label.LabelByForIndex);
@@ -673,26 +672,7 @@ pub const BrowserContext = struct {
             .visibility_cache = cache,
             .label_index = label_index,
             .temp_arena = temp_arena,
-        };
-    }
-
-    pub fn axnodeQueryWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.QueryWriter.Opts) !AXNode.QueryWriter {
-        // See axnodeWriter for the frame-binding rationale.
-        const fallback = self.session.currentFrame() orelse return error.FrameNotLoaded;
-        const frame = root.dom.ownerFrame(fallback);
-        const cache = try frame.call_arena.create(Element.VisibilityCache);
-        cache.* = .empty;
-        const label_index = try frame.call_arena.create(Label.LabelByForIndex);
-        label_index.* = .{};
-        return .{
-            .root = root,
-            .registry = &self.node_registry,
-            .frame = frame,
-            .visibility_cache = cache,
-            .label_index = label_index,
-            .temp_arena = temp_arena,
-            .accessible_name = opts.accessible_name,
-            .role = opts.role,
+            .filter = opts.filter,
         };
     }
 

--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -25,12 +25,14 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         enable,
         disable,
         getFullAXTree,
+        queryAXTree,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
         .getFullAXTree => return getFullAXTree(cmd),
+        .queryAXTree => return queryAXTree(cmd),
     }
 }
 fn enable(cmd: *CDP.Command) !void {
@@ -66,4 +68,85 @@ fn getFullAXTree(cmd: *CDP.Command) !void {
     defer frame.releaseArena(temp_arena);
 
     return cmd.sendResult(.{ .nodes = try bc.axnodeWriter(temp_arena, node, .{}) }, .{});
+}
+
+fn queryAXTree(cmd: *CDP.Command) !void {
+    const Params = struct {
+        nodeId: ?u32 = null,
+        backendNodeId: ?u32 = null,
+        objectId: ?[]const u8 = null,
+        accessibleName: ?[]const u8 = null,
+        role: ?[]const u8 = null,
+    };
+    // Default-construct on missing params so we can return our specific
+    // "node identifier required" error rather than a generic InvalidParams.
+    const params = (try cmd.params(Params)) orelse Params{};
+
+    // objectId requires the JS inspector and an attached runtime — defer to a
+    // follow-up. Real clients (Capybara, Stagehand) usually have a nodeId from
+    // a prior DOM.querySelector/DOM.getDocument call.
+    if (params.objectId != null and params.nodeId == null and params.backendNodeId == null) {
+        return cmd.sendError(-32000, "Accessibility.queryAXTree by objectId is not yet supported; use nodeId or backendNodeId", .{});
+    }
+
+    const input_id = params.nodeId orelse params.backendNodeId orelse {
+        return cmd.sendError(-32000, "Either nodeId, backendNodeId or objectId must be specified", .{});
+    };
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const node = bc.node_registry.lookup_by_id.get(input_id) orelse return error.NodeNotFound;
+
+    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    return cmd.sendResult(.{ .nodes = try bc.axnodeQueryWriter(temp_arena, node, .{
+        .accessible_name = params.accessibleName,
+        .role = params.role,
+    }) }, .{});
+}
+
+const testing = @import("../testing.zig");
+
+test "cdp.accessibility: queryAXTree requires nodeId or backendNodeId" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
+
+    // Pass filters but no node identifier — exercises the missing-id branch.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Accessibility.queryAXTree",
+        .params = .{ .role = "button" },
+    });
+    try ctx.expectSentError(-32000, "Either nodeId, backendNodeId or objectId must be specified", .{ .id = 1 });
+}
+
+test "cdp.accessibility: queryAXTree with objectId only is not yet supported" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Accessibility.queryAXTree",
+        .params = .{ .objectId = "OBJ-X" },
+    });
+    try ctx.expectSentError(-32000, "Accessibility.queryAXTree by objectId is not yet supported; use nodeId or backendNodeId", .{ .id = 1 });
+}
+
+test "cdp.accessibility: queryAXTree with unknown nodeId returns error" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Accessibility.queryAXTree",
+        .params = .{ .nodeId = 99999 },
+    });
+    try ctx.expectSentError(-31998, "NodeNotFound", .{ .id = 1 });
 }

--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
+const dom = @import("dom.zig");
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
@@ -78,63 +79,38 @@ fn queryAXTree(cmd: *CDP.Command) !void {
         accessibleName: ?[]const u8 = null,
         role: ?[]const u8 = null,
     };
-    // Default-construct on missing params so we can return our specific
-    // "node identifier required" error rather than a generic InvalidParams.
-    const params = (try cmd.params(Params)) orelse Params{};
-
-    // objectId requires the JS inspector and an attached runtime — defer to a
-    // follow-up. Real clients (Capybara, Stagehand) usually have a nodeId from
-    // a prior DOM.querySelector/DOM.getDocument call.
-    if (params.objectId != null and params.nodeId == null and params.backendNodeId == null) {
-        return cmd.sendError(-32000, "Accessibility.queryAXTree by objectId is not yet supported; use nodeId or backendNodeId", .{});
-    }
-
-    const input_id = params.nodeId orelse params.backendNodeId orelse {
-        return cmd.sendError(-32000, "Either nodeId, backendNodeId or objectId must be specified", .{});
-    };
+    const params = (try cmd.params(Params)) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const node = bc.node_registry.lookup_by_id.get(input_id) orelse return error.NodeNotFound;
+    const node = try dom.getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
     const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 
-    return cmd.sendResult(.{ .nodes = try bc.axnodeQueryWriter(temp_arena, node, .{
-        .accessible_name = params.accessibleName,
-        .role = params.role,
+    return cmd.sendResult(.{ .nodes = try bc.axnodeWriter(temp_arena, node, .{
+        .filter = .{
+            .accessible_name = params.accessibleName,
+            .role = params.role,
+        },
     }) }, .{});
 }
 
 const testing = @import("../testing.zig");
 
-test "cdp.accessibility: queryAXTree requires nodeId or backendNodeId" {
+test "cdp.accessibility: queryAXTree requires nodeId, backendNodeId or objectId" {
     var ctx = try testing.context();
     defer ctx.deinit();
 
     _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
 
-    // Pass filters but no node identifier — exercises the missing-id branch.
+    // Pass filters but no node identifier — dom.getNode returns MissingParams.
     try ctx.processMessage(.{
         .id = 1,
         .method = "Accessibility.queryAXTree",
         .params = .{ .role = "button" },
     });
-    try ctx.expectSentError(-32000, "Either nodeId, backendNodeId or objectId must be specified", .{ .id = 1 });
-}
-
-test "cdp.accessibility: queryAXTree with objectId only is not yet supported" {
-    var ctx = try testing.context();
-    defer ctx.deinit();
-
-    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
-
-    try ctx.processMessage(.{
-        .id = 1,
-        .method = "Accessibility.queryAXTree",
-        .params = .{ .objectId = "OBJ-X" },
-    });
-    try ctx.expectSentError(-32000, "Accessibility.queryAXTree by objectId is not yet supported; use nodeId or backendNodeId", .{ .id = 1 });
+    try ctx.expectSentError(-31998, "MissingParams", .{ .id = 1 });
 }
 
 test "cdp.accessibility: queryAXTree with unknown nodeId returns error" {

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -459,7 +459,7 @@ fn scrollIntoViewIfNeeded(cmd: *CDP.Command) !void {
     return cmd.sendResult(null, .{});
 }
 
-fn getNode(arena: Allocator, bc: *CDP.BrowserContext, node_id: ?Node.Id, backend_node_id: ?Node.Id, object_id: ?[]const u8) !*Node {
+pub fn getNode(arena: Allocator, bc: *CDP.BrowserContext, node_id: ?Node.Id, backend_node_id: ?Node.Id, object_id: ?[]const u8) !*Node {
     const input_node_id = node_id orelse backend_node_id;
     if (input_node_id) |input_node_id_| {
         return bc.node_registry.lookup_by_id.get(input_node_id_) orelse return error.NodeNotFound;


### PR DESCRIPTION
## Summary

Adds `Accessibility.queryAXTree`, the standard CDP primitive for finding AX nodes by role and/or accessible name without serializing the full tree. Motivating use case: agentic / MCP automation clients (Capybara drivers, Playwright + Stagehand, custom MCP integrations) that need *"find all buttons named Submit"* against complex pages where `getFullAXTree` round-trips multi-MB JSON.

Bundles a small fix to the pre-existing `axnodeWriter` while it's in scope — see "Cross-cutting frame-binding fix" below.

## What this PR changes

- **`src/cdp/AXNode.zig`** — `Writer` now takes an optional `Opts.filter`. When `filter == null`, behavior is unchanged (full AX tree, the `getFullAXTree` path). When set, `toJSON` branches into `walkQuery` / `emitMatch`: walks the DOM subtree rooted at the requested node, visits every descendant (including nodes that would be ignored in the AX tree, per the CDP spec), and emits a flat JSON array of matches. A shared `resolveRole` helper handles label-promotion for both the tree path (`writeNode`) and the query path (`emitMatch`) so the two can't drift.
- **`src/cdp/domains/accessibility.zig`** — New `queryAXTree` action in the dispatch enum + handler. Resolves the input node via `dom.getNode`, which already handles `nodeId` / `backendNodeId` / `objectId`. Threads the filter through `axnodeWriter`.
- **`src/cdp/domains/dom.zig`** — Promoted `getNode` from file-private to `pub` so accessibility can reuse it. No behavior change for the existing `DOM.*` callers.
- **`src/cdp/CDP.zig`** — `BrowserContext.axnodeWriter` is now the single entry point (both `getFullAXTree` and `queryAXTree` use it). Frame binding goes through `root.dom.ownerFrame(currentFrame)` (see fix section below).

## Label-promotion parity with `getFullAXTree`

`emitMatch` reuses the shared `resolveRole` helper, so when a `<label>` targets a CSS-hidden checkbox/radio (toggle-switch / CSS-only radio pattern), the label is emitted with the input's role. Without this, `queryAXTree(role="checkbox", name="Enable feature")` on a toggle-switch fixture would return the `display:none` input — a non-actionable target. Real automation clients (Capybara `find`, MCP agents) would then issue a click that silently fails.

## Cross-cutting frame-binding fix

`axnodeWriter` (used by both `getFullAXTree` and `queryAXTree` now) used to bind the writer to `session.currentFrame()`. That's wrong when the root node lives in a different frame — accessible-name resolution (via `Label.findLabelByFor` against `ownerDocument`) and visibility checks (via `frame._style_manager`) are per-frame, so a cross-frame query would compute names/ignored-state against the wrong document.

The writer now derives the frame via `root.dom.ownerFrame(currentFrame)`. The fallback (`currentFrame`) only matters for orphan / detached nodes; for any DOM-attached node, `ownerFrame` returns the right one. This also corrects a latent bug in `getFullAXTree` where the handler resolves the requested `frameId` for the *root document* but the writer then overrode with `currentFrame` for everything else.

## Performance posture

The headline benchmark (123MB peak / 9× faster than headless Chrome) is the reason this primitive matters at all — `getFullAXTree` is the expensive path on rich pages. `queryAXTree`:

- Walks the DOM subtree once
- Reuses the existing visibility / label caches built per call
- Filters before serialization — output is bounded by match count, not subtree size

No new retained state, no extra HTTP, no layout dependency. The frame-binding fix replaces one pointer assignment with one method call (`ownerFrame`) — no measurable overhead.

## Caveats

MVP scope. Each item is a mechanical follow-up PR:

1. **Matches emit empty `properties` and `childIds` arrays and no `parentId`.** Per CDP spec these fields are optional. Clients that need full properties call `Accessibility.getFullAXTree` on a matched nodeId. Cross-reference support is the obvious next PR.
2. **`frameId` not parsed by `queryAXTree`** — queries the frame derived from the supplied nodeId. Clients pass a nodeId already scoped to the frame they care about; explicit `frameId` would be redundant. `getFullAXTree` continues to honor `frameId` for consistency with its prior contract.

## Where to focus review

- `src/cdp/AXNode.zig` — `resolveRole` is the single source of truth for the label-promotion-aware role lookup, called by both `writeNode` (tree mode) and `emitMatch` (query mode). The `walkQuery` walk is intentionally different from `writeNodeChildren`: per the queryAXTree spec it visits AX-ignored nodes (and reports their state via `ignored: true`) rather than pruning hidden subtrees.
- `src/cdp/CDP.zig` — `axnodeWriter` is now the only AX writer entry point; the `ownerFrame(currentFrame)` change applies to both modes. `getFullAXTree` previously bound to `currentFrame` for non-root nodes, so this changes existing behavior on cross-frame queries. The previous behavior was buggy, but if anything in the test suite or downstream code depends on it, this will surface it.
- `src/cdp/domains/dom.zig` — `getNode` is now `pub`. No call-site changes.

## Test plan

- [x] 4 unit tests for query mode in `src/cdp/AXNode.zig`: filter by role, by name, combined-with-label-promotion, no match — all exercise the unified `Writer` with `Opts.filter` set
- [x] 2 CDP-wire integration tests in `src/cdp/domains/accessibility.zig`: missing node identifier (now via `dom.getNode → error.MissingParams`), unknown nodeId
- [x] Full suite: `make test` reports **658 of 658 tests pass** — including the existing `AXNode: writer` and `AXNode: writer prunes hidden and resolves labels` tests, which exercise the tree path post-refactor (verifies `resolveRole` extraction didn't change tree behavior)
- [x] `zig fmt --check ./*.zig ./**/*.zig` clean
