### PR TITLE
ci: tighten mcp-smoke jq assertions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -476,6 +476,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          jq --version
+
           timeout 30 ./lightpanda mcp > mcp.out <<'JSONRPC'
           {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0.0"}}}
           {"jsonrpc":"2.0","method":"notifications/initialized"}
@@ -484,8 +486,5 @@ jobs:
 
           cat mcp.out
 
-          grep '"id":1' mcp.out \
-            | jq -e '.result.protocolVersion == "2024-11-05"' > /dev/null
-
-          grep '"id":2' mcp.out \
-            | jq -e '.result.tools | type == "array" and length > 0' > /dev/null
+          jq -ec 'select(.id == 1) | .result.protocolVersion == "2024-11-05"' mcp.out > /dev/null
+          jq -ec 'select(.id == 2) | .result.tools | type == "array" and length > 0' mcp.out > /dev/null


### PR DESCRIPTION
Follow-up to #2481.

- Replace `grep '"id":N' mcp.out | jq -e ...` with `jq -ec 'select(.id == N) | ...' mcp.out`. The grep form also matched `"id":10`, `"id":11`, ... and any tool description containing that substring; numeric `select` is type-correct. `jq -e` still fails the job when `select` produces no output (exit 4), so the smoke semantics are preserved.
- Add `jq --version` at the top of the script so the job fails fast and loud if the `ubuntu-latest` image ever stops shipping jq.