### PR TITLE
feat(cdp): fire mouseup on Input.dispatchMouseEvent mouseReleased

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3941,6 +3941,27 @@ pub fn triggerMouseMove(self: *Frame, x: f64, y: f64) !void {
     try self._event_manager.dispatch(target.asEventTarget(), enter_event.asEvent());
 }
 
+pub fn triggerMouseRelease(self: *Frame, x: f64, y: f64) !void {
+    const target = (try self.window._document.elementFromPoint(x, y, self)) orelse return;
+    if (comptime IS_DEBUG) {
+        log.debug(.frame, "frame mouse release", .{
+            .url = self.url,
+            .node = target,
+            .x = x,
+            .y = y,
+            .type = self._type,
+        });
+    }
+    const up_event: *MouseEvent = try .initTrusted(comptime .wrap("mouseup"), .{
+        .bubbles = true,
+        .cancelable = true,
+        .composed = true,
+        .clientX = x,
+        .clientY = y,
+    }, self);
+    try self._event_manager.dispatch(target.asEventTarget(), up_event.asEvent());
+}
+
 // callback when the "click" event reaches the frame.
 pub fn handleClick(self: *Frame, target: *Node) !void {
     // TODO: Also support <area> elements when implement

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -96,7 +96,7 @@ fn dispatchMouseEvent(cmd: *CDP.Command) !void {
 
     // quickly ignore types we know we don't handle
     switch (params.type) {
-        .mouseWheel, .mouseReleased => return,
+        .mouseWheel => return,
         else => {},
     }
 
@@ -104,8 +104,9 @@ fn dispatchMouseEvent(cmd: *CDP.Command) !void {
     const frame = bc.session.currentFrame() orelse return;
     switch (params.type) {
         .mousePressed => try frame.triggerMouseClick(params.x, params.y),
+        .mouseReleased => try frame.triggerMouseRelease(params.x, params.y),
         .mouseMoved => try frame.triggerMouseMove(params.x, params.y),
-        .mouseWheel, .mouseReleased => unreachable,
+        .mouseWheel => unreachable,
     }
     // result already sent
 }
@@ -164,5 +165,42 @@ test "cdp.input: dispatchMouseEvent mouseMoved fires hover events" {
     });
 
     const result = try ls.local.compileAndRun("window.hovered === true && window.entered === true && window.moved === true", null);
+    try testing.expect(result.isTrue());
+}
+
+test "cdp.input: dispatchMouseEvent mouseReleased fires mouseup" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const frame = try bc.session.createPage();
+    const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
+    try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
+    var runner = try bc.session.runner(.{});
+    try runner.wait(.{ .ms = 2000 });
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    var try_catch: lp.js.TryCatch = undefined;
+    try_catch.init(&ls.local);
+    defer try_catch.deinit();
+
+    _ = try ls.local.compileAndRun(
+        \\document.getElementById('hoverTarget')
+        \\  .addEventListener('mouseup', () => { window.released = true; });
+    , null);
+
+    const rect_x = try (try ls.local.compileAndRun("document.getElementById('hoverTarget').getBoundingClientRect().x", null)).toF64();
+    const rect_y = try (try ls.local.compileAndRun("document.getElementById('hoverTarget').getBoundingClientRect().y", null)).toF64();
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Input.dispatchMouseEvent",
+        .params = .{ .type = "mouseReleased", .x = rect_x, .y = rect_y },
+    });
+
+    const result = try ls.local.compileAndRun("window.released === true", null);
     try testing.expect(result.isTrue());
 }


### PR DESCRIPTION
Follow-up to #2636. In that PR's review @krichprollsch noted: "Would be great to have the mouse wheel and mouse release in followup PRs". This implements the mouse release half.

CDP `Input.dispatchMouseEvent` with `type: "mouseReleased"` was silently ignored. This wires it to dispatch a `mouseup` event on the element at the given point.

## Changes

- `src/browser/Frame.zig`: add `triggerMouseRelease(x, y)` — hit-tests the point with `elementFromPoint` and dispatches a trusted `mouseup` event on the target, mirroring `triggerMouseClick` / `triggerMouseMove` and the `mouseup` semantics already used by `WebDriver.zig`.
- `src/cdp/domains/input.zig`: route `dispatchMouseEvent` `mouseReleased` to `triggerMouseRelease` instead of returning early, and add a test asserting `mouseup` fires.

Mouse wheel (`mouseWheel`) will follow in a separate PR, as suggested.

## Verified

- `make test` passes (772/772, no leaks); new test `cdp.input: dispatchMouseEvent mouseReleased fires mouseup`.
- `zig fmt --check ./*.zig ./**/*.zig` clean.
- `make build` succeeds.