### PR TITLE
telemetry: send agent_replay mode on non-interactive usage

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -72,7 +72,7 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
 
     app.app_dir_path = getAndMakeAppDir(allocator);
 
-    app.telemetry = try Telemetry.init(app, config.mode);
+    app.telemetry = try Telemetry.init(app, config.mode, config.interactive());
     errdefer app.telemetry.deinit(allocator);
 
     app.arena_pool = ArenaPool.init(allocator, .{});

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -269,6 +269,15 @@ pub fn deinit(self: *const Config, allocator: Allocator) void {
     }
 }
 
+pub fn interactive(self: *const Config) bool {
+    return switch (self.mode) {
+        .fetch => false,
+        .serve, .mcp => true,
+        .agent => |opts| opts.script_file == null,
+        else => unreachable,
+    };
+}
+
 pub fn tlsVerifyHost(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,

--- a/src/main.zig
+++ b/src/main.zig
@@ -196,7 +196,15 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             var failed: bool = false;
             var cancelled: bool = false;
             {
-                var worker_thread = try std.Thread.spawn(.{}, agentThread, .{ allocator, app, opts, &failed, &cancelled, &sig_bridge });
+                var worker_thread = try std.Thread.spawn(.{}, agentThread, .{
+                    allocator,
+                    main_arena,
+                    app,
+                    opts,
+                    &failed,
+                    &cancelled,
+                    &sig_bridge,
+                });
                 defer worker_thread.join();
 
                 app.network.run();
@@ -209,7 +217,15 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     }
 }
 
-fn agentThread(allocator: std.mem.Allocator, app: *App, opts: Config.Agent, failed: *bool, cancelled: *bool, sig_bridge: *lp.Agent.SigBridge) void {
+fn agentThread(
+    allocator: std.mem.Allocator,
+    arena: std.mem.Allocator,
+    app: *App,
+    opts: Config.Agent,
+    failed: *bool,
+    cancelled: *bool,
+    sig_bridge: *lp.Agent.SigBridge,
+) void {
     defer app.network.stop();
 
     var agent_instance = lp.Agent.init(allocator, app, opts) catch |err| {
@@ -225,6 +241,18 @@ fn agentThread(allocator: std.mem.Allocator, app: *App, opts: Config.Agent, fail
     sig_bridge.attach(agent_instance);
     defer agent_instance.deinit();
     defer sig_bridge.detach();
+
+    if (agent_instance.ai_client) |cli| {
+        app.telemetry.record(.{ .llm = .{
+            .provider = @tagName(cli),
+            .model = arena.dupe(u8, agent_instance.model) catch null,
+        } });
+    } else {
+        app.telemetry.record(.{ .llm = .{
+            .provider = "nollm",
+            .model = null,
+        } });
+    }
 
     if (!agent_instance.run()) {
         failed.* = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -198,7 +198,6 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             {
                 var worker_thread = try std.Thread.spawn(.{}, agentThread, .{
                     allocator,
-                    main_arena,
                     app,
                     opts,
                     &failed,
@@ -219,7 +218,6 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
 
 fn agentThread(
     allocator: std.mem.Allocator,
-    arena: std.mem.Allocator,
     app: *App,
     opts: Config.Agent,
     failed: *bool,
@@ -243,15 +241,13 @@ fn agentThread(
     defer sig_bridge.detach();
 
     if (agent_instance.ai_client) |cli| {
-        app.telemetry.record(.{ .llm = .{
-            .provider = @tagName(cli),
-            .model = arena.dupe(u8, agent_instance.model) catch null,
-        } });
+        app.telemetry.record(.{
+            .llm = app.telemetry.llm_init(@tagName(cli), agent_instance.model),
+        });
     } else {
-        app.telemetry.record(.{ .llm = .{
-            .provider = "nollm",
-            .model = null,
-        } });
+        app.telemetry.record(.{
+            .llm = app.telemetry.llm_init("nollm", null),
+        });
     }
 
     if (!agent_instance.run()) {

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -26,16 +26,18 @@ mutex: std.Thread.Mutex = .{},
 
 iid: ?[36]u8 = null,
 run_mode: Config.RunMode = .serve,
+interactive: bool = false,
 
 head: std.atomic.Value(usize) = .init(0),
 tail: std.atomic.Value(usize) = .init(0),
 dropped: std.atomic.Value(u32) = .init(0),
 buffer: [BUFFER_SIZE]telemetry.Event = undefined,
 
-pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode) !void {
+pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode, interactive: bool) !void {
     self.* = .{
         .iid = iid,
         .run_mode = run_mode,
+        .interactive = interactive,
         .allocator = app.allocator,
         .network = &app.network,
         .writer = std.Io.Writer.Allocating.init(app.allocator),
@@ -110,7 +112,12 @@ fn postEvent(self: *LightPanda) !void {
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
     const iid: ?[]const u8 = if (self.iid) |*id| id else null;
-    const wrapped = LightPandaEvent{ .iid = iid, .mode = self.run_mode, .event = event };
+    const wrapped = LightPandaEvent{
+        .iid = iid,
+        .mode = self.run_mode,
+        .event = event,
+        .interactive = self.interactive,
+    };
 
     const checkpoint = self.writer.written().len;
 
@@ -127,6 +134,7 @@ fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
 const LightPandaEvent = struct {
     iid: ?[]const u8,
     mode: Config.RunMode,
+    interactive: bool,
     event: telemetry.Event,
 
     pub fn jsonStringify(self: *const LightPandaEvent, writer: anytype) !void {
@@ -136,7 +144,13 @@ const LightPandaEvent = struct {
         try writer.write(self.iid);
 
         try writer.objectField("mode");
-        try writer.write(self.mode);
+        // Special case: when running agent mode in non-interactive, we send a
+        // special running mode.
+        if (self.mode == .agent and self.interactive == false) {
+            try writer.write("agent_replay");
+        } else {
+            try writer.write(self.mode);
+        }
 
         try writer.objectField("os");
         try writer.write(builtin.os.tag);

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -28,7 +28,7 @@ fn TelemetryT(comptime P: type) type {
 
         const Self = @This();
 
-        pub fn init(app: *App, run_mode: Config.RunMode) !Self {
+        pub fn init(app: *App, run_mode: Config.RunMode, interactive: bool) !Self {
             const disabled = isDisabled();
             if (builtin.mode != .Debug and builtin.is_test == false) {
                 log.info(.telemetry, "telemetry status", .{ .disabled = disabled });
@@ -39,7 +39,7 @@ fn TelemetryT(comptime P: type) type {
             const provider = try app.allocator.create(P);
             errdefer app.allocator.destroy(provider);
 
-            try P.init(provider, app, iid, run_mode);
+            try P.init(provider, app, iid, run_mode, interactive);
 
             return .{
                 .disabled = disabled,
@@ -129,14 +129,14 @@ test "telemetry: always disabled in debug builds" {
     try testing.expectEqual(true, isDisabled());
 
     const FailingProvider = struct {
-        fn init(_: *@This(), _: *App, _: ?[36]u8, _: Config.RunMode) !void {}
+        fn init(_: *@This(), _: *App, _: ?[36]u8, _: Config.RunMode, _: bool) !void {}
         fn deinit(_: *@This()) void {}
         pub fn send(_: *@This(), _: Event) !void {
             unreachable;
         }
     };
 
-    var telemetry = try TelemetryT(FailingProvider).init(testing.test_app, .serve);
+    var telemetry = try TelemetryT(FailingProvider).init(testing.test_app, .serve, false);
     defer telemetry.deinit(testing.test_app.allocator);
     telemetry.record(.{ .run = {} });
 }
@@ -160,7 +160,7 @@ test "telemetry: getOrCreateId" {
 }
 
 test "telemetry: sends event to provider" {
-    var telemetry = try TelemetryT(MockProvider).init(testing.test_app, .serve);
+    var telemetry = try TelemetryT(MockProvider).init(testing.test_app, .serve, false);
     defer telemetry.deinit(testing.test_app.allocator);
     telemetry.disabled = false;
     const mock = telemetry.provider;
@@ -179,7 +179,7 @@ const MockProvider = struct {
     allocator: Allocator,
     events: std.ArrayList(Event),
 
-    fn init(self: *MockProvider, app: *App, _: ?[36]u8, _: Config.RunMode) !void {
+    fn init(self: *MockProvider, app: *App, _: ?[36]u8, _: Config.RunMode, _: bool) !void {
         self.* = .{
             .events = .{},
             .allocator = app.allocator,

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zenai = @import("zenai");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -60,6 +60,10 @@ fn TelemetryT(comptime P: type) type {
                 log.warn(.telemetry, "record error", .{ .err = err, .type = @tagName(std.meta.activeTag(event)) });
             };
         }
+
+        pub fn llm_init(_: *Self, provider: [:0]const u8, model: ?[]const u8) Event.LLM {
+            return Event.LLM.init(provider, model);
+        }
     };
 }
 
@@ -117,7 +121,36 @@ pub const Event = union(enum) {
 
     const LLM = struct {
         provider: [:0]const u8,
-        model: ?[]const u8,
+        model: ?Model,
+
+        const Model = struct {
+            len: u8,
+            buffer: [32]u8,
+
+            pub fn wrap(_s: ?[]const u8) ?Model {
+                if (_s == null) return null;
+
+                const l = @min(_s.?.len, 32);
+                var m: Model = .{
+                    .len = l,
+                    .buffer = undefined,
+                };
+                @memcpy(m.buffer[0..l], _s.?[0..l]);
+
+                return m;
+            }
+
+            pub fn jsonStringify(self: *const Model, writer: anytype) !void {
+                try writer.write(self.buffer[0..self.len]);
+            }
+        };
+
+        pub fn init(provider: [:0]const u8, _model: ?[]const u8) LLM {
+            return .{
+                .provider = provider,
+                .model = Model.wrap(_model),
+            };
+        }
     };
 };
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zenai = @import("zenai");
 const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
@@ -103,6 +104,7 @@ pub const Event = union(enum) {
     run: void,
     navigate: Navigate,
     buffer_overflow: BufferOverflow,
+    llm: LLM,
 
     const Navigate = struct {
         tls: bool,
@@ -112,6 +114,11 @@ pub const Event = union(enum) {
 
     const BufferOverflow = struct {
         dropped: u32,
+    };
+
+    const LLM = struct {
+        provider: [:0]const u8,
+        model: ?[]const u8,
     };
 };
 


### PR DESCRIPTION
Introduce an `interactive()` func from Config which is sent to the telemetry.
Use the `interactive` field in `agent` mode to send a custom `agent_replay` mode to the telemetry.  

add a new `llm` event w/ `provider` and `model`.

Relates with https://github.com/lightpanda-io/telemetry/pull/40