### PR TITLE
Agent model provider picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.zig-cache/
 /.lp-cache/
 /.lp-history
+/.lp-agent
 /zig-pkg/
 zig-out
 lightpanda.id

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .hash = "N-V-__8AABGOuAC_dhAN07kfoP4dycCFi8Bka4O-tuhriNH8",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#a80cf31db94d9faef9a78de168aeafc66f024bf6",
-            .hash = "zenai-0.0.0-iOY_VJrDAwCnp_jAaVldpQtlHBDxwBPX0pLUsSFzxj8H",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#a59849c6fa1099d62e0a8b344edbbb6bae82f049",
+            .hash = "zenai-0.0.0-iOY_VFjEAwCcttg3FVcZy5kYvjsyX-4IA-xNpddZSCip",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline.git#48d94027aec0408dc58af9ca2dfedf4720870e8c",

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -51,8 +51,9 @@ etc.) without giving Lightpanda its own API key.
 | Ollama      | `--provider ollama`    | none (local)                         |
 
 Defaults: `--model` falls back to a sensible per-provider default; in the REPL,
-`/model` lists models for the active provider and changes the current selection.
-`--base-url` overrides the API endpoint (Ollama defaults to
+`/provider` lists providers and changes the current selection, and `/model`
+lists models for the active provider and changes the current model. `--base-url`
+overrides the API endpoint (Ollama defaults to
 `http://localhost:11434/v1`).
 
 ### Provider auto-detection
@@ -257,9 +258,10 @@ from selector drift, not to redesign the script.
   match.
 - **Persistent history**: stored in `.lp-history` in the working directory.
 - **Meta slash commands**: `/help` lists tools (`/help <tool>` prints the
-  JSON schema), `/model` lists and changes the active model, `/quit` exits the
-  REPL, `/verbosity <low|medium|high>` tunes the log level. These are REPL-only
-  and never recorded.
+  JSON schema), `/provider` lists and changes the active provider, `/model`
+  lists and changes the active model, `/quit` exits the REPL,
+  `/verbosity <low|medium|high>` tunes the log level. These are REPL-only and
+  never recorded.
   ```
   > /goto https://example.com
   > /findElement role=button name=Submit

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -50,8 +50,10 @@ etc.) without giving Lightpanda its own API key.
 | Gemini      | `--provider gemini`    | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
 | Ollama      | `--provider ollama`    | none (local)                         |
 
-Defaults: `--model` falls back to a sensible per-provider default; `--base-url`
-overrides the API endpoint (Ollama defaults to `http://localhost:11434/v1`).
+Defaults: `--model` falls back to a sensible per-provider default; in the REPL,
+`/model` lists models for the active provider and changes the current selection.
+`--base-url` overrides the API endpoint (Ollama defaults to
+`http://localhost:11434/v1`).
 
 ### Provider auto-detection
 
@@ -255,8 +257,9 @@ from selector drift, not to redesign the script.
   match.
 - **Persistent history**: stored in `.lp-history` in the working directory.
 - **Meta slash commands**: `/help` lists tools (`/help <tool>` prints the
-  JSON schema), `/quit` exits the REPL, `/verbosity <low|medium|high>` tunes
-  the log level. These are REPL-only and never recorded.
+  JSON schema), `/model` lists and changes the active model, `/quit` exits the
+  REPL, `/verbosity <low|medium|high>` tunes the log level. These are REPL-only
+  and never recorded.
   ```
   > /goto https://example.com
   > /findElement role=button name=Submit

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -51,10 +51,9 @@ etc.) without giving Lightpanda its own API key.
 | Ollama      | `--provider ollama`    | none (local)                         |
 
 Defaults: `--model` falls back to a sensible per-provider default; in the REPL,
-`/provider` lists providers and changes the current selection, and `/model`
-lists models for the active provider and changes the current model. `--base-url`
-overrides the API endpoint (Ollama defaults to
-`http://localhost:11434/v1`).
+`/provider <name>` and `/model <name>` change the current selection (Tab
+completes the candidates). `--base-url` overrides the API endpoint (Ollama
+defaults to `http://localhost:11434/v1`).
 
 ### Provider auto-detection
 
@@ -258,10 +257,11 @@ from selector drift, not to redesign the script.
   match.
 - **Persistent history**: stored in `.lp-history` in the working directory.
 - **Meta slash commands**: `/help` lists tools (`/help <tool>` prints the
-  JSON schema), `/provider` lists and changes the active provider, `/model`
-  lists and changes the active model, `/quit` exits the REPL,
-  `/verbosity <low|medium|high>` tunes the log level. These are REPL-only and
-  never recorded.
+  JSON schema), `/provider [name]` and `/model [name]` change the active
+  provider/model — Tab after the space completes from detected providers and
+  the provider's fetched model list, and bare `/provider`/`/model` print the
+  current selection — `/quit` exits the REPL, `/verbosity <low|medium|high>`
+  tunes the log level. These are REPL-only and never recorded.
   ```
   > /goto https://example.com
   > /findElement role=button name=Submit

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -57,17 +57,20 @@ defaults to `http://localhost:11434/v1`).
 
 ### Provider auto-detection
 
-When `--provider` is omitted, lightpanda inspects the environment and picks one:
+When `--provider` is omitted, lightpanda picks one in this order, printing a
+one-line notice (on stderr) of what it chose:
 
-- **No keys set** → falls back to the basic REPL (PandaScript only). Natural
-  language, `/login`, `/acceptCookies`, and `--self-heal` will reject. A
-  one-line notice is printed so you know which mode you landed in.
-- **Exactly one key set** → that provider is used. A one-line notice
-  identifies the env var that won.
-- **Multiple keys set, on a TTY** → a numbered prompt asks which to use.
-- **Multiple keys set, non-interactive** → the agent fails fast and tells
-  you to pass `--provider` explicitly. Ollama is never auto-detected
-  (no env var to look at) — pass `--provider ollama` if you want it.
+1. **Remembered** → the provider/model you last selected with `/provider` or
+   `/model`, persisted per-directory in `.lp-agent`, as long as its key is
+   still set.
+2. **Auto-detected** → otherwise the first key found in priority order
+   (`ANTHROPIC_API_KEY` → `GOOGLE_API_KEY`/`GEMINI_API_KEY` → `OPENAI_API_KEY`).
+   Switch any time with `/provider` in the REPL, or override with `--provider`.
+3. **No keys set** → falls back to the basic REPL (PandaScript only). Natural
+   language, `/login`, `/acceptCookies`, and `--self-heal` will reject.
+
+Ollama is never auto-detected (no env var to look at) — pass `--provider
+ollama`, or select it once with `/provider ollama` and it'll be remembered.
 
 `--no-llm` is the explicit bypass: it forces the basic REPL even when an
 API key is present or `--provider` is set. Use it to test PandaScript

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -232,7 +232,6 @@ const Commands = cli.Builder(.{
             .{ .name = "verbosity", .type = ?AgentVerbosity },
             .{ .name = "list_models", .type = bool },
             .{ .name = "no_llm", .type = bool },
-            .{ .name = "pick_model", .type = bool },
         },
         .shared_options = CommonOptions,
     },

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1675,15 +1675,7 @@ fn deinitAiClient(allocator: std.mem.Allocator, ai_client: zenai.provider.Client
 }
 
 fn availableProviders(buf: []Credentials) []Credentials {
-    var n: usize = 0;
-    inline for (@typeInfo(Config.AiProvider).@"enum".fields) |field| {
-        const provider: Config.AiProvider = @enumFromInt(field.value);
-        if (zenai.provider.envApiKey(provider)) |key| {
-            buf[n] = .{ .provider = provider, .key = key };
-            n += 1;
-        }
-    }
-    return buf[0..n];
+    return zenai.provider.detectKeys(buf, std.enums.values(Config.AiProvider));
 }
 
 fn pickProvider(found: []const Credentials) !Credentials {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -46,8 +46,6 @@ pub const UserError = error{
     MissingApiKey,
     MissingProvider,
     ConflictingFlags,
-    AmbiguousProvider,
-    NotInteractive,
 };
 
 pub fn isUserError(err: anyerror) bool {
@@ -228,10 +226,13 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
 
     const model: []u8 = if (opts.model) |m|
         try allocator.dupe(u8, m)
-    else if (llm) |l| blk: {
-        if (resolved) |r| if (r.source == .remembered) break :blk try allocator.dupe(u8, remembered.?.model);
-        break :blk try allocator.dupe(u8, defaultModel(l.provider));
-    } else try allocator.dupe(u8, "");
+    else if (resolved) |r|
+        if (r.source == .remembered)
+            try allocator.dupe(u8, remembered.?.model)
+        else
+            try allocator.dupe(u8, defaultModel(r.credentials.provider))
+    else
+        try allocator.dupe(u8, "");
     errdefer allocator.free(model);
 
     if (resolved) |r| switch (r.source) {
@@ -586,15 +587,16 @@ fn handleVerbosity(self: *Agent, rest: []const u8) void {
     self.terminal.printInfo("verbosity: {s}", .{@tagName(level)});
 }
 
-fn requireLlm(self: *Agent, name: []const u8) ?Credentials {
-    return self.model_credentials orelse {
+fn requireLlm(self: *Agent, name: []const u8) bool {
+    if (self.model_credentials == null) {
         self.terminal.printError("{s} requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{name});
-        return null;
-    };
+        return false;
+    }
+    return true;
 }
 
 fn handleModel(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
-    if (self.requireLlm("/model") == null) return;
+    if (!self.requireLlm("/model")) return;
 
     const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
     if (trimmed.len == 0) {
@@ -615,7 +617,8 @@ fn setModel(self: *Agent, model: []const u8) !void {
 }
 
 fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
-    const current = self.requireLlm("/provider") orelse return;
+    if (!self.requireLlm("/provider")) return;
+    const current = self.model_credentials.?;
 
     const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
     if (trimmed.len == 0) {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -142,6 +142,10 @@ allocator: std.mem.Allocator,
 ai_client: ?zenai.provider.Client,
 model_credentials: ?Credentials,
 model_base_url: ?[:0]const u8,
+/// Cached chat-model ids for the current provider, backed by
+/// `model_completion_arena` and invalidated on `/provider` switch.
+model_completions: ?ModelCompletions,
+model_completion_arena: std.heap.ArenaAllocator,
 notification: *lp.Notification,
 browser: lp.Browser,
 session: *lp.Session,
@@ -242,6 +246,8 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
         .ai_client = null,
         .model_credentials = llm,
         .model_base_url = opts.base_url,
+        .model_completions = null,
+        .model_completion_arena = .init(allocator),
         .notification = notification,
         .browser = undefined,
         .session = undefined,
@@ -277,7 +283,14 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     self.ai_client = if (llm) |l| try initAiClient(allocator, l, opts.base_url) else null;
     errdefer if (self.ai_client) |c| deinitAiClient(allocator, c);
 
-    if (will_repl) self.terminal.attachCompleter();
+    if (will_repl) {
+        self.terminal.attachCompleter();
+        self.terminal.completion_source = .{
+            .context = @ptrCast(self),
+            .providers = completionProviders,
+            .models = completionModels,
+        };
+    }
 
     if (recorder_path) |p| {
         if (Recorder.init(allocator, std.fs.cwd(), p)) |r| {
@@ -298,6 +311,7 @@ pub fn deinit(self: *Agent) void {
     if (self.save_path) |p| self.allocator.free(p);
     self.terminal.deinit();
     self.message_arena.deinit();
+    self.model_completion_arena.deinit();
     self.messages.deinit(self.allocator);
     self.node_registry.deinit();
     self.browser.deinit();
@@ -555,46 +569,22 @@ fn handleVerbosity(self: *Agent, rest: []const u8) void {
     self.terminal.printInfo("verbosity: {s}", .{@tagName(level)});
 }
 
-fn requireLlmNoArg(self: *Agent, name: []const u8, rest: []const u8) ?Credentials {
-    const llm = self.model_credentials orelse {
+fn requireLlm(self: *Agent, name: []const u8) ?Credentials {
+    return self.model_credentials orelse {
         self.terminal.printError("{s} requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{name});
         return null;
     };
-    if (std.mem.trim(u8, rest, &std.ascii.whitespace).len != 0) {
-        self.terminal.printError("usage: {s}", .{name});
-        return null;
-    }
-    return llm;
 }
 
-fn handleModel(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
-    const llm = self.requireLlmNoArg("/model", rest) orelse return;
+fn handleModel(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
+    if (self.requireLlm("/model") == null) return;
 
-    self.terminal.printInfo("Current model: {s}", .{self.model});
-    self.terminal.printInfo("Fetching models for {s}...", .{@tagName(llm.provider)});
-
-    const ids = zenai.provider.listChatModelIds(self.allocator, arena, llm.provider, llm.key, self.model_base_url) catch |err| {
-        self.terminal.printError("list models failed: {s}", .{@errorName(err)});
-        return;
-    };
-    if (ids.len == 0) {
-        self.terminal.printError("no models returned for {s}", .{@tagName(llm.provider)});
+    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
+    if (trimmed.len == 0) {
+        self.terminal.printInfo("Current model: {s} (Tab to list)", .{self.model});
         return;
     }
-
-    var current_idx: ?usize = null;
-    for (ids, 0..) |id, i| if (std.mem.eql(u8, id, self.model)) {
-        current_idx = i;
-        break;
-    };
-
-    const header = std.fmt.allocPrint(arena, "Pick model for {s}:", .{@tagName(llm.provider)}) catch
-        "Pick model:";
-    const idx = Terminal.promptNumberedChoice(header, ids, current_idx) catch {
-        self.terminal.printInfo("Model unchanged.", .{});
-        return;
-    };
-    self.setModel(ids[idx]) catch |err| {
+    self.setModel(trimmed) catch |err| {
         self.terminal.printError("failed to set model: {s}", .{@errorName(err)});
     };
 }
@@ -607,34 +597,27 @@ fn setModel(self: *Agent, model: []const u8) !void {
 }
 
 fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
-    const current = self.requireLlmNoArg("/provider", rest) orelse return;
+    const current = self.requireLlm("/provider") orelse return;
 
-    var buf: [@typeInfo(Config.AiProvider).@"enum".fields.len]Credentials = undefined;
-    const providers = availableProviders(&buf);
-    if (providers.len == 0) {
-        self.terminal.printError("no providers available", .{});
+    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
+    if (trimmed.len == 0) {
+        self.terminal.printInfo("Current provider: {s} (Tab to list)", .{@tagName(current.provider)});
         return;
     }
 
-    var labels: [@typeInfo(Config.AiProvider).@"enum".fields.len][]const u8 = undefined;
-    var current_idx: ?usize = null;
-    for (providers, 0..) |p, i| {
-        labels[i] = @tagName(p.provider);
-        if (p.provider == current.provider) current_idx = i;
-    }
-
-    self.terminal.printInfo("Current provider: {s}", .{@tagName(current.provider)});
-    const idx = Terminal.promptNumberedChoice("Pick provider:", labels[0..providers.len], current_idx) catch {
-        self.terminal.printInfo("Provider unchanged.", .{});
+    const provider = std.meta.stringToEnum(Config.AiProvider, trimmed) orelse {
+        self.terminal.printError("unknown provider: {s}", .{trimmed});
         return;
     };
-    const selected = providers[idx];
-    if (selected.provider == current.provider) {
-        self.terminal.printInfo("provider: {s}", .{@tagName(current.provider)});
+    if (provider == current.provider) {
+        self.terminal.printInfo("provider: {s}", .{@tagName(provider)});
         return;
     }
-
-    self.setProvider(selected) catch |err| {
+    const key = zenai.provider.envApiKey(provider) orelse {
+        self.terminal.printError("no API key for {s}; set {s}", .{ @tagName(provider), zenai.provider.envVarName(provider) });
+        return;
+    };
+    self.setProvider(.{ .provider = provider, .key = key }) catch |err| {
         self.terminal.printError("failed to set provider: {s}", .{@errorName(err)});
     };
 }
@@ -647,6 +630,7 @@ fn setProvider(self: *Agent, credentials: Credentials) !void {
     if (self.ai_client) |client| deinitAiClient(self.allocator, client);
     self.ai_client = new_client;
     self.model_credentials = credentials;
+    self.model_completions = null;
     self.allocator.free(self.model);
     self.model = new_model;
     self.terminal.printInfo("provider: {s}", .{@tagName(credentials.provider)});
@@ -837,11 +821,11 @@ fn printSlashHelp(self: *Agent, arena: std.mem.Allocator, target: []const u8) vo
                 .{},
             ),
             .model => self.terminal.printInfo(
-                "/model — Show available models and change the current model",
+                "/model [name] — change the model; Tab completes the provider's models, bare /model shows the current one",
                 .{},
             ),
             .provider => self.terminal.printInfo(
-                "/provider — Show available providers and change the current provider",
+                "/provider [name] — change the provider; Tab completes detected providers, bare /provider shows the current one",
                 .{},
             ),
         }
@@ -1676,6 +1660,43 @@ fn deinitAiClient(allocator: std.mem.Allocator, ai_client: zenai.provider.Client
 
 fn availableProviders(buf: []Credentials) []Credentials {
     return zenai.provider.detectKeys(buf, std.enums.values(Config.AiProvider));
+}
+
+const ModelCompletions = struct {
+    provider: Config.AiProvider,
+    /// Empty when the fetch failed — cached so the per-keystroke hinter doesn't
+    /// re-hit the network on every press.
+    ids: []const []const u8,
+};
+
+/// `CompletionSource.providers`. Stateless — `context` (the `*Agent`) is unused,
+/// present only for the shared callback shape.
+fn completionProviders(context: *anyopaque, arena: std.mem.Allocator) []const []const u8 {
+    _ = context;
+    var buf: [@typeInfo(Config.AiProvider).@"enum".fields.len]Credentials = undefined;
+    const found = availableProviders(&buf);
+    const names = arena.alloc([]const u8, found.len) catch return &.{};
+    for (found, 0..) |f, i| names[i] = @tagName(f.provider);
+    return names;
+}
+
+/// `CompletionSource.models`. Blocks on a one-time fetch per provider, caching
+/// success or empty so the per-keystroke hinter pays the round-trip only once.
+fn completionModels(context: *anyopaque, _: std.mem.Allocator) []const []const u8 {
+    const self: *Agent = @ptrCast(@alignCast(context));
+    const llm = self.model_credentials orelse return &.{};
+    if (self.model_completions) |c| if (c.provider == llm.provider) return c.ids;
+
+    _ = self.model_completion_arena.reset(.retain_capacity);
+    const ids = zenai.provider.listChatModelIds(
+        self.allocator,
+        self.model_completion_arena.allocator(),
+        llm.provider,
+        llm.key,
+        self.model_base_url,
+    ) catch &.{};
+    self.model_completions = .{ .provider = llm.provider, .ids = ids };
+    return ids;
 }
 
 fn pickProvider(found: []const Credentials) !Credentials {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -140,6 +140,8 @@ const synthesis_prompt =
 
 allocator: std.mem.Allocator,
 ai_client: ?zenai.provider.Client,
+model_credentials: ?Credentials,
+model_base_url: ?[:0]const u8,
 notification: *lp.Notification,
 browser: lp.Browser,
 session: *lp.Session,
@@ -199,7 +201,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     // the REPL accepts natural language and an absent API key would only
     // surface at the first non-PandaScript line — too late to be useful.
     // Pure replay (`agent <script>.lp`) stays allowed: no REPL, no LLM needed.
-    const requires_llm = is_one_shot or opts.self_heal or opts.pick_model or (will_repl and !opts.no_llm);
+    const requires_llm = is_one_shot or opts.self_heal or (will_repl and !opts.no_llm);
 
     // Skip resolve when --no-llm forces no client, or no mode could use one
     // (pure replay) — otherwise resolve prints "No API key detected" for a
@@ -211,19 +213,15 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
             std.debug.print("--no-llm forbids LLM use; drop it to run this mode.\n", .{});
         } else if (opts.self_heal) {
             std.debug.print("--self-heal needs an LLM — set an API key.\n", .{});
-        } else if (opts.pick_model) {
-            std.debug.print("--pick-model needs an LLM — set an API key.\n", .{});
         }
         return error.MissingProvider;
     }
 
-    // Resolve model BEFORE the heavy init so --pick-model's prompt fires
-    // before browser / ai_client setup.
-    // Precedence: --model > --pick-model > defaultModel.
+    // Precedence: --model > defaultModel.
     const model: []u8 = if (opts.model) |m|
         try allocator.dupe(u8, m)
     else if (llm) |l|
-        if (opts.pick_model) try pickModel(allocator, l, opts.base_url) else try allocator.dupe(u8, defaultModel(l.provider))
+        try allocator.dupe(u8, defaultModel(l.provider))
     else
         try allocator.dupe(u8, "");
     errdefer allocator.free(model);
@@ -243,6 +241,8 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     self.* = .{
         .allocator = allocator,
         .ai_client = null,
+        .model_credentials = llm,
+        .model_base_url = opts.base_url,
         .notification = notification,
         .browser = undefined,
         .session = undefined,
@@ -555,6 +555,7 @@ fn handleMeta(self: *Agent, arena: std.mem.Allocator, meta: *const SlashCommand.
         .help => self.printSlashHelp(arena, rest),
         .verbosity => self.handleVerbosity(rest),
         .save => self.handleSave(arena, rest),
+        .model => self.handleModel(arena, rest),
     }
     return false;
 }
@@ -570,6 +571,54 @@ fn handleVerbosity(self: *Agent, rest: []const u8) void {
     };
     self.terminal.verbosity = level;
     self.terminal.printInfo("verbosity: {s}", .{@tagName(level)});
+}
+
+fn handleModel(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
+    const llm = self.model_credentials orelse {
+        self.terminal.printError("/model requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{});
+        return;
+    };
+
+    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
+    if (trimmed.len != 0) {
+        self.terminal.printError("usage: /model", .{});
+        return;
+    }
+
+    self.terminal.printInfo("Current model: {s}", .{self.model});
+    self.terminal.printInfo("Fetching models for {s}...", .{@tagName(llm.provider)});
+
+    const ids = zenai.provider.listChatModelIds(self.allocator, arena, llm.provider, llm.key, self.model_base_url) catch |err| {
+        self.terminal.printError("list models failed: {s}", .{@errorName(err)});
+        return;
+    };
+    if (ids.len == 0) {
+        self.terminal.printError("no models returned for {s}", .{@tagName(llm.provider)});
+        return;
+    }
+
+    var current_idx: ?usize = null;
+    for (ids, 0..) |id, i| if (std.mem.eql(u8, id, self.model)) {
+        current_idx = i;
+        break;
+    };
+
+    const header = std.fmt.allocPrint(arena, "Pick model for {s}:", .{@tagName(llm.provider)}) catch
+        "Pick model:";
+    const idx = Terminal.promptNumberedChoice(header, ids, current_idx) catch {
+        self.terminal.printInfo("Model unchanged.", .{});
+        return;
+    };
+    self.setModel(ids[idx]) catch |err| {
+        self.terminal.printError("failed to set model: {s}", .{@errorName(err)});
+    };
+}
+
+fn setModel(self: *Agent, model: []const u8) !void {
+    const new_model = try self.allocator.dupe(u8, model);
+    self.allocator.free(self.model);
+    self.model = new_model;
+    self.terminal.printInfo("model: {s}", .{self.model});
 }
 
 const SaveMode = enum { replace, append };
@@ -753,6 +802,10 @@ fn printSlashHelp(self: *Agent, arena: std.mem.Allocator, target: []const u8) vo
             ),
             .save => self.terminal.printInfo(
                 "/save [filename.lp] — save recorded REPL actions to [filename.lp]. Without a filename, creates a random session-*.lp file in the current directory.",
+                .{},
+            ),
+            .model => self.terminal.printInfo(
+                "/model — Show available models and change the current model",
                 .{},
             ),
         }
@@ -1530,7 +1583,7 @@ pub fn listModels(allocator: std.mem.Allocator, opts: Config.Agent) !void {
         return error.ConflictingFlags;
     }
     if (opts.task != null or opts.self_heal or opts.interactive or
-        opts.script_file != null or opts.pick_model)
+        opts.script_file != null)
     {
         log.fatal(.app, "list-models is exclusive", .{
             .hint = "--list-models only takes --provider/--model/--base-url",
@@ -1574,52 +1627,6 @@ fn pickProvider(found: []const Credentials) !Credentials {
         return error.UserCancelled;
     };
     return found[idx];
-}
-
-/// Fetch the provider's chat-capable model list and prompt the user to pick
-/// one. Empty input picks the baked-in default. Always returns an owned
-/// heap buffer (including for the default case) so the caller has one
-/// uniform free path.
-fn pickModel(allocator: std.mem.Allocator, llm: Credentials, base_url: ?[:0]const u8) ![]u8 {
-    if (!Terminal.interactiveTty()) {
-        log.fatal(.app, "pick-model needs a TTY", .{
-            .hint = "rerun in a terminal or pass --model explicitly",
-        });
-        return error.NotInteractive;
-    }
-
-    var arena: std.heap.ArenaAllocator = .init(allocator);
-    defer arena.deinit();
-
-    // Runs before `SigBridge.attach` — Ctrl-C during the synchronous HTTP
-    // fetch is dropped; the picker prompt catches the next press via stdin EINTR.
-    std.debug.print("Fetching models for {s}…\n", .{@tagName(llm.provider)});
-    const ids = zenai.provider.listChatModelIds(allocator, arena.allocator(), llm.provider, llm.key, base_url) catch |err| {
-        log.fatal(.app, "list models failed", .{ .err = @errorName(err) });
-        return err;
-    };
-    if (ids.len == 0) {
-        log.fatal(.app, "no models returned", .{ .provider = @tagName(llm.provider) });
-        return error.NoModels;
-    }
-
-    const default_model = defaultModel(llm.provider);
-    var default_idx: ?usize = null;
-    for (ids, 0..) |id, i| if (std.mem.eql(u8, id, default_model)) {
-        default_idx = i;
-        break;
-    };
-
-    var header_buf: [128]u8 = undefined;
-    const enter_hint: []const u8 = if (default_idx == null) "" else " (Enter for default)";
-    const header = std.fmt.bufPrint(&header_buf, "Pick model for {s}{s}:", .{ @tagName(llm.provider), enter_hint }) catch
-        "Pick model:";
-
-    const idx = Terminal.promptNumberedChoice(header, ids, default_idx) catch {
-        std.debug.print("Cancelled — pass --model to skip the picker.\n", .{});
-        return error.UserCancelled;
-    };
-    return try allocator.dupe(u8, ids[idx]);
 }
 
 test "capToolOutput: truncates at UTF-8 codepoint boundary" {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -275,26 +275,8 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     self.session.cancel_hook = .{ .context = @ptrCast(self), .check = checkCancel };
     self.verifier = .{ .session = self.session, .node_registry = &self.node_registry };
 
-    self.ai_client = if (llm) |l| switch (l.provider) {
-        inline else => |tag| blk: {
-            const ProviderClient = zenai.provider.Client;
-            const ClientPtr = @FieldType(ProviderClient, @tagName(tag));
-            const Client = @typeInfo(ClientPtr).pointer.child;
-            const client = try allocator.create(Client);
-            const url: ?[]const u8 = opts.base_url orelse if (tag == .ollama) "http://localhost:11434/v1" else null;
-            client.* = .init(allocator, l.key, if (url) |u|
-                .{ .base_url = u, .retry_policy = .long_running }
-            else
-                .{ .retry_policy = .long_running });
-            break :blk @unionInit(ProviderClient, @tagName(tag), client);
-        },
-    } else null;
-    errdefer if (self.ai_client) |c| switch (c) {
-        inline else => |client| {
-            client.deinit();
-            allocator.destroy(client);
-        },
-    };
+    self.ai_client = if (llm) |l| try initAiClient(allocator, l, opts.base_url) else null;
+    errdefer if (self.ai_client) |c| deinitAiClient(allocator, c);
 
     if (will_repl) self.terminal.attachCompleter();
 
@@ -556,6 +538,7 @@ fn handleMeta(self: *Agent, arena: std.mem.Allocator, meta: *const SlashCommand.
         .verbosity => self.handleVerbosity(rest),
         .save => self.handleSave(arena, rest),
         .model => self.handleModel(arena, rest),
+        .provider => self.handleProvider(arena, rest),
     }
     return false;
 }
@@ -618,6 +601,62 @@ fn setModel(self: *Agent, model: []const u8) !void {
     const new_model = try self.allocator.dupe(u8, model);
     self.allocator.free(self.model);
     self.model = new_model;
+    self.terminal.printInfo("model: {s}", .{self.model});
+}
+
+fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
+    const current = self.model_credentials orelse {
+        self.terminal.printError("/provider requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{});
+        return;
+    };
+
+    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
+    if (trimmed.len != 0) {
+        self.terminal.printError("usage: /provider", .{});
+        return;
+    }
+
+    var buf: [@typeInfo(Config.AiProvider).@"enum".fields.len]Credentials = undefined;
+    const providers = availableProviders(&buf);
+    if (providers.len == 0) {
+        self.terminal.printError("no providers available", .{});
+        return;
+    }
+
+    var labels: [@typeInfo(Config.AiProvider).@"enum".fields.len][]const u8 = undefined;
+    var current_idx: ?usize = null;
+    for (providers, 0..) |p, i| {
+        labels[i] = @tagName(p.provider);
+        if (p.provider == current.provider) current_idx = i;
+    }
+
+    self.terminal.printInfo("Current provider: {s}", .{@tagName(current.provider)});
+    const idx = Terminal.promptNumberedChoice("Pick provider:", labels[0..providers.len], current_idx) catch {
+        self.terminal.printInfo("Provider unchanged.", .{});
+        return;
+    };
+    const selected = providers[idx];
+    if (selected.provider == current.provider) {
+        self.terminal.printInfo("provider: {s}", .{@tagName(current.provider)});
+        return;
+    }
+
+    self.setProvider(selected) catch |err| {
+        self.terminal.printError("failed to set provider: {s}", .{@errorName(err)});
+    };
+}
+
+fn setProvider(self: *Agent, credentials: Credentials) !void {
+    const new_client = try initAiClient(self.allocator, credentials, self.model_base_url);
+    errdefer deinitAiClient(self.allocator, new_client);
+
+    const new_model = try self.allocator.dupe(u8, defaultModel(credentials.provider));
+    if (self.ai_client) |client| deinitAiClient(self.allocator, client);
+    self.ai_client = new_client;
+    self.model_credentials = credentials;
+    self.allocator.free(self.model);
+    self.model = new_model;
+    self.terminal.printInfo("provider: {s}", .{@tagName(credentials.provider)});
     self.terminal.printInfo("model: {s}", .{self.model});
 }
 
@@ -806,6 +845,10 @@ fn printSlashHelp(self: *Agent, arena: std.mem.Allocator, target: []const u8) vo
             ),
             .model => self.terminal.printInfo(
                 "/model — Show available models and change the current model",
+                .{},
+            ),
+            .provider => self.terminal.printInfo(
+                "/provider — Show available providers and change the current provider",
                 .{},
             ),
         }
@@ -1609,6 +1652,45 @@ fn defaultModel(p: Config.AiProvider) []const u8 {
         .gemini => "gemini-3.5-flash",
         .ollama => "gemma4",
     };
+}
+
+fn initAiClient(allocator: std.mem.Allocator, credentials: Credentials, base_url: ?[:0]const u8) !zenai.provider.Client {
+    return switch (credentials.provider) {
+        inline else => |tag| blk: {
+            const ProviderClient = zenai.provider.Client;
+            const ClientPtr = @FieldType(ProviderClient, @tagName(tag));
+            const Client = @typeInfo(ClientPtr).pointer.child;
+            const client = try allocator.create(Client);
+            errdefer allocator.destroy(client);
+            const url: ?[]const u8 = base_url orelse if (tag == .ollama) "http://localhost:11434/v1" else null;
+            client.* = .init(allocator, credentials.key, if (url) |u|
+                .{ .base_url = u, .retry_policy = .long_running }
+            else
+                .{ .retry_policy = .long_running });
+            break :blk @unionInit(ProviderClient, @tagName(tag), client);
+        },
+    };
+}
+
+fn deinitAiClient(allocator: std.mem.Allocator, ai_client: zenai.provider.Client) void {
+    switch (ai_client) {
+        inline else => |client| {
+            client.deinit();
+            allocator.destroy(client);
+        },
+    }
+}
+
+fn availableProviders(buf: []Credentials) []Credentials {
+    var n: usize = 0;
+    inline for (@typeInfo(Config.AiProvider).@"enum".fields) |field| {
+        const provider: Config.AiProvider = @enumFromInt(field.value);
+        if (zenai.provider.envApiKey(provider)) |key| {
+            buf[n] = .{ .provider = provider, .key = key };
+            n += 1;
+        }
+    }
+    return buf[0..n];
 }
 
 fn pickProvider(found: []const Credentials) !Credentials {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -210,7 +210,12 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
     // Skip resolve when --no-llm forces no client, or no mode could use one
     // (pure replay) — otherwise resolve prints "No API key detected" for a
     // run that does not need one.
-    const llm: ?Credentials = if (opts.no_llm or !requires_llm) null else try resolveCredentials(opts);
+    const resolve = !opts.no_llm and requires_llm;
+    const remembered: ?Remembered = if (resolve) loadRemembered(allocator) else null;
+    defer if (remembered) |r| allocator.free(r.model);
+
+    const resolved: ?ResolvedProvider = if (resolve) try resolveCredentials(opts, remembered) else null;
+    const llm: ?Credentials = if (resolved) |r| r.credentials else null;
 
     if (llm == null and requires_llm) {
         if (opts.no_llm) {
@@ -223,11 +228,23 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
 
     const model: []u8 = if (opts.model) |m|
         try allocator.dupe(u8, m)
-    else if (llm) |l|
-        try allocator.dupe(u8, defaultModel(l.provider))
-    else
-        try allocator.dupe(u8, "");
+    else if (llm) |l| blk: {
+        if (resolved) |r| if (r.source == .remembered) break :blk try allocator.dupe(u8, remembered.?.model);
+        break :blk try allocator.dupe(u8, defaultModel(l.provider));
+    } else try allocator.dupe(u8, "");
     errdefer allocator.free(model);
+
+    if (resolved) |r| switch (r.source) {
+        .flag => {},
+        .remembered => std.debug.print(
+            "Resuming provider {s}, model {s} (remembered in ./.lp-agent). Change with --provider/--model or /provider, /model.\n",
+            .{ @tagName(r.credentials.provider), model },
+        ),
+        .detected => std.debug.print(
+            "Auto-selected provider {s}, model {s}. Set --provider/--model or use /provider, /model to change.\n",
+            .{ @tagName(r.credentials.provider), model },
+        ),
+    };
 
     const notification: *lp.Notification = try .init(allocator);
     errdefer notification.deinit();
@@ -593,6 +610,7 @@ fn setModel(self: *Agent, model: []const u8) !void {
     const new_model = try self.allocator.dupe(u8, model);
     self.allocator.free(self.model);
     self.model = new_model;
+    if (self.model_credentials) |c| saveRemembered(c.provider, self.model);
     self.terminal.printInfo("model: {s}", .{self.model});
 }
 
@@ -633,6 +651,7 @@ fn setProvider(self: *Agent, credentials: Credentials) !void {
     self.model_completions = null;
     self.allocator.free(self.model);
     self.model = new_model;
+    saveRemembered(credentials.provider, self.model);
     self.terminal.printInfo("provider: {s}", .{@tagName(credentials.provider)});
     self.terminal.printInfo("model: {s}", .{self.model});
 }
@@ -1561,7 +1580,14 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
 /// Determine which provider to use and read its env key. Returns null
 /// only when no `--provider` was given AND no env key exists (the caller
 /// decides whether that's fatal — basic REPL tolerates it).
-fn resolveCredentials(opts: Config.Agent) !?Credentials {
+const ResolvedProvider = struct {
+    credentials: Credentials,
+    source: enum { flag, remembered, detected },
+};
+
+/// Precedence: `--provider` > remembered (if its key is still set) > first
+/// detected. Null means no key at all (the reason is already printed).
+fn resolveCredentials(opts: Config.Agent, remembered: ?Remembered) !?ResolvedProvider {
     if (opts.provider) |p| {
         const key = zenai.provider.envApiKey(p) orelse {
             std.debug.print(
@@ -1570,27 +1596,51 @@ fn resolveCredentials(opts: Config.Agent) !?Credentials {
             );
             return error.MissingApiKey;
         };
-        return .{ .provider = p, .key = key };
+        return .{ .credentials = .{ .provider = p, .key = key }, .source = .flag };
     }
+
+    if (remembered) |r| if (zenai.provider.envApiKey(r.provider)) |key| {
+        return .{ .credentials = .{ .provider = r.provider, .key = key }, .source = .remembered };
+    };
 
     var buf: [zenai.provider.default_candidates.len]Credentials = undefined;
     const found = zenai.provider.detectKeys(&buf, zenai.provider.default_candidates);
+    if (found.len == 0) {
+        std.debug.print(
+            \\No API key detected. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY.
+            \\If you want to use the REPL in basic mode (without LLM integration) you can pass the --no-llm option.
+            \\
+        , .{});
+        return null;
+    }
+    return .{ .credentials = found[0], .source = .detected };
+}
 
-    return switch (found.len) {
-        0 => blk: {
-            std.debug.print(
-                \\No API key detected. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY.
-                \\If you want to use the REPL in basic mode (without LLM integration) you can pass the --no-llm option.
-                \\
-            , .{});
-            break :blk null;
-        },
-        1 => blk: {
-            std.debug.print("Detected {s} — using --provider {s}.\n", .{ zenai.provider.envVarName(found[0].provider), @tagName(found[0].provider) });
-            break :blk found[0];
-        },
-        else => try pickProvider(found),
-    };
+const remembered_path = ".lp-agent";
+
+/// Last user-selected provider/model, persisted per-directory in `.lp-agent`.
+/// `model` is owned by the caller.
+const Remembered = struct {
+    provider: Config.AiProvider,
+    model: []const u8,
+};
+
+fn loadRemembered(allocator: std.mem.Allocator) ?Remembered {
+    const data = std.fs.cwd().readFileAlloc(allocator, remembered_path, 1024) catch return null;
+    defer allocator.free(data);
+    var it = std.mem.tokenizeScalar(u8, data, '\n');
+    const p_str = std.mem.trim(u8, it.next() orelse return null, &std.ascii.whitespace);
+    const m_str = std.mem.trim(u8, it.next() orelse return null, &std.ascii.whitespace);
+    const provider = std.meta.stringToEnum(Config.AiProvider, p_str) orelse return null;
+    if (m_str.len == 0) return null;
+    return .{ .provider = provider, .model = allocator.dupe(u8, m_str) catch return null };
+}
+
+/// Best-effort persist of the current selection; failures are ignored.
+fn saveRemembered(provider: Config.AiProvider, model: []const u8) void {
+    var buf: [512]u8 = undefined;
+    const data = std.fmt.bufPrint(&buf, "{s}\n{s}\n", .{ @tagName(provider), model }) catch return;
+    std.fs.cwd().writeFile(.{ .sub_path = remembered_path, .data = data }) catch {};
 }
 
 /// One-shot for `--list-models`: resolve provider+key, fetch chat-capable
@@ -1610,7 +1660,8 @@ pub fn listModels(allocator: std.mem.Allocator, opts: Config.Agent) !void {
         });
         return error.ConflictingFlags;
     }
-    const llm = (try resolveCredentials(opts)) orelse return error.MissingProvider;
+    const resolved = (try resolveCredentials(opts, null)) orelse return error.MissingProvider;
+    const llm = resolved.credentials;
 
     var arena: std.heap.ArenaAllocator = .init(allocator);
     defer arena.deinit();
@@ -1697,24 +1748,6 @@ fn completionModels(context: *anyopaque, _: std.mem.Allocator) []const []const u
     ) catch &.{};
     self.model_completions = .{ .provider = llm.provider, .ids = ids };
     return ids;
-}
-
-fn pickProvider(found: []const Credentials) !Credentials {
-    if (!Terminal.interactiveTty()) {
-        log.fatal(.app, "multiple API keys detected", .{
-            .hint = "Pass --provider explicitly when running non-interactively",
-        });
-        return error.AmbiguousProvider;
-    }
-
-    var labels: [@typeInfo(Config.AiProvider).@"enum".fields.len][]const u8 = undefined;
-    for (found, 0..) |f, i| labels[i] = @tagName(f.provider);
-
-    const idx = Terminal.promptNumberedChoice("Multiple API keys detected. Pick provider:", labels[0..found.len], null) catch {
-        std.debug.print("Cancelled — pass --provider to skip the picker.\n", .{});
-        return error.UserCancelled;
-    };
-    return found[idx];
 }
 
 test "capToolOutput: truncates at UTF-8 codepoint boundary" {

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -217,7 +217,6 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
         return error.MissingProvider;
     }
 
-    // Precedence: --model > defaultModel.
     const model: []u8 = if (opts.model) |m|
         try allocator.dupe(u8, m)
     else if (llm) |l|
@@ -556,17 +555,20 @@ fn handleVerbosity(self: *Agent, rest: []const u8) void {
     self.terminal.printInfo("verbosity: {s}", .{@tagName(level)});
 }
 
-fn handleModel(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
+fn requireLlmNoArg(self: *Agent, name: []const u8, rest: []const u8) ?Credentials {
     const llm = self.model_credentials orelse {
-        self.terminal.printError("/model requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{});
-        return;
+        self.terminal.printError("{s} requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{name});
+        return null;
     };
-
-    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
-    if (trimmed.len != 0) {
-        self.terminal.printError("usage: /model", .{});
-        return;
+    if (std.mem.trim(u8, rest, &std.ascii.whitespace).len != 0) {
+        self.terminal.printError("usage: {s}", .{name});
+        return null;
     }
+    return llm;
+}
+
+fn handleModel(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
+    const llm = self.requireLlmNoArg("/model", rest) orelse return;
 
     self.terminal.printInfo("Current model: {s}", .{self.model});
     self.terminal.printInfo("Fetching models for {s}...", .{@tagName(llm.provider)});
@@ -605,16 +607,7 @@ fn setModel(self: *Agent, model: []const u8) !void {
 }
 
 fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
-    const current = self.model_credentials orelse {
-        self.terminal.printError("/provider requires an LLM. Drop --no-llm and set an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY).", .{});
-        return;
-    };
-
-    const trimmed = std.mem.trim(u8, rest, &std.ascii.whitespace);
-    if (trimmed.len != 0) {
-        self.terminal.printError("usage: /provider", .{});
-        return;
-    }
+    const current = self.requireLlmNoArg("/provider", rest) orelse return;
 
     var buf: [@typeInfo(Config.AiProvider).@"enum".fields.len]Credentials = undefined;
     const providers = availableProviders(&buf);

--- a/src/agent/SlashCommand.zig
+++ b/src/agent/SlashCommand.zig
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! REPL-only meta slash commands (`/help`, `/quit`, `/verbosity`). Meta
+//! REPL-only meta slash commands (`/help`, `/quit`, `/verbosity`, `/model`). Meta
 //! commands aren't PandaScript — they're handled by `Agent.handleMeta`
 //! and never reach the recorder. PandaScript schema primitives live in
 //! `lp.script.Schema`; consumers should import that directly.
@@ -44,7 +44,7 @@ pub const MetaCommand = struct {
 
     /// Dispatched by `Agent.handleMeta` via an exhaustive switch so adding
     /// a new meta command is a compile error until it's wired up there too.
-    const Tag = enum { help, quit, verbosity, save };
+    const Tag = enum { help, quit, verbosity, save, model };
 };
 
 pub const meta_commands = [_]MetaCommand{
@@ -52,6 +52,7 @@ pub const meta_commands = [_]MetaCommand{
     .{ .tag = .quit, .name = "quit", .hint = "", .values = &.{}, .description = "Exit the REPL" },
     .{ .tag = .verbosity, .name = "verbosity", .hint = "<low|medium|high>", .values = &.{ "low", "medium", "high" }, .description = "Set REPL agent verbosity; bare /verbosity prints the current level" },
     .{ .tag = .save, .name = "save", .hint = "[filename.lp]", .values = &.{}, .description = "Save this REPL session as a PandaScript file" },
+    .{ .tag = .model, .name = "model", .hint = "", .values = &.{}, .description = "Show available models and change the current model" },
 };
 
 /// LLM-driven slash commands. Parsed via `script.Command.parse` (they're

--- a/src/agent/SlashCommand.zig
+++ b/src/agent/SlashCommand.zig
@@ -53,8 +53,8 @@ pub const meta_commands = [_]MetaCommand{
     .{ .tag = .quit, .name = "quit", .hint = "", .values = &.{}, .description = "Exit the REPL" },
     .{ .tag = .verbosity, .name = "verbosity", .hint = "<low|medium|high>", .values = &.{ "low", "medium", "high" }, .description = "Set REPL agent verbosity; bare /verbosity prints the current level" },
     .{ .tag = .save, .name = "save", .hint = "[filename.lp]", .values = &.{}, .description = "Save this REPL session as a PandaScript file" },
-    .{ .tag = .model, .name = "model", .hint = "", .values = &.{}, .description = "Show available models and change the current model" },
-    .{ .tag = .provider, .name = "provider", .hint = "", .values = &.{}, .description = "Show available providers and change the current provider" },
+    .{ .tag = .model, .name = "model", .hint = "[name]", .values = &.{}, .description = "Change the model (Tab completes the provider's models); bare /model shows the current one" },
+    .{ .tag = .provider, .name = "provider", .hint = "[name]", .values = &.{}, .description = "Change the provider (Tab completes detected providers); bare /provider shows the current one" },
 };
 
 /// LLM-driven slash commands. Parsed via `script.Command.parse` (they're

--- a/src/agent/SlashCommand.zig
+++ b/src/agent/SlashCommand.zig
@@ -16,7 +16,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! REPL-only meta slash commands (`/help`, `/quit`, `/verbosity`, `/model`). Meta
+//! REPL-only meta slash commands (`/help`, `/quit`, `/verbosity`, `/model`,
+//! `/provider`). Meta
 //! commands aren't PandaScript — they're handled by `Agent.handleMeta`
 //! and never reach the recorder. PandaScript schema primitives live in
 //! `lp.script.Schema`; consumers should import that directly.
@@ -44,7 +45,7 @@ pub const MetaCommand = struct {
 
     /// Dispatched by `Agent.handleMeta` via an exhaustive switch so adding
     /// a new meta command is a compile error until it's wired up there too.
-    const Tag = enum { help, quit, verbosity, save, model };
+    const Tag = enum { help, quit, verbosity, save, model, provider };
 };
 
 pub const meta_commands = [_]MetaCommand{
@@ -53,6 +54,7 @@ pub const meta_commands = [_]MetaCommand{
     .{ .tag = .verbosity, .name = "verbosity", .hint = "<low|medium|high>", .values = &.{ "low", "medium", "high" }, .description = "Set REPL agent verbosity; bare /verbosity prints the current level" },
     .{ .tag = .save, .name = "save", .hint = "[filename.lp]", .values = &.{}, .description = "Save this REPL session as a PandaScript file" },
     .{ .tag = .model, .name = "model", .hint = "", .values = &.{}, .description = "Show available models and change the current model" },
+    .{ .tag = .provider, .name = "provider", .hint = "", .values = &.{}, .description = "Show available providers and change the current provider" },
 };
 
 /// LLM-driven slash commands. Parsed via `script.Command.parse` (they're

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -691,10 +691,6 @@ fn logSink(bytes: []const u8) void {
     _ = std.posix.write(std.posix.STDERR_FILENO, bytes) catch {};
 }
 
-pub fn interactiveTty() bool {
-    return std.posix.isatty(std.posix.STDIN_FILENO) and std.posix.isatty(std.posix.STDERR_FILENO);
-}
-
 /// Current terminal width in columns, queried via TIOCGWINSZ on stderr.
 /// Null when stderr isn't a tty, the ioctl fails, or the kernel reports 0
 /// (some pseudo-ttys leave the field unset). Cheap enough to call per

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -64,6 +64,16 @@ verbosity: Verbosity,
 repl_arena: ?std.heap.ArenaAllocator,
 stderr_is_tty: bool,
 spinner: Spinner,
+completion_source: ?CompletionSource = null,
+
+/// Lets the completer/hinter pull dynamic candidates from the `Agent` without
+/// `Terminal` depending on it (same idiom as `Session.cancel_hook`).
+pub const CompletionSource = struct {
+    context: *anyopaque,
+    providers: *const fn (context: *anyopaque, arena: std.mem.Allocator) []const []const u8,
+    /// May block on an HTTP fetch.
+    models: *const fn (context: *anyopaque, arena: std.mem.Allocator) []const []const u8,
+};
 
 // Flat name list for the "match any slash command" search/completion paths.
 const all_slash_names: [browser_tools.names.len + SlashCommand.meta_commands.len + Command.llm_tags.len][]const u8 = blk: {
@@ -288,20 +298,33 @@ fn addPartialKeyCompletions(
 }
 
 fn addMetaValueCompletions(
+    self: *Terminal,
     cenv: ?*c.ic_completion_env_t,
     input: []const u8,
     body: []const u8,
     meta: *const SlashCommand.MetaCommand,
     buf: *[completion_buf_len:0]u8,
 ) void {
-    if (meta.values.len == 0) return;
     // Past the first positional arg — don't offer value completions anymore.
     if (std.mem.indexOfAny(u8, body, &std.ascii.whitespace) != null) return;
-    const partial = body;
-    const prefix = input[0 .. input.len - partial.len];
-    for (meta.values) |v| {
-        addPrefixedCompletion(cenv, buf, input, prefix, v, "", partial);
-    }
+    const prefix = input[0 .. input.len - body.len];
+
+    // `/provider` / `/model` candidates are resolved at runtime, not in `meta.values`.
+    if (self.completion_source) |src| switch (meta.tag) {
+        .provider, .model => {
+            var name_buf: [512]u8 = undefined;
+            var fba: std.heap.FixedBufferAllocator = .init(&name_buf);
+            const names = if (meta.tag == .provider)
+                src.providers(src.context, fba.allocator())
+            else
+                src.models(src.context, fba.allocator());
+            for (names) |v| addPrefixedCompletion(cenv, buf, input, prefix, v, "", body);
+            return;
+        },
+        else => {},
+    };
+
+    for (meta.values) |v| addPrefixedCompletion(cenv, buf, input, prefix, v, "", body);
 }
 
 // Completes `$LP_*` against the live process environment.
@@ -326,6 +349,7 @@ fn addEnvVarCompletions(
 }
 
 fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callconv(.c) void {
+    const self: *Terminal = @ptrCast(@alignCast(c.ic_completion_arg(cenv) orelse return));
     const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(prefix)), 0);
 
     var buf: [completion_buf_len:0]u8 = undefined;
@@ -346,7 +370,7 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
                 if (Schema.findByName(parts.name)) |schema| {
                     addPartialKeyCompletions(cenv, input, parts.rest, schema, &buf);
                 } else if (SlashCommand.findMeta(parts.name)) |meta| {
-                    addMetaValueCompletions(cenv, input, parts.rest, meta, &buf);
+                    self.addMetaValueCompletions(cenv, input, parts.rest, meta, &buf);
                 }
             };
             // Fall through so `value=$LP_` picks up env completions.
@@ -373,7 +397,7 @@ fn completionCallback(cenv: ?*c.ic_completion_env_t, prefix: [*c]const u8) callc
 var hint_buf: [completion_buf_len:0]u8 = undefined;
 
 fn hintsCallback(input_c: [*c]const u8, arg: ?*anyopaque) callconv(.c) [*c]const u8 {
-    _ = arg;
+    const self: *Terminal = @ptrCast(@alignCast(arg orelse return null));
     const input = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(input_c)), 0);
     if (input.len == 0) return null;
 
@@ -389,7 +413,7 @@ fn hintsCallback(input_c: [*c]const u8, arg: ?*anyopaque) callconv(.c) [*c]const
             return renderSchemaHint(schema, parts.rest, ends_ws);
         }
         if (SlashCommand.findMeta(parts.name)) |meta| {
-            return renderMetaHint(meta, parts.rest, ends_ws);
+            return self.renderMetaHint(meta, parts.rest, ends_ws);
         }
         return null;
     }
@@ -423,20 +447,42 @@ fn writeHints(lead: []const u8, fragments: []const []const u8) [*c]const u8 {
     return @ptrCast(&hint_buf);
 }
 
-// Renders a meta command's value hint, e.g. `<low|medium|high>` for
-// `/verbosity`. While the user is mid-typing a value, shows the matching
-// value's suffix.
-fn renderMetaHint(meta: *const SlashCommand.MetaCommand, body: []const u8, ends_ws: bool) [*c]const u8 {
+// Ghosts a meta command's argument: detected providers are synchronous, so
+// `/provider` previews a real name from the start; `/model` needs a fetch, so
+// it shows the `[name]` placeholder until the name is committed (`/model `),
+// then the first fetch blocks and is cached. Static values (`/verbosity`)
+// match `meta.values`.
+fn renderMetaHint(self: *Terminal, meta: *const SlashCommand.MetaCommand, body: []const u8, ends_ws: bool) [*c]const u8 {
     if (meta.hint.len == 0) return null;
+    if (ends_ws and body.len != 0) return null; // value already committed
+
+    if (self.completion_source) |src| {
+        var name_buf: [512]u8 = undefined;
+        var fba: std.heap.FixedBufferAllocator = .init(&name_buf);
+        if (meta.tag == .provider) {
+            const lead: []const u8 = if (body.len == 0 and !ends_ws) " " else "";
+            return ghostFirstMatch(src.providers(src.context, fba.allocator()), body, lead);
+        }
+        if (meta.tag == .model and (ends_ws or body.len != 0)) {
+            return ghostFirstMatch(src.models(src.context, fba.allocator()), body, "");
+        }
+    }
+
     if (body.len == 0) {
         var frags: [1][]const u8 = .{meta.hint};
         return writeHints(if (ends_ws) "" else " ", &frags);
     }
-    // Value already committed (trailing space past it) or past the first arg.
     if (ends_ws) return null;
-    for (meta.values) |v| {
+    return ghostFirstMatch(meta.values, body, "");
+}
+
+/// Ghosts `lead` + the suffix of the first `names` entry that prefix-matches
+/// `body`. `names` is `anytype` to accept both the `[:0]`-terminated
+/// `meta.values` and a runtime `[]const []const u8`.
+fn ghostFirstMatch(names: anytype, body: []const u8, lead: []const u8) [*c]const u8 {
+    for (names) |v| {
         if (!std.ascii.startsWithIgnoreCase(v, body)) continue;
-        const text = std.fmt.bufPrintZ(&hint_buf, "{s}", .{v[body.len..]}) catch return null;
+        const text = std.fmt.bufPrintZ(&hint_buf, "{s}{s}", .{ lead, v[body.len..] }) catch return null;
         return text.ptr;
     }
     return null;

--- a/src/help.zon
+++ b/src/help.zon
@@ -162,6 +162,8 @@
     \\
     \\                           Allowed values:
     \\                             "anthropic", "openai", "gemini", "ollama".
+    \\                           In the REPL, use /provider to list and change
+    \\                           providers.
     \\
     \\--no-llm                   Force the basic REPL even when an API key is
     \\                           present or --provider is set. Useful for testing

--- a/src/help.zon
+++ b/src/help.zon
@@ -171,12 +171,8 @@
     \\
     \\--model <MODEL>            The model name to use.
     \\                           Defaults to a sensible default per provider.
-    \\                           Wins over --pick-model.
-    \\
-    \\--pick-model               Fetch the provider's model list and prompt you
-    \\                           to pick one at startup, instead of using the
-    \\                           baked-in default. Requires a TTY. Ignored when
-    \\                           --model is also passed.
+    \\                           In the REPL, use /model to list and change
+    \\                           models for the active provider.
     \\
     \\--base-url <URL>           Override the API base URL for the provider.
     \\                           Defaults to the provider's standard endpoint.


### PR DESCRIPTION
Add `/model` and `/provider` commands on the REPL.
Remove `pick-model` option in the CLI args.