### PR TITLE
Guard against null function

### DIFF
--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -23,6 +23,7 @@ const js = @import("js.zig");
 
 const v8 = js.v8;
 const log = lp.log;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Function = @This();
 
@@ -51,6 +52,20 @@ pub fn withThis(self: *const Function, value: anytype) !Function {
 
 pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Object {
     const local = self.local;
+
+    if (comptime IS_DEBUG == false) {
+        // This should not be possible, yet it happens. In Release, we'll log an
+        // error and hope for the best. In Debug, we'll let the code execute
+        // and v8 will crash on the null reference. This null value almost
+        // certainly comes from a Global that was reset and thus gets unwrapped
+        // to null (but I haven't figured out the flow that can cause that). This
+        // does indicate that we might be in some shutdown state, so just
+        // return an error might not be too bad.
+        if (@intFromPtr(self.handle) == 0) {
+            log.err(.browser, "newInstance on dead handle", .{});
+            return error.DeadFunctionHandle;
+        }
+    }
 
     var try_catch: js.TryCatch = undefined;
     try_catch.init(local);
@@ -107,6 +122,20 @@ const CallOpts = struct {
 fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype, caught: *js.TryCatch.Caught, comptime opts: CallOpts) !T {
     caught.* = .{};
     const local = self.local;
+
+    if (comptime IS_DEBUG == false) {
+        // This should not be possible, yet it happens. In Release, we'll log an
+        // error and hope for the best. In Debug, we'll let the code execute
+        // and v8 will crash on the null reference. This null value almost
+        // certainly comes from a Global that was reset and thus gets unwrapped
+        // to null (but I haven't figured out the flow that can cause that). This
+        // does indicate that we might be in some shutdown state, so just
+        // return an error might not be too bad.
+        if (@intFromPtr(self.handle) == 0) {
+            log.err(.browser, "call on dead handle", .{});
+            return error.DeadFunctionHandle;
+        }
+    }
 
     // When we're calling a function from within JavaScript itself, this isn't
     // necessary. We're within a Caller instantiation, which will already have


### PR DESCRIPTION
I'm not sure how this is happening, but we occasionally see an attempt to execute a null v8::Function (from crash reports). It seems pretty clear that this is a Global that is being reset, but I can't figure out a path where a global is reset while a callback is still active. So, in != .Debug mode, we null check functions before executing and return an error.

This potentially will work without causing any new/different issues. If this is a global being reset, than we must be in some teardown state, and it probably doesn't matter if a JS callback is or isn't executed.

In case anyone ends up here and wonders about the guard, here's a stack from a crash dump:

```
Fatal V8 Error
---
location: v8::Function::Call
message: Function to be called is a null pointer
???:?:?: 0x2ac0b59 in ??? (???)
???:?:?: 0x2ace19b in ??? (???)
/src/browser/js/Function.zig:160:41: 0x268db23 in callWithThis__anon_236231 (lightpanda)
/src/browser/EventManagerBase.zig:259:30: 0x2614b53 in dispatchDirect__anon_179346 (lightpanda)
/src/browser/EventManager.zig:137:33: 0x261737e in stateChanged (lightpanda)
/src/browser/webapi/net/XMLHttpRequest.zig:580:30: 0x2621b21 in handleError (lightpanda)
/src/browser/webapi/net/XMLHttpRequest.zig:542:21: 0x2628bbd in httpErrorCallback (lightpanda)
/src/network/layer/Forward.zig:70:13: 0x29193de in errorCallback (lightpanda)
/src/browser/HttpClient.zig:1447:36: 0x2784aa6 in processMessage (lightpanda)
/src/cdp/CDP.zig:314:24: 0x26a3244 in dispatchParsed (lightpanda)
/src/cdp/CDP.zig:187:31: 0x252df34 in drainInbox (lightpanda)
/src/browser/HttpClient.zig:416:24: 0x27f01ab in handleConnection (lightpanda)
/home/runner/work/_temp/91356985-8cc1-40de-b1b8-395a29b4bd91/zig-x86_64-linux-0.15.2/lib/std/Thread.zig:509:13: 0x26877f3 in entryFn (lightpanda)
???:?:?: 0x7df4279d11f4 in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7df4279d11f4` was not available, trace may be incomplete
```