### PR TITLE
Robots Deny on Next Tick

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -191,11 +191,11 @@ fn layerWith(self: anytype, next: Layer) Layer {
 
 pub const NextTickNode = struct {
     pub const Run =
-        *const fn (*Transfer, *anyopaque) void;
-    pub const Abort = *const fn (*anyopaque) void;
+        *const fn (*Transfer, ?*anyopaque) void;
+    pub const Abort = *const fn (?*anyopaque) void;
 
     node: std.DoublyLinkedList.Node = .{},
-    ctx: *anyopaque,
+    ctx: ?*anyopaque,
     run: Run,
     abort: ?Abort = null,
 };
@@ -473,7 +473,7 @@ pub fn tick(self: *Client, timeout_ms: u32, mode: DrainMode) !void {
 pub fn runNextTick(
     self: *Client,
     transfer: *Transfer,
-    ctx: *anyopaque,
+    ctx: ?*anyopaque,
     params: struct { run: NextTickNode.Run, abort: ?NextTickNode.Abort = null },
 ) !void {
     transfer._next_tick_node = .{ .ctx = ctx, .run = params.run, .abort = params.abort };
@@ -656,7 +656,7 @@ const Synthetic = struct {
         return std.mem.startsWith(u8, url, "data:") or std.mem.startsWith(u8, url, "blob:");
     }
 
-    fn run(transfer: *Transfer, _: *anyopaque) void {
+    fn run(transfer: *Transfer, _: ?*anyopaque) void {
         // prevents a callback that triggers a navigation queue from killing
         // this transfer from under us.
         transfer.state = .completing;

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -628,7 +628,7 @@ fn requestT(self: *Client, req: Request, owner: ?*Owner) !*Transfer {
     if (Synthetic.isSynthetic(req.url)) {
         // The 2nd transfer is the callback context. We don't actually use it,
         // we're just sticking transfer in there to have something.
-        self.runNextTick(transfer, transfer, .{ .run = Synthetic.run }) catch |err| {
+        self.runNextTick(transfer, null, .{ .run = Synthetic.run }) catch |err| {
             if (transfer.state == .created) {
                 transfer.abort(err);
             }

--- a/src/network/layer/CacheLayer.zig
+++ b/src/network/layer/CacheLayer.zig
@@ -76,18 +76,18 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
 
         try transfer.client.runNextTick(transfer, ctx, .{
             .run = struct {
-                fn run(t: *Transfer, ctx_ptr: *anyopaque) void {
+                fn run(t: *Transfer, ctx_ptr: ?*anyopaque) void {
                     defer t.deinit();
 
-                    const c: *CachedResponse = @ptrCast(@alignCast(ctx_ptr));
+                    const c: *CachedResponse = @ptrCast(@alignCast(ctx_ptr.?));
                     serveFromCache(&t.req, c) catch |err| {
                         t.req.error_callback(t.req.ctx, err);
                     };
                 }
             }.run,
             .abort = struct {
-                fn abort(ctx_ptr: *anyopaque) void {
-                    const c: *CachedResponse = @ptrCast(@alignCast(ctx_ptr));
+                fn abort(ctx_ptr: ?*anyopaque) void {
+                    const c: *CachedResponse = @ptrCast(@alignCast(ctx_ptr.?));
                     switch (c.data) {
                         .buffer => |_| {},
                         .file => |f| f.file.close(),

--- a/src/network/layer/RobotsLayer.zig
+++ b/src/network/layer/RobotsLayer.zig
@@ -70,8 +70,21 @@ fn request(ptr: *anyopaque, transfer: *Transfer) anyerror!void {
                 const path = URL.getPathname(url);
 
                 if (!robots.isAllowed(path)) {
-                    log.warn(.http, "blocked by robots", .{ .url = url });
-                    return error.RobotsBlocked;
+                    try transfer.client.runNextTick(
+                        transfer,
+                        null,
+                        .{
+                            .run = struct {
+                                fn run(t: *Transfer, _: ?*anyopaque) void {
+                                    defer t.deinit();
+
+                                    log.warn(.http, "blocked by robots", .{ .url = t.req.url });
+                                    t.req.error_callback(t.req.ctx, error.RobotsBlocked);
+                                }
+                            }.run,
+                        },
+                    );
+                    return;
                 }
             },
             .absent => {},


### PR DESCRIPTION
This fires the `RobotsBlocked` error when the RobotsLayer synchronously denies a request on the next tick.