### PR TITLE
Remove the navigator.getBattery dummy implementation

### DIFF
--- a/src/browser/tests/navigator/navigator.html
+++ b/src/browser/tests/navigator/navigator.html
@@ -139,16 +139,9 @@
 </script>
 
 <script id=getBattery type=module>
-  {
-    const state = await testing.async();
-    try {
-      await navigator.getBattery();
-      state.resolve()
-      await state.done(() => { testing.fail('getBattery should reject'); });
-    } catch (err) {
-      state.resolve()
-      await state.done(() => { testing.expectEqual('NotSupportedError', err.name); });
-    }
-  }
+  // Like Firefox, we don't expose navigator.getBattery. Sites already
+  // have to handle it being undefined, so this is a real-browser shape
+  // rather than a stub that always rejects.
+  testing.expectEqual('undefined', typeof navigator.getBattery);
 </script>
 

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -139,11 +139,6 @@ pub fn getModelContext(_: *const Navigator, frame: *Frame) *ModelContext {
     return &frame.window._model_context;
 }
 
-pub fn getBattery(_: *const Navigator, frame: *Frame) !js.Promise {
-    log.info(.not_implemented, "navigator.getBattery", .{});
-    return frame.js.local.?.rejectErrorPromise(.{ .dom_exception = .{ .err = error.NotSupported } });
-}
-
 pub fn registerProtocolHandler(_: *const Navigator, scheme: []const u8, url: [:0]const u8, frame: *const Frame) !void {
     try validateProtocolHandlerScheme(scheme);
     try validateProtocolHandlerURL(url, frame);
@@ -248,7 +243,6 @@ pub const JsApi = struct {
 
     // Methods
     pub const javaEnabled = bridge.function(Navigator.javaEnabled, .{});
-    pub const getBattery = bridge.function(Navigator.getBattery, .{});
     pub const permissions = bridge.accessor(Navigator.getPermissions, null, .{});
     pub const storage = bridge.accessor(Navigator.getStorage, null, .{});
     pub const userAgentData = bridge.accessor(Navigator.getUserAgentData, null, .{});


### PR DESCRIPTION
Firefox currently doesn't implement this API. Sites already have to check if it exists, e.g `navigator.getBattery == undefined`. Implementing the method but making it fail, it's the worst of both wolds.