### PR TITLE
Coerce value to strings on string.String (SSO) target

### DIFF
--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -767,14 +767,8 @@ fn jsValueToStruct(self: *const Local, comptime T: type, js_val: js.Value) !?T {
             if (!js_str.containsOnlyOneByte()) return error.InvalidCharacterError;
             return .{ .bytes = try js_str.toOneByteSlice(self.call_arena) };
         },
-        string.String => {
-            const js_str = js_val.isString() orelse return null;
-            return try js_str.toSSO(false);
-        },
-        string.Global => {
-            const js_str = js_val.isString() orelse return null;
-            return try js_str.toSSO(true);
-        },
+        string.String => try js_val.toSSO(false),
+        string.Global => try js_val.toSSO(true),
         else => {
             if (!js_val.isObject()) {
                 return null;

--- a/src/browser/tests/element/dataset.html
+++ b/src/browser/tests/element/dataset.html
@@ -36,6 +36,11 @@
 
   testing.expectEqual('value', el.dataset.newAttr);
   testing.expectEqual('value', el.getAttribute('data-new-attr'));
+
+  el.dataset.newAttr = true;
+
+  testing.expectEqual('true', el.dataset.newAttr);
+  testing.expectEqual('true', el.getAttribute('data-new-attr'));
 }
 </script>
 


### PR DESCRIPTION
When `[]const u8` is a web api parameter, we'll coerce the value to a string, e.g. true -> "true". This is correct for almost every API. APIs can also opt to use a string.String (or string.String.Global). This is purely meant as an optimization, but its behavior is currently different than `[]const u8` as the bridge will only map actual JS strings to it.

This commit makes String and []const u8 behave the same, so that the only decision as to which to use is about performance.

(APIs that strictly want a string should use js.String or js.Value and do the type check)