### PR TITLE
Performance WebAPI on Worker

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -47,7 +47,6 @@ const ShadowRoot = @import("webapi/ShadowRoot.zig");
 const Performance = @import("webapi/Performance.zig");
 const Screen = @import("webapi/Screen.zig");
 const VisualViewport = @import("webapi/VisualViewport.zig");
-const PerformanceObserver = @import("webapi/PerformanceObserver.zig");
 const AbstractRange = @import("webapi/AbstractRange.zig");
 const MutationObserver = @import("webapi/MutationObserver.zig");
 const IntersectionObserver = @import("webapi/IntersectionObserver.zig");
@@ -173,11 +172,6 @@ _intersection_delivery_scheduled: bool = false,
 // Slots that need slotchange events to be fired
 _slots_pending_slotchange: std.AutoHashMapUnmanaged(*Element.Html.Slot, void) = .{},
 _slotchange_delivery_scheduled: bool = false,
-
-/// List of active PerformanceObservers.
-/// Contrary to MutationObserver and IntersectionObserver, these are regular tasks.
-_performance_observers: std.ArrayList(*PerformanceObserver) = .{},
-_performance_delivery_scheduled: bool = false,
 
 // Lookup for customized built-in elements. Maps element pointer to definition.
 _customized_builtin_definitions: std.AutoHashMapUnmanaged(*Element, *CustomElementDefinition) = .{},
@@ -321,7 +315,7 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
         ._proto = undefined,
         ._document = self.document,
         ._location = &default_location,
-        ._performance = Performance.init(),
+        ._performance = .init(),
         ._screen = screen,
         ._visual_viewport = visual_viewport,
         ._cross_origin_wrapper = undefined,
@@ -1594,61 +1588,8 @@ pub fn getElementByIdFromNode(self: *Frame, node: *Node, id: []const u8) ?*Eleme
     return null;
 }
 
-pub fn registerPerformanceObserver(self: *Frame, observer: *PerformanceObserver) !void {
-    return self._performance_observers.append(self.arena, observer);
-}
-
-pub fn unregisterPerformanceObserver(self: *Frame, observer: *PerformanceObserver) void {
-    for (self._performance_observers.items, 0..) |perf_observer, i| {
-        if (perf_observer == observer) {
-            _ = self._performance_observers.swapRemove(i);
-            return;
-        }
-    }
-}
-
-/// Updates performance observers with the new entry.
-/// This doesn't emit callbacks but rather fills the queues of observers.
-pub fn notifyPerformanceObservers(self: *Frame, entry: *Performance.Entry) !void {
-    for (self._performance_observers.items) |observer| {
-        if (observer.interested(entry)) {
-            observer._entries.append(self.arena, entry) catch |err| {
-                log.err(.frame, "notifyPerformanceObservers", .{ .err = err, .type = self._type, .url = self.url });
-            };
-        }
-    }
-
-    try self.schedulePerformanceObserverDelivery();
-}
-
-/// Schedules async delivery of performance observer records.
-pub fn schedulePerformanceObserverDelivery(self: *Frame) !void {
-    // Already scheduled.
-    if (self._performance_delivery_scheduled) {
-        return;
-    }
-    self._performance_delivery_scheduled = true;
-
-    return self.js.scheduler.add(
-        self,
-        struct {
-            fn run(_frame: *anyopaque) anyerror!?u32 {
-                const frame: *Frame = @ptrCast(@alignCast(_frame));
-                frame._performance_delivery_scheduled = false;
-
-                // Dispatch performance observer events.
-                for (frame._performance_observers.items) |observer| {
-                    if (observer.hasRecords()) {
-                        try observer.dispatch(frame);
-                    }
-                }
-
-                return null;
-            }
-        }.run,
-        0,
-        .{ .low_priority = true },
-    );
+pub fn performance(self: *Frame) *Performance {
+    return &self.window._performance;
 }
 
 pub fn registerMutationObserver(self: *Frame, observer: *MutationObserver) !void {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -569,6 +569,9 @@ pub const Function = struct {
         null_as_undefined: bool = false,
         cache: ?Caching = null,
         embedded_receiver: bool = false,
+        exposed: Exposed = .both,
+
+        pub const Exposed = enum { both, window, worker };
 
         // We support two ways to cache a value directly into a v8::Object. The
         // difference between the two is like the difference between a Map

--- a/src/browser/js/Execution.zig
+++ b/src/browser/js/Execution.zig
@@ -37,6 +37,7 @@ const EventManagerBase = @import("../EventManagerBase.zig");
 const Blob = @import("../webapi/Blob.zig");
 const Event = @import("../webapi/Event.zig");
 const EventTarget = @import("../webapi/EventTarget.zig");
+const Performance = @import("../webapi/Performance.zig");
 
 const String = lp.String;
 const Allocator = std.mem.Allocator;
@@ -127,6 +128,12 @@ pub fn dispatch(
 pub fn hasDirectListeners(self: *const Execution, target: *EventTarget, typ: []const u8, handler: anytype) bool {
     return switch (self.context.global) {
         inline else => |g| g.hasDirectListeners(target, typ, handler),
+    };
+}
+
+pub fn performance(self: *const Execution) *Performance {
+    return switch (self.context.global) {
+        inline else => |g| g.performance(),
     };
 }
 

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -31,6 +31,20 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Snapshot = @This();
 
+const Caller = @import("Caller.zig");
+
+const Realm = enum {
+    window,
+    worker,
+
+    fn asExposed(comptime self: Realm) Caller.Function.Opts.Exposed {
+        return switch (self) {
+            .window => .window,
+            .worker => .worker,
+        };
+    }
+};
+
 const embedded_snapshot_blob = if (lp.build_config.snapshot_path) |path| @embedFile(path) else "";
 
 // When creating our Snapshot, we use local function templates for every Zig type.
@@ -184,13 +198,13 @@ pub fn create() !Snapshot {
 
         {
             const Window = @import("../webapi/Window.zig");
-            const index = try createSnapshotContext(&PageJsApis, Window.JsApi, isolate, snapshot_creator.?, &templates);
+            const index = try createSnapshotContext(.window, &PageJsApis, Window.JsApi, isolate, snapshot_creator.?, &templates);
             std.debug.assert(index == 0);
         }
 
         {
             const WorkerGlobalScope = @import("../webapi/WorkerGlobalScope.zig");
-            const index = try createSnapshotContext(&WorkerJsApis, WorkerGlobalScope.JsApi, isolate, snapshot_creator.?, &templates);
+            const index = try createSnapshotContext(.worker, &WorkerJsApis, WorkerGlobalScope.JsApi, isolate, snapshot_creator.?, &templates);
             std.debug.assert(index == 1);
         }
     }
@@ -206,6 +220,7 @@ pub fn create() !Snapshot {
 }
 
 fn createSnapshotContext(
+    comptime realm: Realm,
     comptime ContextApis: []const type,
     comptime GlobalScopeApi: type,
     isolate: *v8.Isolate,
@@ -257,8 +272,13 @@ fn createSnapshotContext(
 
     const global_obj = v8.v8__Context__Global(context);
 
-    // Attach constructors for this context's APIs to the global
+    // Attach constructors for this context's APIs to the global, and for any
+    // type with members tagged [Exposed=Window]/[Exposed=Worker], prune the
+    // ones that don't match this realm from the per-context Func.prototype.
+    const prototype_key = v8.v8__String__NewFromUtf8(isolate, "prototype", v8.kNormal, 9);
+
     inline for (ContextApis) |JsApi| {
+        @setEvalBranchQuota(10_000);
         const template_index = comptime bridge.JsApiLookup.getId(JsApi);
         const func = v8.v8__FunctionTemplate__GetFunction(templates[template_index], context);
         if (@hasDecl(JsApi.Meta, "name")) {
@@ -283,6 +303,25 @@ fn createSnapshotContext(
                     properties = v8.None;
                 }
                 v8.v8__Object__DefineOwnProperty(global_obj, context, v8_class_name, func, properties, &maybe_result);
+            }
+        }
+
+        // WebIDL [Exposed=...] gating. Members are installed on the shared
+        // FunctionTemplate by attachClass; here we delete the ones that don't
+        // match this realm from the per-context Func.prototype.
+        if (comptime hasGatedMember(JsApi)) {
+            const func_obj: *const v8.Object = @ptrCast(func);
+            if (v8.v8__Object__Get(func_obj, context, prototype_key)) |proto_handle| {
+                const proto_obj: *const v8.Object = @ptrCast(proto_handle);
+                inline for (@typeInfo(JsApi).@"struct".decls) |d| {
+                    const exposed = comptime memberExposed(@field(JsApi, d.name));
+                    if (comptime exposed != .both and exposed != realm.asExposed()) {
+                        const name: [:0]const u8 = d.name;
+                        const name_v8 = v8.v8__String__NewFromUtf8(isolate, name.ptr, v8.kNormal, @intCast(name.len));
+                        var maybe_deleted: v8.MaybeBool = undefined;
+                        v8.v8__Object__Delete(proto_obj, context, name_v8, &maybe_deleted);
+                    }
+                }
             }
         }
     }
@@ -321,6 +360,25 @@ fn createSnapshotContext(
     }
 
     return v8.v8__SnapshotCreator__AddContext(snapshot_creator, context);
+}
+
+fn hasGatedMember(comptime JsApi: type) bool {
+    comptime {
+        for (@typeInfo(JsApi).@"struct".decls) |d| {
+            if (memberExposed(@field(JsApi, d.name)) != .both) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+fn memberExposed(value: anytype) Caller.Function.Opts.Exposed {
+    const T = @TypeOf(value);
+    if (T == bridge.Accessor or T == bridge.Function) {
+        return value.exposed;
+    }
+    return .both;
 }
 
 fn countExternalReferences() comptime_int {

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -984,7 +984,9 @@ pub const WorkerJsApis = flattenTypes(&.{
     @import("../webapi/net/XMLHttpRequestEventTarget.zig"),
     @import("../webapi/FileReader.zig"),
     @import("../webapi/ImageData.zig"),
-    // @import("../webapi/Performance.zig"),
+    @import("../webapi/Performance.zig"),
+    @import("../webapi/PerformanceObserver.zig"),
+    @import("../webapi/EventCounts.zig"),
 });
 
 // Master list of ALL JS APIs across all contexts.

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -145,6 +145,7 @@ pub const Function = struct {
     arity: usize,
     noop: bool = false,
     wpt_only: bool = false,
+    exposed: Caller.Function.Opts.Exposed = .both,
     cache: ?Caller.Function.Opts.Caching = null,
     func: *const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void,
 
@@ -153,6 +154,7 @@ pub const Function = struct {
             .cache = opts.cache,
             .static = opts.static,
             .wpt_only = opts.wpt_only,
+            .exposed = opts.exposed,
             // Non-static methods receive `self` as their first param; static
             // methods don't, so don't skip the first param for them.
             .arity = getArity(@TypeOf(func), if (opts.static) 0 else 1),
@@ -205,6 +207,7 @@ pub const Accessor = struct {
     static: bool = false,
     deletable: bool = true,
     wpt_only: bool = false,
+    exposed: Caller.Function.Opts.Exposed = .both,
     cache: ?Caller.Function.Opts.Caching = null,
     getter: ?*const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void = null,
     setter: ?*const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void = null,
@@ -215,6 +218,7 @@ pub const Accessor = struct {
             .static = opts.static,
             .wpt_only = opts.wpt_only,
             .deletable = opts.deletable,
+            .exposed = opts.exposed,
         };
 
         if (@typeInfo(@TypeOf(getter)) != .null) {
@@ -986,7 +990,9 @@ pub const WorkerJsApis = flattenTypes(&.{
     @import("../webapi/ImageData.zig"),
     @import("../webapi/Performance.zig"),
     @import("../webapi/PerformanceObserver.zig"),
-    @import("../webapi/EventCounts.zig"),
+    // EventCounts is reachable only via Performance.eventCounts, which is
+    // [Exposed=Window] (pruned from Worker by Snapshot.pruneExposed). The
+    // type itself is in PageJsApis via Performance.registerTypes().
 });
 
 // Master list of ALL JS APIs across all contexts.

--- a/src/browser/tests/performance-worker.js
+++ b/src/browser/tests/performance-worker.js
@@ -1,0 +1,101 @@
+// Exercises the Performance API inside a worker. Receives a command from
+// the page and posts results back.
+self.onmessage = async function(e) {
+  const cmd = e.data;
+  try {
+    if (cmd.kind === 'basic') {
+      const t = performance.now();
+      postMessage({
+        ok: true,
+        has_performance: typeof performance === 'object',
+        is_self_performance: performance === self.performance,
+        now_is_number: typeof t === 'number',
+        now_non_negative: t >= 0,
+        origin_is_number: typeof performance.timeOrigin === 'number',
+        origin_positive: performance.timeOrigin > 0,
+      });
+      return;
+    }
+
+    if (cmd.kind === 'marks_and_measures') {
+      performance.clearMarks();
+      performance.clearMeasures();
+
+      const m = performance.mark('w-start', { startTime: 1.5 });
+      performance.mark('w-end', { startTime: 10 });
+      const me = performance.measure('w-dur', { start: 'w-start', end: 'w-end' });
+
+      const marks = performance.getEntriesByType('mark');
+      const measures = performance.getEntriesByType('measure');
+      const byName = performance.getEntriesByName('w-start');
+
+      postMessage({
+        ok: true,
+        mark_is_mark: m instanceof PerformanceMark,
+        mark_start_time: m.startTime,
+        measure_is_measure: me instanceof PerformanceMeasure,
+        measure_duration: me.duration,
+        mark_count: marks.length,
+        measure_count: measures.length,
+        by_name_count: byName.length,
+      });
+      return;
+    }
+
+    if (cmd.kind === 'event_counts') {
+      const ec = performance.eventCounts;
+      const keys = Array.from(ec.keys());
+      let iter_count = 0;
+      for (const [k, v] of ec) {
+        if (typeof k === 'string' && typeof v === 'number') iter_count++;
+      }
+      postMessage({
+        ok: true,
+        size: ec.size,
+        has_click: ec.has('click'),
+        has_scroll: ec.has('scroll'),
+        get_click_is_number: typeof ec.get('click') === 'number',
+        keys_length: keys.length,
+        iter_count,
+      });
+      return;
+    }
+
+    if (cmd.kind === 'observer') {
+      // The whole point of this test: the observer callback must fire in
+      // the worker's JS context, driven by the worker's scheduler.
+      performance.clearMarks();
+
+      let resolveCb;
+      const fired = new Promise((r) => { resolveCb = r; });
+
+      const observer = new PerformanceObserver((list, obs) => {
+        resolveCb({
+          entries: list.getEntries().map((e) => ({ name: e.name, type: e.entryType })),
+          same_observer: obs === observer,
+        });
+      });
+      observer.observe({ entryTypes: ['mark'] });
+
+      performance.mark('observed-1');
+      performance.mark('observed-2');
+
+      const result = await fired;
+      observer.disconnect();
+
+      postMessage({
+        ok: true,
+        observer_is_observer: observer instanceof PerformanceObserver,
+        entry_count: result.entries.length,
+        first_name: result.entries[0] && result.entries[0].name,
+        first_type: result.entries[0] && result.entries[0].type,
+        same_observer: result.same_observer,
+      });
+      return;
+    }
+
+    postMessage({ ok: false, err: 'unknown command' });
+  } catch (err) {
+    postMessage({ ok: false, err: String(err), stack: err.stack });
+  }
+};

--- a/src/browser/tests/performance-worker.js
+++ b/src/browser/tests/performance-worker.js
@@ -42,21 +42,14 @@ self.onmessage = async function(e) {
       return;
     }
 
-    if (cmd.kind === 'event_counts') {
-      const ec = performance.eventCounts;
-      const keys = Array.from(ec.keys());
-      let iter_count = 0;
-      for (const [k, v] of ec) {
-        if (typeof k === 'string' && typeof v === 'number') iter_count++;
-      }
+    if (cmd.kind === 'window_only_partials_hidden') {
+      // eventCounts, timing and navigation are [Exposed=Window] partials —
+      // they must not exist on a worker's performance object.
       postMessage({
         ok: true,
-        size: ec.size,
-        has_click: ec.has('click'),
-        has_scroll: ec.has('scroll'),
-        get_click_is_number: typeof ec.get('click') === 'number',
-        keys_length: keys.length,
-        iter_count,
+        has_event_counts: 'eventCounts' in performance,
+        has_timing: 'timing' in performance,
+        has_navigation: 'navigation' in performance,
       });
       return;
     }

--- a/src/browser/tests/performance.html
+++ b/src/browser/tests/performance.html
@@ -571,21 +571,18 @@
   }
 </script>
 
-<script id=worker_event_counts type=module>
+<script id=worker_window_only_partials_hidden type=module>
   {
     const state = await testing.async();
     const worker = new Worker('./performance-worker.js');
     worker.onmessage = (e) => state.resolve(e.data);
-    setTimeout(() => worker.postMessage({ kind: 'event_counts' }), 100);
+    setTimeout(() => worker.postMessage({ kind: 'window_only_partials_hidden' }), 100);
 
     await state.done((data) => {
       testing.expectTrue(data.ok, 'worker error: ' + data.err);
-      testing.expectEqual(36, data.size);
-      testing.expectEqual(true, data.has_click);
-      testing.expectEqual(false, data.has_scroll);
-      testing.expectEqual(true, data.get_click_is_number);
-      testing.expectEqual(36, data.keys_length);
-      testing.expectEqual(36, data.iter_count);
+      testing.expectEqual(false, data.has_event_counts);
+      testing.expectEqual(false, data.has_timing);
+      testing.expectEqual(false, data.has_navigation);
     });
   }
 </script>

--- a/src/browser/tests/performance.html
+++ b/src/browser/tests/performance.html
@@ -531,3 +531,79 @@
     testing.expectEqual(36, count);
   }
 </script>
+
+<script id=worker_basic type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./performance-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'basic' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker error: ' + data.err);
+      testing.expectEqual(true, data.has_performance);
+      testing.expectEqual(true, data.is_self_performance);
+      testing.expectEqual(true, data.now_is_number);
+      testing.expectEqual(true, data.now_non_negative);
+      testing.expectEqual(true, data.origin_is_number);
+      testing.expectEqual(true, data.origin_positive);
+    });
+  }
+</script>
+
+<script id=worker_marks_and_measures type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./performance-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'marks_and_measures' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker error: ' + data.err);
+      testing.expectEqual(true, data.mark_is_mark);
+      testing.expectEqual(1.5, data.mark_start_time);
+      testing.expectEqual(true, data.measure_is_measure);
+      testing.expectEqual(8.5, data.measure_duration);
+      testing.expectEqual(2, data.mark_count);
+      testing.expectEqual(1, data.measure_count);
+      testing.expectEqual(1, data.by_name_count);
+    });
+  }
+</script>
+
+<script id=worker_event_counts type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./performance-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'event_counts' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker error: ' + data.err);
+      testing.expectEqual(36, data.size);
+      testing.expectEqual(true, data.has_click);
+      testing.expectEqual(false, data.has_scroll);
+      testing.expectEqual(true, data.get_click_is_number);
+      testing.expectEqual(36, data.keys_length);
+      testing.expectEqual(36, data.iter_count);
+    });
+  }
+</script>
+
+<script id=worker_observer type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./performance-worker.js');
+    worker.onmessage = (e) => state.resolve(e.data);
+    setTimeout(() => worker.postMessage({ kind: 'observer' }), 100);
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker error: ' + data.err);
+      testing.expectEqual(true, data.observer_is_observer);
+      testing.expectEqual(2, data.entry_count);
+      testing.expectEqual('observed-1', data.first_name);
+      testing.expectEqual('mark', data.first_type);
+      testing.expectEqual(true, data.same_observer);
+    });
+  }
+</script>

--- a/src/browser/webapi/EventCounts.zig
+++ b/src/browser/webapi/EventCounts.zig
@@ -20,9 +20,9 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
+const Frame = @import("../Frame.zig");
 
 const log = lp.log;
-const Execution = js.Execution;
 
 pub fn registerTypes() []const type {
     return &.{
@@ -100,16 +100,16 @@ pub fn getSize(_: *const EventCounts) u32 {
     return tracked_event_types.len;
 }
 
-pub fn keys(self: *EventCounts, exec: *const Execution) !*KeyIterator {
-    return .init(.{ .event_counts = self }, exec);
+pub fn keys(self: *EventCounts, frame: *Frame) !*KeyIterator {
+    return .init(.{ .event_counts = self }, frame);
 }
 
-pub fn values(self: *EventCounts, exec: *const Execution) !*ValueIterator {
-    return .init(.{ .event_counts = self }, exec);
+pub fn values(self: *EventCounts, frame: *Frame) !*ValueIterator {
+    return .init(.{ .event_counts = self }, frame);
 }
 
-pub fn entries(self: *EventCounts, exec: *const Execution) !*EntryIterator {
-    return .init(.{ .event_counts = self }, exec);
+pub fn entries(self: *EventCounts, frame: *Frame) !*EntryIterator {
+    return .init(.{ .event_counts = self }, frame);
 }
 
 pub fn forEach(self: *EventCounts, cb_: js.Function, js_this_: ?js.Object) !void {
@@ -158,7 +158,7 @@ pub const Iterator = struct {
 
     pub const Entry = struct { []const u8, u32 };
 
-    pub fn next(self: *Iterator, _: *const Execution) ?Iterator.Entry {
+    pub fn next(self: *Iterator, _: *const Frame) ?Iterator.Entry {
         const index = self.index;
         if (index >= tracked_event_types.len) {
             return null;

--- a/src/browser/webapi/EventCounts.zig
+++ b/src/browser/webapi/EventCounts.zig
@@ -20,9 +20,9 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const Frame = @import("../Frame.zig");
 
 const log = lp.log;
+const Execution = js.Execution;
 
 pub fn registerTypes() []const type {
     return &.{
@@ -100,16 +100,16 @@ pub fn getSize(_: *const EventCounts) u32 {
     return tracked_event_types.len;
 }
 
-pub fn keys(self: *EventCounts, frame: *Frame) !*KeyIterator {
-    return .init(.{ .event_counts = self }, frame);
+pub fn keys(self: *EventCounts, exec: *const Execution) !*KeyIterator {
+    return .init(.{ .event_counts = self }, exec);
 }
 
-pub fn values(self: *EventCounts, frame: *Frame) !*ValueIterator {
-    return .init(.{ .event_counts = self }, frame);
+pub fn values(self: *EventCounts, exec: *const Execution) !*ValueIterator {
+    return .init(.{ .event_counts = self }, exec);
 }
 
-pub fn entries(self: *EventCounts, frame: *Frame) !*EntryIterator {
-    return .init(.{ .event_counts = self }, frame);
+pub fn entries(self: *EventCounts, exec: *const Execution) !*EntryIterator {
+    return .init(.{ .event_counts = self }, exec);
 }
 
 pub fn forEach(self: *EventCounts, cb_: js.Function, js_this_: ?js.Object) !void {
@@ -158,7 +158,7 @@ pub const Iterator = struct {
 
     pub const Entry = struct { []const u8, u32 };
 
-    pub fn next(self: *Iterator, _: *const Frame) ?Iterator.Entry {
+    pub fn next(self: *Iterator, _: *const Execution) ?Iterator.Entry {
         const index = self.index;
         if (index >= tracked_event_types.len) {
             return null;

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -365,9 +365,9 @@ pub const JsApi = struct {
     pub const getEntriesByType = bridge.function(Performance.getEntriesByType, .{});
     pub const getEntriesByName = bridge.function(Performance.getEntriesByName, .{});
     pub const timeOrigin = bridge.accessor(Performance.getTimeOrigin, null, .{});
-    pub const timing = bridge.accessor(Performance.getTiming, null, .{});
-    pub const navigation = bridge.accessor(Performance.getNavigation, null, .{});
-    pub const eventCounts = bridge.accessor(Performance.getEventCounts, null, .{});
+    pub const timing = bridge.accessor(Performance.getTiming, null, .{ .exposed = .window });
+    pub const navigation = bridge.accessor(Performance.getNavigation, null, .{ .exposed = .window });
+    pub const eventCounts = bridge.accessor(Performance.getEventCounts, null, .{ .exposed = .window });
 };
 
 pub const Entry = struct {

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -1,10 +1,31 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const js = @import("../js/js.zig");
-const Frame = @import("../Frame.zig");
 const datetime = @import("../../datetime.zig");
 
 const EventCounts = @import("EventCounts.zig");
+const PerformanceObserver = @import("PerformanceObserver.zig");
 
+const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
 
 pub fn registerTypes() []const type {
@@ -19,6 +40,11 @@ _timing: PerformanceTiming = .{},
 _navigation: PerformanceNavigation = .{},
 _event_counts: EventCounts = .{},
 
+// PerformanceObserver infrastructure. Lives here (rather than on the owning
+// Frame/WorkerGlobalScope) so that both contexts get observers for free.
+_observers: std.ArrayList(*PerformanceObserver) = .{},
+_delivery_scheduled: bool = false,
+
 /// Get high-resolution timestamp in microseconds, rounded to 5μs increments
 /// to match browser behavior (prevents fingerprinting)
 fn highResTimestamp() u64 {
@@ -32,9 +58,6 @@ fn highResTimestamp() u64 {
 pub fn init() Performance {
     return .{
         ._time_origin = highResTimestamp(),
-        ._entries = .{},
-        ._timing = .{},
-        ._navigation = .{},
     };
 }
 
@@ -66,12 +89,13 @@ pub fn mark(
     self: *Performance,
     name: []const u8,
     _options: ?Mark.Options,
-    frame: *Frame,
+    exec: *const Execution,
 ) !*Mark {
-    const m = try Mark.init(name, _options, frame);
-    try self._entries.append(frame.arena, m._proto);
-    // Notify about the change.
-    try frame.notifyPerformanceObservers(m._proto);
+    const opts = _options orelse Mark.Options{};
+    const start_time = opts.startTime orelse self.now();
+    const m = try Mark.init(name, opts.detail, start_time, exec);
+    try self._entries.append(exec.arena, m._proto);
+    try self.notifyObservers(m._proto, exec);
     return m;
 }
 
@@ -85,7 +109,7 @@ pub fn measure(
     name: []const u8,
     maybe_options_or_start: ?MeasureOptionsOrStartMark,
     maybe_end_mark: ?[]const u8,
-    frame: *Frame,
+    exec: *const Execution,
 ) !*Measure {
     if (maybe_options_or_start) |options_or_start| switch (options_or_start) {
         .measure_options => |options| {
@@ -119,11 +143,10 @@ pub fn measure(
                 start_timestamp,
                 end_timestamp,
                 options.duration,
-                frame,
+                exec,
             );
-            try self._entries.append(frame.arena, m._proto);
-            // Notify about the change.
-            try frame.notifyPerformanceObservers(m._proto);
+            try self._entries.append(exec.arena, m._proto);
+            try self.notifyObservers(m._proto, exec);
             return m;
         },
         .start_mark => |start_mark| {
@@ -144,19 +167,17 @@ pub fn measure(
                 start_timestamp,
                 end_timestamp,
                 null,
-                frame,
+                exec,
             );
-            try self._entries.append(frame.arena, m._proto);
-            // Notify about the change.
-            try frame.notifyPerformanceObservers(m._proto);
+            try self._entries.append(exec.arena, m._proto);
+            try self.notifyObservers(m._proto, exec);
             return m;
         },
     };
 
-    const m = try Measure.init(name, null, 0.0, self.now(), null, frame);
-    try self._entries.append(frame.arena, m._proto);
-    // Notify about the change.
-    try frame.notifyPerformanceObservers(m._proto);
+    const m = try Measure.init(name, null, 0.0, self.now(), null, exec);
+    try self._entries.append(exec.arena, m._proto);
+    try self.notifyObservers(m._proto, exec);
     return m;
 }
 
@@ -193,12 +214,12 @@ pub fn getEntries(self: *const Performance) []*Entry {
     return self._entries.items;
 }
 
-pub fn getEntriesByType(self: *const Performance, entry_type: []const u8, frame: *Frame) ![]const *Entry {
-    return filterEntriesByType(frame.call_arena, self._entries.items, entry_type);
+pub fn getEntriesByType(self: *const Performance, entry_type: []const u8, exec: *const Execution) ![]const *Entry {
+    return filterEntriesByType(exec.call_arena, self._entries.items, entry_type);
 }
 
-pub fn getEntriesByName(self: *const Performance, name: []const u8, entry_type: ?[]const u8, frame: *Frame) ![]const *Entry {
-    return filterEntriesByName(frame.call_arena, self._entries.items, name, entry_type);
+pub fn getEntriesByName(self: *const Performance, name: []const u8, entry_type: ?[]const u8, exec: *const Execution) ![]const *Entry {
+    return filterEntriesByName(exec.call_arena, self._entries.items, name, entry_type);
 }
 
 // Also used by PerformanceObserver
@@ -270,6 +291,59 @@ fn getMarkTime(self: *const Performance, mark_name: []const u8) !f64 {
     }
 
     return error.SyntaxError; // Mark not found
+}
+
+pub fn registerObserver(self: *Performance, observer: *PerformanceObserver, exec: *const Execution) !void {
+    return self._observers.append(exec.arena, observer);
+}
+
+pub fn unregisterObserver(self: *Performance, observer: *PerformanceObserver) void {
+    for (self._observers.items, 0..) |o, i| {
+        if (o == observer) {
+            _ = self._observers.swapRemove(i);
+            return;
+        }
+    }
+}
+
+/// Append the entry to every interested observer's queue and schedule async
+/// delivery. Does NOT fire the callbacks synchronously — that happens later
+/// via the scheduled task.
+pub fn notifyObservers(self: *Performance, entry: *Entry, exec: *const Execution) !void {
+    for (self._observers.items) |observer| {
+        if (observer.interested(entry)) {
+            observer._entries.append(exec.arena, entry) catch |err| {
+                lp.log.err(.frame, "Performance.notifyObservers", .{ .err = err });
+            };
+        }
+    }
+
+    try self.scheduleDelivery(exec);
+}
+
+pub fn scheduleDelivery(self: *Performance, exec: *const Execution) !void {
+    if (self._delivery_scheduled) {
+        return;
+    }
+    self._delivery_scheduled = true;
+
+    return exec._scheduler.add(
+        self,
+        struct {
+            fn run(_self: *anyopaque) anyerror!?u32 {
+                const perf: *Performance = @ptrCast(@alignCast(_self));
+                perf._delivery_scheduled = false;
+                for (perf._observers.items) |observer| {
+                    if (observer.hasRecords()) {
+                        try observer.dispatch();
+                    }
+                }
+                return null;
+            }
+        }.run,
+        0,
+        .{ .name = "Performance.deliverObservers" },
+    );
 }
 
 pub const JsApi = struct {
@@ -380,23 +454,20 @@ pub const Mark = struct {
         startTime: ?f64 = null,
     };
 
-    pub fn init(name: []const u8, _opts: ?Options, frame: *Frame) !*Mark {
-        const opts = _opts orelse Options{};
-        const start_time = opts.startTime orelse frame.window._performance.now();
-
+    pub fn init(name: []const u8, maybe_detail: ?js.Value, start_time: f64, exec: *const Execution) !*Mark {
         if (start_time < 0.0) {
             return error.TypeError;
         }
 
-        const detail = if (opts.detail) |d| try d.persist() else null;
-        const m = try frame._factory.create(Mark{
+        const detail = if (maybe_detail) |d| try d.persist() else null;
+        const m = try exec._factory.create(Mark{
             ._proto = undefined,
             ._detail = detail,
         });
 
-        const entry = try frame._factory.create(Entry{
+        const entry = try exec._factory.create(Entry{
             ._start_time = start_time,
-            ._name = try frame.dupeString(name),
+            ._name = try exec.dupeString(name),
             ._type = .{ .mark = m },
         });
         m._proto = entry;
@@ -441,7 +512,7 @@ pub const Measure = struct {
         start_timestamp: f64,
         end_timestamp: f64,
         maybe_duration: ?f64,
-        frame: *Frame,
+        exec: *const Execution,
     ) !*Measure {
         const duration = maybe_duration orelse (end_timestamp - start_timestamp);
         if (duration < 0.0) {
@@ -449,15 +520,15 @@ pub const Measure = struct {
         }
 
         const detail = if (maybe_detail) |d| try d.persist() else null;
-        const m = try frame._factory.create(Measure{
+        const m = try exec._factory.create(Measure{
             ._proto = undefined,
             ._detail = detail,
         });
 
-        const entry = try frame._factory.create(Entry{
+        const entry = try exec._factory.create(Entry{
             ._start_time = start_timestamp,
             ._duration = duration,
-            ._name = try frame.dupeString(name),
+            ._name = try exec.dupeString(name),
             ._type = .{ .measure = m },
         });
         m._proto = entry;

--- a/src/browser/webapi/PerformanceObserver.zig
+++ b/src/browser/webapi/PerformanceObserver.zig
@@ -20,10 +20,10 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
-const Frame = @import("../Frame.zig");
 const Performance = @import("Performance.zig");
 
 const log = lp.log;
+const Allocator = std.mem.Allocator;
 const Execution = js.Execution;
 
 pub fn registerTypes() []const type {
@@ -42,16 +42,27 @@ _interests: u16,
 /// Entries this observer hold.
 /// Don't mutate these; other observers may hold pointers to them.
 _entries: std.ArrayList(*Performance.Entry),
+/// The Performance that owns this observer (Window's or Worker's).
+_performance: *Performance,
+/// JS context the observer's callback was created in. Captured at init so
+/// dispatch() can enter the right scope without needing an Execution.
+_js: *js.Context,
+/// Long-lived arena (Frame's or WorkerGlobalScope's) for entry list growth
+/// and takeRecords' returned slice.
+_arena: Allocator,
 
 const DefaultDurationThreshold: f64 = 104;
 
 /// Creates a new PerformanceObserver object with the given observer callback.
-pub fn init(callback: js.Function.Global, frame: *Frame) !*PerformanceObserver {
-    return frame._factory.create(PerformanceObserver{
+pub fn init(callback: js.Function.Global, exec: *const Execution) !*PerformanceObserver {
+    return exec._factory.create(PerformanceObserver{
         ._callback = callback,
         ._duration_threshold = DefaultDurationThreshold,
         ._interests = 0,
         ._entries = .{},
+        ._performance = exec.performance(),
+        ._js = exec.context,
+        ._arena = exec.arena,
     });
 }
 
@@ -63,11 +74,7 @@ const ObserveOptions = struct {
 };
 
 /// TODO: Support `buffered` option.
-pub fn observe(
-    self: *PerformanceObserver,
-    maybe_options: ?ObserveOptions,
-    frame: *Frame,
-) !void {
+pub fn observe(self: *PerformanceObserver, maybe_options: ?ObserveOptions, exec: *const Execution) !void {
     const options: ObserveOptions = maybe_options orelse .{};
     // Update threshold.
     self._duration_threshold = @max(@floor(options.durationThreshold / 8) * 8, 16);
@@ -107,10 +114,10 @@ pub fn observe(
         return;
     }
 
-    // If we had no interests before, it means Page is not aware of
-    // this observer.
+    // If we had no interests before, it means the Performance is not aware
+    // of this observer.
     if (self._interests == 0) {
-        try frame.registerPerformanceObserver(self);
+        try self._performance.registerObserver(self, exec);
     }
 
     // Update interests.
@@ -120,19 +127,19 @@ pub fn observe(
     // Per spec, buffered is only valid with the type option, not entryTypes.
     // Delivery is async via a queued task, not synchronous.
     if (options.buffered and options.type != null and !self.hasRecords()) {
-        for (frame.window._performance._entries.items) |entry| {
+        for (self._performance._entries.items) |entry| {
             if (self.interested(entry)) {
-                try self._entries.append(frame.arena, entry);
+                try self._entries.append(self._arena, entry);
             }
         }
         if (self.hasRecords()) {
-            try frame.schedulePerformanceObserverDelivery();
+            try self._performance.scheduleDelivery(exec);
         }
     }
 }
 
-pub fn disconnect(self: *PerformanceObserver, frame: *Frame) void {
-    frame.unregisterPerformanceObserver(self);
+pub fn disconnect(self: *PerformanceObserver) void {
+    self._performance.unregisterObserver(self);
     // Reset observer.
     self._duration_threshold = DefaultDurationThreshold;
     self._interests = 0;
@@ -141,10 +148,10 @@ pub fn disconnect(self: *PerformanceObserver, frame: *Frame) void {
 
 /// Returns the current list of PerformanceEntry objects
 /// stored in the performance observer, emptying it out.
-pub fn takeRecords(self: *PerformanceObserver, frame: *Frame) ![]*Performance.Entry {
-    // Use frame.arena instead of call_arena because this slice is wrapped in EntryList
-    // and may be accessed later.
-    const records = try frame.arena.dupe(*Performance.Entry, self._entries.items);
+pub fn takeRecords(self: *PerformanceObserver) ![]*Performance.Entry {
+    // Use the long-lived arena instead of call_arena because this slice is
+    // wrapped in EntryList and may be accessed later.
+    const records = try self._arena.dupe(*Performance.Entry, self._entries.items);
     self._entries.clearRetainingCapacity();
     return records;
 }
@@ -167,11 +174,11 @@ pub inline fn hasRecords(self: *const PerformanceObserver) bool {
 }
 
 /// Runs the PerformanceObserver's callback with records; emptying it out.
-pub fn dispatch(self: *PerformanceObserver, frame: *Frame) !void {
-    const records = try self.takeRecords(frame);
+pub fn dispatch(self: *PerformanceObserver) !void {
+    const records = try self.takeRecords();
 
     var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
+    self._js.localScope(&ls);
     defer ls.deinit();
 
     var caught: js.TryCatch.Caught = undefined;

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -39,6 +39,7 @@ const Crypto = @import("Crypto.zig");
 const Console = @import("Console.zig");
 const Timers = @import("Timers.zig");
 const EventTarget = @import("EventTarget.zig");
+const Performance = @import("Performance.zig");
 const WorkerLocation = @import("WorkerLocation.zig");
 const MessageEvent = @import("event/MessageEvent.zig");
 const ErrorEvent = @import("event/ErrorEvent.zig");
@@ -95,6 +96,7 @@ _closed: bool = false,
 _proto: *EventTarget,
 _console: Console = .init,
 _crypto: Crypto = .init,
+_performance: Performance,
 _on_error: ?JS.Function.Global = null,
 _on_rejection_handled: ?JS.Function.Global = null,
 _on_unhandled_rejection: ?JS.Function.Global = null,
@@ -138,6 +140,7 @@ pub fn init(worker: *Worker, url: [:0]const u8) !*WorkerGlobalScope {
         ._event_manager = .init(arena),
         ._script_manager = undefined,
         ._location = .{ ._url = url },
+        ._performance = .init(),
     });
     errdefer factory.destroy(self);
 
@@ -246,6 +249,10 @@ pub fn getConsole(self: *WorkerGlobalScope) *Console {
 
 pub fn getCrypto(self: *WorkerGlobalScope) *Crypto {
     return &self._crypto;
+}
+
+pub fn performance(self: *WorkerGlobalScope) *Performance {
+    return &self._performance;
 }
 
 pub fn getLocation(self: *WorkerGlobalScope) *WorkerLocation {
@@ -628,6 +635,15 @@ pub const JsApi = struct {
     pub const self = bridge.accessor(WorkerGlobalScope.getSelf, null, .{});
     pub const console = bridge.accessor(WorkerGlobalScope.getConsole, null, .{});
     pub const crypto = bridge.accessor(WorkerGlobalScope.getCrypto, null, .{});
+    pub const performance = bridge.accessor(struct {
+        // Unnecessary, But, our WebAPI getters are ALWAYS `fn getPerformance()...`.
+        // But for performance, we _need_ to have fn performance() *Performance to
+        // have parity with frame. So rather than having method called `performance`
+        // and one called `getPerformance`, we create this wrapper here.
+        pub fn wrap(wgs: *WorkerGlobalScope) *Performance {
+            return wgs.performance();
+        }
+    }.wrap, null, .{});
     pub const location = bridge.accessor(WorkerGlobalScope.getLocation, null, .{});
 
     pub const onerror = bridge.accessor(WorkerGlobalScope.getOnError, WorkerGlobalScope.setOnError, .{});


### PR DESCRIPTION
This includes EventCounts and PerformanceObserver. This change is like any other WebAPI on Worker change (e.g. Frame -> js.Execution), but we need the performance observer hooks in addition to that. Thankfully, every Frame/Worker only has 1 Performance instance, so we can move the observers and delivery from the Frame to the Performance instance so that both Frame and WGS gain the behavior.