### PR TITLE
terminal: better error diagnostics

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -256,6 +256,8 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     errdefer self.node_registry.deinit();
     errdefer self.terminal.deinit();
     errdefer self.message_arena.deinit();
+    self.terminal.installLogSink();
+    errdefer self.terminal.uninstallLogSink();
 
     try self.browser.init(app, .{}, null);
     errdefer self.browser.deinit();
@@ -297,6 +299,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
 }
 
 pub fn deinit(self: *Agent) void {
+    self.terminal.uninstallLogSink();
     if (self.recorder) |*r| r.deinit();
     self.terminal.deinit();
     self.message_arena.deinit();

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -610,6 +610,32 @@ pub fn freeLine(line: []const u8) void {
     c.ic_free(@ptrCast(@constCast(line.ptr)));
 }
 
+// Free-function `lp.log.sink` can't capture self; the agent sets this
+// before installing the sink and clears it on teardown.
+var active_for_log: ?*Terminal = null;
+
+pub fn installLogSink(self: *Terminal) void {
+    active_for_log = self;
+    lp.log.sink = logSink;
+}
+
+pub fn uninstallLogSink(self: *Terminal) void {
+    _ = self;
+    lp.log.sink = null;
+    active_for_log = null;
+}
+
+fn logSink(bytes: []const u8) void {
+    if (active_for_log) |t| {
+        // REPL already surfaces the clean `● ...` outcome line
+        if (t.isRepl()) return;
+        if (t.spinner.emitAbove(bytes)) return;
+    }
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
+    _ = std.posix.write(std.posix.STDERR_FILENO, bytes) catch {};
+}
+
 pub fn interactiveTty() bool {
     return std.posix.isatty(std.posix.STDIN_FILENO) and std.posix.isatty(std.posix.STDERR_FILENO);
 }

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -663,9 +663,9 @@ pub fn printAssistant(_: *Terminal, text: []const u8) void {
 const max_result_display_len = 2000;
 
 /// Tool-outcome line shared by REPL slash commands and LLM tool calls.
-/// REPL: green ● on success, red ● on error (`name` is already on the
-/// preceding `[tool: …]` line). Non-REPL gates on `medium+` and prefixes
-/// `[result: name]`; same green/red coloring.
+/// REPL: green ● on success, red ● on error. Non-REPL prefixes `[result:
+/// name]`; success gates on `medium+`, errors bypass the gate so a
+/// failing script still surfaces *why* at the default verbosity.
 pub fn printToolOutcome(self: *Terminal, name: []const u8, text: []const u8, is_error: bool) void {
     if (self.repl_arena) |*a| {
         defer _ = a.reset(.retain_capacity);
@@ -674,7 +674,7 @@ pub fn printToolOutcome(self: *Terminal, name: []const u8, text: []const u8, is_
         _ = std.posix.write(std.posix.STDERR_FILENO, bytes) catch {};
         return;
     }
-    if (!atLeast(self.verbosity, .medium)) return;
+    if (!is_error and !atLeast(self.verbosity, .medium)) return;
     const truncated = text[0..@min(text.len, max_result_display_len)];
     const ellipsis: []const u8 = if (text.len > max_result_display_len) "..." else "";
     const color: []const u8 = if (is_error) ansi.red else ansi.green;

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -198,6 +198,10 @@ _load_state: LoadState = .waiting,
 
 _parse_state: ParseState = .pre,
 
+/// `frameErrorCallback` swallows the failure into a placeholder page;
+/// callers that need to detect it read this.
+_last_navigate_error: ?anyerror = null,
+
 _notified_network_idle: IdleNotification = .init,
 _notified_network_almost_idle: IdleNotification = .init,
 
@@ -522,6 +526,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     lp.assert(self._load_state == .waiting, "frame.renavigate", .{});
     const session = self._session;
     self._load_state = .parsing;
+    self._last_navigate_error = null;
 
     const req_id = self._session.browser.http_client.nextReqId();
     log.info(.frame, "navigate", .{
@@ -1261,6 +1266,7 @@ fn frameDoneCallback(ctx: *anyopaque) !void {
 fn frameErrorCallback(ctx: *anyopaque, err: anyerror) void {
     var self: *Frame = @ptrCast(@alignCast(ctx));
 
+    self._last_navigate_error = err;
     log.err(.frame, "navigate failed", .{ .err = err, .type = self._type, .url = self.url });
 
     // A pending root navigation that failed before commit: discard the

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -507,6 +507,8 @@ pub fn call(
     arguments: ?std.json.Value,
 ) ToolError!ToolResult {
     const tool = std.meta.stringToEnum(Tool, tool_name) orelse return ToolError.InvalidParams;
+    if (diagnoseArgs(arena, arguments)) |msg|
+        return .{ .text = msg, .is_error = true };
     const substituted = try substituteStringArgs(arena, tool, arguments);
 
     return switch (tool) {
@@ -1212,6 +1214,31 @@ fn resolveBySelector(session: *lp.Session, selector: []const u8) ToolError!NodeA
 }
 
 pub const ParseArgsError = error{ OutOfMemory, InvalidParams };
+
+/// Surface field/value context for known typed args — `std.json`'s parse
+/// errors only carry the tag (`InvalidEnumTag`, …), not which field failed.
+fn diagnoseArgs(arena: std.mem.Allocator, arguments: ?std.json.Value) ?[]const u8 {
+    const args = arguments orelse return null;
+    if (args != .object) return null;
+
+    if (args.object.get("waitUntil")) |v| switch (v) {
+        .string => |s| if (std.meta.stringToEnum(lp.Config.WaitUntil, s) == null)
+            return formatEnumError(arena, "waitUntil", s, lp.Config.WaitUntil),
+        else => return std.fmt.allocPrint(arena, "waitUntil must be a string", .{}) catch null,
+    };
+
+    return null;
+}
+
+fn formatEnumError(arena: std.mem.Allocator, field: []const u8, got: []const u8, comptime E: type) ?[]const u8 {
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    aw.writer.print("invalid {s} '{s}'. Expected one of: ", .{ field, got }) catch return null;
+    inline for (std.meta.fields(E), 0..) |f, i| {
+        if (i > 0) aw.writer.writeAll(", ") catch return null;
+        aw.writer.writeAll(f.name) catch return null;
+    }
+    return aw.written();
+}
 
 pub fn parseValue(comptime T: type, arena: std.mem.Allocator, value: std.json.Value) ParseArgsError!T {
     return std.json.parseFromValueLeaky(T, arena, value, .{ .ignore_unknown_fields = true }) catch |err| switch (err) {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -511,6 +511,22 @@ pub fn call(
         return .{ .text = msg, .is_error = true };
     const substituted = try substituteStringArgs(arena, tool, arguments);
 
+    return dispatch(arena, session, registry, tool, substituted) catch |err| {
+        if (err == error.NavigationFailed) {
+            if (formatNavigationError(arena, session)) |text|
+                return .{ .text = text, .is_error = true };
+        }
+        return err;
+    };
+}
+
+fn dispatch(
+    arena: std.mem.Allocator,
+    session: *lp.Session,
+    registry: *CDPNode.Registry,
+    tool: Tool,
+    substituted: ?std.json.Value,
+) ToolError!ToolResult {
     return switch (tool) {
         .goto => .{ .text = try execGoto(arena, session, registry, substituted) },
         .search => .{ .text = try execSearch(arena, session, registry, substituted) },
@@ -537,6 +553,12 @@ pub fn call(
         .getUrl => .{ .text = try execGetUrl(session) },
         .getCookies => .{ .text = try execGetCookies(arena, session) },
     };
+}
+
+fn formatNavigationError(arena: std.mem.Allocator, session: *lp.Session) ?[]const u8 {
+    const frame = session.currentFrame() orelse return null;
+    const err = frame._last_navigate_error orelse return null;
+    return std.fmt.allocPrint(arena, "navigation failed: {s}", .{@errorName(err)}) catch null;
 }
 
 /// Run JavaScript against the current page. The script need not be
@@ -1198,6 +1220,9 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
         .ms = timeout orelse 10000,
         .until = waitUntil orelse .done,
     }) catch |err| return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
+
+    const frame = session.currentFrame() orelse return ToolError.NavigationFailed;
+    if (frame._last_navigate_error != null) return ToolError.NavigationFailed;
 }
 
 fn resolveNodeAndPage(session: *lp.Session, registry: *CDPNode.Registry, node_id: CDPNode.Id) ToolError!NodeAndPage {

--- a/src/log.zig
+++ b/src/log.zig
@@ -52,6 +52,11 @@ const Opts = struct {
 
 pub var opts = Opts{};
 
+/// Optional sink for formatted log lines. The agent's REPL terminal sets
+/// this so log output can be routed through `Spinner.emitAbove` instead
+/// of trampling the spinner line on stderr.
+pub var sink: ?*const fn (bytes: []const u8) void = null;
+
 // synchronizes access to last_log
 var last_log_lock: Thread.Mutex = .{};
 
@@ -113,6 +118,17 @@ pub fn fatal(comptime scope: Scope, comptime msg: []const u8, data: anytype) voi
 
 pub fn log(comptime scope: Scope, level: Level, comptime msg: []const u8, data: anytype) void {
     if (enabled(scope, level) == false) {
+        return;
+    }
+
+    if (sink) |s| {
+        var buf: [4096]u8 = undefined;
+        var w: std.Io.Writer = .fixed(&buf);
+        logTo(scope, level, msg, data, &w) catch |log_err| {
+            std.debug.print("$time={d} $level=fatal $scope={s} $msg=\"log err\" err={s} log_msg=\"{s}\"\n", .{ timestamp(.clock), @errorName(log_err), @tagName(scope), msg });
+            return;
+        };
+        s(w.buffered());
         return;
     }
 

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -898,6 +898,22 @@ test "MCP - waitForSelector: timeout" {
     }, out.written());
 }
 
+test "MCP - goto with bad waitUntil surfaces rich error" {
+    defer testing.reset();
+    var out: std.io.Writer.Allocating = .init(testing.arena_allocator);
+    const server = try testLoadPage("about:blank", &out.writer);
+    defer server.deinit();
+
+    const msg =
+        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"goto","arguments":{"url":"about:blank","waitUntil":"x"}}}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, msg);
+    const written = out.written();
+    try testing.expect(std.mem.indexOf(u8, written, "invalid waitUntil 'x'") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "load") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "isError\":true") != null);
+}
+
 fn testLoadPage(url: [:0]const u8, writer: *std.Io.Writer) !*Server {
     var server = try Server.init(testing.allocator, testing.test_app, writer);
     errdefer server.deinit();


### PR DESCRIPTION
Validate tool arguments like `waitUntil` before parsing to provide clearer error messages with expected enum values.

Solves items 3 and 14 in #2525