### PR TITLE
feat(webapi): reflect name and value on HTMLParamElement

### DIFF
--- a/src/browser/tests/element/html/param.html
+++ b/src/browser/tests/element/html/param.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<param id="p1" name="n0" value="v0">
+
+<script id="name">
+  {
+    const p = document.getElementById('p1');
+    testing.expectEqual('n0', p.name);
+
+    p.name = 'n1';
+    testing.expectEqual('n1', p.getAttribute('name'));
+
+    p.setAttribute('name', 'n2');
+    testing.expectEqual('n2', p.name);
+
+    const p2 = document.createElement('param');
+    testing.expectEqual('', p2.name);
+  }
+</script>
+
+<script id="value">
+  {
+    const p = document.getElementById('p1');
+    testing.expectEqual('v0', p.value);
+
+    p.value = 'v1';
+    testing.expectEqual('v1', p.getAttribute('value'));
+
+    p.setAttribute('value', 'v2');
+    testing.expectEqual('v2', p.value);
+
+    const p2 = document.createElement('param');
+    testing.expectEqual('', p2.value);
+  }
+</script>

--- a/src/browser/webapi/element/html/Param.zig
+++ b/src/browser/webapi/element/html/Param.zig
@@ -1,4 +1,5 @@
 const js = @import("../../../js/js.zig");
+const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
@@ -14,6 +15,22 @@ pub fn asNode(self: *Param) *Node {
     return self.asElement().asNode();
 }
 
+pub fn getName(self: *Param) []const u8 {
+    return self.asElement().getAttributeSafe(comptime .wrap("name")) orelse "";
+}
+
+pub fn setName(self: *Param, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
+}
+
+pub fn getValue(self: *Param) []const u8 {
+    return self.asElement().getAttributeSafe(comptime .wrap("value")) orelse "";
+}
+
+pub fn setValue(self: *Param, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("value"), .wrap(value), frame);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Param);
 
@@ -22,4 +39,12 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    pub const name = bridge.accessor(Param.getName, Param.setName, .{ .ce_reactions = true });
+    pub const value = bridge.accessor(Param.getValue, Param.setValue, .{ .ce_reactions = true });
 };
+
+const testing = @import("../../../../testing.zig");
+test "WebApi: HTML.Param" {
+    try testing.htmlRunner("element/html/param.html", .{});
+}


### PR DESCRIPTION
HTMLParamElement is already registered as a concrete element type, but its \`name\` and \`value\` attributes were not reflected. This adds them as plain DOMString reflections per HTML 15.3 (https://html.spec.whatwg.org/multipage/obsolete.html#htmlparamelement), following the same idiom as HTMLTimeElement and HTMLDataElement.

## Changes

- \`src/browser/webapi/element/html/Param.zig\`: add \`name\` and \`value\` getter/setter accessors (empty string default when the attribute is absent).
- \`src/browser/tests/element/html/param.html\`: test fixture covering attribute-to-property and property-to-attribute reflection plus the empty-string default for both attributes.

## Why

Moves the html/dom/reflection-obsolete.html WPT row closer to green.

## Verified

- \`make test\` passes (764/764, no leaks); the new \`WebApi: HTML.Param\` test is included.
- \`zig fmt --check ./*.zig ./**/*.zig\` clean.
- \`make build\` succeeds.