### PR TITLE
Capture 401 and 407 bodies

### DIFF
--- a/src/TestHTTPServer.zig
+++ b/src/TestHTTPServer.zig
@@ -90,8 +90,13 @@ fn handleConnection(self: *TestHTTPServer, conn: std.net.Server.Connection) !voi
         };
 
         self.handler(&req) catch |err| {
-            std.debug.print("test http error '{s}': {}\n", .{ req.head.target, err });
-            try req.respond("server error", .{ .status = .internal_server_error });
+            switch (err) {
+                error.BrokenPipe => {},
+                else => {
+                    std.debug.print("test http error '{s}': {}\n", .{ req.head.target, err });
+                    try req.respond("server error", .{ .status = .internal_server_error });
+                },
+            }
             return;
         };
     }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -4300,5 +4300,16 @@ test "Frame: httpMetadata 404" {
     defer testing.test_session.removePage();
     const meta = frame.httpMetadata();
     try testing.expect(meta.status != null);
-    try std.testing.expectEqual(@as(u16, 404), meta.status.?);
+    try testing.expectEqual(404, meta.status.?);
+}
+
+test "Frame: 401" {
+    var frame = try testing.pageTest("401", .{});
+    defer testing.reset();
+    defer frame._session.removePage();
+
+    var buf = std.Io.Writer.Allocating.init(testing.allocator);
+    defer buf.deinit();
+    try @import("dump.zig").root(frame.document, .{}, &buf.writer, frame);
+    try testing.expectEqual("<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head><body><pre>No</pre></body></html>", buf.written());
 }

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1871,7 +1871,7 @@ pub const Transfer = struct {
                 log.err(.http, "getResponseCode", .{ .err = err, .source = "body callback" });
                 return http.writefunc_error;
             };
-            if ((status >= 300 and status <= 399) or status == 401 or status == 407) {
+            if (status >= 300 and status <= 399) {
                 res.skip_body = true;
                 return @intCast(chunk_len);
             }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -653,6 +653,15 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/src/browser/tests/401")) {
+        return req.respond("No", .{
+            .status = .unauthorized,
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/plain" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/404.js")) {
         // Valid JS body served with a 404 status. Used to assert that
         // ScriptManager does NOT execute the body of a failed script


### PR DESCRIPTION
We currently skip capturing 401 and 407 bodies. This appears to be an optimization with the intent that it won't be needed. While that might be true in some cases (though, not sure when), it isn't always true. A page.navigate to a 401 should display the content.

(Also, tried to silence meaningless BrokenPipe noise in tests).