### PR TITLE
cdp: raise inbound WebSocket message cap to 100MB

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -32,9 +32,13 @@ const Allocator = std.mem.Allocator;
 pub const CDP_MAX_HTTP_REQUEST_SIZE = 4096;
 
 // max message size
+// 100MB matches Chrome's inbound DevTools ceiling (kReceiveBufferSizeForDevTools
+// in content/browser/devtools/devtools_http_handler.cc). This is only a
+// hostile-input ceiling, not a per-connection allocation: the reader buffer
+// starts at 16KB and grows on demand (see network/WS.zig).
 // +14 for max websocket payload overhead
 // +140 for the max control packet that might be interleaved in a message
-pub const CDP_MAX_MESSAGE_SIZE = 512 * 1024 + 14 + 140;
+pub const CDP_MAX_MESSAGE_SIZE = 100 * 1024 * 1024 + 14 + 140;
 
 // TCP keepalive parameters applied to accepted CDP connections.
 // Detection window ≈ IDLE + CNT * INTVL = 4 + 3*2 = 10s.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -427,8 +427,8 @@ test "Client: read invalid websocket message" {
         );
     }
 
-    // length of message is 0000 0810, i.e: 1024 * 512 + 265
-    try assertWebSocketError(1009, &.{ 129, 255, 0, 0, 0, 0, 0, 8, 1, 0, 'm', 'a', 's', 'k' });
+    // declared payload length is 0x0800 0000, i.e. 128MB — above CDP_MAX_MESSAGE_SIZE
+    try assertWebSocketError(1009, &.{ 129, 255, 0, 0, 0, 0, 8, 0, 0, 0, 'm', 'a', 's', 'k' });
 
     // continuation type message must come after a normal message
     // even when not a fin frame
@@ -507,6 +507,45 @@ test "Client: close message" {
         // fin | close, masked | len, 4-byte mask
         &.{ 136, 128, 0, 0, 0, 0 },
     );
+}
+
+test "Client: large websocket message" {
+    // A message bigger than the historical 512KB ceiling must be framed
+    // and dispatched, not answered with a 1009 close. CDP clients
+    // routinely send Runtime.evaluate / Page.addScriptToEvaluateOnNewDocument
+    // payloads of this size (e.g. injecting a bundled JS library).
+    const allocator = testing.allocator;
+
+    const prefix = "{\"id\":9,\"method\":\"Browser.getVersion\",\"pad\":\"";
+    const suffix = "\"}";
+    const payload_len = 600 * 1024;
+
+    const payload = try allocator.alloc(u8, payload_len);
+    defer allocator.free(payload);
+    @memcpy(payload[0..prefix.len], prefix);
+    @memset(payload[prefix.len .. payload_len - suffix.len], 'a');
+    @memcpy(payload[payload_len - suffix.len ..], suffix);
+
+    // fin | text, masked | 127 (8-byte extended length), big-endian
+    // length, all-zero mask (XOR no-op)
+    var header = [_]u8{ 129, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    std.mem.writeInt(u64, header[2..10], payload_len, .big);
+
+    var c = try createTestClient();
+    defer c.deinit();
+
+    try c.handshake();
+    try c.stream.writeAll(&header);
+    try c.stream.writeAll(payload);
+
+    const msg = try c.readWebsocketMessage() orelse return error.NoMessage;
+    defer if (msg.cleanup_fragment) {
+        c.reader.cleanup();
+    };
+
+    try testing.expectEqual(.text, msg.type);
+    try testing.expect(std.mem.indexOf(u8, msg.data, "\"id\":9") != null);
+    try testing.expect(std.mem.indexOf(u8, msg.data, "protocolVersion") != null);
 }
 
 test "server: 404" {


### PR DESCRIPTION
## What

Inbound CDP WebSocket messages larger than `CDP_MAX_MESSAGE_SIZE` (512KB + 154 bytes of frame overhead) close the connection with code 1009 and no JSON-RPC response — every pending command and all session state is lost. A `Runtime.evaluate` whose expression is a bundled JS library (553KB minified is a common real-world size) kills the connection on its own. This PR raises the cap to 100MB, matching Chrome's inbound DevTools ceiling ([`kReceiveBufferSizeForDevTools`](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/devtools/devtools_http_handler.cc)).

Closes #2716.

## Root cause

`src/cdp/Connection.zig` instantiates `WS.Reader(true, Config.CDP_MAX_MESSAGE_SIZE)`. In `src/network/WS.zig`, `Reader.next()` returns `error.TooLarge` as soon as a frame header declares a length above the cap; `errorReply` maps that to the 1009 close frame and the worker tears the connection down. The cap predates the lazily-growing reader buffer: since `init` starts at 16KB and `growBuffer` expands on demand, the constant is purely a ceiling — it no longer protects any preallocated buffer, it just rejects messages that Chrome would accept.

```mermaid
flowchart LR
    A[Runtime.evaluate 600KB message] --> B[frame length above 512KB cap]
    B --> C[error.TooLarge]
    C --> D[WS close 1009, session lost]
    style B fill:#fdd
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/Config.zig` — `CDP_MAX_MESSAGE_SIZE`: raised from 512KB to 100MB (Chrome's inbound ceiling), with a comment explaining it is a hostile-input ceiling, not a per-connection allocation. The `+14 +140` frame/control overhead is unchanged.
- `src/Server.zig` — updated the 1009 assertion in `Client: read invalid websocket message` to declare a 128MB frame (above the new cap — the ceiling is kept; a declared-length check against garbage input is still worth having).
- `src/Server.zig` — new test `Client: large websocket message`: a single 600KB text frame carrying a real `Browser.getVersion` command is framed, dispatched, and answered end-to-end instead of being rejected.

```mermaid
flowchart LR
    A[Runtime.evaluate 600KB message] --> B[reader buffer grows on demand]
    B --> C[frame dispatched to CDP]
    C --> D[JSON-RPC result returned]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit tests**: `src/Server.zig` — `Client: large websocket message` (fails on `main` with a 1009 close, passes with this commit) and the updated 1009 ceiling assertion in `Client: read invalid websocket message`. Full `zig build test`: 792/792.
- **Reproducer**: the `repro.sh` from #2716 — a ~400KB control `Runtime.evaluate` plus a ~600KB one — exits 1 on nightly 6703 (600KB gets a 1009 close) and exits 0 with this commit (both return results).

## Notes

- Memory: the reader buffer starts at 16KB and only grows when a large frame actually arrives, so well-behaved clients pay nothing for the higher ceiling. A grown buffer is retained for the connection's lifetime (same behavior as today).
- A JSON-RPC "message too large" error instead of the close was considered and rejected: the command `id` lives inside the payload being refused, so it can't be echoed back without buffering the frame, and skipping a frame silently would desync the client. The 1009 close stays for messages above the new ceiling.
