### PR TITLE
Don't allow document.close during document.write

### DIFF
--- a/src/browser/tests/custom_elements/reentrant_document_close.html
+++ b/src/browser/tests/custom_elements/reentrant_document_close.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<head>
+<script src="../testing.js"></script>
+</head>
+<body>
+<!-- Regression test for a SIGSEGV triggered by re-entrant document.close().
+
+     Sibling to reentrant_document_write.html: that test covers a written
+     <script> calling document.write() re-entrantly. This one covers the
+     document.close() path, which the streaming parser's `feeding` guard did
+     NOT protect.
+
+     A script run by the script-created parser executes synchronously inside
+     html5ever's feed() (we're popping that <script>). If that script calls
+     document.close(), the close ran html5ever_streaming_parser_finish() on the
+     handle still mid-feed on the stack. html5ever's streaming parser is not
+     re-entrant: finishing it there walked an empty open-elements stack and
+     panicked with "no current element", then segfaulted.
+
+     The fix defers the finish: a re-entrant close flags the document, and the
+     write() driving the feed loop completes the close once the loop unwinds and
+     any markup the same script queued has drained. A custom element in the
+     written markup ensures a reaction is queued in the pop scope that crashed. -->
+<script id="reentrant_close">
+window.nestedCloseRan = false;
+window.connectedRan = false;
+
+class ReentrantClose extends HTMLElement {
+    connectedCallback() {
+        window.connectedRan = true;
+    }
+}
+customElements.define('reentrant-close', ReentrantClose);
+
+// onload runs after the initial parse, so document.write() goes through the
+// script-created parser (the path that crashed).
+testing.onload(function () {
+    document.open();
+    document.write(
+        '<reentrant-close></reentrant-close>' +
+        '<scr' + 'ipt>' +
+        'window.nestedCloseRan = true;' +
+        'document.write("<p>nested</p>");' +
+        'document.close();' +
+        '</scr' + 'ipt>'
+    );
+
+    // Reaching here without crashing is the whole point of the test.
+    testing.expectTrue(window.nestedCloseRan);
+    testing.expectTrue(window.connectedRan);
+
+    // The re-entrant close deferred the parser finish until the feed loop
+    // unwound; by now the queued <p>nested</p> has been parsed.
+    testing.expectEqual('nested', document.querySelector('p').textContent);
+});
+</script>
+</body>
+</html>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -63,6 +63,7 @@ _implementation: ?*DOMImplementation = null,
 _fonts: ?*FontFaceSet = null,
 _write_insertion_point: ?*Node = null,
 _script_created_parser: ?Parser.Streaming = null,
+_close_requested: bool = false,
 _adopted_style_sheets: ?js.Object.Global = null,
 _selection: Selection = .{ ._rc = .init(1) },
 
@@ -764,7 +765,20 @@ fn writeInternal(self: *Document, text: []const []const u8, append_newline: bool
                         log.warn(.dom, "flush after parser panic", .{ .err = flush_err });
                     };
                     self._script_created_parser = null;
+                    self._close_requested = false;
                 };
+            }
+        }
+
+        if (self._close_requested) {
+            // document.close was executed during a document.write. We couldn't
+            // execute that during the write, but we can now.
+            if (self._script_created_parser) |*parser| {
+                if (parser.feeding == false) {
+                    try self.finishScriptCreatedParser(frame);
+                }
+            } else {
+                self._close_requested = false;
             }
         }
         return;
@@ -891,9 +905,22 @@ pub fn close(self: *Document, call_frame: *Frame) !void {
         return error.InvalidStateError;
     }
 
-    if (self._script_created_parser == null) {
+    if (self._script_created_parser) |*parser| {
+        if (parser.feeding) {
+            // we're currently in a document.write, we cannot close. We flag
+            // the close and process it at the next safe spot.
+            self._close_requested = true;
+            return;
+        }
+    } else {
         return;
     }
+
+    try self.finishScriptCreatedParser(frame);
+}
+
+fn finishScriptCreatedParser(self: *Document, frame: *Frame) !void {
+    self._close_requested = false;
 
     // done() finishes html5ever's handle and runs the final flushPendingText.
     // Even if flushPendingText errors, the handle is already finished and we


### PR DESCRIPTION
56181bbe6cff14701940ec3db29eae96867f90a3 protected against a document.write generating a document.write.

This protects against a document.write generating a document.close. We cannot immediately close, so we 'queue' the close (via a boolean) and defer it until the write is complete.

Fixes crash in WPT: /html/webappapis/dynamic-markup-insertion/document-write/iframe_010.html From what I can tell, this is the last one of these.