### PR TITLE
Fix CDP server stall/SIGTERM hang in optimized builds (Network drops CDP sockets from poll set)

### DIFF
--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -722,8 +722,15 @@ pub fn run(self: *Network) void {
                 break :blk min_timeout;
             }
 
+            // curl_multi_timeout reports -1 when curl has no timeout
+            // preference (idle) and 0 when it wants to be serviced
+            // immediately. Treat both as "no curl-imposed deadline" and
+            // fall back to min_timeout — otherwise @min(min_timeout, -1)
+            // would be -1, i.e. poll() blocks forever, starving onTick
+            // (telemetry's periodic flush) and removing the safety net
+            // that bounds any missed wakeup to min_timeout.
             const curl_timeout = self.getCurlTimeout();
-            if (curl_timeout == 0) {
+            if (curl_timeout <= 0) {
                 break :blk min_timeout;
             }
 
@@ -860,7 +867,16 @@ fn acceptConnections(self: *Network) void {
 }
 
 fn preparePollFds(self: *Network, multi: *libcurl.CurlM) void {
-    const curl_fds = self.pollfds[PSEUDO_POLLFDS..];
+    // Only the curl slice — NOT through to the end of pollfds. The CDP
+    // socket fds live in [cdp_start..] and are owned by
+    // prepareCdpPollFds, which only rebuilds them when cdp_dirty is set
+    // (a steady-state optimization). Slicing to the end here would
+    // @memset those fds to -1 every iteration once a multi exists (which
+    // happens as soon as telemetry sends its first request), silently
+    // dropping every live CDP socket from the poll set — Network then
+    // never reads another CDP message (#2508) nor observes peer
+    // EOF/shutdown (#2507).
+    const curl_fds = self.pollfds[PSEUDO_POLLFDS..self.cdp_start];
     @memset(curl_fds, .{ .fd = -1, .events = 0, .revents = 0 });
 
     var fd_count: c_uint = 0;
@@ -1052,4 +1068,41 @@ fn loadCerts(allocator: Allocator) !libcurl.CurlBlob {
         .data = result.ptr,
         .flags = 0,
     };
+}
+
+const testing = @import("../testing.zig");
+
+test "Network: preparePollFds leaves the CDP fd region untouched" {
+    // Regression for #2507 / #2508. Once a multi exists (telemetry creates
+    // one in optimized builds), preparePollFds runs every loop iteration.
+    // It rebuilds only the curl slice [PSEUDO_POLLFDS..cdp_start]; the CDP
+    // region [cdp_start..] is owned by prepareCdpPollFds, which keeps its
+    // entries across iterations and only rebuilds when cdp_dirty is set.
+    // A slice that ran to the end of pollfds @memset those CDP sockets to
+    // -1, silently dropping every live CDP connection from the poll set —
+    // so Network stopped reading CDP messages (#2508) and never observed
+    // peer EOF/shutdown (#2507). curl global is initialized by the test
+    // harness (App.init -> Network.init).
+    const multi = libcurl.curl_multi_init() orelse return error.FailedToInitMulti;
+    defer libcurl.curl_multi_cleanup(multi) catch {};
+
+    const curl_slots = 4;
+    const cdp_slots = 3;
+    var pollfds: [PSEUDO_POLLFDS + curl_slots + cdp_slots]posix.pollfd = undefined;
+    @memset(&pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
+
+    // preparePollFds only reads self.pollfds and self.cdp_start.
+    var nw: Network = undefined;
+    nw.pollfds = &pollfds;
+    nw.cdp_start = PSEUDO_POLLFDS + curl_slots;
+
+    // Two live CDP sockets parked in the CDP region, mimicking the steady
+    // state between cdp_dirty rebuilds.
+    pollfds[nw.cdp_start] = .{ .fd = 4242, .events = posix.POLL.IN, .revents = 0 };
+    pollfds[nw.cdp_start + 1] = .{ .fd = 4243, .events = posix.POLL.IN, .revents = 0 };
+
+    nw.preparePollFds(multi);
+
+    try testing.expectEqual(@as(posix.fd_t, 4242), pollfds[nw.cdp_start].fd);
+    try testing.expectEqual(@as(posix.fd_t, 4243), pollfds[nw.cdp_start + 1].fd);
 }


### PR DESCRIPTION
## What this fixes

Two regressions from #2495, both reproducing **only in optimized builds** (`-Doptimize=ReleaseFast`/`ReleaseSafe`, i.e. the nightly):

- **#2508** — after the first one or two CDP commands the server stops answering. In a minimal repro `Browser.getVersion` (id=1) succeeds, then `Target.setAutoAttach` (id=2) never gets a reply — a hard stall (no recovery, no logs). This makes the next nightly unusable for Playwright/Puppeteer.
- **#2507** — once a CDP connection has been served, the process ignores `SIGTERM` and must be `SIGKILL`ed (20/20 in a release build).

Both have a single root cause.

## Root cause

`preparePollFds` (`src/network/Network.zig`) rebuilds the curl portion of `pollfds` each loop iteration, but sliced to the **end** of the array:

```zig
const curl_fds = self.pollfds[PSEUDO_POLLFDS..];   // runs into the CDP region
@memset(curl_fds, .{ .fd = -1, .events = 0, .revents = 0 });
```

`pollfds` is three contiguous regions:

```
[0]                            wakeup pipe
[1]                            listener
[PSEUDO_POLLFDS .. cdp_start]  curl multi fds   (httpMaxConcurrent)
[cdp_start .. end]             CDP socket fds   (maxConnections)   <-- wiped every iteration
```

`prepareCdpPollFds` owns `[cdp_start..]` and only rebuilds it when `cdp_dirty` is set (a steady-state optimization). So the `@memset` reset every live CDP socket fd to `-1` on each iteration and they were never re-added — the Network thread silently stopped polling them.

This only triggers once Network owns a curl `multi` handle. **The only caller of `network.submitRequest` is telemetry** (`telemetry/lightpanda.zig:108`), and **telemetry is disabled in Debug builds** (`telemetry/telemetry.zig:14`). Regular HTTP/navigation runs on the *worker's* handles, not Network's multi. That's why Debug always worked and only optimized builds broke — it's telemetry creating the multi, not the optimizer.

With the CDP socket unwatched:
- Network never reads further client messages → **#2508**.
- Network never sees the client's EOF / `Connection.shutdown` → the worker (blocked in `curl_multi_poll`) is never told to disconnect, so it loops forever and `Server.deinit` waits on it → **#2507**.

`lldb` on a stalled process confirmed it: the Network thread parked in `poll(timeout=-1)` while id=2 sat unread on the socket.

## What this PR changes

```zig
// preparePollFds: clear/rebuild ONLY the curl region, never the CDP region
const curl_fds = self.pollfds[PSEUDO_POLLFDS..self.cdp_start];
```

Plus a defensive timeout fix in the same loop: `curl_multi_timeout` returns `-1` when curl is idle, so `@min(250, curl_timeout)` was `@min(250, -1) = -1` — `poll()` blocked forever. That starved `onTick` (telemetry's periodic flush) and turned any missed wakeup into a permanent hang. Treat `curl_timeout <= 0` as "no curl deadline" and fall back to the 250 ms cap.

## Why these constants

- **`cdp_start` boundary** — `httpMaxConcurrent` (default 10) is the designed size of the curl region, and Network's multi only ever serves telemetry (a single request), so the region has ample headroom.
- **250 ms** — the existing `min_timeout`; it bounds onTick latency and now also bounds any missed wakeup, so this whole class of bug can no longer hard-hang.

## Where to focus review

- The `preparePollFds` slice boundary, and that the `cdp_dirty` reuse optimization in `prepareCdpPollFds` is now sound again (nothing else touches `[cdp_start..]` between rebuilds).

## Test plan

- [x] New unit test `Network: preparePollFds leaves the CDP fd region untouched` — confirmed it **fails** on the old slice and **passes** on the fix.
- [x] `make test` — 718/718 pass.
- [x] `zig fmt --check` clean.
- [x] #2507 repro on a ReleaseFast build: **0/25** hang (was 20/20).
- [x] #2508 repro on a ReleaseFast build: full Puppeteer-style startup sequence completes (was stalling at id=2).

Fixes #2507
Fixes #2508
