### PR TITLE
Add --enable-external-stylesheets flag with fetch + parse

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -100,6 +100,7 @@ const CommonOptions = .{
     .{ .name = "storage_sqlite_path", .type = ?[:0]const u8 },
     .{ .name = "disable_subframes", .type = bool },
     .{ .name = "disable_workers", .type = bool },
+    .{ .name = "enable_external_stylesheets", .type = bool },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -250,6 +251,13 @@ pub fn disableSubframes(self: *const Config) bool {
 pub fn disableWorkers(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| opts.disable_workers,
+        else => unreachable,
+    };
+}
+
+pub fn enableExternalStylesheets(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp => |opts| opts.enable_external_stylesheets,
         else => unreachable,
     };
 }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1749,16 +1749,24 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
         return;
     }
 
-    const sheet = try CSSStyleSheet.initWithOwner(element, self);
+    // Reuse the cached sheet on re-fetch (href mutation on a connected
+    // link) so `document.styleSheets` keeps a single entry per <link>
+    // instead of accumulating one per href change. On first load, create
+    // and register; on subsequent loads, replace content in place.
+    const sheet = link._sheet orelse blk: {
+        const new_sheet = try CSSStyleSheet.initWithOwner(element, self);
+        link._sheet = new_sheet;
+        const sheets = try self.document.getStyleSheets(self);
+        try sheets.add(new_sheet, self);
+        break :blk new_sheet;
+    };
+
     sheet._href = try self.arena.dupe(u8, resolved);
     sheet.replaceSync(response.body.items, self) catch |err| {
         log.warn(.browser, "external stylesheet parse", .{ .err = err, .url = resolved });
         try self.fireLinkEvent(link, comptime .wrap("error"));
         return;
     };
-
-    const sheets = try self.document.getStyleSheets(self);
-    try sheets.add(sheet, self);
 
     try self.fireLinkEvent(link, comptime .wrap("load"));
 }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -52,6 +52,7 @@ const AbstractRange = @import("webapi/AbstractRange.zig");
 const MutationObserver = @import("webapi/MutationObserver.zig");
 const IntersectionObserver = @import("webapi/IntersectionObserver.zig");
 const Worker = @import("webapi/Worker.zig");
+const CSSStyleSheet = @import("webapi/css/CSSStyleSheet.zig");
 const CustomElementDefinition = @import("webapi/CustomElementDefinition.zig");
 const PageTransitionEvent = @import("webapi/event/PageTransitionEvent.zig");
 const SubmitEvent = @import("webapi/event/SubmitEvent.zig");
@@ -1677,6 +1678,94 @@ pub fn queueLoad(self: *Frame, html: *Element.Html) !void {
             }
         }.cleanup, 0, .{ .name = "frame.dispatchLoad" });
     }
+}
+
+// Hard cap on a single external stylesheet body. CSS rule storage is per-
+// arena so a hostile sheet could otherwise inflate page memory; 2 MiB is
+// well above anything seen on real sites (Tailwind's `preflight + utilities`
+// build is ~400 KiB gzipped, ~3 MiB raw — at which point a site should be
+// splitting by route anyway).
+const MAX_STYLESHEET_BYTES: usize = 2 * 1024 * 1024;
+
+// Synchronously fetch and parse an external `<link rel=stylesheet>`. Opt-in
+// behind `session.load_external_stylesheets` — scrapers/crawlers that don't
+// need accurate visibility checks still get the cheap no-fetch path via
+// `Link.linkAddedCallback`. Mirrors `ScriptManager.addFromElement`'s use of
+// `syncRequest`: stylesheets are render-blocking in real browsers, so a
+// synchronous fetch from inside the parser callback matches expected
+// document-load ordering without manual `_pending_loads` bookkeeping.
+pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
+    if (self.isGoingAway()) return;
+
+    const element = link.asElement();
+    const href = element.getAttributeSafe(comptime .wrap("href")) orelse return;
+    if (href.len == 0) return;
+
+    const arena = try self.getArena(.medium, "Frame.loadExternalStylesheet");
+    defer self._session.releaseArena(arena);
+
+    const resolved = URL.resolve(arena, self.base(), href, .{ .encoding = self.charset }) catch |err| {
+        log.warn(.browser, "external stylesheet resolve", .{ .err = err, .href = href });
+        try self.fireLinkEvent(link, comptime .wrap("error"));
+        return;
+    };
+
+    const session = self._session;
+    // HttpClient takes ownership of `headers` via the request struct (see
+    // HttpClient.zig:411 — must NOT pair with a local `defer deinit`).
+    var headers = try session.browser.http_client.newHeaders();
+    try headers.add("Accept: text/css,*/*;q=0.1");
+
+    var response = session.browser.http_client.syncRequest(arena, .{
+        .url = resolved,
+        .method = .GET,
+        .frame_id = self._frame_id,
+        .loader_id = self._loader_id,
+        .headers = headers,
+        .cookie_jar = &session.cookie_jar,
+        .cookie_origin = self.url,
+        .resource_type = .stylesheet,
+        .notification = session.notification,
+    }) catch |err| {
+        log.warn(.browser, "external stylesheet fetch", .{ .err = err, .url = resolved });
+        try self.fireLinkEvent(link, comptime .wrap("error"));
+        return;
+    };
+    defer response.deinit(arena);
+
+    if (response.status < 200 or response.status >= 300) {
+        log.info(.browser, "external stylesheet status", .{ .status = response.status, .url = resolved });
+        try self.fireLinkEvent(link, comptime .wrap("error"));
+        return;
+    }
+
+    if (response.body.items.len > MAX_STYLESHEET_BYTES) {
+        log.warn(.browser, "external stylesheet too large", .{
+            .bytes = response.body.items.len,
+            .max = MAX_STYLESHEET_BYTES,
+            .url = resolved,
+        });
+        try self.fireLinkEvent(link, comptime .wrap("error"));
+        return;
+    }
+
+    const sheet = try CSSStyleSheet.initWithOwner(element, self);
+    sheet._href = try self.arena.dupe(u8, resolved);
+    sheet.replaceSync(response.body.items, self) catch |err| {
+        log.warn(.browser, "external stylesheet parse", .{ .err = err, .url = resolved });
+        try self.fireLinkEvent(link, comptime .wrap("error"));
+        return;
+    };
+
+    const sheets = try self.document.getStyleSheets(self);
+    try sheets.add(sheet, self);
+
+    try self.fireLinkEvent(link, comptime .wrap("load"));
+}
+
+fn fireLinkEvent(self: *Frame, link: *Element.Html.Link, name: String) !void {
+    const event = try Event.initTrusted(name, .{}, self._page);
+    try self._event_manager.dispatch(link._proto.asEventTarget(), event);
 }
 
 fn dispatchLoad(self: *Frame) !void {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1697,6 +1697,15 @@ const MAX_STYLESHEET_BYTES: usize = 2 * 1024 * 1024;
 pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
     if (self.isGoingAway()) return;
 
+    // Fragment-parsed links (innerHTML / outerHTML / DOMParser /
+    // Range.createContextualFragment / <template>.content) reach
+    // `Link.Build.created` like any other parser-instantiated element, but
+    // their owner subtree may never be attached to the live document. A
+    // network fetch + sheet registration against `self.document` would be
+    // a visible side effect of merely parsing markup. Mirrors the
+    // `nodeIsReady` short-circuit at the existing parser-path guard.
+    if (self._parse_mode == .fragment) return;
+
     const element = link.asElement();
     const href = element.getAttributeSafe(comptime .wrap("href")) orelse return;
     if (href.len == 0) return;
@@ -1711,10 +1720,28 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
     };
 
     const session = self._session;
-    // HttpClient takes ownership of `headers` via the request struct (see
-    // HttpClient.zig:411 — must NOT pair with a local `defer deinit`).
+    // HttpClient takes ownership of `headers` via the request struct on
+    // successful `syncRequest` (see HttpClient.zig:411). Until ownership
+    // transfers, `errdefer` covers the OOM window in `headers.add` /
+    // `headersForRequest` so the initial `newHeaders()` slist doesn't
+    // leak. Once `syncRequest` is entered the request struct handles
+    // cleanup — do NOT add a plain `defer deinit` here.
     var headers = try session.browser.http_client.newHeaders();
+    errdefer headers.deinit();
     try headers.add("Accept: text/css,*/*;q=0.1");
+    try self.headersForRequest(&headers);
+
+    // Set the script-manager `is_evaluating` flag for the same reason
+    // `ScriptManager.addFromElement` does: `syncRequest` pumps the CDP
+    // socket inline, so a `Target.closeTarget` / `Page.close` arriving
+    // mid-fetch would otherwise drive `Session.removePage` while this
+    // function still holds pointers to `self`. The check in
+    // `Session.removePage` (Session.zig:253) consults
+    // `frame.anyScriptEvaluating()`, which only sees this flag.
+    const sm = &self._script_manager.base;
+    const was_evaluating = sm.is_evaluating;
+    sm.is_evaluating = true;
+    defer sm.is_evaluating = was_evaluating;
 
     var response = session.browser.http_client.syncRequest(arena, .{
         .url = resolved,
@@ -1753,20 +1780,32 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
     // link) so `document.styleSheets` keeps a single entry per <link>
     // instead of accumulating one per href change. On first load, create
     // and register; on subsequent loads, replace content in place.
+    //
+    // First-load creation assigns `link._sheet` AFTER `sheets.add`
+    // succeeds so an OOM during registration doesn't cache an unregistered
+    // sheet (which would short-circuit every future re-fetch via the
+    // `orelse` branch, leaving the sheet permanently unreachable through
+    // `document.styleSheets`).
     const sheet = link._sheet orelse blk: {
         const new_sheet = try CSSStyleSheet.initWithOwner(element, self);
-        link._sheet = new_sheet;
         const sheets = try self.document.getStyleSheets(self);
         try sheets.add(new_sheet, self);
+        link._sheet = new_sheet;
         break :blk new_sheet;
     };
 
-    sheet._href = try self.arena.dupe(u8, resolved);
+    // Parse first, only swap `_href` on success. `replaceSync` itself is
+    // not atomic (clears rules before the insert loop), so a mid-parse
+    // OOM still drops the old rules — full atomicity would require a
+    // scratch-list pattern in `CSSStyleSheet.replaceSync`. Keeping
+    // `_href` consistent with what the sheet actually contains is the
+    // minimum.
     sheet.replaceSync(response.body.items, self) catch |err| {
         log.warn(.browser, "external stylesheet parse", .{ .err = err, .url = resolved });
         try self.fireLinkEvent(link, comptime .wrap("error"));
         return;
     };
+    sheet._href = try self.arena.dupe(u8, resolved);
 
     try self.fireLinkEvent(link, comptime .wrap("load"));
 }
@@ -3109,6 +3148,20 @@ pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpt
                 style._sheet = null;
             }
             self._style_manager.sheetModified();
+        } else if (el.is(Element.Html.Link)) |link| {
+            // External stylesheet links registered via Frame.loadExternalStylesheet
+            // must be symmetrically deregistered on disconnect, or
+            // `document.styleSheets` accumulates phantom entries and the
+            // visibility cascade keeps honoring rules from removed links —
+            // exactly the SPA theme-switch pattern (append new sheet,
+            // remove old) the feature exists to serve.
+            if (link._sheet) |sheet| {
+                if (self.document._style_sheets) |sheets| {
+                    sheets.remove(sheet);
+                }
+                link._sheet = null;
+                self._style_manager.sheetModified();
+            }
         }
     }
 }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1687,47 +1687,41 @@ pub fn queueLoad(self: *Frame, html: *Element.Html) !void {
 // splitting by route anyway).
 const MAX_STYLESHEET_BYTES: usize = 2 * 1024 * 1024;
 
-// Synchronously fetch and parse an external `<link rel=stylesheet>`. Opt-in
-// behind `session.load_external_stylesheets` — scrapers/crawlers that don't
-// need accurate visibility checks still get the cheap no-fetch path via
-// `Link.linkAddedCallback`. Mirrors `ScriptManager.addFromElement`'s use of
-// `syncRequest`: stylesheets are render-blocking in real browsers, so a
-// synchronous fetch from inside the parser callback matches expected
-// document-load ordering without manual `_pending_loads` bookkeeping.
-pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
-    if (self.isGoingAway()) return;
+// Synchronously fetch and parse an external `<link rel=stylesheet>`.
+// href is passed in as an optimization since the [currently] only callsite has
+// it, so why look it up again?
+pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []const u8) !void {
+    if (self.isGoingAway() or href.len == 0) {
+        return;
+    }
 
-    // Fragment-parsed links (innerHTML / outerHTML / DOMParser /
-    // Range.createContextualFragment / <template>.content) reach
-    // `Link.Build.created` like any other parser-instantiated element, but
-    // their owner subtree may never be attached to the live document. A
-    // network fetch + sheet registration against `self.document` would be
-    // a visible side effect of merely parsing markup. Mirrors the
-    // `nodeIsReady` short-circuit at the existing parser-path guard.
-    if (self._parse_mode == .fragment) return;
+    const session = self._session;
 
+    // this feature is disabled by default, and can be turned on via a command
+    // line flag or via an CDP command
+    if (session.load_external_stylesheets == false) {
+        return self.queueLoad(link._proto);
+    }
+
+    // Fragment-parsed links (innerHTML, DOMParser, ...) may not be attached.
+    // TODO: this isn't correct in all cases. If the link is added into an
+    // attached node, I think we SHOULD load it.
+    if (self._parse_mode == .fragment) {
+        return;
+    }
     const element = link.asElement();
-    const href = element.getAttributeSafe(comptime .wrap("href")) orelse return;
-    if (href.len == 0) return;
 
-    const arena = try self.getArena(.medium, "Frame.loadExternalStylesheet");
-    defer self._session.releaseArena(arena);
+    const arena = try session.getArena(.medium, "Frame.loadExternalStylesheet");
+    defer session.releaseArena(arena);
 
     const resolved = URL.resolve(arena, self.base(), href, .{ .encoding = self.charset }) catch |err| {
-        log.warn(.browser, "external stylesheet resolve", .{ .err = err, .href = href });
-        try self.fireLinkEvent(link, comptime .wrap("error"));
+        log.warn(.http, "external stylesheet resolve", .{ .err = err, .href = href });
+        try self.fireElementEvent(element, comptime .wrap("error"));
         return;
     };
 
-    const session = self._session;
-    // HttpClient takes ownership of `headers` via the request struct on
-    // successful `syncRequest` (see HttpClient.zig:411). Until ownership
-    // transfers, `errdefer` covers the OOM window in `headers.add` /
-    // `headersForRequest` so the initial `newHeaders()` slist doesn't
-    // leak. Once `syncRequest` is entered the request struct handles
-    // cleanup — do NOT add a plain `defer deinit` here.
-    var headers = try session.browser.http_client.newHeaders();
-    errdefer headers.deinit();
+    const http_client = &session.browser.http_client;
+    var headers = try http_client.newHeaders();
     try headers.add("Accept: text/css,*/*;q=0.1");
     try self.headersForRequest(&headers);
 
@@ -1743,7 +1737,7 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
     sm.is_evaluating = true;
     defer sm.is_evaluating = was_evaluating;
 
-    var response = session.browser.http_client.syncRequest(arena, .{
+    var response = http_client.syncRequest(arena, .{
         .url = resolved,
         .method = .GET,
         .frame_id = self._frame_id,
@@ -1754,26 +1748,23 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
         .resource_type = .stylesheet,
         .notification = session.notification,
     }) catch |err| {
-        log.warn(.browser, "external stylesheet fetch", .{ .err = err, .url = resolved });
-        try self.fireLinkEvent(link, comptime .wrap("error"));
-        return;
+        log.warn(.http, "external stylesheet fetch", .{ .err = err, .url = resolved });
+        return self.fireElementEvent(element, comptime .wrap("error"));
     };
     defer response.deinit(arena);
 
     if (response.status < 200 or response.status >= 300) {
-        log.info(.browser, "external stylesheet status", .{ .status = response.status, .url = resolved });
-        try self.fireLinkEvent(link, comptime .wrap("error"));
-        return;
+        log.info(.http, "external stylesheet status", .{ .status = response.status, .url = resolved });
+        return self.fireElementEvent(element, comptime .wrap("error"));
     }
 
     if (response.body.items.len > MAX_STYLESHEET_BYTES) {
-        log.warn(.browser, "external stylesheet too large", .{
+        log.warn(.http, "external stylesheet too large", .{
             .bytes = response.body.items.len,
             .max = MAX_STYLESHEET_BYTES,
             .url = resolved,
         });
-        try self.fireLinkEvent(link, comptime .wrap("error"));
-        return;
+        return self.fireElementEvent(element, comptime .wrap("error"));
     }
 
     // Reuse the cached sheet on re-fetch (href mutation on a connected
@@ -1801,18 +1792,17 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link) !void {
     // `_href` consistent with what the sheet actually contains is the
     // minimum.
     sheet.replaceSync(response.body.items, self) catch |err| {
-        log.warn(.browser, "external stylesheet parse", .{ .err = err, .url = resolved });
-        try self.fireLinkEvent(link, comptime .wrap("error"));
-        return;
+        log.warn(.http, "external stylesheet parse", .{ .err = err, .url = resolved });
+        return self.fireElementEvent(element, comptime .wrap("error"));
     };
     sheet._href = try self.arena.dupe(u8, resolved);
 
-    try self.fireLinkEvent(link, comptime .wrap("load"));
+    try self.fireElementEvent(element, comptime .wrap("load"));
 }
 
-fn fireLinkEvent(self: *Frame, link: *Element.Html.Link, name: String) !void {
+fn fireElementEvent(self: *Frame, el: *Element, name: String) !void {
     const event = try Event.initTrusted(name, .{}, self._page);
-    try self._event_manager.dispatch(link._proto.asEventTarget(), event);
+    try self._event_manager.dispatch(el.asEventTarget(), event);
 }
 
 fn dispatchLoad(self: *Frame) !void {
@@ -1827,8 +1817,7 @@ fn dispatchLoad(self: *Frame) !void {
 
     for (to_process.items) |html_element| {
         if (has_dom_load_listener or html_element.hasAttributeFunction(.onload, self)) {
-            const event = try Event.initTrusted(comptime .wrap("load"), .{}, self._page);
-            try self._event_manager.dispatch(html_element.asEventTarget(), event);
+            try self.fireElementEvent(html_element.asElement(), comptime .wrap("load"));
         }
     }
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -910,6 +910,7 @@ pub const Request = struct {
         xhr,
         script,
         fetch,
+        stylesheet,
 
         // Allowed Values: Document, Stylesheet, Image, Media, Font, Script,
         // TextTrack, XHR, Fetch, Prefetch, EventSource, WebSocket, Manifest,
@@ -921,6 +922,7 @@ pub const Request = struct {
                 .xhr => "XHR",
                 .script => "Script",
                 .fetch => "Fetch",
+                .stylesheet => "Stylesheet",
             };
         }
     };

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -91,6 +91,15 @@ subframe_loading_enabled: bool = true,
 // session init; the LP.configureLoading CDP method can flip it per-session.
 worker_loading_enabled: bool = true,
 
+// Opt-in fetch of external <link rel=stylesheet> resources. Defaults to
+// false to preserve the current rendering-free fast path: drivers that
+// don't need accurate visibility checks pay nothing. Set from the
+// `--enable-external-stylesheets` CLI flag at session init; the
+// LP.configureLoading CDP method can flip it per-session. Currently
+// unread — the fetch path lands in a follow-up that depends on the
+// network refactor in #2303.
+load_external_stylesheets: bool = false,
+
 pub fn init(self: *Session, browser: *Browser, notification: *Notification) !void {
     const allocator = browser.app.allocator;
     const arena_pool = browser.arena_pool;
@@ -112,6 +121,7 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         // CLI defaults; LP.configureLoading can flip these per-session.
         .subframe_loading_enabled = !browser.app.config.disableSubframes(),
         .worker_loading_enabled = !browser.app.config.disableWorkers(),
+        .load_external_stylesheets = browser.app.config.enableExternalStylesheets(),
     };
 }
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -95,9 +95,9 @@ worker_loading_enabled: bool = true,
 // false to preserve the current rendering-free fast path: drivers that
 // don't need accurate visibility checks pay nothing. Set from the
 // `--enable-external-stylesheets` CLI flag at session init; the
-// LP.configureLoading CDP method can flip it per-session. Currently
-// unread — the fetch path lands in a follow-up that depends on the
-// network refactor in #2303.
+// LP.configureLoading CDP method can flip it per-session. When true,
+// `Link.linkAddedCallback` routes to `Frame.loadExternalStylesheet`
+// (synchronous fetch + parse + register on `document.styleSheets`).
 load_external_stylesheets: bool = false,
 
 pub fn init(self: *Session, browser: *Browser, notification: *Notification) !void {

--- a/src/browser/tests/css/external_stylesheet.html
+++ b/src/browser/tests/css/external_stylesheet.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<head>
+  <script src="../testing.js"></script>
+  <link id="ext" rel="stylesheet" href="/styles/visibility.css">
+</head>
+<body>
+  <div id="visible">always visible</div>
+  <div id="hidden" class="ext-hide">hidden by external rule</div>
+
+  <script id="ext_stylesheet_registered">
+  {
+    // The parser-synchronous fetch in Frame.loadExternalStylesheet runs
+    // before this script executes, so document.styleSheets reflects the
+    // fetched sheet by the time we look.
+    testing.expectEqual(1, document.styleSheets.length);
+
+    const sheet = document.styleSheets[0];
+    testing.expectEqual(testing.ORIGIN + '/styles/visibility.css', sheet.href);
+    testing.expectEqual(1, sheet.cssRules.length);
+    testing.expectEqual('.ext-hide', sheet.cssRules[0].selectorText);
+  }
+  </script>
+
+  <script id="ext_stylesheet_cascade">
+  {
+    // External rule must reach StyleManager: a `.ext-hide` element should
+    // report checkVisibility() === false, exactly as if the rule were
+    // declared inline in a `<style>` block.
+    testing.expectTrue(document.getElementById('visible').checkVisibility());
+    testing.expectFalse(document.getElementById('hidden').checkVisibility());
+  }
+  </script>
+
+  <script id="ext_stylesheet_dynamic_load_event">
+  {
+    // Dynamically-inserted <link> fires `load` after the fetch completes.
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/visibility.css';
+    testing.async(async () => {
+      const fired = await new Promise(resolve => {
+        link.addEventListener('load', () => resolve(true));
+        link.addEventListener('error', () => resolve(false));
+        document.head.appendChild(link);
+      });
+      testing.expectEqual(true, fired);
+    });
+    testing.expectEqual(true, true);
+  }
+  </script>
+
+  <script id="ext_stylesheet_404_fires_error">
+  {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/404.css';
+    testing.async(async () => {
+      const evt = await new Promise(resolve => {
+        link.addEventListener('load', () => resolve('load'));
+        link.addEventListener('error', () => resolve('error'));
+        document.head.appendChild(link);
+      });
+      testing.expectEqual('error', evt);
+    });
+    testing.expectEqual(true, true);
+  }
+  </script>
+
+  <script id="ext_stylesheet_oversize_fires_error">
+  {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/oversize.css';
+    testing.async(async () => {
+      const evt = await new Promise(resolve => {
+        link.addEventListener('load', () => resolve('load'));
+        link.addEventListener('error', () => resolve('error'));
+        document.head.appendChild(link);
+      });
+      testing.expectEqual('error', evt);
+    });
+    testing.expectEqual(true, true);
+  }
+  </script>
+</body>

--- a/src/browser/tests/css/external_stylesheet.html
+++ b/src/browser/tests/css/external_stylesheet.html
@@ -82,4 +82,42 @@
     testing.expectEqual(true, true);
   }
   </script>
+
+  <script id="ext_stylesheet_href_change_replaces">
+  {
+    // Mutating link.href on a connected stylesheet link must REPLACE the
+    // cached sheet's rules, not append a second entry to
+    // document.styleSheets. Regression test for the stale-sheet
+    // accumulation bug caught in code review.
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/visibility.css';
+    testing.async(async () => {
+      const baseline = document.styleSheets.length;
+
+      await new Promise(resolve => {
+        link.addEventListener('load', () => resolve(), { once: true });
+        document.head.appendChild(link);
+      });
+      const afterFirst = document.styleSheets.length;
+      testing.expectEqual(baseline + 1, afterFirst);
+
+      const second = await new Promise(resolve => {
+        link.addEventListener('load', () => resolve('load'), { once: true });
+        link.addEventListener('error', () => resolve('error'), { once: true });
+        link.href = '/styles/visibility2.css';
+      });
+      testing.expectEqual('load', second);
+      testing.expectEqual(afterFirst, document.styleSheets.length);
+
+      // New rules must be in effect after the swap. The reused sheet is
+      // the last registered one (the static head link registered first).
+      const sheet = document.styleSheets[afterFirst - 1];
+      testing.expectEqual(testing.ORIGIN + '/styles/visibility2.css', sheet.href);
+      testing.expectEqual(1, sheet.cssRules.length);
+      testing.expectEqual('.ext-hide-2', sheet.cssRules[0].selectorText);
+    });
+    testing.expectEqual(true, true);
+  }
+  </script>
 </body>

--- a/src/browser/tests/css/external_stylesheet.html
+++ b/src/browser/tests/css/external_stylesheet.html
@@ -125,21 +125,27 @@
   {
     // Stylesheet links parsed via innerHTML / outerHTML /
     // insertAdjacentHTML / Range.createContextualFragment / <template>
-    // content must NOT trigger a network fetch or register a sheet on
-    // the live document — the owning subtree may never be attached.
-    // Regression test for the fragment-mode bypass caught in code review.
+    // content / DOMParser.parseFromString must NOT trigger a network
+    // fetch or register a sheet on the live document — the owning
+    // subtree may never be attached or belongs to a different Document.
     //
-    // Assertion is synchronous on purpose: parseHtmlAsChildren runs
-    // inline, so any unintended sheet registration would be visible
-    // immediately. Deferring to testing.onload would race against the
-    // async tests above that legitimately add sheets.
-    //
-    // DOMParser.parseFromString is a separate case (parses with
-    // `_parse_mode = .document` into a *different* Document) and is not
-    // covered by the same gate — tracked as a follow-up.
+    // Assertion is synchronous on purpose: both parse paths run inline,
+    // so any unintended sheet registration would be visible immediately.
+    // Deferring to testing.onload would race against the async tests
+    // above that legitimately add sheets.
     const before = document.styleSheets.length;
+
     const div = document.createElement('div');
     div.innerHTML = '<link rel="stylesheet" href="/styles/visibility.css">';
+    testing.expectEqual(before, document.styleSheets.length);
+
+    const parsed = new DOMParser().parseFromString(
+      '<html><head><link rel="stylesheet" href="/styles/visibility2.css"></head><body></body></html>',
+      'text/html'
+    );
+    // Parsed link exists in the new document...
+    testing.expectEqual(1, parsed.querySelectorAll('link').length);
+    // ...but no sheet on the live document.
     testing.expectEqual(before, document.styleSheets.length);
   }
   </script>

--- a/src/browser/tests/css/external_stylesheet.html
+++ b/src/browser/tests/css/external_stylesheet.html
@@ -120,4 +120,60 @@
     testing.expectEqual(true, true);
   }
   </script>
+
+  <script id="ext_stylesheet_fragment_parse_skipped">
+  {
+    // Stylesheet links parsed via innerHTML / outerHTML /
+    // insertAdjacentHTML / Range.createContextualFragment / <template>
+    // content must NOT trigger a network fetch or register a sheet on
+    // the live document — the owning subtree may never be attached.
+    // Regression test for the fragment-mode bypass caught in code review.
+    //
+    // Assertion is synchronous on purpose: parseHtmlAsChildren runs
+    // inline, so any unintended sheet registration would be visible
+    // immediately. Deferring to testing.onload would race against the
+    // async tests above that legitimately add sheets.
+    //
+    // DOMParser.parseFromString is a separate case (parses with
+    // `_parse_mode = .document` into a *different* Document) and is not
+    // covered by the same gate — tracked as a follow-up.
+    const before = document.styleSheets.length;
+    const div = document.createElement('div');
+    div.innerHTML = '<link rel="stylesheet" href="/styles/visibility.css">';
+    testing.expectEqual(before, document.styleSheets.length);
+  }
+  </script>
+
+  <script id="ext_stylesheet_disconnect_removes">
+  {
+    // Removing a connected stylesheet link must drop its sheet from
+    // document.styleSheets. Without symmetric deregistration the SPA
+    // theme-switch pattern (append new, remove old) would accumulate
+    // phantom entries and stale cascade rules.
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/visibility2.css';
+    testing.async(async () => {
+      const baseline = document.styleSheets.length;
+
+      await new Promise(resolve => {
+        link.addEventListener('load', () => resolve(), { once: true });
+        document.head.appendChild(link);
+      });
+      testing.expectEqual(baseline + 1, document.styleSheets.length);
+
+      link.remove();
+      testing.expectEqual(baseline, document.styleSheets.length);
+
+      // Re-appending must register fresh — the disconnect cleanup
+      // cleared link._sheet so the cached short-circuit doesn't apply.
+      await new Promise(resolve => {
+        link.addEventListener('load', () => resolve(), { once: true });
+        document.head.appendChild(link);
+      });
+      testing.expectEqual(baseline + 1, document.styleSheets.length);
+    });
+    testing.expectEqual(true, true);
+  }
+  </script>
 </body>

--- a/src/browser/tests/element/html/link.html
+++ b/src/browser/tests/element/html/link.html
@@ -137,3 +137,19 @@
   });
 }
 </script>
+
+<script id="ext_stylesheet_disabled_default">
+{
+  // Flag defaults off — a <link rel=stylesheet> must NOT register a sheet
+  // on document.styleSheets and must NOT touch the network. The synthetic
+  // load event still fires (asserted by other tests above).
+  const before = document.styleSheets.length;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/styles/visibility.css';
+  document.head.appendChild(link);
+  testing.onload(() => {
+    testing.expectEqual(before, document.styleSheets.length);
+  });
+}
+</script>

--- a/src/browser/webapi/DOMParser.zig
+++ b/src/browser/webapi/DOMParser.zig
@@ -53,6 +53,17 @@ pub fn parseFromString(
     const arena = try frame.getArena(.medium, "DOMParser.parseFromString");
     defer frame.releaseArena(arena);
 
+    // DOMParser builds a detached Document. Borrow the same fragment
+    // parse-mode that `parseHtmlAsChildren` uses so frame-side hooks
+    // triggered from `Build.created` / `nodeIsReady` (external stylesheet
+    // fetches, script execution, mutation-observer fan-out, default-script
+    // injection) treat the parsed nodes as detached and skip
+    // side effects on the live document. The frame's `_parse_mode` is
+    // restored on exit.
+    const previous_parse_mode = frame._parse_mode;
+    frame._parse_mode = .fragment;
+    defer frame._parse_mode = previous_parse_mode;
+
     return switch (target_mime) {
         .@"text/html" => {
             // Create a new HTMLDocument

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -26,6 +26,12 @@ const HtmlElement = @import("../Html.zig");
 
 const Link = @This();
 _proto: *HtmlElement,
+// Cached CSSStyleSheet for an external `rel=stylesheet` once
+// `Frame.loadExternalStylesheet` has registered it. Re-fetches (href
+// mutated on a connected link) reuse this sheet via `replaceSync` so the
+// old rules are dropped instead of accumulating in `document.styleSheets`.
+// Mirrors `Style._sheet`.
+_sheet: ?*@import("../../css/CSSStyleSheet.zig") = null,
 
 pub fn asElement(self: *Link) *Element {
     return self._proto._proto;

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -124,8 +124,8 @@ pub fn linkAddedCallback(self: *Link, frame: *Frame) !void {
     // which fires the load/error event itself. Other rels (preload,
     // modulepreload) and the disabled case keep the rendering-free stub that
     // fires a synthetic `load` event without touching the network.
-    if (std.mem.eql(u8, rel, "stylesheet") and frame._session.load_external_stylesheets) {
-        return frame.loadExternalStylesheet(self);
+    if (std.mem.eql(u8, rel, "stylesheet")) {
+        return frame.loadExternalStylesheet(self, href);
     }
 
     try frame.queueLoad(self._proto);
@@ -174,5 +174,7 @@ test "WebApi: HTML.Link" {
 }
 
 test "WebApi: HTML.Link external stylesheet" {
+    const filter: testing.LogFilter = .init(&.{.http});
+    defer filter.deinit();
     try testing.htmlRunner("css/external_stylesheet.html", .{ .load_external_stylesheets = true });
 }

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -114,6 +114,14 @@ pub fn linkAddedCallback(self: *Link, frame: *Frame) !void {
         return;
     }
 
+    // Opt-in fetch for `rel="stylesheet"` — drives `frame.loadExternalStylesheet`,
+    // which fires the load/error event itself. Other rels (preload,
+    // modulepreload) and the disabled case keep the rendering-free stub that
+    // fires a synthetic `load` event without touching the network.
+    if (std.mem.eql(u8, rel, "stylesheet") and frame._session.load_external_stylesheets) {
+        return frame.loadExternalStylesheet(self);
+    }
+
     try frame.queueLoad(self._proto);
 }
 
@@ -143,7 +151,22 @@ pub const JsApi = struct {
     }
 };
 
+// Parser-created <link> elements are void (no closing tag) so they never
+// reach `Frame.nodeComplete`. Mirror `Image.Build.created` so static head
+// links in HTML go through `linkAddedCallback` at element-create time,
+// with attributes already populated by `populateElementAttributes`.
+pub const Build = struct {
+    pub fn created(node: *Node, frame: *Frame) !void {
+        const self = node.as(Link);
+        return self.linkAddedCallback(frame);
+    }
+};
+
 const testing = @import("../../../../testing.zig");
 test "WebApi: HTML.Link" {
     try testing.htmlRunner("element/html/link.html", .{});
+}
+
+test "WebApi: HTML.Link external stylesheet" {
+    try testing.htmlRunner("css/external_stylesheet.html", .{ .load_external_stylesheets = true });
 }

--- a/src/cdp/domains/fetch.zig
+++ b/src/cdp/domains/fetch.zig
@@ -209,6 +209,7 @@ pub fn requestIntercept(bc: *CDP.BrowserContext, intercept: *const Notification.
             .xhr => "XHR",
             .document => "Document",
             .fetch => "Fetch",
+            .stylesheet => "Stylesheet",
         },
         .networkId = &id.toRequestId(transfer), // matches the Network REQ-ID
     }, .{ .session_id = session_id });
@@ -453,6 +454,7 @@ pub fn requestAuthRequired(bc: *CDP.BrowserContext, intercept: *const Notificati
             .xhr => "XHR",
             .document => "Document",
             .fetch => "Fetch",
+            .stylesheet => "Stylesheet",
         },
         .authChallenge = .{
             .origin = "", // TODO get origin, could be the proxy address for example.

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -68,11 +68,13 @@ fn configureLoading(cmd: *CDP.Command) !void {
     const params = (try cmd.params(struct {
         subFrame: ?bool = null,
         worker: ?bool = null,
+        externalStylesheets: ?bool = null,
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
     if (params.subFrame) |v| bc.session.subframe_loading_enabled = v;
     if (params.worker) |v| bc.session.worker_loading_enabled = v;
+    if (params.externalStylesheets) |v| bc.session.load_external_stylesheets = v;
     return cmd.sendResult(null, .{});
 }
 
@@ -685,6 +687,39 @@ test "cdp.lp: configureLoading toggles subFrame and worker independently" {
         .params = .{ .subFrame = true, .worker = true },
     });
     try ctx.expectSentResult(null, .{ .id = 3 });
+    try testing.expectEqual(true, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(true, bc.session.worker_loading_enabled);
+}
+
+test "cdp.lp: configureLoading toggles externalStylesheets independently" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    _ = try bc.session.createPage();
+
+    // Default is opt-in: off unless the CLI flag or CDP toggle enables it.
+    try testing.expectEqual(false, bc.session.load_external_stylesheets);
+
+    // Enable via CDP; the other two loading toggles stay at their defaults.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "LP.configureLoading",
+        .params = .{ .externalStylesheets = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+    try testing.expectEqual(true, bc.session.load_external_stylesheets);
+    try testing.expectEqual(true, bc.session.subframe_loading_enabled);
+    try testing.expectEqual(true, bc.session.worker_loading_enabled);
+
+    // Flip back off; partial params must not reset the other fields.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "LP.configureLoading",
+        .params = .{ .externalStylesheets = false },
+    });
+    try ctx.expectSentResult(null, .{ .id = 2 });
+    try testing.expectEqual(false, bc.session.load_external_stylesheets);
     try testing.expectEqual(true, bc.session.subframe_loading_enabled);
     try testing.expectEqual(true, bc.session.worker_loading_enabled);
 }

--- a/src/help.zon
+++ b/src/help.zon
@@ -152,6 +152,20 @@
     \\                           script fetch is initiated and its scope never runs.
     \\                           Defaults to false.
     \\
+    \\--enable-external-stylesheets
+    \\                           Fetch external <link rel=stylesheet> resources so
+    \\                           their rules contribute to computed styles (and
+    \\                           therefore to visibility checks like display,
+    \\                           visibility, opacity, pointer-events). The default
+    \\                           skips these fetches, which makes utility-class-
+    \\                           heavy sites read as not-visible from the driver
+    \\                           side. Currently a no-op: reserves the surface
+    \\                           (CLI + LP.configureLoading externalStylesheets)
+    \\                           so drivers can adopt it before the fetch path
+    \\                           lands in a follow-up. Drivers can also toggle
+    \\                           this per-session via LP.configureLoading.
+    \\                           Defaults to false.
+    \\
     \\--block-private-networks   Block HTTP requests to private/internal IP
     \\                           addresses after DNS resolution.
     \\                           Defaults to false.

--- a/src/help.zon
+++ b/src/help.zon
@@ -156,11 +156,7 @@
     \\                           Fetch external <link rel=stylesheet> resources so
     \\                           their rules contribute to computed styles (and
     \\                           therefore to visibility checks like display,
-    \\                           visibility, opacity, pointer-events). The default
-    \\                           skips these fetches, which makes utility-class-
-    \\                           heavy sites read as not-visible from the driver
-    \\                           side. Drivers can also toggle this per-session
-    \\                           via LP.configureLoading.
+    \\                           visibility, opacity, pointer-events).
     \\                           Defaults to false.
     \\
     \\--block-private-networks   Block HTTP requests to private/internal IP

--- a/src/help.zon
+++ b/src/help.zon
@@ -159,11 +159,8 @@
     \\                           visibility, opacity, pointer-events). The default
     \\                           skips these fetches, which makes utility-class-
     \\                           heavy sites read as not-visible from the driver
-    \\                           side. Currently a no-op: reserves the surface
-    \\                           (CLI + LP.configureLoading externalStylesheets)
-    \\                           so drivers can adopt it before the fetch path
-    \\                           lands in a follow-up. Drivers can also toggle
-    \\                           this per-session via LP.configureLoading.
+    \\                           side. Drivers can also toggle this per-session
+    \\                           via LP.configureLoading.
     \\                           Defaults to false.
     \\
     \\--block-private-networks   Block HTTP requests to private/internal IP

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -341,6 +341,7 @@ const WEB_API_TEST_ROOT = "src/browser/tests/";
 const HtmlRunnerOpts = struct {
     timeout_ms: u32 = 2000,
     inject_script: ?[]const u8 = null,
+    load_external_stylesheets: bool = false,
 };
 
 pub fn htmlRunner(comptime path: []const u8, opts: HtmlRunnerOpts) !void {
@@ -352,6 +353,9 @@ pub fn htmlRunner(comptime path: []const u8, opts: HtmlRunnerOpts) !void {
         test_session.inject_scripts = inject_scripts[0..1];
     }
     defer test_session.inject_scripts = &.{};
+
+    test_session.load_external_stylesheets = opts.load_external_stylesheets;
+    defer test_session.load_external_stylesheets = false;
 
     const root = try std.fs.path.joinZ(arena_allocator, &.{ WEB_API_TEST_ROOT, path });
     const stat = std.fs.cwd().statFile(root) catch |err| {
@@ -674,6 +678,42 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         return req.respond(&.{ 0, 0, 1, 2, 0, 0, 9 }, .{
             .extra_headers = &.{
                 .{ .name = "Content-Type", .value = "application/octet-stream" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/styles/visibility.css")) {
+        // Used by css/external_stylesheet.html — drives the visibility
+        // cascade through StyleManager via Frame.loadExternalStylesheet
+        // so a `.ext-hide` element is observable to checkVisibility().
+        return req.respond(".ext-hide { display: none; }", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/css" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/styles/404.css")) {
+        return req.respond("/* unused */", .{
+            .status = .not_found,
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/css" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/styles/oversize.css")) {
+        // Body that exceeds Frame.MAX_STYLESHEET_BYTES (2 MiB) — written as a
+        // long sequence of valid declarations so the response itself parses
+        // fine and the error path is exercised by the size cap, not by a
+        // CSS parse failure.
+        const chunk = ".pad { color: #abcdef; } "; // 25 bytes
+        const repeats = (2 * 1024 * 1024 / chunk.len) + 1024;
+        var body = try std.ArrayList(u8).initCapacity(arena_allocator, chunk.len * repeats);
+        for (0..repeats) |_| body.appendSliceAssumeCapacity(chunk);
+        return req.respond(body.items, .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/css" },
             },
         });
     }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -693,6 +693,17 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/styles/visibility2.css")) {
+        // Second visibility sheet used by the href-change regression test:
+        // mutating link.href must replace the cached sheet's rules in place,
+        // not append a new entry to document.styleSheets.
+        return req.respond(".ext-hide-2 { display: none; }", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/css" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/styles/404.css")) {
         return req.respond("/* unused */", .{
             .status = .not_found,


### PR DESCRIPTION
## What this fixes

Lightpanda silently dropped every `<link rel="stylesheet">` — no fetch, no
parse, no entry on `document.styleSheets`, no contribution to the visibility
cascade. Inline `<style>` blocks worked end-to-end via StyleManager, but
external sheets were explicitly marked "out of scope for the headless engine"
(see `StyleManager.zig:124-125` on `main`). That gap hurts agentic and
testing use cases where accurate `checkVisibility()` / `getComputedStyle()`
matters, while leaving the cheap no-fetch fast path intact for pure
scraping/crawling.

## What this PR changes

Behind the opt-in `--enable-external-stylesheets` flag (or
`LP.configureLoading.externalStylesheets` per-session), `<link rel=stylesheet>`
elements — both parser-emitted and JS-created — now:

1. Resolve `href` against the frame base.
2. Fetch synchronously via `HttpClient.syncRequest` (same path
   `ScriptManager.addFromElement` uses).
3. Hand the body to `CSSStyleSheet.replaceSync`, which parses + populates
   `cssRules` + calls `StyleManager.sheetModified()`.
4. Register the sheet on `document.styleSheets` and fire `load` (or `error`
   on any failure — status non-2xx, oversize body, parse error).

The whole feature is gated on `session.load_external_stylesheets`. With the
flag off, behavior is unchanged from `main`: the synthetic load-event stub
in `linkAddedCallback` still fires for `rel=stylesheet/preload/modulepreload`,
no network traffic, no entries on `document.styleSheets`.

## Notable design choices

**Synchronous fetch from the parser callback.** Matches
`ScriptManager.addFromElement` precedent and how real browsers handle CSS
(render-blocking). Lets us reuse `_pending_loads` semantics without
bookkeeping — by the time `linkAddedCallback` returns, the sheet is live.

**`replaceSync` does the parse + cascade wiring.** No `StyleManager` or
`CSSStyleSheet` API changes; the existing inline-`<style>` ingestion path
already does exactly what's needed once we hand it the bytes.

**Cached sheet on `Link._sheet`.** Mirrors `Style._sheet`. On the first
load the sheet is created and registered on `document.styleSheets`; on
subsequent loads (e.g., mutating `link.href` on a connected element) the
existing sheet is reused via `replaceSync` so the styleSheets list stays
stable and old rules don't accumulate. Fetch failures leave the previous
sheet intact — matches browser behavior where a broken `href` doesn't
invalidate the previously loaded sheet until the link itself is removed.
Disconnect cleanup removes the sheet symmetrically so SPA theme-switch
patterns (append new sheet, remove old) don't leak phantom entries.

**`Build.created` on Link.** Pre-existing gap: static `<link>` elements
(void, no closing tag) never reached `nodeComplete` → `linkAddedCallback`
was a dead callback for static head links. Mirrors `Image.Build.created`.
Side effect: the synthetic `load` event now also fires for static
`<link rel=stylesheet>` in the disabled-flag case — matches browser
behavior, brings Link in line with Image.

**Fragment-mode gate.** `Build.created` fires for parser-instantiated
elements before attachment, including content parsed via `innerHTML` /
`outerHTML` / `insertAdjacentHTML` / `Range.createContextualFragment` /
`<template>` content / `DOMParser.parseFromString`. Without a guard these
would have fetched against the live document and registered phantom
sheets even when the parsed subtree was never attached.
`loadExternalStylesheet` short-circuits on `_parse_mode == .fragment`,
and `DOMParser.parseFromString` now brackets its `parser.parse` calls
with the same fragment parse-mode `parseHtmlAsChildren` uses (which also
incidentally stops DOMParser-emitted `<script>` tags from executing
against the live frame).

**`is_evaluating` bracket around `syncRequest`.** Sync HTTP from inside
the parser callback pumps the CDP socket, so a `Target.closeTarget`
arriving mid-fetch could otherwise drive `Session.removePage` while we
still hold `self` — UAF. The bracket every other `syncRequest` caller
uses is what `Session.removePage`'s reentrancy guard
(`anyScriptEvaluating()`) checks.

**`.stylesheet` ResourceType.** CDP Network events now report
`"Stylesheet"` per spec, instead of falling back to `"Fetch"`.

## Why 2 MiB cap (and what it actually protects)

The 2 MiB cap in `Frame.loadExternalStylesheet` is a **CSS-parser-arena
protection**, not a network protection. It bounds how much CSS the parser
will turn into `CSSRule` objects on the frame's medium arena.

Network-level streaming protection already exists via
`HttpClient.max_response_size`, enforced at `HttpClient.zig:1496/1534/1545`
both pre-request (Content-Length) and per-chunk during the body callback.
Drivers that need a tighter network cap should set
`config.httpMaxResponseSize`.

A per-request streaming cap specifically for stylesheets would let us
short-circuit large responses before the global cap, but it requires a new
field on the `Request` struct in `HttpClient.zig` — exactly the territory
#2303 is refactoring. Deferred to a follow-up after the network layer
stabilizes.

Tailwind's full `preflight + utilities` raw build is ~3 MiB; at that size
a site should already be splitting by route. 2 MiB is well above anything
seen on real production sites.

## Caveats (v1)

- No CORS check. Cross-origin sheets fetch regardless of the `crossorigin`
  attribute. Matches how scripts work today.
- No MIME enforcement. `SyncResponse` doesn't expose response headers, and
  changing that touches `HttpClient.zig` — #2303 territory. Follow-up.
- 2 MiB cap is post-buffer (see "Why 2 MiB" above). Network cap from
  `HttpClient.max_response_size` already streams.
- `CSSStyleSheet.replaceSync` itself is not atomic: it clears `cssRules`
  before its insert loop, so an OOM mid-insert can leave the cached sheet
  with old rules dropped and new rules partially loaded. `_href` is held
  back until `replaceSync` succeeds, so URL/content stay consistent — but
  full atomicity would require a scratch-list pattern in `replaceSync`.
- No `@import` recursion or `url(...)` font/image fetch.

## Where to focus review

- `Frame.loadExternalStylesheet` (size cap, `is_evaluating` bracket,
  `errdefer`/ownership-transfer on headers, `_href` ordering, cached-sheet
  reuse on re-fetch).
- `Link._sheet` field + `Build.created` + the disconnect-walker branch
  in `Frame.zig` — confirms the no-leak invariant under
  append/remove/href-mutation.
- `DOMParser.parseFromString` parse-mode bracket — incidentally also
  stops DOMParser scripts from running against the live frame.
- `src/browser/tests/css/external_stylesheet.html` — eight sub-tests
  covering static + dynamic load, cascade reaching StyleManager, 404,
  oversize, href-change-replaces-sheet, fragment-parse-skipped (innerHTML
  + DOMParser), disconnect-removes.

## Real-world validation

Built `1.0.0-dev.6282+fdbe2a269` (`ReleaseSafe`) and ran against the
[`capybara-lightpanda`](https://github.com/navidemad/capybara-lightpanda)
driver suite as a downstream sanity check:

| Scenario | Flag OFF | Flag ON | Result |
|---|---|---|---|
| **Synthetic page** — external sheet with `.hide-me { display: none }`, `checkVisibility()` on a matching div | `styleSheets=0`, `checkVisibility=true` | `styleSheets=1`, `checkVisibility=false` | ✅ Cascade reflects external CSS only when enabled |
| **`rake test:all`** — full capybara-lightpanda test suite (313 runs, 562 assertions) | 313/313, 4 skips | 313/313, same 4 skips | ✅ No regressions from new fetch path or `Build.created` |
| **`https://lightpanda.io/`** — production page load via the gem | `styleSheets=2` (inline only) | `styleSheets=3` (+1 external link) | ✅ Flag actually pulls in external CSS in the wild |

The driver was invoked via a small `LIGHTPANDA_EXTRA_ARGS` passthrough on
its `Process#build_args` so the same cached binary could be A/B-tested
without rebuilding. No driver-side code knows about the flag — purely a
CLI/CDP toggle.

## Compatibility with #2303

Keeping this PR in draft until #2303 lands, per @krichprollsch's note about
not piling new fetch sites onto the in-flight network refactor. Disjoint
files apart from `HttpClient.zig` (1 enum variant) and `cdp/domains/fetch.zig`
(2 switch arms). Rebase delta after #2303 lands is concrete and small:

### Concrete rebase delta

<details>
<summary>What #2303 changes that touches this PR</summary>

**1. `Request` struct splits into two types.** Post-2303 introduces a
`RequestParams` struct (input to `syncRequest` and `Client.request`) that's
a strict subset of `Request`:

| Field                  | Pre-2303 `Request` | Post-2303 `RequestParams` |
|------------------------|--------------------|---------------------------|
| `frame_id`, `loader_id`, `method`, `url`, `headers`, `body`, `cookie_jar`, `cookie_origin`, `resource_type`, `credentials`, `notification`, `timeout_ms` | yes | yes |
| `arena`, `request_id`  | n/a                | injected by `Client.request` |
| `protect_from_abort`   | n/a                | yes (navigation abort safety) |
| `ctx`, callback hooks (`start_callback`, `header_callback`, `data_callback`, `done_callback`, `error_callback`, `shutdown_callback`) | yes | n/a (sync doesn't need them) |
| `skip_robots`          | yes                | n/a |

Rebase change at the `loadExternalStylesheet` call site: the field set we
pass (`url`, `method`, `frame_id`, `loader_id`, `headers`, `cookie_jar`,
`cookie_origin`, `resource_type`, `notification`) is already a subset of
`RequestParams`, so the struct literal compiles unchanged. The type the
compiler infers becomes `RequestParams` instead of `Request`. No code edit
needed at the call site itself.

**2. `ResourceType` enum lives in two parallel places.** Post-2303 has
`RequestParams.ResourceType` AND `Request.ResourceType`, both with identical
variant lists. The rebase must add `.stylesheet` to *both* enums and to
both `string()` mappings (currently this PR only touches one because pre-2303
has a single enum).

**3. Threading model changes — transparent for this PR.** `HttpClient`
becomes a thin wrapper around `Network.Handle`; libcurl runs on a shared
main thread with cross-thread signaling. `syncRequest` from a CDP worker
thread (where `linkAddedCallback` already executes) keeps its blocking
semantics — the worker thread waits on a condition variable while the main
thread drives the transfer. We inherit the same stability guarantee
`ScriptManager.addFromElement` does; if #2303 breaks `syncRequest` under
the new threading model, scripts break too, so the whole browser is gated
on that path working.

**4. `HttpClient.process` internals change** (`network.getConnection()` →
`handle.getConnection()`) — doesn't affect our code, no rebase action.

**5. CDP `fetch.zig` switches.** Same `.stylesheet` arms apply pre- and
post-2303; the surrounding diff might shift line numbers but the change is
mechanically identical.

### Estimated rebase work

5–10 minutes once #2303 lands: add `.stylesheet` to the second
`ResourceType` enum + `string()` mapping in `HttpClient.zig`, re-run
`make test`. No semantic changes to the stylesheet fetch path.

</details>

## Test plan

- [x] `make test` — 694/694 pass
- [x] `zig fmt --check ./*.zig ./**/*.zig` clean
- [x] `WebApi: HTML.Link` — flag-disabled assertion confirms no sheet
      registered when off
- [x] `WebApi: HTML.Link external stylesheet` — flag-enabled covers
      static + dynamic load, cascade, 404, oversize,
      href-change-replaces, fragment-parse-skipped (innerHTML +
      DOMParser), disconnect-removes
- [x] Downstream driver: `capybara-lightpanda` `rake test:all` 313/313
      pass identically with flag on/off
- [x] Real-world: `https://lightpanda.io/` loads cleanly and picks up
      the external stylesheet with the flag enabled

Refs #2343