### PR TITLE
agent: revise the saved script on repeat /save

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -171,6 +171,19 @@ const script_skill =
 // With the save instructions and the skill-like agent script documentation.
 const save_system_prompt = browser_tools.save_synthesis_prompt ++ "\n" ++ script_skill;
 
+// Swapped in instead of `save_system_prompt` when the user message carries a
+// previously saved script: the "this session" framing above would otherwise
+// make the model discard it as out-of-scope.
+const save_revision_note =
+    \\This save REVISES an existing script, included in the user message. Its
+    \\goal spans every session that contributed to it, not just this one. Use
+    \\it as the base: keep its steps, structure, and output shape unchanged
+    \\except where this session's commands or the user's instruction require
+    \\a change, and add what this session contributes. Output the complete
+    \\updated script — never a fragment, diff, or continuation.
+;
+const save_revision_system_prompt = browser_tools.save_synthesis_prompt ++ "\n" ++ save_revision_note ++ "\n" ++ script_skill;
+
 const synthesis_prompt =
     \\You have used your tool budget or cannot finish the exploration.
     \\Give your best final answer NOW based ONLY on what you actually observed
@@ -891,7 +904,9 @@ fn resolveSavePathAndMode(self: *Agent, arena: std.mem.Allocator, filename: ?[]c
                 return null;
             }
         }
-        return .{ .path = saved, .mode = .append };
+        // A repeat save reuses the destination without re-asking: revision
+        // when a model can merge, plain append for the verbatim dump.
+        return .{ .path = saved, .mode = if (self.ai_client != null) .update else .append };
     } else if (filename) |name| {
         const exists = save.fileExists(name) catch |err| {
             self.terminal.printError("failed to inspect {s}: {s}", .{ name, @errorName(err) });
@@ -964,11 +979,27 @@ fn promptSaveMode(self: *Agent, path: []const u8) ?save.Mode {
     var header_buf: [256]u8 = undefined;
     const header = std.fmt.bufPrint(&header_buf, "{s} already exists. Pick save mode:", .{path}) catch
         "File already exists. Pick save mode:";
-    const idx = Terminal.promptNumberedChoice(header, std.meta.fieldNames(save.Mode), 0) catch {
+    const with_llm = self.ai_client != null;
+    const modes: []const save.Mode = if (with_llm)
+        &.{ .update, .append, .replace }
+    else
+        &.{ .append, .replace };
+    const labels: []const [:0]const u8 = if (with_llm)
+        &.{
+            "update — revise the saved script with this session's actions and the prompt",
+            "append — keep the file as-is and add the new script at the end",
+            "replace — discard the file and write a fresh script",
+        }
+    else
+        &.{
+            "append — add the recorded commands at the end",
+            "replace — overwrite with the recorded commands",
+        };
+    const idx = Terminal.promptNumberedChoice(header, labels, 0) catch {
         self.terminal.printInfo("Save cancelled.", .{});
         return null;
     };
-    return @enumFromInt(idx);
+    return modes[idx];
 }
 
 fn failSave(self: *Agent, reason: []const u8) void {
@@ -1002,10 +1033,10 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
     const resolved = self.resolveSavePathAndMode(arena, filename) orelse return;
     const path = resolved.path;
 
-    // For synthesis, append means revise: the saved script is handed back to
-    // the model, which returns the complete updated script, so the write
-    // itself always truncates.
-    const previous_script: ?[]const u8 = if (resolved.mode == .append)
+    // Only update feeds the saved script back to the model; append stays
+    // blind — the script is synthesized from this session alone and written
+    // after the existing content.
+    const previous_script: ?[]const u8 = if (resolved.mode == .update)
         save.readScript(arena, path) catch |err| {
             self.terminal.printError("failed to read {s}: {s}", .{ path, @errorName(err) });
             return;
@@ -1019,7 +1050,7 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
     // regular turns keep the driver prompt. (`messages[0]` is the system
     // message — rollback and prune never touch it.)
     const plain_system = self.conversation.messages.items[0].content;
-    self.conversation.messages.items[0].content = save_system_prompt;
+    self.conversation.messages.items[0].content = if (previous_script != null) save_revision_system_prompt else save_system_prompt;
     defer self.conversation.messages.items[0].content = plain_system;
 
     const ma = self.conversation.arena.allocator();
@@ -1072,7 +1103,7 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
     // The save turn is a meta-action; keep it out of the ongoing conversation.
     self.conversation.rollback(baseline);
 
-    save.writeContentFile(path, script, .replace) catch |err| {
+    save.writeContentFile(path, script, resolved.mode) catch |err| {
         self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
         return;
     };
@@ -1096,7 +1127,7 @@ fn buildSaveSynthesisMessage(self: *Agent, arena: std.mem.Allocator, path: []con
     var out: std.Io.Writer.Allocating = .init(arena);
     const w = &out.writer;
     if (previous_script) |script| {
-        try w.print("\nThe script saved to {s} so far — revise or extend it per the rest of this message, and output the complete updated script:\n", .{path});
+        try w.print("\nThe previously saved script in {s}, the base you are revising:\n", .{path});
         try w.writeAll(script);
     }
     const recorded = self.save_buffer.bytes();

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -887,7 +887,7 @@ fn resolveSavePathAndMode(self: *Agent, arena: std.mem.Allocator, filename: ?[]c
     if (self.save_path) |saved| {
         if (filename) |name| {
             if (!std.mem.eql(u8, saved, name)) {
-                self.terminal.printError("already saving to {s}; use /save without a filename to append to it", .{saved});
+                self.terminal.printError("already saving to {s}; use /save without a filename to update it", .{saved});
                 return null;
             }
         }
@@ -988,8 +988,30 @@ fn abortSave(self: *Agent, baseline: usize, reason: []const u8) void {
 fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8, prompt: ?[]const u8) void {
     const provider_client = self.ai_client.?;
 
+    // With nothing recorded and no prompt, a re-synthesis has nothing to act
+    // on — it would just re-roll the previous output.
+    if (self.save_buffer.bytes().len == 0 and prompt == null) {
+        if (self.save_path) |saved| {
+            self.terminal.printWarning("nothing ran since the last save; run more commands or give a prompt to revise {s}, e.g. /save <what to change>", .{saved});
+        } else {
+            self.terminal.printWarning("nothing to save yet; run some commands or give a prompt, e.g. /save <what the script should do>", .{});
+        }
+        return;
+    }
+
     const resolved = self.resolveSavePathAndMode(arena, filename) orelse return;
     const path = resolved.path;
+
+    // For synthesis, append means revise: the saved script is handed back to
+    // the model, which returns the complete updated script, so the write
+    // itself always truncates.
+    const previous_script: ?[]const u8 = if (resolved.mode == .append)
+        save.readScript(arena, path) catch |err| {
+            self.terminal.printError("failed to read {s}: {s}", .{ path, @errorName(err) });
+            return;
+        }
+    else
+        null;
 
     self.conversation.ensureSystemPrompt() catch return self.failSave("out of memory");
 
@@ -1003,7 +1025,7 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
     const ma = self.conversation.arena.allocator();
     const baseline = self.conversation.messages.items.len;
 
-    const user_msg = self.buildSaveSynthesisMessage(ma, prompt) catch return self.failSave("out of memory");
+    const user_msg = self.buildSaveSynthesisMessage(ma, path, previous_script, prompt) catch return self.failSave("out of memory");
     self.conversation.messages.append(self.allocator, .{ .role = .user, .content = user_msg }) catch return self.failSave("out of memory");
 
     self.terminal.spinner.start();
@@ -1050,7 +1072,7 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
     // The save turn is a meta-action; keep it out of the ongoing conversation.
     self.conversation.rollback(baseline);
 
-    save.writeContentFile(path, script, resolved.mode) catch |err| {
+    save.writeContentFile(path, script, .replace) catch |err| {
         self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
         return;
     };
@@ -1070,12 +1092,17 @@ fn rememberSavePath(self: *Agent, path: []const u8) void {
     self.save_path = dup;
 }
 
-fn buildSaveSynthesisMessage(self: *Agent, arena: std.mem.Allocator, prompt: ?[]const u8) ![]const u8 {
+fn buildSaveSynthesisMessage(self: *Agent, arena: std.mem.Allocator, path: []const u8, previous_script: ?[]const u8, prompt: ?[]const u8) ![]const u8 {
     var out: std.Io.Writer.Allocating = .init(arena);
     const w = &out.writer;
+    if (previous_script) |script| {
+        try w.print("\nThe script saved to {s} so far — revise or extend it per the rest of this message, and output the complete updated script:\n", .{path});
+        try w.writeAll(script);
+    }
     const recorded = self.save_buffer.bytes();
     if (recorded.len > 0) {
-        try w.writeAll("\nCommands and JS that actually ran this session:\n");
+        const since: []const u8 = if (previous_script != null) " since the last save" else " this session";
+        try w.print("\nCommands and JS that actually ran{s}:\n", .{since});
         try w.writeAll(recorded);
     }
     if (prompt) |p| {
@@ -1144,7 +1171,7 @@ fn printSlashHelp(self: *Agent, arena: std.mem.Allocator, target: []const u8) vo
                 .{},
             ),
             .save => self.terminal.printInfo(
-                "/save [filename.js] [prompt] — save the session to [filename.js] (a random session-*.js if omitted). With an LLM, synthesizes an idiomatic script from the session and the optional prompt; with --no-llm, dumps the recorded actions verbatim.",
+                "/save [filename.js] [prompt] — save the session to [filename.js] (a random session-*.js if omitted). With an LLM, synthesizes an idiomatic script from the session and the optional prompt, and a repeat /save with a prompt revises the saved script; with --no-llm, dumps the recorded actions verbatim.",
                 .{},
             ),
             .load => self.terminal.printInfo(

--- a/src/agent/save.zig
+++ b/src/agent/save.zig
@@ -73,6 +73,17 @@ pub fn randomFilename(arena: std.mem.Allocator) ![]const u8 {
     return error.NameCollision;
 }
 
+/// Read a previously saved script back for revision. Returns null when there
+/// is nothing to feed the model: the file does not exist or is blank.
+pub fn readScript(arena: std.mem.Allocator, path: []const u8) !?[]const u8 {
+    const content = std.fs.cwd().readFileAlloc(arena, path, 1024 * 1024) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    if (std.mem.trim(u8, content, &std.ascii.whitespace).len == 0) return null;
+    return content;
+}
+
 pub fn fileExists(path: []const u8) !bool {
     std.fs.cwd().access(path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,

--- a/src/agent/save.zig
+++ b/src/agent/save.zig
@@ -25,7 +25,10 @@ const std = @import("std");
 const lp = @import("lightpanda");
 const Schema = lp.Schema;
 
-pub const Mode = enum { append, replace };
+/// How a save treats an existing destination file. `update` is synthesis-only:
+/// the model merges the saved script with the new material and returns the
+/// complete result, so at the file level it writes like `replace`.
+pub const Mode = enum { append, replace, update };
 
 pub const Command = struct { filename: ?[]const u8, prompt: ?[]const u8 };
 
@@ -93,7 +96,7 @@ pub fn fileExists(path: []const u8) !bool {
 }
 
 pub fn writeContentFile(path: []const u8, content: []const u8, mode: Mode) !void {
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = mode == .replace });
+    const file = try std.fs.cwd().createFile(path, .{ .truncate = mode != .append });
     defer file.close();
     if (mode == .append) {
         try file.seekFromEnd(0);


### PR DESCRIPTION
A second /save with nothing recorded and no prompt sent an empty user message, which Anthropic rejects (HTTP 400: text content blocks must be non-empty). Bail out early instead, telling the user to run commands or give a prompt.

When a /save targets an existing script (a remembered save path, or choosing append for an existing file), feed the file contents back to the model and ask for the complete updated script, then overwrite. This makes '/save fix X' actually fix the saved script — previously the blind regeneration was appended after the buggy one. The --no-llm dump path keeps its verbatim append semantics.