### PR TITLE
Add `make download-v8` to fetch prebuilt V8 and skip the source build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.zig-cache/
 /.lp-cache/
-/v8/
 /zig-pkg/
 zig-out
 lightpanda.id

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.zig-cache/
 /.lp-cache/
+/v8/
 /zig-pkg/
 zig-out
 lightpanda.id

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ Lightpanda accepts pull requests through GitHub.
 
 See [AGENTS.md](AGENTS.md) for the full set of test, formatting, and code conventions (test filters, the leak-detection invariant, `@import` alias case, struct-init inference).
 
+### Skip the V8 source build
+
+By default the build compiles V8 from source, which takes several minutes. Run
+`make download-v8` once to fetch the matching prebuilt archive from the
+[`zig-v8-fork`](https://github.com/lightpanda-io/zig-v8-fork/releases) releases
+instead; later `make build` / `make test` pick it up automatically.
+
 ## Before opening a PR
 
 - [ ] Tests pass (`make test`).

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,12 @@ V8_VERSION := $(shell awk -F\' '/^  v8:/{f=1} f&&/default:/{print $$2; exit}' $(
 ZIG_V8_TAG := $(shell awk -F\' '/^  zig-v8:/{f=1} f&&/default:/{print $$2; exit}' $(V8_ACTION))
 V8_ARCHIVE := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).a
 V8_CACHE   := .lp-cache/prebuilt-v8/$(V8_ARCHIVE)
-V8_LINK    := v8/libc_v8.a
 
-# If the prebuilt archive is in place and the caller hasn't set ZIGFLAGS, link
-# against it (the same flag CI passes) rather than building V8 from source.
+# If the prebuilt archive is in place and the caller hasn't set ZIGFLAGS, point
+# the build at it rather than building V8 from source.
 ifeq ($(strip $(ZIGFLAGS)),)
-  ifneq ($(wildcard $(V8_LINK)),)
-    ZIGFLAGS := -Dprebuilt_v8_path=$(V8_LINK)
+  ifneq ($(wildcard $(V8_CACHE)),)
+    ZIGFLAGS := -Dprebuilt_v8_path=$(V8_CACHE)
   endif
 endif
 
@@ -77,14 +76,13 @@ help:
 
 ## Download the prebuilt V8 archive (skips the 10+ min source build)
 download-v8:
-	@mkdir -p $(dir $(V8_CACHE)) $(dir $(V8_LINK))
+	@mkdir -p $(dir $(V8_CACHE))
 	@test -f $(V8_CACHE) || ( \
 		printf "\033[36mDownloading prebuilt V8 $(V8_VERSION) ($(ZIG_V8_TAG))...\033[0m\n"; \
 		curl -fL --progress-bar -o $(V8_CACHE) \
 			https://github.com/lightpanda-io/zig-v8-fork/releases/download/$(ZIG_V8_TAG)/$(V8_ARCHIVE) \
 		|| (rm -f $(V8_CACHE); printf "\033[33mDownload ERROR\033[0m\n"; exit 1) )
-	@ln -sf $(abspath $(V8_CACHE)) $(V8_LINK)
-	@printf "\033[33mV8 ready: %s -> %s\033[0m\n" "$(V8_LINK)" "$(V8_CACHE)"
+	@printf "\033[33mV8 ready: %s\033[0m\n" "$(V8_CACHE)"
 
 ## Build v8 snapshot
 build-v8-snapshot:
@@ -130,7 +128,7 @@ end2end:
 	@test -d ../demo
 	cd ../demo && go run runner/main.go
 
-## Remove build artifacts (keeps v8/ and zig-pkg/ — slow to re-fetch)
+## Remove build artifacts (keeps .lp-cache/ and zig-pkg/ — slow to re-fetch)
 clean:
 	rm -rf zig-out .zig-cache src/snapshot.bin
 	cd src/html5ever && cargo clean

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,27 @@ else
 endif
 
 
+# Prebuilt V8
+# -----------
+# Building V8 from source takes 10+ minutes. `make download-v8` fetches the
+# matching prebuilt archive from the zig-v8-fork releases instead. The versions
+# are read from the install action so they can't drift from CI.
+V8_ACTION := .github/actions/install/action.yml
+V8_VERSION := $(shell awk -F\' '/^  v8:/{f=1} f&&/default:/{print $$2; exit}' $(V8_ACTION))
+ZIG_V8_TAG := $(shell awk -F\' '/^  zig-v8:/{f=1} f&&/default:/{print $$2; exit}' $(V8_ACTION))
+V8_ARCHIVE := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).a
+V8_CACHE   := .lp-cache/prebuilt-v8/$(V8_ARCHIVE)
+V8_LINK    := v8/libc_v8.a
+
+# If the prebuilt archive is in place and the caller hasn't set ZIGFLAGS, link
+# against it (the same flag CI passes) rather than building V8 from source.
+ifeq ($(strip $(ZIGFLAGS)),)
+  ifneq ($(wildcard $(V8_LINK)),)
+    ZIGFLAGS := -Dprebuilt_v8_path=$(V8_LINK)
+  endif
+endif
+
+
 # Infos
 # -----
 .PHONY: help
@@ -52,7 +73,18 @@ help:
 
 # $(ZIG) commands
 # ------------
-.PHONY: build build-v8-snapshot build-dev run run-release test bench data end2end clean
+.PHONY: build build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
+
+## Download the prebuilt V8 archive (skips the 10+ min source build)
+download-v8:
+	@mkdir -p $(dir $(V8_CACHE)) $(dir $(V8_LINK))
+	@test -f $(V8_CACHE) || ( \
+		printf "\033[36mDownloading prebuilt V8 $(V8_VERSION) ($(ZIG_V8_TAG))...\033[0m\n"; \
+		curl -fL --progress-bar -o $(V8_CACHE) \
+			https://github.com/lightpanda-io/zig-v8-fork/releases/download/$(ZIG_V8_TAG)/$(V8_ARCHIVE) \
+		|| (rm -f $(V8_CACHE); printf "\033[33mDownload ERROR\033[0m\n"; exit 1) )
+	@ln -sf $(abspath $(V8_CACHE)) $(V8_LINK)
+	@printf "\033[33mV8 ready: %s -> %s\033[0m\n" "$(V8_LINK)" "$(V8_CACHE)"
 
 ## Build v8 snapshot
 build-v8-snapshot:


### PR DESCRIPTION
Building V8 from source on a fresh checkout takes 10+ minutes. CI avoids this by downloading a prebuilt archive from the `zig-v8-fork` releases and passing `-Dprebuilt_v8_path` (see `.github/actions/install/action.yml` and `.github/workflows/zig-test.yml`). This brings the same shortcut to local builds:

- `make download-v8` fetches the archive matching the `v8` / `zig-v8` versions (read straight from `action.yml`, so they can't drift from CI) and symlinks it to `v8/libc_v8.a`, the same path CI uses.
- When `v8/libc_v8.a` exists and the caller hasn't set `ZIGFLAGS`, the Makefile links against it instead of building V8 from source. So after one `make download-v8`, plain `make build` / `make test` skip the source build with no extra flags.
- A short CONTRIBUTING note points contributors at the target.

Note the V8 dependency has no default lookup: it builds from source unless `-Dprebuilt_v8_path` is passed. That's why the Makefile sets the flag rather than relying on the symlink alone.

Verified on macOS arm64: `make download-v8` creates the symlink, and `make build-dev` with `ZIGFLAGS` unset builds against the prebuilt archive without a source rebuild. `v8/` is added to `.gitignore`.

Supersedes #2516, which documented the manual path on its own.
