### PR TITLE
mcp: ping's response must be an object not an array

### DIFF
--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -137,5 +137,5 @@ test "MCP.Server - Integration: ping request returns an empty result" {
 
     try router.processRequests(server, &in_reader);
 
-    try testing.expectJson(.{ .jsonrpc = "2.0", .id = "ping-1", .result = .{} }, out_alloc.writer.buffered());
+    try testing.expectJson(.{ .jsonrpc = "2.0", .id = "ping-1", .result = struct {}{} }, out_alloc.writer.buffered());
 }

--- a/src/mcp/router.zig
+++ b/src/mcp/router.zig
@@ -100,7 +100,7 @@ fn handleInitialize(server: *Server, req: protocol.Request) !void {
 
 fn handlePing(server: *Server, req: protocol.Request) !void {
     const id = req.id orelse return;
-    try server.sendResult(id, .{});
+    try server.sendResult(id, struct {}{});
 }
 
 const testing = @import("../testing.zig");
@@ -131,7 +131,7 @@ test "MCP.router - handleMessage - synchronous unit tests" {
     try handleMessage(server, aa,
         \\{"jsonrpc":"2.0","id":2,"method":"ping"}
     );
-    try testing.expectJson(.{ .jsonrpc = "2.0", .id = 2, .result = .{} }, out_alloc.writer.buffered());
+    try testing.expectJson(.{ .jsonrpc = "2.0", .id = 2, .result = struct {}{} }, out_alloc.writer.buffered());
     out_alloc.writer.end = 0;
 
     // 3. Tools list


### PR DESCRIPTION
The array returned breaks the mcp keep alive feature implemented by the official mcp client in Go.