### PR TITLE
test,perf: Fix leaky thread in test runner

### DIFF
--- a/src/TestHTTPServer.zig
+++ b/src/TestHTTPServer.zig
@@ -81,8 +81,7 @@ fn handleConnection(self: *TestHTTPServer, conn: std.net.Server.Connection) !voi
 
     while (true) {
         var req = http_server.receiveHead() catch |err| switch (err) {
-            error.ReadFailed => continue,
-            error.HttpConnectionClosing => continue,
+            error.ReadFailed, error.HttpConnectionClosing => return,
             else => {
                 std.debug.print("Test HTTP Server error: {}\n", .{err});
                 return err;

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -48,6 +48,7 @@ const TestContext = struct {
     pub fn deinit(self: *TestContext) void {
         if (self.cdp_initialized) self.cdp_.deinit();
         posix.close(self.socket);
+        posix.close(self.cdp_socket);
         base.reset();
     }
 


### PR DESCRIPTION
The TestHTTPServer leaks a thread for every connection that shuts down. This commit correctly releases it. It also closes a leaking CDP socket.

Full test went from 20s -> 10s for me