### PR TITLE
network: terminate live CDP connections on shutdown

### DIFF
--- a/src/Inbox.zig
+++ b/src/Inbox.zig
@@ -39,6 +39,13 @@ const Inbox = @This();
 mutex: std.Thread.Mutex = .{},
 queue: DoublyLinkedList = .{},
 
+// One-way latch, set by the worker's drainInbox the first time it
+// observes a .disconnect (or .close) and never cleared. Ensures that, on
+// multiple drains, the terminated state is preserved / communicated. This is
+// specifically meant to handle the case where a disconnect is captured during
+// a syncRequest and we want the following non-nested tick to pick it up again.
+terminated: bool = false,
+
 pub fn deinit(self: *Inbox, arena_pool: *ArenaPool) void {
     self.mutex.lock();
     defer self.mutex.unlock();

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -398,6 +398,10 @@ pub fn abortRequests(_: *Client, owner: *Owner) void {
 const DrainMode = enum { all, sync_wait };
 
 pub fn tick(self: *Client, timeout_ms: u32, mode: DrainMode) !void {
+    if (self.inbox.terminated) {
+        return error.ClientDisconnected;
+    }
+
     try self.drainQueue();
     try self.perform(@intCast(timeout_ms));
     // perform/processMessages just released a batch of connections back to
@@ -536,6 +540,10 @@ const SyncContext = struct {
 };
 
 pub fn syncRequest(self: *Client, allocator: Allocator, req: Request) !SyncResponse {
+    if (self.inbox.terminated) {
+        return error.ClientDisconnected;
+    }
+
     var sync_ctx = SyncContext{ .allocator = allocator, .body = .empty };
     errdefer sync_ctx.body.deinit(allocator);
 
@@ -719,10 +727,12 @@ fn drainInbox(self: *Client, mode: DrainMode) !void {
             .close => {
                 cdp.onClose();
                 cdp.onDisconnect(null);
+                self.inbox.terminated = true;
                 return error.ClientDisconnected;
             },
             .disconnect => |err| {
                 cdp.onDisconnect(err);
+                self.inbox.terminated = true;
                 return error.ClientDisconnected;
             },
         }

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -541,6 +541,9 @@ const SyncContext = struct {
 
 pub fn syncRequest(self: *Client, allocator: Allocator, req: Request) !SyncResponse {
     if (self.inbox.terminated) {
+        // request() takes ownership of req.headers on every path; we return
+        // before calling it, so free the curl_slist here to avoid leaking it.
+        req.headers.deinit();
         return error.ClientDisconnected;
     }
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -1331,3 +1331,27 @@ test "cdp: STARTUP sessionId" {
         try ctx.expectSentResult(null, .{ .id = 4, .index = 2, .session_id = "STARTUP" });
     }
 }
+
+test "cdp: disconnect latches so the worker keeps exiting" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const client = &ctx.cdp().browser.http_client;
+
+    // Simulate the Network thread delivering a peer disconnect into the
+    // worker's inbox — the dropCdp(notify=true) path used on peer EOF and,
+    // since #2510, on shutdown via shutdownCdpLinks.
+    {
+        const arena = try client.arena_pool.acquire(.tiny, "test disconnect");
+        client.inbox.push(arena, .{ .disconnect = null });
+    }
+
+    // First tick drains the .disconnect and tears the link down.
+    try testing.expectError(error.ClientDisconnected, client.tick(0, .all));
+
+    // The inbox is now empty. Without the latch this second tick would fall
+    // through to perform/poll with no producer left to wake it, so the worker
+    // would never exit and Server.deinit() would spin on active_threads
+    // (#2510). The latch keeps the terminal state sticky so the worker exits.
+    try testing.expectError(error.ClientDisconnected, client.tick(0, .all));
+}

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -1355,3 +1355,36 @@ test "cdp: disconnect latches so the worker keeps exiting" {
     // (#2510). The latch keeps the terminal state sticky so the worker exits.
     try testing.expectError(error.ClientDisconnected, client.tick(0, .all));
 }
+
+test "cdp: syncRequest short-circuits after disconnect" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const client = &ctx.cdp().browser.http_client;
+
+    // Latch terminated via a drained disconnect (as above).
+    {
+        const arena = try client.arena_pool.acquire(.tiny, "test disconnect");
+        client.inbox.push(arena, .{ .disconnect = null });
+    }
+    try testing.expectError(error.ClientDisconnected, client.tick(0, .all));
+
+    // A synchronous fetch attempted after the latch returns ClientDisconnected
+    // without starting the request. syncRequest also frees req.headers on this
+    // early-return path (it returns before request() takes ownership); that
+    // free isn't asserted here because curl_slist is C-allocated and escapes the
+    // per-test leak check, so it's verified by review. The latch check returns
+    // before any other req field is read, so the rest are placeholders.
+    const headers = try client.newHeaders();
+    try testing.expectError(error.ClientDisconnected, client.syncRequest(testing.allocator, .{
+        .frame_id = 0,
+        .loader_id = 0,
+        .method = .GET,
+        .url = "http://127.0.0.1:9582/",
+        .headers = headers,
+        .cookie_jar = null,
+        .cookie_origin = "",
+        .resource_type = .fetch,
+        .notification = undefined,
+    }));
+}

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -697,12 +697,11 @@ fn shutdownCdpLinks(self: *Network) void {
 
     var it = self.cdp_links.first;
     while (it) |node| {
-        const next = node.next;
+        it = node.next;
         const link: *CdpLink = @fieldParentPtr("node", node);
         if (link.state == .live) {
             self.dropCdp(link, null, true);
         }
-        it = next;
     }
 
     self.cdp_unregister.broadcast();

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -683,6 +683,35 @@ fn processCdpEvents(self: *Network) void {
     }
 }
 
+// On shutdown, force-disconnect every still-live CDP link. Each link's
+// worker thread blocks in curl_multi_poll and is woken ONLY by this
+// (Network) thread via dropCdp -> handles.wakeup(). If the run loop
+// exits with links still live, those workers never wake and
+// Server.deinit() spins on active_threads forever (issue #2510).
+// Mirrors the peer-EOF path in processCdpEvents: dropCdp(notify=true)
+// pushes a .disconnect into the worker's inbox and wakes it, so
+// cdp.tick() returns false and the worker exits.
+fn shutdownCdpLinks(self: *Network) void {
+    self.cdp_mutex.lock();
+    defer self.cdp_mutex.unlock();
+
+    var any_removed = false;
+    var it = self.cdp_links.first;
+    while (it) |node| {
+        const next = node.next;
+        const link: *CdpLink = @fieldParentPtr("node", node);
+        if (link.state == .live) {
+            self.dropCdp(link, null, true);
+            any_removed = true;
+        }
+        it = next;
+    }
+
+    if (any_removed) {
+        self.cdp_unregister.broadcast();
+    }
+}
+
 pub fn run(self: *Network) void {
     var drain_buf: [64]u8 = undefined;
     var running_handles: c_int = 0;
@@ -760,13 +789,24 @@ pub fn run(self: *Network) void {
 
         self.fireTicks();
 
-        if (self.shutdown.load(.acquire) and running_handles == 0) {
-            // Check if fireTicks submitted new requests (e.g. telemetry flush).
-            // If so, continue the loop to drain and send them before exiting.
-            self.submission_mutex.lock();
-            const has_pending = self.submission_queue.first != null;
-            self.submission_mutex.unlock();
-            if (!has_pending) break;
+        if (self.shutdown.load(.acquire)) {
+            // Force-disconnect any still-live CDP clients so their worker
+            // threads wake from curl_multi_poll and exit. A worker is woken
+            // only by this (Network) thread; if the loop exits with links
+            // still live, those workers block forever and Server.deinit()
+            // spins on active_threads (issue #2510). Idempotent — a no-op
+            // once the links are drained.
+            self.shutdownCdpLinks();
+
+            if (running_handles == 0) {
+                // Check if fireTicks submitted new requests (e.g. telemetry
+                // flush). If so, continue the loop to drain and send them
+                // before exiting.
+                self.submission_mutex.lock();
+                const has_pending = self.submission_queue.first != null;
+                self.submission_mutex.unlock();
+                if (!has_pending) break;
+            }
         }
     }
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -787,7 +787,7 @@ pub fn run(self: *Network) void {
 
         if (self.shutdown.load(.acquire)) {
             // Drain any live CDP links so their workers can exit (issue #2510).
-            // Idempo tent — no-op once drained, safe to call every iteration
+            // Idempotent — no-op once drained, safe to call every iteration
             self.shutdownCdpLinks();
 
             if (running_handles == 0) {

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -695,21 +695,17 @@ fn shutdownCdpLinks(self: *Network) void {
     self.cdp_mutex.lock();
     defer self.cdp_mutex.unlock();
 
-    var any_removed = false;
     var it = self.cdp_links.first;
     while (it) |node| {
         const next = node.next;
         const link: *CdpLink = @fieldParentPtr("node", node);
         if (link.state == .live) {
             self.dropCdp(link, null, true);
-            any_removed = true;
         }
         it = next;
     }
 
-    if (any_removed) {
-        self.cdp_unregister.broadcast();
-    }
+    self.cdp_unregister.broadcast();
 }
 
 pub fn run(self: *Network) void {
@@ -790,12 +786,8 @@ pub fn run(self: *Network) void {
         self.fireTicks();
 
         if (self.shutdown.load(.acquire)) {
-            // Force-disconnect any still-live CDP clients so their worker
-            // threads wake from curl_multi_poll and exit. A worker is woken
-            // only by this (Network) thread; if the loop exits with links
-            // still live, those workers block forever and Server.deinit()
-            // spins on active_threads (issue #2510). Idempotent — a no-op
-            // once the links are drained.
+            // Drain any live CDP links so their workers can exit (issue #2510).
+            // Idempo tent — no-op once drained, safe to call every iteration
             self.shutdownCdpLinks();
 
             if (running_handles == 0) {
@@ -805,7 +797,10 @@ pub fn run(self: *Network) void {
                 self.submission_mutex.lock();
                 const has_pending = self.submission_queue.first != null;
                 self.submission_mutex.unlock();
-                if (!has_pending) break;
+
+                if (!has_pending) {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## What

`lightpanda serve` ignored a single `SIGTERM` while a CDP connection was live — the process only exited if the socket was closed before the signal, or after a third signal. A conventional one-shot graceful stop (`kill -TERM <pid>` then `waitpid`) hung after the client had driven a session.

Closes #2510.

## Root cause

On shutdown the sighandler runs `Network.stop` (sets `shutdown`, lets the run loop exit) **before** `Server.shutdown`. A live CDP worker parks in `curl_multi_poll` and is woken **only** by the Network thread via `dropCdp -> handles.wakeup()`. Once the run loop exits with links still live, nothing can wake those workers, so `Server.deinit()`'s `while (active_threads > 0)` loop spins forever.

```mermaid
flowchart TD
    A1[SIGTERM] --> A2["Network.stop: shutdown = true"]
    A2 --> A3{"run loop: shutdown and running_handles == 0"}
    A3 -->|break| A4["Network thread exits<br/>(live CDP links abandoned)"]
    A4 --> A5["Server.shutdown: conn.shutdown()"]
    A5 --> A6["worker still parked in curl_multi_poll<br/>(nothing left to wake it)"]
    A6 --> A7["Server.deinit: while active_threads &gt; 0<br/>spins forever"]
```

## Change

`Network.run`, on observing `shutdown`, now calls a new `shutdownCdpLinks()` that drops every still-live CDP link via the existing peer-EOF path (`dropCdp(notify=true)` — pushes `.disconnect` into the worker's inbox and wakes it out of `curl_multi_poll`). The worker's `cdp.tick()` then returns false and it exits before the loop breaks. The helper is idempotent (a no-op once the links are drained).

```mermaid
flowchart TD
    B1[SIGTERM] --> B2["Network.stop: shutdown = true"]
    B2 --> B3["run loop: shutdownCdpLinks()<br/>dropCdp(notify=true) per live link"]
    B3 --> B4["worker woken: .disconnect in inbox<br/>+ curl_multi_wakeup"]
    B4 --> B5["cdp.tick() returns false<br/>worker exits, active_threads -&gt; 0"]
    B3 --> B6[run loop breaks, Network exits]
    B5 --> B7["Server.deinit returns cleanly"]
```

## Test plan

- [x] `zig build test` — 717/717 pass.
- [x] End-to-end (ReleaseFast build): the reproducer below — a raw CDP client that opens a WebSocket and sends **one** `SIGTERM` with the connection still open — now **exits cleanly**; before the fix it stayed alive 12s+ until `SIGKILL`. Closing the socket before `SIGTERM` already worked and still does.

No in-process unit test: the shutdown path is multi-threaded (sighandler thread → Network run loop → per-connection worker), and the without-fix failure mode is a `Server.deinit()` spin rather than an assertion. The link's lifetime is guarded by `unregisterCdp`'s synchronous handoff *on the Network thread*, so dropping links from any other thread (e.g. a test) risks a use-after-free on `cdp_poll_snapshot`. A race-free test would need a dedicated `Server`/`Network` instance plus a watchdog — happy to add that if you'd like it in the suite.

## Reproducer

Self-contained (Lightpanda + Python stdlib, no extra deps), telemetry disabled to show this is independent of #2509:

```python
import socket, base64, os, sys, subprocess, time, signal

BIN = sys.argv[1]
print("binary:", subprocess.run([BIN, "version"], capture_output=True, text=True).stdout.strip())

def ws_connect(port):
    s = socket.create_connection(("127.0.0.1", port), timeout=5)
    key = base64.b64encode(os.urandom(16)).decode()
    s.sendall(("GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
               "Sec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n" % key).encode())
    buf = b""
    while b"\r\n\r\n" not in buf:
        buf += s.recv(1)
    assert buf.startswith(b"HTTP/1.1 101"), buf[:40]
    return s

def run(label, close_before_sigterm, port):
    env = dict(os.environ); env["LIGHTPANDA_DISABLE_TELEMETRY"] = "true"
    p = subprocess.Popen([BIN, "serve", "--host", "127.0.0.1", "--port", str(port), "--log_level", "error"],
                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, start_new_session=True)
    time.sleep(2)
    s = ws_connect(port)               # one CDP WebSocket; no commands sent
    if close_before_sigterm:
        s.close(); time.sleep(0.3)
    p.send_signal(signal.SIGTERM)      # exactly ONE SIGTERM
    deadline = time.time() + 12
    while time.time() < deadline:
        if p.poll() is not None:
            print("[%s] exited on SIGTERM (ok)" % label); break
        time.sleep(0.25)
    else:
        print("[%s] *** SIGTERM IGNORED — still alive 12s after one SIGTERM ***" % label)
        os.killpg(os.getpgid(p.pid), signal.SIGKILL)
    try: s.close()
    except OSError: pass
    try: p.wait(timeout=3)
    except Exception:
        try: os.killpg(os.getpgid(p.pid), signal.SIGKILL)
        except Exception: pass

run("WS closed before SIGTERM", True, 39920)
run("WS still open at SIGTERM", False, 39921)
```

Before this PR the second case prints `SIGTERM IGNORED`; after it, both print `exited on SIGTERM (ok)`.
