### PR TITLE
docs: add troubleshooting section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,20 @@ otherwise we're not able to accept your contributions.
 The process signature uses the [CLA assistant
 lite](https://github.com/marketplace/actions/cla-assistant-lite). You can see
 an example of the process in [#303](https://github.com/lightpanda-io/browser/pull/303).
+
+## Troubleshooting
+
+**Build fails with "unknown target" error?**
+- Check `zig version` matches the project's expected version
+- Run `zig env` to see the current target triple
+- On macOS Apple Silicon, ensure Rosetta 2 is installed if building x86 binaries
+
+**V8 download fails or times out?**
+- Check your internet connection and proxy settings
+- Try manually downloading from https://github.com/lightpanda-io/zig-v8-fork/releases
+- Place the archive in the expected download directory
+
+**Tests fail with "memory leak" error?**
+- The test runner in debug builds detects any unfreed allocations
+- Run `make test` with `TEST_VERBOSE=true` to see which test leaks
+- Check that all allocated resources are properly freed


### PR DESCRIPTION
## Summary
- Added troubleshooting section to CONTRIBUTING.md
- Covers: build target errors, V8 download failures, memory leak test failures

## Problem
New contributors had no guidance for common build and test issues in CONTRIBUTING.md.

## Solution
Added troubleshooting section with solutions for:
1. "unknown target" build error — check Zig version, use zig env, install Rosetta 2
2. V8 download failures — check connection, manual download option
3. Memory leak test failures — use TEST_VERBOSE=true, check resource cleanup

## Tests
Documentation only.

## Risk / Compatibility
- Docs only, no runtime changes