### PR TITLE
Implement input type=file support (FileList, input.files/value, DOM.setFileInputFiles)

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -36,6 +36,7 @@ const CustomElementReactions = @import("CustomElementReactions.zig");
 
 const URL = @import("URL.zig");
 const Blob = @import("webapi/Blob.zig");
+const FileList = @import("webapi/FileList.zig");
 const Node = @import("webapi/Node.zig");
 const Event = @import("webapi/Event.zig");
 const EventTarget = @import("webapi/EventTarget.zig");
@@ -145,6 +146,10 @@ _event_target_attr_listeners: GlobalEventHandlersLookup = .empty,
 
 // Blob URL registry for URL.createObjectURL/revokeObjectURL
 _blob_urls: std.StringHashMapUnmanaged(*Blob) = .{},
+
+// FileLists owned by `<input type=file>` elements. Each holds refs on its
+// File objects (reference counted via their Blob proto); released at teardown.
+_file_lists: std.ArrayList(*FileList) = .{},
 
 /// `load` events that'll be fired before window's `load` event.
 /// A call to `documentIsComplete` (which calls `_documentIsComplete`) resets it.
@@ -397,6 +402,12 @@ pub fn deinit(self: *Frame) void {
             var it = self._blob_urls.valueIterator();
             while (it.next()) |blob| {
                 blob.*.releaseRef(page);
+            }
+        }
+
+        for (self._file_lists.items) |file_list| {
+            for (file_list._files) |file| {
+                file._proto.releaseRef(page);
             }
         }
 
@@ -1639,6 +1650,11 @@ pub fn unregisterMutationObserver(self: *Frame, observer: *MutationObserver) voi
 pub fn registerIntersectionObserver(self: *Frame, observer: *IntersectionObserver) !void {
     observer.acquireRef();
     try self._intersection_observers.append(self.arena, observer);
+}
+
+// Tracks a file input's FileList so its File refs are released at teardown.
+pub fn trackFileList(self: *Frame, file_list: *FileList) !void {
+    try self._file_lists.append(self.arena, file_list);
 }
 
 pub fn unregisterIntersectionObserver(self: *Frame, observer: *IntersectionObserver) void {

--- a/src/browser/tests/cdp/input_file.html
+++ b/src/browser/tests/cdp/input_file.html
@@ -1,0 +1,1 @@
+<input id="upload" type="file">

--- a/src/browser/tests/element/html/input_file.html
+++ b/src/browser/tests/element/html/input_file.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<input id="f1" type="file">
+<input id="f2" type="file" multiple>
+<input id="t1" type="text">
+
+<script id="files_initial">
+  {
+    const f1 = document.getElementById('f1');
+    testing.expectEqual(true, f1.files instanceof FileList);
+    testing.expectEqual(0, f1.files.length);
+    testing.expectEqual(null, f1.files.item(0));
+    testing.expectEqual('', f1.value);
+
+    // Identity preserved across reads.
+    testing.expectEqual(true, f1.files === f1.files);
+  }
+</script>
+
+<script id="files_non_file_input_is_null">
+  {
+    const t1 = document.getElementById('t1');
+    testing.expectEqual(null, t1.files);
+  }
+</script>
+
+<script id="value_setter">
+  {
+    const f1 = document.getElementById('f1');
+    // Per spec: setting value to "" is a no-op; anything else throws.
+    f1.value = '';
+    testing.expectEqual('', f1.value);
+
+    let threw = false;
+    try { f1.value = 'foo'; } catch (e) { threw = true; }
+    testing.expectEqual(true, threw);
+  }
+</script>

--- a/src/browser/tests/element/html/input_file.html
+++ b/src/browser/tests/element/html/input_file.html
@@ -18,6 +18,27 @@
   }
 </script>
 
+<script id="files_iteration_empty">
+  {
+    // The list can't be populated from JS (no DataTransfer), but the indexed
+    // getter and iterator protocol must still be wired up correctly on an
+    // empty list. Populated indexing/iteration is covered by the CDP test
+    // "setFileInputFiles exposes files to JS".
+    const f1 = document.getElementById('f1');
+
+    // Indexed getter: out-of-range is undefined (not null, unlike item()).
+    testing.expectEqual(undefined, f1.files[0]);
+
+    // Iterable: spread, Array.from and for-of all work and yield nothing.
+    testing.expectEqual('function', typeof f1.files[Symbol.iterator]);
+    testing.expectEqual(0, [...f1.files].length);
+    testing.expectEqual(0, Array.from(f1.files).length);
+    let count = 0;
+    for (const _ of f1.files) count++;
+    testing.expectEqual(0, count);
+  }
+</script>
+
 <script id="files_non_file_input_is_null">
   {
     const t1 = document.getElementById('t1');

--- a/src/browser/webapi/FileList.zig
+++ b/src/browser/webapi/FileList.zig
@@ -2,6 +2,13 @@ const js = @import("../js/js.zig");
 
 const File = @import("File.zig");
 
+pub fn registerTypes() []const type {
+    return &.{
+        FileList,
+        FileList.Iterator,
+    };
+}
+
 const FileList = @This();
 
 _files: []*File = &.{},
@@ -11,9 +18,31 @@ pub fn getLength(self: *const FileList) u32 {
 }
 
 pub fn item(self: *const FileList, index: u32) ?*File {
-    if (index >= self._files.len) return null;
+    if (index >= self._files.len) {
+        return null;
+    }
     return self._files[index];
 }
+
+pub fn iterator(self: *FileList, exec: *const js.Execution) !*Iterator {
+    return Iterator.init(.{
+        .index = 0,
+        .list = self,
+    }, exec);
+}
+
+const GenericIterator = @import("collections/iterator.zig").Entry;
+pub const Iterator = GenericIterator(struct {
+    index: u32,
+    list: *FileList,
+
+    pub fn next(self: *@This(), _: *const js.Execution) ?*File {
+        const index = self.index;
+        const file = self.list.item(index) orelse return null;
+        self.index = index + 1;
+        return file;
+    }
+}, null);
 
 pub const JsApi = struct {
     pub const bridge = js.Bridge(FileList);
@@ -22,9 +51,19 @@ pub const JsApi = struct {
         pub const name = "FileList";
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
-        pub const empty_with_no_proto = true;
     };
 
     pub const length = bridge.accessor(FileList.getLength, null, .{});
     pub const item = bridge.function(FileList.item, .{});
+    pub const @"[]" = bridge.indexed(FileList.item, getIndexes, .{ .null_as_undefined = true });
+    pub const symbol_iterator = bridge.iterator(FileList.iterator, .{});
+
+    fn getIndexes(self: *FileList, exec: *const js.Execution) !js.Array {
+        const len = self.getLength();
+        var arr = exec.js.local.?.newArray(len);
+        for (0..len) |i| {
+            _ = try arr.set(@intCast(i), i, .{});
+        }
+        return arr;
+    }
 };

--- a/src/browser/webapi/FileList.zig
+++ b/src/browser/webapi/FileList.zig
@@ -1,16 +1,18 @@
 const js = @import("../js/js.zig");
 
+const File = @import("File.zig");
+
 const FileList = @This();
 
-/// Padding to avoid zero-size struct, which causes identity_map pointer collisions.
-_pad: bool = false,
+_files: []*File = &.{},
 
-pub fn getLength(_: *const FileList) u32 {
-    return 0;
+pub fn getLength(self: *const FileList) u32 {
+    return @intCast(self._files.len);
 }
 
-pub fn item(_: *const FileList, _: u32) ?*@import("File.zig") {
-    return null;
+pub fn item(self: *const FileList, index: u32) ?*File {
+    if (index >= self._files.len) return null;
+    return self._files[index];
 }
 
 pub const JsApi = struct {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -31,6 +31,8 @@ const Event = @import("../../Event.zig");
 const InputEvent = @import("../../event/InputEvent.zig");
 const ValidityState = @import("ValidityState.zig");
 const popover = @import("../popover.zig");
+const File = @import("../../File.zig");
+const FileList = @import("../../FileList.zig");
 
 const String = lp.String;
 
@@ -87,6 +89,7 @@ _indeterminate: bool = false,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,
 _popover_target: ?*Element = null,
+_files: ?*FileList = null,
 
 _selection_start: u32 = 0,
 _selection_end: u32 = 0,
@@ -226,6 +229,54 @@ pub fn getValidity(self: *Input, frame: *Frame) !*ValidityState {
     return v;
 }
 
+/// Lazily allocates this input's FileList and registers it with the frame so
+/// the refcounted File objects it holds are released at frame teardown.
+fn ensureFileList(self: *Input, frame: *Frame) !*FileList {
+    if (self._files) |fl| return fl;
+    const fl = try frame._factory.create(FileList{ ._files = &.{} });
+    try frame.trackFileList(fl);
+    self._files = fl;
+    return fl;
+}
+
+/// Returns the FileList for a `type="file"` input (lazily allocated, identity preserved).
+/// Non-file inputs return null per HTMLInputElement IDL.
+pub fn getFiles(self: *Input, frame: *Frame) !?*FileList {
+    if (self._input_type != .file) return null;
+    return try self.ensureFileList(frame);
+}
+
+/// Replaces the selected file list and fires `input` + `change` events.
+/// Used by CDP `DOM.setFileInputFiles` and any future DataTransfer-style setter.
+///
+/// The FileList holds a reference on each File (whose backing arena is reference
+/// counted via its Blob proto), so we acquire on the incoming files and release
+/// the outgoing ones; the frame releases whatever remains at teardown.
+pub fn setFiles(self: *Input, files: []const *File, frame: *Frame) !void {
+    if (self._input_type != .file) return error.InvalidStateError;
+    const fl = try self.ensureFileList(frame);
+
+    const dupe = try frame._factory._slab.allocator().dupe(*File, files);
+    for (dupe) |file| file._proto.acquireRef();
+    for (fl._files) |old| old._proto.releaseRef(frame._page);
+    fl._files = dupe;
+
+    try self.dispatchInputEvent(null, "insertReplacementText", frame);
+    const change_evt = try Event.initTrusted(comptime .wrap("change"), .{ .bubbles = true }, frame._page);
+    try frame._event_manager.dispatch(self.asElement().asEventTarget(), change_evt);
+}
+
+/// JS-binding wrapper for the `value` getter: for type=file, return the spec
+/// "C:\\fakepath\\<name>" string; otherwise delegate to plain getValue().
+pub fn getValueForJS(self: *const Input, frame: *Frame) ![]const u8 {
+    if (self._input_type == .file) {
+        const fl = self._files orelse return "";
+        if (fl._files.len == 0) return "";
+        return try std.fmt.allocPrint(frame.arena, "C:\\fakepath\\{s}", .{fl._files[0]._name});
+    }
+    return self.getValue();
+}
+
 pub fn getValidationMessage(self: *const Input, frame: *Frame) []const u8 {
     if (!self.getWillValidate()) return "";
     if (self._custom_validity) |msg| return msg;
@@ -276,8 +327,7 @@ pub fn suffersValueMissing(self: *const Input, frame: *Frame) bool {
     return switch (self._input_type) {
         .checkbox => !self._checked,
         .radio => !self.radioGroupHasChecked(frame),
-        // TODO: file inputs aren't supported yet (#2175); treat as always-empty when required.
-        .file => true,
+        .file => if (self._files) |fl| fl._files.len == 0 else true,
         .text, .password, .email, .url, .tel, .search, .number, .date, .time, .@"datetime-local", .month, .week, .color => blk: {
             const v = self._value orelse self._default_value orelse "";
             break :blk v.len == 0;
@@ -1326,7 +1376,8 @@ pub const JsApi = struct {
 
     pub const onselectionchange = bridge.accessor(Input.getOnSelectionChange, Input.setOnSelectionChange, .{});
     pub const @"type" = bridge.accessor(Input.getType, Input.setType, .{ .ce_reactions = true });
-    pub const value = bridge.accessor(Input.getValue, setValueFromJS, .{ .dom_exception = true });
+    pub const value = bridge.accessor(Input.getValueForJS, setValueFromJS, .{ .dom_exception = true, .ce_reactions = true });
+    pub const files = bridge.accessor(Input.getFiles, null, .{});
     pub const defaultValue = bridge.accessor(Input.getDefaultValue, Input.setDefaultValue, .{ .ce_reactions = true });
     pub const checked = bridge.accessor(Input.getChecked, Input.setChecked, .{});
     pub const defaultChecked = bridge.accessor(Input.getDefaultChecked, Input.setDefaultChecked, .{ .ce_reactions = true });
@@ -1469,6 +1520,7 @@ test "WebApi: HTML.Input" {
     try testing.htmlRunner("element/html/input_radio.html", .{});
     try testing.htmlRunner("element/html/input-attrs.html", .{});
     try testing.htmlRunner("element/html/input-validity.html", .{});
+    try testing.htmlRunner("element/html/input_file.html", .{});
 }
 
 test "isValidFloatingPoint" {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -232,8 +232,11 @@ pub fn getValidity(self: *Input, frame: *Frame) !*ValidityState {
 /// Lazily allocates this input's FileList and registers it with the frame so
 /// the refcounted File objects it holds are released at frame teardown.
 fn ensureFileList(self: *Input, frame: *Frame) !*FileList {
-    if (self._files) |fl| return fl;
-    const fl = try frame._factory.create(FileList{ ._files = &.{} });
+    if (self._files) |fl| {
+        return fl;
+    }
+
+    const fl = try frame._factory.create(FileList{});
     try frame.trackFileList(fl);
     self._files = fl;
     return fl;
@@ -242,7 +245,9 @@ fn ensureFileList(self: *Input, frame: *Frame) !*FileList {
 /// Returns the FileList for a `type="file"` input (lazily allocated, identity preserved).
 /// Non-file inputs return null per HTMLInputElement IDL.
 pub fn getFiles(self: *Input, frame: *Frame) !?*FileList {
-    if (self._input_type != .file) return null;
+    if (self._input_type != .file) {
+        return null;
+    }
     return try self.ensureFileList(frame);
 }
 
@@ -253,15 +258,27 @@ pub fn getFiles(self: *Input, frame: *Frame) !?*FileList {
 /// counted via its Blob proto), so we acquire on the incoming files and release
 /// the outgoing ones; the frame releases whatever remains at teardown.
 pub fn setFiles(self: *Input, files: []const *File, frame: *Frame) !void {
-    if (self._input_type != .file) return error.InvalidStateError;
-    const fl = try self.ensureFileList(frame);
+    if (self._input_type != .file) {
+        return error.InvalidStateError;
+    }
 
-    const dupe = try frame._factory._slab.allocator().dupe(*File, files);
-    for (dupe) |file| file._proto.acquireRef();
-    for (fl._files) |old| old._proto.releaseRef(frame._page);
+    const fl = try self.ensureFileList(frame);
+    const dupe = try frame.arena.dupe(*File, files);
+
+    for (dupe) |file| {
+        file._proto.acquireRef();
+    }
+
+    for (fl._files) |old| {
+        old._proto.releaseRef(frame._page);
+    }
+
     fl._files = dupe;
 
-    try self.dispatchInputEvent(null, "insertReplacementText", frame);
+    // A file input fires `input` then `change`, both as plain bubbling Events
+    // (not InputEvents — `inputType`/`data` only apply to editable text inputs).
+    const input_evt = try Event.initTrusted(comptime .wrap("input"), .{ .bubbles = true }, frame._page);
+    try frame._event_manager.dispatch(self.asElement().asEventTarget(), input_evt);
     const change_evt = try Event.initTrusted(comptime .wrap("change"), .{ .bubbles = true }, frame._page);
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), change_evt);
 }
@@ -269,12 +286,15 @@ pub fn setFiles(self: *Input, files: []const *File, frame: *Frame) !void {
 /// JS-binding wrapper for the `value` getter: for type=file, return the spec
 /// "C:\\fakepath\\<name>" string; otherwise delegate to plain getValue().
 pub fn getValueForJS(self: *const Input, frame: *Frame) ![]const u8 {
-    if (self._input_type == .file) {
-        const fl = self._files orelse return "";
-        if (fl._files.len == 0) return "";
-        return try std.fmt.allocPrint(frame.arena, "C:\\fakepath\\{s}", .{fl._files[0]._name});
+    if (self._input_type != .file) {
+        return self.getValue();
     }
-    return self.getValue();
+
+    const fl = self._files orelse return "";
+    if (fl._files.len == 0) {
+        return "";
+    }
+    return try std.fmt.allocPrint(frame.call_arena, "C:\\fakepath\\{s}", .{fl._files[0]._name});
 }
 
 pub fn getValidationMessage(self: *const Input, frame: *Frame) []const u8 {

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -858,6 +858,78 @@ test "cdp.dom: setFileInputFiles on file input" {
     try ctx.expectSentResult(null, .{ .id = 3 });
 }
 
+test "cdp.dom: setFileInputFiles exposes files to JS" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/input_file.html" });
+
+    try ctx.processMessage(.{ .id = 1, .method = "DOM.performSearch", .params = .{ .query = "input" } });
+    try ctx.expectSentResult(.{ .searchId = "0", .resultCount = 1 }, .{ .id = 1 });
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "DOM.getSearchResults",
+        .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 1 },
+    });
+    try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 2 });
+
+    // Two files, so we can assert ordering as well as identity and iteration.
+    var tmp_dir = try std.fs.cwd().makeOpenPath(".zig-cache/tmp", .{});
+    defer tmp_dir.close();
+    {
+        const a = try tmp_dir.createFile("a.txt", .{ .truncate = true });
+        defer a.close();
+        try a.writeAll("aaa");
+        const b = try tmp_dir.createFile("b.txt", .{ .truncate = true });
+        defer b.close();
+        try b.writeAll("bbbb");
+    }
+
+    const frame = bc.session.currentFrame().?;
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    // Listen on `document` so reaching the handler also proves the events
+    // bubbled up from the input. Record interface + bubbles + order + target.
+    _ = try ls.local.compileAndRun(
+        \\window.__evts = [];
+        \\const rec = (e) => window.__evts.push(
+        \\  [e.type, e instanceof InputEvent, e.bubbles, e.target.id].join(':'));
+        \\document.addEventListener('input', rec);
+        \\document.addEventListener('change', rec);
+    , null);
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "DOM.setFileInputFiles",
+        .params = .{
+            .nodeId = 1,
+            .files = &[_][]const u8{ ".zig-cache/tmp/a.txt", ".zig-cache/tmp/b.txt" },
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 3 });
+
+    // The only way to observe a populated FileList from JS: set it via CDP,
+    // then read it back. Covers length, item(), the indexed getter and the
+    // iterator (spread / Array.from), which can't be exercised on an empty list.
+    // Also asserts the fired events: `input` then `change`, both plain bubbling
+    // Events (not InputEvents) targeting the input.
+    const result = try ls.local.compileAndRun(
+        \\const f = document.getElementById('upload');
+        \\f.files.length === 2 &&
+        \\f.files.item(0).name === 'a.txt' &&
+        \\f.files[0] instanceof File && f.files[0].name === 'a.txt' &&
+        \\f.files[1].name === 'b.txt' &&
+        \\f.files[2] === undefined &&
+        \\[...f.files].map((x) => x.name).join(',') === 'a.txt,b.txt' &&
+        \\Array.from(f.files, (x) => x.name).join(',') === 'a.txt,b.txt' &&
+        \\Object.keys(f.files).join(',') === '0,1' &&
+        \\window.__evts.join(',') === 'input:false:true:upload,change:false:true:upload'
+    , null);
+    try testing.expect(result.isTrue());
+}
+
 test "cdp.dom: setFileInputFiles rejects non-input node" {
     var ctx = try testing.context();
     defer ctx.deinit();

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -28,6 +28,10 @@ const js = @import("../../browser/js/js.zig");
 const DOMNode = @import("../../browser/webapi/Node.zig");
 const Selector = @import("../../browser/webapi/selector/Selector.zig");
 const xpath = @import("../../browser/xpath/Evaluator.zig");
+const Input = @import("../../browser/webapi/element/html/Input.zig");
+const File = @import("../../browser/webapi/File.zig");
+const Blob = @import("../../browser/webapi/Blob.zig");
+const Page = @import("../../browser/Page.zig");
 
 const log = lp.log;
 const Allocator = std.mem.Allocator;
@@ -50,6 +54,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         getFrameOwner,
         getOuterHTML,
         requestNode,
+        setFileInputFiles,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
@@ -69,6 +74,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .getFrameOwner => return getFrameOwner(cmd),
         .getOuterHTML => return getOuterHTML(cmd),
         .requestNode => return requestNode(cmd),
+        .setFileInputFiles => return setFileInputFiles(cmd),
     }
 }
 
@@ -607,6 +613,100 @@ fn requestNode(cmd: *CDP.Command) !void {
     return cmd.sendResult(.{ .nodeId = node.id }, .{});
 }
 
+// Cap matches Chrome's effective per-file limit; large enough for realistic
+// uploads, small enough to avoid runaway reads from a misbehaving driver.
+const MAX_FILE_BYTES: usize = 100 * 1024 * 1024;
+
+// https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-setFileInputFiles
+fn setFileInputFiles(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        files: []const []const u8,
+        nodeId: ?Node.Id = null,
+        backendNodeId: ?Node.Id = null,
+        objectId: ?[]const u8 = null,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+
+    const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
+    const element = node.dom.is(DOMNode.Element) orelse return error.NodeIsNotAnElement;
+    const input = element.is(Input) orelse return error.NotAnInputElement;
+    if (input._input_type != .file) return error.NotAFileInput;
+
+    var files = try cmd.arena.alloc(*File, params.files.len);
+    {
+        // Files are created at refcount 0; setFiles takes ownership. If a later
+        // path fails to load, release the arenas of the ones already created.
+        var created: usize = 0;
+        errdefer for (files[0..created]) |f| f._proto.deinit(frame._page);
+        for (params.files, 0..) |path, i| {
+            files[i] = try fileFromDiskPath(path, frame._page);
+            created = i + 1;
+        }
+    }
+    try input.setFiles(files, frame);
+
+    return cmd.sendResult(null, .{});
+}
+
+fn fileFromDiskPath(path: []const u8, page: *Page) !*File {
+    // Mirror File.init: a Blob and File sharing one reference-counted arena,
+    // but read the bytes straight off disk into it (single copy, no JS parts).
+    const arena = try page.getArena(.large, "File");
+    errdefer page.releaseArena(arena);
+
+    const data = try std.fs.cwd().readFileAlloc(arena, path, MAX_FILE_BYTES);
+    const stat = try std.fs.cwd().statFile(path);
+    const basename = std.fs.path.basename(path);
+
+    const blob = try arena.create(Blob);
+    const file = try arena.create(File);
+    blob.* = .{
+        ._rc = .{},
+        ._arena = arena,
+        ._type = .{ .file = file },
+        ._slice = data,
+        ._mime = mimeFromExtension(basename),
+    };
+    file.* = .{
+        ._proto = blob,
+        ._name = try arena.dupe(u8, basename),
+        ._last_modified = @intCast(@divTrunc(stat.mtime, std.time.ns_per_ms)),
+    };
+    return file;
+}
+
+fn mimeFromExtension(name: []const u8) []const u8 {
+    const dot = std.mem.lastIndexOfScalar(u8, name, '.') orelse return "application/octet-stream";
+    if (dot + 1 >= name.len) return "application/octet-stream";
+    var buf: [16]u8 = undefined;
+    const ext_raw = name[dot + 1 ..];
+    if (ext_raw.len > buf.len) return "application/octet-stream";
+    const ext = std.ascii.lowerString(buf[0..ext_raw.len], ext_raw);
+
+    const Map = std.StaticStringMap([]const u8);
+    const map = Map.initComptime(.{
+        .{ "txt", "text/plain" },
+        .{ "html", "text/html" },
+        .{ "htm", "text/html" },
+        .{ "css", "text/css" },
+        .{ "js", "text/javascript" },
+        .{ "json", "application/json" },
+        .{ "xml", "application/xml" },
+        .{ "pdf", "application/pdf" },
+        .{ "png", "image/png" },
+        .{ "jpg", "image/jpeg" },
+        .{ "jpeg", "image/jpeg" },
+        .{ "gif", "image/gif" },
+        .{ "webp", "image/webp" },
+        .{ "svg", "image/svg+xml" },
+        .{ "csv", "text/csv" },
+        .{ "zip", "application/zip" },
+    });
+    return map.get(ext) orelse "application/octet-stream";
+}
+
 const testing = @import("../testing.zig");
 test "cdp.dom: getSearchResults unknown search id" {
     var ctx = try testing.context();
@@ -715,6 +815,131 @@ test "cdp.dom: performSearch with XPath" {
         .params = .{ .query = "div p" },
     });
     try ctx.expectSentResult(.{ .searchId = "4", .resultCount = 2 }, .{ .id = 24 });
+}
+
+test "cdp.dom: setFileInputFiles on file input" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/input_file.html" });
+
+    // Find the file input via performSearch → getSearchResults.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "DOM.performSearch",
+        .params = .{ .query = "input" },
+    });
+    try ctx.expectSentResult(.{ .searchId = "0", .resultCount = 1 }, .{ .id = 1 });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "DOM.getSearchResults",
+        .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 1 },
+    });
+    try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 2 });
+
+    // Drop a temp file we can upload.
+    var tmp_dir = try std.fs.cwd().makeOpenPath(".zig-cache/tmp", .{});
+    defer tmp_dir.close();
+    {
+        const f = try tmp_dir.createFile("upload.txt", .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("hello upload");
+    }
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "DOM.setFileInputFiles",
+        .params = .{
+            .nodeId = 1,
+            .files = &[_][]const u8{".zig-cache/tmp/upload.txt"},
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 3 });
+}
+
+test "cdp.dom: setFileInputFiles rejects non-input node" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/dom1.html" });
+
+    // dom1.html has <p> elements — pick one by search.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "DOM.performSearch",
+        .params = .{ .query = "p" },
+    });
+    try ctx.expectSentResult(.{ .searchId = "0", .resultCount = 2 }, .{ .id = 1 });
+
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "DOM.getSearchResults",
+        .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 1 },
+    });
+    try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 2 });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "DOM.setFileInputFiles",
+        .params = .{
+            .nodeId = 1,
+            .files = &[_][]const u8{".zig-cache/tmp/upload.txt"},
+        },
+    });
+    try ctx.expectSentError(-31998, "NotAnInputElement", .{ .id = 3 });
+}
+
+test "cdp.dom: setFileInputFiles requires a node identifier" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/input_file.html" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "DOM.setFileInputFiles",
+        .params = .{
+            .files = &[_][]const u8{".zig-cache/tmp/upload.txt"},
+        },
+    });
+    try ctx.expectSentError(-31998, "MissingParams", .{ .id = 1 });
+}
+
+test "cdp.dom: setFileInputFiles errors (and leaks nothing) when a path is missing" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/input_file.html" });
+
+    try ctx.processMessage(.{ .id = 1, .method = "DOM.performSearch", .params = .{ .query = "input" } });
+    try ctx.expectSentResult(.{ .searchId = "0", .resultCount = 1 }, .{ .id = 1 });
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "DOM.getSearchResults",
+        .params = .{ .searchId = "0", .fromIndex = 0, .toIndex = 1 },
+    });
+    try ctx.expectSentResult(.{ .nodeIds = &.{1} }, .{ .id = 2 });
+
+    // First path exists, second does not: the first File is created then must be
+    // freed when the second read fails (the test runner panics on a leak).
+    var tmp_dir = try std.fs.cwd().makeOpenPath(".zig-cache/tmp", .{});
+    defer tmp_dir.close();
+    {
+        const f = try tmp_dir.createFile("upload.txt", .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("hello upload");
+    }
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "DOM.setFileInputFiles",
+        .params = .{
+            .nodeId = 1,
+            .files = &[_][]const u8{ ".zig-cache/tmp/upload.txt", ".zig-cache/tmp/does-not-exist.txt" },
+        },
+    });
+    try ctx.expectSentError(-31998, "FileNotFound", .{ .id = 3 });
 }
 
 test "cdp.dom: isXPathQuery heuristic" {


### PR DESCRIPTION
## What

Implements `<input type=file>` support, building on the W3C `Blob`/`File` API in the first commit.

- **`FileList`** now backs a real `[]*File` (was a zero-size stub): `length` and `item(i)` work.
- **`input.files`** returns a live, identity-stable `FileList` for `type=file`, and `null` for every other input type (per the IDL).
- **`input.value`** returns the spec `C:\fakepath\<name>` string for file inputs; setting it to anything but `""` throws.
- Required file inputs report `valueMissing` only when empty (was a hardcoded always-empty `TODO`).
- **CDP `DOM.setFileInputFiles`** loads files from disk into a file input, sniffs MIME by extension, and fires `input` + `change`: the upload entry point for WebDriver/automation.

## Memory ownership
  
`File`/`Blob` own a reference-counted pooled arena, normally released when V8 finalizes the JS wrapper. Files set via CDP may never be read from JS, so the owning `Frame` now tracks each input's `FileList`, `acquireRef`s the files it holds, and releases them at teardown, mirroring how `URL.createObjectURL` blobs are managed. Without this they leak an arena (caught by the test runner's leak detector). A scoped `errdefer` also frees partially-created files if one path in a multi-file set fails to load.
  
## Not in scope

- multipart/form-data encoding of files on form submit
- drag-and-drop / `DataTransfer`

## Tests

- `element/html/input_file.html`: `files` identity/length/item, `null` for non-file inputs, `value` getter/setter.
- `cdp.dom: setFileInputFiles`: happy path, non-input node, missing node id, and partial-failure (no-leak) path.
- `make test` green; `zig fmt --check` clean.
  
Closes #2175
