### PR TITLE
rewrite help in a more compact way

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -544,25 +544,9 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
         // Requested help for everything.
         .help => {
             const template = comptimePrint(
-                \\
                 \\{s}
                 \\
-                \\
-                \\{s}
-                \\
-                \\
-                \\{s}
-                \\
-                \\
-                \\{s}
-                \\
-                \\
-                \\{s}
-                \\
-                \\
-                \\{s}
-                \\
-            , .{ Help.general, Help.fetch_cmd, Help.serve_cmd, Help.mcp_cmd, Help.version, Help.help });
+            , .{Help.general});
             std.debug.print(template, .{exec_name});
         },
         inline .fetch, .serve, .mcp => |tag| {
@@ -571,13 +555,7 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
                 \\
                 \\{s}
                 \\
-                \\{s}
-                \\
-            , .{
-                @field(Help, @tagName(tag) ++ "_cmd"),
-                @field(Help, @tagName(tag) ++ "_options"),
-                Help.common_options,
-            });
+            , .{ @field(Help, @tagName(tag)), Help.common_options });
             std.debug.print(template, .{ exec_name, info_or_warn, pretty_or_logfmt });
         },
         .version => {

--- a/src/help.zon
+++ b/src/help.zon
@@ -1,18 +1,23 @@
 .{
     //                                                                     MAX_HELP_LEN|
     .general =
-    \\Command can be either "fetch", "serve", "mcp" or "help".
-    \\Use '{0s} help <command>' for details.
+    \\usage: {0s} <command> [arguments]
+    \\
+    \\The commands are:
+    \\  serve       starts a WebSocket CDP server
+    \\  fetch       fetches the specified URL
+    \\  mcp         starts an MCP (Model Context Protocol) server over stdio
+    \\  version     displays the version of {0s}
+    \\  help        displays this message
+    \\
+    \\Use "{0s} help <command>" for more information about a command.
     ,
-    .serve_cmd =
-    \\serve command
+    .serve =
+    \\usage: {0s} serve [OPTIONS] [COMMON_OPTIONS]
+    \\
     \\Starts a WebSocket CDP server.
     \\
-    \\Usage:
-    \\  {0s} serve [OPTIONS] [COMMON_OPTIONS]
-    ,
-    .serve_options =
-    \\Options:
+    \\options:
     \\--host <HOST>              Host of the CDP server.
     \\                           Defaults to "127.0.0.1".
     \\
@@ -35,15 +40,12 @@
     \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
     \\                           Defaults to no cookie loading.
     ,
-    .fetch_cmd =
-    \\fetch command
+    .fetch =
+    \\usage: {0s} fetch <url> [OPTIONS] [COMMON_OPTIONS]
+    \\
     \\Fetches the specified URL.
     \\
-    \\Usage:
-    \\  {0s} fetch <url> [OPTIONS] [COMMON_OPTIONS]
-    ,
-    .fetch_options =
-    \\Options:
+    \\options:
     \\--dump <DUMP>              Dumps the document to stdout.
     \\                           Defaults to no dump.
     \\
@@ -115,15 +117,12 @@
     \\                           (write-only).
     \\                           Defaults to no cookie saving.
     ,
-    .mcp_cmd =
-    \\mcp command
+    .mcp =
+    \\usage: {0s} mcp [OPTIONS] [COMMON_OPTIONS]
+    \\
     \\Starts an MCP (Model Context Protocol) server over stdio.
     \\
-    \\Usage:
-    \\  {0s} mcp [OPTIONS] [COMMON_OPTIONS]
-    ,
-    .mcp_options =
-    \\Options:
+    \\options:
     \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
     \\                           Defaults to no cookie loading.
     \\
@@ -132,21 +131,18 @@
     \\                           Defaults to no cookie saving.
     ,
     .version =
-    \\version command
-    \\Displays the version of {0s}.
+    \\usage:  {0s} version
     \\
-    \\Usage:
-    \\  {0s} version
+    \\Displays the version of {0s}.
     ,
     .help =
-    \\help command
-    \\Displays this message.
+    \\usage: {0s} help
     \\
-    \\Usage:
-    \\  {0s} help
+    \\Displays help message for a command.
+    \\
     ,
     .common_options =
-    \\Common Options:
+    \\common options:
     \\--insecure-disable-tls-host-verification
     \\                           Disables host verification on all HTTP requests.
     \\                           Only set this if you understand and accept the risk.

--- a/src/help.zon
+++ b/src/help.zon
@@ -18,27 +18,25 @@
     \\Starts a WebSocket CDP server.
     \\
     \\options:
-    \\--host <HOST>              Host of the CDP server.
-    \\                           Defaults to "127.0.0.1".
-    \\
-    \\--port <INT>               Port of the CDP server.
-    \\                           Defaults to 9222.
-    \\
-    \\--advertise-host <HOST>
-    \\                           The host to advertise, e.g. in the /json/version
-    \\                           response. Useful, for example, when --host is 0.0.0.0.
-    \\                           Defaults to --host value.
-    \\
-    \\--cdp-max-connections <INT>
-    \\                           Maximum number of simultaneous CDP connections.
-    \\                           Defaults to 16.
-    \\
-    \\--cdp-max-pending-connections <INT>
-    \\                           Maximum pending connections in the accept queue.
-    \\                           Defaults to 128.
-    \\
-    \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
-    \\                           Defaults to no cookie loading.
+    \\  --host <HOST>
+    \\          Host of the CDP server.
+    \\          Defaults to "127.0.0.1".
+    \\  --port <INT>
+    \\          Port of the CDP server.
+    \\          Defaults to 9222.
+    \\  --advertise-host <HOST>
+    \\          The host to advertise, e.g. in the /json/version response. Useful,
+    \\          for example, when --host is 0.0.0.0.
+    \\          Defaults to --host value.
+    \\  --cdp-max-connections <INT>
+    \\          Maximum number of simultaneous CDP connections.
+    \\          Defaults to 16.
+    \\  --cdp-max-pending-connections <INT>
+    \\          Maximum pending connections in the accept queue.
+    \\          Defaults to 128.
+    \\  --cookie <PATH>
+    \\          Path to a JSON file to load cookies from (read-only).
+    \\          Defaults to no cookie loading.
     ,
     .fetch =
     \\usage: {0s} fetch <url> [OPTIONS] [COMMON_OPTIONS]
@@ -46,76 +44,67 @@
     \\Fetches the specified URL.
     \\
     \\options:
-    \\--dump <DUMP>              Dumps the document to stdout.
-    \\                           Defaults to no dump.
-    \\
-    \\                           Allowed values:
-    \\                             html               Serialized HTML of the DOM.
-    \\                             markdown           Converts content to Markdown.
-    \\                             semantic_tree      JSON-serialized semantic tree.
-    \\                             semantic_tree_text Pruned plain-text semantic tree.
-    \\
-    \\--strip-mode <STRIP>       Comma-separated list of tag groups to remove from dump.
-    \\                           Defaults to no-strip.
-    \\
-    \\                           Allowed values:
-    \\                             js   script and link[as=script, rel=preload].
-    \\                             ui   Includes img, picture, video, CSS and SVG.
-    \\                             css  Includes style and link[rel=stylesheet].
-    \\                             full Strip everything.
-    \\
-    \\--json                     Capture and print the status of the fetch in a
-    \\                           JSON string and output it. When used with
-    \\                           --dump <MODE> this will wrap the dumped content
-    \\                           within the JSON value.
-    \\
-    \\--with-base                Add a <base> tag in dump.
-    \\                           Defaults to false.
-    \\
-    \\--with-frames              Includes the contents of iframes.
-    \\                           Defaults to false.
-    \\
-    \\--wait-ms <INT>            Wait time in milliseconds. Supersedes all other --wait
-    \\                           parameters.
-    \\                           Defaults to 5000.
-    \\
-    \\--wait-until <UNTIL>       Wait until the specified event. Checked before other
-    \\                           --wait-* options.
-    \\                           Defaults to 'done'. If --wait-selector, --wait-script
-    \\                           or --wait-script-file specified, defaults to none.
-    \\
-    \\                           Allowed values:
-    \\                             "load", "domcontentloaded", "networkidle", "done".
-    \\
-    \\--wait-selector <QUERY>    Wait for an element matching the CSS selector to
-    \\                           appear. Checked after --wait-until condition is met.
-    \\
-    \\--wait-script <EXPR>       Wait for a JavaScript expression to return truthy.
-    \\                           Checked after --wait-until condition is met.
-    \\
-    \\--wait-script-file <PATH>  Like --wait-script, but reads the script from a file.
-    \\
-    \\--inject-script <EXPR>     JavaScript to execute as the document's <head> is
-    \\                           parsed, before any other scripts in the page run.
-    \\                           Can be passed multiple times; scripts run in order.
-    \\
-    \\--inject-script-file <PATH>
-    \\                           Like --inject-script, but reads the script from a file.
-    \\                           Can be passed multiple times; can be mixed with
-    \\                           --inject-script and runs in CLI order.
-    \\
-    \\--terminate-ms <INT>       Hard deadline in milliseconds. After this time elapses,
-    \\                           JavaScript execution is forcibly terminated (e.g. for
-    \\                           pages with endless scripts). Unlike --wait-ms, which
-    \\                           only stops waiting, --terminate-ms aborts the page.
-    \\                           Defaults to no terminate.
-    \\
-    \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
-    \\                           Defaults to no cookie loading.
-    \\
-    \\--cookie-jar <PATH>        Path to a JSON file to save cookies to on exit.
-    \\                           (write-only).
-    \\                           Defaults to no cookie saving.
+    \\  --dump <DUMP>
+    \\          Dumps the document to stdout.
+    \\          Defaults to no dump.
+    \\          Allowed values:
+    \\              html               Serialized HTML of the DOM.
+    \\              markdown           Converts content to Markdown.
+    \\              semantic_tree      JSON-serialized semantic tree.
+    \\              semantic_tree_text Pruned plain-text semantic tree.
+    \\  --strip-mode <STRIP>
+    \\          Comma-separated list of tag groups to remove from dump.
+    \\          Defaults to no-strip.
+    \\          Allowed values:
+    \\              js   script and link[as=script, rel=preload].
+    \\              ui   Includes img, picture, video, CSS and SVG.
+    \\              css  Includes style and link[rel=stylesheet].
+    \\              full Strip everything.
+    \\  --json
+    \\          Capture and print the status of the fetch in a JSON string and output
+    \\          it. When used with --dump <MODE> this will wrap the dumped content
+    \\          within the JSON value.
+    \\  --with-base
+    \\          Add a <base> tag in dump.
+    \\          Defaults to false.
+    \\  --with-frames
+    \\          Includes the contents of iframes.
+    \\          Defaults to false.
+    \\  --wait-ms <INT>
+    \\          Wait time in milliseconds. Supersedes all other --wait parameters.
+    \\          Defaults to 5000.
+    \\  --wait-until <UNTIL>
+    \\          Wait until the specified event. Checked before other --wait-* options.
+    \\          Defaults to 'done'. If --wait-selector, --wait-script or
+    \\          --wait-script-file specified, defaults to none.
+    \\          Allowed values: "load", "domcontentloaded", "networkidle", "done".
+    \\  --wait-selector <QUERY>
+    \\          Wait for an element matching the CSS selector to appear. Checked after
+    \\          --wait-until condition is met.
+    \\  --wait-script <EXPR>
+    \\          Wait for a JavaScript expression to return truthy. Checked after
+    \\          --wait-until condition is met.
+    \\  --wait-script-file <PATH>
+    \\          Like --wait-script, but reads the script from a file.
+    \\  --inject-script <EXPR>
+    \\          JavaScript to execute as the document's <head> is parsed, before any
+    \\          other scripts in the page run. Can be passed multiple times; scripts
+    \\          run in order.
+    \\  --inject-script-file <PATH>
+    \\          Like --inject-script, but reads the script from a file. Can be passed
+    \\          multiple times; can be mixed with --inject-script and runs in CLI order.
+    \\  --terminate-ms <INT>
+    \\          Hard deadline in milliseconds. After this time elapses, JavaScript
+    \\          execution is forcibly terminated (e.g. for pages with endless scripts).
+    \\          Unlike --wait-ms, which only stops waiting, --terminate-ms aborts the
+    \\          page.
+    \\          Defaults to no terminate.
+    \\  --cookie <PATH>
+    \\          Path to a JSON file to load cookies from (read-only).
+    \\          Defaults to no cookie loading.
+    \\  --cookie-jar <PATH>
+    \\          Path to a JSON file to save cookies to on exit (write-only).
+    \\          Defaults to no cookie saving.
     ,
     .mcp =
     \\usage: {0s} mcp [OPTIONS] [COMMON_OPTIONS]
@@ -123,12 +112,12 @@
     \\Starts an MCP (Model Context Protocol) server over stdio.
     \\
     \\options:
-    \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
-    \\                           Defaults to no cookie loading.
-    \\
-    \\--cookie-jar <PATH>        Path to a JSON file to save cookies to on exit.
-    \\                           (write-only).
-    \\                           Defaults to no cookie saving.
+    \\  --cookie <PATH>
+    \\          Path to a JSON file to load cookies from (read-only).
+    \\          Defaults to no cookie loading.
+    \\  --cookie-jar <PATH>
+    \\          Path to a JSON file to save cookies to on exit (write-only).
+    \\          Defaults to no cookie saving.
     ,
     .version =
     \\usage:  {0s} version
@@ -139,119 +128,99 @@
     \\usage: {0s} help
     \\
     \\Displays help message for a command.
-    \\
     ,
     .common_options =
     \\common options:
-    \\--insecure-disable-tls-host-verification
-    \\                           Disables host verification on all HTTP requests.
-    \\                           Only set this if you understand and accept the risk.
-    \\
-    \\--obey-robots              Fetches and obeys robots.txt of the target page.
-    \\                           Defaults to false.
-    \\
-    \\--disable-subframes        Skip loading <iframe> elements. The parser still
-    \\                           registers them in the DOM, but no child frame or
-    \\                           Page.frameAttached events are produced.
-    \\                           Defaults to false.
-    \\
-    \\--disable-workers          Skip loading dedicated Web Workers. The Worker
-    \\                           constructor still returns a Worker object, but no
-    \\                           script fetch is initiated and its scope never runs.
-    \\                           Defaults to false.
-    \\
-    \\--block-private-networks   Block HTTP requests to private/internal IP
-    \\                           addresses after DNS resolution.
-    \\                           Defaults to false.
-    \\
-    \\--block-cidrs <LIST>       Additional CIDR ranges to block, comma-separated.
-    \\                           Prefix with '-' to allow (exempt from blocking).
-    \\                           e.g. --block-cidrs 10.0.0.0/8,-10.0.0.42/32
-    \\                           Can be combined with --block-private-networks.
-    \\
-    \\--http-proxy <URL>         HTTP proxy for all HTTP requests.
-    \\                           username:password may be included for basic auth.
-    \\                           Defaults to none.
-    \\
-    \\--proxy-bearer-token <TOKEN>
-    \\                           Token sent for bearer authentication with the
-    \\                           proxy: Proxy-Authorization: Bearer <token>.
-    \\
-    \\--http-max-concurrent <INT>
-    \\                           Maximum number of concurrent HTTP requests.
-    \\                           Defaults to 10.
-    \\
-    \\--http-max-host-open <INT> Maximum open connections to a given host:port.
-    \\                           Defaults to 4.
-    \\
-    \\--http-connect-timeout <INT>
-    \\                           Time in ms to establish an HTTP connection before
-    \\                           timing out. 0 means never.
-    \\                           Defaults to 0.
-    \\
-    \\--http-timeout <INT>       Maximum time in ms the transfer is allowed to
-    \\                           complete. 0 means never.
-    \\                           Defaults to 10000.
-    \\
-    \\--http-max-response-size <INT>
-    \\                           Limits the acceptable response size for any
-    \\                           request (e.g. XHR, fetch, script loading).
-    \\                           Defaults to no limit.
-    \\
-    \\--ws-max-concurrent <INT>  Maximum number of concurrent WebSocket connections.
-    \\                           Defaults to 8.
-    \\
-    \\--log-level <LEVEL>        The log level.
-    \\                           Defaults to {1s}.
-    \\
-    \\                           Allowed values:
-    \\                             "debug", "info", "warn", "error", "fatal".
-    \\
-    \\--log-format <FORMAT>      The log format.
-    \\                           Defaults to {2s}.
-    \\
-    \\                           Allowed values: "pretty", "logfmt".
-    \\
-    \\--log-filter-scopes <SCOPES>
-    \\                           Filter out too-verbose logs per scope,
-    \\                           comma-separated. e.g. http, unknown_prop, event.
-    \\
-    \\--user-agent <STRING>      Override the User-Agent header entirely.
-    \\                           Must not impersonate other browsers; any value
-    \\                           containing "Mozilla" is forbidden. The browser
-    \\                           still sends Sec-Ch-Ua. Incompatible with
-    \\                           --user-agent-suffix.
-    \\
-    \\--user-agent-suffix <STRING>
-    \\                           Suffix appended to the Lightpanda/X.Y User-Agent.
-    \\
-    \\--web-bot-auth-key-file <PATH>
-    \\                           Path to the Ed25519 private key PEM file.
-    \\
-    \\--web-bot-auth-keyid <STRING>
-    \\                           The JWK thumbprint of your public key.
-    \\
-    \\--web-bot-auth-domain <DOMAIN>
-    \\                           Your domain, e.g. yourdomain.com.
-    \\
-    \\--http-cache-dir <PATH>    Directory used as a filesystem cache for network
-    \\                           resources. Omitting this disables caching.
-    \\                           Defaults to no caching.
-    \\
-    \\--cookie <PATH>            Path to a JSON file to load cookies from (read-only).
-    \\                           Defaults to no cookie loading.
-    \\
-    \\--cookie-jar <PATH>        Path to a JSON file to save cookies to on exit
-    \\                           (write-only).
-    \\                           Defaults to no cookie saving.
-    \\
-    \\--storage-engine <ENGINE>  The storage engine to use.
-    \\                           Defaults to none.
-    \\
-    \\                           Allowed values: "none", "sqlite".
-    \\
-    \\--storage-sqlite-path <PATH>
-    \\                           Path to the SQLite database file for persistent
-    \\                           storage. Use ":memory:" for in-memory storage.
+    \\  --insecure-disable-tls-host-verification
+    \\          Disables host verification on all HTTP requests.
+    \\          Only set this if you understand and accept the risk.
+    \\  --obey-robots
+    \\          Fetches and obeys robots.txt of the target page.
+    \\          Defaults to false.
+    \\  --disable-subframes
+    \\          Skip loading <iframe> elements. The parser still registers them in the
+    \\          DOM, but no child frame or Page.frameAttached events are produced.
+    \\          Defaults to false.
+    \\  --disable-workers
+    \\          Skip loading dedicated Web Workers. The Worker constructor still
+    \\          returns a Worker object, but no script fetch is initiated and its scope
+    \\          never runs.
+    \\          Defaults to false.
+    \\  --block-private-networks
+    \\          Block HTTP requests to private/internal IP addresses after DNS
+    \\          resolution.
+    \\          Defaults to false.
+    \\  --block-cidrs <LIST>
+    \\          Additional CIDR ranges to block, comma-separated.
+    \\          Prefix with '-' to allow (exempt from blocking).
+    \\          e.g. --block-cidrs 10.0.0.0/8,-10.0.0.42/32
+    \\          Can be combined with --block-private-networks.
+    \\  --http-proxy <URL>
+    \\          HTTP proxy for all HTTP requests.
+    \\          username:password may be included for basic auth.
+    \\          Defaults to none.
+    \\  --proxy-bearer-token <TOKEN>
+    \\          Token sent for bearer authentication with the proxy:
+    \\          Proxy-Authorization: Bearer <token>.
+    \\  --http-max-concurrent <INT>
+    \\          Maximum number of concurrent HTTP requests.
+    \\          Defaults to 10.
+    \\  --http-max-host-open <INT>
+    \\          Maximum open connections to a given host:port.
+    \\          Defaults to 4.
+    \\  --http-connect-timeout <INT>
+    \\          Time in ms to establish an HTTP connection before timing out. 0 means
+    \\          never.
+    \\          Defaults to 0.
+    \\  --http-timeout <INT>
+    \\          Maximum time in ms the transfer is allowed to complete. 0 means never.
+    \\          Defaults to 10000.
+    \\  --http-max-response-size <INT>
+    \\          Limits the acceptable response size for any request
+    \\          e.g. XHR, fetch, script loading.
+    \\          Defaults to no limit.
+    \\  --ws-max-concurrent <INT>
+    \\          Maximum number of concurrent WebSocket connections.
+    \\          Defaults to 8.
+    \\  --log-level <LEVEL>
+    \\          The log level.
+    \\          Defaults to {1s}.
+    \\          Allowed values: "debug", "info", "warn", "error", "fatal".
+    \\  --log-format <FORMAT>
+    \\          The log format.
+    \\          Defaults to {2s}.
+    \\          Allowed values: "pretty", "logfmt".
+    \\  --log-filter-scopes <SCOPES>
+    \\          Filter out too-verbose logs per scope, comma-separated.
+    \\          e.g. http, unknown_prop, event.
+    \\  --user-agent <STRING>
+    \\          Override the User-Agent header entirely. Must not impersonate other
+    \\          browsers; any value containing "Mozilla" is forbidden. The browser
+    \\          still sends Sec-Ch-Ua. Incompatible with --user-agent-suffix.
+    \\  --user-agent-suffix <STRING>
+    \\          Suffix appended to the Lightpanda/X.Y User-Agent.
+    \\  --web-bot-auth-key-file <PATH>
+    \\          Path to the Ed25519 private key PEM file.
+    \\  --web-bot-auth-keyid <STRING>
+    \\          The JWK thumbprint of your public key.
+    \\  --web-bot-auth-domain <DOMAIN>
+    \\          Your domain, e.g. yourdomain.com.
+    \\  --http-cache-dir <PATH>
+    \\          Directory used as a filesystem cache for network resources. Omitting
+    \\          this disables caching.
+    \\          Defaults to no caching.
+    \\  --cookie <PATH>
+    \\          Path to a JSON file to load cookies from (read-only).
+    \\          Defaults to no cookie loading.
+    \\  --cookie-jar <PATH>
+    \\          Path to a JSON file to save cookies to on exit (write-only).
+    \\          Defaults to no cookie saving.
+    \\  --storage-engine <ENGINE>
+    \\          The storage engine to use.
+    \\          Defaults to none.
+    \\          Allowed values: "none", "sqlite".
+    \\  --storage-sqlite-path <PATH>
+    \\          Path to the SQLite database file for persistent storage.
+    \\          Use ":memory:" for in-memory storage.
     ,
 }


### PR DESCRIPTION
Inspired by go help output


```
$ ./zig-out/bin/lightpanda help
usage: lightpanda <command> [arguments]

The commands are:
  serve       starts a WebSocket CDP server
  fetch       fetches the specified URL
  mcp         starts an MCP (Model Context Protocol) server over stdio
  version     displays the version of lightpanda
  help        displays this message

Use "lightpanda help <command>" for more information about a command.
```


```
$ ./zig-out/bin/lightpanda help serve
usage: lightpanda serve [OPTIONS] [COMMON_OPTIONS]

Starts a WebSocket CDP server.

options:
--host <HOST>              Host of the CDP server.
                           Defaults to "127.0.0.1".

--port <INT>               Port of the CDP server.
                           Defaults to 9222.
[...]
```