### PR TITLE
Make various Window/Worker accessors settable

### DIFF
--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -1508,6 +1508,13 @@ pub fn newException(self: *const Local, ex: anytype) js.Exception {
     };
 }
 
+pub fn getGlobal(self: *const Local) js.Object {
+    return .{
+        .local = self,
+        .handle = v8.v8__Context__Global(self.handle).?,
+    };
+}
+
 // Convert a Global (or optional Global) to a Local (or optional Local).
 // Meant to be used from either frame.js.toLocal, where the context must have an
 // non-null local (orelse panic), or from a LocalScope

--- a/src/browser/tests/console/console.html
+++ b/src/browser/tests/console/console.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
+<script id=replaceable>
+    "use strict";
+    // console is [Replaceable] (Console Standard): assignment must replace it
+    // even in strict mode — neither throwing nor silently no-op'ing, and even
+    // after console has already been read.
+    const prev = window.console;
+    window.console = {marker: 42};
+    testing.expectEqual(42, window.console.marker);
+    testing.expectEqual(42, console.marker);
+    // restore: console is now a writable data property, so this just overwrites it.
+    window.console = prev;
+    testing.expectEqual(true, window.console === prev);
+</script>
+
 <script id=entries>
     {
         const entries = Object.entries(console);

--- a/src/browser/tests/window/replaceable.html
+++ b/src/browser/tests/window/replaceable.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=replaceable>
+    "use strict";
+    // [Replaceable] attributes: assignment must replace the value (not throw,
+    // not silently no-op), even in strict mode, and survive being read first.
+    function checkReplaceable(name) {
+        const prev = window[name];
+        window[name] = "REPLACED:" + name;
+        testing.expectEqual("REPLACED:" + name, window[name]);
+        // now a writable own data property; this restores the original value.
+        window[name] = prev;
+        testing.expectEqual(true, window[name] === prev);
+    }
+    [
+        "console", "self", "frames", "parent", "length",
+        "scrollX", "scrollY", "pageXOffset", "pageYOffset",
+        "innerWidth", "innerHeight", "devicePixelRatio",
+    ].forEach(checkReplaceable);
+</script>
+
+<script id=not-replaceable>
+    "use strict";
+    // [LegacyUnforgeable] / plain readonly attributes must STILL throw on
+    // assignment in strict mode (location is excluded: it navigates).
+    function expectReadOnly(name) {
+        let threw = false;
+        try { window[name] = {}; } catch (e) { threw = true; }
+        testing.expectEqual(true, threw);
+    }
+    ["window", "top", "document", "navigator"].forEach(expectReadOnly);
+</script>

--- a/src/browser/tests/worker/replaceable-worker.js
+++ b/src/browser/tests/worker/replaceable-worker.js
@@ -1,0 +1,27 @@
+// `console` and `self` are [Replaceable] on WorkerGlobalScope: assignment must
+// replace the value even in strict mode, rather than throwing through the
+// getter-only accessor. Capture the global in a local binding first, since
+// `self` is itself replaceable (reassigning it would break global lookups).
+(function () {
+  "use strict";
+  const g = self;
+  try {
+    const results = {};
+
+    const prevConsole = g.console;
+    g.console = { marker: 7 };
+    results.console_replaced = g.console.marker === 7;
+    g.console = prevConsole;
+    results.console_restored = g.console === prevConsole;
+
+    const prevSelf = g.self;
+    g.self = "REPLACED";
+    results.self_replaced = g.self === "REPLACED";
+    g.self = prevSelf;
+    results.self_restored = g.self === prevSelf;
+
+    g.postMessage({ ok: true, results });
+  } catch (e) {
+    g.postMessage({ ok: false, err: String(e) });
+  }
+})();

--- a/src/browser/tests/worker/worker.html
+++ b/src/browser/tests/worker/worker.html
@@ -172,6 +172,25 @@
   }
 </script>
 
+<script id="worker_replaceable" type=module>
+  {
+    const state = await testing.async();
+    const worker = new Worker('./replaceable-worker.js');
+
+    worker.onmessage = function(event) {
+      state.resolve(event.data);
+    };
+
+    await state.done((data) => {
+      testing.expectTrue(data.ok, 'worker replaceable error: ' + data.err);
+      testing.expectEqual(true, data.results.console_replaced);
+      testing.expectEqual(true, data.results.console_restored);
+      testing.expectEqual(true, data.results.self_replaced);
+      testing.expectEqual(true, data.results.self_restored);
+    });
+  }
+</script>
+
 <script id="worker_webapi_net" type=module>
   {
     const state = await testing.async();

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -168,6 +168,42 @@ pub fn getConsole(self: *Window) *Console {
     return &self._console;
 }
 
+pub fn setConsole(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "console");
+}
+
+pub fn setSelf(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "self");
+}
+
+pub fn setFrames(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "frames");
+}
+
+pub fn setParent(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "parent");
+}
+
+pub fn setLength(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "length");
+}
+
+pub fn setScrollX(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "scrollX");
+}
+
+pub fn setScrollY(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "scrollY");
+}
+
+pub fn setPageXOffset(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "pageXOffset");
+}
+
+pub fn setPageYOffset(_: *Window, value: js.Value) void {
+    replaceGlobalProperty(value, "pageYOffset");
+}
+
 pub fn getNavigator(self: *Window) *Navigator {
     return &self._navigator;
 }
@@ -763,6 +799,14 @@ pub fn unhandledPromiseRejection(self: *Window, no_handler: bool, rejection: js.
     }
 }
 
+// `console` and a handful of other Window attributes are [Replaceable]: assigning
+// to them redefines the attribute as an own data property on the global instead
+// of throwing (which a getter-only accessor does in strict mode / modules).
+fn replaceGlobalProperty(value: js.Value, comptime name: []const u8) void {
+    const global = value.local.getGlobal();
+    _ = global.defineOwnProperty(name, value, 0);
+}
+
 pub const Access = union(enum) {
     window: *Window,
     cross_origin: *CrossOriginWindow,
@@ -861,12 +905,12 @@ pub const JsApi = struct {
     };
 
     pub const document = bridge.accessor(Window.getDocument, null, .{ .cache = .{ .internal = 1 }, .deletable = false });
-    pub const console = bridge.accessor(Window.getConsole, null, .{ .cache = .{ .internal = 2 } });
+    pub const console = bridge.accessor(Window.getConsole, Window.setConsole, .{});
 
     pub const top = bridge.accessor(Window.getTop, null, .{});
-    pub const self = bridge.accessor(Window.getWindow, null, .{});
+    pub const self = bridge.accessor(Window.getWindow, Window.setSelf, .{});
     pub const window = bridge.accessor(Window.getWindow, null, .{});
-    pub const parent = bridge.accessor(Window.getParent, null, .{});
+    pub const parent = bridge.accessor(Window.getParent, Window.setParent, .{});
     pub const navigator = bridge.accessor(Window.getNavigator, null, .{});
     pub const screen = bridge.accessor(Window.getScreen, null, .{});
     pub const visualViewport = bridge.accessor(Window.getVisualViewport, null, .{});
@@ -910,13 +954,13 @@ pub const JsApi = struct {
     pub const getSelection = bridge.function(Window.getSelection, .{});
     pub const frameElement = bridge.accessor(Window.getFrameElement, null, .{});
 
-    pub const frames = bridge.accessor(Window.getWindow, null, .{});
+    pub const frames = bridge.accessor(Window.getWindow, Window.setFrames, .{});
     pub const index = bridge.indexed(Window.getFrame, null, .{ .null_as_undefined = true });
-    pub const length = bridge.accessor(Window.getFramesLength, null, .{});
-    pub const scrollX = bridge.accessor(Window.getScrollX, null, .{});
-    pub const scrollY = bridge.accessor(Window.getScrollY, null, .{});
-    pub const pageXOffset = bridge.accessor(Window.getScrollX, null, .{});
-    pub const pageYOffset = bridge.accessor(Window.getScrollY, null, .{});
+    pub const length = bridge.accessor(Window.getFramesLength, Window.setLength, .{});
+    pub const scrollX = bridge.accessor(Window.getScrollX, Window.setScrollX, .{});
+    pub const scrollY = bridge.accessor(Window.getScrollY, Window.setScrollY, .{});
+    pub const pageXOffset = bridge.accessor(Window.getScrollX, Window.setPageXOffset, .{});
+    pub const pageYOffset = bridge.accessor(Window.getScrollY, Window.setPageYOffset, .{});
     pub const scrollTo = bridge.function(Window.scrollTo, .{});
     pub const scroll = bridge.function(Window.scrollTo, .{});
     pub const scrollBy = bridge.function(Window.scrollBy, .{});
@@ -927,9 +971,10 @@ pub const JsApi = struct {
     // sites not to try to access those features
     pub const isSecureContext = bridge.property(false, .{ .template = false });
 
-    pub const innerWidth = bridge.property(1920, .{ .template = false });
-    pub const innerHeight = bridge.property(1080, .{ .template = false });
-    pub const devicePixelRatio = bridge.property(1, .{ .template = false });
+    // [Replaceable] (CSSOM-View): writable so assignment overwrites rather than throws.
+    pub const innerWidth = bridge.property(1920, .{ .template = false, .readonly = false });
+    pub const innerHeight = bridge.property(1080, .{ .template = false, .readonly = false });
+    pub const devicePixelRatio = bridge.property(1, .{ .template = false, .readonly = false });
 
     pub const opener = bridge.accessor(Window.getOpener, null, .{});
     pub const closed = bridge.accessor(Window.getClosed, null, .{});

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -245,6 +245,14 @@ pub fn getConsole(self: *WorkerGlobalScope) *Console {
     return &self._console;
 }
 
+pub fn setConsole(_: *WorkerGlobalScope, value: JS.Value) void {
+    replaceGlobalProperty(value, "console");
+}
+
+pub fn setSelf(_: *WorkerGlobalScope, value: JS.Value) void {
+    replaceGlobalProperty(value, "self");
+}
+
 pub fn getCrypto(self: *WorkerGlobalScope) *Crypto {
     return &self._crypto;
 }
@@ -554,6 +562,14 @@ pub fn clearInterval(self: *WorkerGlobalScope, id: u32) void {
     self._timers.clear(id);
 }
 
+// `console` and `self` are [Replaceable] assignment redefines them as own data
+// properties on the global rather than throwing through the getter-only accessor
+// in strict mode.
+fn replaceGlobalProperty(value: JS.Value, comptime name: []const u8) void {
+    const global = value.local.getGlobal();
+    _ = global.defineOwnProperty(name, value, 0);
+}
+
 const FunctionSetter = union(enum) {
     func: JS.Function.Global,
     anything: JS.Value,
@@ -630,8 +646,8 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const self = bridge.accessor(WorkerGlobalScope.getSelf, null, .{});
-    pub const console = bridge.accessor(WorkerGlobalScope.getConsole, null, .{});
+    pub const self = bridge.accessor(WorkerGlobalScope.getSelf, WorkerGlobalScope.setSelf, .{});
+    pub const console = bridge.accessor(WorkerGlobalScope.getConsole, WorkerGlobalScope.setConsole, .{});
     pub const crypto = bridge.accessor(WorkerGlobalScope.getCrypto, null, .{});
     pub const performance = bridge.accessor(struct {
         // Unnecessary, But, our WebAPI getters are ALWAYS `fn getPerformance()...`.


### PR DESCRIPTION
window.console (and many others) should be settable. This is the [Replaceable] WebIDL attribute.

This improves loading of https://www.browserscan.net/bot-detection which would immediately break/fail because we would throw on window.console setting.

This appears to come from obfuscator.io's disableConsoleOutput flag, so the issue might be relatively common.