### PR TITLE
forms: encode <input type=file> in multipart/form-data submissions

### DIFF
--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -47,14 +47,16 @@ pub const Entry = struct {
         fn asString(self: *const Value) []const u8 {
             return switch (self.*) {
                 .string => |*s| s.str(),
-                .file => unreachable, // nothing currently creates this type of value
+                // A file's string form (urlencoded / text-plain submission, and
+                // FormData.get) is its filename, per the form-submission spec.
+                .file => |f| f.getName(),
             };
         }
 
         pub fn format(self: Value, writer: *std.Io.Writer) !void {
             return switch (self) {
                 .string => |s| s.format(writer),
-                .file => unreachable, // nothing currently creates this type of value
+                .file => |f| writer.writeAll(f.getName()),
             };
         }
     };
@@ -244,8 +246,20 @@ fn multipartEncodeEntry(entry: *const Entry, boundary: []const u8, writer: *std.
             try writer.writeAll(s.str());
             try writer.writeAll("\r\n");
         },
-        // File entries need a real payload (filename + bytes + Content-Type) — not yet wired.
-        .file => log.warn(.not_implemented, "FormData.multipart.file", .{}),
+        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm
+        // RFC 7578 §4.2 / §4.4: file parts carry a `filename` parameter on the
+        // Content-Disposition header, an explicit Content-Type, then the raw bytes.
+        .file => |file| {
+            try writer.writeAll("Content-Disposition: form-data; name=\"");
+            try writeMultipartName(writer, entry.name.str());
+            try writer.writeAll("\"; filename=\"");
+            try writeMultipartName(writer, file.getName());
+            try writer.writeAll("\"\r\n");
+            const mime = file._proto.getType();
+            try writer.print("Content-Type: {s}\r\n\r\n", .{if (mime.len == 0) "application/octet-stream" else mime});
+            try writer.writeAll(file._proto._slice);
+            try writer.writeAll("\r\n");
+        },
     }
 }
 
@@ -340,6 +354,22 @@ fn collectForm(arena: Allocator, form_: ?*Form, submitter_: ?*Element, frame: *F
         const value = blk: {
             if (element.is(Form.Input)) |input| {
                 const input_type = input._input_type;
+                if (input_type == .file) {
+                    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+                    // Append one entry per selected file. If none are selected,
+                    // append a single entry with an empty File (empty name and
+                    // body, type application/octet-stream).
+                    const fl = (try input.getFiles(frame)).?;
+                    if (fl._files.len == 0) {
+                        const empty = try File.init(null, "", .{ .type = "application/octet-stream" }, frame._page);
+                        try appendFile(&list, arena, name, empty);
+                    } else {
+                        for (fl._files) |file| {
+                            try appendFile(&list, arena, name, file);
+                        }
+                    }
+                    continue;
+                }
                 if (input_type == .checkbox or input_type == .radio) {
                     if (!input.getChecked()) {
                         continue;
@@ -393,6 +423,13 @@ fn appendString(list: *std.ArrayList(Entry), arena: Allocator, name: []const u8,
     try list.append(arena, .{
         .name = try String.init(arena, name, .{}),
         .value = .{ .string = try String.init(arena, value, .{}) },
+    });
+}
+
+fn appendFile(list: *std.ArrayList(Entry), arena: Allocator, name: []const u8, file: *File) !void {
+    try list.append(arena, .{
+        .name = try String.init(arena, name, .{}),
+        .value = .{ .file = file },
     });
 }
 
@@ -471,6 +508,54 @@ test "FormData: multipart escapes name CR/LF/quote" {
         "--B\r\n" ++
             "Content-Disposition: form-data; name=\"a%22b%0D%0Ac\"\r\n\r\n" ++
             "v\r\n" ++
+            "--B--\r\n",
+        buf.written(),
+    );
+}
+
+test "FormData: multipart file entry writes filename, content-type, and bytes" {
+    const allocator = testing.arena_allocator;
+    const Blob = @import("../Blob.zig");
+
+    // Mirror the shape produced by DOM.setFileInputFiles: a Blob holding the
+    // raw bytes + MIME, and a File naming it. No Page needed for encoding.
+    var blob = Blob{
+        ._rc = .{},
+        ._arena = allocator,
+        ._type = .generic,
+        ._slice = "the file body\nwith two lines",
+        ._mime = "text/plain",
+    };
+    var file = File{
+        ._proto = &blob,
+        ._name = "report.txt",
+        ._last_modified = 0,
+    };
+
+    var fd = FormData{
+        ._arena = allocator,
+        ._entries = .empty,
+    };
+    try fd.append("field", "value");
+    try fd._entries.append(allocator, .{
+        .name = try String.init(allocator, "document", .{}),
+        .value = .{ .file = &file },
+    });
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    try fd.write(.{
+        .encoding = .{ .formdata = "B" },
+        .allocator = allocator,
+    }, &buf.writer);
+
+    try testing.expectString(
+        "--B\r\n" ++
+            "Content-Disposition: form-data; name=\"field\"\r\n\r\n" ++
+            "value\r\n" ++
+            "--B\r\n" ++
+            "Content-Disposition: form-data; name=\"document\"; filename=\"report.txt\"\r\n" ++
+            "Content-Type: text/plain\r\n\r\n" ++
+            "the file body\nwith two lines\r\n" ++
             "--B--\r\n",
         buf.written(),
     );


### PR DESCRIPTION
## What

Submitting a `<form enctype="multipart/form-data">` that contains an `<input type="file">` produced a body with no file in it — no `filename` parameter, no `Content-Type`, no bytes — so servers received an empty field. The file *was* selected (`DOM.setFileInputFiles` populates `input.files` and fires `change`); only the submission encoding was missing.

Closes #2662.

## Root cause

In `src/browser/webapi/net/FormData.zig`, `collectForm` builds the form entry list. A `type=file` input had no dedicated branch, so it fell through to `input.getValue()`, which returns `""` for file inputs — the file became an empty string entry. The multipart serializer `multipartEncodeEntry` also had its `.file` arm stubbed (`log.warn(.not_implemented, ...)`), but that was dead code since no `.file` entry was ever created.

```mermaid
flowchart LR
    A[submit form] --> B[collectForm builds entry list]
    B --> C[file input uses getValue empty string]
    C --> D[multipart body has no file part]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/webapi/net/FormData.zig` — `collectForm`: emit one `.file` entry per selected file for `type=file` inputs, or a single empty-file entry when none are selected, per the [HTML entry-list algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set).
- `src/browser/webapi/net/FormData.zig` — `multipartEncodeEntry`: implement the `.file` arm — `Content-Disposition` with a `filename` parameter, an explicit `Content-Type` (defaulting to `application/octet-stream`), then the raw bytes, per [RFC 7578 §4.2/§4.4](https://www.rfc-editor.org/rfc/rfc7578#section-4.2).
- `Value.asString` / `Value.format`: report a file by its filename so the `application/x-www-form-urlencoded` and `text/plain` encodings (and `FormData.get`) no longer hit `unreachable` now that `.file` entries exist.

```mermaid
flowchart LR
    A[submit form] --> B[collectForm emits one entry per file]
    B --> C[multipartEncodeEntry writes filename type bytes]
    C --> D[multipart body carries the file]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit test**: `FormData: multipart file entry writes filename, content-type, and bytes` (in `src/browser/webapi/net/FormData.zig`) — fails on `main`, passes with this commit. Reverting the `.file` encoder arm makes it fail again. Full `zig build test` is green (782/782).
- **Reproducer** (from #2662): a `multipart/form-data` form + file input, driven over CDP (`DOM.setFileInputFiles` then submit), with a tiny server reporting what it received. On `main` it prints `multipart=True filename=False sentinel=False` and exits 1; with this commit it prints `multipart=True filename=True sentinel=True` and exits 0.

## Notes

- Per spec, an empty file input still contributes a part (`filename=""`, empty body, `application/octet-stream`); this PR matches that.
- `FormData.get()` on a file entry returns the filename string rather than a `File` object. That's a pre-existing JS-API fidelity limitation (the binding returns `[]const u8`) and is unchanged here — out of scope for this fix.
