### PR TITLE
DeferringLayer correctly handle header stop/errors

### DIFF
--- a/src/network/layer/DeferringLayer.zig
+++ b/src/network/layer/DeferringLayer.zig
@@ -259,6 +259,7 @@ const DeferredContext = struct {
 
                     if (!proceed) {
                         self.forward.forwardErr(error.Abort);
+                        return;
                     }
                 },
                 .data => |chunk| {


### PR DESCRIPTION
When forwardHeader signals not to proceed, fire() should stop.

This is the direct fix to https://github.com/lightpanda-io/browser/issues/2622