### PR TITLE
docs(contributing): document prebuilt V8 to skip the source build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,26 @@ Lightpanda accepts pull requests through GitHub.
 
 See [AGENTS.md](AGENTS.md) for the full set of test, formatting, and code conventions (test filters, the leak-detection invariant, `@import` alias case, struct-init inference).
 
+### Skip the V8 source build
+
+`make build` and `make test` need V8. Without a prebuilt library, the build
+compiles V8 from source, which takes several minutes. To skip that, reuse the
+same prebuilt archive CI uses:
+
+1. From the [`zig-v8-fork`
+   releases](https://github.com/lightpanda-io/zig-v8-fork/releases), download the
+   asset matching the `v8` and `zig-v8` versions pinned in
+   [`.github/actions/install/action.yml`](.github/actions/install/action.yml):
+   `libc_v8_<v8>_<os>_<arch>.a`.
+2. Point the build at it via `ZIGFLAGS`, which the Makefile forwards to every
+   `zig build`:
+
+   ```sh
+   ZIGFLAGS=-Dprebuilt_v8_path=/abs/path/to/libc_v8_<v8>_<os>_<arch>.a make test
+   ```
+
+   Export `ZIGFLAGS` in your shell to apply it to every build.
+
 ## Before opening a PR
 
 - [ ] Tests pass (`make test`).


### PR DESCRIPTION
CONTRIBUTING's Development section points contributors at `make test` / `make build`, but doesn't mention that on a fresh checkout these compile V8 from source (several minutes) when no prebuilt library is present. CI already avoids this by downloading a prebuilt archive from the `zig-v8-fork` releases, so this adds a short note showing how to do the same locally via `ZIGFLAGS=-Dprebuilt_v8_path=...`, the flag the Makefile already forwards.
