### PR TITLE
chore: fix three typos in comments and error message

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -1026,7 +1026,7 @@ pub const BrowserContext = struct {
         // reserve 10 bytes for websocket header
         buf.appendSliceAssumeCapacity(&.{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
 
-        // -1  because we dont' want the closing brace '}'
+        // -1  because we don't want the closing brace '}'
         buf.appendSliceAssumeCapacity(msg[0 .. msg.len - 1]);
         buf.appendSliceAssumeCapacity(field);
         buf.appendSliceAssumeCapacity(session_id);

--- a/src/storage/sqlite/Pool.zig
+++ b/src/storage/sqlite/Pool.zig
@@ -98,7 +98,7 @@ pub fn release(self: *Pool, conn: Sqlite.Conn) void {
 
 const testing = @import("../../testing.zig");
 test "Sqlite: Pool" {
-    // :memory: _has_ to run with a single connetion in the pool, which isn't
+    // :memory: _has_ to run with a single connection in the pool, which isn't
     // that useful for testing. So we create a temp file.
 
     std.fs.cwd().deleteFile("/tmp/lightpanda_test.sqlite") catch {};

--- a/src/storage/sqlite/Sqlite.zig
+++ b/src/storage/sqlite/Sqlite.zig
@@ -198,7 +198,7 @@ const Statement = struct {
                 const data = c.sqlite3_column_text(stmt, @intCast(index));
                 return @as([*c]const u8, @ptrCast(data))[0..@intCast(len) :0];
             },
-            else => @compileError("unsupport column type: " ++ @typeName(T)),
+            else => @compileError("unsupported column type: " ++ @typeName(T)),
         };
     }
 


### PR DESCRIPTION
## Summary

- `src/cdp/CDP.zig:1029` — "we dont' want" → "we don't want"
- `src/storage/sqlite/Pool.zig:101` — test comment "single connetion" → "single connection"
- `src/storage/sqlite/Sqlite.zig:201` — `@compileError` message "unsupport column type" → "unsupported column type"

Comment / compile-time string only; no runtime behavior change.