### PR TITLE
repl: add dynamic status bar

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .hash = "zenai-0.0.0-iOY_VB3OAwAQcfi4LDtd-gO9TB_Utf3oTAekMqvKXfC8",
         },
         .isocline = .{
-            .url = "git+https://github.com/arrufat/isocline#32cedce0f1385f3964b7535fac13a5c30a758c74",
-            .hash = "N-V-__8AAAlGEwAxx-g1VHXQEiWKTiikaUYFQdNjqfWTxW90",
+            .url = "git+https://github.com/arrufat/isocline#94433ba3afa8e1ebb0187af17838a8d853a3829c",
+            .hash = "N-V-__8AAN1eEwARQB47r-8X1xDq8PCgmuiYsqQlcNW39Czq",
         },
     },
     .paths = .{""},

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -206,16 +206,10 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
 
     if (resolved) |r| {
         if (r.source == .picked) {
-            settings.saveRemembered(r.credentials.provider, model);
+            settings.saveRemembered(r.credentials.provider, model) catch {};
         }
-        std.debug.print(Terminal.ansi.dim ++ "  Provider: {s}, Model: {s} ", .{ @tagName(r.credentials.provider), model });
-        switch (r.source) {
-            .flag => {},
-            .remembered => std.debug.print("(from ./.lp-agent.zon) ", .{}),
-            .detected => std.debug.print("(auto-selected) ", .{}),
-            .picked => std.debug.print("(saved to /.lp-agent.zon) ", .{}),
-        }
-        std.debug.print("\n\n" ++ Terminal.ansi.reset, .{});
+        // provider/model now live in the status bar; just space before the help
+        std.debug.print("\n", .{});
     }
 
     const notification: *lp.Notification = try .init(allocator);
@@ -461,21 +455,21 @@ fn runTurn(self: *Agent, input: TurnInput) bool {
 
 fn runRepl(self: *Agent) void {
     if (self.ai_client) |_| {
-        self.terminal.printItalic("  Use natural language or slash commands", .{});
+        self.terminal.printItalic("  Use natural language or commands", .{});
     } else {
-        self.terminal.printItalic("  Basic REPL (--no-llm) - slash commands only.", .{});
+        self.terminal.printItalic("  Basic REPL (--no-llm) - commands only.", .{});
         self.terminal.printDimmed("  To enable natural language, " ++ llm_setup_hint ++ ".", .{});
     }
-    self.terminal.printDimmed("  /help to list slash commands\t\t\tTab completes/cycles through commands", .{});
+    self.terminal.printDimmed("  /help to list commands", .{});
     self.terminal.printDimmed("  /quit to exit", .{});
-    self.terminal.printDimmed("  ! for JS mode (eval against the page)\t\tEsc exits JS mode", .{});
+    self.terminal.printDimmed("  ! for JS mode", .{});
     log.debug(.app, "tools loaded", .{ .count = globalTools().len });
 
     repl: while (true) {
         std.debug.print("\n", .{});
+        self.updateStatusBar();
         const line = Terminal.readLine("") orelse break;
         defer Terminal.freeLine(line);
-        std.debug.print("\n", .{});
 
         // Slash commands and idle Ctrl-C set the cancel flag without
         // clearing V8's terminate state; drain both before the next turn.
@@ -484,7 +478,11 @@ fn runRepl(self: *Agent) void {
         }
 
         const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
-        if (trimmed.len == 0) continue;
+        if (trimmed.len == 0) {
+            self.terminal.clearPromptFrame();
+            continue;
+        }
+        std.debug.print("\n", .{});
 
         var arena: std.heap.ArenaAllocator = .init(self.allocator);
         defer arena.deinit();
@@ -630,8 +628,23 @@ fn setModel(self: *Agent, model: []const u8) !void {
     const new_model = try self.allocator.dupe(u8, model);
     self.allocator.free(self.model);
     self.model = new_model;
-    if (self.model_credentials) |c| settings.saveRemembered(c.provider, self.model);
-    self.terminal.printInfo("model: {s}", .{self.model});
+    const c = self.model_credentials orelse {
+        self.terminal.printInfo("model: {s}", .{self.model});
+        return;
+    };
+    if (settings.saveRemembered(c.provider, self.model)) {
+        self.terminal.printInfo("model: {s} (saved to {s})", .{ self.model, settings.remembered_path });
+    } else |_| {
+        self.terminal.printInfo("model: {s}", .{self.model});
+    }
+}
+
+fn updateStatusBar(self: *Agent) void {
+    if (self.ai_client == null) {
+        self.terminal.setStatus("basic REPL — slash commands only", "/help");
+        return;
+    }
+    self.terminal.setStatus(self.model, "! JS · Tab completes · /help");
 }
 
 fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
@@ -672,9 +685,12 @@ fn setProvider(self: *Agent, credentials: Credentials) !void {
     self.model_completions = null;
     self.allocator.free(self.model);
     self.model = new_model;
-    settings.saveRemembered(credentials.provider, self.model);
     self.terminal.printInfo("provider: {s}", .{@tagName(credentials.provider)});
-    self.terminal.printInfo("model: {s}", .{self.model});
+    if (settings.saveRemembered(credentials.provider, self.model)) {
+        self.terminal.printInfo("model: {s} (saved to {s})", .{ self.model, settings.remembered_path });
+    } else |_| {
+        self.terminal.printInfo("model: {s}", .{self.model});
+    }
     _ = completionModels(self, self.allocator);
 }
 

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -71,6 +71,10 @@ spinner: Spinner,
 completion_source: ?CompletionSource = null,
 /// True while the REPL is in JS mode; set by isocline's mode callback.
 js_mode: bool = false,
+/// Base (REPL-mode) status text, owned; `renderStatus` overrides it with a
+/// JS-mode label when active. Recomposed per turn so the bar tracks resizes.
+status_left: std.ArrayList(u8) = .empty,
+status_right: std.ArrayList(u8) = .empty,
 
 /// Lets the completer/hinter pull dynamic candidates from the `Agent` without
 /// `Terminal` depending on it (same idiom as `Session.cancel_hook`).
@@ -108,12 +112,19 @@ pub fn attachCompleter(self: *Terminal) void {
     c.ic_set_default_completer(&completionCallback, self);
     c.ic_set_default_hinter(&hintsCallback, self);
     c.ic_set_mode_callback(&modeCallback, self);
+    c.ic_set_resize_callback(&resizeCallback, self);
     c.ic_set_default_highlighter(&highlighterCallback, self);
 }
 
 fn modeCallback(active: bool, arg: ?*anyopaque) callconv(.c) void {
     const self: *Terminal = @ptrCast(@alignCast(arg orelse return));
     self.js_mode = active;
+    self.renderStatus();
+}
+
+fn resizeCallback(arg: ?*anyopaque) callconv(.c) void {
+    const self: *Terminal = @ptrCast(@alignCast(arg orelse return));
+    self.renderStatus();
 }
 
 pub fn jsMode(self: *const Terminal) bool {
@@ -143,7 +154,7 @@ pub fn init(allocator: std.mem.Allocator, history_path: ?[:0]const u8, verbosity
         // `!` on an empty prompt toggles JS mode; state callback wired in attachCompleter.
         c.ic_set_prompt_mode("[" ++ style_jsmode ++ "]![/" ++ style_jsmode ++ "] ", '!');
         // Blank continuation marker so multiline input isn't prefixed with `>`.
-        c.ic_set_prompt_marker(null, "");
+        c.ic_set_prompt_marker("❯ ", "");
         _ = c.ic_enable_highlight(true);
         if (history_path) |path| {
             c.ic_set_history(path.ptr, -1); // -1 → 200-entry default cap
@@ -165,6 +176,8 @@ fn isRepl(self: *const Terminal) bool {
 
 pub fn deinit(self: *Terminal) void {
     self.spinner.deinit();
+    self.status_left.deinit(self.allocator);
+    self.status_right.deinit(self.allocator);
     if (self.repl_arena) |*a| a.deinit();
 }
 
@@ -768,6 +781,68 @@ pub fn columns() ?u16 {
     const rc = std.c.ioctl(std.posix.STDERR_FILENO, req, &ws);
     if (rc != 0 or ws.col == 0) return null;
     return ws.col;
+}
+
+/// Erase the frame after an empty submit. The bars collapse on submit, leaving
+/// the spacing and prompt lines with the cursor one line below; move up two and
+/// clear to end of screen.
+pub fn clearPromptFrame(self: *Terminal) void {
+    if (!self.isRepl()) return;
+    std.debug.print("\x1b[2A\r\x1b[J", .{});
+}
+
+/// Set the REPL-mode status text (provider/model on the left, hints on the
+/// right) and render the bar. JS mode overrides this text live via `renderStatus`.
+pub fn setStatus(self: *Terminal, left: []const u8, right: []const u8) void {
+    if (!self.isRepl()) return;
+    self.status_left.clearRetainingCapacity();
+    self.status_right.clearRetainingCapacity();
+    self.status_left.appendSlice(self.allocator, left) catch return;
+    self.status_right.appendSlice(self.allocator, right) catch return;
+    self.renderStatus();
+}
+
+fn renderStatus(self: *Terminal) void {
+    if (!self.isRepl()) return;
+    if (self.js_mode) {
+        self.writeStatusBar("JS mode", "Esc exits JS mode");
+    } else {
+        self.writeStatusBar(self.status_left.items, self.status_right.items);
+    }
+}
+
+/// Status bar below the input: a rule, then dimmed `left` flush-left and `right`
+/// flush-right. isocline copies the string, so the temporary buffer is freed here.
+fn writeStatusBar(self: *Terminal, left: []const u8, right: []const u8) void {
+    const a = self.allocator;
+    // stay one short of the last column: not all terminals render it reliably
+    const w: usize = (columns() orelse 80) -| 1;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(a);
+
+    // a dim full-width rule, shared by both bars
+    buf.appendSlice(a, "[faint]") catch return;
+    for (0..w) |_| buf.appendSlice(a, "─") catch return;
+    buf.appendSlice(a, "[/]") catch return;
+
+    // top bar: just the rule
+    buf.append(a, 0) catch return;
+    c.ic_set_top_bar(buf.items.ptr);
+    _ = buf.pop(); // drop the terminator, keep the rule
+
+    // bottom bar: the rule, then dimmed `left` flush-left and `right` flush-right
+    buf.appendSlice(a, "\n[faint]  ") catch return;
+    buf.appendSlice(a, left) catch return;
+    const used = 2 + displayWidth(left) + displayWidth(right);
+    buf.appendNTimes(a, ' ', if (used < w) w - used else 1) catch return;
+    buf.appendSlice(a, right) catch return;
+    buf.appendSlice(a, "[/]") catch return;
+    buf.append(a, 0) catch return;
+    c.ic_set_bottom_bar(buf.items.ptr);
+}
+
+fn displayWidth(s: []const u8) usize {
+    return std.unicode.utf8CountCodepoints(s) catch s.len;
 }
 
 pub fn interactiveTty() bool {

--- a/src/agent/settings.zig
+++ b/src/agent/settings.zig
@@ -91,7 +91,7 @@ pub fn resolveCredentials(opts: Config.Agent, remembered: ?Remembered, allow_pic
     return .{ .credentials = found[idx], .source = .picked };
 }
 
-const remembered_path = ".lp-agent.zon";
+pub const remembered_path = ".lp-agent.zon";
 
 /// Last user-selected provider/model, persisted per-directory in `.lp-agent.zon`.
 /// `model` is owned by the caller.
@@ -112,11 +112,11 @@ pub fn loadRemembered(allocator: std.mem.Allocator) ?Remembered {
 }
 
 /// Best-effort persist of the current selection; failures are ignored.
-pub fn saveRemembered(provider: Config.AiProvider, model: []const u8) void {
+pub fn saveRemembered(provider: Config.AiProvider, model: []const u8) !void {
     var buf: [512]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    std.zon.stringify.serialize(Remembered{ .provider = provider, .model = model }, .{}, &w) catch return;
-    std.fs.cwd().writeFile(.{ .sub_path = remembered_path, .data = w.buffered() }) catch {};
+    try std.zon.stringify.serialize(Remembered{ .provider = provider, .model = model }, .{}, &w);
+    try std.fs.cwd().writeFile(.{ .sub_path = remembered_path, .data = w.buffered() });
 }
 
 pub fn availableProviders(buf: []Credentials) []Credentials {


### PR DESCRIPTION
Integrates isocline's top and bottom bar APIs to display the active provider, model, and shortcut hints. Updates the status bar on terminal resize and mode switches.