### PR TITLE
Fix double-free of async <script> arena on retried/aborted (204) fetches

### DIFF
--- a/src/ArenaPool.zig
+++ b/src/ArenaPool.zig
@@ -171,13 +171,11 @@ pub fn release(self: *ArenaPool, allocator: Allocator) void {
     const entry: *Entry = @fieldParentPtr("arena", arena);
     const bucket = entry.bucket;
 
-    // Reset the arena before acquiring the lock to minimize lock hold time
-    _ = arena.reset(.{ .retain_with_limit = bucket.retain_bytes });
-
-    self.mutex.lock();
-    defer self.mutex.unlock();
-
     if (IS_DEBUG) {
+        // Must precede arena.reset below: a double-release hits a dangling
+        // Entry, so resetting first GP-faults before this panic can fire.
+        self.mutex.lock();
+        defer self.mutex.unlock();
         if (self._leak_track.getPtr(entry.debug)) |count| {
             count.* -= 1;
             if (count.* < 0) {
@@ -189,6 +187,12 @@ pub fn release(self: *ArenaPool, allocator: Allocator) void {
             @panic("ArenaPool: release of untracked arena");
         }
     }
+
+    // Reset the arena before acquiring the lock to minimize lock hold time.
+    _ = arena.reset(.{ .retain_with_limit = bucket.retain_bytes });
+
+    self.mutex.lock();
+    defer self.mutex.unlock();
 
     if ((comptime SAFETY) or bucket.free_list_len >= bucket.free_list_max) {
         // In Debug, we never pool. It can mask UAF bugs.

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1131,7 +1131,7 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     self.removeConn(msg.conn);
     transfer._conn = null;
 
-    try transfer.req.done_callback(transfer.req.ctx);
+    try transfer.requestComplete();
 
     return true;
 }
@@ -1510,6 +1510,12 @@ pub const Transfer = struct {
 
     _notified_fail: bool = false,
 
+    // Latches on the first terminal callback (done or error) and, unlike
+    // _notified_fail, is never reset across retries. Ensures a ctx that frees
+    // itself in that callback (e.g. a Script releasing its pooled arena) gets
+    // exactly one terminal callback over the transfer's lifetime, never two.
+    _terminated: bool = false,
+
     // Set when conn is temporarily detached from transfer during redirect
     // reconfiguration. Used by processMessages to release the orphaned conn
     // if reconfiguration fails. Transient inside the redirect path only.
@@ -1737,11 +1743,23 @@ pub const Transfer = struct {
         if (self._notified_fail) return;
         self._notified_fail = true;
 
+        // See _terminated.
+        if (self._terminated) return;
+        self._terminated = true;
+
         if (execute_callback) {
             self.req.error_callback(self.req.ctx, err);
         } else if (self.req.shutdown_callback) |cb| {
             cb(self.req.ctx);
         }
+    }
+
+    // Success counterpart to requestFailed: fire done_callback at most once,
+    // sharing the _terminated latch so done and error can't both reach the ctx.
+    fn requestComplete(self: *Transfer) !void {
+        if (self._terminated) return;
+        self._terminated = true;
+        try self.req.done_callback(self.req.ctx);
     }
 
     fn configureConn(self: *Transfer, conn: *http.Connection) anyerror!void {


### PR DESCRIPTION
Fixes #2622

## Problem

A `Transfer` could deliver **two terminal callbacks** (done *and* error) to the same `ctx` over its lifetime:

- `_notified_fail` only dedups *errors within a single attempt* and is **reset on retry** (`Transfer.reset`).
- `done_callback` was **not latched at all**.

For an `async` `<script>` whose fetch is retried/aborted with a non-200 (observed: `204`), both `Script.doneCallback` (→ `evaluate` → `script.deinit`) and `Script.errorCallback` (→ `script.deinit`) could run for the same `Script`. Since each `deinit` releases the `Script`'s pooled arena, the second release double-frees it:

- **Debug:** GP fault in `ArenaPool.release` (`@fieldParentPtr` + `arena.reset` on a dangling `Entry`).
- **ReleaseFast:** free-list corruption → arenas leak unbounded (RSS → ~18 GiB).

## Fix

**Primary (transfer layer).** Add a `_terminated` latch on `Transfer` that guarantees exactly one terminal callback over the transfer's whole lifetime. Unlike `_notified_fail`, it is **never reset** — legitimate retries/redirects all call `reset()` *before* any terminal callback runs, so they're unaffected. `done_callback` now goes through a new `requestComplete()` that shares the latch with `requestFailed()`, so done and error can't both reach the ctx.

**Defense-in-depth (`ArenaPool.release`).** Run the existing debug double-free check **before** `arena.reset()`, so any future stray double-release panics loudly (`ArenaPool: double-free detected`) instead of GP-faulting on a dangling `Entry` and silently corrupting the pool.

## Testing

- `make test` — 768/768 pass.
- `zig fmt --check` clean on both changed files.