### PR TITLE
webapi: fire readystatechange at document on readiness changes

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -919,6 +919,8 @@ pub fn documentIsLoaded(self: *Frame) void {
 }
 
 pub fn _documentIsLoaded(self: *Frame) !void {
+    try self.dispatchReadyStateChange();
+
     const event = try Event.initTrusted(.wrap("DOMContentLoaded"), .{ .bubbles = true }, self._page);
     try self._event_manager.dispatch(
         self.document.asEventTarget(),
@@ -931,6 +933,18 @@ pub fn _documentIsLoaded(self: *Frame) !void {
         .loader_id = self._loader_id,
         .timestamp = timestamp(.monotonic),
     });
+}
+
+// Fired at the document on every change to document.readyState: before
+// DOMContentLoaded (readiness -> interactive) and before the load event
+// (readiness -> complete). Does not bubble.
+// https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+fn dispatchReadyStateChange(self: *Frame) !void {
+    const event = try Event.initTrusted(.wrap("readystatechange"), .{}, self._page);
+    try self._event_manager.dispatch(
+        self.document.asEventTarget(),
+        event,
+    );
 }
 
 pub fn scriptsCompletedLoading(self: *Frame) void {
@@ -994,6 +1008,7 @@ pub fn documentIsComplete(self: *Frame) void {
 
 fn _documentIsComplete(self: *Frame) !void {
     self.document._ready_state = .complete;
+    try self.dispatchReadyStateChange();
 
     // Run load events before window.load.
     try self.dispatchLoad();

--- a/src/browser/tests/page/readystatechange.html
+++ b/src/browser/tests/page/readystatechange.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+<script id=readystatechange>
+  // This script runs while document.readyState === 'loading'. A readystatechange
+  // listener registered here must observe every subsequent readiness change.
+  // Per "update the current document readiness", the document fires
+  // readystatechange on each change to document.readyState — twice during a
+  // normal load: interactive, then complete.
+  // https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+  const states = [];
+  const order = [];
+
+  testing.expectEqual('loading', document.readyState);
+
+  document.addEventListener('readystatechange', function(e) {
+    testing.expectEqual(document, e.target);
+    states.push(document.readyState);
+    order.push('readystatechange:' + document.readyState);
+  });
+  document.addEventListener('DOMContentLoaded', function() {
+    order.push('DOMContentLoaded');
+  });
+
+  testing.onload(() => {
+    // readystatechange fires twice, in readiness order.
+    testing.expectEqual(['interactive', 'complete'], states);
+    // The interactive change fires before DOMContentLoaded; the complete change
+    // fires before the load event (this onload callback runs on load).
+    testing.expectEqual(
+      ['readystatechange:interactive', 'DOMContentLoaded', 'readystatechange:complete'],
+      order,
+    );
+    testing.expectEqual('complete', document.readyState);
+  });
+</script>


### PR DESCRIPTION
## What

`document.readyState` transitions correctly during a load (`loading` → `interactive` → `complete`) and `DOMContentLoaded` + `load` both fire, but the `readystatechange` event was never dispatched at the `Document`. Per [HTML Standard — current document readiness](https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness), every readiness change must fire `readystatechange` at the document — twice per normal load. This PR dispatches it at both readiness flips, mirroring how `DOMContentLoaded` is emitted.

Closes #2707.

## Root cause

The two readiness flips during load live in `src/browser/Frame.zig`: `documentIsLoaded` sets `_ready_state = .interactive` then dispatches `DOMContentLoaded`, and `_documentIsComplete` sets `_ready_state = .complete` then dispatches `load`. Both updated the state field; neither dispatched `readystatechange`, and no other code path does.

```mermaid
flowchart LR
    A[readiness flips] --> B[state field updated only]
    B --> C[readystatechange listeners never fire]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — new `dispatchReadyStateChange` helper: fires a trusted, non-bubbling, non-cancelable `readystatechange` event at the document.
- `src/browser/Frame.zig` — `_documentIsLoaded`: dispatch it first, so the `interactive` firing precedes `DOMContentLoaded` (per the parser's ["the end" steps](https://html.spec.whatwg.org/multipage/parsing.html#the-end)).
- `src/browser/Frame.zig` — `_documentIsComplete`: dispatch it right after the flip to `.complete`, before the `load` event.

```mermaid
flowchart LR
    A[readiness flips] --> B[dispatch readystatechange]
    B --> C[DOMContentLoaded or load follows]
    style B fill:#dfd
    style C fill:#dfd
```

The other two `_ready_state` assignments (`Document.zig`'s `document.open()` reset and `DOMImplementation.createHTMLDocument`'s initial state) are deliberately untouched — they set an initial/reset state for a fresh document rather than walking a loading document through its readiness transitions.

## Test

- **HTML fixture**: `src/browser/tests/page/readystatechange.html` (runs under `test "WebApi: Frame"`'s `htmlRunner("page")`). Registers a `readystatechange` listener while `readyState === 'loading'` and asserts: exactly two firings (`interactive`, `complete`), `e.target === document`, and the spec ordering `readystatechange:interactive` → `DOMContentLoaded` → `readystatechange:complete` → load. Fails on `main`, passes with this commit.
- **Full suite**: `zig build test` — 791/791 pass.
- **Reproducer**: the `repro.sh` from #2707 exits 1 on `main` / nightly 6709 and exits 0 with this commit; the lifecycle log becomes `["script-eval:loading","readystatechange:interactive","DOMContentLoaded:interactive","readystatechange:complete","load:complete"]`, matching Chrome.

## Notes

Scoped to the load pipeline. `document.open()` also flips readiness back to `loading` (and per spec that change fires `readystatechange` too), but it goes through a different reset path — happy to cover it here or in a follow-up if you'd like.
