### PR TITLE
docs: add build prerequisites for Fedora/RHEL and Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,26 @@ For systems with [**Nix**](https://nixos.org/download/), you can use the devShel
 nix develop
 ```
 
-For **MacOS**, you need cmake and [Rust](https://rust-lang.org/tools/install/).
-```
+For **MacOS**, you need cmake, clang, and [Rust](https://rust-lang.org/tools/install/).
+
+```bash
 brew install cmake
+# clang is usually included with Xcode command line tools
+xcode-select --install
+```
+
+For **Fedora/RHEL-based Linux**:
+
+```bash
+sudo dnf install clang cmake curl git pkg-config \
+    libglib2.0-devel keyutils-libs-devel libidn2-devel
+```
+
+For **Arch Linux**:
+
+```bash
+sudo pacman -S base-devel cmake clang curl git \
+    pkg-config glib2 keyutils libidn2
 ```
 
 ### Build and run


### PR DESCRIPTION
## Summary
- Added build prerequisite instructions for Fedora/RHEL-based Linux and Arch Linux to README.md
- Expanded macOS instructions to include clang via Xcode command line tools

## Problem
The README only documented build prerequisites for Debian/Ubuntu, Nix, and basic macOS. Users on Fedora, RHEL, CentOS, Arch, and other distributions had no guidance on required packages.

## Solution
Added package installation commands for:
1. **Fedora/RHEL-based Linux** - dnf install with clang, cmake, and required dev libs
2. **Arch Linux** - pacman install with base-devel and required deps
3. **macOS** - expanded to include xcode-select for clang

## Tests
Documentation change only.

## Risk / Compatibility
- Docs only, no runtime changes
- Does not affect existing Debian/Ubuntu or Nix instructions