### PR TITLE
browser: clear session slot when Session.init fails

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -109,6 +109,7 @@ pub fn deinit(self: *Browser) void {
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {
     self.closeSession();
     self.session = @as(Session, undefined);
+    errdefer self.session = null;
     const session = &self.session.?;
     try Session.init(session, self, notification);
     return session;


### PR DESCRIPTION
newSession set self.session to undefined, but left it non-null if Session.init failed. closeSession() then ran deinit() on garbage:

- double-released the arena
- read undefined fields on the never-assigned path

Add an errdefer to null the slot on failure.