### PR TITLE
ci: smoke test the MCP stdio server

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -450,3 +450,36 @@ jobs:
       - run: chmod a+x ./lightpanda
 
       - run: ./lightpanda fetch https://demo-browser.lightpanda.io/campfire-commerce/
+
+  mcp-smoke:
+    name: mcp smoke
+    needs: zig-build-release
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: lightpanda-build-release
+
+      - run: chmod a+x ./lightpanda
+
+      - name: jsonrpc round trip over stdio
+        run: |
+          set -euo pipefail
+
+          timeout 30 ./lightpanda mcp > mcp.out <<'JSONRPC'
+          {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0.0"}}}
+          {"jsonrpc":"2.0","method":"notifications/initialized"}
+          {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+          JSONRPC
+
+          cat mcp.out
+
+          grep '"id":1' mcp.out \
+            | jq -e '.result.protocolVersion == "2024-11-05"' > /dev/null
+
+          grep '"id":2' mcp.out \
+            | jq -e '.result.tools | type == "array" and length > 0' > /dev/null


### PR DESCRIPTION
The `mcp` subcommand is the agentic on-ramp documented in the README, but nothing in CI exercises it today. A regression that breaks JSON-RPC parsing or tool registration could ship to nightly without anyone noticing.

This adds an `mcp-smoke` job to `e2e-test.yml` that reuses the existing `lightpanda-build-release` artifact:

1. Pipes `initialize` + `notifications/initialized` + `tools/list` over stdin to `./lightpanda mcp`.
2. Asserts with `jq` that `protocolVersion == "2024-11-05"` and `result.tools` is a non-empty array.

Marginal cost ~1 minute. No matrix, no node client, no extra build.

## Test plan

- [x] Verified the roundtrip locally with a debug build: exit code 0, both `jq -e` assertions pass under `set -euo pipefail`.
- [ ] CI run on this PR.
