### PR TITLE
feat(cdp): implement Browser.setDownloadBehavior file downloads

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -277,8 +277,8 @@ pub const CookieChanged = struct {
 
 // Emitted by Frame when a navigation response is treated as a file download
 // (Content-Disposition: attachment) under an `allow`/`allowAndName`
-// `Browser.setDownloadBehavior`. The CDP page domain turns this into a
-// `Page.downloadWillBegin` event. All fields point at Frame-owned memory that
+// `Browser.setDownloadBehavior`. The CDP browser domain turns this into a
+// `Browser.downloadWillBegin` event. All fields point at Frame-owned memory that
 // outlives the synchronous dispatch.
 pub const DownloadWillBegin = struct {
     frame_id: u32,

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -96,6 +96,8 @@ const EventListeners = struct {
     model_context_tool_added: List = .{},
     model_context_tool_removed: List = .{},
     cookie_changed: List = .{},
+    download_will_begin: List = .{},
+    download_progress: List = .{},
 };
 
 const Events = union(enum) {
@@ -123,6 +125,8 @@ const Events = union(enum) {
     model_context_tool_added: *const ModelContextToolEvent,
     model_context_tool_removed: *const ModelContextToolEvent,
     cookie_changed: *const CookieChanged,
+    download_will_begin: *const DownloadWillBegin,
+    download_progress: *const DownloadProgress,
 };
 const EventType = std.meta.FieldEnum(Events);
 
@@ -269,6 +273,34 @@ pub const CookieChanged = struct {
     same_site: Cookie.SameSite,
 
     pub const Kind = enum { changed, deleted };
+};
+
+// Emitted by Frame when a navigation response is treated as a file download
+// (Content-Disposition: attachment) under an `allow`/`allowAndName`
+// `Browser.setDownloadBehavior`. The CDP page domain turns this into a
+// `Page.downloadWillBegin` event. All fields point at Frame-owned memory that
+// outlives the synchronous dispatch.
+pub const DownloadWillBegin = struct {
+    frame_id: u32,
+    guid: []const u8,
+    url: []const u8,
+    suggested_filename: []const u8,
+};
+
+// Emitted by Frame as a download is written to disk: once when it starts
+// (`.in_progress`) and once when the body is fully written (`.completed`).
+// The CDP browser domain turns this into a `Browser.downloadProgress` event.
+pub const DownloadProgress = struct {
+    guid: []const u8,
+    total_bytes: u64,
+    received_bytes: u64,
+    state: State,
+
+    pub const State = enum {
+        in_progress,
+        completed,
+        canceled,
+    };
 };
 
 pub const DialogResponse = struct {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1198,7 +1198,165 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !HttpClient.HeaderResu
         });
     }
 
+    // If the response is a file download, stream its body to disk instead of
+    // parsing it as a page. This sets _parse_state to .download, which the
+    // data/done callbacks below special-case.
+    _ = try self.maybeStartDownload(response);
+
     return .proceed;
+}
+
+// Returns true when the response was set up as a file download. A response is
+// treated as a download when Browser.setDownloadBehavior opted in
+// (allow/allowAndName) and the response carries Content-Disposition: attachment.
+// See issue #2701.
+fn maybeStartDownload(self: *Frame, response: HttpClient.Response) !bool {
+    const session = self._session;
+    switch (session.download_behavior) {
+        .allow, .allow_and_name => {},
+        .default, .deny => return false,
+    }
+
+    const disposition = blk: {
+        var it = response.headerIterator();
+        while (it.next()) |hdr| {
+            if (std.ascii.eqlIgnoreCase(hdr.name, "content-disposition")) {
+                break :blk hdr.value;
+            }
+        }
+        return false;
+    };
+    if (isAttachment(disposition) == false) {
+        return false;
+    }
+
+    const download_path = session.download_path orelse {
+        log.warn(.frame, "download without downloadPath", .{ .url = self.url });
+        return false;
+    };
+
+    var guid_buf: [36]u8 = undefined;
+    @import("../id.zig").uuidv4(&guid_buf);
+    const guid = try self.arena.dupe(u8, &guid_buf);
+
+    const suggested = dispositionFilename(disposition) orelse urlBasename(self.url) orelse guid;
+    const suggested_filename = try self.arena.dupe(u8, suggested);
+
+    // allowAndName stores the file under its guid; allow uses the suggested name.
+    const on_disk_name = switch (session.download_behavior) {
+        .allow_and_name => guid,
+        else => suggested_filename,
+    };
+
+    std.fs.cwd().makePath(download_path) catch |err| {
+        log.err(.frame, "download makePath", .{ .err = err, .path = download_path });
+        return false;
+    };
+    var dir = std.fs.cwd().openDir(download_path, .{}) catch |err| {
+        log.err(.frame, "download openDir", .{ .err = err, .path = download_path });
+        return false;
+    };
+    defer dir.close();
+    const file = dir.createFile(on_disk_name, .{ .truncate = true }) catch |err| {
+        log.err(.frame, "download createFile", .{ .err = err, .name = on_disk_name });
+        return false;
+    };
+
+    const total: ?u64 = if (response.contentLength()) |cl| cl else null;
+
+    self._parse_state = .{ .download = .{
+        .guid = guid,
+        .file = file,
+        .filename = suggested_filename,
+        .received = 0,
+        .total = total,
+    } };
+
+    if (session.download_events_enabled) {
+        session.notification.dispatch(.download_will_begin, &.{
+            .frame_id = self._frame_id,
+            .guid = guid,
+            .url = self.url,
+            .suggested_filename = suggested_filename,
+        });
+        session.notification.dispatch(.download_progress, &.{
+            .guid = guid,
+            .total_bytes = total orelse 0,
+            .received_bytes = 0,
+            .state = .in_progress,
+        });
+    }
+
+    return true;
+}
+
+// True when a Content-Disposition value's type token is "attachment".
+fn isAttachment(disposition: []const u8) bool {
+    const semi = std.mem.indexOfScalar(u8, disposition, ';') orelse disposition.len;
+    const token = std.mem.trim(u8, disposition[0..semi], " \t");
+    return std.ascii.eqlIgnoreCase(token, "attachment");
+}
+
+// Extracts the filename from a Content-Disposition value, handling the quoted,
+// unquoted, and RFC 5987 (filename*=charset''value) forms. Path components are
+// stripped so the result is always a bare basename.
+fn dispositionFilename(disposition: []const u8) ?[]const u8 {
+    // Prefer the extended filename*= form when present, per RFC 6266.
+    if (paramValue(disposition, "filename*")) |ext| {
+        // charset'lang'value — take everything after the second quote.
+        if (std.mem.indexOfScalar(u8, ext, '\'')) |first| {
+            if (std.mem.indexOfScalarPos(u8, ext, first + 1, '\'')) |second| {
+                return basename(ext[second + 1 ..]);
+            }
+        }
+        return basename(ext);
+    }
+    if (paramValue(disposition, "filename")) |name| {
+        return basename(name);
+    }
+    return null;
+}
+
+// Returns the (optionally quoted) value of `key=` within a parameter list.
+fn paramValue(disposition: []const u8, key: []const u8) ?[]const u8 {
+    var rest = disposition;
+    while (std.mem.indexOfScalar(u8, rest, ';')) |semi| {
+        const param = std.mem.trim(u8, rest[semi + 1 ..][0 .. (std.mem.indexOfScalarPos(u8, rest, semi + 1, ';') orelse rest.len) - semi - 1], " \t");
+        if (std.mem.indexOfScalar(u8, param, '=')) |eq| {
+            const name = std.mem.trim(u8, param[0..eq], " \t");
+            if (std.ascii.eqlIgnoreCase(name, key)) {
+                var value = std.mem.trim(u8, param[eq + 1 ..], " \t");
+                if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
+                    value = value[1 .. value.len - 1];
+                }
+                if (value.len > 0) {
+                    return value;
+                }
+            }
+        }
+        rest = rest[semi + 1 ..];
+    }
+    return null;
+}
+
+// Strips any directory components, guarding against path traversal.
+fn basename(name: []const u8) ?[]const u8 {
+    var out = name;
+    if (std.mem.lastIndexOfAny(u8, out, "/\\")) |i| {
+        out = out[i + 1 ..];
+    }
+    if (out.len == 0 or std.mem.eql(u8, out, ".") or std.mem.eql(u8, out, "..")) {
+        return null;
+    }
+    return out;
+}
+
+// Derives a filename from a URL's last path segment, ignoring query/fragment.
+fn urlBasename(url: []const u8) ?[]const u8 {
+    var path = url;
+    if (std.mem.indexOfScalar(u8, path, '?')) |i| path = path[0..i];
+    if (std.mem.indexOfScalar(u8, path, '#')) |i| path = path[0..i];
+    return basename(path);
 }
 
 fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
@@ -1279,6 +1437,13 @@ fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
             }
         },
         .raw, .image => |*buf| try buf.appendSlice(self.arena, data),
+        .download => |*download| {
+            download.file.writeAll(data) catch |err| {
+                log.err(.frame, "download write", .{ .err = err, .guid = download.guid });
+                return;
+            };
+            download.received += data.len;
+        },
         .pre => unreachable,
         .complete => unreachable,
         .err => unreachable,
@@ -1371,6 +1536,30 @@ fn frameDoneCallback(ctx: *anyopaque) !void {
 
             parser.parse(html);
             self._parse_state = .complete;
+            self.documentIsComplete();
+        },
+        .download => |*download| {
+            download.file.close();
+
+            // Capture before invalidating the union below.
+            const guid = download.guid;
+            const received = download.received;
+            const total = download.total orelse download.received;
+            self._parse_state = .complete;
+
+            const session = self._session;
+            if (session.download_events_enabled) {
+                session.notification.dispatch(.download_progress, &.{
+                    .guid = guid,
+                    .total_bytes = total,
+                    .received_bytes = received,
+                    .state = .completed,
+                });
+            }
+
+            // The body went to disk; commit an empty document so the frame
+            // navigation still completes cleanly (mirrors the .raw path).
+            parser.parse("<html><head><meta charset=\"utf-8\"></head><body></body></html>");
             self.documentIsComplete();
         },
         else => unreachable,
@@ -3793,13 +3982,32 @@ const ParseState = union(enum) {
     image: std.ArrayList(u8),
     raw: std.ArrayList(u8),
     raw_done: []const u8,
+    download: Download,
 
     fn deinit(self: *ParseState, frame: *Frame) void {
         switch (self.*) {
             .html => |html| frame.releaseArena(html.arena),
+            // Only reached when a frame is torn down mid-download (the normal
+            // completion path in frameDoneCallback already closes the file and
+            // transitions to .complete).
+            .download => |*download| download.file.close(),
             else => {},
         }
     }
+};
+
+// An in-flight file download (Content-Disposition: attachment under an
+// allow/allowAndName Browser.setDownloadBehavior). The response body is
+// streamed straight to `file` rather than parsed as a page. See issue #2701.
+const Download = struct {
+    // uuidv4, arena-owned. Matches the guid reported in the CDP events.
+    guid: []const u8,
+    file: std.fs.File,
+    // suggested filename surfaced to the client, arena-owned.
+    filename: []const u8,
+    received: u64,
+    // from Content-Length, when the response advertised one.
+    total: ?u64,
 };
 
 const LoadState = enum {
@@ -4644,6 +4852,35 @@ fn asUint(comptime string: anytype) std.meta.Int(
 }
 
 const testing = @import("../testing.zig");
+
+test "Frame: isAttachment" {
+    try testing.expectEqual(true, isAttachment("attachment"));
+    try testing.expectEqual(true, isAttachment("attachment; filename=\"a.csv\""));
+    try testing.expectEqual(true, isAttachment("  ATTACHMENT ; filename=a.csv"));
+    try testing.expectEqual(false, isAttachment("inline"));
+    try testing.expectEqual(false, isAttachment("inline; filename=a.csv"));
+    try testing.expectEqual(false, isAttachment(""));
+}
+
+test "Frame: dispositionFilename" {
+    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename("attachment; filename=\"report.csv\"").?);
+    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename("attachment; filename=report.csv").?);
+    try testing.expectEqualSlices(u8, "r e.csv", dispositionFilename("attachment; filename=\"r e.csv\"").?);
+    // RFC 5987 extended form is preferred over the plain filename when present
+    // (the value is taken verbatim after the charset'lang' prefix).
+    try testing.expectEqualSlices(u8, "extended.txt", dispositionFilename("attachment; filename=\"fallback.txt\"; filename*=UTF-8''extended.txt").?);
+    try testing.expect(dispositionFilename("attachment") == null);
+    // Path components are stripped to guard against traversal.
+    try testing.expectEqualSlices(u8, "evil.sh", dispositionFilename("attachment; filename=\"../../evil.sh\"").?);
+    try testing.expect(dispositionFilename("attachment; filename=\"..\"") == null);
+}
+
+test "Frame: urlBasename" {
+    try testing.expectEqualSlices(u8, "report.csv", urlBasename("http://x.com/a/b/report.csv").?);
+    try testing.expectEqualSlices(u8, "report.csv", urlBasename("http://x.com/report.csv?v=1#x").?);
+    try testing.expect(urlBasename("http://x.com/") == null);
+}
+
 test "WebApi: Frame" {
     const filter: testing.LogFilter = .init(&.{.http});
     defer filter.deinit();

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -67,6 +67,7 @@ const MouseEvent = @import("webapi/event/MouseEvent.zig");
 const WheelEvent = @import("webapi/event/WheelEvent.zig");
 
 const HttpClient = @import("HttpClient.zig");
+const sys_url = @import("../sys/url.zig");
 
 const timestamp = @import("../datetime.zig").timestamp;
 const milliTimestamp = @import("../datetime.zig").milliTimestamp;
@@ -1214,19 +1215,19 @@ fn maybeStartDownload(self: *Frame, response: HttpClient.Response) !bool {
     const session = self._session;
     switch (session.download_behavior) {
         .allow, .allow_and_name => {},
-        .default, .deny => return false,
+        .deny => return false,
     }
 
-    const disposition = blk: {
+    const disposition: HttpClient.Header = blk: {
         var it = response.headerIterator();
         while (it.next()) |hdr| {
             if (std.ascii.eqlIgnoreCase(hdr.name, "content-disposition")) {
-                break :blk hdr.value;
+                break :blk hdr;
             }
         }
         return false;
     };
-    if (isAttachment(disposition) == false) {
+    if (std.ascii.eqlIgnoreCase(disposition.firstValue(), "attachment") == false) {
         return false;
     }
 
@@ -1235,11 +1236,13 @@ fn maybeStartDownload(self: *Frame, response: HttpClient.Response) !bool {
         return false;
     };
 
+    // `guid` is the CDP "Global Unique Identifier" that ties the
+    // downloadWillBegin / downloadProgress events to one download.
     var guid_buf: [36]u8 = undefined;
     @import("../id.zig").uuidv4(&guid_buf);
     const guid = try self.arena.dupe(u8, &guid_buf);
 
-    const suggested = dispositionFilename(disposition) orelse urlBasename(self.url) orelse guid;
+    const suggested = dispositionFilename(disposition) orelse (try urlBasename(self.arena, self.url)) orelse guid;
     const suggested_filename = try self.arena.dupe(u8, suggested);
 
     // allowAndName stores the file under its guid; allow uses the suggested name.
@@ -1290,59 +1293,32 @@ fn maybeStartDownload(self: *Frame, response: HttpClient.Response) !bool {
     return true;
 }
 
-// True when a Content-Disposition value's type token is "attachment".
-fn isAttachment(disposition: []const u8) bool {
-    const semi = std.mem.indexOfScalar(u8, disposition, ';') orelse disposition.len;
-    const token = std.mem.trim(u8, disposition[0..semi], " \t");
-    return std.ascii.eqlIgnoreCase(token, "attachment");
-}
-
-// Extracts the filename from a Content-Disposition value, handling the quoted,
+// Extracts the filename from a Content-Disposition header, handling the quoted,
 // unquoted, and RFC 5987 (filename*=charset''value) forms. Path components are
 // stripped so the result is always a bare basename.
-fn dispositionFilename(disposition: []const u8) ?[]const u8 {
+fn dispositionFilename(disposition: HttpClient.Header) ?[]const u8 {
     // Prefer the extended filename*= form when present, per RFC 6266.
-    if (paramValue(disposition, "filename*")) |ext| {
+    if (disposition.param("filename*")) |ext| {
         // charset'lang'value — take everything after the second quote.
         if (std.mem.indexOfScalar(u8, ext, '\'')) |first| {
             if (std.mem.indexOfScalarPos(u8, ext, first + 1, '\'')) |second| {
-                return basename(ext[second + 1 ..]);
+                return sanitizeFilename(ext[second + 1 ..]);
             }
         }
-        return basename(ext);
+        return sanitizeFilename(ext);
     }
-    if (paramValue(disposition, "filename")) |name| {
-        return basename(name);
+    if (disposition.param("filename")) |name| {
+        return sanitizeFilename(name);
     }
     return null;
 }
 
-// Returns the (optionally quoted) value of `key=` within a parameter list.
-fn paramValue(disposition: []const u8, key: []const u8) ?[]const u8 {
-    var rest = disposition;
-    while (std.mem.indexOfScalar(u8, rest, ';')) |semi| {
-        const param = std.mem.trim(u8, rest[semi + 1 ..][0 .. (std.mem.indexOfScalarPos(u8, rest, semi + 1, ';') orelse rest.len) - semi - 1], " \t");
-        if (std.mem.indexOfScalar(u8, param, '=')) |eq| {
-            const name = std.mem.trim(u8, param[0..eq], " \t");
-            if (std.ascii.eqlIgnoreCase(name, key)) {
-                var value = std.mem.trim(u8, param[eq + 1 ..], " \t");
-                if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
-                    value = value[1 .. value.len - 1];
-                }
-                if (value.len > 0) {
-                    return value;
-                }
-            }
-        }
-        rest = rest[semi + 1 ..];
-    }
-    return null;
-}
-
-// Strips any directory components, guarding against path traversal.
-fn basename(name: []const u8) ?[]const u8 {
-    var out = name;
-    if (std.mem.lastIndexOfAny(u8, out, "/\\")) |i| {
+// Strips any directory components, guarding against path traversal. Content-
+// Disposition can carry Windows separators, so backslashes are stripped too,
+// regardless of the host platform.
+fn sanitizeFilename(name: []const u8) ?[]const u8 {
+    var out = std.fs.path.basename(name);
+    if (std.mem.lastIndexOfScalar(u8, out, '\\')) |i| {
         out = out[i + 1 ..];
     }
     if (out.len == 0 or std.mem.eql(u8, out, ".") or std.mem.eql(u8, out, "..")) {
@@ -1351,12 +1327,21 @@ fn basename(name: []const u8) ?[]const u8 {
     return out;
 }
 
-// Derives a filename from a URL's last path segment, ignoring query/fragment.
-fn urlBasename(url: []const u8) ?[]const u8 {
-    var path = url;
-    if (std.mem.indexOfScalar(u8, path, '?')) |i| path = path[0..i];
-    if (std.mem.indexOfScalar(u8, path, '#')) |i| path = path[0..i];
-    return basename(path);
+// Derives a filename from a URL's last path segment. The path is taken from a
+// real URL parse (rust-url) so query/fragment and percent-encoding are handled
+// the same way the rest of the browser handles URLs. The result is duped into
+// `arena`, since the parsed URL is freed before this returns.
+fn urlBasename(arena: Allocator, url: []const u8) !?[]const u8 {
+    var err: i32 = 0;
+    const u = sys_url.url_parse(url.ptr, url.len, &err) orelse return null;
+    defer sys_url.url_free(u);
+
+    var ptr: [*]const u8 = undefined;
+    var len: usize = undefined;
+    sys_url.url_get_path(u, &ptr, &len);
+
+    const name = sanitizeFilename(ptr[0..len]) orelse return null;
+    return try arena.dupe(u8, name);
 }
 
 fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
@@ -1439,6 +1424,11 @@ fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
         .raw, .image => |*buf| try buf.appendSlice(self.arena, data),
         .download => |*download| {
             download.file.writeAll(data) catch |err| {
+                // TODO(#2701 follow-up): surface the write failure properly. We
+                // can't set `_parse_state = .err` here because the next chunk
+                // would then hit the `.err => unreachable` branch below, and we
+                // should also emit a `canceled` downloadProgress and remove the
+                // partial file on disk. For now we just log and keep going.
                 log.err(.frame, "download write", .{ .err = err, .guid = download.guid });
                 return;
             };
@@ -4853,32 +4843,32 @@ fn asUint(comptime string: anytype) std.meta.Int(
 
 const testing = @import("../testing.zig");
 
-test "Frame: isAttachment" {
-    try testing.expectEqual(true, isAttachment("attachment"));
-    try testing.expectEqual(true, isAttachment("attachment; filename=\"a.csv\""));
-    try testing.expectEqual(true, isAttachment("  ATTACHMENT ; filename=a.csv"));
-    try testing.expectEqual(false, isAttachment("inline"));
-    try testing.expectEqual(false, isAttachment("inline; filename=a.csv"));
-    try testing.expectEqual(false, isAttachment(""));
+fn dispositionHeader(value: []const u8) HttpClient.Header {
+    return .{ .name = "content-disposition", .value = value };
 }
 
 test "Frame: dispositionFilename" {
-    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename("attachment; filename=\"report.csv\"").?);
-    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename("attachment; filename=report.csv").?);
-    try testing.expectEqualSlices(u8, "r e.csv", dispositionFilename("attachment; filename=\"r e.csv\"").?);
+    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename(dispositionHeader("attachment; filename=\"report.csv\"")).?);
+    try testing.expectEqualSlices(u8, "report.csv", dispositionFilename(dispositionHeader("attachment; filename=report.csv")).?);
+    try testing.expectEqualSlices(u8, "r e.csv", dispositionFilename(dispositionHeader("attachment; filename=\"r e.csv\"")).?);
     // RFC 5987 extended form is preferred over the plain filename when present
     // (the value is taken verbatim after the charset'lang' prefix).
-    try testing.expectEqualSlices(u8, "extended.txt", dispositionFilename("attachment; filename=\"fallback.txt\"; filename*=UTF-8''extended.txt").?);
-    try testing.expect(dispositionFilename("attachment") == null);
+    try testing.expectEqualSlices(u8, "extended.txt", dispositionFilename(dispositionHeader("attachment; filename=\"fallback.txt\"; filename*=UTF-8''extended.txt")).?);
+    try testing.expect(dispositionFilename(dispositionHeader("attachment")) == null);
     // Path components are stripped to guard against traversal.
-    try testing.expectEqualSlices(u8, "evil.sh", dispositionFilename("attachment; filename=\"../../evil.sh\"").?);
-    try testing.expect(dispositionFilename("attachment; filename=\"..\"") == null);
+    try testing.expectEqualSlices(u8, "evil.sh", dispositionFilename(dispositionHeader("attachment; filename=\"../../evil.sh\"")).?);
+    try testing.expectEqualSlices(u8, "evil.sh", dispositionFilename(dispositionHeader("attachment; filename=\"..\\..\\evil.sh\"")).?);
+    try testing.expect(dispositionFilename(dispositionHeader("attachment; filename=\"..\"")) == null);
 }
 
 test "Frame: urlBasename" {
-    try testing.expectEqualSlices(u8, "report.csv", urlBasename("http://x.com/a/b/report.csv").?);
-    try testing.expectEqualSlices(u8, "report.csv", urlBasename("http://x.com/report.csv?v=1#x").?);
-    try testing.expect(urlBasename("http://x.com/") == null);
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    try testing.expectEqualSlices(u8, "report.csv", (try urlBasename(a, "http://x.com/a/b/report.csv")).?);
+    try testing.expectEqualSlices(u8, "report.csv", (try urlBasename(a, "http://x.com/report.csv?v=1#x")).?);
+    try testing.expect((try urlBasename(a, "http://x.com/")) == null);
 }
 
 test "WebApi: Frame" {

--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -38,6 +38,7 @@ const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
 
 pub const Method = http.Method;
+pub const Header = http.Header;
 pub const Headers = http.Headers;
 pub const ResponseHead = http.ResponseHead;
 pub const HeaderIterator = http.HeaderIterator;

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -164,7 +164,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
     const http_client = self.http_client;
 
     switch (frame._parse_state) {
-        .pre, .raw, .text, .image => {
+        .pre, .raw, .text, .image, .download => {
             // The main frame hasn't started/finished navigating.
             // There's no JS to run, and no reason to run the scheduler
             // — unless we're the CDP worker, in which case we want

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -117,16 +117,17 @@ cancel_hook: ?CancelHook = null,
 // `.allow_and_name`, a navigation whose response carries
 // `Content-Disposition: attachment` is written to `download_path` instead
 // of being parsed as a page, and (when `download_events_enabled` is set)
-// `Page.downloadWillBegin` / `Browser.downloadProgress` events are emitted.
+// `Browser.downloadWillBegin` / `Browser.downloadProgress` events are emitted.
 // `download_path` is duped into the Session arena.
-download_behavior: DownloadBehavior = .default,
+download_behavior: DownloadBehavior = .deny,
 download_path: ?[]const u8 = null,
 download_events_enabled: bool = false,
 
 pub const DownloadBehavior = enum {
-    default,
     allow,
     allow_and_name,
+    // The CDP `default` behavior is mapped to `deny`: we don't write downloads
+    // to disk unless the driver explicitly opts in with `allow`/`allowAndName`.
     deny,
 };
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -112,6 +112,24 @@ load_external_stylesheets: bool = false,
 /// timeout.
 cancel_hook: ?CancelHook = null,
 
+// Download handling configured via the `Browser.setDownloadBehavior` CDP
+// method (see issue #2701). When `download_behavior` is `.allow` or
+// `.allow_and_name`, a navigation whose response carries
+// `Content-Disposition: attachment` is written to `download_path` instead
+// of being parsed as a page, and (when `download_events_enabled` is set)
+// `Page.downloadWillBegin` / `Browser.downloadProgress` events are emitted.
+// `download_path` is duped into the Session arena.
+download_behavior: DownloadBehavior = .default,
+download_path: ?[]const u8 = null,
+download_events_enabled: bool = false,
+
+pub const DownloadBehavior = enum {
+    default,
+    allow,
+    allow_and_name,
+    deny,
+};
+
 pub const CancelHook = struct {
     context: *anyopaque,
     check: *const fn (*anyopaque) bool,

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -526,6 +526,10 @@ pub const BrowserContext = struct {
     http_proxy_changed: bool = false,
     user_agent_changed: bool = false,
 
+    // True once we've registered for the download notifications, so repeated
+    // Browser.setDownloadBehavior calls don't add duplicate listeners.
+    download_events_registered: bool = false,
+
     // Extra headers to add to all requests.
     extra_headers: std.ArrayList([*c]const u8) = .empty,
 
@@ -795,6 +799,36 @@ pub const BrowserContext = struct {
 
     pub fn runtimeDisable(self: *BrowserContext) void {
         self.notification.unregister(.runtime_console_message, self);
+    }
+
+    // Registers for the download notifications dispatched by Frame when a
+    // navigation is treated as a file download. Idempotent. See issue #2701.
+    pub fn downloadEventsEnable(self: *BrowserContext) !void {
+        if (self.download_events_registered) {
+            return;
+        }
+        try self.notification.register(.download_will_begin, self, onDownloadWillBegin);
+        try self.notification.register(.download_progress, self, onDownloadProgress);
+        self.download_events_registered = true;
+    }
+
+    pub fn downloadEventsDisable(self: *BrowserContext) void {
+        if (self.download_events_registered == false) {
+            return;
+        }
+        self.notification.unregister(.download_will_begin, self);
+        self.notification.unregister(.download_progress, self);
+        self.download_events_registered = false;
+    }
+
+    pub fn onDownloadWillBegin(ctx: *anyopaque, msg: *const Notification.DownloadWillBegin) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/page.zig").downloadWillBegin(self, msg);
+    }
+
+    pub fn onDownloadProgress(ctx: *anyopaque, msg: *const Notification.DownloadProgress) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/browser.zig").downloadProgress(self, msg);
     }
 
     pub fn webmcpEnable(self: *BrowserContext) !void {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -823,7 +823,7 @@ pub const BrowserContext = struct {
 
     pub fn onDownloadWillBegin(ctx: *anyopaque, msg: *const Notification.DownloadWillBegin) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
-        return @import("domains/page.zig").downloadWillBegin(self, msg);
+        return @import("domains/browser.zig").downloadWillBegin(self, msg);
     }
 
     pub fn onDownloadProgress(ctx: *anyopaque, msg: *const Notification.DownloadProgress) !void {

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -107,7 +107,7 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
     // erroring, which would abort the driver's whole connection. The config is
     // applied once a context exists (drivers re-send it per context).
     const bc = cmd.browser_context orelse {
-        return cmd.sendResult(null, .{ .include_session_id = false });
+        return cmd.sendResult(null, .{});
     };
     const session = bc.session;
 
@@ -123,7 +123,7 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
         bc.downloadEventsDisable();
     }
 
-    return cmd.sendResult(null, .{ .include_session_id = false });
+    return cmd.sendResult(null, .{});
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/Browser/#event-downloadWillBegin

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -19,6 +19,8 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 const CDP = @import("../CDP.zig");
+const Session = @import("../../browser/Session.zig");
+const Notification = @import("../../Notification.zig");
 
 const log = lp.log;
 const PermissionState = @import("../../browser/webapi/Permissions.zig").State;
@@ -73,16 +75,59 @@ fn getVersion(cmd: *CDP.Command) !void {
     }, .{ .include_session_id = false });
 }
 
-// TODO: noop method
+// https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setDownloadBehavior
 fn setDownloadBehavior(cmd: *CDP.Command) !void {
-    // const params = (try cmd.params(struct {
-    //     behavior: []const u8,
-    //     browserContextId: ?[]const u8 = null,
-    //     downloadPath: ?[]const u8 = null,
-    //     eventsEnabled: ?bool = null,
-    // })) orelse return error.InvalidParams;
+    const params = (try cmd.params(struct {
+        behavior: []const u8,
+        browserContextId: ?[]const u8 = null,
+        downloadPath: ?[]const u8 = null,
+        eventsEnabled: ?bool = null,
+    })) orelse return error.InvalidParams;
+
+    const behavior: Session.DownloadBehavior = if (std.mem.eql(u8, params.behavior, "allow"))
+        .allow
+    else if (std.mem.eql(u8, params.behavior, "allowAndName"))
+        .allow_and_name
+    else if (std.mem.eql(u8, params.behavior, "deny"))
+        .deny
+    else if (std.mem.eql(u8, params.behavior, "default"))
+        .default
+    else
+        return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const session = bc.session;
+
+    session.download_behavior = behavior;
+    // downloadPath comes from the (transient) command arena; persist it on the
+    // session arena since Frame reads it on later navigations.
+    session.download_path = if (params.downloadPath) |p| try session.arena.dupe(u8, p) else null;
+    session.download_events_enabled = params.eventsEnabled orelse false;
+
+    if (session.download_events_enabled) {
+        try bc.downloadEventsEnable();
+    } else {
+        bc.downloadEventsDisable();
+    }
 
     return cmd.sendResult(null, .{ .include_session_id = false });
+}
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Browser/#event-downloadProgress
+// Dispatched by Frame as a download is written to disk (see issue #2701).
+pub fn downloadProgress(bc: *CDP.BrowserContext, msg: *const Notification.DownloadProgress) !void {
+    const session_id = bc.session_id orelse return;
+
+    return bc.cdp.sendEvent("Browser.downloadProgress", .{
+        .guid = msg.guid,
+        .totalBytes = msg.total_bytes,
+        .receivedBytes = msg.received_bytes,
+        .state = switch (msg.state) {
+            .in_progress => "inProgress",
+            .completed => "completed",
+            .canceled => "canceled",
+        },
+    }, .{ .session_id = session_id });
 }
 
 fn getWindowForTarget(cmd: *CDP.Command) !void {
@@ -229,4 +274,98 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
     });
     try ctx.expectSentResult(null, .{ .id = 42, .session_id = null });
     try testing.expectEqual(@as(usize, 0), browser.permissions.count());
+}
+
+test "cdp.browser: setDownloadBehavior stores config on the session" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .session_id = "SID-CFG" });
+
+    try ctx.processMessage(.{
+        .id = 34,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{
+            .behavior = "allowAndName",
+            .downloadPath = "/tmp/lp-downloads",
+            .eventsEnabled = true,
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 34, .session_id = null });
+
+    try testing.expectEqual(.allow_and_name, bc.session.download_behavior);
+    try testing.expectEqualSlices(u8, "/tmp/lp-downloads", bc.session.download_path.?);
+    try testing.expect(bc.session.download_events_enabled);
+    try testing.expect(bc.download_events_registered);
+
+    // Flipping back to default tears the registration down again.
+    try ctx.processMessage(.{
+        .id = 35,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{ .behavior = "default" },
+    });
+    try testing.expectEqual(.default, bc.session.download_behavior);
+    try testing.expect(bc.session.download_path == null);
+    try testing.expect(bc.session.download_events_enabled == false);
+    try testing.expect(bc.download_events_registered == false);
+}
+
+test "cdp.browser: setDownloadBehavior rejects an unknown behavior" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .session_id = "SID-BAD" });
+
+    try ctx.processMessage(.{
+        .id = 36,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{ .behavior = "sometimes" },
+    });
+    try ctx.expectSentError(-31998, "InvalidParams", .{ .id = 36 });
+}
+
+test "cdp.browser: setDownloadBehavior writes an attachment to disk and emits events" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const download_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(download_path);
+
+    const bc = try ctx.loadBrowserContext(.{
+        .session_id = "SID-DL",
+        .target_id = "TID-00000000DL".*,
+    });
+
+    try ctx.processMessage(.{
+        .id = 37,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{
+            .behavior = "allow",
+            .downloadPath = download_path,
+            .eventsEnabled = true,
+        },
+    });
+    try ctx.expectSentResult(null, .{ .id = 37, .session_id = null });
+
+    const frame = try bc.session.createPage();
+    try frame.navigate("http://127.0.0.1:9582/download/report.csv", .{});
+    var runner = try bc.session.runner(.{});
+    try runner.wait(.{ .ms = 2000 });
+
+    // The guid is random, so it's omitted from these subset matches.
+    try ctx.expectSentEvent("Page.downloadWillBegin", .{
+        .url = "http://127.0.0.1:9582/download/report.csv",
+        .suggestedFilename = "report.csv",
+    }, .{ .session_id = "SID-DL" });
+    try ctx.expectSentEvent("Browser.downloadProgress", .{
+        .state = "completed",
+        .totalBytes = 30,
+        .receivedBytes = 30,
+    }, .{ .session_id = "SID-DL" });
+
+    const written = try tmp.dir.readFileAlloc(testing.allocator, "report.csv", 1024);
+    defer testing.allocator.free(written);
+    try testing.expectEqualSlices(u8, "col1,col2\nhello,world\n42,1337\n", written);
 }

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
 const Session = @import("../../browser/Session.zig");
 const Notification = @import("../../Notification.zig");
@@ -84,14 +85,18 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
         eventsEnabled: ?bool = null,
     })) orelse return error.InvalidParams;
 
+    if (params.browserContextId != null) {
+        log.warn(.not_implemented, "Browser.setDownloadBehavior", .{ .param = "browserContextId" });
+    }
+
+    // `default` defers the choice to the browser; we map it to `deny` (no
+    // download is written unless a driver explicitly opts in).
     const behavior: Session.DownloadBehavior = if (std.mem.eql(u8, params.behavior, "allow"))
         .allow
     else if (std.mem.eql(u8, params.behavior, "allowAndName"))
         .allow_and_name
-    else if (std.mem.eql(u8, params.behavior, "deny"))
+    else if (std.mem.eql(u8, params.behavior, "deny") or std.mem.eql(u8, params.behavior, "default"))
         .deny
-    else if (std.mem.eql(u8, params.behavior, "default"))
-        .default
     else
         return error.InvalidParams;
 
@@ -119,6 +124,21 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
     }
 
     return cmd.sendResult(null, .{ .include_session_id = false });
+}
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Browser/#event-downloadWillBegin
+// Dispatched by Frame when a navigation response is treated as a file download.
+// The opt-in is Browser.setDownloadBehavior, so we emit Browser.* events only
+// (not the deprecated Page.downloadWillBegin / Page.downloadProgress). See #2701.
+pub fn downloadWillBegin(bc: *CDP.BrowserContext, event: *const Notification.DownloadWillBegin) !void {
+    const session_id = bc.session_id orelse return;
+
+    return bc.cdp.sendEvent("Browser.downloadWillBegin", .{
+        .frameId = &id.toFrameId(event.frame_id),
+        .guid = event.guid,
+        .url = event.url,
+        .suggestedFilename = event.suggested_filename,
+    }, .{ .session_id = session_id });
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/Browser/#event-downloadProgress
@@ -306,13 +326,13 @@ test "cdp.browser: setDownloadBehavior stores config on the session" {
     try testing.expect(bc.session.download_events_enabled);
     try testing.expect(bc.download_events_registered);
 
-    // Flipping back to default tears the registration down again.
+    // `default` maps to `deny` and tears the registration down again.
     try ctx.processMessage(.{
         .id = 35,
         .method = "Browser.setDownloadBehavior",
         .params = .{ .behavior = "default" },
     });
-    try testing.expectEqual(.default, bc.session.download_behavior);
+    try testing.expectEqual(.deny, bc.session.download_behavior);
     try testing.expect(bc.session.download_path == null);
     try testing.expect(bc.session.download_events_enabled == false);
     try testing.expect(bc.download_events_registered == false);
@@ -378,7 +398,7 @@ test "cdp.browser: setDownloadBehavior writes an attachment to disk and emits ev
     try runner.wait(.{ .ms = 2000 });
 
     // The guid is random, so it's omitted from these subset matches.
-    try ctx.expectSentEvent("Page.downloadWillBegin", .{
+    try ctx.expectSentEvent("Browser.downloadWillBegin", .{
         .url = "http://127.0.0.1:9582/download/report.csv",
         .suggestedFilename = "report.csv",
     }, .{ .session_id = "SID-DL" });

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -131,21 +131,17 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
 // The opt-in is Browser.setDownloadBehavior, so we emit Browser.* events only
 // (not the deprecated Page.downloadWillBegin / Page.downloadProgress). See #2701.
 pub fn downloadWillBegin(bc: *CDP.BrowserContext, event: *const Notification.DownloadWillBegin) !void {
-    const session_id = bc.session_id orelse return;
-
     return bc.cdp.sendEvent("Browser.downloadWillBegin", .{
         .frameId = &id.toFrameId(event.frame_id),
         .guid = event.guid,
         .url = event.url,
         .suggestedFilename = event.suggested_filename,
-    }, .{ .session_id = session_id });
+    }, .{});
 }
 
 // https://chromedevtools.github.io/devtools-protocol/tot/Browser/#event-downloadProgress
 // Dispatched by Frame as a download is written to disk (see issue #2701).
 pub fn downloadProgress(bc: *CDP.BrowserContext, msg: *const Notification.DownloadProgress) !void {
-    const session_id = bc.session_id orelse return;
-
     return bc.cdp.sendEvent("Browser.downloadProgress", .{
         .guid = msg.guid,
         .totalBytes = msg.total_bytes,
@@ -155,7 +151,7 @@ pub fn downloadProgress(bc: *CDP.BrowserContext, msg: *const Notification.Downlo
             .completed => "completed",
             .canceled => "canceled",
         },
-    }, .{ .session_id = session_id });
+    }, .{});
 }
 
 fn getWindowForTarget(cmd: *CDP.Command) !void {
@@ -401,12 +397,12 @@ test "cdp.browser: setDownloadBehavior writes an attachment to disk and emits ev
     try ctx.expectSentEvent("Browser.downloadWillBegin", .{
         .url = "http://127.0.0.1:9582/download/report.csv",
         .suggestedFilename = "report.csv",
-    }, .{ .session_id = "SID-DL" });
+    }, .{});
     try ctx.expectSentEvent("Browser.downloadProgress", .{
         .state = "completed",
         .totalBytes = 30,
         .receivedBytes = 30,
-    }, .{ .session_id = "SID-DL" });
+    }, .{});
 
     const written = try tmp.dir.readFileAlloc(testing.allocator, "report.csv", 1024);
     defer testing.allocator.free(written);

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -95,7 +95,15 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
     else
         return error.InvalidParams;
 
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    // Drivers (notably Playwright) send Browser.setDownloadBehavior at the
+    // browser level during connection setup, before any target/context has
+    // been created. Chromium accepts this; we have nowhere to store the config
+    // yet (it lives on the Session), so treat it as a success no-op rather than
+    // erroring, which would abort the driver's whole connection. The config is
+    // applied once a context exists (drivers re-send it per context).
+    const bc = cmd.browser_context orelse {
+        return cmd.sendResult(null, .{ .include_session_id = false });
+    };
     const session = bc.session;
 
     session.download_behavior = behavior;
@@ -308,6 +316,21 @@ test "cdp.browser: setDownloadBehavior stores config on the session" {
     try testing.expect(bc.session.download_path == null);
     try testing.expect(bc.session.download_events_enabled == false);
     try testing.expect(bc.download_events_registered == false);
+}
+
+test "cdp.browser: setDownloadBehavior is a no-op when no context is loaded" {
+    // Drivers (e.g. Playwright) send this at the browser level during
+    // connection setup, before any target/context exists. It must succeed
+    // rather than error, otherwise the driver aborts the whole connection.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    try ctx.processMessage(.{
+        .id = 33,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{ .behavior = "deny", .eventsEnabled = true },
+    });
+    try ctx.expectSentResult(null, .{ .id = 33, .session_id = null });
 }
 
 test "cdp.browser: setDownloadBehavior rejects an unknown behavior" {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -806,6 +806,20 @@ pub fn frameNetworkAlmostIdle(bc: *CDP.BrowserContext, event: *const Notificatio
     return sendPageLifecycle(bc, "networkAlmostIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.loader_id));
 }
 
+// https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-downloadWillBegin
+// Dispatched by Frame when a navigation response is treated as a file download
+// (see issue #2701).
+pub fn downloadWillBegin(bc: *CDP.BrowserContext, event: *const Notification.DownloadWillBegin) !void {
+    const session_id = bc.session_id orelse return;
+
+    return bc.cdp.sendEvent("Page.downloadWillBegin", .{
+        .frameId = &id.toFrameId(event.frame_id),
+        .guid = event.guid,
+        .url = event.url,
+        .suggestedFilename = event.suggested_filename,
+    }, .{ .session_id = session_id });
+}
+
 fn sendPageLifecycle(bc: *CDP.BrowserContext, name: []const u8, timestamp: u64, frame_id: []const u8, loader_id: []const u8) !void {
     // detachTarget could be called, in which case, we still have a frame doing
     // things, but no session.

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -806,20 +806,6 @@ pub fn frameNetworkAlmostIdle(bc: *CDP.BrowserContext, event: *const Notificatio
     return sendPageLifecycle(bc, "networkAlmostIdle", event.timestamp, &id.toFrameId(event.frame_id), &id.toLoaderId(event.loader_id));
 }
 
-// https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-downloadWillBegin
-// Dispatched by Frame when a navigation response is treated as a file download
-// (see issue #2701).
-pub fn downloadWillBegin(bc: *CDP.BrowserContext, event: *const Notification.DownloadWillBegin) !void {
-    const session_id = bc.session_id orelse return;
-
-    return bc.cdp.sendEvent("Page.downloadWillBegin", .{
-        .frameId = &id.toFrameId(event.frame_id),
-        .guid = event.guid,
-        .url = event.url,
-        .suggestedFilename = event.suggested_filename,
-    }, .{ .session_id = session_id });
-}
-
 fn sendPageLifecycle(bc: *CDP.BrowserContext, name: []const u8, timestamp: u64, frame_id: []const u8, loader_id: []const u8) !void {
     // detachTarget could be called, in which case, we still have a frame doing
     // things, but no session.

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -54,6 +54,59 @@ pub const Method = enum(u8) {
 pub const Header = struct {
     name: []const u8,
     value: []const u8,
+
+    pub const Param = struct {
+        key: []const u8,
+        value: []const u8,
+    };
+
+    // The header value up to the first ';', trimmed (e.g. "attachment" for a
+    // Content-Disposition, "text/html" for a Content-Type).
+    pub fn firstValue(self: Header) []const u8 {
+        const end = std.mem.indexOfScalar(u8, self.value, ';') orelse self.value.len;
+        return std.mem.trim(u8, self.value[0..end], " \t");
+    }
+
+    // Iterates the `; key=value` parameters that follow the header's first value.
+    pub fn params(self: Header) ParamIterator {
+        const start = std.mem.indexOfScalar(u8, self.value, ';') orelse self.value.len;
+        return .{ .rest = self.value[start..] };
+    }
+
+    // Returns the (unquoted) value of the first non-empty `key=` parameter, if any.
+    pub fn param(self: Header, key: []const u8) ?[]const u8 {
+        var it = self.params();
+        while (it.next()) |p| {
+            if (p.value.len > 0 and std.ascii.eqlIgnoreCase(p.key, key)) {
+                return p.value;
+            }
+        }
+        return null;
+    }
+
+    pub const ParamIterator = struct {
+        rest: []const u8,
+
+        pub fn next(self: *ParamIterator) ?Param {
+            while (self.rest.len > 0 and self.rest[0] == ';') {
+                self.rest = self.rest[1..];
+                const end = std.mem.indexOfScalar(u8, self.rest, ';') orelse self.rest.len;
+                const segment = self.rest[0..end];
+                self.rest = self.rest[end..];
+
+                const eq = std.mem.indexOfScalar(u8, segment, '=') orelse continue;
+                const key = std.mem.trim(u8, segment[0..eq], " \t");
+                if (key.len == 0) continue;
+
+                var value = std.mem.trim(u8, segment[eq + 1 ..], " \t");
+                if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
+                    value = value[1 .. value.len - 1];
+                }
+                return .{ .key = key, .value = value };
+            }
+            return null;
+        }
+    };
 };
 
 pub const Headers = struct {
@@ -718,6 +771,26 @@ fn makeSockAddrV4(ip: [4]u8) libcurl.CurlSockAddr {
 }
 
 const testing = @import("../testing.zig");
+
+test "Header.firstValue" {
+    try testing.expectEqualSlices(u8, "attachment", (Header{ .name = "Content-Disposition", .value = "attachment" }).firstValue());
+    // firstValue trims but preserves case (callers compare case-insensitively).
+    try testing.expectEqualSlices(u8, "ATTACHMENT", (Header{ .name = "Content-Disposition", .value = "  ATTACHMENT ; filename=a.csv" }).firstValue());
+    try testing.expectEqualSlices(u8, "text/html", (Header{ .name = "Content-Type", .value = "text/html; charset=utf-8" }).firstValue());
+    try testing.expectEqualSlices(u8, "", (Header{ .name = "X", .value = "" }).firstValue());
+}
+
+test "Header.param" {
+    const h: Header = .{ .name = "Content-Disposition", .value = "attachment; filename=\"r e.csv\"; filename*=UTF-8''e.txt" };
+    try testing.expectEqualSlices(u8, "r e.csv", h.param("filename").?);
+    try testing.expectEqualSlices(u8, "r e.csv", h.param("FILENAME").?);
+    try testing.expectEqualSlices(u8, "UTF-8''e.txt", h.param("filename*").?);
+    try testing.expect(h.param("missing") == null);
+    // A bare value with no parameters has nothing to return.
+    try testing.expect((Header{ .name = "Content-Disposition", .value = "attachment" }).param("filename") == null);
+    // Empty values are skipped.
+    try testing.expect((Header{ .name = "Content-Disposition", .value = "attachment; filename=\"\"" }).param("filename") == null);
+}
 
 fn findHeader(headers: Headers, name: []const u8) struct { count: usize, value: []const u8 } {
     var count: usize = 0;

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -821,6 +821,17 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/download/report.csv")) {
+        // A file download: Content-Disposition: attachment drives the
+        // Browser.setDownloadBehavior path (issue #2701).
+        return req.respond("col1,col2\nhello,world\n42,1337\n", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/csv" },
+                .{ .name = "Content-Disposition", .value = "attachment; filename=\"report.csv\"" },
+            },
+        });
+    }
+
     if (std.mem.startsWith(u8, path, "/src/browser/tests/")) {
         // strip off leading / so that it's relative to CWD
         return TestHTTPServer.sendFile(req, path[1..]);


### PR DESCRIPTION
Fixes #2701

## Summary

`Browser.setDownloadBehavior` was a noop (every param commented out, bare success returned), so Lightpanda had no file-download path at all: a response carrying `Content-Disposition: attachment` was treated as a normal navigation,
its body discarded, `downloadPath` ignored, and no download events emitted.

This wires up the full path. When `Browser.setDownloadBehavior` opts in (`allow` / `allowAndName`) and a navigation response carries `Content-Disposition: attachment`, the body is streamed to disk under `downloadPath` instead of being parsed as a page, and, when `eventsEnabled: true`, `Page.downloadWillBegin` and `Browser.downloadProgress` (`inProgress` -> `completed`) are emitted.

## Approach

This follows the existing notification pattern: `Frame` dispatches notifications and the CDP domains consume them and emit CDP events (the same shape as `frame_navigated` -> `Page.frameNavigated`).

- **`Session.zig`**: download config (`download_behavior`, `download_path`, `download_events_enabled`), scoped per CDP connection.
- **`Notification.zig`**: new `DownloadWillBegin` / `DownloadProgress` event
- **`Frame.zig`**: a `.download` parse state that holds the open file; detect the attachment in `frameHeaderDoneCallback`, stream the body to disk in `frameDataCallback`, close + emit `completed` in `frameDoneCallback`, then commit an empty document so the navigation still finishes cleanly (mirrors
  the existing `.raw` path). Content-Disposition parsing handles the quoted, unquoted, and RFC 5987 (`filename*=`) forms, and strips path components to guard against traversal.
- **`Runner.zig`**: `.download` handled as a loading state.
- **`CDP.zig`**: idempotent registration for the download notifications.
- **`browser.zig` / `page.zig`**: `setDownloadBehavior` now parses and stores
  its params and toggles event registration; `Browser.downloadProgress` and `Page.downloadWillBegin` emitters.

## Behavior notes / scope

- **Navigation-initiated downloads only.** Script-initiated `<a download>` clicks are the same operation from JS but go through a different entry point; left as a follow-up.
- **`deny`** falls through to the prior behavior (the response is not written to disk); no cancellation event is emitted.
- RFC 5987 `filename*` values are taken verbatim (no percent-decoding yet).

## Testing

- New end-to-end CDP test: configures `setDownloadBehavior` with a temp `downloadPath`, navigates to a `Content-Disposition: attachment` response, and asserts both `Page.downloadWillBegin` and `Browser.downloadProgress` fire and that the file lands on disk with the correct bytes.
- New tests for config storage, registration toggling, and rejection of an unknown `behavior`.
- New unit tests for the Content-Disposition / filename parsing helpers.
- Full suite green (`make test`), formatting clean (`zig fmt --check`).

## Checklist

- [x] Tests pass (`make test`).
- [x] Formatting is clean (`zig fmt --check ./*.zig ./**/*.zig`).
- [x] CLA signed.