### PR TITLE
webapi: run sequential focus navigation on Tab

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -4196,9 +4196,8 @@ pub fn handleKeydown(self: *Frame, target: *Node, event: *Event) !void {
     }
 
     if (key == .Tab) {
-        // Sequential focus navigation is the default action of a Tab keydown.
-        // Shift+Tab walks backward.
-        return self.moveFocus(if (keyboard_event.getShiftKey()) .backward else .forward);
+        // tab -> forward, shift+tab -> backwards
+        return self.moveFocus(keyboard_event.getShiftKey() == false);
     }
 
     if (target.is(Element.Html.Input)) |input| {
@@ -4231,8 +4230,6 @@ pub fn handleKeydown(self: *Frame, target: *Node, event: *Event) !void {
     }
 }
 
-const FocusDirection = enum { forward, backward };
-
 // Sequential focus navigation: move `document.activeElement` to the next (Tab)
 // or previous (Shift+Tab) focusable element, firing the usual blur/focus events
 // via `Element.focus`. The order is fully determined by tabindex + document
@@ -4242,34 +4239,80 @@ const FocusDirection = enum { forward, backward };
 //      document order.
 // Ties within a group break on document order, and Tab wraps around at the ends.
 // https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation
-fn moveFocus(self: *Frame, direction: FocusDirection) !void {
+fn moveFocus(self: *Frame, forward: bool) !void {
     const document = self.document;
     const current = document._active_element;
-    const forward = direction == .forward;
+
+    const current_tab_index = blk: {
+        const cur = current orelse break :blk 0;
+        const current_html = cur.is(Element.Html) orelse break :blk 0;
+        break :blk current_html.getTabIndex();
+    };
 
     // Single document-order pass tracking two candidates:
-    //   chosen — the closest focusable element strictly past `current` in the
-    //            travel direction.
     //   edge   — the global first (forward) / last (backward) focusable element,
     //            used to wrap around when `current` is at an end, or as the
     //            landing spot when nothing is focused yet.
-    var chosen: ?*Element = null;
+    //   chosen — the closest focusable element strictly past `current` in the
+    //            travel direction.
     var edge: ?*Element = null;
+    var edge_tab_index: i32 = 0;
+
+    var chosen: ?*Element = null;
+    var chosen_tab_index: i32 = 0;
 
     var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(document.asNode(), .{});
-    while (tw.next()) |el| {
-        if (!sequentiallyFocusable(el)) continue;
+    while (tw.next()) |candidate| {
+        if (candidate.isDisabled()) {
+            continue;
+        }
+        if (candidate.is(Element.Html) == null) {
+            continue;
+        }
 
-        if (edge == null or focusOrderBefore(el, edge.?) == forward) {
-            edge = el;
+        const candidate_tab_index = blk: {
+            if (candidate.getAttributeSafe(comptime .wrap("tabindex"))) |attr| {
+                if (Element.Html.parseInteger(attr)) |tab_index| {
+                    if (tab_index < 0) {
+                        continue;
+                    }
+                    break :blk tab_index;
+                }
+                break :blk 0;
+            }
+
+            // no tab index, maybe this item isn't focusable..
+            const focusable = switch (candidate.getTag()) {
+                .button, .select, .textarea, .iframe => true,
+                .input => candidate.as(Element.Html.Input)._input_type != .hidden,
+                .anchor, .area => candidate.getAttributeSafe(comptime .wrap("href")) != null,
+                else => false,
+            };
+            if (focusable == false) {
+                continue;
+            }
+
+            break :blk 0;
+        };
+
+        if (edge == null or focusOrderBefore(candidate, candidate_tab_index, edge.?, edge_tab_index) == forward) {
+            edge = candidate;
+            edge_tab_index = candidate_tab_index;
         }
 
         const cur = current orelse continue;
-        if (el == cur) continue;
-        const past = if (forward) focusOrderBefore(cur, el) else focusOrderBefore(el, cur);
-        if (!past) continue;
-        if (chosen == null or focusOrderBefore(el, chosen.?) == forward) {
-            chosen = el;
+
+        if (candidate == cur) {
+            continue;
+        }
+
+        const past = if (forward) focusOrderBefore(cur, current_tab_index, candidate, candidate_tab_index) else focusOrderBefore(candidate, candidate_tab_index, cur, current_tab_index);
+        if (!past) {
+            continue;
+        }
+        if (chosen == null or focusOrderBefore(candidate, candidate_tab_index, chosen.?, chosen_tab_index) == forward) {
+            chosen = candidate;
+            chosen_tab_index = candidate_tab_index;
         }
     }
 
@@ -4277,45 +4320,22 @@ fn moveFocus(self: *Frame, direction: FocusDirection) !void {
     try next.focus(self);
 }
 
-// True when `el` participates in sequential focus navigation: enabled, with a
-// non-negative tabindex, and either an explicit tabindex or a natively
-// focusable shape. `getTabIndex` defaults several tags to 0, including
-// href-less anchors and hidden inputs, so the structural conditions are
-// re-checked here.
-fn sequentiallyFocusable(el: *Element) bool {
-    const html_el = el.is(Element.Html) orelse return false;
-    if (el.isDisabled()) return false;
-    if (html_el.getTabIndex() < 0) return false;
-
-    if (el.getAttributeSafe(comptime .wrap("tabindex")) != null) return true;
-
-    return switch (el.getTag()) {
-        .button, .select, .textarea, .iframe => true,
-        .input => if (el.is(Element.Html.Input)) |input| input._input_type != .hidden else false,
-        .anchor, .area => el.getAttributeSafe(comptime .wrap("href")) != null,
-        else => false,
-    };
-}
-
 // Orders two focusable elements by sequential focus navigation order: positive
 // tabindex first (ascending), then tabindex 0, ties broken by document order.
-fn focusOrderBefore(a: *Element, b: *Element) bool {
-    const ta = tabOrderIndex(a);
-    const tb = tabOrderIndex(b);
-    if (ta != tb) {
-        const group_a: u8 = if (ta > 0) 0 else 1;
-        const group_b: u8 = if (tb > 0) 0 else 1;
-        if (group_a != group_b) return group_a < group_b;
-        return ta < tb;
+fn focusOrderBefore(a: *Element, a_tab_index: i32, b: *Element, b_tab_index: i32) bool {
+    if (a_tab_index == b_tab_index) {
+        // Equal tabindex → document order: `a` precedes `b` when `b` follows `a`.
+        const FOLLOWING: u16 = 0x04;
+        return (a.asNode().compareDocumentPosition(b.asNode()) & FOLLOWING) != 0;
     }
-    // Equal tabindex → document order: `a` precedes `b` when `b` follows `a`.
-    const FOLLOWING: u16 = 0x04;
-    return (a.asNode().compareDocumentPosition(b.asNode()) & FOLLOWING) != 0;
-}
 
-fn tabOrderIndex(el: *Element) i32 {
-    const html_el = el.is(Element.Html) orelse return 0;
-    return html_el.getTabIndex();
+    const group_a: u8 = if (a_tab_index > 0) 0 else 1;
+    const group_b: u8 = if (b_tab_index > 0) 0 else 1;
+    if (group_a != group_b) {
+        return group_a < group_b;
+    }
+
+    return a_tab_index < b_tab_index;
 }
 
 const SubmitFormOpts = struct {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -4167,7 +4167,11 @@ pub fn handleClick(self: *Frame, target: *Node) !void {
 
 pub fn triggerKeyboard(self: *Frame, keyboard_event: *KeyboardEvent) !void {
     const event = keyboard_event.asEvent();
-    const element = self.window._document._active_element orelse {
+    // Dispatch to the effective active element. When nothing is explicitly
+    // focused this resolves to <body> (matching `document.activeElement`), so
+    // the keydown still fires and its default action — e.g. sequential focus
+    // navigation on Tab — can run.
+    const element = self.window._document.getActiveElement() orelse {
         event.deinit(self._page);
         return;
     };
@@ -4189,6 +4193,12 @@ pub fn handleKeydown(self: *Frame, target: *Node, event: *Event) !void {
 
     if (key == .Dead) {
         return;
+    }
+
+    if (key == .Tab) {
+        // Sequential focus navigation is the default action of a Tab keydown.
+        // Shift+Tab walks backward.
+        return self.moveFocus(if (keyboard_event.getShiftKey()) .backward else .forward);
     }
 
     if (target.is(Element.Html.Input)) |input| {
@@ -4219,6 +4229,93 @@ pub fn handleKeydown(self: *Frame, target: *Node, event: *Event) !void {
         // zig fmt: on
         return textarea.innerInsert(append, self);
     }
+}
+
+const FocusDirection = enum { forward, backward };
+
+// Sequential focus navigation: move `document.activeElement` to the next (Tab)
+// or previous (Shift+Tab) focusable element, firing the usual blur/focus events
+// via `Element.focus`. The order is fully determined by tabindex + document
+// position, so no layout is needed:
+//   1. elements with a positive tabindex, in ascending tabindex order;
+//   2. then elements with tabindex 0 (or a natively-focusable default), in
+//      document order.
+// Ties within a group break on document order, and Tab wraps around at the ends.
+// https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation
+fn moveFocus(self: *Frame, direction: FocusDirection) !void {
+    const document = self.document;
+    const current = document._active_element;
+    const forward = direction == .forward;
+
+    // Single document-order pass tracking two candidates:
+    //   chosen — the closest focusable element strictly past `current` in the
+    //            travel direction.
+    //   edge   — the global first (forward) / last (backward) focusable element,
+    //            used to wrap around when `current` is at an end, or as the
+    //            landing spot when nothing is focused yet.
+    var chosen: ?*Element = null;
+    var edge: ?*Element = null;
+
+    var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(document.asNode(), .{});
+    while (tw.next()) |el| {
+        if (!sequentiallyFocusable(el)) continue;
+
+        if (edge == null or focusOrderBefore(el, edge.?) == forward) {
+            edge = el;
+        }
+
+        const cur = current orelse continue;
+        if (el == cur) continue;
+        const past = if (forward) focusOrderBefore(cur, el) else focusOrderBefore(el, cur);
+        if (!past) continue;
+        if (chosen == null or focusOrderBefore(el, chosen.?) == forward) {
+            chosen = el;
+        }
+    }
+
+    const next = chosen orelse edge orelse return;
+    try next.focus(self);
+}
+
+// True when `el` participates in sequential focus navigation: enabled, with a
+// non-negative tabindex, and either an explicit tabindex or a natively
+// focusable shape. `getTabIndex` defaults several tags to 0, including
+// href-less anchors and hidden inputs, so the structural conditions are
+// re-checked here.
+fn sequentiallyFocusable(el: *Element) bool {
+    const html_el = el.is(Element.Html) orelse return false;
+    if (el.isDisabled()) return false;
+    if (html_el.getTabIndex() < 0) return false;
+
+    if (el.getAttributeSafe(comptime .wrap("tabindex")) != null) return true;
+
+    return switch (el.getTag()) {
+        .button, .select, .textarea, .iframe => true,
+        .input => if (el.is(Element.Html.Input)) |input| input._input_type != .hidden else false,
+        .anchor, .area => el.getAttributeSafe(comptime .wrap("href")) != null,
+        else => false,
+    };
+}
+
+// Orders two focusable elements by sequential focus navigation order: positive
+// tabindex first (ascending), then tabindex 0, ties broken by document order.
+fn focusOrderBefore(a: *Element, b: *Element) bool {
+    const ta = tabOrderIndex(a);
+    const tb = tabOrderIndex(b);
+    if (ta != tb) {
+        const group_a: u8 = if (ta > 0) 0 else 1;
+        const group_b: u8 = if (tb > 0) 0 else 1;
+        if (group_a != group_b) return group_a < group_b;
+        return ta < tb;
+    }
+    // Equal tabindex → document order: `a` precedes `b` when `b` follows `a`.
+    const FOLLOWING: u16 = 0x04;
+    return (a.asNode().compareDocumentPosition(b.asNode()) & FOLLOWING) != 0;
+}
+
+fn tabOrderIndex(el: *Element) i32 {
+    const html_el = el.is(Element.Html) orelse return 0;
+    return html_el.getTabIndex();
 }
 
 const SubmitFormOpts = struct {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -387,12 +387,16 @@ pub fn togglePopover(self: *HtmlElement, force: ?bool, frame: *Frame) !bool {
 }
 
 pub fn getTabIndex(self: *HtmlElement) i32 {
-    const default: i32 = switch (self._type) {
+    if (self.asElement().getAttributeSafe(comptime .wrap("tabindex"))) |attr| {
+        if (parseInteger(attr)) |tab_index| {
+            return tab_index;
+        }
+    }
+
+    return switch (self._type) {
         .anchor, .area, .button, .input, .select, .textarea, .iframe => 0,
         else => -1,
     };
-    const attr = self.asElement().getAttributeSafe(comptime .wrap("tabindex")) orelse return default;
-    return parseInteger(attr) orelse default;
 }
 
 pub fn setTabIndex(self: *HtmlElement, value: i32, frame: *Frame) !void {

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -314,3 +314,59 @@ test "cdp.input: dispatchMouseEvent right button fires contextmenu, double-click
     const result = try ls.local.compileAndRun("window.downButton === 2 && window.ctxButton === 2 && window.dbl === true", null);
     try testing.expect(result.isTrue());
 }
+
+test "cdp.input: dispatchKeyEvent Tab runs sequential focus navigation" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const frame = try bc.session.createPage();
+    const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
+    try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
+    var runner = try bc.session.runner(.{});
+    try runner.wait(.{ .ms = 2000 });
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    var try_catch: lp.js.TryCatch = undefined;
+    try_catch.init(&ls.local);
+    defer try_catch.deinit();
+
+    // Three controls whose tabindex order (1, 2, 3) differs from document
+    // order (2, 1, 3): focus order must follow tabindex, not the tree.
+    _ = try ls.local.compileAndRun(
+        \\document.body.innerHTML =
+        \\  '<input id="i2" tabindex="2">' +
+        \\  '<button id="b1" tabindex="1">b</button>' +
+        \\  '<select id="s3" tabindex="3"></select>';
+    , null);
+
+    // Nothing focused yet → activeElement is <body>.
+    try testing.expect((try ls.local.compileAndRun("document.activeElement === document.body", null)).isTrue());
+
+    // First Tab → lowest positive tabindex (#b1), regardless of document order.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Tab", .code = "Tab" },
+    });
+    try testing.expect((try ls.local.compileAndRun("document.activeElement.id === 'b1'", null)).isTrue());
+
+    // Second Tab → next in tabindex order (#i2).
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Tab", .code = "Tab" },
+    });
+    try testing.expect((try ls.local.compileAndRun("document.activeElement.id === 'i2'", null)).isTrue());
+
+    // Shift+Tab (modifiers bit 8) walks backward → back to #b1.
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Tab", .code = "Tab", .modifiers = 8 },
+    });
+    try testing.expect((try ls.local.compileAndRun("document.activeElement.id === 'b1'", null)).isTrue());
+}


### PR DESCRIPTION
## What

A synthetic `Tab` delivered over CDP (`Input.dispatchKeyEvent` with `key: "Tab"`) did not perform [sequential focus navigation](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation) — `document.activeElement` never advanced. This wires `Tab`/`Shift+Tab` to move focus to the next/previous focusable element, firing the usual `blur`/`focus` events.

Closes #2699.

## Root cause

Two gaps in `src/browser/Frame.zig`:

1. `handleKeydown` (the keydown default-action handler, run from `EventManager` only when the event was not `preventDefault()`-ed) special-cases `Enter` and printable keys but had no `Tab` branch — so `Tab` had no default action even when a control was focused.
2. `triggerKeyboard` read the raw `document._active_element` field, which is `null` until something is explicitly focused, and returned early without dispatching. The first `Tab` on a fresh page happens while nothing is focused, so it was silently dropped.

```mermaid
flowchart LR
    A[Tab keydown via CDP] --> B[triggerKeyboard reads _active_element]
    B --> C[null when nothing focused so keydown dropped]
    C --> D[no Tab branch in handleKeydown]
    D --> E[activeElement stays body]
    style C fill:#fdd
    style D fill:#fdd
    style E fill:#fdd
```

## Fix

- `triggerKeyboard` — dispatch to the effective active element via `getActiveElement()` (resolves to `<body>` when nothing is focused), so the keydown fires and its default action can run. This matches `document.activeElement`'s own fallback.
- `handleKeydown` — add a `Tab` branch that runs `moveFocus` (`Shift+Tab` walks backward).
- `moveFocus` + helpers — a single document-order pass picks the next/previous element in HTML sequential focus navigation order: positive `tabindex` first (ascending), then `tabindex=0` / natively-focusable controls in document order, ties broken by document position, wrapping at the ends. Order comes from the existing `getTabIndex()` + `compareDocumentPosition`; no layout needed.

```mermaid
flowchart LR
    A[Tab keydown via CDP] --> B[triggerKeyboard dispatches to getActiveElement]
    B --> C[keydown fires on body]
    C --> D[handleKeydown runs moveFocus]
    D --> E[focus next by tabindex then document order]
    style B fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `src/cdp/domains/input.zig` — `cdp.input: dispatchKeyEvent Tab runs sequential focus navigation`. Builds a page whose three controls' `tabindex` order (1, 2, 3) differs from document order (2, 1, 3), then drives `Input.dispatchKeyEvent`: from `<body>`, `Tab` → `#b1` (tabindex 1), `Tab` → `#i2` (tabindex 2), `Shift+Tab` → back to `#b1`. Fails on `main`, passes with this commit.
- **Reproducer**: the `repro.sh` from #2699 exits 1 on `main` and 0 with this commit.
- Full `zig build test` suite passes (792/792 locally).

## Notes

- Focusability is determined structurally (enabled, `tabindex >= 0`, plus the control type / explicit `tabindex` / `href`). Elements hidden purely via CSS `display`/`visibility` are not filtered out — consistent with computing focus order without a layout pass; this can be tightened in a follow-up if needed.
- `Tab` from the last focusable element wraps to the first (and `Shift+Tab` from the first wraps to the last), since a headless engine has no browser chrome to receive focus in between.
