### PR TITLE
Add "networkalmostidle" to --wait-until parameter

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -460,6 +460,7 @@ pub const DumpFormat = enum {
 pub const WaitUntil = enum {
     load,
     domcontentloaded,
+    networkalmostidle,
     networkidle,
     done,
 };

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -204,6 +204,9 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
                 .networkidle => if (frame._notified_network_idle == .done) {
                     return .done;
                 },
+                .networkalmostidle => if (frame._notified_network_almost_idle == .done) {
+                    return .done;
+                },
             }
 
             if (http_active == 0 and http_next_tick == 0 and http_client.ws_active == 0 and http_client.queue.first == null and http_client.ready_queue.first == null and (comptime is_cdp) == false) {

--- a/src/help.zon
+++ b/src/help.zon
@@ -77,7 +77,8 @@
     \\          Wait until the specified event. Checked before other --wait-* options.
     \\          Defaults to 'done'. If --wait-selector, --wait-script or
     \\          --wait-script-file specified, defaults to none.
-    \\          Allowed values: "load", "domcontentloaded", "networkidle", "done".
+    \\          Allowed values: "load", "domcontentloaded", "networkalmostidle",
+    \\          "networkidle", "done".
     \\  --wait-selector <QUERY>
     \\          Wait for an element matching the CSS selector to appear. Checked after
     \\          --wait-until condition is met.


### PR DESCRIPTION
Just config hookup, as the `Frame._notified_network_almost_idle` already exists (and is used by CDP).