### PR TITLE
webapi: default navigator.globalPrivacyControl to false

### DIFF
--- a/src/browser/tests/navigator/navigator.html
+++ b/src/browser/tests/navigator/navigator.html
@@ -30,6 +30,12 @@
 
   testing.expectEqual(null, navigator.doNotTrack);
 
+  // GPC must default to false — per https://w3c.github.io/gpc/#javascript-property
+  // the signal reflects an explicit user preference (Firefox defaults to false;
+  // Chrome doesn't expose the property at all). A true default makes
+  // GPC-compliant consent managers reject-all and skip their consent UI.
+  testing.expectEqual(false, navigator.globalPrivacyControl);
+
   // Every Navigator attribute must be a native accessor on the prototype
   for (const name of [
     'userAgent', 'appName', 'appCodeName', 'appVersion', 'platform',

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -97,8 +97,13 @@ pub fn getWebdriver(_: *const Navigator) bool {
     return false;
 }
 
+// Default to false: per https://w3c.github.io/gpc/#javascript-property the
+// signal reflects an explicit user preference, and none is configured here.
+// Firefox defaults to false; Chrome doesn't expose the property. Returning
+// true made GPC-compliant consent managers treat every page load as "reject
+// tracking" and skip their consent UI entirely.
 pub fn getGlobalPrivacyControl(_: *const Navigator) bool {
-    return true;
+    return false;
 }
 
 pub fn getPlatform(_: *const Navigator) []const u8 {


### PR DESCRIPTION
## What

`navigator.globalPrivacyControl` now defaults to `false`. Per the [GPC spec](https://w3c.github.io/gpc/#javascript-property) the property reflects an explicit user preference to opt out of tracking, and no such preference is configured anywhere — so the default must be the absence of the signal. Firefox defaults to `false`; Chrome doesn't expose the property at all.

Closes #2725.

## Why it matters

GPC is an automated "reject tracking" signal. Consent-management code probes it on load and, when truthy, takes the reject-all path and never renders its consent UI. With a hardcoded `true`, every page with a GPC-aware consent banner silently behaved as if the user had already opted out — a behavioral divergence from every default-config real browser. It also contradicted the intent of `navigator.webdriver` returning `false` two functions up in the same file, which exists precisely to avoid this kind of divergence.

```mermaid
flowchart LR
    subgraph before [Before]
        A1[page script reads GPC] --> B1[hardcoded true]
        B1 --> C1[consent manager auto-rejects]
        C1 --> D1[consent UI never renders]
    end
    subgraph after [After]
        A2[page script reads GPC] --> B2[false - no preference configured]
        B2 --> C2[consent manager asks the user]
        C2 --> D2[consent UI renders]
    end
```

## Fix

- `src/browser/webapi/Navigator.zig` — `getGlobalPrivacyControl` returns `false`, with a comment citing the spec and both real-browser defaults.
- `src/browser/tests/navigator/navigator.html` — value assertion `testing.expectEqual(false, navigator.globalPrivacyControl)` next to the existing `doNotTrack` check. The fixture's accessor-shape walk already covered the property, but nothing asserted its value (which is how the `true` slipped through).

## Verification

- `TEST_FILTER='WebApi: Navigator#navigator.html' zig build test` — fails on the new assertion before the fix (`expected: false, got: true`), passes after.
- Full `zig build test`: 795/795.
- End-to-end against the issue's reproducer: exits 1 on nightly `6736`, exits 0 on this branch's debug build (`navigator.globalPrivacyControl = false`, consent banner renders).
