### PR TITLE
Improve navigate to schema-less URL

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -632,7 +632,12 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     self._http_status = null;
     self._http_headers = .empty;
 
-    self.url = try self.arena.dupeZ(u8, request_url);
+    self.url = blk: {
+        if (URL.isCompleteHTTPUrl(request_url)) {
+            break :blk try self.arena.dupeZ(u8, request_url);
+        }
+        break :blk try std.mem.concatWithSentinel(self.arena, u8, &.{ "http://", request_url }, 0);
+    };
     self.origin = try URL.getOrigin(self.arena, self.url);
 
     self._req_id = req_id;


### PR DESCRIPTION
I noticed that `fetch www.openmymind.net` worked but, `fetch www.example.com` didn't. www.openmymind.net redirects to `https://www.openmymind.net/` so in `frameHeaderDoneCallback` we get the updated response.url(). www.example.com doesn't redirect, so self.url remains `www.example.com` which just doesn't work at various parts of the code (Location.init, RobotsLayer...).

Added a quick check in Navigate, if the URL isn't a "complete" URL, stick "http://" infront. There are probably cases where this is wrong, e.g. 'javascript:...' but these don't work anyways.

(Curl works with www.example.com of course).