### PR TITLE
Tweak Response and Request

### DIFF
--- a/src/browser/tests/net/request.html
+++ b/src/browser/tests/net/request.html
@@ -216,3 +216,53 @@
     testing.expectEqual('value', req2.headers.get('X-Custom'));
   }
 </script>
+
+<script id=body_used>
+  testing.async(async () => {
+    const req = new Request('https://example.com', { method: 'POST', body: 'hi' });
+    testing.expectFalse(req.bodyUsed);
+    await req.text();
+    testing.expectTrue(req.bodyUsed);
+
+    // Re-consuming a used body rejects.
+    let rejected = false;
+    try { await req.text(); } catch (e) { rejected = true; }
+    testing.expectTrue(rejected);
+  });
+
+  testing.async(async () => {
+    // A request with no body is never "used".
+    const req = new Request('https://example.com');
+    testing.expectFalse(req.bodyUsed);
+    await req.text();
+    testing.expectFalse(req.bodyUsed);
+  });
+
+  testing.async(async () => {
+    // text() decodes as UTF-8, stripping a leading BOM.
+    const req = new Request('https://example.com', { method: 'POST', body: '﻿hi' });
+    testing.expectEqual('hi', await req.text());
+  });
+</script>
+
+<script id=content_type_from_body>
+  {
+    const req = new Request('https://example.com', { method: 'POST', body: 'x' });
+    testing.expectEqual('text/plain;charset=UTF-8', req.headers.get('content-type'));
+  }
+  {
+    // Buffer sources carry no default Content-Type.
+    const req = new Request('https://example.com', { method: 'POST', body: new Uint8Array([1, 2, 3]) });
+    testing.expectTrue(req.headers.get('content-type') === null);
+  }
+</script>
+
+<script id=priority>
+  {
+    new Request('https://example.com', { priority: 'high' });
+    new Request('https://example.com', { priority: 'low' });
+    new Request('https://example.com', { priority: 'auto' });
+    testing.expectTrue(true);
+  }
+  testing.expectError('TypeError', () => new Request('https://example.com', { priority: 'bogus' }));
+</script>

--- a/src/browser/tests/net/response.html
+++ b/src/browser/tests/net/response.html
@@ -30,7 +30,7 @@
 
   {
     let response3 = new Response("Created", { status: 201, statusText: "Created" });
-    testing.expectEqual("basic", response3.type);
+    testing.expectEqual("default", response3.type);
     testing.expectEqual(201, response3.status);
     testing.expectEqual("Created", response3.statusText);
     testing.expectEqual(true, response3.ok);
@@ -198,4 +198,56 @@
     const body = response.body;
     testing.expectEqual(true, body instanceof ReadableStream);
   });
+</script>
+
+<script id=body_used>
+  testing.async(async () => {
+    const response = new Response('hi');
+    testing.expectFalse(response.bodyUsed);
+    await response.text();
+    testing.expectTrue(response.bodyUsed);
+
+    // Re-consuming a used body rejects.
+    let rejected = false;
+    try { await response.text(); } catch (e) { rejected = true; }
+    testing.expectTrue(rejected);
+  });
+
+  testing.async(async () => {
+    // A bodyless response is never "used".
+    const response = new Response();
+    testing.expectFalse(response.bodyUsed);
+    await response.text();
+    testing.expectFalse(response.bodyUsed);
+  });
+
+  testing.async(async () => {
+    // text() decodes as UTF-8, stripping a leading BOM.
+    const response = new Response('﻿hi');
+    testing.expectEqual('hi', await response.text());
+  });
+</script>
+
+<script id=default_type>
+  {
+    testing.expectEqual('default', new Response('x').type);
+  }
+</script>
+
+<script id=content_type_from_body>
+  {
+    testing.expectEqual('text/plain;charset=UTF-8', new Response('x').headers.get('content-type'));
+  }
+  {
+    const usp = new URLSearchParams({ a: '1' });
+    testing.expectEqual('application/x-www-form-urlencoded;charset=UTF-8', new Response(usp).headers.get('content-type'));
+  }
+  {
+    const blob = new Blob(['x'], { type: 'text/CustomCase' });
+    testing.expectEqual('text/customcase', new Response(blob).headers.get('content-type'));
+  }
+  {
+    // Buffer sources carry no default Content-Type.
+    testing.expectTrue(new Response(new Uint8Array([1, 2, 3])).headers.get('content-type') === null);
+  }
 </script>

--- a/src/browser/webapi/Blob.zig
+++ b/src/browser/webapi/Blob.zig
@@ -125,16 +125,16 @@ fn validateMimeType(arena: Allocator, mime_type: []const u8, full_validation: bo
         _ = Mime.parse(buf) catch return "";
     } else {
         // Simple validation per FileAPI spec (for Blob constructor):
-        // - If any char is outside U+0020-U+007E, return empty string
-        // - Otherwise lowercase
+        // any char outside U+0020-U+007E yields the empty string.
         for (mime_type) |c| {
             if (c < 0x20 or c > 0x7E) {
                 return "";
             }
         }
-        _ = std.ascii.lowerString(buf, buf);
     }
 
+    // FileAPI: Blob.type is the type converted to ASCII lowercase.
+    _ = std.ascii.lowerString(buf, buf);
     return buf;
 }
 

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -48,8 +48,14 @@ pub const Input = Request.Input;
 pub const InitOpts = Request.InitOpts;
 
 pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promise {
-    const request = try Request.init(input, options, exec);
     const resolver = exec.context.local.?.createPromiseResolver();
+
+    // A bad RequestInit (e.g. an invalid priority) must reject the promise,
+    // not throw synchronously.
+    const request = Request.init(input, options, exec) catch {
+        resolver.rejectError("fetch init error", .{ .type_error = "Failed to construct Request" });
+        return resolver.promise();
+    };
 
     if (request._signal) |signal| {
         if (signal._aborted) {

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -26,7 +26,8 @@ const Blob = @import("../Blob.zig");
 const AbortSignal = @import("../AbortSignal.zig");
 
 const Headers = @import("Headers.zig");
-const BodyInit = @import("body_init.zig").BodyInit;
+const body_init = @import("body_init.zig");
+const BodyInit = body_init.BodyInit;
 
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
@@ -41,6 +42,7 @@ _arena: Allocator,
 _cache: Cache,
 _credentials: Credentials,
 _signal: ?*AbortSignal,
+_body_used: bool = false,
 
 pub const Input = union(enum) {
     request: *Request,
@@ -54,7 +56,10 @@ pub const InitOpts = struct {
     cache: Cache = .default,
     credentials: Credentials = .@"same-origin",
     signal: ?*AbortSignal = null,
+    priority: ?[]const u8 = null,
 };
+
+const Priority = enum { high, low, auto };
 
 const Credentials = enum {
     omit,
@@ -81,6 +86,12 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
     };
 
     const opts = opts_ orelse InitOpts{};
+    if (opts.priority) |p| {
+        if (std.meta.stringToEnum(Priority, p) == null) {
+            return error.InvalidArgument;
+        }
+    }
+
     const method = if (opts.method) |m|
         try parseMethod(m, exec)
     else switch (input) {
@@ -182,36 +193,74 @@ pub fn getHeaders(self: *Request, exec: *const Execution) !*Headers {
     return headers;
 }
 
+pub fn getBodyUsed(self: *const Request) bool {
+    if (self._body == null) {
+        return false;
+    }
+    return self._body_used;
+}
+
+// Marks a present body consumed; returns a rejected promise if it already was.
+fn consume(self: *Request, local: *const js.Local) ?js.Promise {
+    if (self._body == null) {
+        return null;
+    }
+
+    if (self._body_used) {
+        return local.rejectPromise(.{ .type_error = "Body has already been read" });
+    }
+    self._body_used = true;
+    return null;
+}
+
 pub fn blob(self: *Request, exec: *const Execution) !js.Promise {
+    const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+
     const body = self._body orelse "";
     const headers = try self.getHeaders(exec);
     const content_type = try headers.get("content-type", exec) orelse "";
 
     const b = try Blob.initFromBytes(body, content_type, true, exec.context.page);
-
-    return exec.context.local.?.resolvePromise(b);
+    return local.resolvePromise(b);
 }
 
-pub fn text(self: *const Request, exec: *const Execution) !js.Promise {
-    const body = self._body orelse "";
-    return exec.context.local.?.resolvePromise(body);
-}
-
-pub fn json(self: *const Request, exec: *const Execution) !js.Promise {
-    const body = self._body orelse "";
+pub fn text(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
-    const value = local.parseJSON(body) catch {
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+    return local.resolvePromise(body_init.stripUtf8Bom(self._body orelse ""));
+}
+
+pub fn json(self: *Request, exec: *const Execution) !js.Promise {
+    const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+
+    const value = local.parseJSON(body_init.stripUtf8Bom(self._body orelse "")) catch {
         return local.rejectPromise(.{ .syntax_error = "failed to parse" });
     };
     return local.resolvePromise(try value.persist());
 }
 
-pub fn arrayBuffer(self: *const Request, exec: *const Execution) !js.Promise {
-    return exec.context.local.?.resolvePromise(js.ArrayBuffer{ .values = self._body orelse "" });
+pub fn arrayBuffer(self: *Request, exec: *const Execution) !js.Promise {
+    const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+    return local.resolvePromise(js.ArrayBuffer{ .values = self._body orelse "" });
 }
 
-pub fn bytes(self: *const Request, exec: *const Execution) !js.Promise {
-    return exec.context.local.?.resolvePromise(js.TypedArray(u8){ .values = self._body orelse "" });
+pub fn bytes(self: *Request, exec: *const Execution) !js.Promise {
+    const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+    return local.resolvePromise(js.TypedArray(u8){ .values = self._body orelse "" });
 }
 
 pub fn clone(self: *const Request, exec: *const Execution) !*Request {
@@ -243,6 +292,7 @@ pub const JsApi = struct {
     pub const cache = bridge.accessor(Request.getCache, null, .{});
     pub const credentials = bridge.accessor(Request.getCredentials, null, .{});
     pub const signal = bridge.accessor(Request.getSignal, null, .{});
+    pub const bodyUsed = bridge.accessor(Request.getBodyUsed, null, .{});
     pub const blob = bridge.function(Request.blob, .{});
     pub const text = bridge.function(Request.text, .{});
     pub const json = bridge.function(Request.json, .{});

--- a/src/browser/webapi/net/Response.zig
+++ b/src/browser/webapi/net/Response.zig
@@ -27,6 +27,7 @@ const Blob = @import("../Blob.zig");
 const ReadableStream = @import("../streams/ReadableStream.zig");
 
 const Headers = @import("Headers.zig");
+const body_init = @import("body_init.zig");
 
 const Execution = js.Execution;
 const Allocator = std.mem.Allocator;
@@ -36,6 +37,7 @@ const Response = @This();
 pub const Type = enum {
     basic,
     cors,
+    default,
     @"error",
     @"opaque",
     opaqueredirect,
@@ -51,6 +53,7 @@ _status_text: []const u8,
 _url: [:0]const u8,
 _is_redirected: bool,
 _http_response: ?HttpClient.Response = null,
+_body_used: bool = false,
 
 const Body = union(enum) {
     empty,
@@ -64,12 +67,7 @@ const InitOpts = struct {
     statusText: ?[]const u8 = null,
 };
 
-/// Body can be: null, string ([]const u8), ReadableStream, Blob, ArrayBuffer
-pub const BodyInit = union(enum) {
-    stream: *ReadableStream,
-    bytes: []const u8,
-    js_val: js.Value,
-};
+pub const BodyInit = body_init.BodyInit;
 
 pub fn init(body_: ?BodyInit, opts_: ?InitOpts, exec: *const Execution) !*Response {
     const session = exec.context.page.session;
@@ -79,21 +77,25 @@ pub fn init(body_: ?BodyInit, opts_: ?InitOpts, exec: *const Execution) !*Respon
     const opts = opts_ orelse InitOpts{};
     const status_text = if (opts.statusText) |st| try arena.dupe(u8, st) else "";
 
-    // Parse body from the union
+    var content_type: ?[]const u8 = null;
     const body: Body = blk: {
         const b = body_ orelse break :blk .empty;
         switch (b) {
-            .bytes => |body_bytes| break :blk .{ .bytes = try arena.dupe(u8, body_bytes) },
             .stream => |stream| break :blk .{ .stream = stream },
-            .js_val => |js_val| {
-                if (js_val.isNullOrUndefined()) {
-                    break :blk .empty;
-                }
-                break :blk .{ .bytes = try arena.dupe(u8, try js_val.toStringSmart()) };
+            else => {
+                const extracted = try b.extract(arena);
+                content_type = extracted.content_type;
+                break :blk .{ .bytes = extracted.bytes };
             },
         }
-        break :blk .empty;
     };
+
+    const headers = try Headers.init(opts.headers, exec);
+    if (content_type) |ct| {
+        if (!headers.has("content-type", exec)) {
+            try headers.append("content-type", ct, exec);
+        }
+    }
 
     const self = try arena.create(Response);
     self.* = .{
@@ -102,9 +104,9 @@ pub fn init(body_: ?BodyInit, opts_: ?InitOpts, exec: *const Execution) !*Respon
         ._status_text = status_text,
         ._url = "",
         ._body = body,
-        ._type = .basic,
+        ._type = .default,
         ._is_redirected = false,
-        ._headers = try Headers.init(opts.headers, exec),
+        ._headers = headers,
     };
     return self;
 }
@@ -168,10 +170,34 @@ pub fn isOK(self: *const Response) bool {
     return self._status >= 200 and self._status <= 299;
 }
 
-pub fn getText(self: *const Response, exec: *const Execution) !js.Promise {
+pub fn getBodyUsed(self: *const Response) bool {
+    return switch (self._body) {
+        .empty => false,
+        else => self._body_used,
+    };
+}
+
+// Marks a present body consumed; returns a rejected promise if it already was.
+fn consume(self: *Response, local: *const js.Local) ?js.Promise {
+    switch (self._body) {
+        .empty => return null,
+        else => {},
+    }
+    if (self._body_used) {
+        return local.rejectPromise(.{ .type_error = "Body has already been read" });
+    }
+    self._body_used = true;
+    return null;
+}
+
+pub fn getText(self: *Response, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+
     const body = switch (self._body) {
-        .bytes => |b| b,
+        .bytes => |b| body_init.stripUtf8Bom(b),
         .empty => "",
         .stream => return local.rejectPromise(.{ .type_error = "Cannot read text from stream body" }),
     };
@@ -180,8 +206,12 @@ pub fn getText(self: *const Response, exec: *const Execution) !js.Promise {
 
 pub fn getJson(self: *Response, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+
     const body = switch (self._body) {
-        .bytes => |b| b,
+        .bytes => |b| body_init.stripUtf8Bom(b),
         .empty => "",
         .stream => return local.rejectPromise(.{ .type_error = "Cannot read JSON from stream body" }),
     };
@@ -193,6 +223,10 @@ pub fn getJson(self: *Response, exec: *const Execution) !js.Promise {
 
 pub fn arrayBuffer(self: *Response, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| {
+        return rejected;
+    }
+
     return switch (self._body) {
         .bytes => |body| local.resolvePromise(js.ArrayBuffer{ .values = body }),
         .empty => local.resolvePromise(js.ArrayBuffer{ .values = "" }),
@@ -313,8 +347,9 @@ const StreamConsumer = struct {
     }
 };
 
-pub fn blob(self: *const Response, exec: *const Execution) !js.Promise {
+pub fn blob(self: *Response, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| return rejected;
     const body = switch (self._body) {
         .bytes => |b| b,
         .empty => "",
@@ -325,8 +360,9 @@ pub fn blob(self: *const Response, exec: *const Execution) !js.Promise {
     return local.resolvePromise(b);
 }
 
-pub fn bytes(self: *const Response, exec: *const Execution) !js.Promise {
+pub fn bytes(self: *Response, exec: *const Execution) !js.Promise {
     const local = exec.context.local.?;
+    if (self.consume(local)) |rejected| return rejected;
     const body = switch (self._body) {
         .bytes => |b| b,
         .empty => "",
@@ -386,6 +422,7 @@ pub const JsApi = struct {
     pub const json = bridge.function(Response.getJson, .{});
     pub const headers = bridge.accessor(Response.getHeaders, null, .{});
     pub const body = bridge.accessor(Response.getBody, null, .{});
+    pub const bodyUsed = bridge.accessor(Response.getBodyUsed, null, .{});
     pub const url = bridge.accessor(Response.getURL, null, .{});
     pub const redirected = bridge.accessor(Response.isRedirected, null, .{});
     pub const arrayBuffer = bridge.function(Response.arrayBuffer, .{});

--- a/src/browser/webapi/net/body_init.zig
+++ b/src/browser/webapi/net/body_init.zig
@@ -30,10 +30,13 @@
 
 const std = @import("std");
 
+const js = @import("../../js/js.zig");
+
 const Blob = @import("../Blob.zig");
 
 const FormData = @import("FormData.zig");
 const URLSearchParams = @import("URLSearchParams.zig");
+const ReadableStream = @import("../streams/ReadableStream.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -41,6 +44,8 @@ pub const BodyInit = union(enum) {
     blob: *Blob,
     form_data: *FormData,
     url_search_params: *URLSearchParams,
+    stream: *ReadableStream,
+    buffer: js.TypedArray(u8),
     bytes: []const u8, // must be last, js.Bridge will map anything to a string
 
     pub fn extract(self: BodyInit, arena: Allocator) !Extracted {
@@ -91,6 +96,22 @@ pub const BodyInit = union(enum) {
                     .content_type = if (blob._mime.len > 0) try arena.dupe(u8, blob._mime) else null,
                 };
             },
+            .buffer => |b| {
+                // Buffer sources carry no default Content-Type (Fetch §6.5).
+                return .{
+                    .bytes = try arena.dupe(u8, b.values),
+                    .content_type = null,
+                };
+            },
+            .stream => {
+                // A ReadableStream body cannot be serialized synchronously.
+                // Callers that support streaming bodies (Response) special-case
+                // the `.stream` arm before calling extract; the Request/XHR
+                // paths that reach here have no place to store a stream, so
+                // they send an empty body. Like other non-string sources, a
+                // stream carries no default Content-Type.
+                return .{ .bytes = "", .content_type = null };
+            },
         }
     }
 };
@@ -103,6 +124,15 @@ pub const Extracted = struct {
     bytes: []const u8,
     content_type: ?[]const u8,
 };
+
+// "UTF-8 decode" (Encoding §4.2) strips a leading BOM; consuming a body as
+// text/json must use it, while arrayBuffer/blob/bytes keep the raw bytes.
+pub fn stripUtf8Bom(bytes: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, bytes, "\xef\xbb\xbf")) {
+        return bytes[3..];
+    }
+    return bytes;
+}
 
 const testing = @import("../../../testing.zig");
 test "BodyInit: bytes pass through with text/plain" {
@@ -149,6 +179,20 @@ test "BodyInit: FormData emits multipart with random boundary" {
     try testing.expect(std.mem.indexOf(u8, r.bytes, "alice@example.com") != null);
     const closer = try std.fmt.allocPrint(arena, "--{s}--\r\n", .{boundary});
     try testing.expect(std.mem.endsWith(u8, r.bytes, closer));
+}
+
+test "BodyInit: buffer source has no default Content-Type" {
+    defer testing.reset();
+    const r = try (BodyInit{ .buffer = .{ .values = "hello" } }).extract(testing.arena_allocator);
+    try testing.expectString("hello", r.bytes);
+    try testing.expectEqual(true, r.content_type == null);
+}
+
+test "stripUtf8Bom" {
+    try testing.expectString("abc", stripUtf8Bom("\xef\xbb\xbfabc"));
+    try testing.expectString("abc", stripUtf8Bom("abc"));
+    try testing.expectString("", stripUtf8Bom("\xef\xbb\xbf"));
+    try testing.expectString("\xef\xbbno-bom", stripUtf8Bom("\xef\xbbno-bom"));
 }
 
 // Blob.extract is exercised end-to-end by the Request/XHR HTML fixture


### PR DESCRIPTION
Implement `bodyUsed` getter for both types. With this implemented, correctly reject requests when `bodyUsed == true`.

Expand Response to use BodyInit (Request was already using it).

Expand BodyInit to discriminate between a TypedArray/BufferArray and a string, which allows us to capture the correct content type.

Add Request.priority and in Request/Response body getters, strip BOM as needed.