### PR TITLE
On blocking read failure, break from loop

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -530,7 +530,9 @@ pub fn syncRequest(self: *Client, allocator: Allocator, req: Request) !SyncRespo
         switch (status) {
             .cdp_socket => {
                 const cdp = self.cdp_client.?;
-                _ = cdp.blocking_read(cdp.ctx);
+                if (cdp.blocking_read(cdp.ctx) == false) {
+                    return error.ClientDisconnected;
+                }
             },
             .normal => continue,
         }


### PR DESCRIPTION
Blocking read failure almost certainly means a disconnect client. As-is, that's an endless loop. Instead, fail the request.