### PR TITLE
tools: map waitForSelector timeout to NodeNotFound

### DIFF
--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -961,9 +961,15 @@ fn execWaitForSelector(arena: std.mem.Allocator, session: *lp.Session, registry:
 
     const timeout_ms = args.timeout orelse 5000;
 
-    const node = lp.actions.waitForSelector(args.selector, timeout_ms, session) catch |err| {
-        if (err == error.InvalidSelector) return ToolError.InvalidParams;
-        return ToolError.InternalError;
+    const node = lp.actions.waitForSelector(args.selector, timeout_ms, session) catch |err| switch (err) {
+        error.InvalidSelector => return ToolError.InvalidParams,
+        // Timeout w/o a match: same outcome as `/hover selector=…` on a missing
+        // node — surface `NodeNotFound` so the LLM sees a consistent signal.
+        error.Timeout => return ToolError.NodeNotFound,
+        else => {
+            log.debug(.browser, "waitForSelector error", .{ .err = @errorName(err) });
+            return ToolError.InternalError;
+        },
     };
 
     const registered = registry.register(node) catch return ToolError.InternalError;

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -886,14 +886,15 @@ test "MCP - waitForSelector: timeout" {
     );
     defer server.deinit();
 
-    // waitForSelector with a short timeout on a non-existent element should error
+    // Missing element after the timeout surfaces as NodeNotFound, matching
+    // the error /hover, /click, etc. produce when their selector misses.
     const msg =
         \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"waitForSelector","arguments":{"selector":"#nonexistent","timeout":100}}}
     ;
     try router.handleMessage(server, testing.arena_allocator, msg);
     try testing.expectJson(.{
         .id = 1,
-        .@"error" = struct {}{},
+        .@"error" = .{ .message = "NodeNotFound" },
     }, out.written());
 }
 


### PR DESCRIPTION
When a selector times out without matching, the outcome is the same as /hover or /click against a missing node. Returning InternalError instead gave inconsistent feedback to the agent.

Map error.Timeout to NodeNotFound and leave the catch-all log + InternalError for genuinely unexpected errors. Tighten the existing MCP - waitForSelector: timeout test to pin the specific error name.

Solves item 3 in #2525  