### PR TITLE
browser/URL: ignore query and fragment slashes in URL resolve

### DIFF
--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -121,7 +121,8 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, o
 
     const scheme_end = std.mem.indexOf(u8, base, "://");
     const authority_start = if (scheme_end) |end| end + 3 else 0;
-    const path_start = std.mem.indexOfScalarPos(u8, base, authority_start, '/') orelse base.len;
+    const path_start = std.mem.indexOfAnyPos(u8, base, authority_start, "/?#") orelse base.len;
+    const path_end = std.mem.indexOfAnyPos(u8, base, path_start, "?#") orelse base.len;
 
     if (path[0] == '/') {
         const result = try std.mem.joinZ(allocator, "", &.{ base[0..path_start], path });
@@ -129,8 +130,8 @@ pub fn resolve(allocator: Allocator, base: [:0]const u8, source_path: anytype, o
     }
 
     var normalized_base: []const u8 = base[0..path_start];
-    if (path_start < base.len) {
-        if (std.mem.lastIndexOfScalar(u8, base[path_start + 1 ..], '/')) |pos| {
+    if (path_start < path_end) {
+        if (std.mem.lastIndexOfScalar(u8, base[path_start + 1 .. path_end], '/')) |pos| {
             normalized_base = base[0 .. path_start + 1 + pos];
         }
     }
@@ -972,6 +973,66 @@ test "URL: resolve" {
             .base = "https://example/xyz/abc/123",
             .path = "something.js",
             .expected = "https://example/xyz/abc/something.js",
+        },
+        .{
+            .base = "http://127.0.0.1:8123/#/login",
+            .path = "api/users/login",
+            .expected = "http://127.0.0.1:8123/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page?next=/foo/bar",
+            .path = "api/users/login",
+            .expected = "https://example/app/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page#/foo/bar",
+            .path = "api/users/login",
+            .expected = "https://example/app/api/users/login",
+        },
+        .{
+            .base = "https://example?next=/foo/bar",
+            .path = "api/users/login",
+            .expected = "https://example/api/users/login",
+        },
+        .{
+            .base = "https://example#/foo/bar",
+            .path = "api/users/login",
+            .expected = "https://example/api/users/login",
+        },
+        .{
+            .base = "https://example?next=/foo/bar",
+            .path = "/api/users/login",
+            .expected = "https://example/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page?next=/foo/bar",
+            .path = "../api/users/login",
+            .expected = "https://example/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page#/foo/bar",
+            .path = "../api/users/login",
+            .expected = "https://example/api/users/login",
+        },
+        .{
+            .base = "https://example/app/dir/?next=/foo/bar",
+            .path = "../api/users/login",
+            .expected = "https://example/app/api/users/login",
+        },
+        .{
+            .base = "https://example/app/dir/#/foo/bar",
+            .path = "../api/users/login",
+            .expected = "https://example/app/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page?next=/foo/bar",
+            .path = "?q=/api/users/login",
+            .expected = "https://example/app/page?q=/api/users/login",
+        },
+        .{
+            .base = "https://example/app/page#/foo/bar",
+            .path = "#/api/users/login",
+            .expected = "https://example/app/page#/api/users/login",
         },
         .{
             .base = "https://example/xyz/abc/123",

--- a/src/browser/tests/net/fetch_hash_route.html
+++ b/src/browser/tests/net/fetch_hash_route.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=fetch_relative_url_ignores_hash_route type=module>
+  {
+    const state = await testing.async();
+    const originalUrl = location.href;
+
+    history.replaceState(null, '', '/#/login');
+    const response = await fetch('xhr', { method: 'POST', body: 'foo' });
+    const text = await response.text();
+
+    history.replaceState(null, '', originalUrl);
+    state.resolve({
+      ok: response.ok,
+      status: response.status,
+      url: response.url,
+      length: text.length,
+    });
+
+    await state.done((data) => {
+      testing.expectEqual(true, data.ok);
+      testing.expectEqual(200, data.status);
+      testing.expectEqual('http://127.0.0.1:9582/xhr', data.url);
+      testing.expectEqual(100, data.length);
+    });
+  }
+</script>

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -270,4 +270,5 @@ fn httpShutdownCallback(ctx: *anyopaque) void {
 const testing = @import("../../../testing.zig");
 test "WebApi: fetch" {
     try testing.htmlRunner("net/fetch.html", .{});
+    try testing.htmlRunner("net/fetch_hash_route.html", .{});
 }


### PR DESCRIPTION
Resolve relative request URLs against only the path component of the base URL. Previously, URL.resolve searched for the last slash in the whole base URL after the authority, so slashes inside a query string or hash route could be mistaken for path directory separators.

The observed failure was a hash-routed page loaded at `http://127.0.0.1:8123/#/login`. When that page ran `fetch("api/users/login", { method: "POST" })`, browser-compatible URL resolution should have requested `http://127.0.0.1:8123/api/users/login`. Instead, Lightpanda 0.3.1 reported the response URL as `http://127.0.0.1:8123/#/api/users/login`, and the HTTP server received `POST /`.

That meant the server returned the single-page app shell instead of the JSON login response. The failure broke a RealWorld/Conduit-style SPA benchmark after login because the app used relative API URLs such as api/users/login. 

The same issue was not limited to fragments. A base URL such as `https://example/app/page?next=/foo/bar` also contains slashes after the path component. Those slashes must not affect how path-relative inputs such as api/users/login or ../api/users/login are merged with the base path.

This change bounds the directory calculation at the first `?` or `#` in the base URL and searches for the last path slash only inside that path component. Root-absolute inputs still keep only the scheme and authority, query-only inputs still replace the query on the current path, and fragment-only inputs still replace the fragment on the current path.

This matches the behavior of the WHATWG URL [algorithm](https://url.spec.whatwg.org/#relative-state), Chromium's relative URL [canonicalization](https://chromium.googlesource.com/chromium/src/+/HEAD/url/url_canon_relative.cc#409), for the cases covered here. All of those implementations split the base URL into components before merging a path-relative reference, so slashes in the query or fragment do not change the base directory.