### PR TITLE
feat(webapi): reflect src, type, width and height on HTMLEmbedElement

### DIFF
--- a/src/browser/tests/element/html/embed.html
+++ b/src/browser/tests/element/html/embed.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<embed id="em1" src="/plugin.swf" type="application/x-shockwave-flash" width="640" height="480">
+<embed id="em2">
+
+<script id="embed-from-html">
+  {
+    const em1 = document.getElementById('em1');
+    testing.expectEqual('HTMLEmbedElement', em1.constructor.name);
+    testing.expectEqual(testing.ORIGIN + '/plugin.swf', em1.src);
+    testing.expectEqual('application/x-shockwave-flash', em1.type);
+    testing.expectEqual('640', em1.width);
+    testing.expectEqual('480', em1.height);
+
+    const em2 = document.getElementById('em2');
+    testing.expectEqual('', em2.src);
+    testing.expectEqual('', em2.type);
+    testing.expectEqual('', em2.width);
+    testing.expectEqual('', em2.height);
+  }
+</script>
+
+<script id="embed-reflection">
+  {
+    const em = document.createElement('embed');
+
+    em.type = 'video/mp4';
+    testing.expectEqual('video/mp4', em.getAttribute('type'));
+    em.setAttribute('type', 'image/svg+xml');
+    testing.expectEqual('image/svg+xml', em.type);
+
+    em.width = '320';
+    testing.expectEqual('320', em.getAttribute('width'));
+    em.setAttribute('width', '160');
+    testing.expectEqual('160', em.width);
+
+    em.height = '240';
+    testing.expectEqual('240', em.getAttribute('height'));
+    em.setAttribute('height', '120');
+    testing.expectEqual('120', em.height);
+  }
+</script>
+
+<script id="embed-src-url">
+  {
+    const em = document.createElement('embed');
+    testing.expectEqual('', em.src);
+
+    em.src = 'https://lightpanda.io/plugin.swf';
+    testing.expectEqual('https://lightpanda.io/plugin.swf', em.src);
+
+    em.src = '/relative.swf';
+    testing.expectEqual(testing.ORIGIN + '/relative.swf', em.src);
+  }
+</script>

--- a/src/browser/webapi/element/html/Embed.zig
+++ b/src/browser/webapi/element/html/Embed.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const js = @import("../../../js/js.zig");
+const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
@@ -27,8 +28,48 @@ _proto: *HtmlElement,
 pub fn asElement(self: *Embed) *Element {
     return self._proto._proto;
 }
+pub fn asConstElement(self: *const Embed) *const Element {
+    return self._proto._proto;
+}
 pub fn asNode(self: *Embed) *Node {
     return self.asElement().asNode();
+}
+
+pub fn getSrc(self: *const Embed, frame: *Frame) ![]const u8 {
+    const element = self.asConstElement();
+    const src = element.getAttributeSafe(comptime .wrap("src")) orelse return "";
+    if (src.len == 0) {
+        return "";
+    }
+    return element.asConstNode().resolveURL(src, frame, .{});
+}
+
+pub fn setSrc(self: *Embed, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
+}
+
+pub fn getType(self: *const Embed) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
+}
+
+pub fn setType(self: *Embed, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
+}
+
+pub fn getWidth(self: *const Embed) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("width")) orelse "";
+}
+
+pub fn setWidth(self: *Embed, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(value), frame);
+}
+
+pub fn getHeight(self: *const Embed) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("height")) orelse "";
+}
+
+pub fn setHeight(self: *Embed, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(value), frame);
 }
 
 pub const JsApi = struct {
@@ -39,4 +80,14 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    pub const height = bridge.accessor(Embed.getHeight, Embed.setHeight, .{ .ce_reactions = true });
+    pub const src = bridge.accessor(Embed.getSrc, Embed.setSrc, .{ .ce_reactions = true });
+    pub const @"type" = bridge.accessor(Embed.getType, Embed.setType, .{ .ce_reactions = true });
+    pub const width = bridge.accessor(Embed.getWidth, Embed.setWidth, .{ .ce_reactions = true });
 };
+
+const testing = @import("../../../../testing.zig");
+test "WebApi: HTML.Embed" {
+    try testing.htmlRunner("element/html/embed.html", .{});
+}


### PR DESCRIPTION
HTMLEmbedElement was registered but reflected none of its content attributes. This adds the four reflected attributes from its IDL per HTML 4.8.6 (https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement).

## Changes

- `src/browser/webapi/element/html/Embed.zig`: reflect `src`, `type`, `width`, `height`. `src` is URL-reflecting (resolved against the document base, mirroring `HTMLImageElement.src`); `type`, `width` and `height` are plain `DOMString` reflections (per the spec, embed's `width`/`height` are strings, not integers).
- `src/browser/tests/element/html/embed.html`: test fixture covering attribute-to-property and property-to-attribute reflection, empty-string defaults, and `src` URL resolution (relative to absolute).

## Verified

- `make test` passes (767/767, no leaks); the new `WebApi: HTML.Embed` test is included.
- `zig fmt --check ./*.zig ./**/*.zig` clean.
- `make build` succeeds.