### PR TITLE
Initial popover support

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -57,6 +57,7 @@ const CSSStyleSheet = @import("webapi/css/CSSStyleSheet.zig");
 const CustomElementDefinition = @import("webapi/CustomElementDefinition.zig");
 const PageTransitionEvent = @import("webapi/event/PageTransitionEvent.zig");
 const SubmitEvent = @import("webapi/event/SubmitEvent.zig");
+const popover = @import("webapi/element/popover.zig");
 const NavigationKind = @import("webapi/navigation/root.zig").NavigationKind;
 const KeyboardEvent = @import("webapi/event/KeyboardEvent.zig");
 const MouseEvent = @import("webapi/event/MouseEvent.zig");
@@ -3121,6 +3122,8 @@ pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpt
 
         Element.Html.Custom.enqueueDisconnectedCallbackOnElement(el, self);
 
+        popover.removeFromOpen(el, self);
+
         // If a <style> element is being removed, remove its sheet from the list
         if (el.is(Element.Html.Style)) |style| {
             if (style._sheet) |sheet| {
@@ -3377,6 +3380,9 @@ pub fn attributeChange(self: *Frame, element: *Element, name: String, value: Str
         if (element.is(Element.Html.Slot)) |slot| {
             self.signalSlotChange(slot);
         }
+    } else if (name.eql(comptime .wrap("popover"))) {
+        const old = if (old_value) |o| o.str() else null;
+        popover.attributeChanged(element, old, value.str(), self);
     }
 }
 
@@ -3403,6 +3409,8 @@ pub fn attributeRemove(self: *Frame, element: *Element, name: String, old_value:
         if (element.is(Element.Html.Slot)) |slot| {
             self.signalSlotChange(slot);
         }
+    } else if (name.eql(comptime .wrap("popover"))) {
+        popover.attributeChanged(element, old_value.str(), null, self);
     }
 }
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -929,6 +929,7 @@ pub const PageJsApis = flattenTypes(&.{
     @import("../webapi/event/PromiseRejectionEvent.zig"),
     @import("../webapi/event/SubmitEvent.zig"),
     @import("../webapi/event/FormDataEvent.zig"),
+    @import("../webapi/event/ToggleEvent.zig"),
     @import("../webapi/MessageChannel.zig"),
     @import("../webapi/MessagePort.zig"),
     @import("../webapi/Worker.zig"),

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -66,6 +66,8 @@ _script_created_parser: ?Parser.Streaming = null,
 _close_requested: bool = false,
 _adopted_style_sheets: ?js.Object.Global = null,
 _selection: Selection = .{ ._rc = .init(1) },
+// Ordered stack of currently-showing popovers
+_open_popovers: std.ArrayList(*Element) = .empty,
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#throw-on-dynamic-markup-insertion-counter
 // Incremented during custom element reactions when parsing. When > 0,
@@ -883,6 +885,7 @@ pub fn open(self: *Document, call_frame: *Frame) !*Document {
     // reset the document
     self._elements_by_id.clearAndFree(frame.arena);
     self._active_element = null;
+    self._open_popovers = .empty;
     self._style_sheets = null;
     self._implementation = null;
     self._ready_state = .loading;

--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -81,6 +81,7 @@ pub const Type = union(enum) {
     form_data_event: *@import("event/FormDataEvent.zig"),
     close_event: *@import("event/CloseEvent.zig"),
     cookie_change_event: *@import("event/CookieChangeEvent.zig"),
+    toggle_event: *@import("event/ToggleEvent.zig"),
 };
 
 pub const Options = struct {
@@ -172,6 +173,7 @@ pub fn is(self: *Event, comptime T: type) ?*T {
         .form_data_event => |e| return if (T == @import("event/FormDataEvent.zig")) e else null,
         .close_event => |e| return if (T == @import("event/CloseEvent.zig")) e else null,
         .cookie_change_event => |e| return if (T == @import("event/CookieChangeEvent.zig")) e else null,
+        .toggle_event => |e| return if (T == @import("event/ToggleEvent.zig")) e else null,
         .ui_event => |e| {
             if (T == @import("event/UIEvent.zig")) {
                 return e;

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -296,11 +296,14 @@ pub const List = struct {
             frame.removeElementId(element, entry._value.str());
         }
 
-        frame.domChanged();
-        frame.attributeRemove(element, result.normalized, old_value);
+        // remove this BEFORE triggering anything, incase that re-enters delete
+        // or some other callback.
         _ = frame._attribute_lookup.remove(@intFromPtr(entry));
         self._list.remove(&entry._node);
         self._len -= 1;
+
+        frame.domChanged();
+        frame.attributeRemove(element, result.normalized, old_value);
         frame._factory.destroy(entry);
     }
 

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -27,6 +27,7 @@ const GlobalEventHandler = global_event_handlers.Handler;
 const Frame = @import("../../Frame.zig");
 const Node = @import("../Node.zig");
 const Element = @import("../Element.zig");
+const popover = @import("popover.zig");
 
 pub const Anchor = @import("html/Anchor.zig");
 pub const Area = @import("html/Area.zig");
@@ -326,7 +327,23 @@ pub fn click(self: *HtmlElement, frame: *Frame) !void {
         .clientX = 0,
         .clientY = 0,
     }, frame)).asEvent();
+
+    // Keep the event alive past dispatch (which runs handlers/microtasks) so we
+    // can read _prevent_default afterwards.
+    event.acquireRef();
+    defer _ = event.releaseRef(frame._page);
+
     try frame._event_manager.dispatch(self.asEventTarget(), event);
+
+    if (event._prevent_default == false) {
+        // toggle the popover_target
+        const explicit: ?*Element = switch (self._type) {
+            .button => |b| b._popover_target,
+            .input => |i| i._popover_target,
+            else => null,
+        };
+        try popover.runInvokerActivation(self, explicit, frame);
+    }
 }
 
 // TODO: Per spec, hidden is a tristate: true | false | "until-found".
@@ -341,6 +358,32 @@ pub fn setHidden(self: *HtmlElement, hidden: bool, frame: *Frame) !void {
     } else {
         try self.asElement().removeAttribute(comptime .wrap("hidden"), frame);
     }
+}
+
+pub fn getPopover(self: *HtmlElement) ?[]const u8 {
+    const s = popover.getState(self.asElement()) orelse return null;
+    return @tagName(s);
+}
+
+pub fn setPopover(self: *HtmlElement, value_: ?[]const u8, frame: *Frame) !void {
+    if (value_) |value| {
+        // does not validate the value, stores it as-is
+        try self.asElement().setAttribute(comptime .wrap("popover"), .wrap(value), frame);
+    } else {
+        try self.asElement().removeAttribute(comptime .wrap("popover"), frame);
+    }
+}
+
+pub fn showPopover(self: *HtmlElement, frame: *Frame) !void {
+    return popover.show(self.asElement(), frame);
+}
+
+pub fn hidePopover(self: *HtmlElement, frame: *Frame) !void {
+    return popover.hide(self.asElement(), frame);
+}
+
+pub fn togglePopover(self: *HtmlElement, force: ?bool, frame: *Frame) !bool {
+    return popover.toggle(self.asElement(), force, frame);
 }
 
 pub fn getTabIndex(self: *HtmlElement) i32 {
@@ -1326,6 +1369,10 @@ pub const JsApi = struct {
     pub const autofocus = bridge.accessor(HtmlElement.getAutofocus, HtmlElement.setAutofocus, .{ .ce_reactions = true });
     pub const dir = bridge.accessor(HtmlElement.getDir, HtmlElement.setDir, .{ .ce_reactions = true });
     pub const hidden = bridge.accessor(HtmlElement.getHidden, HtmlElement.setHidden, .{ .ce_reactions = true });
+    pub const popover = bridge.accessor(HtmlElement.getPopover, HtmlElement.setPopover, .{ .ce_reactions = true });
+    pub const showPopover = bridge.function(HtmlElement.showPopover, .{ .dom_exception = true });
+    pub const hidePopover = bridge.function(HtmlElement.hidePopover, .{ .dom_exception = true });
+    pub const togglePopover = bridge.function(HtmlElement.togglePopover, .{ .dom_exception = true });
     pub const isContentEditable = bridge.accessor(HtmlElement.getIsContentEditable, null, .{});
     pub const lang = bridge.accessor(HtmlElement.getLang, HtmlElement.setLang, .{ .ce_reactions = true });
     pub const nonce = bridge.accessor(HtmlElement.getNonce, HtmlElement.setNonce, .{ .ce_reactions = true });

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -28,11 +28,14 @@ const Form = @import("Form.zig");
 const Event = @import("../../Event.zig");
 const ValidityState = @import("ValidityState.zig");
 
+const popover = @import("../popover.zig");
+
 const Button = @This();
 
 _proto: *HtmlElement,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,
+_popover_target: ?*Element = null,
 
 pub fn asElement(self: *Button) *Element {
     return self._proto._proto;
@@ -228,6 +231,27 @@ pub fn hasCustomValidity(self: *const Button) bool {
     return self._custom_validity != null;
 }
 
+pub fn getPopoverTargetElement(self: *Button, frame: *Frame) ?*Element {
+    return popover.invokerTarget(self.asNode(), self._popover_target, frame);
+}
+
+pub fn setPopoverTargetElement(self: *Button, value: ?*Element, frame: *Frame) !void {
+    self._popover_target = value;
+    if (value == null) {
+        try self.asElement().removeAttribute(.wrap("popovertarget"), frame);
+    } else {
+        try self.asElement().setAttribute(.wrap("popovertarget"), .wrap(""), frame);
+    }
+}
+
+pub fn getPopoverTargetAction(self: *Button) []const u8 {
+    return @tagName(popover.getInvokerAction(self.asElement()));
+}
+
+pub fn setPopoverTargetAction(self: *Button, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttribute(.wrap("popovertargetaction"), .wrap(value), frame);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Button);
 
@@ -249,6 +273,8 @@ pub const JsApi = struct {
     pub const value = bridge.accessor(Button.getValue, Button.setValue, .{ .ce_reactions = true });
     pub const @"type" = bridge.accessor(Button.getType, Button.setType, .{ .ce_reactions = true });
     pub const labels = bridge.accessor(Button.getLabels, null, .{});
+    pub const popoverTargetElement = bridge.accessor(Button.getPopoverTargetElement, Button.setPopoverTargetElement, .{ .ce_reactions = true });
+    pub const popoverTargetAction = bridge.accessor(Button.getPopoverTargetAction, Button.setPopoverTargetAction, .{ .ce_reactions = true });
     pub const willValidate = bridge.accessor(Button.getWillValidate, null, .{});
     pub const validity = bridge.accessor(Button.getValidity, null, .{});
     pub const validationMessage = bridge.accessor(Button.getValidationMessage, null, .{});

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -30,6 +30,7 @@ const Selection = @import("../../Selection.zig");
 const Event = @import("../../Event.zig");
 const InputEvent = @import("../../event/InputEvent.zig");
 const ValidityState = @import("ValidityState.zig");
+const popover = @import("../popover.zig");
 
 const String = lp.String;
 
@@ -85,6 +86,7 @@ _input_type: Type = .text,
 _indeterminate: bool = false,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,
+_popover_target: ?*Element = null,
 
 _selection_start: u32 = 0,
 _selection_end: u32 = 0,
@@ -1284,6 +1286,27 @@ fn uncheckRadioGroup(self: *Input, frame: *Frame) void {
     }
 }
 
+pub fn getPopoverTargetElement(self: *Input, frame: *Frame) ?*Element {
+    return popover.invokerTarget(self.asNode(), self._popover_target, frame);
+}
+
+pub fn setPopoverTargetElement(self: *Input, value: ?*Element, frame: *Frame) !void {
+    self._popover_target = value;
+    if (value == null) {
+        try self.asElement().removeAttribute(.wrap("popovertarget"), frame);
+    } else {
+        try self.asElement().setAttribute(.wrap("popovertarget"), .wrap(""), frame);
+    }
+}
+
+pub fn getPopoverTargetAction(self: *Input) []const u8 {
+    return @tagName(popover.getInvokerAction(self.asElement()));
+}
+
+pub fn setPopoverTargetAction(self: *Input, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttribute(.wrap("popovertargetaction"), .wrap(value), frame);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Input);
 
@@ -1324,6 +1347,8 @@ pub const JsApi = struct {
     pub const formNoValidate = bridge.accessor(Input.getFormNoValidate, Input.setFormNoValidate, .{});
     pub const formTarget = bridge.accessor(Input.getFormTarget, Input.setFormTarget, .{});
     pub const labels = bridge.accessor(Input.getLabels, null, .{});
+    pub const popoverTargetElement = bridge.accessor(Input.getPopoverTargetElement, Input.setPopoverTargetElement, .{ .ce_reactions = true });
+    pub const popoverTargetAction = bridge.accessor(Input.getPopoverTargetAction, Input.setPopoverTargetAction, .{ .ce_reactions = true });
     pub const indeterminate = bridge.accessor(Input.getIndeterminate, Input.setIndeterminate, .{});
     pub const placeholder = bridge.accessor(Input.getPlaceholder, Input.setPlaceholder, .{ .ce_reactions = true });
     pub const pattern = bridge.accessor(Input.getPattern, Input.setPattern, .{ .ce_reactions = true });

--- a/src/browser/webapi/element/popover.zig
+++ b/src/browser/webapi/element/popover.zig
@@ -1,0 +1,320 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// We don't have a layout/rendering engine, so this only models the DOM state:
+// a popover is "showing" iff it's a member of its document's `_open_popovers` list
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const Frame = @import("../../Frame.zig");
+
+const Node = @import("../Node.zig");
+const Element = @import("../Element.zig");
+const ToggleEvent = @import("../event/ToggleEvent.zig");
+
+const HtmlElement = @import("Html.zig");
+
+const log = lp.log;
+const String = lp.String;
+
+pub fn getState(el: *Element) ?State {
+    return State.parse(el.getAttributeSafe(comptime .wrap("popover")));
+}
+pub fn getInvokerAction(el: *Element) Action {
+    return Action.parse(el.getAttributeSafe(.wrap("popovertargetaction")));
+}
+
+pub fn isOpen(el: *Element, frame: *Frame) bool {
+    for (frame.document._open_popovers.items) |p| {
+        if (p == el) {
+            return true;
+        }
+    }
+    return false;
+}
+
+pub fn show(el: *Element, frame: *Frame) !void {
+    const original = getState(el) orelse return error.NotSupported;
+
+    if (el.asNode().isConnected() == false) {
+        return error.InvalidStateError;
+    }
+
+    if (isOpen(el, frame)) {
+        // already showing: no-op (must not throw)
+        return;
+    }
+
+    if (try fireToggle(el, comptime .wrap("beforetoggle"), "closed", "open", true, frame)) {
+        // was canceled
+        return;
+    }
+
+    if (hasChanged(el, frame, original)) {
+        return error.InvalidStateError;
+    }
+
+    if (original != .manual) {
+        // showing an auto/hint popover dismisses other auto/hint popovers
+        try hideUnrelatedAutos(el, frame);
+        if (hasChanged(el, frame, original)) {
+            return error.InvalidStateError;
+        }
+    }
+
+    try frame.document._open_popovers.append(frame.arena, el);
+    frame.domChanged();
+    _ = try fireToggle(el, comptime .wrap("toggle"), "closed", "open", false, frame);
+}
+
+pub fn hide(el: *Element, frame: *Frame) !void {
+    if (getState(el) == null) {
+        return error.NotSupported;
+    }
+    if (isOpen(el, frame) == false) {
+        // already hidden
+        return;
+    }
+    try hideThroughStack(el, frame);
+}
+
+pub fn toggle(el: *Element, force: ?bool, frame: *Frame) !bool {
+    if (getState(el) == null) {
+        return error.NotSupported;
+    }
+
+    const open = isOpen(el, frame);
+    if (force) |f| {
+        if (f and !open) try show(el, frame);
+        if (!f and open) try hide(el, frame);
+    } else if (open) {
+        try hide(el, frame);
+    } else {
+        try show(el, frame);
+    }
+    return isOpen(el, frame);
+}
+
+// Hide every popover shown above `el` in the stack, then `el` itself, firing
+// events top-down so nested popovers close before their ancestors.
+fn hideThroughStack(el: *Element, frame: *Frame) !void {
+    const open = &frame.document._open_popovers;
+    while (isOpen(el, frame)) {
+        const top = open.items[open.items.len - 1];
+        try hideOne(top, frame);
+
+        if (top == el) {
+            break;
+        }
+    }
+}
+
+fn hideUnrelatedAutos(el: *Element, frame: *Frame) !void {
+    // This is a rescan on each round because the event we fire can result in the
+    // list being mutated
+    const node = el.asNode();
+    while (true) {
+        const items = frame.document._open_popovers.items;
+        var target: ?*Element = null;
+        var i: usize = items.len;
+        while (i > 0) {
+            i -= 1;
+            const p = items[i];
+            if (p == el) {
+                continue;
+            }
+            const ps = getState(p) orelse continue;
+            if (ps == .manual) {
+                continue;
+            }
+            if (p.asNode().contains(node)) {
+                continue; // ancestor: keep open
+            }
+            target = p;
+            break;
+        }
+        // nothing left to dismiss
+        const t = target orelse break;
+        try hideOne(t, frame);
+    }
+}
+
+fn hideOne(el: *Element, frame: *Frame) !void {
+    removeFromOpen(el, frame);
+    frame.domChanged();
+    _ = try fireToggle(el, comptime .wrap("beforetoggle"), "open", "closed", false, frame);
+    _ = try fireToggle(el, comptime .wrap("toggle"), "open", "closed", false, frame);
+}
+
+// Called when an element's `popover` content attribute is set, changed, or
+// removed. A showing popover must be hidden if its type changes.
+pub fn attributeChanged(el: *Element, old_value: ?[]const u8, new_value: ?[]const u8, frame: *Frame) void {
+    if (isOpen(el, frame) == false) {
+        return;
+    }
+
+    if (State.parse(old_value) == State.parse(new_value)) {
+        return;
+    }
+
+    hideThroughStack(el, frame) catch |err| {
+        log.err(.bug, "popover.forceClose", .{ .err = err });
+    };
+}
+
+pub fn removeFromOpen(el: *Element, frame: *Frame) void {
+    const list = &frame.document._open_popovers;
+    var i: usize = 0;
+    while (i < list.items.len) : (i += 1) {
+        if (list.items[i] == el) {
+            _ = list.orderedRemove(i);
+            return;
+        }
+    }
+}
+
+// The popover targeted by an invoker (a <button>, or input button), resolving
+// the explicitly IDL-set element or the `popovertarget` IDREF content attribute.
+pub fn invokerTarget(invoker: *Node, explicit: ?*Element, frame: *Frame) ?*Element {
+    if (explicit) |target| {
+        if (target.asNode().getRootNode(null) == invoker.getRootNode(null)) {
+            // The invoker and target must share the same root
+            return target;
+        }
+        return null;
+    }
+    const el = invoker.is(Element) orelse return null;
+    const id = el.getAttributeSafe(.wrap("popovertarget")) orelse return null;
+    return frame.document.getElementById(id, frame);
+}
+
+pub fn runInvokerActivation(invoker: *HtmlElement, explicit: ?*Element, frame: *Frame) !void {
+    switch (invoker._type) {
+        .button => {},
+        .input => |input| switch (input._input_type) {
+            .button, .submit, .reset, .image => {},
+            else => return, // not an invoker
+        },
+        else => return, // not an invoker
+    }
+    const invoker_elem = invoker.asElement();
+    const invoker_node = invoker_elem.asNode();
+
+    const target = invokerTarget(invoker_node, explicit, frame) orelse return;
+
+    if (getState(target) == null) {
+        return;
+    }
+
+    const open = isOpen(target, frame);
+    const result: anyerror!void = switch (getInvokerAction(invoker_elem)) {
+        .toggle => if (open) hide(target, frame) else show(target, frame),
+        .show => if (open) {} else show(target, frame),
+        .hide => if (open) hide(target, frame) else {},
+    };
+
+    // swallow activation errors, they don't propagate
+    result catch |err| switch (err) {
+        error.InvalidStateError, error.NotSupported => {},
+        else => return err,
+    };
+}
+
+fn fireToggle(
+    el: *Element,
+    typ: String,
+    old_state: []const u8,
+    new_state: []const u8,
+    cancelable: bool,
+    frame: *Frame,
+) !bool {
+    const event = (try ToggleEvent.initTrusted(typ, .{
+        .cancelable = cancelable,
+        .oldState = old_state,
+        .newState = new_state,
+    }, frame)).asEvent();
+
+    // Keep the event alive while dispatching so we can read _prevent_default.
+    event.acquireRef();
+    defer _ = event.releaseRef(frame._page);
+
+    try frame._event_manager.dispatch(el.asEventTarget(), event);
+    return event._prevent_default;
+}
+
+fn hasChanged(el: *Element, frame: *Frame, original: State) bool {
+    const now = getState(el) orelse return true;
+    if (now != original) {
+        return true;
+    }
+    if (el.asNode().isConnected() == false) {
+        return true;
+    }
+    if (isOpen(el, frame)) {
+        return true;
+    }
+    return false;
+}
+
+const State = enum {
+    auto,
+    hint,
+    manual,
+
+    fn parse(value_: ?[]const u8) ?State {
+        const value = value_ orelse return null;
+        if (value.len == 0) {
+            return .auto;
+        }
+
+        if (std.ascii.eqlIgnoreCase(value, "auto")) {
+            return .auto;
+        }
+        if (std.ascii.eqlIgnoreCase(value, "manual")) {
+            return .manual;
+        }
+        if (std.ascii.eqlIgnoreCase(value, "hint")) {
+            return .hint;
+        }
+
+        // default for an invalid value
+        return .manual;
+    }
+};
+
+const Action = enum {
+    toggle,
+    show,
+    hide,
+
+    fn parse(value_: ?[]const u8) Action {
+        const value = value_ orelse return .toggle;
+
+        if (std.ascii.eqlIgnoreCase(value, "show")) {
+            return .show;
+        }
+
+        if (std.ascii.eqlIgnoreCase(value, "hide")) {
+            return .hide;
+        }
+
+        // missing/invalid value default
+        return .toggle;
+    }
+};

--- a/src/browser/webapi/event/ToggleEvent.zig
+++ b/src/browser/webapi/event/ToggleEvent.zig
@@ -1,0 +1,107 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const js = @import("../../js/js.zig");
+const Frame = @import("../../Frame.zig");
+
+const Event = @import("../Event.zig");
+const HtmlElement = @import("../element/Html.zig");
+
+const String = lp.String;
+const Allocator = std.mem.Allocator;
+
+/// https://html.spec.whatwg.org/multipage/popover.html#toggleevent
+const ToggleEvent = @This();
+
+_proto: *Event,
+_old_state: []const u8 = "",
+_new_state: []const u8 = "",
+_source: ?*HtmlElement = null,
+
+const ToggleEventOptions = struct {
+    oldState: []const u8 = "",
+    newState: []const u8 = "",
+    source: ?*HtmlElement = null,
+};
+
+const Options = Event.inheritOptions(ToggleEvent, ToggleEventOptions);
+
+pub fn init(typ: []const u8, opts_: ?Options, frame: *Frame) !*ToggleEvent {
+    const arena = try frame.getArena(.tiny, "ToggleEvent");
+    errdefer frame.releaseArena(arena);
+    const type_string = try String.init(arena, typ, .{});
+    return initWithTrusted(arena, type_string, opts_, false, frame);
+}
+
+pub fn initTrusted(typ: String, _opts: ?Options, frame: *Frame) !*ToggleEvent {
+    const arena = try frame.getArena(.tiny, "ToggleEvent.trusted");
+    errdefer frame.releaseArena(arena);
+    return initWithTrusted(arena, typ, _opts, true, frame);
+}
+
+fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool, frame: *Frame) !*ToggleEvent {
+    const opts = _opts orelse Options{};
+
+    const event = try frame._factory.event(
+        arena,
+        typ,
+        ToggleEvent{
+            ._proto = undefined,
+            ._old_state = if (opts.oldState.len > 0) try arena.dupe(u8, opts.oldState) else "",
+            ._new_state = if (opts.newState.len > 0) try arena.dupe(u8, opts.newState) else "",
+            ._source = opts.source,
+        },
+    );
+
+    Event.populatePrototypes(event, opts, trusted);
+    return event;
+}
+
+pub fn asEvent(self: *ToggleEvent) *Event {
+    return self._proto;
+}
+
+pub fn getOldState(self: *const ToggleEvent) []const u8 {
+    return self._old_state;
+}
+
+pub fn getNewState(self: *const ToggleEvent) []const u8 {
+    return self._new_state;
+}
+
+pub fn getSource(self: *const ToggleEvent) ?*HtmlElement {
+    return self._source;
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(ToggleEvent);
+
+    pub const Meta = struct {
+        pub const name = "ToggleEvent";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const constructor = bridge.constructor(ToggleEvent.init, .{});
+    pub const oldState = bridge.accessor(ToggleEvent.getOldState, null, .{});
+    pub const newState = bridge.accessor(ToggleEvent.getNewState, null, .{});
+    pub const source = bridge.accessor(ToggleEvent.getSource, null, .{});
+};

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -530,6 +530,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
     switch (pseudo) {
         // State pseudo-classes
         .modal => return false,
+        .popover_open => return @import("../element/popover.zig").isOpen(el, frame),
         .checked => {
             const input = el.is(Node.Element.Html.Input) orelse return false;
             return input.getChecked();

--- a/src/browser/webapi/selector/Parser.zig
+++ b/src/browser/webapi/selector/Parser.zig
@@ -611,6 +611,7 @@ fn pseudoClass(self: *Parser, arena: Allocator) !Selector.PseudoClass {
             if (fastEql(name, "last-of-type")) return .last_of_type;
             if (fastEql(name, "focus-within")) return .focus_within;
             if (fastEql(name, "out-of-range")) return .out_of_range;
+            if (fastEql(name, "popover-open")) return .popover_open;
         },
         13 => {
             if (fastEql(name, "first-of-type")) return .first_of_type;

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -158,6 +158,7 @@ pub const AttributeMatcher = union(enum) {
 pub const PseudoClass = union(enum) {
     // State pseudo-classes
     modal,
+    popover_open,
     checked,
     disabled,
     enabled,


### PR DESCRIPTION
Start adding support for "popover". This represents the single biggest non- canvas grouping of failures in WPT `/html/**`. I suspect it has little real- world impact, but it isn't impossible something blocks on a missing popup event.

This essentially comes down to supporting various methods (e.g. showPopup) on the HtmlElement as well as making the Input and Button popup-target aware.

The document keeps a list of opened popups which is used when we have to determine if a popup is open (the new :popover-open pseudo selector) or when toggling them.