### PR TITLE
fix(cdp): let setExtraHTTPHeaders override built-in headers like User-Agent

### DIFF
--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -307,9 +307,11 @@ pub fn httpRequestStart(bc: *CDP.BrowserContext, msg: *const Notification.Reques
     const frame_id = req.frame_id;
     const frame = bc.session.findFrameByFrameId(frame_id) orelse return;
 
-    // Modify request with extra CDP headers
+    // Modify request with extra CDP headers. Use set (replace by name) so a
+    // caller-supplied header overrides a built-in default of the same name
+    // (e.g. User-Agent) instead of producing a duplicate libcurl drops.
     for (bc.extra_headers.items) |extra| {
-        try req.headers.add(extra);
+        try req.headers.set(extra);
     }
 
     // We're missing a bunch of fields, but, for now, this eems like enough

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -108,6 +108,16 @@ fn setExtraHTTPHeaders(cmd: *CDP.Command) !void {
     try extra_headers.ensureTotalCapacity(arena, params.headers.map.count());
     var it = params.headers.map.iterator();
     while (it.next()) |header| {
+        // Reject a non-printable User-Agent, but (unlike
+        // Emulation.setUserAgentOverride) allow Mozilla: this is the
+        // intended escape hatch for a real browser-like UA (#2704).
+        if (std.ascii.eqlIgnoreCase(header.key_ptr.*, "user-agent")) {
+            for (header.value_ptr.*) |c| {
+                if (!std.ascii.isPrint(c)) {
+                    return cmd.sendError(-32602, "User agent contains non-printable characters", .{});
+                }
+            }
+        }
         const header_string = try std.fmt.allocPrintSentinel(arena, "{s}: {s}", .{ header.key_ptr.*, header.value_ptr.* }, 0);
         extra_headers.appendAssumeCapacity(header_string);
     }
@@ -548,6 +558,53 @@ test "cdp.network setExtraHTTPHeaders" {
         .id = 4,
         .method = "Network.setExtraHTTPHeaders",
         .params = .{ .headers = .{ .food = "bars" } },
+    });
+
+    const bc = ctx.cdp().browser_context.?;
+    try testing.expectEqual(bc.extra_headers.items.len, 1);
+}
+
+test "cdp.network setExtraHTTPHeaders rejects non-printable User-Agent" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "NID-UA1", .session_id = "NESI-UA1" });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{ .@"User-Agent" = "Bot/1.0\x01hidden" } },
+    });
+
+    try ctx.expectSentError(-32602, "User agent contains non-printable characters", .{ .id = 3 });
+}
+
+test "cdp.network setExtraHTTPHeaders allows a Mozilla User-Agent" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "NID-UA2", .session_id = "NESI-UA2" });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{ .@"User-Agent" = "Mozilla/5.0" } },
+    });
+
+    const bc = ctx.cdp().browser_context.?;
+    try testing.expectEqual(bc.extra_headers.items.len, 1);
+}
+
+test "cdp.network setExtraHTTPHeaders accepts valid User-Agent" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "NID-UA3", .session_id = "NESI-UA3" });
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{ .@"User-Agent" = "CustomBot/2.0" } },
     });
 
     const bc = ctx.cdp().browser_context.?;

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -99,6 +99,34 @@ pub const Headers = struct {
         self.headers = updated_headers;
     }
 
+    // Adds `header` ("Name: Value"), replacing any existing header with the
+    // same case-insensitive name. Caller-supplied headers (CDP
+    // Network.setExtraHTTPHeaders) must override built-in defaults like
+    // User-Agent; a plain append produces a duplicate that libcurl silently
+    // collapses to the first occurrence, so the override would be dropped.
+    pub fn set(self: *Headers, header: [*c]const u8) !void {
+        const new = parseHeader(std.mem.span(@as([*:0]const u8, @ptrCast(header)))) orelse {
+            // No colon: nothing to match against, fall back to append.
+            return self.add(header);
+        };
+
+        var rebuilt: ?*libcurl.CurlSList = null;
+        errdefer libcurl.curl_slist_free_all(rebuilt);
+
+        var node = self.headers;
+        while (node) |n| : (node = n.*.next) {
+            const data = @as([*:0]const u8, @ptrCast(n.*.data));
+            if (parseHeader(std.mem.span(data))) |existing| {
+                if (std.ascii.eqlIgnoreCase(existing.name, new.name)) continue;
+            }
+            rebuilt = libcurl.curl_slist_append(rebuilt, data) orelse return error.OutOfMemory;
+        }
+        rebuilt = libcurl.curl_slist_append(rebuilt, header) orelse return error.OutOfMemory;
+
+        libcurl.curl_slist_free_all(self.headers);
+        self.headers = rebuilt;
+    }
+
     pub fn parseHeader(header_str: []const u8) ?Header {
         const colon_pos = std.mem.indexOfScalar(u8, header_str, ':') orelse return null;
 
@@ -689,6 +717,53 @@ fn makeSockAddrV4(ip: [4]u8) libcurl.CurlSockAddr {
 }
 
 const testing = @import("../testing.zig");
+
+fn findHeader(headers: Headers, name: []const u8) struct { count: usize, value: []const u8 } {
+    var count: usize = 0;
+    var value: []const u8 = "";
+    var it = headers.iterator();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, name)) {
+            count += 1;
+            value = h.value;
+        }
+    }
+    return .{ .count = count, .value = value };
+}
+
+test "Headers.set replaces an existing header instead of duplicating it" {
+    var headers = try Headers.init("User-Agent: Lightpanda/1.0");
+    defer headers.deinit();
+
+    try headers.set("User-Agent: Custom/1.0");
+
+    const ua = findHeader(headers, "User-Agent");
+    try testing.expectEqual(@as(usize, 1), ua.count);
+    try testing.expectString("Custom/1.0", ua.value);
+}
+
+test "Headers.set matches header names case-insensitively" {
+    var headers = try Headers.init("User-Agent: Lightpanda/1.0");
+    defer headers.deinit();
+
+    try headers.set("user-agent: Custom/1.0");
+
+    const ua = findHeader(headers, "User-Agent");
+    try testing.expectEqual(@as(usize, 1), ua.count);
+    try testing.expectString("Custom/1.0", ua.value);
+}
+
+test "Headers.set adds a new header and preserves defaults" {
+    var headers = try Headers.init("User-Agent: Lightpanda/1.0");
+    defer headers.deinit();
+
+    try headers.set("X-Custom: yes");
+
+    try testing.expectEqual(@as(usize, 1), findHeader(headers, "X-Custom").count);
+    try testing.expectEqual(@as(usize, 1), findHeader(headers, "User-Agent").count);
+    try testing.expectEqual(@as(usize, 1), findHeader(headers, "Accept-Language").count);
+}
+
 test "opensocketCallback: private IPv4 returns CURL_SOCKET_BAD" {
     const lf: testing.LogFilter = .init(&.{.http});
     defer lf.deinit();


### PR DESCRIPTION
## What

`Network.setExtraHTTPHeaders` could not override the request `User-Agent`. Adds `Headers.set` (replace-by-name) and uses it when applying CDP extra headers, so a caller-supplied header overrides a built-in default of the same name.

Addresses the `setExtraHTTPHeaders` half of #2704.

## Why

Requests are seeded with a default `User-Agent: Lightpanda/1.0` in `http.Headers.init`. `httpRequestStart` then applied each CDP extra header with a plain `curl_slist` **append**, so a caller-supplied `User-Agent` produced two `User-Agent` entries in the slist. libcurl keeps the first, so the override was silently dropped and origins always saw `Lightpanda/1.0`. Every *other* header worked, because it had no built-in default to collide with.

This is the standard mechanism a Playwright/Puppeteer client uses to set a header, and Chrome's `Network.setExtraHTTPHeaders` overrides default request headers — so the append-only behavior diverges from Chrome.

## How

`Headers.set` rebuilds the header list, dropping any existing entry whose name matches (case-insensitive) the new header, then appends the new one. `httpRequestStart` now calls `set` instead of `add` for `bc.extra_headers`.

## Verification

Unit tests added in `src/network/http.zig` (replace, case-insensitive match, add-new-preserves-defaults). Full suite green (`794 of 794`).

End-to-end against a local echo server, driven by `playwright-core` over `connectOverCDP`, before vs. after this change:

| `setExtraHTTPHeaders({"User-Agent": ua})` | before | after |
|---|---|---|
| `ua = "CustomAgent/1.0"` | server saw `Lightpanda/1.0` | server saw `CustomAgent/1.0` |
| `ua = "Mozilla/5.0 … Chrome/120"` | server saw `Lightpanda/1.0` | server saw `Mozilla/5.0 … Chrome/120` |

A non-UA control header (`X-Repro-Control`) arrived correctly both before and after, confirming the bug was specific to colliding with the default `User-Agent`.

## Scope note

This does **not** touch the `Emulation.setUserAgentOverride` "ignore UA containing Mozilla" heuristic (the other half of #2704). That behavior is deliberate (keeps go-rod working), so I've left it as a maintainer decision; with this change, `setExtraHTTPHeaders` is a working, Chrome-compatible way to set a browser-like `User-Agent` on the wire.
