### PR TITLE
Add StaticRange

### DIFF
--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -282,7 +282,13 @@ pub fn abstractRange(_: *const Factory, arena: Allocator, child: anytype, frame:
         ._type = unionInit(AbstractRange.Type, chain.get(1)),
     };
     chain.setLeaf(1, child);
-    frame._live_ranges.append(&abstract_range._range_link);
+
+    if (abstract_range._type != .static_range) {
+        // StaticRanges are not live, so they don't get added to the frame's
+        // live_ranges list.
+        frame._live_ranges.append(&abstract_range._range_link);
+    }
+
     return chain.get(1);
 }
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -827,6 +827,7 @@ pub const PageJsApis = flattenTypes(&.{
     @import("../webapi/XMLSerializer.zig"),
     @import("../webapi/AbstractRange.zig"),
     @import("../webapi/Range.zig"),
+    @import("../webapi/StaticRange.zig"),
     @import("../webapi/NodeFilter.zig"),
     @import("../webapi/Element.zig"),
     @import("../webapi/element/DOMStringMap.zig"),

--- a/src/browser/tests/staticrange.html
+++ b/src/browser/tests/staticrange.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<script src="testing.js"></script>
+<body>
+<div id="testDiv">abc<span>def</span>ghi</div>
+
+<script id=construct_element>
+{
+  const testDiv = $('#testDiv');
+  const sr = new StaticRange({startContainer: testDiv, startOffset: 1, endContainer: testDiv, endOffset: 2});
+  testing.expectEqual(testDiv, sr.startContainer);
+  testing.expectEqual(1, sr.startOffset);
+  testing.expectEqual(testDiv, sr.endContainer);
+  testing.expectEqual(2, sr.endOffset);
+  testing.expectEqual(false, sr.collapsed);
+}
+</script>
+
+<script id=construct_text>
+{
+  const text = $('#testDiv').firstChild;
+  const sr = new StaticRange({startContainer: text, startOffset: 1, endContainer: text, endOffset: 2});
+  testing.expectEqual(text, sr.startContainer);
+  testing.expectEqual(text, sr.endContainer);
+  testing.expectEqual(false, sr.collapsed);
+}
+</script>
+
+<script id=construct_mixed>
+{
+  const testDiv = $('#testDiv');
+  const text = testDiv.firstChild;
+  const sr = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: text, endOffset: 1});
+  testing.expectEqual(testDiv, sr.startContainer);
+  testing.expectEqual(0, sr.startOffset);
+  testing.expectEqual(text, sr.endContainer);
+  testing.expectEqual(1, sr.endOffset);
+}
+</script>
+
+<script id=construct_comment>
+{
+  const comment = document.createComment('abc');
+  const sr = new StaticRange({startContainer: comment, startOffset: 1, endContainer: comment, endOffset: 2});
+  testing.expectEqual(comment, sr.startContainer);
+  testing.expectEqual(2, sr.endOffset);
+}
+</script>
+
+<script id=construct_pi>
+{
+  const pi = document.createProcessingInstruction('foo', 'abc');
+  const sr = new StaticRange({startContainer: pi, startOffset: 1, endContainer: pi, endOffset: 2});
+  testing.expectEqual(pi, sr.startContainer);
+}
+</script>
+
+<script id=construct_document>
+{
+  const sr = new StaticRange({startContainer: document, startOffset: 0, endContainer: document, endOffset: 1});
+  testing.expectEqual(document, sr.startContainer);
+  testing.expectEqual(false, sr.collapsed);
+}
+</script>
+
+<script id=construct_fragment>
+{
+  const frag = document.createDocumentFragment();
+  const sr = new StaticRange({startContainer: frag, startOffset: 0, endContainer: frag, endOffset: 1});
+  testing.expectEqual(frag, sr.startContainer);
+}
+</script>
+
+<script id=collapsed>
+{
+  const testDiv = $('#testDiv');
+  const sr = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv, endOffset: 0});
+  testing.expectEqual(true, sr.collapsed);
+}
+</script>
+
+<script id=no_offset_validation>
+{
+  // StaticRange is static: it does NOT validate offsets against node length,
+  // nor reorder inverted endpoints (unlike Range).
+  const testDiv = $('#testDiv');
+  const sr = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv, endOffset: 15});
+  testing.expectEqual(0, sr.startOffset);
+  testing.expectEqual(15, sr.endOffset);
+
+  const inverted = new StaticRange({startContainer: testDiv, startOffset: 1, endContainer: document.body, endOffset: 0});
+  testing.expectEqual(testDiv, inverted.startContainer);
+  testing.expectEqual(document.body, inverted.endContainer);
+  testing.expectEqual(0, inverted.endOffset);
+}
+</script>
+
+<script id=prototype_chain>
+{
+  const testDiv = $('#testDiv');
+  const sr = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv, endOffset: 0});
+  testing.expectEqual(true, sr instanceof StaticRange);
+  testing.expectEqual(true, sr instanceof AbstractRange);
+  testing.expectEqual(false, sr instanceof Range);
+  // commonAncestorContainer is Range-only and must NOT leak onto StaticRange.
+  testing.expectEqual('undefined', typeof sr.commonAncestorContainer);
+  // ... but it remains on Range.
+  testing.expectEqual('object', typeof document.createRange().commonAncestorContainer);
+}
+</script>
+
+<script id=invalid_node_type>
+{
+  const testDiv = $('#testDiv');
+  testing.expectError('InvalidNodeTypeError', () => {
+    new StaticRange({startContainer: document.doctype, startOffset: 0, endContainer: document.doctype, endOffset: 0});
+  });
+  const attr = testDiv.getAttributeNode('id');
+  testing.expectError('InvalidNodeTypeError', () => {
+    new StaticRange({startContainer: attr, startOffset: 0, endContainer: attr, endOffset: 0});
+  });
+}
+</script>
+
+<script id=missing_arguments>
+{
+  const testDiv = $('#testDiv');
+  testing.expectError('TypeError', () => new StaticRange());
+  testing.expectError('TypeError', () => new StaticRange({startOffset: 0, endContainer: testDiv, endOffset: 0}));
+  testing.expectError('TypeError', () => new StaticRange({startContainer: testDiv, endContainer: testDiv, endOffset: 0}));
+  testing.expectError('TypeError', () => new StaticRange({startContainer: testDiv, startOffset: 0, endOffset: 0}));
+  testing.expectError('TypeError', () => new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv}));
+  testing.expectError('TypeError', () => new StaticRange({startContainer: null, startOffset: 0, endContainer: testDiv, endOffset: 0}));
+  testing.expectError('TypeError', () => new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: null, endOffset: 0}));
+}
+</script>
+</body>

--- a/src/browser/webapi/AbstractRange.zig
+++ b/src/browser/webapi/AbstractRange.zig
@@ -24,6 +24,7 @@ const Page = @import("../Page.zig");
 
 const Node = @import("Node.zig");
 const Range = @import("Range.zig");
+const StaticRange = @import("StaticRange.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -48,8 +49,11 @@ pub fn acquireRef(self: *AbstractRange) void {
 }
 
 pub fn deinit(self: *AbstractRange, page: *Page) void {
-    if (page.findFrameByLoaderId(self._frame_loader_id)) |frame| {
-        frame._live_ranges.remove(&self._range_link);
+    // StaticRanges are never registered in the live-range list
+    if (self._type != .static_range) {
+        if (page.findFrameByLoaderId(self._frame_loader_id)) |frame| {
+            frame._live_ranges.remove(&self._range_link);
+        }
     }
     page.releaseArena(self._arena);
 }
@@ -60,7 +64,7 @@ pub fn releaseRef(self: *AbstractRange, page: *Page) void {
 
 pub const Type = union(enum) {
     range: *Range,
-    // TODO: static_range: *StaticRange,
+    static_range: *StaticRange,
 };
 
 pub fn as(self: *AbstractRange, comptime T: type) *T {
@@ -70,6 +74,7 @@ pub fn as(self: *AbstractRange, comptime T: type) *T {
 pub fn is(self: *AbstractRange, comptime T: type) ?*T {
     switch (self._type) {
         .range => |r| return if (T == Range) r else null,
+        .static_range => |sr| return if (T == StaticRange) sr else null,
     }
 }
 
@@ -339,5 +344,4 @@ pub const JsApi = struct {
     pub const endContainer = bridge.accessor(AbstractRange.getEndContainer, null, .{});
     pub const endOffset = bridge.accessor(AbstractRange.getEndOffset, null, .{});
     pub const collapsed = bridge.accessor(AbstractRange.getCollapsed, null, .{});
-    pub const commonAncestorContainer = bridge.accessor(AbstractRange.getCommonAncestorContainer, null, .{});
 };

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -43,6 +43,10 @@ pub fn asAbstractRange(self: *Range) *AbstractRange {
     return self._proto;
 }
 
+pub fn getCommonAncestorContainer(self: *const Range) *Node {
+    return self._proto.getCommonAncestorContainer();
+}
+
 pub fn setStart(self: *Range, node: *Node, offset: u32) !void {
     if (node._type == .document_type) {
         return error.InvalidNodeType;
@@ -703,6 +707,7 @@ pub const JsApi = struct {
     pub const END_TO_START = bridge.property(3, .{ .template = true });
 
     pub const constructor = bridge.constructor(Range.init, .{});
+    pub const commonAncestorContainer = bridge.accessor(Range.getCommonAncestorContainer, null, .{});
     pub const setStart = bridge.function(Range.setStart, .{ .dom_exception = true });
     pub const setEnd = bridge.function(Range.setEnd, .{ .dom_exception = true });
     pub const setStartBefore = bridge.function(Range.setStartBefore, .{ .dom_exception = true });

--- a/src/browser/webapi/StaticRange.zig
+++ b/src/browser/webapi/StaticRange.zig
@@ -1,0 +1,85 @@
+// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const js = @import("../js/js.zig");
+const Frame = @import("../Frame.zig");
+
+const Node = @import("Node.zig");
+const AbstractRange = @import("AbstractRange.zig");
+
+const StaticRange = @This();
+
+// The boundary points and `collapsed` accessor live on the shared AbstractRange
+// prototype. Unlike Range, a StaticRange is *static*: the factory keeps it out
+// of the frame's live-range list, so DOM mutations never move its boundaries.
+_proto: *AbstractRange,
+
+// https://dom.spec.whatwg.org/#dictdef-staticrangeinit
+// All members are required. The fields are non-optional with no default, so the
+// argument decoder rejects a missing or null member with a TypeError.
+pub const StaticRangeInit = struct {
+    startContainer: *Node,
+    startOffset: u32,
+    endContainer: *Node,
+    endOffset: u32,
+};
+
+pub fn init(opts: StaticRangeInit, frame: *Frame) !*StaticRange {
+    // https://dom.spec.whatwg.org/#dom-staticrange-staticrange
+    // Throw InvalidNodeTypeError if either container is a DocumentType or Attr.
+    // Note: offsets are stored verbatim — StaticRange does no length validation.
+    if (isInvalidContainer(opts.startContainer) or isInvalidContainer(opts.endContainer)) {
+        return error.InvalidNodeType;
+    }
+
+    const arena = try frame.getArena(.medium, "StaticRange");
+    errdefer frame.releaseArena(arena);
+
+    const static_range = try frame._factory.abstractRange(arena, StaticRange{ ._proto = undefined }, frame);
+    const proto = static_range._proto;
+    proto._start_container = opts.startContainer;
+    proto._start_offset = opts.startOffset;
+    proto._end_container = opts.endContainer;
+    proto._end_offset = opts.endOffset;
+    return static_range;
+}
+
+fn isInvalidContainer(node: *Node) bool {
+    return node._type == .document_type or node._type == .attribute;
+}
+
+pub fn asAbstractRange(self: *StaticRange) *AbstractRange {
+    return self._proto;
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(StaticRange);
+
+    pub const Meta = struct {
+        pub const name = "StaticRange";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const constructor = bridge.constructor(StaticRange.init, .{ .dom_exception = true });
+};
+
+const testing = @import("../../testing.zig");
+test "WebApi: StaticRange" {
+    try testing.htmlRunner("staticrange.html", .{});
+}


### PR DESCRIPTION
This doesn't solve anything, but I was looking at /input-events/ WPT tests and many are stuck with due to this type not existing. I don't expect this to fix any of those tests, but it does move them along a bit further (the /input-events test are all based on editing capabilities that we don't have).

We already had a // todo StaticRange in AbstractRange, and since it's very simple, why not.