### PR TITLE
Extend the TCP read/write timeout from 2 second to 10.

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -624,7 +624,7 @@ fn createTestClient() !TestClient {
     const stream = try std.net.tcpConnectToAddress(address);
 
     const timeout = std.mem.toBytes(posix.timeval{
-        .sec = 2,
+        .sec = 10,
         .usec = 0,
     });
     try posix.setsockopt(stream.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &timeout);


### PR DESCRIPTION
This limit isn't about correctness,it's just about making sure a test doesn't block forever. 2 seconds does seem like plenty of time, but I'm thinking it's a slow/busy CI. If it still happens after this bump, could mean there's an actual issue.