### PR TITLE
telemetry: document env var, add --no-telemetry flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,12 @@ Add to your MCP configuration:
 A skill is available in [lightpanda-io/agent-skill](https://github.com/lightpanda-io/agent-skill).
 
 ### Telemetry
-By default, Lightpanda collects and sends usage telemetry. This can be disabled by setting an environment variable `LIGHTPANDA_DISABLE_TELEMETRY=true`. You can read Lightpanda's privacy policy at: [https://lightpanda.io/privacy-policy](https://lightpanda.io/privacy-policy).
+By default, Lightpanda collects and sends anonymous usage telemetry and crash reports. You can opt out in either of two equivalent ways:
+
+- Pass `--no-telemetry` to any command (`serve`, `fetch`, `mcp`).
+- Set the environment variable `LIGHTPANDA_DISABLE_TELEMETRY` to any value (e.g. `LIGHTPANDA_DISABLE_TELEMETRY=1`). The variable only needs to be present; its value is not inspected.
+
+Telemetry is also always disabled in debug builds. You can read Lightpanda's privacy policy at: [https://lightpanda.io/privacy-policy](https://lightpanda.io/privacy-policy).
 
 ## Status
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -22,7 +22,8 @@ const lp = @import("lightpanda");
 const Config = @import("Config.zig");
 const Snapshot = @import("browser/js/Snapshot.zig");
 const Platform = @import("browser/js/Platform.zig");
-const Telemetry = @import("telemetry/telemetry.zig").Telemetry;
+const telemetry_mod = @import("telemetry/telemetry.zig");
+const Telemetry = telemetry_mod.Telemetry;
 
 const Storage = @import("storage/Storage.zig");
 const Network = @import("network/Network.zig");
@@ -71,6 +72,10 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
     errdefer app.network.deinit();
 
     app.app_dir_path = getAndMakeAppDir(allocator);
+
+    // Propagate `--no-telemetry` so it also suppresses crash reports,
+    // which call telemetry.isDisabled() outside the App lifecycle.
+    telemetry_mod.setDisabledByCli(config.noTelemetry());
 
     app.telemetry = try Telemetry.init(app, config.mode);
     errdefer app.telemetry.deinit(allocator);

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -101,6 +101,7 @@ const CommonOptions = .{
     .{ .name = "disable_subframes", .type = bool },
     .{ .name = "disable_workers", .type = bool },
     .{ .name = "enable_external_stylesheets", .type = bool },
+    .{ .name = "no_telemetry", .type = bool },
 };
 
 fn dumpValidator(_: Allocator, args: *std.process.ArgIterator) !?DumpFormat {
@@ -260,6 +261,16 @@ pub fn enableExternalStylesheets(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp => |opts| opts.enable_external_stylesheets,
         else => unreachable,
+    };
+}
+
+/// True when telemetry has been disabled via `--no-telemetry`.
+/// The `LIGHTPANDA_DISABLE_TELEMETRY` environment variable is handled
+/// separately inside `telemetry.isDisabled()`.
+pub fn noTelemetry(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp => |opts| opts.no_telemetry,
+        .help, .version => false,
     };
 }
 

--- a/src/help.zon
+++ b/src/help.zon
@@ -227,5 +227,11 @@
     \\  --storage-sqlite-path <PATH>
     \\          Path to the SQLite database file for persistent storage.
     \\          Use ":memory:" for in-memory storage.
+    \\  --no-telemetry
+    \\          Disable anonymous usage telemetry and crash reporting.
+    \\          Equivalent to setting the LIGHTPANDA_DISABLE_TELEMETRY
+    \\          environment variable (any value, including empty).
+    \\          See https://lightpanda.io/privacy-policy for details.
+    \\          Defaults to false.
     ,
 }

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -10,8 +10,22 @@ const log = lp.log;
 const IID_FILE = "iid";
 const Allocator = std.mem.Allocator;
 
+// Set from main() once CLI args are parsed. The crash handler and
+// `Telemetry.init` both consult this in addition to the environment
+// variable, so `--no-telemetry` opts out everywhere telemetry would
+// otherwise fire (including crash reporting).
+var cli_disabled: bool = false;
+
+pub fn setDisabledByCli(value: bool) void {
+    cli_disabled = value;
+}
+
 pub fn isDisabled() bool {
     if (builtin.mode == .Debug or builtin.is_test) {
+        return true;
+    }
+
+    if (cli_disabled) {
         return true;
     }
 
@@ -120,12 +134,16 @@ extern fn unsetenv(name: [*:0]u8) c_int;
 
 const testing = @import("../testing.zig");
 test "telemetry: always disabled in debug builds" {
-    // Must be disabled regardless of environment variable.
+    // Must be disabled regardless of environment variable or CLI flag.
     _ = unsetenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"));
     try testing.expectEqual(true, isDisabled());
 
     _ = setenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"), @constCast(""), 0);
     defer _ = unsetenv(@constCast("LIGHTPANDA_DISABLE_TELEMETRY"));
+    try testing.expectEqual(true, isDisabled());
+
+    setDisabledByCli(true);
+    defer setDisabledByCli(false);
     try testing.expectEqual(true, isDisabled());
 
     const FailingProvider = struct {


### PR DESCRIPTION
## Problem

`LIGHTPANDA_DISABLE_TELEMETRY` already opts out of telemetry, but:

- It is missing from `lightpanda --help` (any subcommand).
- The README only mentions it in one sentence and shows it as `=true`, which suggests the value matters — it does not. The current implementation uses `std.process.hasEnvVarConstant`, so the variable just needs to be present (any value, including empty).
- There is no CLI equivalent, so users who do not want to set environment variables (CI configs, one-off invocations, MCP launchers) have no way to opt out.

## Changes

- **Add `--no-telemetry` as a common option** for `serve`, `fetch`, and `mcp`. Wired into the existing `CommonOptions` block in `Config.zig` so it picks up the standard `--kebab-case` / `--snake_case` handling and unknown-flag validation for free.
- **Make the crash reporter honor the flag.** `crash_handler.zig` calls `telemetry.isDisabled()` from a panic context where the `App`/`Config` are not reachable, so I added a module-level `cli_disabled` flag + `setDisabledByCli` setter that `App.init` populates from `config.noTelemetry()` before `Telemetry.init` runs. This guarantees `--no-telemetry` suppresses crash reports too.
- **Document both opt-outs.** `src/help.zon` now lists `--no-telemetry` under common options and references the env var. The README clarifies that the env var only needs to be present (no specific value required) and that debug builds always disable telemetry.
- **Extend the existing telemetry test** to assert that the CLI override path also short-circuits `isDisabled()`.

## Verification

```
zig fmt --check ./*.zig ./**/*.zig    # clean
make test                              # 720 of 720 tests passed

./zig-out/bin/lightpanda help fetch | grep -A4 no-telemetry
  --no-telemetry
          Disable anonymous usage telemetry and crash reporting.
          Equivalent to setting the LIGHTPANDA_DISABLE_TELEMETRY
          environment variable (any value, including empty).
          See https://lightpanda.io/privacy-policy for details.

./zig-out/bin/lightpanda fetch http://example.com --no-telemetryX
FATAL app : unknown argument
      mode = fetch
      arg = --no-telemetryX
```

## Notes

- No existing behavior changes when neither the flag nor env var is set.
- The semantics of `LIGHTPANDA_DISABLE_TELEMETRY` are unchanged; only its documentation is updated to match the actual implementation.
- Debug/test builds remain hard-disabled, matching the prior invariant covered by `telemetry: always disabled in debug builds`.