### PR TITLE
Close session before freeing notification

### DIFF
--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -67,6 +67,7 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
     defer notification.deinit();
 
     var session = try browser.newSession(notification);
+    defer browser.closeSession();
 
     if (app.config.cookieFile()) |cookie_path| {
         cookies.loadFromFile(session, cookie_path);


### PR DESCRIPTION
With the new CookieStore, the session must be freed before the notification is. This is how it works in CDP, but in fetch, we were pretty lazy about it. This caused the notification to be freed first, and then the cookiestore to try to unregister: UAF.