### PR TITLE
agent: add arrow-key navigation to picker

### DIFF
--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -47,6 +47,7 @@ pub const ansi = struct {
     pub const yellow = "\x1b[33m";
     pub const red = "\x1b[31m";
     pub const clear_eol = "\x1b[K";
+    pub const clear_line = "\x1b[2K";
 };
 
 const Verbosity = Config.AgentVerbosity;
@@ -713,21 +714,10 @@ fn promptNumberedChoiceLine(header: []const u8, items: []const []const u8, defau
     return error.NoChoice;
 }
 
-const ChoiceInput = union(enum) {
-    up,
-    down,
-    enter,
-    backspace,
-    cancel,
-    digit: u8,
-    ignore,
-};
+const ChoiceInput = enum { up, down, enter, cancel, ignore };
 
 const ChoiceState = struct {
     selected: usize,
-    typed: [16]u8 = undefined,
-    typed_len: usize = 0,
-    invalid: bool = false,
 
     fn init(default: ?usize) ChoiceState {
         return .{ .selected = default orelse 0 };
@@ -735,42 +725,12 @@ const ChoiceState = struct {
 
     fn apply(self: *ChoiceState, input: ChoiceInput, item_count: usize) ?usize {
         switch (input) {
-            .up => {
-                self.typed_len = 0;
-                self.invalid = false;
-                self.selected = if (self.selected == 0) item_count - 1 else self.selected - 1;
-            },
-            .down => {
-                self.typed_len = 0;
-                self.invalid = false;
-                self.selected = (self.selected + 1) % item_count;
-            },
-            .enter => {
-                if (self.typed_len > 0) {
-                    const parsed = std.fmt.parseInt(usize, self.typed[0..self.typed_len], 10) catch return null;
-                    if (parsed >= 1 and parsed <= item_count) return parsed - 1;
-                    self.invalid = true;
-                    return null;
-                }
-                return self.selected;
-            },
-            .backspace => if (self.typed_len > 0) {
-                self.typed_len -= 1;
-                self.invalid = false;
-            },
-            .digit => |d| if (self.typed_len < self.typed.len) {
-                if (self.invalid) self.typed_len = 0;
-                self.typed[self.typed_len] = d;
-                self.typed_len += 1;
-                self.invalid = false;
-            },
+            .up => self.selected = if (self.selected == 0) item_count - 1 else self.selected - 1,
+            .down => self.selected = (self.selected + 1) % item_count,
+            .enter => return self.selected,
             .cancel, .ignore => {},
         }
         return null;
-    }
-
-    fn typedSlice(self: *const ChoiceState) []const u8 {
-        return self.typed[0..self.typed_len];
     }
 };
 
@@ -808,18 +768,19 @@ fn promptInteractiveChoice(header: []const u8, items: []const []const u8, defaul
     defer raw.restore();
 
     var state = ChoiceState.init(default);
+    const line_count = items.len + 2;
     var first_render = true;
     while (true) {
-        renderChoice(header, items, default, &state, first_render);
+        renderChoice(header, items, default, state.selected, first_render);
         first_render = false;
 
         const input = readChoiceInput() catch return error.UserCancelled;
         if (input == .cancel) {
-            clearChoiceRender(items.len + 2);
+            clearChoiceRender(line_count);
             return error.UserCancelled;
         }
         if (state.apply(input, items.len)) |idx| {
-            clearChoiceRender(items.len + 2);
+            clearChoiceRender(line_count);
             std.debug.print("{s} {s}\r\n", .{ header, items[idx] });
             return idx;
         }
@@ -829,7 +790,7 @@ fn promptInteractiveChoice(header: []const u8, items: []const []const u8, defaul
 fn clearChoiceRender(line_count: usize) void {
     moveChoiceRenderStart(line_count);
     for (0..line_count) |i| {
-        std.debug.print("\x1b[2K", .{});
+        std.debug.print(ansi.clear_line, .{});
         if (i + 1 < line_count) std.debug.print("\r\n", .{});
     }
     moveChoiceRenderStart(line_count);
@@ -843,36 +804,18 @@ fn moveChoiceRenderStart(line_count: usize) void {
     }
 }
 
-fn renderChoice(header: []const u8, items: []const []const u8, default: ?usize, state: *const ChoiceState, first_render: bool) void {
-    const line_count = items.len + 2;
-    const number_width = decimalWidth(items.len);
-    if (!first_render) moveChoiceRenderStart(line_count);
-    std.debug.print("\x1b[2K{s}\r\n", .{header});
+fn renderChoice(header: []const u8, items: []const []const u8, default: ?usize, selected: usize, first_render: bool) void {
+    if (!first_render) moveChoiceRenderStart(items.len + 2);
+    std.debug.print(ansi.clear_line ++ "{s}\r\n", .{header});
     for (items, 0..) |item, idx| {
-        const marker: []const u8 = if (idx == state.selected) ">" else " ";
-        const style: []const u8 = if (idx == state.selected) ansi.bold ++ ansi.cyan else "";
-        const reset: []const u8 = if (idx == state.selected) ansi.reset else "";
+        const on_row = idx == selected;
+        const marker: []const u8 = if (on_row) ">" else " ";
+        const style: []const u8 = if (on_row) ansi.bold ++ ansi.cyan else "";
+        const reset: []const u8 = if (on_row) ansi.reset else "";
         const default_marker: []const u8 = if (default) |d| (if (d == idx) " (default)" else "") else "";
-        std.debug.print("\x1b[2K  {s} {s}", .{ marker, style });
-        const row_number = idx + 1;
-        for (decimalWidth(row_number)..number_width) |_| std.debug.print(" ", .{});
-        std.debug.print("{d}) {s}{s}{s}\r\n", .{ row_number, item, default_marker, reset });
+        std.debug.print(ansi.clear_line ++ "  {s} {s}{s}{s}{s}\r\n", .{ marker, style, item, default_marker, reset });
     }
-    const typed = state.typedSlice();
-    if (state.invalid) {
-        std.debug.print("\x1b[2KInvalid choice: {s}", .{typed});
-    } else if (typed.len > 0) {
-        std.debug.print("\x1b[2K> {s}", .{typed});
-    } else {
-        std.debug.print("\x1b[2K{s}Use Up/Down then Enter, or type a number. Esc cancels.{s}", .{ ansi.dim, ansi.reset });
-    }
-}
-
-fn decimalWidth(n: usize) usize {
-    var width: usize = 1;
-    var value = n;
-    while (value >= 10) : (value /= 10) width += 1;
-    return width;
+    std.debug.print(ansi.clear_line ++ "{s}Use Up/Down then Enter. Esc cancels.{s}", .{ ansi.dim, ansi.reset });
 }
 
 fn readChoiceInput() !ChoiceInput {
@@ -891,8 +834,6 @@ fn readChoiceInput() !ChoiceInput {
                 };
             },
             '\r', '\n' => .enter,
-            127, 8 => .backspace,
-            '0'...'9' => .{ .digit = ch },
             else => .ignore,
         };
     }
@@ -922,16 +863,10 @@ test "ChoiceState: arrows wrap and enter selects highlighted item" {
     try std.testing.expectEqual(@as(?usize, 0), state.apply(.enter, 3));
 }
 
-test "ChoiceState: typed number selects matching item on enter" {
+test "ChoiceState: starts on default and enter returns it" {
     var state = ChoiceState.init(2);
-
-    try std.testing.expectEqual(@as(?usize, null), state.apply(.{ .digit = '2' }, 3));
-    try std.testing.expectEqualStrings("2", state.typedSlice());
-    try std.testing.expectEqual(@as(?usize, 1), state.apply(.enter, 3));
-
-    state = ChoiceState.init(null);
-    try std.testing.expectEqual(@as(?usize, null), state.apply(.{ .digit = '9' }, 3));
-    try std.testing.expectEqual(@as(?usize, null), state.apply(.enter, 3));
+    try std.testing.expectEqual(@as(usize, 2), state.selected);
+    try std.testing.expectEqual(@as(?usize, 2), state.apply(.enter, 3));
 }
 
 pub fn printAssistant(_: *Terminal, text: []const u8) void {

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -665,9 +665,22 @@ pub fn columns() ?u16 {
 }
 
 /// Numbered TTY picker. `default` (if set) marks that row "(default)" and
-/// makes Enter return that index. Errors with NoChoice after 3 invalid
-/// attempts.
+/// makes Enter start on that index. Up/Down moves the active row; Enter
+/// selects it. Numbered input still works for users who prefer typing.
 pub fn promptNumberedChoice(header: []const u8, items: []const []const u8, default: ?usize) !usize {
+    if (items.len == 0) return error.NoChoice;
+    const valid_default: ?usize = if (default) |d| if (d < items.len) d else null else null;
+    if (interactiveTty()) {
+        return promptInteractiveChoice(header, items, valid_default) catch |err| switch (err) {
+            error.NotInteractive => try promptNumberedChoiceLine(header, items, valid_default),
+            else => err,
+        };
+    }
+    return promptNumberedChoiceLine(header, items, valid_default);
+}
+
+/// Line-oriented fallback. Errors with NoChoice after 3 invalid attempts.
+fn promptNumberedChoiceLine(header: []const u8, items: []const []const u8, default: ?usize) !usize {
     var stdin_buf: [128]u8 = undefined;
     var stdin = std.fs.File.stdin().reader(&stdin_buf);
 
@@ -698,6 +711,227 @@ pub fn promptNumberedChoice(header: []const u8, items: []const []const u8, defau
         std.debug.print("Out of range.\n", .{});
     }
     return error.NoChoice;
+}
+
+const ChoiceInput = union(enum) {
+    up,
+    down,
+    enter,
+    backspace,
+    cancel,
+    digit: u8,
+    ignore,
+};
+
+const ChoiceState = struct {
+    selected: usize,
+    typed: [16]u8 = undefined,
+    typed_len: usize = 0,
+    invalid: bool = false,
+
+    fn init(default: ?usize) ChoiceState {
+        return .{ .selected = default orelse 0 };
+    }
+
+    fn apply(self: *ChoiceState, input: ChoiceInput, item_count: usize) ?usize {
+        switch (input) {
+            .up => {
+                self.typed_len = 0;
+                self.invalid = false;
+                self.selected = if (self.selected == 0) item_count - 1 else self.selected - 1;
+            },
+            .down => {
+                self.typed_len = 0;
+                self.invalid = false;
+                self.selected = (self.selected + 1) % item_count;
+            },
+            .enter => {
+                if (self.typed_len > 0) {
+                    const parsed = std.fmt.parseInt(usize, self.typed[0..self.typed_len], 10) catch return null;
+                    if (parsed >= 1 and parsed <= item_count) return parsed - 1;
+                    self.invalid = true;
+                    return null;
+                }
+                return self.selected;
+            },
+            .backspace => if (self.typed_len > 0) {
+                self.typed_len -= 1;
+                self.invalid = false;
+            },
+            .digit => |d| if (self.typed_len < self.typed.len) {
+                if (self.invalid) self.typed_len = 0;
+                self.typed[self.typed_len] = d;
+                self.typed_len += 1;
+                self.invalid = false;
+            },
+            .cancel, .ignore => {},
+        }
+        return null;
+    }
+
+    fn typedSlice(self: *const ChoiceState) []const u8 {
+        return self.typed[0..self.typed_len];
+    }
+};
+
+const RawTerminal = struct {
+    original: std.posix.termios,
+
+    fn enable() !RawTerminal {
+        if (!interactiveTty()) return error.NotInteractive;
+        const original = try std.posix.tcgetattr(std.posix.STDIN_FILENO);
+        var raw = original;
+        raw.iflag.BRKINT = false;
+        raw.iflag.ICRNL = false;
+        raw.iflag.INPCK = false;
+        raw.iflag.ISTRIP = false;
+        raw.iflag.IXON = false;
+        raw.oflag.OPOST = false;
+        raw.cflag.CSIZE = .CS8;
+        raw.lflag.ECHO = false;
+        raw.lflag.ICANON = false;
+        raw.lflag.IEXTEN = false;
+        raw.lflag.ISIG = false;
+        raw.cc[@intFromEnum(std.c.V.MIN)] = 0;
+        raw.cc[@intFromEnum(std.c.V.TIME)] = 1;
+        try std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, raw);
+        return .{ .original = original };
+    }
+
+    fn restore(self: *const RawTerminal) void {
+        std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, self.original) catch {};
+    }
+};
+
+fn promptInteractiveChoice(header: []const u8, items: []const []const u8, default: ?usize) !usize {
+    var raw = try RawTerminal.enable();
+    defer raw.restore();
+
+    var state = ChoiceState.init(default);
+    var first_render = true;
+    while (true) {
+        renderChoice(header, items, default, &state, first_render);
+        first_render = false;
+
+        const input = readChoiceInput() catch return error.UserCancelled;
+        if (input == .cancel) {
+            clearChoiceRender(items.len + 2);
+            return error.UserCancelled;
+        }
+        if (state.apply(input, items.len)) |idx| {
+            clearChoiceRender(items.len + 2);
+            std.debug.print("{s} {s}\r\n", .{ header, items[idx] });
+            return idx;
+        }
+    }
+}
+
+fn clearChoiceRender(line_count: usize) void {
+    moveChoiceRenderStart(line_count);
+    for (0..line_count) |i| {
+        std.debug.print("\x1b[2K", .{});
+        if (i + 1 < line_count) std.debug.print("\r\n", .{});
+    }
+    moveChoiceRenderStart(line_count);
+}
+
+fn moveChoiceRenderStart(line_count: usize) void {
+    if (line_count > 1) {
+        std.debug.print("\x1b[{d}F", .{line_count - 1});
+    } else {
+        std.debug.print("\r", .{});
+    }
+}
+
+fn renderChoice(header: []const u8, items: []const []const u8, default: ?usize, state: *const ChoiceState, first_render: bool) void {
+    const line_count = items.len + 2;
+    const number_width = decimalWidth(items.len);
+    if (!first_render) moveChoiceRenderStart(line_count);
+    std.debug.print("\x1b[2K{s}\r\n", .{header});
+    for (items, 0..) |item, idx| {
+        const marker: []const u8 = if (idx == state.selected) ">" else " ";
+        const style: []const u8 = if (idx == state.selected) ansi.bold ++ ansi.cyan else "";
+        const reset: []const u8 = if (idx == state.selected) ansi.reset else "";
+        const default_marker: []const u8 = if (default) |d| (if (d == idx) " (default)" else "") else "";
+        std.debug.print("\x1b[2K  {s} {s}", .{ marker, style });
+        const row_number = idx + 1;
+        for (decimalWidth(row_number)..number_width) |_| std.debug.print(" ", .{});
+        std.debug.print("{d}) {s}{s}{s}\r\n", .{ row_number, item, default_marker, reset });
+    }
+    const typed = state.typedSlice();
+    if (state.invalid) {
+        std.debug.print("\x1b[2KInvalid choice: {s}", .{typed});
+    } else if (typed.len > 0) {
+        std.debug.print("\x1b[2K> {s}", .{typed});
+    } else {
+        std.debug.print("\x1b[2K{s}Use Up/Down then Enter, or type a number. Esc cancels.{s}", .{ ansi.dim, ansi.reset });
+    }
+}
+
+fn decimalWidth(n: usize) usize {
+    var width: usize = 1;
+    var value = n;
+    while (value >= 10) : (value /= 10) width += 1;
+    return width;
+}
+
+fn readChoiceInput() !ChoiceInput {
+    while (true) {
+        const ch = try readChoiceByte() orelse continue;
+        return switch (ch) {
+            3, 4, 27 => esc: {
+                if (ch != 27) break :esc .cancel;
+                const b1 = try readChoiceByte() orelse break :esc .cancel;
+                if (b1 != '[' and b1 != 'O') break :esc .cancel;
+                const b2 = try readChoiceByte() orelse break :esc .cancel;
+                break :esc switch (b2) {
+                    'A' => .up,
+                    'B' => .down,
+                    else => .ignore,
+                };
+            },
+            '\r', '\n' => .enter,
+            127, 8 => .backspace,
+            '0'...'9' => .{ .digit = ch },
+            else => .ignore,
+        };
+    }
+}
+
+fn readChoiceByte() !?u8 {
+    var buf: [1]u8 = undefined;
+    const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch |err| switch (err) {
+        error.WouldBlock => return null,
+        error.InputOutput => return error.ReadFailed,
+        else => return err,
+    };
+    if (n == 0) return null;
+    return buf[0];
+}
+
+test "ChoiceState: arrows wrap and enter selects highlighted item" {
+    var state = ChoiceState.init(null);
+    try std.testing.expectEqual(@as(usize, 0), state.selected);
+
+    try std.testing.expectEqual(@as(?usize, null), state.apply(.up, 3));
+    try std.testing.expectEqual(@as(usize, 2), state.selected);
+
+    try std.testing.expectEqual(@as(?usize, null), state.apply(.down, 3));
+    try std.testing.expectEqual(@as(usize, 0), state.selected);
+
+    try std.testing.expectEqual(@as(?usize, 0), state.apply(.enter, 3));
+}
+
+test "ChoiceState: typed number selects matching item on enter" {
+    var state = ChoiceState.init(2);
+
+    try std.testing.expectEqual(@as(?usize, null), state.apply(.{ .digit = '2' }, 3));
+    try std.testing.expectEqualStrings("2", state.typedSlice());
+    try std.testing.expectEqual(@as(?usize, 1), state.apply(.enter, 3));
+
+    state = ChoiceState.init(null);
+    try std.testing.expectEqual(@as(?usize, null), state.apply(.{ .digit = '9' }, 3));
+    try std.testing.expectEqual(@as(?usize, null), state.apply(.enter, 3));
 }
 
 pub fn printAssistant(_: *Terminal, text: []const u8) void {

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -650,19 +650,29 @@ pub fn interactiveTty() bool {
     return std.posix.isatty(std.posix.STDIN_FILENO) and std.posix.isatty(std.posix.STDERR_FILENO);
 }
 
-/// Current terminal width in columns, queried via TIOCGWINSZ on stderr.
-/// Null when stderr isn't a tty, the ioctl fails, or the kernel reports 0
-/// (some pseudo-ttys leave the field unset). Cheap enough to call per
-/// render frame — picks up resizes without SIGWINCH plumbing.
-pub fn columns() ?u16 {
+fn windowSize() ?std.posix.winsize {
     var ws: std.posix.winsize = undefined;
     // bitcast via c_uint: on archs where `_IOR` sets the direction bit
     // (MIPS/PPC/SPARC), `IOCGWINSZ` exceeds i32 range — a plain @intCast
     // panics there. The bitcast preserves the bit pattern.
     const req: c_int = @bitCast(@as(c_uint, std.posix.T.IOCGWINSZ));
-    const rc = std.c.ioctl(std.posix.STDERR_FILENO, req, &ws);
-    if (rc != 0 or ws.col == 0) return null;
-    return ws.col;
+    if (std.c.ioctl(std.posix.STDERR_FILENO, req, &ws) != 0) return null;
+    return ws;
+}
+
+/// Current terminal width in columns, queried via TIOCGWINSZ on stderr.
+/// Null when stderr isn't a tty, the ioctl fails, or the kernel reports 0
+/// (some pseudo-ttys leave the field unset). Cheap enough to call per
+/// render frame — picks up resizes without SIGWINCH plumbing.
+pub fn columns() ?u16 {
+    const ws = windowSize() orelse return null;
+    return if (ws.col == 0) null else ws.col;
+}
+
+/// Current terminal height in rows; see `columns` for null conditions.
+pub fn rows() ?u16 {
+    const ws = windowSize() orelse return null;
+    return if (ws.row == 0) null else ws.row;
 }
 
 /// Numbered TTY picker. `default` (if set) marks that row "(default)" and
@@ -671,13 +681,20 @@ pub fn columns() ?u16 {
 pub fn promptNumberedChoice(header: []const u8, items: []const []const u8, default: ?usize) !usize {
     if (items.len == 0) return error.NoChoice;
     const valid_default: ?usize = if (default) |d| if (d < items.len) d else null else null;
-    if (interactiveTty()) {
+    // A picker block taller than the terminal scrolls, drifting the in-place
+    // cursor redraw into garbage; use the line prompt when it won't fit.
+    if (interactiveTty() and choiceBlockFits(items.len)) {
         return promptInteractiveChoice(header, items, valid_default) catch |err| switch (err) {
             error.NotInteractive => try promptNumberedChoiceLine(header, items, valid_default),
             else => err,
         };
     }
     return promptNumberedChoiceLine(header, items, valid_default);
+}
+
+fn choiceBlockFits(item_count: usize) bool {
+    const terminal_rows = rows() orelse return true; // unknown height: allow it
+    return item_count + 2 <= terminal_rows; // header + items + hint
 }
 
 /// Line-oriented fallback. Errors with NoChoice after 3 invalid attempts.

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -48,6 +48,7 @@ pub const ansi = struct {
     pub const red = "\x1b[31m";
     pub const clear_eol = "\x1b[K";
     pub const clear_line = "\x1b[2K";
+    pub const clear_below = "\x1b[0J";
 };
 
 const Verbosity = Config.AgentVerbosity;
@@ -681,20 +682,13 @@ pub fn rows() ?u16 {
 pub fn promptNumberedChoice(header: []const u8, items: []const []const u8, default: ?usize) !usize {
     if (items.len == 0) return error.NoChoice;
     const valid_default: ?usize = if (default) |d| if (d < items.len) d else null else null;
-    // A picker block taller than the terminal scrolls, drifting the in-place
-    // cursor redraw into garbage; use the line prompt when it won't fit.
-    if (interactiveTty() and choiceBlockFits(items.len)) {
+    if (interactiveTty()) {
         return promptInteractiveChoice(header, items, valid_default) catch |err| switch (err) {
             error.NotInteractive => try promptNumberedChoiceLine(header, items, valid_default),
             else => err,
         };
     }
     return promptNumberedChoiceLine(header, items, valid_default);
-}
-
-fn choiceBlockFits(item_count: usize) bool {
-    const terminal_rows = rows() orelse return true; // unknown height: allow it
-    return item_count + 2 <= terminal_rows; // header + items + hint
 }
 
 /// Line-oriented fallback. Errors with NoChoice after 3 invalid attempts.
@@ -735,6 +729,7 @@ const ChoiceInput = enum { up, down, enter, cancel, ignore };
 
 const ChoiceState = struct {
     selected: usize,
+    top: usize = 0,
 
     fn init(default: ?usize) ChoiceState {
         return .{ .selected = default orelse 0 };
@@ -748,6 +743,17 @@ const ChoiceState = struct {
             .cancel, .ignore => {},
         }
         return null;
+    }
+
+    /// Slide the `visible`-row window so `selected` stays inside it, keeping the
+    /// window within the list (a grown viewport must not run past the end).
+    fn scrollInto(self: *ChoiceState, visible: usize, item_count: usize) void {
+        if (self.selected < self.top) {
+            self.top = self.selected;
+        } else if (self.selected >= self.top + visible) {
+            self.top = self.selected - visible + 1;
+        }
+        if (self.top + visible > item_count) self.top = item_count - visible;
     }
 };
 
@@ -781,23 +787,31 @@ const RawTerminal = struct {
 };
 
 fn promptInteractiveChoice(header: []const u8, items: []const []const u8, default: ?usize) !usize {
+    // Need the height to bound the scroll window; without it (or with no room
+    // for even one item row) defer to the scrolling line prompt.
+    if ((rows() orelse return error.NotInteractive) < 3) return error.NotInteractive;
+
     var raw = try RawTerminal.enable();
     defer raw.restore();
 
     var state = ChoiceState.init(default);
-    const line_count = items.len + 2;
-    var first_render = true;
+    // Re-read the height every frame so resizing the terminal (or the font)
+    // between keystrokes resizes the window instead of garbling the redraw.
+    var prev_lines: usize = 0;
     while (true) {
-        renderChoice(header, items, default, state.selected, first_render);
-        first_render = false;
+        const terminal_rows = @max(rows() orelse 3, 3);
+        const visible = @min(items.len, terminal_rows - 2);
+        state.scrollInto(visible, items.len);
+        renderChoice(header, items, default, &state, visible, prev_lines);
+        prev_lines = visible + 2;
 
         const input = readChoiceInput() catch return error.UserCancelled;
         if (input == .cancel) {
-            clearChoiceRender(line_count);
+            clearChoiceRender(prev_lines);
             return error.UserCancelled;
         }
         if (state.apply(input, items.len)) |idx| {
-            clearChoiceRender(line_count);
+            clearChoiceRender(prev_lines);
             std.debug.print("{s} {s}\r\n", .{ header, items[idx] });
             return idx;
         }
@@ -806,11 +820,7 @@ fn promptInteractiveChoice(header: []const u8, items: []const []const u8, defaul
 
 fn clearChoiceRender(line_count: usize) void {
     moveChoiceRenderStart(line_count);
-    for (0..line_count) |i| {
-        std.debug.print(ansi.clear_line, .{});
-        if (i + 1 < line_count) std.debug.print("\r\n", .{});
-    }
-    moveChoiceRenderStart(line_count);
+    std.debug.print(ansi.clear_below, .{});
 }
 
 fn moveChoiceRenderStart(line_count: usize) void {
@@ -821,18 +831,34 @@ fn moveChoiceRenderStart(line_count: usize) void {
     }
 }
 
-fn renderChoice(header: []const u8, items: []const []const u8, default: ?usize, selected: usize, first_render: bool) void {
-    if (!first_render) moveChoiceRenderStart(items.len + 2);
-    std.debug.print(ansi.clear_line ++ "{s}\r\n", .{header});
-    for (items, 0..) |item, idx| {
-        const on_row = idx == selected;
+fn renderChoice(header: []const u8, items: []const []const u8, default: ?usize, state: *const ChoiceState, visible: usize, prev_lines: usize) void {
+    // Rewind over the previous frame, then wipe it (and any rows a now-shorter
+    // frame leaves behind) before drawing.
+    if (prev_lines > 0) moveChoiceRenderStart(prev_lines);
+    std.debug.print(ansi.clear_below, .{});
+    const max_cols = columns();
+    std.debug.print("{s}\r\n", .{header});
+    for (items[state.top..][0..visible], state.top..) |item, idx| {
+        const on_row = idx == state.selected;
         const marker: []const u8 = if (on_row) ">" else " ";
         const style: []const u8 = if (on_row) ansi.bold ++ ansi.cyan else "";
         const reset: []const u8 = if (on_row) ansi.reset else "";
         const default_marker: []const u8 = if (default) |d| (if (d == idx) " (default)" else "") else "";
-        std.debug.print(ansi.clear_line ++ "  {s} {s}{s}{s}{s}\r\n", .{ marker, style, item, default_marker, reset });
+        const shown = truncateChoiceItem(item, max_cols, default_marker.len);
+        std.debug.print("  {s} {s}{s}{s}{s}{s}\r\n", .{ marker, style, shown.text, shown.ellipsis, default_marker, reset });
     }
-    std.debug.print(ansi.clear_line ++ "{s}Use Up/Down then Enter. Esc cancels.{s}", .{ ansi.dim, ansi.reset });
+    std.debug.print("{s}Use Up/Down then Enter. Esc cancels.{s}", .{ ansi.dim, ansi.reset });
+}
+
+/// Trim an item so its row fits one line: `  > name… (default)`. Reserves the
+/// 4-column row prefix and `suffix_len` for the default marker. Byte-sliced, so
+/// it assumes ASCII items (model/provider names); null width passes through.
+fn truncateChoiceItem(item: []const u8, max_cols: ?u16, suffix_len: usize) struct { text: []const u8, ellipsis: []const u8 } {
+    const cols = max_cols orelse return .{ .text = item, .ellipsis = "" };
+    const budget = @as(usize, cols) -| (4 + suffix_len);
+    if (item.len <= budget) return .{ .text = item, .ellipsis = "" };
+    if (budget == 0) return .{ .text = "", .ellipsis = "…" };
+    return .{ .text = item[0 .. budget - 1], .ellipsis = "…" };
 }
 
 fn readChoiceInput() !ChoiceInput {
@@ -884,6 +910,70 @@ test "ChoiceState: starts on default and enter returns it" {
     var state = ChoiceState.init(2);
     try std.testing.expectEqual(@as(usize, 2), state.selected);
     try std.testing.expectEqual(@as(?usize, 2), state.apply(.enter, 3));
+}
+
+test "ChoiceState: viewport follows selection down and on up-wrap" {
+    const visible = 3;
+    const count = 6;
+    var state = ChoiceState.init(null);
+
+    state.scrollInto(visible, count);
+    try std.testing.expectEqual(@as(usize, 0), state.top);
+
+    // Walk down past the window bottom; top trails to keep selection visible.
+    for (0..3) |_| _ = state.apply(.down, count);
+    state.scrollInto(visible, count);
+    try std.testing.expectEqual(@as(usize, 3), state.selected);
+    try std.testing.expectEqual(@as(usize, 1), state.top);
+
+    // Selection still inside the window leaves top put.
+    _ = state.apply(.up, count);
+    state.scrollInto(visible, count);
+    try std.testing.expectEqual(@as(usize, 1), state.top);
+}
+
+test "ChoiceState: up-wrap from top jumps the window to the last item" {
+    const visible = 3;
+    const count = 6;
+    var state = ChoiceState.init(null);
+
+    _ = state.apply(.up, count);
+    state.scrollInto(visible, count);
+    try std.testing.expectEqual(@as(usize, 5), state.selected);
+    try std.testing.expectEqual(@as(usize, 3), state.top);
+}
+
+test "ChoiceState: a grown viewport pulls top back within the list" {
+    const count = 6;
+    var state = ChoiceState.init(null);
+
+    // Scrolled to the bottom with a 3-row window: top = 3.
+    _ = state.apply(.up, count); // selected = 5
+    state.scrollInto(3, count);
+    try std.testing.expectEqual(@as(usize, 3), state.top);
+
+    // Window grows to 5; top must retreat so top + visible stays <= count.
+    state.scrollInto(5, count);
+    try std.testing.expectEqual(@as(usize, 1), state.top);
+
+    // Window grows to the whole list; top pins to 0.
+    state.scrollInto(6, count);
+    try std.testing.expectEqual(@as(usize, 0), state.top);
+}
+
+test "truncateChoiceItem: trims to width and passes short items through" {
+    const fits = truncateChoiceItem("gpt-4o", 40, 0);
+    try std.testing.expectEqualStrings("gpt-4o", fits.text);
+    try std.testing.expectEqualStrings("", fits.ellipsis);
+
+    // 10 cols, 4 reserved for prefix -> 6 budget, last col is the ellipsis.
+    const cut = truncateChoiceItem("anthropic-claude", 10, 0);
+    try std.testing.expectEqualStrings("anthr", cut.text);
+    try std.testing.expectEqualStrings("…", cut.ellipsis);
+
+    // Unknown width never truncates.
+    const unknown = truncateChoiceItem("anthropic-claude", null, 0);
+    try std.testing.expectEqualStrings("anthropic-claude", unknown.text);
 }
 
 pub fn printAssistant(_: *Terminal, text: []const u8) void {


### PR DESCRIPTION
Make the numbered agent choice prompt interactive on TTYs: Up/Down moves the selected row, Enter confirms it, and numeric input still works as before.

Keep the line-based numbered prompt as the non-interactive fallback, restore terminal settings after the raw-mode picker exits, and render raw-mode output with CRLF so menu rows stay aligned. Dim the picker hint text to match existing terminal command hints.