### PR TITLE
Replace active page on synthetic root navigation (about:blank, blob:)

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -488,16 +488,14 @@ fn processRootQueuedNavigation(self: *Session) !void {
     // immediate-swap path for them.
     const is_synthetic = qn.is_about_blank or std.mem.startsWith(u8, qn.url, "blob:");
 
-    if (is_synthetic) {
-        defer self.arena_pool.release(qn.arena);
-        return self.replaceRootImmediate(current_frame._frame_id, qn.url, qn.opts);
-    }
-
     // The qn arena is consumed here regardless of success — frame.navigate
     // dupes the URL into the page's own arena, so we can release the qn
     // arena as soon as navigate returns.
     defer self.arena_pool.release(qn.arena);
 
+    if (is_synthetic) {
+        return self.replaceRootImmediate(current_frame._frame_id, qn.url, qn.opts);
+    }
     return self.initiateRootNavigation(current_frame._frame_id, qn.url, qn.opts);
 }
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -489,7 +489,8 @@ fn processRootQueuedNavigation(self: *Session) !void {
     const is_synthetic = qn.is_about_blank or std.mem.startsWith(u8, qn.url, "blob:");
 
     if (is_synthetic) {
-        return self.replaceRootImmediate(current_frame._frame_id, qn);
+        defer self.arena_pool.release(qn.arena);
+        return self.replaceRootImmediate(current_frame._frame_id, qn.url, qn.opts);
     }
 
     // The qn arena is consumed here regardless of success — frame.navigate
@@ -500,18 +501,18 @@ fn processRootQueuedNavigation(self: *Session) !void {
     return self.initiateRootNavigation(current_frame._frame_id, qn.url, qn.opts);
 }
 
-// Legacy immediate-swap path: tear down the active page and create a new one
-// in its place before issuing the navigation. Used for synthetic navigations
-// (about:blank, blob:) where there is no in-flight HTTP and therefore no
-// "pending" window to span.
-fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !void {
-    defer self.arena_pool.release(qn.arena);
-
+// Immediate-swap path for synthetic navigations (about:blank, blob:): there is
+// no in-flight HTTP and therefore no "pending" window to span — and no
+// frameHeaderDoneCallback to commit a pending Page. Tear down the active page
+// and create a new one in its place, then navigate it. Reached from both the
+// queued-navigation path (processRootQueuedNavigation) and the CDP entry point
+// (initiateRootNavigation); each caller owns any arena tied to `url`/`opts`.
+fn replaceRootImmediate(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
     self.tearDownActivePage();
     const new_frame = try self.installNewActivePage(frame_id);
 
-    new_frame.navigate(qn.url, qn.opts) catch |err| {
-        log.err(.browser, "queued navigation error", .{ .err = err });
+    new_frame.navigate(url, opts) catch |err| {
+        log.err(.browser, "synthetic navigation error", .{ .err = err, .url = url });
         return err;
     };
 }
@@ -523,6 +524,14 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, qn: *QueuedNavigation) !v
 // until commitPendingPage swaps the pointer when response headers arrive.
 pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
     self.discardPendingPage();
+
+    // Synthetic navigations (about:blank, blob:) have no HTTP round-trip and
+    // therefore no frameHeaderDoneCallback to commit a pending Page. Swap the
+    // active Page immediately instead of allocating a pending one that would
+    // never be promoted, leaving the previous document in place (issue #2363).
+    if (std.mem.eql(u8, "about:blank", url) or std.mem.startsWith(u8, url, "blob:")) {
+        return self.replaceRootImmediate(frame_id, url, opts);
+    }
 
     const page = try self.allocatePage(frame_id);
     errdefer self.destroyPage(page);

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -1309,6 +1309,42 @@ test "cdp.frame: navigate inherits original fragment across redirect" {
     }
 }
 
+test "cdp.frame: navigate to about:blank replaces a non-blank document" {
+    // Regression test for #2363. Page.navigate("about:blank") issued against a
+    // tab that already holds a real document must replace the active document
+    // with a fresh about:blank page — not leave the previous page in place.
+    // A synthetic (no-HTTP) navigation has no response-headers callback to
+    // commit a pending Page, so it must swap the active Page immediately.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-AB", .url = "hi.html", .target_id = "TID-AB-0000000".* });
+
+    // Precondition: the tab is on a non-blank document.
+    {
+        const frame = bc.session.currentFrame() orelse unreachable;
+        try testing.expect(std.mem.endsWith(u8, frame.url, "/hi.html"));
+    }
+
+    try ctx.processMessage(.{ .id = 70, .method = "Page.navigate", .params = .{ .url = "about:blank" } });
+    {
+        var runner = try bc.session.runner(.{});
+        try runner.wait(.{ .ms = 2000 });
+    }
+
+    // The active frame must now point at the replaced about:blank document.
+    const frame = bc.session.currentFrame() orelse unreachable;
+    try testing.expectEqualSlices(u8, "about:blank", frame.url);
+
+    // ...and the active page's JS context must agree — the exact symptom in the
+    // bug report was window.location.href staying on the previous URL.
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const v = try ls.local.exec("window.location.href === 'about:blank'", null);
+    try testing.expect(v.toBool());
+}
+
 test "cdp.frame: anchor click sends Referer matching the originating page" {
     // HTML Living Standard "navigate" algorithm + Fetch §4.5 "request's referrer":
     // when a navigation is initiated by a hyperlink click (or form submit, or


### PR DESCRIPTION
## What this fixes

`Page.navigate("about:blank")` against a tab that already holds a real document fired the full navigation event sequence but left the old document in place. After the events settled, `window.location.href`, `document.URL`, `document.body.innerHTML`, and `Page.getFrameTree`'s main-frame URL all still reported the previous page. Plain http→http navigation worked; only synthetic destinations (`about:blank`, `blob:`) broke. The regression came in with the pending-page model (#2297).

## Root cause

The CDP `Page.navigate` handler routes through `Session.initiateRootNavigation` (`src/browser/Session.zig`), which always allocates a *pending* Page. A pending Page only becomes active via `frameHeaderDoneCallback` (`src/browser/Frame.zig:1017`), which runs when HTTP response headers arrive. Synthetic navigations send no HTTP request, so `commitPendingPage` never ran: the pending Page was created, navigated, then orphaned (discarded on the next navigation), and the previous page stayed active.

The immediate-swap path for synthetic navigations (`replaceRootImmediate`) already existed, but it was wired only into the JS-initiated queued path (`processRootQueuedNavigation`), not the CDP entry point.

## What this PR changes

`initiateRootNavigation` now routes synthetic URLs to the immediate-swap path instead of allocating a pending Page:

```zig
if (std.mem.eql(u8, "about:blank", url) or std.mem.startsWith(u8, url, "blob:")) {
    return self.replaceRootImmediate(frame_id, url, opts);
}
```

`replaceRootImmediate` now takes `(frame_id, url, opts)` instead of a `*QueuedNavigation`, so the queued path and the CDP path share it (arena ownership moves to each caller). Putting the guard in `initiateRootNavigation` also covers `Page.reload` and `Page.navigateToHistoryEntry` when the target URL is synthetic.

## Where to focus review

- **`url`/`opts` lifetime across `tearDownActivePage`.** On the CDP path, `url` is the `encoded_url` allocated in the old page's `call_arena`. The swap is safe: `tearDownActivePage` only queues the old page on `_queued_destroy`, and nothing drains that queue until `processQueuedDestroyed` runs, which happens after `replaceRootImmediate` returns from its synchronous `navigate`. The old arena stays alive for the whole call. History entries are covered too: `Navigation.pushEntry` copies the URL into the session arena (`Navigation.zig:182`), and `Page.reload` dupes its URL into `cmd.arena` before teardown.
- **Arena release moved to the caller.** The queued path now runs `defer self.arena_pool.release(qn.arena)` itself, since `replaceRootImmediate` no longer owns the `qn`. The CDP paths carry no `QueuedNavigation`, so there is nothing to free there.

## Test plan

- [x] New regression test `cdp.frame: navigate to about:blank replaces a non-blank document`: confirmed it fails before the fix (`frame.url` stuck on `/hi.html`) and passes after. It checks both the active frame URL and the page's JS context (`window.location.href`).
- [x] `make test`: 721/721 pass.
- [x] `zig fmt --check`: clean.
- [x] The reproducer from the issue, run against a locally built binary: was `FAIL`, now `PASS` (`{"url":"about:blank","body":""}`).

Fixes #2363
