### PR TITLE
webapi: DataTransfer / DataTransferItem / DataTransferItemList + DragEvent (drag-and-drop file upload)

### DIFF
--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -980,6 +980,7 @@ pub const PageJsApis = flattenTypes(&.{
     @import("../webapi/File.zig"),
     @import("../webapi/FileList.zig"),
     @import("../webapi/FileReader.zig"),
+    @import("../webapi/DataTransfer.zig"),
     @import("../webapi/Screen.zig"),
     @import("../webapi/VisualViewport.zig"),
     @import("../webapi/PerformanceObserver.zig"),

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -926,6 +926,7 @@ pub const PageJsApis = flattenTypes(&.{
     @import("../webapi/event/KeyboardEvent.zig"),
     @import("../webapi/event/FocusEvent.zig"),
     @import("../webapi/event/WheelEvent.zig"),
+    @import("../webapi/event/DragEvent.zig"),
     @import("../webapi/event/TextEvent.zig"),
     @import("../webapi/event/InputEvent.zig"),
     @import("../webapi/event/PromiseRejectionEvent.zig"),

--- a/src/browser/tests/data_transfer.html
+++ b/src/browser/tests/data_transfer.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<head>
+  <title>Test DataTransfer Web API</title>
+  <script src="./testing.js"></script>
+</head>
+
+<script id=construction>
+{
+  const dt = new DataTransfer();
+  testing.expectEqual(true, dt instanceof DataTransfer);
+  testing.expectEqual(0, dt.items.length);
+  testing.expectEqual(0, dt.files.length);
+  testing.expectEqual("none", dt.dropEffect);
+  testing.expectEqual("uninitialized", dt.effectAllowed);
+  testing.expectEqual(true, dt.items instanceof DataTransferItemList);
+  testing.expectEqual(true, dt.files instanceof FileList);
+}
+</script>
+
+<script id=effects>
+{
+  const dt = new DataTransfer();
+  dt.dropEffect = "copy";
+  testing.expectEqual("copy", dt.dropEffect);
+  dt.dropEffect = "bogus"; // invalid ignored
+  testing.expectEqual("copy", dt.dropEffect);
+  dt.effectAllowed = "copyMove";
+  testing.expectEqual("copyMove", dt.effectAllowed);
+  dt.effectAllowed = "nope"; // invalid ignored
+  testing.expectEqual("copyMove", dt.effectAllowed);
+}
+</script>
+
+<script id=string_data>
+{
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "hello");
+  testing.expectEqual("hello", dt.getData("text/plain"));
+  // "text" normalizes to "text/plain"
+  testing.expectEqual("hello", dt.getData("text"));
+  // setData via the "text" alias overwrites the same item
+  dt.setData("text", "world");
+  testing.expectEqual("world", dt.getData("text/plain"));
+  testing.expectEqual(1, dt.items.length);
+  // "url" normalizes to "text/uri-list"
+  dt.setData("url", "https://example.com");
+  testing.expectEqual("https://example.com", dt.getData("text/uri-list"));
+  testing.expectEqual(true, dt.types.indexOf("text/plain") !== -1);
+  testing.expectEqual(true, dt.types.indexOf("text/uri-list") !== -1);
+  // getData miss returns ""
+  testing.expectEqual("", dt.getData("application/json"));
+}
+</script>
+
+<script id=items_add_file>
+{
+  const dt = new DataTransfer();
+  const f = new File(["abc"], "a.txt", { type: "text/plain" });
+  const item = dt.items.add(f);
+  testing.expectEqual("file", item.kind);
+  testing.expectEqual("text/plain", item.type);
+  // file is reflected in .files immediately
+  testing.expectEqual(1, dt.files.length);
+  testing.expectEqual("a.txt", dt.files[0].name);
+  testing.expectEqual(true, dt.files[0] instanceof File);
+  // "Files" appears in types when a file item exists
+  testing.expectEqual(true, dt.types.indexOf("Files") !== -1);
+  testing.expectEqual(f, item.getAsFile());
+}
+</script>
+
+<script id=items_add_string>
+{
+  const dt = new DataTransfer();
+  const item = dt.items.add("payload", "text/custom");
+  testing.expectEqual("string", item.kind);
+  testing.expectEqual("text/custom", item.type);
+  testing.expectEqual("payload", dt.getData("text/custom"));
+  testing.expectEqual(null, item.getAsFile());
+}
+</script>
+
+<script id=get_as_string>
+{
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "world");
+  let got = null;
+  dt.items[0].getAsString(function (s) { got = s; });
+  testing.expectEqual("world", got);
+}
+</script>
+
+<script id=remove_and_clear>
+{
+  const dt = new DataTransfer();
+  dt.setData("text/plain", "s");
+  dt.items.add(new File(["x"], "f.txt", { type: "text/plain" }));
+  testing.expectEqual(2, dt.items.length);
+  testing.expectEqual(1, dt.files.length);
+  // remove the string item (index 0)
+  dt.items.remove(0);
+  testing.expectEqual(1, dt.items.length);
+  testing.expectEqual("", dt.getData("text/plain"));
+  testing.expectEqual(1, dt.files.length);
+  // clearData() drops string items, keeps files
+  dt.setData("text/plain", "again");
+  dt.clearData();
+  testing.expectEqual("", dt.getData("text/plain"));
+  testing.expectEqual(1, dt.files.length);
+  // items.clear() drops everything
+  dt.items.clear();
+  testing.expectEqual(0, dt.items.length);
+  testing.expectEqual(0, dt.files.length);
+}
+</script>
+
+<script id=iterate_items>
+{
+  const dt = new DataTransfer();
+  dt.items.add("a", "text/a");
+  dt.items.add("b", "text/b");
+  const kinds = [];
+  for (const it of dt.items) {
+    kinds.push(it.type);
+  }
+  testing.expectEqual("text/a,text/b", kinds.join(","));
+}
+</script>

--- a/src/browser/tests/event/drag.html
+++ b/src/browser/tests/event/drag.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=default>
+{
+  const event = new DragEvent('drop');
+  testing.expectEqual('drop', event.type);
+  testing.expectEqual(true, event instanceof DragEvent);
+  testing.expectEqual(true, event instanceof MouseEvent);
+  testing.expectEqual(true, event instanceof UIEvent);
+  testing.expectEqual(true, event instanceof Event);
+  // no dataTransfer supplied -> null
+  testing.expectEqual(null, event.dataTransfer);
+}
+</script>
+
+<script id=mouse_inherited>
+{
+  const event = new DragEvent('dragover', { clientX: 5, clientY: 9, button: 0 });
+  testing.expectEqual(5, event.clientX);
+  testing.expectEqual(9, event.clientY);
+}
+</script>
+
+<script id=carries_data_transfer>
+{
+  const dt = new DataTransfer();
+  dt.items.add(new File(["x"], "drop.txt", { type: "text/plain" }));
+
+  const event = new DragEvent('drop', { dataTransfer: dt, bubbles: true });
+  testing.expectEqual(dt, event.dataTransfer);
+  testing.expectEqual(1, event.dataTransfer.files.length);
+  testing.expectEqual("drop.txt", event.dataTransfer.files[0].name);
+}
+</script>
+
+<script id=dispatched_drop>
+{
+  const dt = new DataTransfer();
+  dt.items.add(new File(["x"], "drop.txt", { type: "text/plain" }));
+
+  const el = document.createElement('div');
+  let seen = -1;
+  el.addEventListener('drop', function (e) {
+    testing.expectEqual(true, e instanceof DragEvent);
+    seen = e.dataTransfer.files.length;
+  });
+  el.dispatchEvent(new DragEvent('drop', { dataTransfer: dt, bubbles: true }));
+  testing.expectEqual(1, seen);
+}
+</script>
+
+<script id=refcount_balance>
+{
+  // A DragEvent holds a ref on its DataTransfer so the store outlives the event
+  // even if the JS wrapper is dropped first. Build many event/store pairs and
+  // retain none: at teardown every acquire must be matched by a release, or the
+  // leak-checking test runner fails. Encodes the acquire/release contract that a
+  // plain "read the files" assertion wouldn't exercise.
+  let last = 0;
+  for (let i = 0; i < 25; i++) {
+    const dt = new DataTransfer();
+    dt.items.add(new File(["payload"], "f" + i + ".txt", { type: "text/plain" }));
+    const ev = new DragEvent('drop', { dataTransfer: dt });
+    last = ev.dataTransfer.files.length;
+  }
+  testing.expectEqual(1, last);
+}
+</script>

--- a/src/browser/webapi/DataTransfer.zig
+++ b/src/browser/webapi/DataTransfer.zig
@@ -98,8 +98,7 @@ fn normalizeFormat(arena: Allocator, format: []const u8) ![]const u8 {
     if (std.ascii.eqlIgnoreCase(format, "url")) {
         return "text/uri-list";
     }
-    const buf = try arena.dupe(u8, format);
-    return std.ascii.lowerString(buf, buf);
+    return std.ascii.allocLowerString(arena, format);
 }
 
 pub fn getData(self: *const DataTransfer, format: []const u8, frame: *Frame) ![]const u8 {
@@ -114,15 +113,15 @@ pub fn getData(self: *const DataTransfer, format: []const u8, frame: *Frame) ![]
 
 pub fn setData(self: *DataTransfer, format: []const u8, data: []const u8) !void {
     const norm = try normalizeFormat(self._arena, format);
-    const dup = try self._arena.dupe(u8, data);
+    const owned_data = try self._arena.dupe(u8, data);
     for (self._items.items) |it| {
         if (it._kind == .string and std.mem.eql(u8, it._type, norm)) {
-            it._payload = .{ .string = dup };
+            it._payload = .{ .string = owned_data };
             return;
         }
     }
     const it = try self._arena.create(DataTransferItem);
-    it.* = .{ ._kind = .string, ._type = norm, ._payload = .{ .string = dup } };
+    it.* = .{ ._data_transfer = self, ._kind = .string, ._type = norm, ._payload = .{ .string = owned_data } };
     try self._items.append(self._arena, it);
 }
 
@@ -159,11 +158,10 @@ pub fn addItem(self: *DataTransfer, data: js.Value, type_: ?[]const u8, frame: *
         return try self.addFileItem(file, frame);
     } else |_| {}
 
-    const s = try data.toZig([]const u8);
+    const owned_data = try data.toStringSliceWithAlloc(self._arena);
     const norm = try normalizeFormat(self._arena, type_ orelse "");
-    const dup = try self._arena.dupe(u8, s);
     const it = try self._arena.create(DataTransferItem);
-    it.* = .{ ._kind = .string, ._type = norm, ._payload = .{ .string = dup } };
+    it.* = .{ ._data_transfer = self, ._kind = .string, ._type = norm, ._payload = .{ .string = owned_data } };
     try self._items.append(self._arena, it);
     return it;
 }
@@ -171,7 +169,7 @@ pub fn addItem(self: *DataTransfer, data: js.Value, type_: ?[]const u8, frame: *
 fn addFileItem(self: *DataTransfer, file: *File, frame: *Frame) !*DataTransferItem {
     file._proto.acquireRef();
     const it = try self._arena.create(DataTransferItem);
-    it.* = .{ ._kind = .file, ._type = file._proto.getType(), ._payload = .{ .file = file } };
+    it.* = .{ ._data_transfer = self, ._kind = .file, ._type = file._proto.getType(), ._payload = .{ .file = file } };
     try self._items.append(self._arena, it);
     try self.rebuildFiles(frame);
     return it;

--- a/src/browser/webapi/DataTransfer.zig
+++ b/src/browser/webapi/DataTransfer.zig
@@ -1,0 +1,291 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const js = @import("../js/js.zig");
+const Frame = @import("../Frame.zig");
+const Page = @import("../Page.zig");
+
+const File = @import("File.zig");
+const FileList = @import("FileList.zig");
+const DataTransferItem = @import("DataTransferItem.zig");
+const DataTransferItemList = @import("DataTransferItemList.zig");
+
+const Allocator = std.mem.Allocator;
+
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface
+//
+// The canonical drag-data-store: one ordered list of items (string- or
+// file-kind). `.items` is a live DataTransferItemList view; `.files` is a
+// FileList rebuilt from the file-kind items so the two stay in sync. Per v1
+// scope the store is always read/write (no event-phase mode gating).
+const DataTransfer = @This();
+
+pub fn registerTypes() []const type {
+    return &.{
+        DataTransfer,
+        DataTransferItem,
+        DataTransferItemList,
+        DataTransferItemList.Iterator,
+    };
+}
+
+_arena: Allocator,
+// Refcounted so the GC weak-finalizer (or page teardown) releases the pooled
+// arena exactly once; mirrors Blob's lifecycle.
+_rc: lp.RC(u32) = .{},
+_items: std.ArrayList(*DataTransferItem) = .{},
+_item_list: *DataTransferItemList,
+// FileList lives on the factory slab and is frame-tracked, so each File ref it
+// holds is released at frame teardown (same path as `<input type=file>`).
+_files: *FileList,
+_drop_effect: []const u8 = "none",
+_effect_allowed: []const u8 = "uninitialized",
+
+pub fn init(frame: *Frame) !*DataTransfer {
+    const arena = try frame.getArena(.medium, "DataTransfer");
+    errdefer frame.releaseArena(arena);
+
+    const fl = try frame._factory.create(FileList{});
+    try frame.trackFileList(fl);
+
+    const self = try arena.create(DataTransfer);
+    const list = try arena.create(DataTransferItemList);
+    self.* = .{
+        ._arena = arena,
+        ._item_list = list,
+        ._files = fl,
+    };
+    list.* = .{ ._data_transfer = self };
+    return self;
+}
+
+pub fn deinit(self: *DataTransfer, page: *Page) void {
+    page.releaseArena(self._arena);
+}
+
+pub fn acquireRef(self: *DataTransfer) void {
+    self._rc.acquire();
+}
+
+pub fn releaseRef(self: *DataTransfer, page: *Page) void {
+    self._rc.release(self, page);
+}
+
+// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata
+// "text" and "url" are shorthands the spec maps onto MIME types.
+fn normalizeFormat(arena: Allocator, format: []const u8) ![]const u8 {
+    if (std.ascii.eqlIgnoreCase(format, "text")) {
+        return "text/plain";
+    }
+    if (std.ascii.eqlIgnoreCase(format, "url")) {
+        return "text/uri-list";
+    }
+    const buf = try arena.dupe(u8, format);
+    return std.ascii.lowerString(buf, buf);
+}
+
+pub fn getData(self: *const DataTransfer, format: []const u8, frame: *Frame) ![]const u8 {
+    const norm = try normalizeFormat(frame.call_arena, format);
+    for (self._items.items) |it| {
+        if (it._kind == .string and std.mem.eql(u8, it._type, norm)) {
+            return it._payload.string;
+        }
+    }
+    return "";
+}
+
+pub fn setData(self: *DataTransfer, format: []const u8, data: []const u8) !void {
+    const norm = try normalizeFormat(self._arena, format);
+    const dup = try self._arena.dupe(u8, data);
+    for (self._items.items) |it| {
+        if (it._kind == .string and std.mem.eql(u8, it._type, norm)) {
+            it._payload = .{ .string = dup };
+            return;
+        }
+    }
+    const it = try self._arena.create(DataTransferItem);
+    it.* = .{ ._kind = .string, ._type = norm, ._payload = .{ .string = dup } };
+    try self._items.append(self._arena, it);
+}
+
+pub fn clearData(self: *DataTransfer, format_: ?[]const u8, frame: *Frame) !void {
+    if (format_) |format| {
+        const norm = try normalizeFormat(frame.call_arena, format);
+        var i: usize = 0;
+        while (i < self._items.items.len) {
+            const it = self._items.items[i];
+            if (it._kind == .string and std.mem.eql(u8, it._type, norm)) {
+                _ = self._items.orderedRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+        return;
+    }
+    // No format: remove every string item, leave file items in place.
+    var i: usize = 0;
+    while (i < self._items.items.len) {
+        if (self._items.items[i]._kind == .string) {
+            _ = self._items.orderedRemove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+// --- DataTransferItemList delegation ---
+
+// add(File) -> file item ; add(DOMString, DOMString) -> string item.
+pub fn addItem(self: *DataTransfer, data: js.Value, type_: ?[]const u8, frame: *Frame) !?*DataTransferItem {
+    if (data.toZig(*File)) |file| {
+        return try self.addFileItem(file, frame);
+    } else |_| {}
+
+    const s = try data.toZig([]const u8);
+    const norm = try normalizeFormat(self._arena, type_ orelse "");
+    const dup = try self._arena.dupe(u8, s);
+    const it = try self._arena.create(DataTransferItem);
+    it.* = .{ ._kind = .string, ._type = norm, ._payload = .{ .string = dup } };
+    try self._items.append(self._arena, it);
+    return it;
+}
+
+fn addFileItem(self: *DataTransfer, file: *File, frame: *Frame) !*DataTransferItem {
+    file._proto.acquireRef();
+    const it = try self._arena.create(DataTransferItem);
+    it.* = .{ ._kind = .file, ._type = file._proto.getType(), ._payload = .{ .file = file } };
+    try self._items.append(self._arena, it);
+    try self.rebuildFiles(frame);
+    return it;
+}
+
+pub fn removeItem(self: *DataTransfer, index: u32, frame: *Frame) !void {
+    if (index >= self._items.items.len) {
+        return;
+    }
+    const it = self._items.orderedRemove(index);
+    if (it._kind == .file) {
+        it._payload.file._proto.releaseRef(frame._page);
+        try self.rebuildFiles(frame);
+    }
+}
+
+pub fn clearItems(self: *DataTransfer, frame: *Frame) !void {
+    for (self._items.items) |it| {
+        if (it._kind == .file) {
+            it._payload.file._proto.releaseRef(frame._page);
+        }
+    }
+    self._items.clearRetainingCapacity();
+    try self.rebuildFiles(frame);
+}
+
+// Rebuild the FileList slice from the current file-kind items, in order.
+fn rebuildFiles(self: *DataTransfer, frame: *Frame) !void {
+    var files: std.ArrayList(*File) = .{};
+    for (self._items.items) |it| {
+        if (it._kind == .file) {
+            try files.append(frame.arena, it._payload.file);
+        }
+    }
+    self._files._files = try files.toOwnedSlice(frame.arena);
+}
+
+// --- accessors ---
+
+pub fn getFiles(self: *DataTransfer) *FileList {
+    return self._files;
+}
+
+pub fn getItems(self: *DataTransfer) *DataTransferItemList {
+    return self._item_list;
+}
+
+pub fn getTypes(self: *DataTransfer, frame: *Frame) ![][]const u8 {
+    var out: std.ArrayList([]const u8) = .{};
+    var has_files = false;
+    for (self._items.items) |it| {
+        switch (it._kind) {
+            .string => try out.append(frame.call_arena, it._type),
+            .file => has_files = true,
+        }
+    }
+    if (has_files) {
+        try out.append(frame.call_arena, "Files");
+    }
+    return out.toOwnedSlice(frame.call_arena);
+}
+
+pub fn getDropEffect(self: *const DataTransfer) []const u8 {
+    return self._drop_effect;
+}
+
+pub fn setDropEffect(self: *DataTransfer, value: []const u8) !void {
+    inline for (.{ "none", "copy", "link", "move" }) |valid| {
+        if (std.mem.eql(u8, value, valid)) {
+            self._drop_effect = valid;
+            return;
+        }
+    }
+}
+
+pub fn getEffectAllowed(self: *const DataTransfer) []const u8 {
+    return self._effect_allowed;
+}
+
+pub fn setEffectAllowed(self: *DataTransfer, value: []const u8) !void {
+    inline for (.{ "none", "copy", "copyLink", "copyMove", "link", "linkMove", "move", "all", "uninitialized" }) |valid| {
+        if (std.mem.eql(u8, value, valid)) {
+            self._effect_allowed = valid;
+            return;
+        }
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdragimage
+// No-op: Lightpanda has no rendered drag feedback.
+pub fn setDragImage(_: *DataTransfer, _: js.Value, _: i32, _: i32) void {}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(DataTransfer);
+
+    pub const Meta = struct {
+        pub const name = "DataTransfer";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const constructor = bridge.constructor(DataTransfer.init, .{});
+    pub const dropEffect = bridge.accessor(DataTransfer.getDropEffect, DataTransfer.setDropEffect, .{});
+    pub const effectAllowed = bridge.accessor(DataTransfer.getEffectAllowed, DataTransfer.setEffectAllowed, .{});
+    pub const files = bridge.accessor(DataTransfer.getFiles, null, .{});
+    pub const items = bridge.accessor(DataTransfer.getItems, null, .{});
+    pub const types = bridge.accessor(DataTransfer.getTypes, null, .{});
+    pub const getData = bridge.function(DataTransfer.getData, .{});
+    pub const setData = bridge.function(DataTransfer.setData, .{});
+    pub const clearData = bridge.function(DataTransfer.clearData, .{});
+    pub const setDragImage = bridge.function(DataTransfer.setDragImage, .{});
+};
+
+const testing = @import("../../testing.zig");
+test "WebApi: DataTransfer" {
+    try testing.htmlRunner("data_transfer.html", .{});
+}

--- a/src/browser/webapi/DataTransferItem.zig
+++ b/src/browser/webapi/DataTransferItem.zig
@@ -1,0 +1,90 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const js = @import("../js/js.zig");
+
+const File = @import("File.zig");
+
+const log = lp.log;
+
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface
+const DataTransferItem = @This();
+
+pub const Kind = enum { string, file };
+
+_kind: Kind,
+// For string items: the normalized format (e.g. "text/plain").
+// For file items: the File's MIME type.
+_type: []const u8,
+_payload: Payload,
+
+pub const Payload = union(Kind) {
+    string: []const u8,
+    file: *File,
+};
+
+pub fn getKind(self: *const DataTransferItem) []const u8 {
+    return switch (self._kind) {
+        .string => "string",
+        .file => "file",
+    };
+}
+
+pub fn getType(self: *const DataTransferItem) []const u8 {
+    return self._type;
+}
+
+pub fn getAsFile(self: *const DataTransferItem) ?*File {
+    return switch (self._payload) {
+        .file => |f| f,
+        .string => null,
+    };
+}
+
+// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasstring
+// v1 invokes the callback synchronously with the string value. File items and a
+// missing callback are no-ops, per spec.
+pub fn getAsString(self: *const DataTransferItem, cb_: ?js.Function) !void {
+    const cb = cb_ orelse return;
+    const s = switch (self._payload) {
+        .string => |str| str,
+        .file => return,
+    };
+    var caught: js.TryCatch.Caught = undefined;
+    cb.tryCall(void, .{s}, &caught) catch {
+        log.debug(.js, "getAsString callback", .{ .caught = caught, .source = "DataTransferItem" });
+    };
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(DataTransferItem);
+
+    pub const Meta = struct {
+        pub const name = "DataTransferItem";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const kind = bridge.accessor(DataTransferItem.getKind, null, .{});
+    pub const @"type" = bridge.accessor(DataTransferItem.getType, null, .{});
+    pub const getAsFile = bridge.function(DataTransferItem.getAsFile, .{});
+    pub const getAsString = bridge.function(DataTransferItem.getAsString, .{});
+};

--- a/src/browser/webapi/DataTransferItem.zig
+++ b/src/browser/webapi/DataTransferItem.zig
@@ -22,6 +22,8 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 
 const File = @import("File.zig");
+const Page = @import("../Page.zig");
+const DataTransfer = @import("DataTransfer.zig");
 
 const log = lp.log;
 
@@ -30,6 +32,10 @@ const DataTransferItem = @This();
 
 pub const Kind = enum { string, file };
 
+// The owning DataTransfer. The item lives in that DataTransfer's arena and is
+// handed to JS, so it forwards acquireRef/releaseRef to keep the arena alive as
+// long as JS holds the item.
+_data_transfer: *DataTransfer,
 _kind: Kind,
 // For string items: the normalized format (e.g. "text/plain").
 // For file items: the File's MIME type.
@@ -40,6 +46,14 @@ pub const Payload = union(Kind) {
     string: []const u8,
     file: *File,
 };
+
+pub fn acquireRef(self: *DataTransferItem) void {
+    self._data_transfer.acquireRef();
+}
+
+pub fn releaseRef(self: *DataTransferItem, page: *Page) void {
+    self._data_transfer.releaseRef(page);
+}
 
 pub fn getKind(self: *const DataTransferItem) []const u8 {
     return switch (self._kind) {

--- a/src/browser/webapi/DataTransferItemList.zig
+++ b/src/browser/webapi/DataTransferItemList.zig
@@ -18,6 +18,7 @@
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+const Page = @import("../Page.zig");
 
 const DataTransfer = @import("DataTransfer.zig");
 const DataTransferItem = @import("DataTransferItem.zig");
@@ -29,6 +30,14 @@ const DataTransferItem = @import("DataTransferItem.zig");
 const DataTransferItemList = @This();
 
 _data_transfer: *DataTransfer,
+
+pub fn acquireRef(self: *DataTransferItemList) void {
+    self._data_transfer.acquireRef();
+}
+
+pub fn releaseRef(self: *DataTransferItemList, page: *Page) void {
+    self._data_transfer.releaseRef(page);
+}
 
 pub fn getLength(self: *const DataTransferItemList) u32 {
     return @intCast(self._data_transfer._items.items.len);
@@ -68,6 +77,14 @@ const GenericIterator = @import("collections/iterator.zig").Entry;
 pub const Iterator = GenericIterator(struct {
     index: u32,
     list: *DataTransferItemList,
+
+    pub fn acquireRef(self: *@This()) void {
+        self.list.acquireRef();
+    }
+
+    pub fn releaseRef(self: *@This(), page: *Page) void {
+        self.list.releaseRef(page);
+    }
 
     pub fn next(self: *@This(), _: *const js.Execution) ?*DataTransferItem {
         const index = self.index;

--- a/src/browser/webapi/DataTransferItemList.zig
+++ b/src/browser/webapi/DataTransferItemList.zig
@@ -1,0 +1,104 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const js = @import("../js/js.zig");
+const Frame = @import("../Frame.zig");
+
+const DataTransfer = @import("DataTransfer.zig");
+const DataTransferItem = @import("DataTransferItem.zig");
+
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface
+//
+// A live view over the owning DataTransfer's item list; all mutations are
+// delegated to the DataTransfer so `.files` stays in sync.
+const DataTransferItemList = @This();
+
+_data_transfer: *DataTransfer,
+
+pub fn getLength(self: *const DataTransferItemList) u32 {
+    return @intCast(self._data_transfer._items.items.len);
+}
+
+pub fn item(self: *const DataTransferItemList, index: u32) ?*DataTransferItem {
+    const items = self._data_transfer._items.items;
+    if (index >= items.len) {
+        return null;
+    }
+    return items[index];
+}
+
+// add(DOMString data, DOMString type) | add(File data)
+// The overload is resolved by inspecting the first argument: a File yields a
+// file item (the `type` argument is ignored), anything else a string item.
+pub fn add(self: *DataTransferItemList, data: js.Value, type_: ?[]const u8, frame: *Frame) !?*DataTransferItem {
+    return self._data_transfer.addItem(data, type_, frame);
+}
+
+pub fn remove(self: *DataTransferItemList, index: u32, frame: *Frame) !void {
+    return self._data_transfer.removeItem(index, frame);
+}
+
+pub fn clear(self: *DataTransferItemList, frame: *Frame) !void {
+    return self._data_transfer.clearItems(frame);
+}
+
+pub fn iterator(self: *DataTransferItemList, exec: *const js.Execution) !*Iterator {
+    return Iterator.init(.{
+        .index = 0,
+        .list = self,
+    }, exec);
+}
+
+const GenericIterator = @import("collections/iterator.zig").Entry;
+pub const Iterator = GenericIterator(struct {
+    index: u32,
+    list: *DataTransferItemList,
+
+    pub fn next(self: *@This(), _: *const js.Execution) ?*DataTransferItem {
+        const index = self.index;
+        const it = self.list.item(index) orelse return null;
+        self.index = index + 1;
+        return it;
+    }
+}, null);
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(DataTransferItemList);
+
+    pub const Meta = struct {
+        pub const name = "DataTransferItemList";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const length = bridge.accessor(DataTransferItemList.getLength, null, .{});
+    pub const add = bridge.function(DataTransferItemList.add, .{});
+    pub const remove = bridge.function(DataTransferItemList.remove, .{});
+    pub const clear = bridge.function(DataTransferItemList.clear, .{});
+    pub const @"[]" = bridge.indexed(DataTransferItemList.item, getIndexes, .{ .null_as_undefined = true });
+    pub const symbol_iterator = bridge.iterator(DataTransferItemList.iterator, .{});
+
+    fn getIndexes(self: *DataTransferItemList, exec: *const js.Execution) !js.Array {
+        const len = self.getLength();
+        var arr = exec.js.local.?.newArray(len);
+        for (0..len) |i| {
+            _ = try arr.set(@intCast(i), i, .{});
+        }
+        return arr;
+    }
+};

--- a/src/browser/webapi/event/DragEvent.zig
+++ b/src/browser/webapi/event/DragEvent.zig
@@ -1,0 +1,134 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const js = @import("../../js/js.zig");
+const Frame = @import("../../Frame.zig");
+const Page = @import("../../Page.zig");
+
+const Event = @import("../Event.zig");
+const MouseEvent = @import("MouseEvent.zig");
+const DataTransfer = @import("../DataTransfer.zig");
+
+const String = lp.String;
+
+const DragEvent = @This();
+
+_proto: *MouseEvent,
+_data_transfer: ?*DataTransfer,
+
+pub const DragEventOptions = struct {
+    dataTransfer: ?*DataTransfer = null,
+};
+
+pub const Options = Event.inheritOptions(DragEvent, DragEventOptions);
+
+pub fn init(typ: []const u8, _opts: ?Options, frame: *Frame) !*DragEvent {
+    return initWithTrusted(typ, _opts, false, frame);
+}
+
+pub fn initTrusted(typ: []const u8, _opts: ?Options, frame: *Frame) !*DragEvent {
+    return initWithTrusted(typ, _opts, true, frame);
+}
+
+fn initWithTrusted(typ: []const u8, _opts: ?Options, trusted: bool, frame: *Frame) !*DragEvent {
+    const arena = try frame.getArena(.medium, "DragEvent");
+    errdefer frame.releaseArena(arena);
+    const type_string = try String.init(arena, typ, .{});
+
+    const opts = _opts orelse Options{};
+
+    const event = try frame._factory.mouseEvent(
+        arena,
+        type_string,
+        MouseEvent{
+            ._type = .{ .drag_event = undefined },
+            ._proto = undefined,
+            ._screen_x = opts.screenX,
+            ._screen_y = opts.screenY,
+            ._client_x = opts.clientX,
+            ._client_y = opts.clientY,
+            ._ctrl_key = opts.ctrlKey,
+            ._shift_key = opts.shiftKey,
+            ._alt_key = opts.altKey,
+            ._meta_key = opts.metaKey,
+            ._button = std.meta.intToEnum(MouseEvent.MouseButton, opts.button) catch return error.TypeError,
+            ._buttons = opts.buttons,
+            ._related_target = opts.relatedTarget,
+        },
+        DragEvent{
+            ._proto = undefined,
+            ._data_transfer = opts.dataTransfer,
+        },
+    );
+
+    Event.populatePrototypes(event, opts, trusted);
+
+    // Hold a ref on the DataTransfer so its arena outlives this event even if the
+    // JS wrapper is collected first; released in deinit (mirrors MessageEvent's
+    // Blob handling). The shared refcount lives on the Event base, so reach it
+    // through asEvent() rather than the immediate _proto.
+    if (opts.dataTransfer) |dt| {
+        dt.acquireRef();
+    }
+
+    return event;
+}
+
+pub fn deinit(self: *DragEvent, page: *Page) void {
+    if (self._data_transfer) |dt| {
+        dt.releaseRef(page);
+    }
+    self.asEvent().deinit(page);
+}
+
+pub fn acquireRef(self: *DragEvent) void {
+    self.asEvent().acquireRef();
+}
+
+pub fn releaseRef(self: *DragEvent, page: *Page) void {
+    self.asEvent()._rc.release(self, page);
+}
+
+pub fn asEvent(self: *DragEvent) *Event {
+    return self._proto.asEvent();
+}
+
+pub fn getDataTransfer(self: *const DragEvent) ?*DataTransfer {
+    return self._data_transfer;
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(DragEvent);
+
+    pub const Meta = struct {
+        pub const name = "DragEvent";
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+    };
+
+    pub const constructor = bridge.constructor(DragEvent.init, .{});
+    pub const dataTransfer = bridge.accessor(DragEvent.getDataTransfer, null, .{});
+};
+
+const testing = @import("../../../testing.zig");
+test "WebApi: DragEvent" {
+    try testing.htmlRunner("event/drag.html", .{});
+}

--- a/src/browser/webapi/event/InputEvent.zig
+++ b/src/browser/webapi/event/InputEvent.zig
@@ -21,9 +21,11 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
+const Page = @import("../../Page.zig");
 
 const Event = @import("../Event.zig");
 const UIEvent = @import("UIEvent.zig");
+const DataTransfer = @import("../DataTransfer.zig");
 
 const String = lp.String;
 const Allocator = std.mem.Allocator;
@@ -32,12 +34,13 @@ const InputEvent = @This();
 
 _proto: *UIEvent,
 _data: ?[]const u8,
-// TODO: add dataTransfer
+_data_transfer: ?*DataTransfer = null,
 _input_type: []const u8,
 _is_composing: bool,
 
 pub const InputEventOptions = struct {
     data: ?[]const u8 = null,
+    dataTransfer: ?*DataTransfer = null,
     inputType: ?[]const u8 = null,
     isComposing: bool = false,
 };
@@ -69,6 +72,7 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
         InputEvent{
             ._proto = undefined,
             ._data = if (opts.data) |d| try arena.dupe(u8, d) else null,
+            ._data_transfer = opts.dataTransfer,
             ._input_type = if (opts.inputType) |it| try arena.dupe(u8, it) else "",
             ._is_composing = opts.isComposing,
         },
@@ -82,7 +86,29 @@ fn initWithTrusted(arena: Allocator, typ: String, _opts: ?Options, trusted: bool
     rootevt._cancelable = false;
     rootevt._composed = true;
 
+    // Hold a ref on the DataTransfer (when present) for this event's lifetime;
+    // released in deinit. Almost always null for input events, but keeps the
+    // refcount protocol intact when it isn't.
+    if (opts.dataTransfer) |dt| {
+        dt.acquireRef();
+    }
+
     return event;
+}
+
+pub fn deinit(self: *InputEvent, page: *Page) void {
+    if (self._data_transfer) |dt| {
+        dt.releaseRef(page);
+    }
+    self.asEvent().deinit(page);
+}
+
+pub fn acquireRef(self: *InputEvent) void {
+    self.asEvent().acquireRef();
+}
+
+pub fn releaseRef(self: *InputEvent, page: *Page) void {
+    self.asEvent()._rc.release(self, page);
 }
 
 pub fn asEvent(self: *InputEvent) *Event {
@@ -91,6 +117,10 @@ pub fn asEvent(self: *InputEvent) *Event {
 
 pub fn getData(self: *const InputEvent) ?[]const u8 {
     return self._data;
+}
+
+pub fn getDataTransfer(self: *const InputEvent) ?*DataTransfer {
+    return self._data_transfer;
 }
 
 pub fn getInputType(self: *const InputEvent) []const u8 {
@@ -112,6 +142,7 @@ pub const JsApi = struct {
 
     pub const constructor = bridge.constructor(InputEvent.init, .{});
     pub const data = bridge.accessor(InputEvent.getData, null, .{});
+    pub const dataTransfer = bridge.accessor(InputEvent.getDataTransfer, null, .{});
     pub const inputType = bridge.accessor(InputEvent.getInputType, null, .{});
     pub const isComposing = bridge.accessor(InputEvent.getIsComposing, null, .{});
 };

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
 //
 // Francis Bouvier <francis@lightpanda.io>
 // Pierre Tachoire <pierre@lightpanda.io>
@@ -45,6 +45,7 @@ pub const Type = union(enum) {
     generic,
     pointer_event: *PointerEvent,
     wheel_event: *@import("WheelEvent.zig"),
+    drag_event: *@import("DragEvent.zig"),
 };
 
 _type: Type,
@@ -135,6 +136,7 @@ pub fn is(self: *MouseEvent, comptime T: type) ?*T {
         .generic => return if (T == MouseEvent) self else null,
         .pointer_event => |e| return if (T == PointerEvent) e else null,
         .wheel_event => |e| return if (T == @import("WheelEvent.zig")) e else null,
+        .drag_event => |e| return if (T == @import("DragEvent.zig")) e else null,
     }
     return null;
 }


### PR DESCRIPTION
## What this enables

Drag-and-drop file upload. Page JS and test drivers build a `DataTransfer`, add `File` objects to it, and dispatch a `drop`/`dragover` event whose `.dataTransfer` exposes those files as a `FileList`:

```js
const dt = new DataTransfer();
dt.items.add(new File(["…"], "report.pdf", { type: "application/pdf" }));
el.dispatchEvent(new DragEvent("drop", { dataTransfer: dt }));
// handler reads e.dataTransfer.files[0] -> the File
```

Until now `DataTransfer` / `DataTransferItem` were `undefined` (TODO stubs), so that whole pattern threw. This was the last untracked gap in #2043, and the capybara-lightpanda driver needs it for drag-and-drop file-upload system tests.

## What this adds

- **`DataTransfer`** — constructible; `dropEffect`, `effectAllowed`, `types`, `files` (`FileList`), `items` (`DataTransferItemList`), `getData`/`setData`/`clearData`, `setDragImage` (no-op).
- **`DataTransferItem`** — `kind`, `type`, `getAsFile()`, `getAsString(cb)`.
- **`DataTransferItemList`** — `length`, indexed access, `add(data, type)` / `add(file)`, `remove(i)`, `clear()`.
- **`DragEvent`** (extends `MouseEvent`) carrying `dataTransfer`; also resolves the `InputEvent.dataTransfer` TODO.

## How it fits together

`DataTransfer` keeps one ordered drag-data-store of items (string- or file-kind). `.items` is a live view that mutates the store, `.files` is a `FileList` rebuilt from the file-kind items, and `.types` is derived. So `items.add(file)` shows up in `.files` right away and the two never drift.

Memory follows the existing `<input type=file>` path: the backing `FileList` is created on the factory slab and frame-tracked, `add` takes a ref on each `File`, and `remove`/`clear`/teardown drop it, so the leak-checking test runner stays green. The `DataTransfer`'s own arena is refcounted like `Blob`, so the GC finalizer reclaims it. `DataTransferItem`, `DataTransferItemList`, and the item-list iterator all live in that arena but are handed to JS on their own, so each forwards `acquireRef`/`releaseRef` to the owning `DataTransfer` (the same way `XMLHttpRequestUpload` forwards to its `XMLHttpRequest`) — holding any of them from JS keeps the store alive even if the `DataTransfer` wrapper is collected first. A `DragEvent`/`InputEvent` that carries a `DataTransfer` holds a ref the same way, released in `deinit` like `MessageEvent` does with a `Blob`.

`getData`/`setData` apply the spec's format shorthands (`text` becomes `text/plain`, `url` becomes `text/uri-list`). `effectAllowed`/`dropEffect` reject values outside their allow-lists, `setData` replaces or appends, and `clearData()` drops string data but keeps files.

> [!NOTE]
> Deferred to a follow-up: CDP `Input.dispatchDragEvent` injection. The JS-constructible `DataTransfer` plus the drop-event path is what unblocks the common driver pattern; CDP-side synthesis is additive and can land on its own. The v1 drag-data-store is always read/write. It does not model the spec's event-phase read-only/protected mode gating, because drivers build a `DataTransfer` and dispatch without ever entering the restricted phases.

## Where to focus review

- `DataTransfer.zig` / `DataTransferItem.zig` / `DataTransferItemList.zig` — the `File` acquire/release balance across `addFileItem` / `removeItem` / `clearItems` against the frame-tracked `FileList`, and the `acquireRef`/`releaseRef` forwarding from the item, list, and iterator to the owning `DataTransfer` so its arena outlives any JS-held wrapper.
- `DragEvent.zig` / `InputEvent.zig` — these reach the shared refcount through `asEvent()._rc` (their proto chain is deeper than `MessageEvent`'s), acquire the `DataTransfer` on store, and release it in `deinit`.
- `MouseEvent.zig` — the new `drag_event` arm in the type union and `is()`.

## Test plan

- [x] TDD fixtures first: `new DataTransfer()`, `items.add(file)` reflected in `.files`, `getData`/`setData` round-trip with normalization, `remove`/`clear`, item iteration (`data_transfer.html`); a dispatched `drop` `DragEvent` whose `dataTransfer.files` is readable, plus a refcount-balance stress block (`event/drag.html`).
- [x] `make test` — 791/791, no leaks.
- [x] `zig fmt --check ./*.zig ./**/*.zig` clean.
- [x] `zig build` succeeds.

Refs #2043

