### PR TITLE
Notify v8 of memory pressure on session.deinit

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -131,6 +131,8 @@ pub fn deinit(self: *Session) void {
 
     self.cookie_jar.deinit();
 
+    self.browser.env.memoryPressureNotification(.critical);
+
     self.storage_shed.deinit(self.browser.app.allocator);
     self.arena_pool.release(self.arena);
 }


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/2548 removed the _need_ to call v8::Isolate::MemoryPressureNotification on Session.deinit and actually removed the call.

But [my theory] is that this causes our peak memory to be higher. So, I'm adding it back and trying with .moderate instead of the previous critical.

The point of #2548 was to open the door for improving the memory signals to v8 by removing the _need_ for this specific signal. That PR made it so that, for correctness (UAF) we no longer _had_ to call it. The point of the PR wasn't to necessarily improve the signals, so I don't feel too bad about putting this back in.