### PR TITLE
Cleaner cookie ownership

### DIFF
--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -241,7 +241,6 @@ pub fn setCookie(_: *HTMLDocument, cookie_str: []const u8, frame: *Frame) ![]con
         // Invalid cookies should be silently ignored, not throw errors
         return "";
     };
-    errdefer c.deinit();
     if (c.http_only) {
         c.deinit();
         return ""; // HttpOnly cookies cannot be set from JS

--- a/src/browser/webapi/storage/Cookie.zig
+++ b/src/browser/webapi/storage/Cookie.zig
@@ -484,10 +484,9 @@ pub const Jar = struct {
         /// Checks if addition comes from HTTP request or JS context.
         comptime is_http: bool,
     ) !void {
-        const is_expired = isCookieExpired(&cookie, request_time);
-        defer if (is_expired) {
-            cookie.deinit();
-        };
+        // `add` takes ownership of `cookie` unconditionally on entry.
+        var stored = false;
+        defer if (!stored) cookie.deinit();
 
         if (self.cookies.items.len >= max_jar_size) {
             return error.CookieJarQuotaExceeded;
@@ -495,6 +494,8 @@ pub const Jar = struct {
         if (cookie.value.len > max_cookie_size) {
             return error.CookieSizeExceeded;
         }
+
+        const is_expired = isCookieExpired(&cookie, request_time);
 
         for (self.cookies.items, 0..) |*c, i| {
             // We're only looking for the equal one.
@@ -505,7 +506,6 @@ pub const Jar = struct {
             // RFC 6265bis 5.7.2: a non-HTTP API (e.g. document.cookie) must
             // not replace an HttpOnly cookie.
             if (c.http_only and is_http == false) {
-                if (is_expired == false) cookie.deinit();
                 return;
             }
 
@@ -522,6 +522,7 @@ pub const Jar = struct {
                 // after the assignment, c points at the new cookie.
                 c.deinit();
                 self.cookies.items[i] = cookie;
+                stored = true;
                 self.dispatchChange(.changed, &self.cookies.items[i]);
             }
             return;
@@ -529,6 +530,7 @@ pub const Jar = struct {
 
         if (!is_expired) {
             try self.cookies.append(self.allocator, cookie);
+            stored = true;
             self.dispatchChange(.changed, &self.cookies.items[self.cookies.items.len - 1]);
         }
     }

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -427,34 +427,38 @@ fn storeCookie(exec: *const Execution, init: CookieInit) !void {
         if (!is_https) return error.InvalidPrefixedCookie;
     }
 
-    var arena = std.heap.ArenaAllocator.init(session.cookie_jar.allocator);
-    errdefer arena.deinit();
-    const aa = arena.allocator();
+    // The errdefer only protects construction failures. Once we `break :blk`
+    // with the Cookie value, `Jar.add` owns its lifetime.
+    const cookie: Cookie = blk: {
+        var arena = std.heap.ArenaAllocator.init(session.cookie_jar.allocator);
+        errdefer arena.deinit();
+        const aa = arena.allocator();
 
-    const owned_name = try aa.dupe(u8, init.name);
-    const owned_value = try aa.dupe(u8, init.value);
-    const owned_path = try Cookie.parsePath(aa, url, init.path);
-    const owned_domain = try Cookie.parseDomain(aa, url, init.domain);
+        const owned_name = try aa.dupe(u8, init.name);
+        const owned_value = try aa.dupe(u8, init.value);
+        const owned_path = try Cookie.parsePath(aa, url, init.path);
+        const owned_domain = try Cookie.parseDomain(aa, url, init.domain);
 
-    const cookie: Cookie = .{
-        .arena = arena,
-        .name = owned_name,
-        .value = owned_value,
-        .path = owned_path,
-        .domain = owned_domain,
+        break :blk .{
+            .arena = arena,
+            .name = owned_name,
+            .value = owned_value,
+            .path = owned_path,
+            .domain = owned_domain,
 
-        // CookieStore.expires is a unix timestamp in milliseconds; Cookie tracks
-        // expiry in seconds. A timestamp at or before "now" deletes the cookie via
-        // the Jar's expiry path.
-        .expires = if (init.expires) |ms| ms / 1000.0 else null,
+            // CookieStore.expires is a unix timestamp in milliseconds; Cookie tracks
+            // expiry in seconds. A timestamp at or before "now" deletes the cookie via
+            // the Jar's expiry path.
+            .expires = if (init.expires) |ms| ms / 1000.0 else null,
 
-        .secure = secure,
-        .http_only = false,
-        .same_site = switch (init.sameSite) {
-            .strict => .strict,
-            .lax => .lax,
-            .none => .none,
-        },
+            .secure = secure,
+            .http_only = false,
+            .same_site = switch (init.sameSite) {
+                .strict => .strict,
+                .lax => .lax,
+                .none => .none,
+            },
+        };
     };
 
     // CookieStore is a script API, so is_http = false.

--- a/src/cdp/domains/storage.zig
+++ b/src/cdp/domains/storage.zig
@@ -142,30 +142,34 @@ pub fn setCdpCookie(cookie_jar: *CookieJar, param: CdpCookie) !void {
         return error.NotImplemented;
     }
 
-    var arena = std.heap.ArenaAllocator.init(cookie_jar.allocator);
-    errdefer arena.deinit();
-    const a = arena.allocator();
+    // The errdefer only protects construction failures. Once we `break :blk`
+    // with the Cookie value, `Jar.add` owns its lifetime.
+    const cookie = blk: {
+        var arena = std.heap.ArenaAllocator.init(cookie_jar.allocator);
+        errdefer arena.deinit();
+        const a = arena.allocator();
 
-    // NOTE: The param.url can affect the default domain, (NOT path), secure, source port, and source scheme.
-    const domain = try Cookie.parseDomain(a, param.url, param.domain);
-    const path = if (param.path == null) "/" else try Cookie.parsePath(a, null, param.path);
+        // NOTE: The param.url can affect the default domain, (NOT path), secure, source port, and source scheme.
+        const domain = try Cookie.parseDomain(a, param.url, param.domain);
+        const path = if (param.path == null) "/" else try Cookie.parsePath(a, null, param.path);
 
-    const secure = if (param.secure) |s| s else if (param.url) |url| URL.isHTTPS(url) else false;
+        const secure = if (param.secure) |s| s else if (param.url) |url| URL.isHTTPS(url) else false;
 
-    const cookie = Cookie{
-        .arena = arena,
-        .name = try a.dupe(u8, param.name),
-        .value = try a.dupe(u8, param.value),
-        .path = path,
-        .domain = domain,
-        .expires = param.expires,
-        .secure = secure,
-        .http_only = param.httpOnly,
-        .same_site = switch (param.sameSite) {
-            .Strict => .strict,
-            .Lax => .lax,
-            .None => .none,
-        },
+        break :blk Cookie{
+            .arena = arena,
+            .name = try a.dupe(u8, param.name),
+            .value = try a.dupe(u8, param.value),
+            .path = path,
+            .domain = domain,
+            .expires = param.expires,
+            .secure = secure,
+            .http_only = param.httpOnly,
+            .same_site = switch (param.sameSite) {
+                .Strict => .strict,
+                .Lax => .lax,
+                .None => .none,
+            },
+        };
     };
     try cookie_jar.add(cookie, std.time.timestamp(), true);
 }

--- a/src/cookies.zig
+++ b/src/cookies.zig
@@ -77,7 +77,6 @@ fn _loadFromFile(session: *Session, path: []const u8) !void {
         };
 
         jar.add(cookie, now, true) catch |err| {
-            cookie.deinit();
             log.warn(.app, "invalid cookie", .{ .name = jc.name, .err = err });
             continue;
         };


### PR DESCRIPTION
Previously, Cookie.Jar.add would only conditionally take over the cookie. The caller had no way to know whether or not to deinit it. This could result in a double-free on certain error paths.

Cookie.Jar.add now unconditionally takes ownership of the cookie.