### PR TITLE
`StyleManager`: author `display` rule must beat UA `[hidden]` / `display:none`

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -428,16 +428,6 @@ fn isElementHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOp
         opacity_priority = INLINE_PRIORITY;
     }
 
-    // UA stylesheet display:none rules (HTML Rendering §15.3.1 "Hidden elements").
-    // Skipped when an inline `display` is set so author overrides win per cascade.
-    // All UA rules are short-circuited here; the spec marks some as `!important`
-    // (`input[type=hidden]`, `noscript`) and others as normal-origin, but author
-    // CSS overriding `<script>`/`<head>`/closed-`<details>` children is rare
-    // enough that uniform treatment is acceptable.
-    if (options.check_display and display_priority != INLINE_PRIORITY) {
-        if (matchesUaDisplayNoneRule(el)) return true;
-    }
-
     if (display_priority == INLINE_PRIORITY and visibility_priority == INLINE_PRIORITY and opacity_priority == INLINE_PRIORITY) {
         return false;
     }
@@ -527,6 +517,15 @@ fn isElementHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOp
     }
 
     ctx.checkRules(&self.other_rules);
+
+    // UA stylesheet display:none fallback (HTML Rendering §15.3.1 "Hidden
+    // elements"). Applied only when no author rule for `display` matched the
+    // element — per CSS Cascade §6.1 any normal-origin author rule beats UA
+    // origin regardless of specificity, so `.x { display: flex }` on a
+    // `<div class="x" hidden>` must report visible.
+    if (options.check_display and display_priority == 0) {
+        if (matchesUaDisplayNoneRule(el)) display_none = true;
+    }
 
     return (display_none orelse false) or (visibility_hidden orelse false) or (opacity_zero orelse false);
 }

--- a/src/browser/tests/element/check_visibility.html
+++ b/src/browser/tests/element/check_visibility.html
@@ -300,6 +300,116 @@
   }
 </script>
 
+<style id="style-author-beats-ua-hidden">
+  .cv-author-flex { display: flex; }
+  .cv-author-none { display: none; }
+</style>
+
+<script id="author_class_display_overrides_hidden_attr">
+  {
+    // Regression: author `.x { display: flex }` must beat UA `[hidden] {
+    // display: none }` per CSS Cascade §6.1 — any normal-origin author rule
+    // wins over UA origin regardless of specificity. Before the fix, the UA
+    // short-circuit in `isElementHidden` fired before the author rule walk,
+    // so `[hidden]` always won regardless of the class rule.
+    const el = document.createElement("div");
+    el.className = "cv-author-flex";
+    el.setAttribute("hidden", "");
+    document.body.appendChild(el);
+
+    testing.expectEqual(true, el.checkVisibility());
+    // Invariant from `StyleManager.zig:329-331`: checkVisibility() and
+    // `getComputedStyle().display === "none"` must agree.
+    testing.expectEqual(true, window.getComputedStyle(el).display !== "none");
+
+    el.remove();
+  }
+</script>
+
+<script id="author_class_display_none_alone_hides">
+  {
+    // Sanity baseline: class display:none alone still hides correctly.
+    const el = document.createElement("div");
+    el.className = "cv-author-none";
+    document.body.appendChild(el);
+
+    testing.expectEqual(false, el.checkVisibility());
+    testing.expectEqual("none", window.getComputedStyle(el).display);
+
+    el.remove();
+  }
+</script>
+
+<script id="author_class_display_none_with_hidden_attr_stays_hidden">
+  {
+    // Both author and UA say hide → still hidden (author wins, but agrees
+    // with UA).
+    const el = document.createElement("div");
+    el.className = "cv-author-none";
+    el.setAttribute("hidden", "");
+    document.body.appendChild(el);
+
+    testing.expectEqual(false, el.checkVisibility());
+    testing.expectEqual("none", window.getComputedStyle(el).display);
+
+    el.remove();
+  }
+</script>
+
+<script id="author_wildcard_overrides_hidden_attr">
+  {
+    // `*` lives in the `other_rules` bucket. Per CSS Cascade §6.1, any author
+    // rule for `display` — even a wildcard — beats UA origin regardless of
+    // specificity. The style is added dynamically and removed at teardown so
+    // the wildcard doesn't leak onto adjacent tests in the file.
+    const style = document.createElement("style");
+    style.textContent = "* { display: block; }";
+    document.head.appendChild(style);
+
+    const el = document.createElement("div");
+    el.setAttribute("hidden", "");
+    document.body.appendChild(el);
+
+    testing.expectEqual(true, el.checkVisibility());
+    testing.expectEqual(true, window.getComputedStyle(el).display !== "none");
+
+    el.remove();
+    style.remove();
+  }
+</script>
+
+<script id="no_author_rule_hidden_attr_still_hides">
+  {
+    // UA `[hidden]` fallback still applies when no author rule for `display`
+    // matched the element. After the fix the UA short-circuit runs AFTER
+    // the author rule walk, gated on `display_priority == 0`.
+    const el = document.createElement("div");
+    el.setAttribute("hidden", "");
+    document.body.appendChild(el);
+
+    testing.expectEqual(false, el.checkVisibility());
+    testing.expectEqual("none", window.getComputedStyle(el).display);
+
+    el.remove();
+  }
+</script>
+
+<script id="inline_display_with_hidden_attr_regression_guard">
+  {
+    // Inline `display` already wins via INLINE_PRIORITY and passed before
+    // the fix; regression guard so future refactors don't break the path.
+    const el = document.createElement("div");
+    el.setAttribute("hidden", "");
+    el.style.display = "flex";
+    document.body.appendChild(el);
+
+    testing.expectEqual(true, el.checkVisibility());
+    testing.expectEqual(true, window.getComputedStyle(el).display !== "none");
+
+    el.remove();
+  }
+</script>
+
 <script id="deep_nesting">
   {
     const levels = 5;


### PR DESCRIPTION
## What this fixes

`Element.checkVisibility()` and `getComputedStyle(el).display` short-circuited to "hidden" / "none" whenever an element matched the UA `display: none` ruleset (the `hidden` HTML attribute, `<script>` / `<head>` / `<style>` / closed-`<details>` children, `input[type=hidden]`), **even when an author class / id / tag / wildcard rule was supposed to win the cascade** — e.g. `<div class="x" hidden>` with `<style>.x { display: flex }</style>`. Per [CSS Cascade §6.1](https://www.w3.org/TR/css-cascade-4/#cascade-origin), any normal-origin author rule beats a UA-origin rule regardless of specificity. Lightpanda violated that for class / id / tag / wildcard rules.

Root cause was the check order in `StyleManager.isElementHidden`:

```zig
// StyleManager.zig:437-439 (pre-fix)
if (options.check_display and display_priority != INLINE_PRIORITY) {
    if (matchesUaDisplayNoneRule(el)) return true;  // fires BEFORE the author walk
}
```

The author-rule machinery (`addRawRule` / `isRelevant` / `checkRules` + the `id_rules` / `class_rules` / `tag_rules` / `other_rules` buckets) already produces the right answer — `.x { display: flex }` correctly sets `props.display_none = false` at `StyleManager.zig:190` and the rule lands in `class_rules`. Only the UA short-circuit firing first prevented that result from being used. Inline `style="display: flex"` was unaffected because inline pins `display_priority = INLINE_PRIORITY` at `StyleManager.zig:397`, which the old guard at line 437 already skipped.

Surfaced through [`navidemad/capybara-lightpanda`](https://github.com/navidemad/capybara-lightpanda) — the Stimulus + Floating-UI dropdown pattern at `examples/rails_dropdown_minitest_example.rb` (`BuggyDropdownWithFlexCssTest` / `BuggyDropdownWithImportantFlexCssTest`) tripped this: a menu element finished an open / close cycle with `hidden` set and `class="flex"`, Capybara's visibility probe returned false, and `click_on("Archiver")` aborted with `Capybara::ElementNotFound`.

## What this PR changes

- Removes the early UA short-circuit at `StyleManager.zig:437-439`. The `<= 6`-line author rule walk at `StyleManager.zig:500-519` now always runs when the all-inline early-return doesn't fire.
- Adds a new UA fallback **after** the author walk (lines 521-528), gated on `display_priority == 0`:

  ```zig
  // UA stylesheet display:none fallback (HTML Rendering §15.3.1 "Hidden
  // elements"). Applied only when no author rule for `display` matched the
  // element — per CSS Cascade §6.1 any normal-origin author rule beats UA
  // origin regardless of specificity, so `.x { display: flex }` on a
  // `<div class="x" hidden>` must report visible.
  if (options.check_display and display_priority == 0) {
      if (matchesUaDisplayNoneRule(el)) display_none = true;
  }
  ```

The all-inline early-return at `StyleManager.zig:431-433` still skips both the author walk and the UA fallback when inline `display` / `visibility` / `opacity` are all set to non-hiding values — inline beats UA per the cascade, same as before.

No public API changes. `matchesUaDisplayNoneRule`, `addRawRule`, `VisibilityProperties.isRelevant`, the `Ctx.checkRules` walker, and the bucketed rule lists are unchanged.

## Notable design choices

**Why "any author rule wins over UA" is safe.** [CSS Cascade §6.1](https://www.w3.org/TR/css-cascade-4/#cascade-origin) orders origins UA < user < author for normal declarations. There is no specificity comparison between origins — even a wildcard `* { display: block }` (specificity 0) wins over UA `[hidden] { display: none }` (also low specificity). Gating the UA fallback on "any author rule matched display" (`display_priority == 0`) is the correct test.

**Why this doesn't need to compute UA specificity.** UA `!important` rules (`input[type=hidden]`, `noscript`) would technically beat normal-origin author rules per the cascade. We continue to treat all UA `display: none` rules uniformly because (a) `<script>` / `<head>` / `<style>` / `<title>` etc. being made author-visible is a deliberate author choice that the test suite already covers via `inline_display_overrides_ua_default`, and (b) author CSS overriding `input[type=hidden]` is rare enough that uniform treatment is acceptable. This matches the pre-fix behavior for inline overrides, just extended to class / id / tag / wildcard rules.

**Why the perf cost is negligible.** The author rule walk was already happening for the visibility / opacity properties on `[hidden]` elements; only the early-return for `display` skipped it. The walk is `O(1)` hash lookups per class / id / tag bucket (`StyleManager.zig:500-517`), and `[hidden]` elements typically have at most a handful of class rules in the relevant buckets. Hot-path measurement isn't worth the noise floor for the load-bearing operation here.

## Test plan

- [x] `make test` — 693/693 pass; the new tests below are exercised inside `WebApi: Element` → `check_visibility.html` (each HTML file is a single test in the runner, so the suite total is unchanged).
- [x] `zig fmt --check ./*.zig ./**/*.zig` clean.
- [x] `zig build -Doptimize=ReleaseSafe` produces a working `arm64` `zig-out/bin/lightpanda`.
- [x] TDD cycle confirmed: temporarily checking out `main`'s `StyleManager.zig` while keeping the new tests reproduces RED — `author_class_display_overrides_hidden_attr` and `author_wildcard_overrides_hidden_attr` both fail with `expected: true, got: false` for `checkVisibility()`. Restoring the fix returns to GREEN.
- [x] `WebApi: Element#check_visibility` covers six new `<script id="…">` blocks:
  - `author_class_display_overrides_hidden_attr` — primary regression test (`.x { display: flex }` on `<div class="x" hidden>` → `checkVisibility() === true`)
  - `author_class_display_none_alone_hides` — sanity baseline that the existing happy path stays correct.
  - `author_class_display_none_with_hidden_attr_stays_hidden` — author + UA agree.
  - `author_wildcard_overrides_hidden_attr` — `* { display: block }` (lands in `other_rules`) also beats UA `[hidden]`.
  - `no_author_rule_hidden_attr_still_hides` — UA fallback still applies when no author rule matched.
  - `inline_display_with_hidden_attr_regression_guard` — inline still wins via `INLINE_PRIORITY`.
- [x] Downstream driver: [`navidemad/capybara-lightpanda`](https://github.com/navidemad/capybara-lightpanda) `rake test:incremental` — 15/15 test files pass against the freshly built binary, no regressions.
- [x] Downstream repro: `ruby examples/rails_dropdown_minitest_example.rb` — `BuggyDropdownWithFlexCssTest` and `BuggyDropdownWithImportantFlexCssTest` now pass. `BuggyDropdownTest` (no flex CSS, genuinely no author rule to override `[hidden]`) still errors as expected — the spec only requires the cases with `.flex` to recover.

Refs #2496
