### PR TITLE
Cleanup Transfer flag

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -419,10 +419,16 @@ fn drainQueue(self: *Client) !void {
             self.queue.prepend(queue_node);
             return;
         };
-        // Cleared only after we've successfully obtained a connection;
-        // if we put the node back, _queued stays true.
-        transfer._queued = false;
-        try self.makeRequest(conn, transfer);
+        // Bridge state to .created so a failure inside makeRequest before
+        // any commit cleans up via the abort below. makeRequest flips to
+        // .inflight on a successful trackConn.
+        transfer.state = .created;
+        self.makeRequest(conn, transfer) catch |err| {
+            if (transfer.state == .created) {
+                transfer.abort(err);
+            }
+            return err;
+        };
     }
 }
 
@@ -483,9 +489,11 @@ pub fn request(self: *Client, req: Request, owner: ?*Owner) !void {
     // From this point forward, the transfer owns `req` and `arena`. If the
     // layer chain fails before any layer commits the transfer to an external
     // owner (queue / multi handle / pending interception), we clean up here
-    // via transfer.abort which fires error_callback and deinits.
+    // via transfer.abort which fires error_callback and deinits. `.created`
+    // means no commit happened — anything else is held by an owner that
+    // will clean up.
     self.entry_layer.request(transfer) catch |err| {
-        if (!transfer.loop_owned) {
+        if (transfer.state == .created) {
             transfer.abort(err);
         }
         return err;
@@ -575,8 +583,7 @@ fn process(self: *Client, transfer: *Transfer) !void {
     }
 
     self.queue.append(&transfer._node);
-    transfer._queued = true;
-    transfer.loop_owned = true;
+    transfer.state = .queued;
 }
 
 pub fn nextReqId(self: *Client) u32 {
@@ -605,24 +612,26 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
         transfer.reset();
         transfer._auth_challenge = auth;
 
-        transfer._conn = conn;
-        errdefer {
-            transfer._conn = null;
-            self.releaseConn(conn);
-        }
+        // conn is locally held during configure; we don't write it to
+        // `transfer._conn` until trackConn commits it to the multi
+        // handle. If configureConn fails, release the conn back to the
+        // pool — `transfer.state` stays `.created`, and the caller
+        // (Client.request's errdefer or drainQueue's catch) aborts
+        // the transfer.
+        errdefer self.releaseConn(conn);
 
         try transfer.configureConn(conn);
     }
 
     // As soon as trackConn succeeds, the multi handle owns the transfer's
     // lifecycle. perform/processMessages will eventually invoke completion
-    // callbacks and call transfer.deinit. We flag loop_owned so Client.request
-    // (or anyone else holding the transfer pointer) knows not to deinit it.
+    // callbacks and call transfer.deinit.
     self.trackConn(conn) catch |err| {
-        transfer._conn = null;
+        self.releaseConn(conn);
         return err;
     };
-    transfer.loop_owned = true;
+    transfer._conn = conn;
+    transfer.state = .inflight;
 
     if (transfer.req.start_callback) |cb| {
         cb(Response.fromTransfer(transfer)) catch |err| {
@@ -751,6 +760,7 @@ fn isFetchInterceptionMethod(method: []const u8) bool {
 }
 
 fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *Transfer) !bool {
+    // State at entry: .inflight = conn (multi just delivered a completion).
     if (msg.err == null or msg.err.? == error.RecvError) {
         transfer.detectAuthChallenge(msg.conn);
     }
@@ -772,8 +782,11 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
             // Whether or not this is a blocking request, we're not going
             // to process it now. We can end the transfer, which will
             // release the easy handle back into the pool. The transfer
-            // is still valid/alive (just has no handle).
-            transfer.releaseConn();
+            // is still valid/alive (just has no handle); park it for
+            // continueWithAuth.
+            self.removeConn(transfer._conn.?);
+            transfer._conn = null;
+            transfer.state = .{ .parked = .intercept_auth };
             return false;
         }
     }
@@ -787,14 +800,15 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
             const conn = transfer._conn.?;
 
             try self.handles.remove(conn);
-            transfer._conn = null;
-            transfer._detached_conn = conn; // signal orphan for processMessages cleanup
+            // Conn temporarily out of multi during reconfigure.
+            // _detached_conn lets processMessages release it if any of
+            // the steps below throw. State stays .inflight; _conn stays set
+            transfer._detached_conn = conn;
 
             transfer.reset();
             try transfer.configureConn(conn);
             try self.handles.add(conn);
             transfer._detached_conn = null;
-            transfer._conn = conn; // reattach after successful re-add
 
             _ = try self.perform(0);
 
@@ -817,10 +831,10 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
         break :blk std.ascii.eqlIgnoreCase(hdr.value, "close");
     };
 
-    // make sure the transfer can't be immediately aborted from a callback
-    // since we still need it here.
-    transfer._performing = true;
-    defer transfer._performing = false;
+    // Transition to .completing so re-entrant aborts from user callbacks
+    // defer their teardown to processMessages. (_conn carries through
+    // from .inflight; nothing to set here.)
+    transfer.state = .completing;
 
     if (msg.err != null and !is_conn_close_recv) {
         transfer.requestFailed(transfer.res.callback_error orelse msg.err.?, true);
@@ -843,15 +857,17 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     if (body.len > 0) {
         try transfer.req.data_callback(Response.fromTransfer(transfer), body);
 
-        if (transfer.aborted) {
+        if (transfer.state == .aborted) {
             transfer.requestFailed(error.Abort, true);
             return true;
         }
     }
 
     // release conn ASAP so that it's available; some done_callbacks
-    // will load more resources.
-    transfer.releaseConn();
+    // will load more resources. State stays .completing — the
+    // processMessages caller still owns deinit.
+    self.removeConn(msg.conn);
+    transfer._conn = null;
 
     try transfer.req.done_callback(transfer.req.ctx);
 
@@ -1151,34 +1167,32 @@ pub const Transfer = struct {
     owner: ?*Owner,
     owner_node: std.DoublyLinkedList.Node = .{},
 
-    // Latched true by the first commit point that hands the transfer off to
-    // an external owner: client.queue.append, successful trackConn, or
-    // InterceptionLayer pausing for a CDP response. Once set, Client.request's
-    // errdefer skips cleanup — whoever now owns the transfer will deinit it.
-    loop_owned: bool = false,
+    // The transfer's lifecycle position. Source of truth for
+    // "is this committed?" and "can we deinit synchronously?".
+    // The conn the transfer holds (if any) is tracked separately
+    // in `_conn` — orthogonal to state. See `State` below.
+    state: State = .created,
 
-    // True iff `_node` is currently linked in `client.queue` (waiting for a
-    // libcurl handle). Set in `Client.process` on enqueue, cleared in
-    // `Client.tick` on popFirst, and used by `Transfer.deinit` to safely
-    // unlink — `deinit` has no other way to detect queue membership, and
-    // a transfer aborted while queued (e.g. via owner-list abort) would
-    // otherwise leave a dangling `_node` in `client.queue` that the next
-    // `tick` would dereference and hand to libcurl.
-    _queued: bool = false,
+    // Conn the transfer currently holds. Set when makeRequest commits
+    // the conn to the multi handle; cleared by the "release ASAP" step
+    // inside processOneMessage, by the auth-parking path, and by deinit.
+    // Lifetime is decoupled from `state` on purpose: a single transition
+    // shouldn't have to thread the conn pointer, and aborts in mid-flight
+    // can let `deinit` find the conn via this field instead of carrying
+    // it on every state variant.
+    _conn: ?*http.Connection = null,
 
     req: Request,
     res: Transfer.Response = .{},
     client: *Client,
 
     start_time: u64,
-    aborted: bool = false,
 
     _notified_fail: bool = false,
 
-    _conn: ?*http.Connection = null,
     // Set when conn is temporarily detached from transfer during redirect
     // reconfiguration. Used by processMessages to release the orphaned conn
-    // if reconfiguration fails.
+    // if reconfiguration fails. Transient inside the redirect path only.
     _detached_conn: ?*http.Connection = null,
 
     _auth_challenge: ?http.AuthChallenge = null,
@@ -1186,22 +1200,78 @@ pub const Transfer = struct {
     // number of times the transfer has been tried.
     // incremented by reset func.
     _tries: u8 = 0,
-    _performing: bool = false,
     _redirect_count: u8 = 0,
 
     // for when a Transfer is queued in the client.queue
     _node: std.DoublyLinkedList.Node = .{},
 
-    fn releaseConn(self: *Transfer) void {
-        if (self._conn) |conn| {
-            self.client.removeConn(conn);
-            self._conn = null;
-        }
+    pub const State = union(enum) {
+        // Pre-commit. Only valid inside the request flow (Client.request
+        // or a re-entry like continueTransfer / unpark) before any commit
+        // point hands the transfer to an external owner. Client.request's
+        // errdefer uses `.created` to decide whether to abort.
+        created,
+
+        // On client.queue, waiting for a libcurl handle. `_node` is
+        // linked into client.queue.
+        queued,
+
+        // Conn (in `_conn`) is in the multi handle; libcurl owns the
+        // lifecycle. processOneMessage will eventually fire callbacks
+        // for us.
+        inflight,
+
+        // processOneMessage is running user callbacks. The conn may
+        // still be in `_conn` (header/data phase) or have been cleared
+        // by the "release ASAP" step before done_callback fires.
+        completing,
+
+        // External owner is holding the transfer paused. The owner is
+        // responsible for resuming or terminating it.
+        parked: ParkedBy,
+
+        // detachInPerform ran; user callbacks are noop'd, owner link is
+        // cleared, processOneMessage / processMessages will deinit on
+        // exit. `_conn` (if any) is what `deinit` will release once
+        // libcurl is done with it.
+        aborted,
+    };
+
+    pub const ParkedBy = enum {
+        // CDP Fetch interception, request phase.
+        intercept_request,
+
+        // CDP Fetch interception, response phase. Reserved for when
+        // response interception lands; not currently emitted.
+        intercept_response,
+
+        // CDP auth challenge — processOneMessage stashed the transfer
+        // waiting for continueWithAuth.
+        intercept_auth,
+
+        // RobotsLayer holds the transfer pending a robots.txt fetch.
+        robots,
+    };
+
+    // Layer-facing: park the transfer for an external owner. The caller
+    // must be holding the transfer in the request flow (state == .created).
+    pub fn park(self: *Transfer, by: ParkedBy) void {
+        lp.assert(self.state == .created, "Transfer.park", .{ .state = self.state });
+        self.state = .{ .parked = by };
+    }
+
+    // Layer-facing: take the transfer out of .parked and return it to
+    // the request flow (.created). Caller is expected to re-enter the
+    // layer chain or call abort(); if neither happens the transfer is
+    // stranded.
+    pub fn unpark(self: *Transfer) void {
+        lp.assert(self.state == .parked, "Transfer.unpark", .{ .state = self.state });
+        self.state = .created;
     }
 
     pub fn deinit(self: *Transfer) void {
-        if (self._conn) |conn| {
-            self.client.removeConn(conn);
+        if (self._conn) |c| {
+            self.client.removeConn(c);
             self._conn = null;
         }
 
@@ -1209,9 +1279,8 @@ pub const Transfer = struct {
         // Without this, deinit'ing a queued transfer (e.g. via owner-list
         // abort during navigation) leaves a dangling _node in the queue
         // that the next tick would pop and hand to libcurl → UAF.
-        if (self._queued) {
+        if (self.state == .queued) {
             self.client.queue.remove(&self._node);
-            self._queued = false;
         }
 
         // Drop the id→*Transfer index entry before freeing the memory.
@@ -1255,23 +1324,24 @@ pub const Transfer = struct {
     // Decide whether to tear down now or defer until processOneMessage
     // eventually drains the in-flight curl handle.
     //
-    // Two cases force deferral:
-    //   * `_performing` — processOneMessage is currently processing THIS
-    //     transfer (set/cleared around the callback chain). It will call
-    //     `transfer.deinit` itself after the chain returns; deiniting
-    //     here would double-free. Note that `_conn` is cleared partway
-    //     through this window (the "release conn ASAP" step before
-    //     done_callback fires), so we cannot rely on `_conn != null`.
-    //   * `client.performing` + we have a libcurl handle — libcurl could
-    //     still fire callbacks for us. Releasing the arena now would UAF
+    // Two states force deferral:
+    //   * `.completing` — processOneMessage is currently processing
+    //     this transfer. It will call `transfer.deinit` itself after the
+    //     chain returns; deiniting here would double-free. This covers
+    //     both the with-conn and post-release-ASAP windows.
+    //   * `.inflight` while `client.performing` — libcurl could still
+    //     fire callbacks for us. Releasing the arena now would UAF
     //     from inside curl.
     //
-    // Otherwise (parked / queued / never-trackConn'd / fully drained),
-    // there is nothing left referencing this transfer and we can safely
-    // deinit inline even from inside a perform callback.
+    // Otherwise (created / queued / parked / fully drained), there is
+    // nothing left referencing this transfer and we can safely deinit
+    // inline.
     fn detachOrDeinit(self: *Transfer) void {
-        const must_defer = self._performing or
-            (self.client.performing and self._conn != null);
+        const must_defer = switch (self.state) {
+            .completing => true,
+            .inflight => self.client.performing,
+            else => false,
+        };
         if (must_defer) {
             self.detachInPerform();
         } else {
@@ -1282,8 +1352,9 @@ pub const Transfer = struct {
     // Deferred-cleanup path when we can't synchronously deinit.
     //
     // We:
-    //   - flag `aborted` so processOneMessage's normal-completion paths
-    //     short-circuit when they next see this transfer,
+    //   - transition state to `.aborted` so processOneMessage's
+    //     normal-completion paths short-circuit when they next see
+    //     this transfer,
     //   - noop every user callback so libcurl naturally draining the
     //     in-flight response can't re-enter user code,
     //   - unlink from owner.transfers and clear `owner` so the owning
@@ -1292,7 +1363,9 @@ pub const Transfer = struct {
     //     `owner == null` and skips the list-remove that would otherwise
     //     UAF against a freed list.
     fn detachInPerform(self: *Transfer) void {
-        self.aborted = true;
+        // `_conn` (if any) rides through .aborted untouched; deinit
+        // releases it once libcurl is done.
+        self.state = .aborted;
         self.req.start_callback = null;
         self.req.shutdown_callback = null;
         self.req.header_callback = Noop.headerCallback;
@@ -1570,7 +1643,7 @@ pub const Transfer = struct {
             return err;
         };
 
-        return proceed and transfer.aborted == false;
+        return proceed and transfer.state != .aborted;
     }
 
     fn dataCallback(buffer: [*]const u8, chunk_count: usize, chunk_len: usize, data: *anyopaque) usize {
@@ -1620,7 +1693,7 @@ pub const Transfer = struct {
             return http.writefunc_error;
         };
 
-        if (transfer.aborted) {
+        if (transfer.state == .aborted) {
             return http.writefunc_error;
         }
 
@@ -1629,12 +1702,11 @@ pub const Transfer = struct {
 
     pub fn responseHeaderIterator(self: *Transfer) HeaderIterator {
         // We always have a real curl request here. We handle injection up in InterceptionLayer.
-        lp.assert(self._conn != null, "Transfer.responseHeaderIterator", .{ .value = self._conn != null });
-        const conn = self._conn.?;
-
+        const c = self._conn;
+        lp.assert(c != null, "Transfer.responseHeaderIterator", .{ .value = c != null });
         // If we have a connection, than this is a real curl request and we
         // iterate through the header that curl maintains.
-        return .{ .curl = .{ .conn = conn } };
+        return .{ .curl = .{ .conn = c.? } };
     }
 
     // This function should be called during the dataCallback. Calling it after
@@ -1645,10 +1717,10 @@ pub const Transfer = struct {
     }
 
     fn getContentLengthRawValue(self: *const Transfer) ?[]const u8 {
-        if (self._conn) |conn| {
+        if (self._conn) |c| {
             // If we have a connection, than this is a normal request. We can get the
             // header value from the connection.
-            const cl = conn.getResponseHeader("content-length", 0) orelse return null;
+            const cl = c.getResponseHeader("content-length", 0) orelse return null;
             return cl.value;
         }
 
@@ -1700,6 +1772,7 @@ pub fn continueTransfer(self: *Client, transfer: *Transfer) !void {
     }
 
     self.interception_layer.intercepted -= 1;
+    transfer.unpark();
     return self.process(transfer);
 }
 

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1241,10 +1241,6 @@ pub const Transfer = struct {
         // CDP Fetch interception, request phase.
         intercept_request,
 
-        // CDP Fetch interception, response phase. Reserved for when
-        // response interception lands; not currently emitted.
-        intercept_response,
-
         // CDP auth challenge — processOneMessage stashed the transfer
         // waiting for continueWithAuth.
         intercept_auth,
@@ -1261,9 +1257,11 @@ pub const Transfer = struct {
     }
 
     // Layer-facing: take the transfer out of .parked and return it to
-    // the request flow (.created). Caller is expected to re-enter the
-    // layer chain or call abort(); if neither happens the transfer is
-    // stranded.
+    // the request flow (.created). This assumes pre-inflight handling (i.e. the
+    // transfer was in .created before being parked). This is true today, but
+    // could become false if Request Interception ever supports the "response"
+    // requestStage (although, to support this, I think the safety of transfers
+    // post-perform would need to be improved),
     pub fn unpark(self: *Transfer) void {
         lp.assert(self.state == .parked, "Transfer.unpark", .{ .state = self.state });
         self.state = .created;

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -576,7 +576,7 @@ pub const Script = struct {
                     .a9 = self.debug_transfer_easy_id,
                     .b1 = transfer.id,
                     .b2 = transfer._tries,
-                    .b3 = transfer.aborted,
+                    .b3 = transfer.state == .aborted,
                     .b4 = transfer.res.bytes_received,
                     .b5 = transfer._notified_fail,
                     .b8 = transfer._auth_challenge != null,
@@ -585,7 +585,7 @@ pub const Script = struct {
                 self.header_callback_called = true;
                 self.debug_transfer_id = transfer.id;
                 self.debug_transfer_tries = transfer._tries;
-                self.debug_transfer_aborted = transfer.aborted;
+                self.debug_transfer_aborted = transfer.state == .aborted;
                 self.debug_transfer_bytes_received = transfer.res.bytes_received;
                 self.debug_transfer_notified_fail = transfer._notified_fail;
                 self.debug_transfer_auth_challenge = transfer._auth_challenge != null;

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -74,7 +74,7 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
 
         // Cache hit: serve synchronously from the original callbacks, then
         // tear down. On error, the transfer is still alive and Client.request's
-        // errdefer will handle cleanup (loop_owned is still false).
+        // errdefer will handle cleanup (state stays .created).
         try serveFromCache(req, &cached);
         transfer.deinit();
         return;

--- a/src/network/layer/InterceptionLayer.zig
+++ b/src/network/layer/InterceptionLayer.zig
@@ -92,10 +92,10 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
 
     // Paused: the CDP listener stashed `transfer` and will eventually call
     // continueRequest / abortRequest / fulfillRequest. Until then, CDP owns
-    // the transfer's lifecycle, so flag it loop_owned to keep the outer
-    // Client.request errdefer from tearing it down.
+    // the transfer's lifecycle. Park keeps the outer Client.request errdefer
+    // from tearing it down.
     self.intercepted += 1;
-    transfer.loop_owned = true;
+    transfer.park(.intercept_request);
     if (comptime IS_DEBUG) {
         log.debug(.http, "wait for interception", .{ .intercepted = self.intercepted });
     }
@@ -188,8 +188,8 @@ pub const InterceptContext = struct {
 };
 
 // CDP-driven resolution entry points. The transfer was paused inside `request`
-// (loop_owned = true). One of these three is called by CDP to resume / drop
-// the transfer.
+// (state = .parked = .intercept_request). One of these three is called by CDP
+// to resume / drop the transfer.
 
 pub fn continueRequest(self: *InterceptionLayer, transfer: *Transfer) anyerror!void {
     if (comptime IS_DEBUG) {
@@ -199,12 +199,12 @@ pub fn continueRequest(self: *InterceptionLayer, transfer: *Transfer) anyerror!v
     self.intercepted -= 1;
 
     // Resume the layer chain. Ownership is re-handed to whichever subsequent
-    // layer commits the transfer (queue, multi, or another pause). If the
-    // chain fails before any commit, we clean up here. Mirror the errdefer
+    // layer commits the transfer (queue, multi, or another park). If the
+    // chain fails before any commit, we clean up here — mirror the errdefer
     // pattern in Client.request.
-    transfer.loop_owned = false;
+    transfer.unpark();
     self.next.request(transfer) catch |err| {
-        if (!transfer.loop_owned) {
+        if (transfer.state == .created) {
             transfer.abort(err);
         }
         return err;

--- a/src/network/layer/RobotsLayer.zig
+++ b/src/network/layer/RobotsLayer.zig
@@ -97,10 +97,10 @@ fn fetchRobotsThenRequest(
         entry.value_ptr.* = .empty;
 
         try entry.value_ptr.append(self.allocator, transfer);
-        transfer.loop_owned = true;
+        transfer.park(.robots);
         errdefer {
             entry.value_ptr.deinit(self.allocator);
-            transfer.loop_owned = false;
+            transfer.unpark();
         }
 
         const robots_ctx = try transfer.arena.create(RobotsContext);
@@ -143,7 +143,7 @@ fn fetchRobotsThenRequest(
         // until robots.txt resolves. Without this, Client.request's errdefer (or
         // any caller's cleanup) would deinit a transfer that's still on the
         // pending list, leaving flushPending with a dangling pointer.
-        transfer.loop_owned = true;
+        transfer.park(.robots);
     }
 }
 
@@ -156,12 +156,12 @@ fn flushPending(self: *RobotsLayer, robots_url: [:0]const u8, allowed: bool) voi
             log.warn(.http, "blocked by robots", .{ .url = transfer.req.url });
             transfer.abort(error.RobotsBlocked);
         } else {
-            // Reset ownership: handing back to the layer chain. If a downstream
-            // layer commits (multi / queue / pause), it'll flip loop_owned back
-            // to true. If it fails before committing, we clean up here.
-            transfer.loop_owned = false;
+            // Hand back to the layer chain. If a downstream layer commits
+            // (multi / queue / park), state advances past .created. If it
+            // fails before committing, we clean up here.
+            transfer.unpark();
             self.next.request(transfer) catch |e| {
-                if (!transfer.loop_owned) {
+                if (transfer.state == .created) {
                     transfer.abort(e);
                 }
             };


### PR DESCRIPTION
Replaces 4 boolean flags with a state. Makes it easier to figure out what the state of the transfer is, and removes the possibility of inconsistent flags .e.g queued + loop_owned.

loop_owned -> state != .created
_queued -> state == .queued
_perform -> state == .completing
aborted -> state == .aborted