### PR TITLE
minor: remove 'leak' word from test name

### DIFF
--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -978,7 +978,7 @@ test "cdp.dom: setFileInputFiles requires a node identifier" {
     try ctx.expectSentError(-31998, "MissingParams", .{ .id = 1 });
 }
 
-test "cdp.dom: setFileInputFiles errors (and leaks nothing) when a path is missing" {
+test "cdp.dom: setFileInputFiles errors when a path is missing" {
     var ctx = try testing.context();
     defer ctx.deinit();
 


### PR DESCRIPTION
Keep ability to grep for 'leak' meaningful by not having it show up on success. The assertion is redundant anyways, presumably no test leaks.