### PR TITLE
docs: add build commands quick reference table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ zig build -Dsnapshot_path=../../snapshot.bin
 
 See [#1279](https://github.com/lightpanda-io/browser/pull/1279) for more details.
 
+## Build Commands Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Build release binary |
+| `make build-dev` | Build debug binary |
+| `make test` | Run all tests |
+| `make download-v8` | Download prebuilt V8 |
+| `zig build run` | Build and run |
+| `zig fmt --check .` | Check formatting |
+
 ## Test
 
 ### Unit Tests


### PR DESCRIPTION
## Summary
- Added "Build Commands Quick Reference" section to README
- Provides a table of common build commands for quick lookup

## Problem
Users had to scroll through lengthy documentation to find basic build commands.

## Solution
Added a quick reference table with the most common commands:
- make build / make build-dev
- make test
- make download-v8
- zig build run
- zig fmt --check .

## Testing
Documentation only.