### PR TITLE
websocket: send Origin header on upgrade requests

### DIFF
--- a/src/TestWSServer.zig
+++ b/src/TestWSServer.zig
@@ -111,6 +111,20 @@ fn handleClient(client: posix.socket_t) void {
         @memcpy(cookie_buf[0..cookie_len], value[0..cookie_len]);
     }
 
+    // Same for the Origin header, exposed via the `get-origin` command.
+    // Match on "\r\nOrigin: " so the obsolete Sec-WebSocket-Origin header
+    // can never alias it.
+    var origin_buf: [1024]u8 = undefined;
+    var origin_len: usize = 0;
+    const origin_header = "\r\nOrigin: ";
+    if (std.mem.indexOf(u8, request, origin_header)) |origin_start| {
+        const value_start = origin_start + origin_header.len;
+        const value_end = std.mem.indexOfScalarPos(u8, request, value_start, '\r') orelse value_start;
+        const value = request[value_start..value_end];
+        origin_len = @min(value.len, origin_buf.len);
+        @memcpy(origin_buf[0..origin_len], value[0..origin_len]);
+    }
+
     // Compute accept key
     var hasher = std.crypto.hash.Sha1.init(.{});
     hasher.update(key);
@@ -144,7 +158,7 @@ fn handleClient(client: posix.socket_t) void {
 
         // Handle commands or echo
         if (frame.opcode == 1) { // Text
-            handleTextMessage(client, frame.payload, cookie_buf[0..cookie_len]) catch break;
+            handleTextMessage(client, frame.payload, cookie_buf[0..cookie_len], origin_buf[0..origin_len]) catch break;
         } else if (frame.opcode == 2) { // Binary
             handleBinaryMessage(client, frame.payload) catch break;
         }
@@ -249,7 +263,7 @@ const RecvBuffer = struct {
     }
 };
 
-fn handleTextMessage(client: posix.socket_t, payload: []const u8, cookie_header: []const u8) !void {
+fn handleTextMessage(client: posix.socket_t, payload: []const u8, cookie_header: []const u8, origin_header: []const u8) !void {
     // Command: force-close - close socket immediately without close frame
     if (std.mem.eql(u8, payload, "force-close")) {
         return error.ForceClose;
@@ -260,6 +274,14 @@ fn handleTextMessage(client: posix.socket_t, payload: []const u8, cookie_header:
     // upgrade regression test.
     if (std.mem.eql(u8, payload, "get-cookie")) {
         try sendFrame(client, 1, "cookie:", cookie_header);
+        return;
+    }
+
+    // Command: get-origin - send the Origin header value the upgrade
+    // request carried (empty string if none). Used by the origin-on-
+    // upgrade regression test.
+    if (std.mem.eql(u8, payload, "get-origin")) {
+        try sendFrame(client, 1, "origin:", origin_header);
         return;
     }
 

--- a/src/browser/tests/net/websocket.html
+++ b/src/browser/tests/net/websocket.html
@@ -745,3 +745,26 @@
   document.cookie = 'b=; path=/; Max-Age=0';
 }
 </script>
+
+<script id=origin_on_upgrade type=module>
+{
+  // The upgrade request must carry the document's origin in an Origin
+  // header — RFC 6455 §4.1 requires it for browser clients. Origin-checking
+  // endpoints (CSRF protection on WS servers) reject upgrades that arrive
+  // without it, before the handshake ever completes.
+  const state = await testing.async();
+  let received = [];
+
+  let ws = new WebSocket('ws://127.0.0.1:9584/');
+
+  ws.addEventListener('open', () => { ws.send('get-origin'); });
+  ws.addEventListener('message', (e) => { received.push(e.data); ws.close(); });
+  ws.addEventListener('close', () => { state.resolve(); });
+
+  await state.done(() => {
+    // The origin is the document's (fixture HTTP server, port 9582) —
+    // not the WS endpoint's 9584.
+    testing.expectEqual(['origin:http://127.0.0.1:9582'], received);
+  });
+}
+</script>

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -133,12 +133,21 @@ pub fn init(url: []const u8, protocols: [][]const u8, exec: *const Execution) !*
 
     var headers = try http_client.newHeaders();
     errdefer headers.deinit();
-    var has_extra_headers = false;
 
     if (protocols.len > 0) {
         const header = try std.fmt.allocPrintSentinel(arena, "Sec-WebSocket-Protocol: {s}", .{try std.mem.join(arena, ", ", protocols)}, 0);
         try headers.add(header);
-        has_extra_headers = true;
+    }
+
+    {
+        // The upgrade is a browser-initiated HTTP request and must carry the
+        // document's origin (RFC 6455 §4.1). Origin-checking endpoints (CSRF
+        // protection on WS servers) reject upgrades that arrive without it.
+        // Non-tuple origins (about:blank, data:) serialize to "null", like
+        // Chrome sends for opaque origins.
+        const origin = (try URL.getOrigin(arena, exec.url.*)) orelse "null";
+        const header = try std.fmt.allocPrintSentinel(arena, "Origin: {s}", .{origin}, 0);
+        try headers.add(header);
     }
 
     {
@@ -155,9 +164,7 @@ pub fn init(url: []const u8, protocols: [][]const u8, exec: *const Execution) !*
         }
     }
 
-    if (has_extra_headers) {
-        try conn.setHeaders(&headers);
-    }
+    try conn.setHeaders(&headers);
 
     const self = try exec._factory.eventTargetWithAllocator(arena, WebSocket{
         ._exec = exec,


### PR DESCRIPTION
## What

Page-initiated WebSocket upgrade requests now carry the document's origin in an `Origin` header, as RFC 6455 §4.1 requires for browser clients. Servers that check the origin as CSRF protection previously rejected every connection because the header never arrived.

Closes #2709.

## Root cause

`WebSocket.init` (`src/browser/webapi/net/WebSocket.zig`) builds the upgrade's extra headers (`Sec-WebSocket-Protocol` when protocols are passed, `Cookie` from the jar since #2582), but nothing ever added `Origin`, so the handshake went out without it.

```mermaid
flowchart LR
    A[new WebSocket in page JS] --> B[init builds protocol and cookie headers only]
    B --> C[upgrade sent without Origin]
    C --> D[origin-checking server rejects handshake]
    style B fill:#fdd
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/browser/webapi/net/WebSocket.zig` — `init`: serialize the executing document's origin via `URL.getOrigin` and add it as an `Origin` header next to the existing `Sec-WebSocket-Protocol` setup. Opaque origins (`about:blank`, `data:`) serialize to `null`, matching what Chrome sends. Since the header is now always present, the `has_extra_headers` flag is gone and `conn.setHeaders` runs unconditionally.
- `src/TestWSServer.zig` — captures the upgrade request's `Origin` header and serves it back via a new `get-origin` command (mirrors the existing `get-cookie`).
- `src/browser/tests/net/websocket.html` — new `origin_on_upgrade` fixture asserts the upgrade carried the fixture server's origin (`http://127.0.0.1:9582`), not the WS endpoint's.

```mermaid
flowchart LR
    A[new WebSocket in page JS] --> B[init adds Origin from document origin]
    B --> C[upgrade carries Origin header]
    C --> D[origin check passes and handshake completes]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit test**: `origin_on_upgrade` fixture under `WebApi: WebSocket`. Fails on `main` with `expected "origin:http://127.0.0.1:9582", got "origin:"`, passes with this commit. Full `zig build test`: 791/791.
- **Reproducer**: the `repro.sh` from #2709 exits 1 on `main` and 0 with this commit. It captures the upgrade headers server-side and asserts `Origin` equals the serving page's origin.

## Notes

The worker path inherits the fix unchanged: `exec.url` is the worker script URL there, so worker-created WebSockets send the worker's origin.
