### PR TITLE
Cookie.PreparedUri: Use only URL.getPathname for target url

### DIFF
--- a/src/browser/webapi/storage/Cookie.zig
+++ b/src/browser/webapi/storage/Cookie.zig
@@ -574,11 +574,7 @@ pub const Jar = struct {
         origin_url: ?[:0]const u8 = null,
     };
     pub fn forRequest(self: *Jar, target_url: [:0]const u8, writer: anytype, opts: LookupOpts) !void {
-        const target = PreparedUri{
-            .host = URL.getHostname(target_url),
-            .path = URL.getPathname(target_url),
-            .secure = URL.isSecure(target_url),
-        };
+        const target = PreparedUri.init(target_url);
         const same_site = try areSameSite(opts.origin_url, target.host);
 
         removeExpired(self, opts.request_time);
@@ -668,6 +664,15 @@ pub const PreparedUri = struct {
     host: []const u8, // Percent encoded, lower case
     path: []const u8, // Percent encoded
     secure: bool, // True if scheme is https
+
+    // init assumes url lifetime exceeds preparedUri one.
+    pub fn init(url: [:0]const u8) PreparedUri {
+        return .{
+            .host = URL.getHostname(url),
+            .path = URL.getPathname(url),
+            .secure = URL.isSecure(url),
+        };
+    }
 };
 
 fn trim(str: []const u8) []const u8 {

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -67,11 +67,7 @@ fn onCookieChanged(ctx: *anyopaque, data: *const Notification.CookieChanged) !vo
     // current document — same filter as `match` (HttpOnly hidden,
     // same-site treated as first-party against the document URL).
     const doc_url = exec.url.*;
-    const target = Cookie.PreparedUri{
-        .host = URL.getHostname(doc_url),
-        .path = URL.getPathname(doc_url),
-        .secure = URL.isSecure(doc_url),
-    };
+    const target = Cookie.PreparedUri.init(doc_url);
     if (target.host.len == 0) return;
 
     const probe = Cookie{

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -230,11 +230,7 @@ fn getCookies(cmd: *CDP.Command) !void {
 
     var urls = try std.ArrayList(CdpStorage.PreparedUri).initCapacity(cmd.arena, param_urls.len);
     for (param_urls) |url| {
-        urls.appendAssumeCapacity(.{
-            .host = URL.getHostname(url),
-            .path = URL.getPathname(url),
-            .secure = URL.isSecure(url),
-        });
+        urls.appendAssumeCapacity(CdpStorage.PreparedUri.init(url));
     }
 
     var jar = &bc.session.cookie_jar;

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -231,8 +231,8 @@ fn getCookies(cmd: *CDP.Command) !void {
     var urls = try std.ArrayList(CdpStorage.PreparedUri).initCapacity(cmd.arena, param_urls.len);
     for (param_urls) |url| {
         urls.appendAssumeCapacity(.{
-            .host = try Cookie.parseDomain(cmd.arena, url, null),
-            .path = try Cookie.parsePath(cmd.arena, url, null),
+            .host = URL.getHostname(url),
+            .path = URL.getPathname(url),
             .secure = URL.isSecure(url),
         });
     }


### PR DESCRIPTION
Use `URL.getPathname` and `URL.getHostname` to build `Cookie.PreparedUri` on `cdp.getCookies` command.
We used to apply `Cookie.parsePath` and `Cookie.parseDomain` which are invalid to build the target's `PreparedUri` leading to not returning relevant cookies.


Relates with #2610