### PR TITLE
docs: add test output and troubleshooting sections to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,25 @@ otherwise we're not able to accept your contributions.
 The process signature uses the [CLA assistant
 lite](https://github.com/marketplace/actions/cla-assistant-lite). You can see
 an example of the process in [#303](https://github.com/lightpanda-io/browser/pull/303).
+
+## Test Output
+
+When a test fails with a memory leak error, the output shows which test leaked.
+Run with `TEST_VERBOSE=true make test` for detailed allocation tracking.
+
+## Troubleshooting
+
+**Build fails with "unknown target" error?**
+- Check `zig version` matches the project's expected version
+- Run `zig env` to see the current target triple
+- On macOS Apple Silicon, ensure Rosetta 2 is installed if building x86 binaries
+
+**V8 download fails or times out?**
+- Check your internet connection and proxy settings
+- Try manually downloading from https://github.com/lightpanda-io/zig-v8-fork/releases
+- Place the archive in the expected download directory
+
+**Tests fail with "memory leak" error?**
+- The test runner in debug builds detects any unfreed allocations
+- Run `make test` with `TEST_VERBOSE=true` to see which test leaks
+- Check that all allocated resources are properly freed


### PR DESCRIPTION
## Summary
- Added "Test Output" section explaining how to interpret memory leak errors
- Added "Troubleshooting" section with solutions for common build issues:
  - Zig version mismatch
  - V8 download failures
  - Memory leak test failures

## Problem
No troubleshooting section existed in CONTRIBUTING.md. Users hit common issues without guidance.

## Solution
Added troubleshooting section with actionable solutions for the 3 most common issues:
1. "unknown target" — check Zig version and target triple
2. V8 download failures — manual download fallback
3. Memory leak tests — TEST_VERBOSE=true

## Testing
Documentation only.