### PR TITLE
fix: drop orphaned deferred contexts on frame teardown

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -895,7 +895,10 @@ pub fn abortTransfers(self: *Frame) void {
     for (self.child_frames.items) |child| {
         child.abortTransfers();
     }
-    self._session.browser.http_client.abortOwner(&self._http_owner);
+    const http_client = &self._session.browser.http_client;
+    http_client.abortOwner(&self._http_owner);
+    // abortOwner misses deferred contexts whose transfer already completed.
+    http_client.deferring_layer.cancelFrame(self._frame_id);
 }
 
 pub fn documentIsLoaded(self: *Frame) void {

--- a/src/network/layer/DeferringLayer.zig
+++ b/src/network/layer/DeferringLayer.zig
@@ -113,6 +113,25 @@ pub fn flushFrame(self: *DeferringLayer, frame_id: u32) void {
     }
 }
 
+/// Drop orphaned deferred contexts for a frame that's going away. A `terminal`
+/// context's transfer already completed while deferred, so it's been deinited
+/// and unlinked from the owner — abortOwner can't reach it, yet it lingers in
+/// `active` pointing at a forward target (the Fetch) whose arena page teardown
+/// is about to free, and a later flushFrame would fire into it. Non-terminal
+/// contexts still have a live transfer that cleans them up itself.
+pub fn cancelFrame(self: *DeferringLayer, frame_id: u32) void {
+    var node = self.active.first;
+    while (node) |n| {
+        node = n.next;
+        const ctx: *DeferredContext = @fieldParentPtr("node", n);
+        if (ctx.frame_id != frame_id or !ctx.terminal) {
+            continue;
+        }
+        self.active.remove(n);
+        ctx.deinit();
+    }
+}
+
 pub fn drainAll(self: *DeferringLayer) void {
     while (self.active.popFirst()) |node| {
         const ctx: *DeferredContext = @fieldParentPtr("node", node);


### PR DESCRIPTION
## Crash

`SIGSEGV` in `Fetch.httpHeaderDoneCallback`, fired via `DeferringLayer.flushFrame` → `DeferredContext.fire` during HTML parsing of a navigation. Reported from a crash log where the trigger was a user message arriving mid-navigation.

## Root cause — use-after-free

A `fetch()` allocates its `Fetch`/`Response` in a **session** arena (`Response.zig`). When the fetch is deferred behind a parser-blocking script, the `DeferringLayer` keeps a `DeferredContext` (in a **different** arena) whose `forward.ctx` is a raw pointer back to the `Fetch` (`Forward.zig`).

If the fetch's network **completes while deferred**, its `Transfer` is deinited and unlinked from the frame's owner. The `DeferredContext` is left orphaned in the `active` list (marked `terminal`), waiting for a `flushFrame` that, for that fetch, will never come.

On page teardown, `Frame.abortTransfers → HttpClient.abortOwner` only walks **live** owner transfers, so it never reaches the orphan. The page is destroyed and the `Fetch` arena freed — but the orphaned context still lives in `active`. A later `flushFrame(frame_id)` (e.g. when the next page's parser-blocking script pops) replays the buffered `.header` event into the freed `Fetch`, faulting at the first `self._signal` deref. This matches the reported stack and the garbage (text-like) faulting address.

The structural gap: nothing drains the `DeferringLayer` per-frame on teardown — `flushFrame` is only called from `ScriptManager`, and `drainAll` only runs at full client shutdown.

## Fix

Add `DeferringLayer.cancelFrame(frame_id)`, called from `Frame.abortTransfers` after `abortOwner`. It removes and deinits the orphaned (`terminal`) contexts, severing the dangling pointer before the page frees the `Fetch`.

The `terminal` filter is load-bearing: `terminal` is set only in the deferred done/err branches, so it uniquely identifies a transfer that has already completed and been deinited. Non-terminal contexts still have a live transfer that cleans them up through its own callback path — touching those double-frees the context arena (caught by the `cdp.frame: reload replays POST navigation` test during development).

## Testing

- `zig build` clean, `zig fmt --check` clean.
- Full suite: **779/779 pass, no leaks, no double-free.**

## Follow-up (out of scope)

A pre-existing secondary issue this surfaces: an orphaned fetch's `Response` arena is never reclaimed until session end (its `done`/`shutdown` callbacks never fire). Forwarding shutdown from `cancelFrame` to free it is possible but riskier — it double-frees on paths where another teardown already releases that arena — so it's left as a separate follow-up.