### PR TITLE
`URL`: Rework URL web API with rust-url

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -349,7 +349,11 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
     });
     errdefer browser.env.destroyContext(self.js);
 
-    self.window._location = try Location.init("about:blank", self);
+    const location = try Location.init("about:blank", self);
+    // We're holding a reference in Zig-side.
+    location.acquireRef();
+    errdefer location.releaseRef(page);
+    self.window._location = location;
 
     document._frame = self;
 
@@ -429,6 +433,9 @@ pub fn deinit(self: *Frame) void {
         if (document._fonts) |f| {
             f.releaseRef(page);
         }
+
+        // Release our reference to location.
+        self.window._location.releaseRef(page);
     }
 
     const browser = page.session.browser;
@@ -559,7 +566,14 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         // have to do this to make sure window.location is at a unique _address_.
         // If we don't do this, multiple window._location will have the same
         // address and thus be mapped to the same v8::Object in the identity map.
-        self.window._location = try Location.init(self.url, self);
+        //
+        // We don't hold a reference to old location anymore.
+        self.window._location.releaseRef(self._page);
+        // Create new location.
+        const location = try Location.init(self.url, self);
+        location.acquireRef();
+        errdefer location.releaseRef(self._page);
+        self.window._location = location;
 
         if (is_blob) {
             // strip out blob:
@@ -795,7 +809,14 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     const is_fragment_navigation = !std.mem.eql(u8, target.url, resolved_url) and URL.eqlDocument(target.url, resolved_url);
     if (!opts.force and is_fragment_navigation) {
         target.url = try target.arena.dupeZ(u8, resolved_url);
-        target.window._location = try Location.init(target.url, target);
+
+        // Release our reference to the previous location before replacing it.
+        target.window._location.releaseRef(target._page);
+        const location = try Location.init(target.url, target);
+        location.acquireRef();
+        errdefer location.releaseRef(target._page);
+        target.window._location = location;
+
         if (target.parent == null) {
             try session.navigation.updateEntries(target.url, opts.kind, target, true);
         }
@@ -1073,8 +1094,13 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !bool {
         }
     }
 
-    self.window._location = try Location.init(self.url, self);
-    self.document._location = self.window._location;
+    // Release our reference to location before.
+    self.window._location.releaseRef(self._page);
+    // Init new location.
+    const location = try Location.init(self.url, self);
+    location.acquireRef();
+    errdefer location.releaseRef(self._page);
+    self.window._location = location;
 
     if (comptime IS_DEBUG) {
         log.debug(.frame, "navigate header", .{

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -69,7 +69,6 @@ const HttpClient = @import("HttpClient.zig");
 const timestamp = @import("../datetime.zig").timestamp;
 const milliTimestamp = @import("../datetime.zig").milliTimestamp;
 
-const WebApiURL = @import("webapi/URL.zig");
 const GlobalEventHandlersLookup = @import("webapi/global_event_handlers.zig").Lookup;
 
 const log = lp.log;
@@ -77,9 +76,6 @@ const String = lp.String;
 const IFrame = Element.Html.IFrame;
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
-
-var default_url = WebApiURL{ ._raw = "about:blank" };
-pub var default_location: Location = Location{ ._url = &default_url };
 
 pub const BUF_SIZE = 1024;
 
@@ -331,7 +327,7 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
         ._frame = self,
         ._proto = undefined,
         ._document = self.document,
-        ._location = &default_location,
+        ._location = undefined,
         ._performance = .init(),
         ._screen = screen,
         ._visual_viewport = visual_viewport,
@@ -352,6 +348,8 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
         .call_arena = self.call_arena,
     });
     errdefer browser.env.destroyContext(self.js);
+
+    self.window._location = try Location.init("about:blank", self);
 
     document._frame = self;
 
@@ -557,7 +555,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     if (is_about_blank or is_blob) {
         self.url = if (is_about_blank) "about:blank" else try self.arena.dupeZ(u8, request_url);
 
-        // even though this might be the same _data_ as `default_location`, we
+        // even though about:blank navigations may share the same _data_, we
         // have to do this to make sure window.location is at a unique _address_.
         // If we don't do this, multiple window._location will have the same
         // address and thus be mapped to the same v8::Object in the identity map.

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -352,7 +352,6 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
     const location = try Location.init("about:blank", self);
     // We're holding a reference in Zig-side.
     location.acquireRef();
-    errdefer location.releaseRef(page);
     self.window._location = location;
 
     document._frame = self;
@@ -568,7 +567,6 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         // address and thus be mapped to the same v8::Object in the identity map.
         const location = try Location.init(self.url, self);
         location.acquireRef();
-        errdefer location.releaseRef(self._page);
         // We're not holding a ref to old location anymore.
         self.window._location.releaseRef(self._page);
         self.window._location = location;
@@ -810,7 +808,6 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
 
         const location = try Location.init(target.url, target);
         location.acquireRef();
-        errdefer location.releaseRef(target._page);
         target.window._location.releaseRef(target._page);
         target.window._location = location;
 
@@ -1094,7 +1091,6 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !bool {
     // Init new location.
     const location = try Location.init(self.url, self);
     location.acquireRef();
-    errdefer location.releaseRef(self._page);
     self.window._location.releaseRef(self._page);
     self.window._location = location;
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -566,13 +566,11 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         // have to do this to make sure window.location is at a unique _address_.
         // If we don't do this, multiple window._location will have the same
         // address and thus be mapped to the same v8::Object in the identity map.
-        //
-        // We don't hold a reference to old location anymore.
-        self.window._location.releaseRef(self._page);
-        // Create new location.
         const location = try Location.init(self.url, self);
         location.acquireRef();
         errdefer location.releaseRef(self._page);
+        // We're not holding a ref to old location anymore.
+        self.window._location.releaseRef(self._page);
         self.window._location = location;
 
         if (is_blob) {
@@ -810,11 +808,10 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     if (!opts.force and is_fragment_navigation) {
         target.url = try target.arena.dupeZ(u8, resolved_url);
 
-        // Release our reference to the previous location before replacing it.
-        target.window._location.releaseRef(target._page);
         const location = try Location.init(target.url, target);
         location.acquireRef();
         errdefer location.releaseRef(target._page);
+        target.window._location.releaseRef(target._page);
         target.window._location = location;
 
         if (target.parent == null) {
@@ -1094,12 +1091,11 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !bool {
         }
     }
 
-    // Release our reference to location before.
-    self.window._location.releaseRef(self._page);
     // Init new location.
     const location = try Location.init(self.url, self);
     location.acquireRef();
     errdefer location.releaseRef(self._page);
+    self.window._location.releaseRef(self._page);
     self.window._location = location;
 
     if (comptime IS_DEBUG) {

--- a/src/browser/tests/url.html
+++ b/src/browser/tests/url.html
@@ -1,35 +1,31 @@
 <!DOCTYPE html>
 <script src="testing.js"></script>
-<script id=url>
+<script id=parse>
   testing.expectEqual("function", typeof window.URL);
 
+  // about:blank is a valid non-special URL, not a parse error.
+  {
+    const url = new URL('about:blank');
+    testing.expectEqual('about:blank', url.toString());
+  }
+
+  // Absolute URL, no base.
   {
     const url = new URL('http://example.com/path');
     testing.expectEqual('http://example.com/path', url.toString());
   }
 
+  // A provided base is parsed unconditionally: an unparseable base throws a
+  // TypeError even when the input is absolute (WHATWG URL constructor step 2).
   {
-    const base = 'http://example.com/path/';
-    const url = new URL('subpath', base);
-    testing.expectEqual('http://example.com/path/subpath', url.toString());
+    testing.withError((err) => {
+      testing.expectEqual(true, err.toString().includes('TypeError'));
+    }, () => {
+      const url = new URL('http://example.com/absolute', 'invalid base');
+    });
   }
 
-  {
-    const base = 'http://example.com/path/subpath';
-    const url = new URL('/newpath', base);
-    testing.expectEqual('http://example.com/newpath', url.toString());
-  }
-
-  {
-    const url = new URL('?a=b', 'http://example.com/path');
-    testing.expectEqual('http://example.com/path?a=b', url.toString());
-  }
-
-  {
-    const url = new URL('#hash', 'http://example.com/path');
-    testing.expectEqual('http://example.com/path#hash', url.toString());
-  }
-
+  // A relative URL with no base is a parse failure -> TypeError.
   {
     testing.withError((err) => {
       testing.expectEqual(true, err.toString().includes('TypeError'));
@@ -69,88 +65,51 @@
       const url = new URL('');
     });
   }
+</script>
 
+<script id=parse_with_base>
+  // Relative path resolves against the base's directory.
   {
-    testing.withError((err) => {
-      testing.expectEqual(true, err.toString().includes('TypeError'));
-    }, () => {
-      const url = new URL('foo.js', 'not a url');
-    });
+    const base = 'http://example.com/path/';
+    const url = new URL('subpath', base);
+    testing.expectEqual('http://example.com/path/subpath', url.toString());
+  }
+
+  // Absolute path replaces the base's path.
+  {
+    const base = 'http://example.com/path/subpath';
+    const url = new URL('/newpath', base);
+    testing.expectEqual('http://example.com/newpath', url.toString());
+  }
+
+  // Query-only and fragment-only relative references.
+  {
+    const url = new URL('?a=b', 'http://example.com/path');
+    testing.expectEqual('http://example.com/path?a=b', url.toString());
   }
 
   {
-    testing.withError((err) => {
-      testing.expectEqual(true, err.toString().includes('TypeError'));
-    }, () => {
-      const url = new URL('foo.js', 'bar/baz');
-    });
+    const url = new URL('#hash', 'http://example.com/path');
+    testing.expectEqual('http://example.com/path#hash', url.toString());
   }
 
-  {
-    const url = new URL('http://example.com/absolute', 'invalid base');
-    testing.expectEqual('http://example.com/absolute', url.toString());
-  }
-
+  // Dot-segment resolution.
   {
     const base = 'http://example.com/a/b/c/d';
     const url = new URL('../foo', base);
     testing.expectEqual('http://example.com/a/b/foo', url.toString());
   }
 
-  {
-    // IDN hosts are converted to punycode (UTS#46).
-    const url = new URL('https://räksmörgås.se/x');
-    testing.expectEqual('xn--rksmrgs-5wao1o.se', url.hostname);
-    testing.expectEqual('https://xn--rksmrgs-5wao1o.se/x', url.href);
-  }
-
-  {
-    // Valid punycode passes through unchanged.
-    const url = new URL('https://xn--rksmrgs-5wao1o.se/x');
-    testing.expectEqual('xn--rksmrgs-5wao1o.se', url.hostname);
-  }
-
-  {
-    // An invalid domain (malformed punycode) is a parse failure -> TypeError.
-    testing.withError((err) => {
-      testing.expectEqual(true, err.toString().includes('TypeError'));
-    }, () => {
-      const url = new URL('https://xn--0.pt/x');
-    });
-  }
-
+  // Over-popping ".." clamps at the root.
   {
     const base = 'http://example.com/a/b/c/d';
     const url = new URL('../../../../../foo', base);
     testing.expectEqual('http://example.com/foo', url.toString());
   }
 
+  // Resolving against a base that carries its own query/fragment.
   {
     const base = 'http://example.com/path?a=b';
-    const url = new URL('?c=d', base);
-    testing.expectEqual('http://example.com/path?c=d', url.toString());
-  }
-
-  {
-    const base = 'http://example.com/path?a=b';
-    const url = new URL('#hash', base);
-    testing.expectEqual('http://example.com/path?a=b#hash', url.toString());
-  }
-
-  {
-    const base = 'http://example.com/path#hash';
-    const url = new URL('?c=d', base);
-    testing.expectEqual('http://example.com/path?c=d', url.toString());
-  }
-
-  {
-    const base = 'http://example.com/path#hash';
-    const url = new URL('#newhash', base);
-    testing.expectEqual('http://example.com/path#newhash', url.toString());
-  }
-
-  {
-    const base = 'http://example.com/path?a=b#hash';
     const url = new URL('?c=d', base);
     testing.expectEqual('http://example.com/path?c=d', url.toString());
   }
@@ -167,79 +126,236 @@
     testing.expectEqual('http://example.com/path/sub', url.toString());
   }
 
+  // A relative input against an unparseable base is a failure -> TypeError.
   {
-    const url = new URL('http://example.com/path?a=b#hash');
-    testing.expectEqual(url.toString(), url.href);
-    testing.expectEqual('?a=b', url.search);
-    testing.expectEqual('#hash', url.hash);
+    testing.withError((err) => {
+      testing.expectEqual(true, err.toString().includes('TypeError'));
+    }, () => {
+      const url = new URL('foo.js', 'not a url');
+    });
   }
 
   {
-    const url = new URL('http://example.com/path');
-    testing.expectEqual('', url.search);
-    testing.expectEqual('', url.hash);
+    testing.withError((err) => {
+      testing.expectEqual(true, err.toString().includes('TypeError'));
+    }, () => {
+      const url = new URL('foo.js', 'bar/baz');
+    });
   }
 
+  // Protocol-relative reference adopts the base's scheme.
   {
-    const url = new URL('http://example.com/path?a=b');
-    testing.expectEqual('?a=b', url.search);
-    testing.expectEqual('', url.hash);
+    const url = new URL('//other.com/p', 'http://example.com/x');
+    testing.expectEqual('http://other.com/p', url.toString());
   }
 
+  // Relative resolution preserves the base's userinfo and port.
   {
-    const url = new URL('http://example.com/path#hash');
-    testing.expectEqual('', url.search);
-    testing.expectEqual('#hash', url.hash);
+    const url = new URL('/x', 'http://user:pass@example.com:8080/a');
+    testing.expectEqual('http://user:pass@example.com:8080/x', url.toString());
   }
 
+  // Single-dot segment in the reference resolves against the base directory.
   {
-    const url = new URL('http://example.com/path/to/resource?query=1#fragment');
-    testing.expectEqual('/path/to/resource', url.pathname);
+    const url = new URL('./x', 'http://example.com/a/b');
+    testing.expectEqual('http://example.com/a/x', url.toString());
   }
 
+  // An empty reference copies the base but drops its fragment.
+  {
+    const url = new URL('', 'http://example.com/path?q=1#frag');
+    testing.expectEqual('http://example.com/path?q=1', url.toString());
+  }
+</script>
+
+<script id=parse_normalization>
+  // Scheme is lowercased.
+  {
+    const url = new URL('HTTP://example.com/');
+    testing.expectEqual('http://example.com/', url.toString());
+  }
+
+  // Host is lowercased.
+  {
+    const url = new URL('http://EXAMPLE.COM/');
+    testing.expectEqual('http://example.com/', url.toString());
+  }
+
+  // A missing path serializes as "/".
   {
     const url = new URL('http://example.com');
-    testing.expectEqual('/', url.pathname);
+    testing.expectEqual('http://example.com/', url.toString());
   }
 
+  // Default ports are dropped.
+  {
+    testing.expectEqual('http://example.com/', new URL('http://example.com:80/').toString());
+    testing.expectEqual('https://example.com/', new URL('https://example.com:443/').toString());
+  }
+
+  // Non-default ports are kept.
+  {
+    const url = new URL('http://example.com:8080/');
+    testing.expectEqual('http://example.com:8080/', url.toString());
+  }
+
+  // Dot segments are collapsed in the input path itself.
+  {
+    const url = new URL('http://example.com/a/./b/../c');
+    testing.expectEqual('http://example.com/a/c', url.toString());
+  }
+
+  // Empty path segments are preserved.
+  {
+    const url = new URL('http://example.com/a//b');
+    testing.expectEqual('http://example.com/a//b', url.toString());
+  }
+
+  // Leading and trailing spaces are stripped from the input.
+  {
+    const url = new URL('  http://example.com/  ');
+    testing.expectEqual('http://example.com/', url.toString());
+  }
+
+  // Tabs and newlines are removed from anywhere in the input.
+  {
+    const url = new URL('http://exa\tmple.com/pa\nth');
+    testing.expectEqual('http://example.com/path', url.toString());
+  }
+
+  // An empty query and an empty fragment are preserved in serialization.
+  {
+    testing.expectEqual('http://example.com/p?', new URL('http://example.com/p?').toString());
+    testing.expectEqual('http://example.com/p#', new URL('http://example.com/p#').toString());
+  }
+</script>
+
+<script id=parse_special>
+  // Backslashes act as path separators for special schemes.
+  {
+    const url = new URL('http:\\\\example.com\\path');
+    testing.expectEqual('http://example.com/path', url.toString());
+  }
+
+  // Userinfo is parsed and serialized.
+  {
+    const url = new URL('http://user:pass@example.com/');
+    testing.expectEqual('http://user:pass@example.com/', url.toString());
+  }
+
+  // An IPv6 literal host keeps its brackets.
+  {
+    const url = new URL('http://[::1]:8080/');
+    testing.expectEqual('http://[::1]:8080/', url.toString());
+  }
+
+  // An IPv6 host with a default port drops the port.
+  {
+    const url = new URL('http://[::1]:80/');
+    testing.expectEqual('http://[::1]/', url.toString());
+  }
+
+  // file: URLs parse with an empty host.
+  {
+    const url = new URL('file:///path/to/file');
+    testing.expectEqual('file:///path/to/file', url.toString());
+  }
+</script>
+
+<script id=can_parse>
+  testing.expectEqual('function', typeof URL.canParse);
+
+  // Parseable absolute URLs (no base) -> true. canParse mirrors the
+  // constructor: true exactly when `new URL(...)` would not throw.
+  {
+    testing.expectEqual(true, URL.canParse('https://example.com'));
+    testing.expectEqual(true, URL.canParse('http://example.com/path'));
+    testing.expectEqual(true, URL.canParse('https://example.com:8080/path?a=b#hash'));
+    testing.expectEqual(true, URL.canParse('ftp://example.com'));
+    testing.expectEqual(true, URL.canParse('HTTP://EXAMPLE.COM'));
+  }
+
+  // Non-special but parseable schemes -> true.
+  {
+    testing.expectEqual(true, URL.canParse('about:blank'));
+    testing.expectEqual(true, URL.canParse('mailto:foo@bar.com'));
+    testing.expectEqual(true, URL.canParse('data:text/plain,hello'));
+    testing.expectEqual(true, URL.canParse('file:///etc/hosts'));
+  }
+
+  // Relative or malformed input (no base) -> false.
+  {
+    testing.expectEqual(false, URL.canParse(''));
+    testing.expectEqual(false, URL.canParse('foo.js'));
+    testing.expectEqual(false, URL.canParse('/path/to/file'));
+    testing.expectEqual(false, URL.canParse('?query=value'));
+    testing.expectEqual(false, URL.canParse('#fragment'));
+    testing.expectEqual(false, URL.canParse('//only-host'));
+    testing.expectEqual(false, URL.canParse('http://'));
+  }
+
+  // Relative input resolved against a valid base -> true.
+  {
+    testing.expectEqual(true, URL.canParse('subpath', 'http://example.com/path/'));
+    testing.expectEqual(true, URL.canParse('/newpath', 'http://example.com/path'));
+    testing.expectEqual(true, URL.canParse('?a=b', 'http://example.com/path'));
+    testing.expectEqual(true, URL.canParse('#hash', 'http://example.com/path'));
+    testing.expectEqual(true, URL.canParse('../foo', 'http://example.com/a/b/c'));
+    testing.expectEqual(true, URL.canParse('//other.com/p', 'http://example.com/'));
+    testing.expectEqual(true, URL.canParse('', 'http://example.com/path'));
+  }
+
+  // Absolute input with a valid base -> true (base parses, input wins).
+  {
+    testing.expectEqual(true, URL.canParse('http://example.com/absolute', 'http://base.com'));
+    testing.expectEqual(true, URL.canParse('https://example.com/path', 'https://other.com'));
+  }
+
+  // The base is parsed unconditionally: an unparseable base -> false, even
+  // when the input itself is absolute (mirrors the constructor throwing).
+  {
+    testing.expectEqual(false, URL.canParse('http://example.com/absolute', 'invalid base'));
+    testing.expectEqual(false, URL.canParse('foo.js', 'not a url'));
+    testing.expectEqual(false, URL.canParse('foo.js', 'bar/baz'));
+    testing.expectEqual(false, URL.canParse('subpath', 'relative/path'));
+    testing.expectEqual(false, URL.canParse('http://example.com', ''));
+    testing.expectEqual(false, URL.canParse('http://example.com', 'relative'));
+  }
+
+  // An undefined base is treated as "no base given".
+  {
+    testing.expectEqual(true, URL.canParse('https://example.com', undefined));
+    testing.expectEqual(false, URL.canParse('foo.js', undefined));
+    testing.expectEqual(false, URL.canParse('subpath', undefined));
+  }
+</script>
+
+<script id=username>
+  // Username is parsed from the userinfo component.
   {
     const url = new URL('http://user:pass@example.com/path');
     testing.expectEqual('user', url.username);
-    testing.expectEqual('pass', url.password);
-    testing.expectEqual('/path', url.pathname);
   }
 
+  // Userinfo with no password still exposes the username.
   {
     const url = new URL('http://user@example.com/');
     testing.expectEqual('user', url.username);
-    testing.expectEqual('', url.password);
   }
 
-  {
-    const url = new URL('http://user:@example.com/');
-    testing.expectEqual('user', url.username);
-    testing.expectEqual('', url.password);
-  }
-
+  // No userinfo -> empty username.
   {
     const url = new URL('http://example.com/');
     testing.expectEqual('', url.username);
-    testing.expectEqual('', url.password);
   }
 
+  // An already-encoded username is preserved verbatim.
   {
-    const url = new URL('https://user:pass@example.com/path');
-    testing.expectEqual('user', url.username);
-    testing.expectEqual('pass', url.password);
-    testing.expectEqual('/path', url.pathname);
+    const url = new URL('https://user%40domain@example.com/');
+    testing.expectEqual('user%40domain', url.username);
   }
 
-  {
-    const url = new URL('https://user@example.com/');
-    testing.expectEqual('user', url.username);
-    testing.expectEqual('', url.password);
-  }
-
+  // Setting a username on a URL with no userinfo adds it.
   {
     const url = new URL('https://example.com/path');
     url.username = 'newuser';
@@ -247,6 +363,7 @@
     testing.expectEqual('https://newuser@example.com/path', url.href);
   }
 
+  // Setting a username replaces an existing one.
   {
     const url = new URL('https://olduser@example.com/path');
     url.username = 'newuser';
@@ -254,39 +371,23 @@
     testing.expectEqual('https://newuser@example.com/path', url.href);
   }
 
+  // Setting the username preserves an existing password (seen via href).
   {
     const url = new URL('https://olduser:pass@example.com/path');
     url.username = 'newuser';
     testing.expectEqual('newuser', url.username);
-    testing.expectEqual('pass', url.password);
     testing.expectEqual('https://newuser:pass@example.com/path', url.href);
   }
 
+  // Clearing the username drops the userinfo.
   {
     const url = new URL('https://user@example.com/path');
-    url.password = 'secret';
-    testing.expectEqual('user', url.username);
-    testing.expectEqual('secret', url.password);
-    testing.expectEqual('https://user:secret@example.com/path', url.href);
-  }
-
-  {
-    const url = new URL('https://user:oldpass@example.com/path');
-    url.password = 'newpass';
-    testing.expectEqual('user', url.username);
-    testing.expectEqual('newpass', url.password);
-    testing.expectEqual('https://user:newpass@example.com/path', url.href);
-  }
-
-  {
-    const url = new URL('https://user:pass@example.com/path');
     url.username = '';
-    url.password = '';
     testing.expectEqual('', url.username);
-    testing.expectEqual('', url.password);
     testing.expectEqual('https://example.com/path', url.href);
   }
 
+  // The username setter percent-encodes characters in the userinfo set.
   {
     const url = new URL('https://example.com/path');
     url.username = 'user@domain';
@@ -302,6 +403,324 @@
 
   {
     const url = new URL('https://example.com/path');
+    url.username = 'user/name';
+    testing.expectEqual('user%2Fname', url.username);
+  }
+
+  {
+    const url = new URL('https://example.com/path');
+    url.username = 'a b';
+    testing.expectEqual('a%20b', url.username);
+  }
+</script>
+
+<script id=hostname>
+  // hostname is the host without the port.
+  {
+    const url = new URL('http://example.com/path');
+    testing.expectEqual('example.com', url.hostname);
+  }
+
+  {
+    const url = new URL('http://example.com:8080/path');
+    testing.expectEqual('example.com', url.hostname);
+  }
+
+  // A host-less URL has an empty hostname.
+  {
+    const url = new URL('about:blank');
+    testing.expectEqual('', url.hostname);
+  }
+
+  // Hosts are lowercased.
+  {
+    const url = new URL('http://EXAMPLE.COM/');
+    testing.expectEqual('example.com', url.hostname);
+  }
+
+  // IDN hosts are exposed in their punycode form.
+  {
+    const url = new URL('https://räksmörgås.se/');
+    testing.expectEqual('xn--rksmrgs-5wao1o.se', url.hostname);
+  }
+
+  // An IPv6 literal keeps its brackets.
+  {
+    const url = new URL('http://[::1]:8080/');
+    testing.expectEqual('[::1]', url.hostname);
+  }
+
+  // Setting the hostname is reflected in the getter and href.
+  {
+    const url = new URL('https://example.com/path');
+    url.hostname = 'newhost.com';
+    testing.expectEqual('newhost.com', url.hostname);
+    testing.expectEqual('https://newhost.com/path', url.href);
+  }
+
+  // Setting the hostname leaves an existing port untouched (seen via href).
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.hostname = 'newhost.com';
+    testing.expectEqual('newhost.com', url.hostname);
+    testing.expectEqual('https://newhost.com:8080/path', url.href);
+  }
+</script>
+
+<script id=host>
+  // host includes the port when present.
+  {
+    const url = new URL('http://example.com:8080/path');
+    testing.expectEqual('example.com:8080', url.host);
+  }
+
+  // host omits a default port.
+  {
+    const url = new URL('https://example.com:443/path');
+    testing.expectEqual('example.com', url.host);
+  }
+
+  // No port -> host is just the hostname.
+  {
+    const url = new URL('http://example.com/path');
+    testing.expectEqual('example.com', url.host);
+  }
+
+  // Host-less URL -> empty host.
+  {
+    const url = new URL('about:blank');
+    testing.expectEqual('', url.host);
+  }
+
+  // IPv6 literal, with and without port.
+  {
+    const url = new URL('http://[::1]:8080/');
+    testing.expectEqual('[::1]:8080', url.host);
+  }
+
+  // Setting host with a port updates both hostname and port.
+  {
+    const url = new URL('https://example.com/path');
+    url.host = 'newhost.com:9000';
+    testing.expectEqual('newhost.com:9000', url.host);
+    testing.expectEqual('newhost.com', url.hostname);
+    testing.expectEqual('https://newhost.com:9000/path', url.href);
+  }
+
+  // Setting host without a port leaves an existing port untouched.
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.host = 'newhost.com';
+    testing.expectEqual('newhost.com:8080', url.host);
+    testing.expectEqual('https://newhost.com:8080/path', url.href);
+  }
+
+  // Setting host to an IPv6 literal with a port.
+  {
+    const url = new URL('https://example.com/path');
+    url.host = '[::1]:9000';
+    testing.expectEqual('[::1]:9000', url.host);
+    testing.expectEqual('https://[::1]:9000/path', url.href);
+  }
+
+  // A trailing colon clears the port.
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.host = 'newhost.com:';
+    testing.expectEqual('newhost.com', url.host);
+    testing.expectEqual('https://newhost.com/path', url.href);
+  }
+</script>
+
+<script id=port>
+  // A non-default port is exposed as a string.
+  {
+    const url = new URL('http://example.com:8080/path');
+    testing.expectEqual('8080', url.port);
+  }
+
+  // No explicit port -> empty string.
+  {
+    const url = new URL('http://example.com/path');
+    testing.expectEqual('', url.port);
+  }
+
+  // A default port is not surfaced.
+  {
+    testing.expectEqual('', new URL('http://example.com:80/').port);
+    testing.expectEqual('', new URL('https://example.com:443/').port);
+  }
+
+  // Setting a port is reflected in the getter and href.
+  {
+    const url = new URL('https://example.com/path');
+    url.port = '8080';
+    testing.expectEqual('8080', url.port);
+    testing.expectEqual('https://example.com:8080/path', url.href);
+  }
+
+  // Setting the scheme's default port drops it.
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.port = '443';
+    testing.expectEqual('', url.port);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+
+  // Setting an empty string clears the port.
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.port = '';
+    testing.expectEqual('', url.port);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+
+  // An invalid port is silently ignored, leaving the existing port intact.
+  {
+    const url = new URL('https://example.com:8080/path');
+    url.port = 'abc';
+    testing.expectEqual('8080', url.port);
+    url.port = '99999'; // out of u16 range
+    testing.expectEqual('8080', url.port);
+  }
+
+  // The maximum port value is accepted.
+  {
+    const url = new URL('https://example.com/path');
+    url.port = '65535';
+    testing.expectEqual('65535', url.port);
+  }
+</script>
+
+<script id=protocol>
+  // protocol is the scheme followed by ':'.
+  {
+    testing.expectEqual('https:', new URL('https://example.com/').protocol);
+    testing.expectEqual('http:', new URL('http://example.com/').protocol);
+    testing.expectEqual('ftp:', new URL('ftp://example.com/').protocol);
+    testing.expectEqual('about:', new URL('about:blank').protocol);
+  }
+
+  // Setting the protocol with or without a trailing ':' both work.
+  {
+    const url = new URL('https://example.com/path');
+    url.protocol = 'http';
+    testing.expectEqual('http:', url.protocol);
+    testing.expectEqual('http://example.com/path', url.href);
+  }
+
+  {
+    const url = new URL('http://example.com/path');
+    url.protocol = 'https:';
+    testing.expectEqual('https:', url.protocol);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+</script>
+
+<script id=pathname>
+  // pathname is the path portion of the URL.
+  {
+    const url = new URL('http://example.com/path/to/resource?q=1#frag');
+    testing.expectEqual('/path/to/resource', url.pathname);
+  }
+
+  // A host-only URL has a root path.
+  {
+    const url = new URL('http://example.com');
+    testing.expectEqual('/', url.pathname);
+  }
+
+  // Setting an absolute path.
+  {
+    const url = new URL('https://example.com/path');
+    url.pathname = '/newpath';
+    testing.expectEqual('/newpath', url.pathname);
+    testing.expectEqual('https://example.com/newpath', url.href);
+  }
+
+  // A leading slash is added if missing.
+  {
+    const url = new URL('https://example.com/path');
+    url.pathname = 'newpath';
+    testing.expectEqual('/newpath', url.pathname);
+  }
+
+  // Setting the path leaves query and fragment intact.
+  {
+    const url = new URL('https://example.com/path?a=b#hash');
+    url.pathname = '/new/path';
+    testing.expectEqual('/new/path', url.pathname);
+    testing.expectEqual('https://example.com/new/path?a=b#hash', url.href);
+  }
+
+  // The path setter percent-encodes spaces.
+  {
+    const url = new URL('https://example.com/path');
+    url.pathname = '/a b/c d';
+    testing.expectEqual('/a%20b/c%20d', url.pathname);
+  }
+
+  // Already-encoded sequences are not double-encoded.
+  {
+    const url = new URL('https://example.com/path');
+    url.pathname = '/already%20encoded';
+    testing.expectEqual('/already%20encoded', url.pathname);
+  }
+</script>
+
+<script id=password>
+  // password is parsed from the userinfo component.
+  {
+    const url = new URL('https://user:pass@example.com/path');
+    testing.expectEqual('pass', url.password);
+  }
+
+  // Userinfo with no password -> empty.
+  {
+    const url = new URL('https://user@example.com/');
+    testing.expectEqual('', url.password);
+  }
+
+  // Explicit empty password (user:@) -> empty.
+  {
+    const url = new URL('https://user:@example.com/');
+    testing.expectEqual('', url.password);
+  }
+
+  // No userinfo -> empty password.
+  {
+    const url = new URL('https://example.com/');
+    testing.expectEqual('', url.password);
+  }
+
+  // Setting a password adds it to the userinfo.
+  {
+    const url = new URL('https://user@example.com/path');
+    url.password = 'secret';
+    testing.expectEqual('secret', url.password);
+    testing.expectEqual('https://user:secret@example.com/path', url.href);
+  }
+
+  // Replacing an existing password.
+  {
+    const url = new URL('https://user:oldpass@example.com/path');
+    url.password = 'newpass';
+    testing.expectEqual('newpass', url.password);
+    testing.expectEqual('https://user:newpass@example.com/path', url.href);
+  }
+
+  // Clearing username and password drops the userinfo.
+  {
+    const url = new URL('https://user:pass@example.com/path');
+    url.username = '';
+    url.password = '';
+    testing.expectEqual('', url.password);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+
+  // The password setter percent-encodes userinfo-set characters.
+  {
+    const url = new URL('https://example.com/path');
     url.password = 'pass@word';
     testing.expectEqual('pass%40word', url.password);
   }
@@ -314,107 +733,199 @@
 
   {
     const url = new URL('https://example.com/path');
-    url.username = 'user/name';
-    testing.expectEqual('user%2Fname', url.username);
-  }
-
-  {
-    const url = new URL('https://example.com/path');
     url.password = 'pass?word';
     testing.expectEqual('pass%3Fword', url.password);
   }
+</script>
 
+<script id=hash>
+  // hash includes the leading '#'.
   {
-    const url = new URL('https://user%40domain:pass%3Aword@example.com/path');
-    testing.expectEqual('user%40domain', url.username);
-    testing.expectEqual('pass%3Aword', url.password);
+    const url = new URL('https://example.com/path#section');
+    testing.expectEqual('#section', url.hash);
   }
 
+  // No fragment -> empty hash.
   {
-    const url = new URL('https://example.com:8080/path?a=b#hash');
-    url.username = 'user';
-    url.password = 'pass';
-    testing.expectEqual('https://user:pass@example.com:8080/path?a=b#hash', url.href);
-    testing.expectEqual('8080', url.port);
-    testing.expectEqual('?a=b', url.search);
-    testing.expectEqual('#hash', url.hash);
+    const url = new URL('https://example.com/path');
+    testing.expectEqual('', url.hash);
   }
 
+  // An empty fragment ('...#') -> empty hash.
   {
-    const url = new URL('http://user:pass@example.com:8080/path?query=1#hash');
-    testing.expectEqual('http:', url.protocol);
-    testing.expectEqual('example.com', url.hostname);
-    testing.expectEqual('8080', url.port);
-    testing.expectEqual('http://example.com:8080', url.origin);
+    const url = new URL('https://example.com/path#');
+    testing.expectEqual('', url.hash);
+  }
+
+  // Setting the hash, with and without a leading '#'.
+  {
+    const url = new URL('https://example.com/path');
+    url.hash = '#section';
+    testing.expectEqual('#section', url.hash);
+    testing.expectEqual('https://example.com/path#section', url.href);
   }
 
   {
     const url = new URL('https://example.com/path');
-    testing.expectEqual('https:', url.protocol);
-    testing.expectEqual('example.com', url.hostname);
-    testing.expectEqual('', url.port);
-    testing.expectEqual('https://example.com', url.origin);
+    url.hash = 'section';
+    testing.expectEqual('#section', url.hash);
+    testing.expectEqual('https://example.com/path#section', url.href);
   }
 
+  // Replacing an existing fragment.
   {
-    const url = new URL('https://example.com:443/path');
-    testing.expectEqual('https:', url.protocol);
-    testing.expectEqual('example.com', url.hostname);
-    testing.expectEqual('443', url.port);
-    testing.expectEqual('https://example.com', url.origin);
+    const url = new URL('https://example.com/path#old');
+    url.hash = 'new';
+    testing.expectEqual('#new', url.hash);
+    testing.expectEqual('https://example.com/path#new', url.href);
   }
 
+  // Setting an empty string clears the fragment entirely.
   {
-    const url = new URL('http://example.com:80/path');
-    testing.expectEqual('http:', url.protocol);
-    testing.expectEqual('example.com', url.hostname);
-    testing.expectEqual('80', url.port);
-    testing.expectEqual('http://example.com', url.origin);
+    const url = new URL('https://example.com/path#section');
+    url.hash = '';
+    testing.expectEqual('', url.hash);
+    testing.expectEqual('https://example.com/path', url.href);
   }
 
+  // The hash setter percent-encodes spaces.
   {
-    const url = new URL('ftp://example.com/path');
-    testing.expectEqual('ftp:', url.protocol);
-    testing.expectEqual('null', url.origin);
+    const url = new URL('https://example.com/path');
+    url.hash = 'a b';
+    testing.expectEqual('#a%20b', url.hash);
+  }
+
+  // Setting the hash leaves the path and query intact.
+  {
+    const url = new URL('https://example.com/path?a=b#hash');
+    url.hash = 'newhash';
+    testing.expectEqual('#newhash', url.hash);
+    testing.expectEqual('https://example.com/path?a=b#newhash', url.href);
   }
 </script>
 
-<script id=searchParams>
+<script id=search>
+  // search includes the leading '?'.
   {
-    const url = new URL('https://example.com/path?foo=bar&baz=qux');
-    testing.expectEqual('bar', url.searchParams.get('foo'));
-    testing.expectEqual('qux', url.searchParams.get('baz'));
-    testing.expectEqual(2, url.searchParams.size);
+    const url = new URL('http://example.com/path?a=b');
+    testing.expectEqual('?a=b', url.search);
   }
 
   {
-    const url = new URL('https://example.com/path?foo=bar&baz=qux');
-    url.searchParams.set('foo', 'updated');
-    url.searchParams.append('new', 'param');
-    const href = url.href;
-    testing.expectEqual(true, href.includes('foo=updated'));
-    testing.expectEqual(true, href.includes('new=param'));
+    const url = new URL('http://example.com/path?x=1&y=2');
+    testing.expectEqual('?x=1&y=2', url.search);
+  }
+
+  // No query -> empty search.
+  {
+    const url = new URL('http://example.com/path');
+    testing.expectEqual('', url.search);
+  }
+
+  // An empty query ('...?') -> empty search.
+  {
+    const url = new URL('http://example.com/path?');
+    testing.expectEqual('', url.search);
+  }
+
+  // Setting the search, with and without a leading '?'.
+  {
+    const url = new URL('https://example.com/path');
+    url.search = 'a=b';
+    testing.expectEqual('?a=b', url.search);
+    testing.expectEqual('https://example.com/path?a=b', url.href);
   }
 
   {
     const url = new URL('https://example.com/path');
-    testing.expectEqual(0, url.searchParams.size);
-    url.searchParams.set('added', 'value');
-    testing.expectEqual(true, url.href.includes('?added=value'));
+    url.search = '?a=b';
+    testing.expectEqual('?a=b', url.search);
+    testing.expectEqual('https://example.com/path?a=b', url.href);
   }
 
+  // Replacing an existing query.
   {
-    const url = new URL('https://example.com/path?a=1#section');
-    testing.expectEqual('1', url.searchParams.get('a'));
-    url.searchParams.set('b', '2');
-    const href = url.href;
-    testing.expectEqual(true, href.includes('a=1'));
-    testing.expectEqual(true, href.includes('b=2'));
-    testing.expectEqual(true, href.endsWith('#section'));
+    const url = new URL('https://example.com/path?old=1');
+    url.search = 'new=2';
+    testing.expectEqual('?new=2', url.search);
+    testing.expectEqual('https://example.com/path?new=2', url.href);
   }
 
+  // Setting an empty string clears the query entirely.
   {
-    const url = new URL('https://example.com/?x=1&y=2&z=3');
+    const url = new URL('https://example.com/path?a=b');
+    url.search = '';
+    testing.expectEqual('', url.search);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+
+  // The search setter percent-encodes spaces.
+  {
+    const url = new URL('https://example.com/path');
+    url.search = 'a=b c';
+    testing.expectEqual('?a=b%20c', url.search);
+  }
+
+  // Setting the search leaves the path and fragment intact.
+  {
+    const url = new URL('https://example.com/path?old=1#frag');
+    url.search = 'new=2';
+    testing.expectEqual('?new=2', url.search);
+    testing.expectEqual('https://example.com/path?new=2#frag', url.href);
+  }
+
+  // searchParams is seeded from the parsed query.
+  {
+    const url = new URL('http://example.com/?a=b&c=d');
+    testing.expectEqual('b', url.searchParams.get('a'));
+    testing.expectEqual('d', url.searchParams.get('c'));
+    testing.expectEqual(2, url.searchParams.size);
+  }
+</script>
+
+<script id=href_setter>
+  // Setting href re-parses with no base: an absolute URL replaces everything.
+  {
+    const url = new URL('https://example.com/path?a=b#hash');
+    url.href = 'http://other.com/';
+    testing.expectEqual('http://other.com/', url.href);
+  }
+
+  // A failed href setter throws TypeError and leaves the URL unchanged
+  // (also exercises the no-use-after-free path).
+  {
+    const url = new URL('https://example.com/path');
+    testing.withError((err) => {
+      testing.expectEqual(true, err.toString().includes('TypeError'));
+    }, () => {
+      url.href = 'not a url';
+    });
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+</script>
+
+<script id=search_params_sync>
+  // Materializing an empty searchParams must not add a spurious '?'.
+  {
+    const url = new URL('http://example.com/');
+    url.searchParams;
+    testing.expectEqual('http://example.com/', url.href);
+    testing.expectEqual('', url.search);
+  }
+
+  // searchParams mutations are reflected in both search and href.
+  {
+    const url = new URL('http://example.com/path');
+    url.searchParams.append('a', '1');
+    url.searchParams.append('b', '2');
+    testing.expectEqual('?a=1&b=2', url.search);
+    testing.expectEqual(true, url.href.includes('a=1'));
+    testing.expectEqual(true, url.href.includes('b=2'));
+  }
+
+  // delete is reflected in href.
+  {
+    const url = new URL('http://example.com/?x=1&y=2&z=3');
     url.searchParams.delete('y');
     const href = url.href;
     testing.expectEqual(true, href.includes('x=1'));
@@ -422,463 +933,64 @@
     testing.expectEqual(true, href.includes('z=3'));
   }
 
+  // searchParams is the same object across accesses.
   {
-    const url = new URL('https://example.com/?test=1');
-    const sp1 = url.searchParams;
-    const sp2 = url.searchParams;
-    testing.expectEqual(true, sp1 === sp2);
+    const url = new URL('http://example.com/?test=1');
+    testing.expectEqual(true, url.searchParams === url.searchParams);
   }
 
+  // Clearing via url.search='' preserves the searchParams object identity and
+  // empties it (SameObject), and removes the query from search/href.
   {
-    const url = new URL('https://example.com/path?a=1&b=2');
-    url.searchParams.delete('a');
-    url.searchParams.delete('b');
-    testing.expectEqual('https://example.com/path', url.href);
-  }
+    const url = new URL('http://example.com/?a=b');
+    const sp = url.searchParams;
+    testing.expectEqual('b', sp.get('a'));
 
-  {
-    let url = new URL("https://foo.bar");
-    const searchParams = url.searchParams;
-
-    // SearchParams should be empty.
-    testing.expectEqual(0, searchParams.size);
-
-    url.href = "https://lightpanda.io?over=9000&light=panda";
-    // It won't hurt to check href and host too.
-    testing.expectEqual("https://lightpanda.io/?over=9000&light=panda", url.href);
-    testing.expectEqual("lightpanda.io", url.host);
-    // SearchParams should be updated too when URL is set.
-    testing.expectEqual(2, searchParams.size);
-    testing.expectEqual("9000", searchParams.get("over"));
-    testing.expectEqual("panda", searchParams.get("light"));
+    url.search = '';
+    testing.expectEqual(true, url.searchParams === sp);
+    testing.expectEqual(0, sp.size);
+    testing.expectEqual(null, sp.get('a'));
+    testing.expectEqual('', url.search);
+    testing.expectEqual('http://example.com/', url.href);
   }
 </script>
 
-<script id=stringifier>
-{
-  const url1 = new URL('https://example.com/api');
-  const url2 = new URL(url1);
-  testing.expectEqual('https://example.com/api', url2.href);
-}
-
-{
-  const obj = {
-    toString() {
-      return 'https://example.com/custom';
-    }
-  };
-  const url = new URL(obj);
-  testing.expectEqual('https://example.com/custom', url.href);
-}
-
-{
-  const baseUrl = new URL('https://example.com/');
-  const url = new URL('/path', baseUrl);
-  testing.expectEqual('https://example.com/path', url.href);
-}
-
-{
-  const obj = {
-    toString() {
-      return 'https://example.com/';
-    }
-  };
-  const url = new URL('/relative', obj);
-  testing.expectEqual('https://example.com/relative', url.href);
-}
-
-{
-  const anchor = document.createElement('a');
-  anchor.href = 'https://example.com/test';
-  const url = new URL(anchor);
-  testing.expectEqual('https://example.com/test', url.href);
-}
-
-{
-  const anchor = document.createElement('a');
-  anchor.href = 'https://example.com/base/';
-  const url = new URL('relative', anchor);
-  testing.expectEqual('https://example.com/base/relative', url.href);
-}
-</script>
-
-<script id=setters>
-{
-  const url = new URL('https://example.com/path');
-  url.href = 'https://newdomain.com/newpath';
-  testing.expectEqual('https://newdomain.com/newpath', url.href);
-  testing.expectEqual('newdomain.com', url.hostname);
-  testing.expectEqual('/newpath', url.pathname);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b#hash');
-  url.href = 'http://other.com/';
-  testing.expectEqual('http://other.com/', url.href);
-  testing.expectEqual('', url.search);
-  testing.expectEqual('', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.protocol = 'http';
-  testing.expectEqual('http://example.com/path', url.href);
-  testing.expectEqual('http:', url.protocol);
-}
-
-{
-  const url = new URL('http://example.com/path');
-  url.protocol = 'https:';
-  testing.expectEqual('https://example.com/path', url.href);
-  testing.expectEqual('https:', url.protocol);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.hostname = 'newhost.com';
-  testing.expectEqual('https://newhost.com/path', url.href);
-  testing.expectEqual('newhost.com', url.hostname);
-}
-
-{
-  const url = new URL('https://example.com:8080/path');
-  url.hostname = 'newhost.com';
-  testing.expectEqual('https://newhost.com:8080/path', url.href);
-  testing.expectEqual('newhost.com', url.hostname);
-  testing.expectEqual('8080', url.port);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.host = 'newhost.com:9000';
-  testing.expectEqual('https://newhost.com:9000/path', url.href);
-  testing.expectEqual('newhost.com', url.hostname);
-  testing.expectEqual('9000', url.port);
-}
-
-{
-  const url = new URL('https://example.com:8080/path');
-  url.host = 'newhost.com';
-  testing.expectEqual('https://newhost.com:8080/path', url.href);
-  testing.expectEqual('newhost.com', url.hostname);
-  testing.expectEqual('8080', url.port);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.port = '8080';
-  testing.expectEqual('https://example.com:8080/path', url.href);
-  testing.expectEqual('8080', url.port);
-}
-
-{
-  const url = new URL('https://example.com:8080/path');
-  url.port = '';
-  testing.expectEqual('https://example.com/path', url.href);
-  testing.expectEqual('', url.port);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.port = '443';
-  testing.expectEqual('https://example.com/path', url.href);
-  testing.expectEqual('', url.port);
-}
-
-{
-  const url = new URL('http://example.com/path');
-  url.port = '80';
-  testing.expectEqual('http://example.com/path', url.href);
-  testing.expectEqual('', url.port);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.pathname = '/newpath';
-  testing.expectEqual('https://example.com/newpath', url.href);
-  testing.expectEqual('/newpath', url.pathname);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.pathname = 'newpath';
-  testing.expectEqual('https://example.com/newpath', url.href);
-  testing.expectEqual('/newpath', url.pathname);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b#hash');
-  url.pathname = '/new/path';
-  testing.expectEqual('https://example.com/new/path?a=b#hash', url.href);
-  testing.expectEqual('/new/path', url.pathname);
-}
-
-// Pathname setter must percent-encode spaces and special characters
-{
-  const url = new URL('http://a/');
-  url.pathname = 'c d';
-  testing.expectEqual('http://a/c%20d', url.href);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.pathname = '/path with spaces/file name';
-  testing.expectEqual('https://example.com/path%20with%20spaces/file%20name', url.href);
-  testing.expectEqual('/path%20with%20spaces/file%20name', url.pathname);
-}
-
-// Already-encoded sequences should not be double-encoded
-{
-  const url = new URL('https://example.com/path');
-  url.pathname = '/already%20encoded';
-  testing.expectEqual('https://example.com/already%20encoded', url.href);
-}
-
-// This is the exact check the URL polyfill uses to decide if native URL is sufficient
-{
-  const url = new URL('b', 'http://a');
-  url.pathname = 'c d';
-  testing.expectEqual('http://a/c%20d', url.href);
-  testing.expectEqual(true, !!url.searchParams);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.search = '?a=b';
-  testing.expectEqual('https://example.com/path?a=b', url.href);
-  testing.expectEqual('?a=b', url.search);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.search = 'a=b';
-  testing.expectEqual('https://example.com/path?a=b', url.href);
-  testing.expectEqual('?a=b', url.search);
-}
-
-{
-  const url = new URL('https://example.com/path?old=value');
-  url.search = 'new=value';
-  testing.expectEqual('https://example.com/path?new=value', url.href);
-  testing.expectEqual('?new=value', url.search);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b#hash');
-  url.search = 'c=d';
-  testing.expectEqual('https://example.com/path?c=d#hash', url.href);
-  testing.expectEqual('?c=d', url.search);
-  testing.expectEqual('#hash', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.hash = '#section';
-  testing.expectEqual('https://example.com/path#section', url.href);
-  testing.expectEqual('#section', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.hash = 'section';
-  testing.expectEqual('https://example.com/path#section', url.href);
-  testing.expectEqual('#section', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path#old');
-  url.hash = 'new';
-  testing.expectEqual('https://example.com/path#new', url.href);
-  testing.expectEqual('#new', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b#hash');
-  url.hash = 'newhash';
-  testing.expectEqual('https://example.com/path?a=b#newhash', url.href);
-  testing.expectEqual('?a=b', url.search);
-  testing.expectEqual('#newhash', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path#hash');
-  url.hash = '';
-  testing.expectEqual('https://example.com/path', url.href);
-  testing.expectEqual('', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.hash = '#a b';
-  testing.expectEqual('https://example.com/path#a%20b', url.href);
-  testing.expectEqual('#a%20b', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path');
-  url.hash = 'a b';
-  testing.expectEqual('https://example.com/path#a%20b', url.href);
-  testing.expectEqual('#a%20b', url.hash);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b');
-  url.search = '';
-  testing.expectEqual('https://example.com/path', url.href);
-  testing.expectEqual('', url.search);
-}
-
-{
-  const url = new URL('https://example.com/path?a=b');
-  const sp = url.searchParams;
-  testing.expectEqual('b', sp.get('a'));
-  url.search = 'c=d';
-
-  testing.expectEqual('d', url.searchParams.get('c'));
-  testing.expectEqual(null, url.searchParams.get('a'));
-}
-
-{
-  const url = new URL('https://example.com/path?a=b');
-  const sp = url.searchParams;
-  testing.expectEqual('b', sp.get('a'));
-  url.search = 'c=d b';
-
-  testing.expectEqual('d b', url.searchParams.get('c'));
-  testing.expectEqual(null, url.searchParams.get('a'));
-
-  url.search = 'c d=d b';
-  testing.expectEqual('d b', url.searchParams.get('c d'));
-  testing.expectEqual(null, url.searchParams.get('c'));
-}
-
-{
-  const url = new URL('https://example.com/path?a=b');
-  const sp = url.searchParams;
-  testing.expectEqual('b', sp.get('a'));
-  url.href = 'https://example.com/other?x=y';
-
-  testing.expectEqual('y', url.searchParams.get('x'));
-  testing.expectEqual(null, url.searchParams.get('a'));
-}
-</script>
-
-<script id=canParse>
-{
-  testing.expectEqual('function', typeof URL.canParse);
-}
-
-{
-  testing.expectEqual(true, URL.canParse('https://example.com'));
-  testing.expectEqual(true, URL.canParse('http://example.com/path'));
-  testing.expectEqual(true, URL.canParse('https://example.com:8080/path?a=b#hash'));
-  testing.expectEqual(true, URL.canParse('ftp://example.com'));
-}
-
-{
-  testing.expectEqual(false, URL.canParse(''));
-  testing.expectEqual(false, URL.canParse('foo.js'));
-  testing.expectEqual(false, URL.canParse('/path/to/file'));
-  testing.expectEqual(false, URL.canParse('?query=value'));
-  testing.expectEqual(false, URL.canParse('#fragment'));
-}
-
-{
-  testing.expectEqual(true, URL.canParse('subpath', 'http://example.com/path/'));
-  testing.expectEqual(true, URL.canParse('/newpath', 'http://example.com/path'));
-  testing.expectEqual(true, URL.canParse('?a=b', 'http://example.com/path'));
-  testing.expectEqual(true, URL.canParse('#hash', 'http://example.com/path'));
-  testing.expectEqual(true, URL.canParse('../foo', 'http://example.com/a/b/c'));
-}
-
-{
-  testing.expectEqual(false, URL.canParse('foo.js', undefined));
-  testing.expectEqual(false, URL.canParse('subpath', undefined));
-  testing.expectEqual(false, URL.canParse('../foo', undefined));
-}
-
-{
-  testing.expectEqual(false, URL.canParse('foo.js', 'not a url'));
-  testing.expectEqual(false, URL.canParse('foo.js', 'bar/baz'));
-  testing.expectEqual(false, URL.canParse('subpath', 'relative/path'));
-}
-
-{
-  testing.expectEqual(false, URL.canParse('http://example.com/absolute', 'invalid base'));
-  testing.expectEqual(false, URL.canParse('https://example.com/path', 'not-a-url'));
-}
-
-{
-  testing.expectEqual(false, URL.canParse('http://example.com', ''));
-  testing.expectEqual(false, URL.canParse('http://example.com', 'relative'));
-}
-
-{
-  testing.expectEqual(true, URL.canParse('http://example.com/absolute', 'http://base.com'));
-  testing.expectEqual(true, URL.canParse('https://example.com/path', 'https://other.com'));
-}
-</script>
-
-<script id=query_encode>
+<script id=origin>
+  // origin is scheme://host[:port], with default ports omitted.
   {
-    let url = new URL('https://foo.bar/path?a=~&b=%7E#fragment');
-    testing.expectEqual("~", url.searchParams.get('a'));
-    testing.expectEqual("~", url.searchParams.get('b'));
+    const url = new URL('http://user:pass@example.com:8080/path?query=1#hash');
+    testing.expectEqual('http://example.com:8080', url.origin);
+  }
 
-    url.searchParams.append('c', 'foo');
-    testing.expectEqual("foo", url.searchParams.get('c'));
-    testing.expectEqual(1, url.searchParams.getAll('c').length);
-    testing.expectEqual("foo", url.searchParams.getAll('c')[0]);
-    testing.expectEqual(3, url.searchParams.size);
+  {
+    const url = new URL('https://example.com/path');
+    testing.expectEqual('https://example.com', url.origin);
+  }
 
-    // search is dynamic
-    testing.expectEqual("?a=%7E&b=%7E&c=foo", url.search);
+  {
+    const url = new URL('https://example.com:443/path');
+    testing.expectEqual('https://example.com', url.origin);
+  }
+
+  {
+    const url = new URL('http://example.com:80/path');
+    testing.expectEqual('http://example.com', url.origin);
+  }
+
+  // ftp is a special, tuple-origin scheme (like http/https/ws/wss).
+  {
+    testing.expectEqual('ftp://example.com', new URL('ftp://example.com/path').origin);
+  }
+
+  // Non-special schemes have an opaque (null) origin.
+  {
+    testing.expectEqual('null', new URL('about:blank').origin);
+    testing.expectEqual('null', new URL('mailto:foo@bar.com').origin);
   }
 </script>
 
-<script id=objectURL>
-{
-  // Test createObjectURL with Blob
-  const blob = new Blob(['<html><body>Hello</body></html>'], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-
-  testing.expectEqual('string', typeof url);
-  testing.expectEqual(true, url.startsWith('blob:'));
-  testing.expectEqual(true, url.includes('http'));
-}
-
-{
-  // Test revokeObjectURL
-  const blob = new Blob(['test'], { type: 'text/plain' });
-  const url = URL.createObjectURL(blob);
-
-  testing.expectEqual(true, url.startsWith('blob:'));
-
-  URL.revokeObjectURL(url);
-  URL.revokeObjectURL(url); // Second revoke should be safe
-}
-
-{
-  // Test with non-blob URL (should be safe/silent)
-  URL.revokeObjectURL('http://example.com/notblob');
-  URL.revokeObjectURL('');
-  testing.expectEqual(true, true);
-}
-
-{
-  // Test uniqueness
-  const blob1 = new Blob(['test1']);
-  const blob2 = new Blob(['test2']);
-  const url1 = URL.createObjectURL(blob1);
-  const url2 = URL.createObjectURL(blob2);
-
-  testing.expectEqual(false, url1 === url2);
-  testing.expectEqual(true, url1.startsWith('blob:'));
-  testing.expectEqual(true, url2.startsWith('blob:'));
-}
-</script>
-
-<script id="about:blank">
+<script id=about_blank>
+  // about:blank exposes every component consistently.
   {
     const url = new URL('about:blank');
     testing.expectEqual('about:blank', url.href);
@@ -891,12 +1003,12 @@
     testing.expectEqual('', url.hostname);
     testing.expectEqual('', url.port);
     testing.expectEqual('', url.search);
+    testing.expectEqual('', url.hash);
   }
 </script>
 
 <script id=idna>
-  // WHATWG "domain to ASCII": non-ASCII hosts are converted to punycode at
-  // parse time, so getters always return the ASCII form.
+  // IDN hosts are converted to punycode (UTS#46) at parse time.
   {
     const url = new URL('https://räksmörgås.se/');
     testing.expectEqual('xn--rksmrgs-5wao1o.se', url.hostname);
@@ -904,17 +1016,16 @@
     testing.expectEqual('https://xn--rksmrgs-5wao1o.se/', url.href);
   }
 
-  // UTS#46 non-transitional processing preserves ß rather than mapping to ss.
+  // UTS#46 non-transitional processing preserves ß.
   {
     const url = new URL('https://faß.de/');
     testing.expectEqual('xn--fa-hia.de', url.hostname);
   }
 
-  // Pure-ASCII hosts must not be touched.
+  // Pure-ASCII hosts are untouched.
   {
     const url = new URL('https://example.com/');
     testing.expectEqual('example.com', url.hostname);
-    testing.expectEqual('https://example.com/', url.href);
   }
 
   // IDN preserved alongside port, userinfo, path, query, and fragment.
@@ -940,5 +1051,138 @@
     const url = new URL('/about', 'https://räksmörgås.se/');
     testing.expectEqual('xn--rksmrgs-5wao1o.se', url.hostname);
     testing.expectEqual('https://xn--rksmrgs-5wao1o.se/about', url.href);
+  }
+</script>
+
+<script id=stringifier>
+  // The constructor stringifies its url/base arguments.
+  {
+    const url1 = new URL('https://example.com/api');
+    const url2 = new URL(url1);
+    testing.expectEqual('https://example.com/api', url2.href);
+  }
+
+  {
+    const obj = { toString() { return 'https://example.com/custom'; } };
+    const url = new URL(obj);
+    testing.expectEqual('https://example.com/custom', url.href);
+  }
+
+  {
+    const baseUrl = new URL('https://example.com/');
+    const url = new URL('/path', baseUrl);
+    testing.expectEqual('https://example.com/path', url.href);
+  }
+
+  {
+    const obj = { toString() { return 'https://example.com/'; } };
+    const url = new URL('/relative', obj);
+    testing.expectEqual('https://example.com/relative', url.href);
+  }
+
+  {
+    const anchor = document.createElement('a');
+    anchor.href = 'https://example.com/test';
+    const url = new URL(anchor);
+    testing.expectEqual('https://example.com/test', url.href);
+  }
+
+  {
+    const anchor = document.createElement('a');
+    anchor.href = 'https://example.com/base/';
+    const url = new URL('relative', anchor);
+    testing.expectEqual('https://example.com/base/relative', url.href);
+  }
+</script>
+
+<script id=object_url>
+  // createObjectURL mints a unique blob: URL.
+  {
+    const blob = new Blob(['<html><body>Hello</body></html>'], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    testing.expectEqual('string', typeof url);
+    testing.expectEqual(true, url.startsWith('blob:'));
+  }
+
+  // revokeObjectURL is idempotent and safe on non-blob URLs.
+  {
+    const blob = new Blob(['test'], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    URL.revokeObjectURL(url);
+    URL.revokeObjectURL(url);
+    URL.revokeObjectURL('http://example.com/notblob');
+    URL.revokeObjectURL('');
+  }
+
+  // Each createObjectURL is unique.
+  {
+    const url1 = URL.createObjectURL(new Blob(['test1']));
+    const url2 = URL.createObjectURL(new Blob(['test2']));
+    testing.expectEqual(false, url1 === url2);
+  }
+</script>
+
+<script id=search_params>
+  // get / size from the parsed query.
+  {
+    const url = new URL('https://example.com/path?foo=bar&baz=qux');
+    testing.expectEqual('bar', url.searchParams.get('foo'));
+    testing.expectEqual('qux', url.searchParams.get('baz'));
+    testing.expectEqual(2, url.searchParams.size);
+  }
+
+  // set + append are reflected in href.
+  {
+    const url = new URL('https://example.com/path?foo=bar');
+    url.searchParams.set('foo', 'updated');
+    url.searchParams.append('new', 'param');
+    const href = url.href;
+    testing.expectEqual(true, href.includes('foo=updated'));
+    testing.expectEqual(true, href.includes('new=param'));
+  }
+
+  // set on a query-less URL adds the query.
+  {
+    const url = new URL('https://example.com/path');
+    testing.expectEqual(0, url.searchParams.size);
+    url.searchParams.set('added', 'value');
+    testing.expectEqual(true, url.href.includes('?added=value'));
+  }
+
+  // searchParams mutation preserves the fragment.
+  {
+    const url = new URL('https://example.com/path?a=1#section');
+    url.searchParams.set('b', '2');
+    const href = url.href;
+    testing.expectEqual(true, href.includes('a=1'));
+    testing.expectEqual(true, href.includes('b=2'));
+    testing.expectEqual(true, href.endsWith('#section'));
+  }
+
+  // Setting href updates the live searchParams object in place.
+  {
+    const url = new URL('https://foo.bar');
+    const searchParams = url.searchParams;
+    testing.expectEqual(0, searchParams.size);
+
+    url.href = 'https://lightpanda.io?over=9000&light=panda';
+    testing.expectEqual('https://lightpanda.io/?over=9000&light=panda', url.href);
+    testing.expectEqual('lightpanda.io', url.host);
+    testing.expectEqual(2, searchParams.size);
+    testing.expectEqual('9000', searchParams.get('over'));
+    testing.expectEqual('panda', searchParams.get('light'));
+  }
+
+  // Percent-encoding: '~' and '%7E' both decode to '~', and search is dynamic.
+  {
+    const url = new URL('https://foo.bar/path?a=~&b=%7E#fragment');
+    testing.expectEqual('~', url.searchParams.get('a'));
+    testing.expectEqual('~', url.searchParams.get('b'));
+
+    url.searchParams.append('c', 'foo');
+    testing.expectEqual('foo', url.searchParams.get('c'));
+    testing.expectEqual(1, url.searchParams.getAll('c').length);
+    testing.expectEqual(3, url.searchParams.size);
+    testing.expectEqual('?a=%7E&b=%7E&c=foo', url.search);
   }
 </script>

--- a/src/browser/tests/window/location.html
+++ b/src/browser/tests/window/location.html
@@ -31,3 +31,40 @@
 <script id=location_search_setter>
   testing.expectEqual('function', typeof Object.getOwnPropertyDescriptor(Location.prototype, 'search').set);
 </script>
+
+<div id="sec1"></div>
+<div id="sec2"></div>
+
+<script id=location_target>
+  // :target must reflect the CURRENT location's fragment. Each fragment
+  // navigation replaces the backing Location, so this verifies the selector
+  // reads the live location (not a stale/freed one), and that fragment
+  // navigation releases the previous Location without breaking the chain.
+  const sec1 = document.getElementById('sec1');
+  const sec2 = document.getElementById('sec2');
+
+  location.hash = "#sec1";
+  testing.expectEqual(true, sec1.matches(':target'));
+  testing.expectEqual(false, sec2.matches(':target'));
+
+  // Navigate to a new fragment: :target must follow the new location.
+  location.hash = "#sec2";
+  testing.expectEqual(false, sec1.matches(':target'));
+  testing.expectEqual(true, sec2.matches(':target'));
+
+  // No fragment -> nothing is :target.
+  location.hash = "";
+  testing.expectEqual(false, sec1.matches(':target'));
+  testing.expectEqual(false, sec2.matches(':target'));
+</script>
+
+<script id=location_fragment_churn>
+  // Hammer fragment navigation: every iteration creates a new Location and must
+  // release the previous one. Consistency must hold throughout.
+  for (let i = 0; i < 50; i++) {
+    location.hash = "#h" + i;
+    testing.expectEqual("#h" + i, location.hash);
+  }
+  location.hash = "";
+  testing.expectEqual("", location.hash);
+</script>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -50,7 +50,6 @@ const Document = @This();
 _type: Type,
 _proto: *Node,
 _frame: ?*Frame = null,
-_location: ?*Location = null,
 _url: ?[:0]const u8 = null, // URL for documents created via DOMImplementation (about:blank)
 _ready_state: ReadyState = .loading,
 _current_script: ?*Element.Html.Script = null,

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -62,7 +62,8 @@ pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8
     _ = try frame._session.navigation.pushEntry(url, .{ .source = .history, .value = json }, frame, true);
 
     frame.url = url;
-    frame.window._location._url = try URL.init(url, null, &frame.js.execution);
+    // setHref == reinitializing.
+    try frame.window._location._url.setHref(url, &frame.js.execution);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, frame: *Frame) !void {
@@ -76,7 +77,13 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
     _ = try frame._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, frame, true);
 
     frame.url = url;
-    frame.window._location = try Location.init(url, frame);
+
+    frame.window._location.releaseRef(frame._page);
+    // Initialize new location.
+    const location = try Location.init(url, frame);
+    location.acquireRef();
+    errdefer location.releaseRef(frame._page);
+    frame.window._location = location;
 }
 
 fn goInner(delta: i32, frame: *Frame) !void {

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -20,9 +20,7 @@ const std = @import("std");
 const js = @import("../js/js.zig");
 
 const Frame = @import("../Frame.zig");
-const Location = @import("Location.zig");
 const PopStateEvent = @import("event/PopStateEvent.zig");
-const URL = @import("URL.zig");
 
 const History = @This();
 
@@ -77,13 +75,8 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
     _ = try frame._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, frame, true);
 
     frame.url = url;
-
-    frame.window._location.releaseRef(frame._page);
-    // Initialize new location.
-    const location = try Location.init(url, frame);
-    location.acquireRef();
-    errdefer location.releaseRef(frame._page);
-    frame.window._location = location;
+    // setHref == reinitializing.
+    try frame.window._location._url.setHref(url, &frame.js.execution);
 }
 
 fn goInner(delta: i32, frame: *Frame) !void {

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -116,7 +116,7 @@ pub fn reload(_: *const Location, frame: *Frame) !void {
 }
 
 pub fn toString(self: *const Location, exec: *const js.Execution) ![:0]const u8 {
-    return self._url.toString(exec);
+    return self._url.toString1(exec);
 }
 
 pub const JsApi = struct {

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -17,8 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
+const Page = @import("../Page.zig");
 const URL = @import("URL.zig");
 const U = @import("../URL.zig");
 const Frame = @import("../Frame.zig");
@@ -26,12 +28,28 @@ const Frame = @import("../Frame.zig");
 const Location = @This();
 
 _url: *URL,
+_rc: lp.RC(u32) = .{},
 
 pub fn init(raw_url: []const u8, frame: *Frame) !*Location {
     const url = try URL.init(raw_url, null, &frame.js.execution);
+    url.acquireRef();
+    errdefer url.releaseRef(frame._page);
+
     return frame._factory.create(Location{
         ._url = url,
     });
+}
+
+pub fn deinit(self: *const Location, page: *Page) void {
+    self._url.releaseRef(page);
+}
+
+pub fn acquireRef(self: *Location) void {
+    self._rc.acquire();
+}
+
+pub fn releaseRef(self: *Location, page: *Page) void {
+    self._rc.release(self, page);
 }
 
 pub fn getPathname(self: *const Location) []const u8 {

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -27,7 +27,7 @@ const Location = @This();
 
 _url: *URL,
 
-pub fn init(raw_url: [:0]const u8, frame: *Frame) !*Location {
+pub fn init(raw_url: []const u8, frame: *Frame) !*Location {
     const url = try URL.init(raw_url, null, &frame.js.execution);
     return frame._factory.create(Location{
         ._url = url,
@@ -115,8 +115,8 @@ pub fn reload(_: *const Location, frame: *Frame) !void {
     return frame.scheduleNavigation(frame.url, .{ .reason = .script, .kind = .reload }, .{ .script = frame });
 }
 
-pub fn toString(self: *const Location, exec: *const js.Execution) ![:0]const u8 {
-    return self._url.toString1(exec);
+pub fn toString(self: *const Location, exec: *const js.Execution) ![]const u8 {
+    return self._url.toString(exec);
 }
 
 pub const JsApi = struct {

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -20,7 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
-const U_ = @import("../../sys/url.zig");
+const U = @import("../../sys/url.zig");
 const Page = @import("../Page.zig");
 const URLSearchParams = @import("net/URLSearchParams.zig");
 const Blob = @import("Blob.zig");
@@ -28,7 +28,7 @@ const Execution = js.Execution;
 
 const URL = @This();
 
-_url: *U_.Url = undefined,
+_url: *U.Url = undefined,
 /// Largest port possible is 65535; which require 5 bytes.
 _port: [5]u8 = undefined,
 _search_params: ?*URLSearchParams = null,
@@ -55,7 +55,7 @@ pub fn init(url: []const u8, maybe_base: ?[]const u8, exec: *const Execution) !*
 
 pub fn deinit(self: *URL, _: *Page) void {
     // Not tracked by arena.
-    U_.url_free(self._url);
+    U.url_free(self._url);
 }
 
 pub fn acquireRef(self: *URL) void {
@@ -69,12 +69,12 @@ pub fn releaseRef(self: *URL, page: *Page) void {
 pub fn getUsername(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    U_.url_get_username(self._url, &out, &len);
+    U.url_get_username(self._url, &out, &len);
     return out[0..len];
 }
 
 pub fn setUsername(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_username(self._url, value.ptr, value.len);
+    const res = U.url_set_username(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetUsername;
     }
@@ -83,7 +83,7 @@ pub fn setUsername(self: *URL, value: []const u8) !void {
 pub fn getPassword(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const res = U_.url_get_password(self._url, &out, &len);
+    const res = U.url_get_password(self._url, &out, &len);
     if (res != 0) {
         return "";
     }
@@ -91,7 +91,7 @@ pub fn getPassword(self: *const URL) []const u8 {
 }
 
 pub fn setPassword(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_password(self._url, value.ptr, value.len);
+    const res = U.url_set_password(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetPassword;
     }
@@ -100,12 +100,12 @@ pub fn setPassword(self: *URL, value: []const u8) !void {
 pub fn getPathname(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    U_.url_get_path(self._url, &out, &len);
+    U.url_get_path(self._url, &out, &len);
     return out[0..len];
 }
 
 pub fn setPathname(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_path(self._url, value.ptr, value.len);
+    const res = U.url_set_path(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetPathname;
     }
@@ -114,14 +114,14 @@ pub fn setPathname(self: *URL, value: []const u8) !void {
 pub fn getProtocol(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    U_.url_get_scheme(self._url, &out, &len);
+    U.url_get_scheme(self._url, &out, &len);
     // rust-url's scheme() omits the ':'. The serialization always has it right
     // after the scheme ("https://..."), so we extend the borrowed slice by one.
     return out[0 .. len + 1];
 }
 
 pub fn setProtocol(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_scheme(self._url, value.ptr, value.len);
+    const res = U.url_set_scheme(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetProtocol;
     }
@@ -130,14 +130,14 @@ pub fn setProtocol(self: *URL, value: []const u8) !void {
 pub fn getHostname(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    if (U_.url_get_hostname(self._url, &out, &len) != 0) {
+    if (U.url_get_hostname(self._url, &out, &len) != 0) {
         return "";
     }
     return out[0..len];
 }
 
 pub fn setHostname(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_hostname(self._url, value.ptr, value.len);
+    const res = U.url_set_hostname(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetHostname;
     }
@@ -146,21 +146,21 @@ pub fn setHostname(self: *URL, value: []const u8) !void {
 pub fn getHost(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    if (U_.url_get_host(self._url, &out, &len) != 0) {
+    if (U.url_get_host(self._url, &out, &len) != 0) {
         return "";
     }
     return out[0..len];
 }
 
 pub fn setHost(self: *URL, value: []const u8) !void {
-    const res = U_.url_set_host(self._url, value.ptr, value.len);
+    const res = U.url_set_host(self._url, value.ptr, value.len);
     if (res != 0) {
         return error.SetHost;
     }
 }
 
 pub fn getPort(self: *URL) []const u8 {
-    const port = U_.urlGetPort(self._url) orelse return "";
+    const port = U.urlGetPort(self._url) orelse return "";
     return std.fmt.bufPrint(&self._port, "{d}", .{port}) catch unreachable;
 }
 
@@ -168,17 +168,17 @@ pub fn getPort(self: *URL) []const u8 {
 pub fn setPort(self: *URL, maybe_value: ?[]const u8) void {
     // A null or empty value clears the port.
     const value = maybe_value orelse {
-        _ = U_.url_set_port_to_null(self._url);
+        _ = U.url_set_port_to_null(self._url);
         return;
     };
     if (value.len == 0) {
-        _ = U_.url_set_port_to_null(self._url);
+        _ = U.url_set_port_to_null(self._url);
         return;
     }
 
     // Ignore invalid port numbers, leaving the port unchanged.
     const port = std.fmt.parseInt(u16, value, 10) catch return;
-    _ = U_.url_set_port(self._url, port);
+    _ = U.url_set_port(self._url, port);
 }
 
 pub fn getSearch(self: *const URL, exec: *const Execution) ![]const u8 {
@@ -195,7 +195,7 @@ pub fn getSearch(self: *const URL, exec: *const Execution) ![]const u8 {
 
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const res = U_.url_get_query(self._url, &out, &len);
+    const res = U.url_get_query(self._url, &out, &len);
     if (res != 0 or len == 0) {
         return "";
     }
@@ -212,14 +212,14 @@ pub fn setSearch(self: *URL, value: []const u8, exec: *const Execution) !void {
             search_params._params = .empty;
         }
 
-        U_.url_set_query_to_null(self._url);
+        U.url_set_query_to_null(self._url);
         return;
     }
 
     // Strip a single leading '?', then set the query.
     const query = if (value[0] == '?') value[1..] else value;
 
-    const res = U_.url_set_query(self._url, query.ptr, query.len);
+    const res = U.url_set_query(self._url, query.ptr, query.len);
     if (res != 0) {
         return error.SetSearch;
     }
@@ -228,14 +228,14 @@ pub fn setSearch(self: *URL, value: []const u8, exec: *const Execution) !void {
     const search_params = self._search_params orelse return;
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const search_value = if (U_.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
+    const search_value = if (U.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
     try search_params.updateFromString(search_value, exec);
 }
 
 pub fn getHash(self: *const URL) []const u8 {
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const res = U_.url_get_fragment(self._url, &out, &len);
+    const res = U.url_get_fragment(self._url, &out, &len);
     // WHATWG `hash` is "" for both a null and an empty fragment.
     if (res != 0 or len == 0) {
         return "";
@@ -248,12 +248,12 @@ pub fn getHash(self: *const URL) []const u8 {
 pub fn setHash(self: *URL, value: []const u8) !void {
     // An empty value clears the fragment entirely (removes the '#').
     if (value.len == 0) {
-        U_.url_set_fragment_to_null(self._url);
+        U.url_set_fragment_to_null(self._url);
         return;
     }
     // Strip a single leading '#', then set the fragment.
     const fragment = if (value[0] == '#') value[1..] else value;
-    const res = U_.url_set_fragment(self._url, fragment.ptr, fragment.len);
+    const res = U.url_set_fragment(self._url, fragment.ptr, fragment.len);
     if (res != 0) {
         return error.SetHash;
     }
@@ -267,7 +267,7 @@ pub fn getSearchParams(self: *URL, exec: *const Execution) !*URLSearchParams {
     // Get current search string (omitting '?').
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const search_value = if (U_.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
+    const search_value = if (U.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
 
     const params = try URLSearchParams.init(.{ .query_string = search_value }, exec);
     self._search_params = params;
@@ -275,7 +275,7 @@ pub fn getSearchParams(self: *URL, exec: *const Execution) !*URLSearchParams {
 }
 
 pub fn getOrigin(self: *const URL, exec: *const Execution) ![]const u8 {
-    const origin = U_.url_get_origin(self._url);
+    const origin = U.url_get_origin(self._url);
     defer origin.deinit();
 
     return exec.call_arena.dupe(u8, origin.slice());
@@ -286,29 +286,29 @@ pub fn setHref(self: *URL, value: []const u8, exec: *const Execution) !void {
     // must not free self._url before we know we have a replacement, or any
     // later access would be a use-after-free).
     var err: i32 = 0;
-    const url = U_.url_parse(value.ptr, value.len, &err) orelse return error.TypeError;
+    const url = U.url_parse(value.ptr, value.len, &err) orelse return error.TypeError;
 
-    U_.url_free(self._url);
+    U.url_free(self._url);
     self._url = url;
 
     // Update existing searchParams if exists.
     const search_params = self._search_params orelse return;
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    const search_value = if (U_.url_get_query(url, &out, &len) == 0) out[0..len] else "";
+    const search_value = if (U.url_get_query(url, &out, &len) == 0) out[0..len] else "";
     try search_params.updateFromString(search_value, exec);
 }
 
 pub fn toString(self: *const URL, exec: *const Execution) ![]const u8 {
     if (self._search_params) |search_params| {
         if (search_params.getSize() == 0) {
-            U_.url_set_query_to_null(self._url);
+            U.url_set_query_to_null(self._url);
         } else {
             var buf = std.Io.Writer.Allocating.init(exec.call_arena);
             defer buf.deinit();
             try search_params.toString(&buf.writer);
             const query = buf.written();
-            if (U_.url_set_query(self._url, query.ptr, query.len) != 0) {
+            if (U.url_set_query(self._url, query.ptr, query.len) != 0) {
                 return error.ToString;
             }
         }
@@ -316,15 +316,15 @@ pub fn toString(self: *const URL, exec: *const Execution) ![]const u8 {
 
     var out: [*]const u8 = undefined;
     var len: usize = 0;
-    U_.url_to_string(self._url, &out, &len);
+    U.url_to_string(self._url, &out, &len);
     return out[0..len];
 }
 
 pub fn canParse(url: []const u8, maybe_base: ?[]const u8) bool {
     if (maybe_base) |base| {
-        return U_.url_can_parse_with_base(base.ptr, base.len, url.ptr, url.len);
+        return U.url_can_parse_with_base(base.ptr, base.len, url.ptr, url.len);
     }
-    return U_.url_can_parse(url.ptr, url.len);
+    return U.url_can_parse(url.ptr, url.len);
 }
 
 pub fn createObjectURL(blob: *Blob, exec: *const Execution) ![]const u8 {

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -17,9 +17,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
 const U_ = @import("../../sys/url.zig");
+const Page = @import("../Page.zig");
 const URLSearchParams = @import("net/URLSearchParams.zig");
 const Blob = @import("Blob.zig");
 const Execution = js.Execution;
@@ -30,6 +32,8 @@ _url: *U_.Url = undefined,
 /// Largest port possible is 65535; which require 5 bytes.
 _port: [5]u8 = undefined,
 _search_params: ?*URLSearchParams = null,
+/// We have to track lifetime of URL to free `_url`.
+_rc: lp.RC(u32) = .{},
 
 // convenience
 pub const resolve = @import("../URL.zig").resolve;
@@ -57,6 +61,19 @@ pub fn init(url: []const u8, maybe_base: ?[]const u8, exec: *const Execution) !*
     errdefer U_.url_free(u);
 
     return exec._factory.create(URL{ ._url = u });
+}
+
+pub fn deinit(self: *URL, _: *Page) void {
+    // Not tracked by arena.
+    U_.url_free(self._url);
+}
+
+pub fn acquireRef(self: *URL) void {
+    self._rc.acquire();
+}
+
+pub fn releaseRef(self: *URL, page: *Page) void {
+    self._rc.release(self, page);
 }
 
 pub fn getUsername(self: *const URL) []const u8 {

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -41,24 +41,14 @@ pub const eqlDocument = @import("../URL.zig").eqlDocument;
 
 pub fn init(url: []const u8, maybe_base: ?[]const u8, exec: *const Execution) !*URL {
     // NOTE: about:blank address is valid in rust-url.
-
     var err: i32 = 0;
-    if (maybe_base) |base| {
-        const base_url = U_.url_parse(base.ptr, base.len, &err) orelse return error.TypeError;
-        errdefer U_.url_free(base_url);
-
-        const joined_url = U_.url_join(base_url, url.ptr, url.len, &err) orelse return error.TypeError;
-        errdefer U_.url_free(joined_url);
-        // `base_url` has no use now.
-        U_.url_free(base_url);
-
-        return exec._factory.create(URL{ ._url = joined_url });
-    }
-
-    const u = U_.url_parse(url.ptr, url.len, &err) orelse {
-        return error.TypeError;
+    const u = blk: {
+        if (maybe_base) |base| {
+            break :blk U.url_parse_with_base(base.ptr, base.len, url.ptr, url.len, &err) orelse return error.TypeError;
+        }
+        break :blk U.url_parse(url.ptr, url.len, &err) orelse return error.TypeError;
     };
-    errdefer U_.url_free(u);
+    errdefer U.url_free(u);
 
     return exec._factory.create(URL{ ._url = u });
 }

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -19,21 +19,16 @@
 const std = @import("std");
 const js = @import("../js/js.zig");
 
-const U = @import("../URL.zig");
 const U_ = @import("../../sys/url.zig");
 const URLSearchParams = @import("net/URLSearchParams.zig");
 const Blob = @import("Blob.zig");
 const Execution = js.Execution;
 
-const Allocator = std.mem.Allocator;
-
 const URL = @This();
 
-_raw: [:0]const u8 = undefined,
 _url: *U_.Url = undefined,
 /// Largest port possible is 65535; which require 5 bytes.
 _port: [5]u8 = undefined,
-_arena: ?Allocator = null,
 _search_params: ?*URLSearchParams = null,
 
 // convenience
@@ -180,29 +175,54 @@ pub fn setPort(self: *URL, maybe_value: ?[]const u8) void {
 }
 
 pub fn getSearch(self: *const URL, exec: *const Execution) ![]const u8 {
-    // If searchParams has been accessed, generate search from it
-    if (self._search_params) |sp| {
-        if (sp.getSize() == 0) {
+    if (self._search_params) |search_params| {
+        if (search_params.getSize() == 0) {
             return "";
         }
+
         var buf = std.Io.Writer.Allocating.init(exec.call_arena);
         try buf.writer.writeByte('?');
-        try sp.toString(&buf.writer);
+        try search_params.toString(&buf.writer);
         return buf.written();
     }
-    return U.getSearch(self._raw);
+
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    const res = U_.url_get_query(self._url, &out, &len);
+    if (res != 0 or len == 0) {
+        return "";
+    }
+
+    // rust-url's query() omits the '?', which always precedes the query.
+    return (out - 1)[0 .. len + 1];
 }
 
 pub fn setSearch(self: *URL, value: []const u8, exec: *const Execution) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setSearch(self._raw, value, allocator);
+    // Empty value clears the query entirely.
+    if (value.len == 0) {
+        // Reset searchParams.
+        if (self._search_params) |search_params| {
+            search_params._params = .empty;
+        }
 
-    // Update existing searchParams if it exists
-    if (self._search_params) |sp| {
-        const search = U.getSearch(self._raw);
-        const search_value = if (search.len > 0) search[1..] else "";
-        try sp.updateFromString(search_value, exec);
+        U_.url_set_query_to_null(self._url);
+        return;
     }
+
+    // Strip a single leading '?', then set the query.
+    const query = if (value[0] == '?') value[1..] else value;
+
+    const res = U_.url_set_query(self._url, query.ptr, query.len);
+    if (res != 0) {
+        return error.SetSearch;
+    }
+
+    // If searchParams exists, update it too.
+    const search_params = self._search_params orelse return;
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    const search_value = if (U_.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
+    try search_params.updateFromString(search_value, exec);
 }
 
 pub fn getHash(self: *const URL) []const u8 {
@@ -237,9 +257,10 @@ pub fn getSearchParams(self: *URL, exec: *const Execution) !*URLSearchParams {
         return sp;
     }
 
-    // Get current search string (without the '?')
-    const search = try self.getSearch(exec);
-    const search_value = if (search.len > 0) search[1..] else "";
+    // Get current search string (omitting '?').
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    const search_value = if (U_.url_get_query(self._url, &out, &len) == 0) out[0..len] else "";
 
     const params = try URLSearchParams.init(.{ .query_string = search_value }, exec);
     self._search_params = params;
@@ -254,66 +275,42 @@ pub fn getOrigin(self: *const URL, exec: *const Execution) ![]const u8 {
 }
 
 pub fn setHref(self: *URL, value: []const u8, exec: *const Execution) !void {
-    // This behaves the same as initializing a URL.
+    // Parse first: a failed href setter must leave the URL unchanged (and we
+    // must not free self._url before we know we have a replacement, or any
+    // later access would be a use-after-free).
     var err: i32 = 0;
     const url = U_.url_parse(value.ptr, value.len, &err) orelse return error.TypeError;
-    errdefer U_.url_free(url);
 
-    // Free the current URL.
     U_.url_free(self._url);
     self._url = url;
 
-    // Update existing searchParams if it exists.
-    if (self._search_params) |sp| {
-        const search = U.getSearch(self.toString());
-        const search_value = if (search.len > 0) search[1..] else "";
-        try sp.updateFromString(search_value, exec);
-    }
-}
-
-pub fn toString(self: *const URL) []const u8 {
-    var ptr: [*]const u8 = undefined;
+    // Update existing searchParams if exists.
+    const search_params = self._search_params orelse return;
+    var out: [*]const u8 = undefined;
     var len: usize = 0;
-    U_.url_to_string(self._url, &ptr, &len);
-    return ptr[0..len];
+    const search_value = if (U_.url_get_query(url, &out, &len) == 0) out[0..len] else "";
+    try search_params.updateFromString(search_value, exec);
 }
 
-pub fn toString1(self: *const URL, exec: *const Execution) ![:0]const u8 {
-    const sp = self._search_params orelse {
-        return self._raw;
-    };
-
-    // Rebuild URL from searchParams
-    const raw = self._raw;
-
-    // Find the base (everything before ? or #)
-    const base_end = std.mem.indexOfAnyPos(u8, raw, 0, "?#") orelse raw.len;
-    const base = raw[0..base_end];
-
-    // Get the hash if it exists
-    const hash = self.getHash();
-
-    // Build the new URL string
-    var buf = std.Io.Writer.Allocating.init(exec.call_arena);
-    try buf.writer.writeAll(base);
-
-    // Add / if missing (e.g., "https://example.com" -> "https://example.com/")
-    // Only add if pathname is just "/" and not already in the base
-    const pathname = U.getPathname(raw);
-    if (std.mem.eql(u8, pathname, "/") and !std.mem.endsWith(u8, base, "/")) {
-        try buf.writer.writeByte('/');
+pub fn toString(self: *const URL, exec: *const Execution) ![]const u8 {
+    if (self._search_params) |search_params| {
+        if (search_params.getSize() == 0) {
+            U_.url_set_query_to_null(self._url);
+        } else {
+            var buf = std.Io.Writer.Allocating.init(exec.call_arena);
+            defer buf.deinit();
+            try search_params.toString(&buf.writer);
+            const query = buf.written();
+            if (U_.url_set_query(self._url, query.ptr, query.len) != 0) {
+                return error.ToString;
+            }
+        }
     }
 
-    // Only add ? if there are params
-    if (sp.getSize() > 0) {
-        try buf.writer.writeByte('?');
-        try sp.toString(&buf.writer);
-    }
-
-    try buf.writer.writeAll(hash);
-    try buf.writer.writeByte(0);
-
-    return buf.written()[0 .. buf.written().len - 1 :0];
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    U_.url_to_string(self._url, &out, &len);
+    return out[0..len];
 }
 
 pub fn canParse(url: []const u8, maybe_base: ?[]const u8) bool {

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const js = @import("../js/js.zig");
 
 const U = @import("../URL.zig");
+const U_ = @import("../../sys/url.zig");
 const URLSearchParams = @import("net/URLSearchParams.zig");
 const Blob = @import("Blob.zig");
 const Execution = js.Execution;
@@ -28,7 +29,10 @@ const Allocator = std.mem.Allocator;
 
 const URL = @This();
 
-_raw: [:0]const u8,
+_raw: [:0]const u8 = undefined,
+_url: *U_.Url = undefined,
+/// Largest port possible is 65535; which require 5 bytes.
+_port: [5]u8 = undefined,
 _arena: ?Allocator = null,
 _search_params: ?*URLSearchParams = null,
 
@@ -36,83 +40,143 @@ _search_params: ?*URLSearchParams = null,
 pub const resolve = @import("../URL.zig").resolve;
 pub const eqlDocument = @import("../URL.zig").eqlDocument;
 
-pub fn init(url: [:0]const u8, base_: ?[:0]const u8, exec: *const Execution) !*URL {
-    const arena = exec.arena;
-    const context_url = exec.url.*;
+pub fn init(url: []const u8, maybe_base: ?[]const u8, exec: *const Execution) !*URL {
+    // NOTE: about:blank address is valid in rust-url.
 
-    if (std.mem.eql(u8, url, "about:blank")) {
-        return exec._factory.create(URL{
-            ._raw = "about:blank",
-            ._arena = arena,
-        });
+    var err: i32 = 0;
+    if (maybe_base) |base| {
+        const base_url = U_.url_parse(base.ptr, base.len, &err) orelse return error.TypeError;
+        errdefer U_.url_free(base_url);
+
+        const joined_url = U_.url_join(base_url, url.ptr, url.len, &err) orelse return error.TypeError;
+        errdefer U_.url_free(joined_url);
+        // `base_url` has no use now.
+        U_.url_free(base_url);
+
+        return exec._factory.create(URL{ ._url = joined_url });
     }
-    const url_is_absolute = @import("../URL.zig").isCompleteHTTPUrl(url);
 
-    const base = if (base_) |b| blk: {
-        // If URL is absolute, base is ignored (but we still use context url internally)
-        if (url_is_absolute) {
-            break :blk context_url;
-        }
-        // For relative URLs, base must be a valid absolute URL
-        if (!@import("../URL.zig").isCompleteHTTPUrl(b)) {
-            return error.TypeError;
-        }
-        break :blk b;
-    } else if (!url_is_absolute) {
+    const u = U_.url_parse(url.ptr, url.len, &err) orelse {
         return error.TypeError;
-    } else context_url;
+    };
+    errdefer U_.url_free(u);
 
-    const raw = try resolve(arena, base, url, .{ .always_dupe = true });
-
-    return exec._factory.create(URL{
-        ._raw = raw,
-        ._arena = arena,
-    });
+    return exec._factory.create(URL{ ._url = u });
 }
 
 pub fn getUsername(self: *const URL) []const u8 {
-    return U.getUsername(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    U_.url_get_username(self._url, &out, &len);
+    return out[0..len];
 }
 
 pub fn setUsername(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setUsername(self._raw, value, allocator);
+    const res = U_.url_set_username(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetUsername;
+    }
 }
 
 pub fn getPassword(self: *const URL) []const u8 {
-    return U.getPassword(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    const res = U_.url_get_password(self._url, &out, &len);
+    if (res != 0) {
+        return "";
+    }
+    return out[0..len];
 }
 
 pub fn setPassword(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setPassword(self._raw, value, allocator);
+    const res = U_.url_set_password(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetPassword;
+    }
 }
 
 pub fn getPathname(self: *const URL) []const u8 {
-    return U.getPathname(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    U_.url_get_path(self._url, &out, &len);
+    return out[0..len];
+}
+
+pub fn setPathname(self: *URL, value: []const u8) !void {
+    const res = U_.url_set_path(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetPathname;
+    }
 }
 
 pub fn getProtocol(self: *const URL) []const u8 {
-    return U.getProtocol(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    U_.url_get_scheme(self._url, &out, &len);
+    // rust-url's scheme() omits the ':'. The serialization always has it right
+    // after the scheme ("https://..."), so we extend the borrowed slice by one.
+    return out[0 .. len + 1];
+}
+
+pub fn setProtocol(self: *URL, value: []const u8) !void {
+    const res = U_.url_set_scheme(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetProtocol;
+    }
 }
 
 pub fn getHostname(self: *const URL) []const u8 {
-    return U.getHostname(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    if (U_.url_get_hostname(self._url, &out, &len) != 0) {
+        return "";
+    }
+    return out[0..len];
+}
+
+pub fn setHostname(self: *URL, value: []const u8) !void {
+    const res = U_.url_set_hostname(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetHostname;
+    }
 }
 
 pub fn getHost(self: *const URL) []const u8 {
-    return U.getHost(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    if (U_.url_get_host(self._url, &out, &len) != 0) {
+        return "";
+    }
+    return out[0..len];
 }
 
-pub fn getPort(self: *const URL) []const u8 {
-    return U.getPort(self._raw);
+pub fn setHost(self: *URL, value: []const u8) !void {
+    const res = U_.url_set_host(self._url, value.ptr, value.len);
+    if (res != 0) {
+        return error.SetHost;
+    }
 }
 
-pub fn getOrigin(self: *const URL, exec: *const Execution) ![]const u8 {
-    return (try U.getOrigin(exec.call_arena, self._raw)) orelse {
-        // yes, a null string, that's what the spec wants
-        return "null";
+pub fn getPort(self: *URL) []const u8 {
+    const port = U_.urlGetPort(self._url) orelse return "";
+    return std.fmt.bufPrint(&self._port, "{d}", .{port}) catch unreachable;
+}
+
+/// Spec requires us to silently ignore errors of this setter.
+pub fn setPort(self: *URL, maybe_value: ?[]const u8) void {
+    // A null or empty value clears the port.
+    const value = maybe_value orelse {
+        _ = U_.url_set_port_to_null(self._url);
+        return;
     };
+    if (value.len == 0) {
+        _ = U_.url_set_port_to_null(self._url);
+        return;
+    }
+
+    // Ignore invalid port numbers, leaving the port unchanged.
+    const port = std.fmt.parseInt(u16, value, 10) catch return;
+    _ = U_.url_set_port(self._url, port);
 }
 
 pub fn getSearch(self: *const URL, exec: *const Execution) ![]const u8 {
@@ -129,8 +193,43 @@ pub fn getSearch(self: *const URL, exec: *const Execution) ![]const u8 {
     return U.getSearch(self._raw);
 }
 
+pub fn setSearch(self: *URL, value: []const u8, exec: *const Execution) !void {
+    const allocator = self._arena orelse return error.NoAllocator;
+    self._raw = try U.setSearch(self._raw, value, allocator);
+
+    // Update existing searchParams if it exists
+    if (self._search_params) |sp| {
+        const search = U.getSearch(self._raw);
+        const search_value = if (search.len > 0) search[1..] else "";
+        try sp.updateFromString(search_value, exec);
+    }
+}
+
 pub fn getHash(self: *const URL) []const u8 {
-    return U.getHash(self._raw);
+    var out: [*]const u8 = undefined;
+    var len: usize = 0;
+    const res = U_.url_get_fragment(self._url, &out, &len);
+    // WHATWG `hash` is "" for both a null and an empty fragment.
+    if (res != 0 or len == 0) {
+        return "";
+    }
+    // rust-url's fragment() omits the '#', which always precedes the fragment
+    // in the serialization, so step the borrowed slice back one byte for it.
+    return (out - 1)[0 .. len + 1];
+}
+
+pub fn setHash(self: *URL, value: []const u8) !void {
+    // An empty value clears the fragment entirely (removes the '#').
+    if (value.len == 0) {
+        U_.url_set_fragment_to_null(self._url);
+        return;
+    }
+    // Strip a single leading '#', then set the fragment.
+    const fragment = if (value[0] == '#') value[1..] else value;
+    const res = U_.url_set_fragment(self._url, fragment.ptr, fragment.len);
+    if (res != 0) {
+        return error.SetHash;
+    }
 }
 
 pub fn getSearchParams(self: *URL, exec: *const Execution) !*URLSearchParams {
@@ -147,62 +246,39 @@ pub fn getSearchParams(self: *URL, exec: *const Execution) !*URLSearchParams {
     return params;
 }
 
+pub fn getOrigin(self: *const URL, exec: *const Execution) ![]const u8 {
+    const origin = U_.url_get_origin(self._url);
+    defer origin.deinit();
+
+    return exec.call_arena.dupe(u8, origin.slice());
+}
+
 pub fn setHref(self: *URL, value: []const u8, exec: *const Execution) !void {
-    const base = if (U.isCompleteHTTPUrl(value)) exec.url.* else self._raw;
-    const raw = try U.resolve(self._arena orelse exec.arena, base, value, .{ .always_dupe = true });
-    self._raw = raw;
+    // This behaves the same as initializing a URL.
+    var err: i32 = 0;
+    const url = U_.url_parse(value.ptr, value.len, &err) orelse return error.TypeError;
+    errdefer U_.url_free(url);
 
-    // Update existing searchParams if it exists
+    // Free the current URL.
+    U_.url_free(self._url);
+    self._url = url;
+
+    // Update existing searchParams if it exists.
     if (self._search_params) |sp| {
-        const search = U.getSearch(raw);
+        const search = U.getSearch(self.toString());
         const search_value = if (search.len > 0) search[1..] else "";
         try sp.updateFromString(search_value, exec);
     }
 }
 
-pub fn setProtocol(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setProtocol(self._raw, value, allocator);
+pub fn toString(self: *const URL) []const u8 {
+    var ptr: [*]const u8 = undefined;
+    var len: usize = 0;
+    U_.url_to_string(self._url, &ptr, &len);
+    return ptr[0..len];
 }
 
-pub fn setHost(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setHost(self._raw, value, allocator);
-}
-
-pub fn setHostname(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setHostname(self._raw, value, allocator);
-}
-
-pub fn setPort(self: *URL, value: ?[]const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setPort(self._raw, value, allocator);
-}
-
-pub fn setPathname(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setPathname(self._raw, value, allocator);
-}
-
-pub fn setSearch(self: *URL, value: []const u8, exec: *const Execution) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setSearch(self._raw, value, allocator);
-
-    // Update existing searchParams if it exists
-    if (self._search_params) |sp| {
-        const search = U.getSearch(self._raw);
-        const search_value = if (search.len > 0) search[1..] else "";
-        try sp.updateFromString(search_value, exec);
-    }
-}
-
-pub fn setHash(self: *URL, value: []const u8) !void {
-    const allocator = self._arena orelse return error.NoAllocator;
-    self._raw = try U.setHash(self._raw, value, allocator);
-}
-
-pub fn toString(self: *const URL, exec: *const Execution) ![:0]const u8 {
+pub fn toString1(self: *const URL, exec: *const Execution) ![:0]const u8 {
     const sp = self._search_params orelse {
         return self._raw;
     };
@@ -240,11 +316,11 @@ pub fn toString(self: *const URL, exec: *const Execution) ![:0]const u8 {
     return buf.written()[0 .. buf.written().len - 1 :0];
 }
 
-pub fn canParse(url: []const u8, base_: ?[]const u8) bool {
-    if (base_) |b| {
-        return U.isCompleteHTTPUrl(b);
+pub fn canParse(url: []const u8, maybe_base: ?[]const u8) bool {
+    if (maybe_base) |base| {
+        return U_.url_can_parse_with_base(base.ptr, base.len, url.ptr, url.len);
     }
-    return U.isCompleteHTTPUrl(url);
+    return U_.url_can_parse(url.ptr, url.len);
 }
 
 pub fn createObjectURL(blob: *Blob, exec: *const Execution) ![]const u8 {

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -619,7 +619,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
         },
         .target => {
             const element_id = el.getAttributeSafe(comptime .wrap("id")) orelse return false;
-            const location = frame.document._location orelse return false;
+            const location = frame.document.getLocation() orelse return false;
             const hash = location.getHash();
             if (hash.len <= 1) return false;
             return std.mem.eql(u8, element_id, hash[1..]);

--- a/src/html5ever/Cargo.lock
+++ b/src/html5ever/Cargo.lock
@@ -63,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +201,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "typed-arena",
+ "url",
  "xml5ever",
 ]
 
@@ -262,6 +272,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -503,6 +519,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf-8"

--- a/src/html5ever/Cargo.toml
+++ b/src/html5ever/Cargo.toml
@@ -17,6 +17,7 @@ tikv-jemalloc-ctl = {version = "0.6.1", features = ["stats"]}
 xml5ever = "0.39.0"
 encoding_rs = "0.8"
 idna = "1.1.0"
+url = "2.5.8"
 
 [profile.release]
 lto = true

--- a/src/html5ever/url.rs
+++ b/src/html5ever/url.rs
@@ -18,6 +18,7 @@
 // IDNA-2008 behavior diverged from the spec. Value-in / value-out: a UTF-8
 // host string becomes its punycode form, or an error.
 
+use ::url::Url;
 use std::os::raw::c_uchar;
 use std::slice;
 
@@ -80,4 +81,358 @@ pub extern "C" fn lpurl_free(ptr: *mut c_uchar, len: usize) {
         let slice = std::ptr::slice_from_raw_parts_mut(ptr, len + 1);
         drop(Box::from_raw(slice));
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_parse(ptr: *const c_uchar, len: usize, err: *mut i32) -> *mut Url {
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => {
+            *err = url::ParseError::EmptyHost as i32;
+            return std::ptr::null_mut();
+        }
+    };
+
+    match Url::parse(slice) {
+        Ok(url) => Box::into_raw(Box::new(url)),
+        Err(e) => {
+            *err = e as i32;
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_join(
+    base: *const Url,
+    ptr: *const c_uchar,
+    len: usize,
+    err: *mut i32,
+) -> *mut Url {
+    let base = unsafe { &*base };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => {
+            *err = url::ParseError::EmptyHost as i32;
+            return std::ptr::null_mut();
+        }
+    };
+
+    match base.join(slice) {
+        Ok(url) => Box::into_raw(Box::new(url)),
+        Err(e) => {
+            *err = e as i32;
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_can_parse(ptr: *const c_uchar, len: usize) -> bool {
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return false,
+    };
+
+    Url::parse(slice).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_can_parse_with_base(
+    base_ptr: *const c_uchar,
+    base_len: usize,
+    ptr: *const c_uchar,
+    len: usize,
+) -> bool {
+    let base_slice = match str_from(base_ptr, base_len) {
+        Some(s) => s,
+        None => return false,
+    };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return false,
+    };
+
+    match Url::parse(base_slice) {
+        Ok(url) => url.join(slice).is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_free(url: *mut Url) {
+    if url.is_null() {
+        return;
+    }
+    drop(Box::from_raw(url));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_to_string(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) {
+    let url = unsafe { &*url };
+    let s = url.as_str();
+    *out_ptr = s.as_ptr();
+    *out_len = s.len();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_username(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    match url.set_username(slice) {
+        Ok(()) => 0,
+        Err(()) => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_username(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) {
+    let url = unsafe { &*url };
+    let username = url.username();
+    *out_ptr = username.as_ptr();
+    *out_len = username.len();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_password(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    match url.set_password(Some(slice)) {
+        Ok(()) => 0,
+        Err(()) => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_password(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) -> i32 {
+    let url = unsafe { &*url };
+    match url.password() {
+        Some(password) => {
+            *out_ptr = password.as_ptr();
+            *out_len = password.len();
+            0
+        }
+        None => -1,
+    }
+}
+
+#[repr(C)]
+pub struct OwnedString {
+    pub ptr: *mut c_uchar,
+    pub len: usize,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free_owned_string(owned: OwnedString) {
+    if owned.ptr.is_null() || owned.len == 0 {
+        return;
+    }
+
+    unsafe {
+        let slice = std::ptr::slice_from_raw_parts_mut(owned.ptr, owned.len);
+        drop(Box::from_raw(slice));
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_origin(url: *const Url) -> OwnedString {
+    let url = unsafe { &*url };
+    let origin = url.origin().ascii_serialization();
+    let len = origin.len();
+    let ptr = Box::into_raw(origin.into_bytes().into_boxed_slice()) as *mut c_uchar;
+    OwnedString { ptr, len }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_port(url: *mut Url, port: u16) -> i32 {
+    let url = unsafe { &mut *url };
+    match url.set_port(Some(port)) {
+        Ok(()) => 0,
+        Err(()) => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_port(url: *const Url) -> i32 {
+    let url = unsafe { &*url };
+    match url.port() {
+        Some(port) => port as i32,
+        None => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_host(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    match url.set_host(Some(slice)) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_host(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) -> i32 {
+    let url = unsafe { &*url };
+
+    match url.host_str() {
+        Some(h) => unsafe {
+            *out_ptr = h.as_ptr();
+            *out_len = h.len();
+            0
+        },
+        None => unsafe {
+            *out_len = 0;
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_scheme(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    match url.set_scheme(slice) {
+        Ok(()) => 0,
+        Err(()) => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_scheme(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) {
+    let url = unsafe { &*url };
+    let scheme = url.scheme();
+    *out_ptr = scheme.as_ptr();
+    *out_len = scheme.len();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_path(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    url.set_path(slice);
+    0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_path(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) {
+    let url = unsafe { &*url };
+    let path = url.path();
+    *out_ptr = path.as_ptr();
+    *out_len = path.len();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_query(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    url.set_query(Some(slice));
+    0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_query(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) -> i32 {
+    let url = unsafe { &*url };
+    match url.query() {
+        Some(query) => {
+            *out_ptr = query.as_ptr();
+            *out_len = query.len();
+            0
+        }
+        None => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_fragment(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    url.set_fragment(Some(slice));
+    0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_fragment(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) -> i32 {
+    let url = unsafe { &*url };
+    match url.fragment() {
+        Some(fragment) => {
+            *out_ptr = fragment.as_ptr();
+            *out_len = fragment.len();
+            0
+        }
+        None => -1,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_href(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) {
+    let url = unsafe { &*url };
+    let href = url.as_str();
+    *out_ptr = href.as_ptr();
+    *out_len = href.len();
 }

--- a/src/html5ever/url.rs
+++ b/src/html5ever/url.rs
@@ -462,6 +462,12 @@ pub unsafe extern "C" fn url_set_query(url: *mut Url, ptr: *const c_uchar, len: 
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn url_set_query_to_null(url: *mut Url) {
+    let url = unsafe { &mut *url };
+    url.set_query(None);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn url_get_query(
     url: *const Url,
     out_ptr: *mut *const c_uchar,

--- a/src/html5ever/url.rs
+++ b/src/html5ever/url.rs
@@ -103,6 +103,44 @@ pub unsafe extern "C" fn url_parse(ptr: *const c_uchar, len: usize, err: *mut i3
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn url_parse_with_base(
+    base_ptr: *const c_uchar,
+    base_len: usize,
+    ptr: *const c_uchar,
+    len: usize,
+    err: *mut i32,
+) -> *mut Url {
+    let base_slice = match str_from(base_ptr, base_len) {
+        Some(s) => s,
+        None => {
+            *err = url::ParseError::EmptyHost as i32;
+            return std::ptr::null_mut();
+        }
+    };
+    let slice = match str_from(ptr, len) {
+        Some(s) => s,
+        None => {
+            *err = url::ParseError::EmptyHost as i32;
+            return std::ptr::null_mut();
+        }
+    };
+
+    match Url::parse(base_slice) {
+        Ok(base) => match base.join(slice) {
+            Ok(url) => Box::into_raw(Box::new(url)),
+            Err(e) => {
+                *err = e as i32;
+                std::ptr::null_mut()
+            }
+        },
+        Err(e) => {
+            *err = e as i32;
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn url_join(
     base: *const Url,
     ptr: *const c_uchar,

--- a/src/html5ever/url.rs
+++ b/src/html5ever/url.rs
@@ -273,6 +273,15 @@ pub unsafe extern "C" fn url_set_port(url: *mut Url, port: u16) -> i32 {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn url_set_port_to_null(url: *mut Url) -> i32 {
+    let url = unsafe { &mut *url };
+    match url.set_port(None) {
+        Ok(()) => 0,
+        Err(()) => -1,
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn url_get_port(url: *const Url) -> i32 {
     let url = unsafe { &*url };
     match url.port() {
@@ -281,8 +290,9 @@ pub unsafe extern "C" fn url_get_port(url: *const Url) -> i32 {
     }
 }
 
+/// WHATWG `hostname` setter: sets the host without touching the port.
 #[no_mangle]
-pub unsafe extern "C" fn url_set_host(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+pub unsafe extern "C" fn url_set_hostname(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
     let url = unsafe { &mut *url };
 
     let slice = match str_from(ptr, len) {
@@ -296,8 +306,10 @@ pub unsafe extern "C" fn url_set_host(url: *mut Url, ptr: *const c_uchar, len: u
     }
 }
 
+/// WHATWG `hostname` getter: the host without the port. Borrows into the Url's
+/// buffer; returns -1 (and writes an empty slice) when there is no host.
 #[no_mangle]
-pub unsafe extern "C" fn url_get_host(
+pub unsafe extern "C" fn url_get_hostname(
     url: *const Url,
     out_ptr: *mut *const c_uchar,
     out_len: *mut usize,
@@ -315,6 +327,76 @@ pub unsafe extern "C" fn url_get_host(
             -1
         },
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_get_host(
+    url: *const Url,
+    out_ptr: *mut *const c_uchar,
+    out_len: *mut usize,
+) -> i32 {
+    let url = unsafe { &*url };
+    if url.host_str().is_none() {
+        unsafe {
+            *out_len = 0;
+        }
+        return -1;
+    }
+
+    let host = &url[url::Position::BeforeHost..url::Position::AfterPort];
+    unsafe {
+        *out_ptr = host.as_ptr();
+        *out_len = host.len();
+    }
+    0
+}
+
+/// rust-url's `set_host` discards any trailing `:port`, so we split it off
+/// ourselves (respecting IPv6 `[...]` literals) and apply the port separately.
+#[no_mangle]
+pub unsafe extern "C" fn url_set_host(url: *mut Url, ptr: *const c_uchar, len: usize) -> i32 {
+    let url = unsafe { &mut *url };
+    let input = match str_from(ptr, len) {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    // Find the port separator ':', but only outside an IPv6 [...] literal.
+    let colon = if input.starts_with('[') {
+        input
+            .find(']')
+            .and_then(|b| input[b..].find(':').map(|i| b + i))
+    } else {
+        input.find(':')
+    };
+
+    let Some(i) = colon else {
+        // No port given: set the host only, leaving any existing port untouched.
+        return if url.set_host(Some(input)).is_ok() {
+            0
+        } else {
+            -1
+        };
+    };
+
+    let (host, port_str) = (&input[..i], &input[i + 1..]);
+
+    // Validate the port up-front so we never apply the host and then fail.
+    let new_port: Option<u16> = if port_str.is_empty() {
+        None // "host:" clears the port
+    } else {
+        match port_str.parse::<u16>() {
+            Ok(p) => Some(p),
+            Err(_) => return -1,
+        }
+    };
+
+    if url.set_host(Some(host)).is_err() {
+        return -1;
+    }
+    // set_port only errors on cannot-be-a-base, already ruled out by set_host.
+    let _ = url.set_port(new_port);
+    0
 }
 
 #[no_mangle]
@@ -406,6 +488,12 @@ pub unsafe extern "C" fn url_set_fragment(url: *mut Url, ptr: *const c_uchar, le
 
     url.set_fragment(Some(slice));
     0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn url_set_fragment_to_null(url: *mut Url) {
+    let url = unsafe { &mut *url };
+    url.set_fragment(None);
 }
 
 #[no_mangle]

--- a/src/sys/url.zig
+++ b/src/sys/url.zig
@@ -51,6 +51,9 @@ pub const ParseError = enum(i32) {
 /// If return value is null, `err` indicates `ParseError`.
 pub extern "c" fn url_parse(ptr: [*]const u8, len: usize, err: *i32) ?*Url;
 /// If return value is null, `err` indicates `ParseError`.
+/// More efficient than url_parse + url_join combination where possible.
+pub extern "c" fn url_parse_with_base(base_ptr: [*]const u8, base_len: usize, ptr: [*]const u8, len: usize, err: *i32) ?*Url;
+/// If return value is null, `err` indicates `ParseError`.
 pub extern "c" fn url_join(base: *const Url, ptr: [*]const u8, len: usize, err: *i32) ?*Url;
 pub extern "c" fn url_free(url: *Url) void;
 pub extern "c" fn url_can_parse(ptr: [*]const u8, len: usize) bool;

--- a/src/sys/url.zig
+++ b/src/sys/url.zig
@@ -1,0 +1,71 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Bindings for Servo's rust-url (https://github.com/servo/rust-url).
+//! Check @src/html5ever/url.rs for Rust-side of the bindings.
+
+const std = @import("std");
+const mem = std.mem;
+
+pub const Url = anyopaque;
+
+pub const OwnedString = extern struct {
+    ptr: [*]const u8,
+    len: usize,
+
+    pub inline fn deinit(self: OwnedString) void {
+        return free_owned_string(self);
+    }
+
+    pub inline fn slice(self: OwnedString) []const u8 {
+        return self.ptr[0..self.len];
+    }
+};
+
+/// https://docs.rs/url/latest/url/enum.ParseError.html
+pub const ParseError = enum(i32) {
+    EmptyHost,
+    IdnaError,
+    InvalidPort,
+    InvalidIpv4Address,
+    InvalidIpv6Address,
+    InvalidDomainCharacter,
+    RelativeUrlWithoutBase,
+    RelativeUrlWithCannotBeABaseBase,
+    SetHostOnCannotBeABaseUrl,
+    Overflow,
+};
+
+/// If return value is null, `err` indicates `ParseError`.
+pub extern "c" fn url_parse(ptr: [*]const u8, len: usize, err: *i32) ?*Url;
+/// If return value is null, `err` indicates `ParseError`.
+pub extern "c" fn url_join(base: *const Url, ptr: [*]const u8, len: usize, err: *i32) ?*Url;
+pub extern "c" fn url_free(url: *Url) void;
+pub extern "c" fn url_can_parse(ptr: [*]const u8, len: usize) bool;
+pub extern "c" fn url_can_parse_with_base(base_ptr: [*]const u8, base_len: usize, ptr: [*]const u8, len: usize) bool;
+pub extern "c" fn url_to_string(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_set_host(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_host(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+/// This function allocates on Rust-side.
+pub extern "c" fn url_get_origin(url: *const Url) OwnedString;
+pub extern "c" fn free_owned_string(owned: OwnedString) void;
+pub extern "c" fn url_set_port(url: *Url, port: u16) i32;
+
+extern "c" fn url_get_port(url: *const Url) i32;
+pub inline fn urlGetPort(url: *const Url) ?u16 {
+    const result = url_get_port(url);
+    if (result < 0) return null;
+    return @intCast(result);
+}

--- a/src/sys/url.zig
+++ b/src/sys/url.zig
@@ -56,12 +56,27 @@ pub extern "c" fn url_free(url: *Url) void;
 pub extern "c" fn url_can_parse(ptr: [*]const u8, len: usize) bool;
 pub extern "c" fn url_can_parse_with_base(base_ptr: [*]const u8, base_len: usize, ptr: [*]const u8, len: usize) bool;
 pub extern "c" fn url_to_string(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_set_hostname(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_hostname(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
 pub extern "c" fn url_set_host(url: *Url, ptr: [*]const u8, len: usize) i32;
-pub extern "c" fn url_get_host(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_get_host(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
 /// This function allocates on Rust-side.
 pub extern "c" fn url_get_origin(url: *const Url) OwnedString;
 pub extern "c" fn free_owned_string(owned: OwnedString) void;
 pub extern "c" fn url_set_port(url: *Url, port: u16) i32;
+/// Sets the port to null.
+pub extern "c" fn url_set_port_to_null(url: *Url) i32;
+pub extern "c" fn url_set_username(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_username(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_set_password(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_password(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
+pub extern "c" fn url_set_path(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_path(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_set_scheme(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_get_scheme(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) void;
+pub extern "c" fn url_set_fragment(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_set_fragment_to_null(url: *Url) void;
+pub extern "c" fn url_get_fragment(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
 
 extern "c" fn url_get_port(url: *const Url) i32;
 pub inline fn urlGetPort(url: *const Url) ?u16 {

--- a/src/sys/url.zig
+++ b/src/sys/url.zig
@@ -77,6 +77,9 @@ pub extern "c" fn url_get_scheme(url: *const Url, out_ptr: *[*]const u8, out_len
 pub extern "c" fn url_set_fragment(url: *Url, ptr: [*]const u8, len: usize) i32;
 pub extern "c" fn url_set_fragment_to_null(url: *Url) void;
 pub extern "c" fn url_get_fragment(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
+pub extern "c" fn url_set_query(url: *Url, ptr: [*]const u8, len: usize) i32;
+pub extern "c" fn url_set_query_to_null(url: *Url) void;
+pub extern "c" fn url_get_query(url: *const Url, out_ptr: *[*]const u8, out_len: *usize) i32;
 
 extern "c" fn url_get_port(url: *const Url) i32;
 pub inline fn urlGetPort(url: *const Url) ?u16 {


### PR DESCRIPTION
This PR reworks our Web API URL implementation by taking advantage of rust-url package.