### PR TITLE
Prevent double-free on Synthetic URL

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -602,6 +602,9 @@ const Synthetic = struct {
     }
 
     fn run(transfer: *Transfer, _: *anyopaque) void {
+        // prevents a callback that triggers a navigation queue from killing
+        // this transfer from under us.
+        transfer.state = .completing;
         defer transfer.deinit();
 
         const fulfilled = build(transfer) catch |err| {


### PR DESCRIPTION
If a synthetic url (blob URL) causes a navigation event, the frame abort will deinit the transfer, causing the `defer transfer.deinit()` atop Synthetic.run from firing. Flag the transfer as .completing to prevent this from happening. This mimics what non-synthetic urls do.