### PR TITLE
ci: raise cdp bench MAX_VmHWM to 29000

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -237,7 +237,7 @@ jobs:
     needs: zig-build-release
 
     env:
-      MAX_VmHWM: 28000 # 28MB (KB)
+      MAX_VmHWM: 29000 # 29MB (KB)
       MAX_CG_PEAK: 8000 # 8MB (KB)
       MAX_AVG_DURATION: 17
 


### PR DESCRIPTION
The agent branch grew .text by ~2.8MB (mostly std monomorphization from the new script/agent modules); none of it executes in serve mode and anonymous/heap memory is byte-identical to main (716-724KB Private_Dirty across main, agent-dev, and a build with the agent code compiled out).

The VmHWM delta is file-backed pages of the binary: the kernel maps them in large readahead/THP chunks around each touched page, so peak RSS shifts with link layout on every relink. The agent-less test build measured 4.2MB *below* main while running the identical serve path, purely from folio/window boundaries moving. At 28000 the gate was failing on layout noise (28028-28064), not a regression.