### PR TITLE
Don't overlog ClientDisconnected

### DIFF
--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -93,6 +93,7 @@ fn _wait(self: *Runner, comptime is_cdp: bool, opts: WaitOpts) !void {
         const tick_result = self._tick(is_cdp, tick_opts) catch |err| {
             switch (err) {
                 error.JsError => {}, // already logged (with hopefully more context)
+                error.ClientDisconnected => {}, // CDP layer already logged this
                 else => log.err(.browser, "session wait", .{
                     .err = err,
                     .url = self.frame.url,


### PR DESCRIPTION
Since the CDP rework, error.ClientDisconnected surfaces to the Runner. There's no reason to log this (especially as at an error level). It's perfectly normal and has already been logged at the CDP level.