### PR TITLE
Fix potential segfault in CustomElement definition

### DIFF
--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -55,7 +55,6 @@ pub fn define(self: *CustomElementRegistry, name: []const u8, constructor: js.Fu
         break :blk tag;
     } else null;
 
-
     // Do not use getOrPut here to hold the GetOrPut entry until we need to write
     // the definition. constructor.getPropertyValue() can fire a get accessor
     // which could callback here and alter self._definitions, invalidating any

--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -55,8 +55,12 @@ pub fn define(self: *CustomElementRegistry, name: []const u8, constructor: js.Fu
         break :blk tag;
     } else null;
 
-    const gop = try self._definitions.getOrPut(frame.arena, name);
-    if (gop.found_existing) {
+
+    // Do not use getOrPut here to hold the GetOrPut entry until we need to write
+    // the definition. constructor.getPropertyValue() can fire a get accessor
+    // which could callback here and alter self._definitions, invalidating any
+    // GOP pointer we have.
+    if (self._definitions.contains(name)) {
         // Yes, this is the correct error to return when trying to redefine a name
         return error.NotSupported;
     }
@@ -95,6 +99,10 @@ pub fn define(self: *CustomElementRegistry, name: []const u8, constructor: js.Fu
         }
     }
 
+    const gop = try self._definitions.getOrPut(frame.arena, owned_name);
+    if (gop.found_existing) {
+        return error.NotSupported;
+    }
     gop.key_ptr.* = owned_name;
     gop.value_ptr.* = definition;
 


### PR DESCRIPTION
Fixes crash in WPT /custom-elements/CustomElementRegistry.html

define has to get `observedAttributes` which itself could call define, invalidating any GetOrPutEntry pointers. Need to do it as two distinct lookup.