### PR TITLE
Add Script cache to Runner.waitForScript

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.4.6'
+    default: 'v0.4.7'
   v8:
     description: 'v8 version to install'
     required: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.0.365.4
-ARG ZIG_V8=v0.4.6
+ARG ZIG_V8=v0.4.7
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.6.tar.gz",
-            .hash = "v8-0.0.0-xddH67-YBABDa7EPYFKQsWLdpK8xJvVVmDsKIaGPGID7",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.7.tar.gz",
+            .hash = "v8-0.0.0-xddH63edBADvfTFAnAlB6WutVta1yhsLuyPdXXt_BnKK",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -297,13 +297,35 @@ pub fn waitForSelector(self: *Runner, selector: [:0]const u8, timeout_ms: u32) !
     }
 }
 
-pub fn waitForScript(runner: *Runner, script: [:0]const u8, timeout_ms: u32) !void {
+pub fn waitForScript(runner: *Runner, src: [:0]const u8, timeout_ms: u32) !void {
     var timer = try std.time.Timer.start();
+
+    // Compile the script once and re-use the compiled form. A tick can create a
+    // new context (an internal navigation), so we keep an unbound script (one
+    // not bound to a particular context) and bind it to the current context on
+    // each tick. Compilation is context-independent, so we can do it up front
+    // in whatever context the frame currently has.
+    var compiled: js.Script.Unbound.Global = blk: {
+        var ls: js.Local.Scope = undefined;
+        runner.frame.js.localScope(&ls);
+        defer ls.deinit();
+
+        var try_catch: js.TryCatch = undefined;
+        try_catch.init(&ls.local);
+        defer try_catch.deinit();
+
+        const s = ls.local.compile(src, "wait_script") catch |err| {
+            const caught = try_catch.caughtOrError(runner.frame.call_arena, err);
+            log.err(.app, "wait script error", .{ .err = caught });
+            return error.ScriptError;
+        };
+        break :blk s.getUnboundScript().persist(ls.local.isolate);
+    };
+    defer compiled.deinit();
 
     while (true) {
         const frame = runner.frame;
 
-        // Execute the script and check if it returns truthy
         var ls: js.Local.Scope = undefined;
         frame.js.localScope(&ls);
         defer ls.deinit();
@@ -312,7 +334,8 @@ pub fn waitForScript(runner: *Runner, script: [:0]const u8, timeout_ms: u32) !vo
         try_catch.init(&ls.local);
         defer try_catch.deinit();
 
-        const value = ls.local.exec(script, "wait_script") catch |err| {
+        const script = compiled.get(ls.local.isolate).bindToCurrentContext(&ls.local);
+        const value = script.run() catch |err| {
             const caught = try_catch.caughtOrError(frame.call_arena, err);
             log.err(.app, "wait script error", .{ .err = caught });
             return error.ScriptError;

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -172,6 +172,28 @@ pub fn compileFunction(
 }
 
 pub fn compileAndRun(self: *const Local, src: []const u8, name: ?[]const u8) !js.Value {
+    const script = try self.compile(src, name);
+    return script.run();
+}
+
+// Compile `src` into a context-bound Script
+pub fn compile(self: *const Local, src: []const u8, name: ?[]const u8) !js.Script {
+    const result = try self.compileWithCache(src, name, null);
+    return result.script;
+}
+
+pub const CompileResult = struct {
+    script: js.Script,
+    // True only when `cached_data` was supplied AND V8 rejected it (source,
+    // V8 version, or flag mismatch) and recompiled from source. Always false
+    // when no cached_data was passed. Callers should drop/refresh a rejected
+    // cache entry.
+    cache_rejected: bool,
+};
+
+// Like compile, but takes an optional cached_data which is a previously
+// compiled and serialized script (see Script.Unbound.createCodeCache)
+pub fn compileWithCache(self: *const Local, src: []const u8, name: ?[]const u8, cached_data: ?[]const u8) !CompileResult {
     const script_name = self.isolate.initStringHandle(name orelse "anonymous");
     const script_source = self.isolate.initStringHandle(src);
 
@@ -179,22 +201,32 @@ pub fn compileAndRun(self: *const Local, src: []const u8, name: ?[]const u8) !js
     var origin: v8.ScriptOrigin = undefined;
     v8.v8__ScriptOrigin__CONSTRUCT(&origin, @ptrCast(script_name));
 
+    // The Source takes ownership of the CachedData pointer (it holds it in a
+    // unique_ptr), so we must not delete it ourselves — Source__DESTRUCT does.
+    const cached: ?*v8.ScriptCompilerCachedData = if (cached_data) |bytes|
+        v8.v8__ScriptCompiler__CachedData__NEW(bytes.ptr, @intCast(bytes.len))
+    else
+        null;
+
     // Create ScriptCompilerSource
     var script_comp_source: v8.ScriptCompilerSource = undefined;
-    v8.v8__ScriptCompiler__Source__CONSTRUCT2(script_source, &origin, null, &script_comp_source);
+    v8.v8__ScriptCompiler__Source__CONSTRUCT2(script_source, &origin, cached, &script_comp_source);
     defer v8.v8__ScriptCompiler__Source__DESTRUCT(&script_comp_source);
+
+    const options: v8.CompileOptions = if (cached != null) v8.kConsumeCodeCache else v8.kNoCompileOptions;
 
     // Compile the script
     const v8_script = v8.v8__ScriptCompiler__Compile(
         self.handle,
         &script_comp_source,
-        v8.kNoCompileOptions,
+        options,
         v8.kNoCacheNoReason,
     ) orelse return error.CompilationError;
 
-    // Run the script
-    const result = v8.v8__Script__Run(v8_script, self.handle) orelse return error.JsException;
-    return .{ .local = self, .handle = result };
+    return .{
+        .script = .{ .local = self, .handle = v8_script },
+        .cache_rejected = if (cached) |c| c.*.rejected else false,
+    };
 }
 
 // == Zig -> JS ==

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -1,0 +1,124 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const js = @import("js.zig");
+const Isolate = @import("Isolate.zig");
+
+const v8 = js.v8;
+const Allocator = std.mem.Allocator;
+
+const Script = @This();
+
+local: *const js.Local,
+handle: *const v8.Script,
+
+pub fn run(self: Script) !js.Value {
+    const result = v8.v8__Script__Run(self.handle, self.local.handle) orelse return error.JsException;
+    return .{ .local = self.local, .handle = result };
+}
+
+// The context-independent script. Binding it back to a context returns a Script
+// which can be run.
+pub fn getUnboundScript(self: Script) Unbound {
+    return .{ .handle = v8.v8__Script__GetUnboundScript(self.handle).? };
+}
+
+pub const Unbound = struct {
+    handle: *const v8.UnboundScript,
+
+    pub fn bindToCurrentContext(self: Unbound, local: *const js.Local) Script {
+        return .{
+            .local = local,
+            .handle = v8.v8__UnboundScript__BindToCurrentContext(self.handle).?,
+        };
+    }
+
+    // Serialize the script. The returned bytes can be persisted and passed back
+    // into local.compileWithCache
+    pub fn createCodeCache(self: Unbound, allocator: Allocator) ![]u8 {
+        const cached = v8.v8__ScriptCompiler__CreateCodeCache(self.handle) orelse return error.CodeCacheFailed;
+        defer v8.v8__ScriptCompiler__CachedData__DELETE(cached);
+        const len: usize = @intCast(cached.*.length);
+        return allocator.dupe(u8, cached.*.data[0..len]);
+    }
+
+    pub fn persist(self: Unbound, isolate: Isolate) Global {
+        var global: v8.Global = undefined;
+        v8.v8__Global__New(isolate.handle, self.handle, &global);
+        return .{ .handle = global };
+    }
+
+    pub const Global = struct {
+        handle: v8.Global,
+
+        pub fn deinit(self: *Global) void {
+            v8.v8__Global__Reset(&self.handle);
+        }
+
+        pub fn get(self: *const Global, isolate: Isolate) Unbound {
+            return .{ .handle = @ptrCast(v8.v8__Global__Get(&self.handle, isolate.handle)) };
+        }
+    };
+};
+
+const testing = @import("../../testing.zig");
+test "Script: persisted unbound script re-binds and re-runs" {
+    const session = testing.test_session;
+    const frame = try session.createPage();
+    defer session.removePage();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const script = try ls.local.compile("1 + 2", "rebind_test");
+    try testing.expectEqual(3, try (try script.run()).toI32());
+
+    var unbound = script.getUnboundScript().persist(ls.local.isolate);
+    defer unbound.deinit();
+
+    const rebound = unbound.get(ls.local.isolate).bindToCurrentContext(&ls.local);
+    try testing.expectEqual(3, try (try rebound.run()).toI32());
+}
+
+test "Script: code cache round-trips and rejects a source mismatch" {
+    const session = testing.test_session;
+    const frame = try session.createPage();
+    defer session.removePage();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const src = "function add(a, b) { return a + b; } add(40, 2);";
+
+    const produced = try ls.local.compile(src, "cache_test");
+    const bytes = try produced.getUnboundScript().createCodeCache(testing.allocator);
+    defer testing.allocator.free(bytes);
+    try testing.expect(bytes.len > 0);
+
+    const hit = try ls.local.compileWithCache(src, "cache_test", bytes);
+    try testing.expectEqual(false, hit.cache_rejected);
+    try testing.expectEqual(42, try (try hit.script.run()).toI32());
+
+    const miss = try ls.local.compileWithCache("1 + 1;", "cache_test", bytes);
+    try testing.expectEqual(true, miss.cache_rejected);
+    try testing.expectEqual(2, try (try miss.script.run()).toI32());
+}

--- a/src/browser/js/js.zig
+++ b/src/browser/js/js.zig
@@ -46,6 +46,7 @@ pub const Function = @import("Function.zig");
 pub const Promise = @import("Promise.zig");
 pub const RegExp = @import("RegExp.zig");
 pub const Module = @import("Module.zig");
+pub const Script = @import("Script.zig");
 pub const BigInt = @import("BigInt.zig");
 pub const Number = @import("Number.zig");
 pub const Integer = @import("Integer.zig");


### PR DESCRIPTION
This adds script compilation to the Runner.waitForScript loop. The goal here isn't really to improve waitForScript - we generally expect these scripts to be very simple. The goal is to introduce script caching so that it could be used in more important places (e.g. ScriptManager).

Depends on https://github.com/lightpanda-io/zig-v8-fork/pull/181