### PR TITLE
feat(cdp): honor Browser.grantPermissions / setPermission / resetPermissions

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -26,6 +26,7 @@ const js = @import("js/js.zig");
 const Page = @import("Page.zig");
 const Session = @import("Session.zig");
 const HttpClient = @import("HttpClient.zig");
+const PermissionState = @import("webapi/Permissions.zig").State;
 
 const ArenaPool = App.ArenaPool;
 const Allocator = std.mem.Allocator;
@@ -41,6 +42,13 @@ session: ?Session,
 allocator: Allocator,
 arena_pool: *ArenaPool,
 http_client: HttpClient,
+
+// Permission state set via CDP Browser.grantPermissions / setPermission /
+// resetPermissions, keyed by permission name (e.g. "geolocation"). Read back
+// by navigator.permissions.query(). Scoped to the Browser so it persists
+// across page navigations, mirroring how Chrome scopes permissions to the
+// browser context. Keys are owned by `allocator`; values are enum tags.
+permissions: std.StringHashMapUnmanaged(PermissionState) = .empty,
 
 // used by sessions to allocate pages.
 page_pool: std.heap.MemoryPool(Page),
@@ -104,6 +112,32 @@ pub fn deinit(self: *Browser) void {
     self.fc_identity_pool.deinit();
     self.page_pool.deinit();
     self.http_client.deinit();
+    self.clearPermissions();
+    self.permissions.deinit(self.allocator);
+}
+
+// Set (or overwrite) the stored state for a permission. The name is duped into
+// `allocator`; the state is a plain enum tag. Used by CDP
+// Browser.grantPermissions / setPermission.
+pub fn setPermission(self: *Browser, name: []const u8, state: PermissionState) !void {
+    const gop = try self.permissions.getOrPut(self.allocator, name);
+    if (!gop.found_existing) {
+        gop.key_ptr.* = self.allocator.dupe(u8, name) catch |err| {
+            _ = self.permissions.remove(name);
+            return err;
+        };
+    }
+    gop.value_ptr.* = state;
+}
+
+// Clear all stored permissions, freeing the keys. Used by CDP
+// Browser.resetPermissions and on teardown.
+pub fn clearPermissions(self: *Browser) void {
+    var it = self.permissions.keyIterator();
+    while (it.next()) |key| {
+        self.allocator.free(key.*);
+    }
+    self.permissions.clearRetainingCapacity();
 }
 
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -25,7 +25,6 @@ const v8 = js.v8;
 const Frame = @import("Frame.zig");
 const Session = @import("Session.zig");
 const Factory = @import("Factory.zig");
-const PermissionState = @import("webapi/Permissions.zig").State;
 
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
@@ -70,11 +69,6 @@ frame_arena: Allocator,
 // Origin map for same-origin context sharing. Entries live for the Page's
 // lifetime.
 origins: std.StringHashMapUnmanaged(*js.Origin) = .empty,
-
-// Permission state set via CDP Browser.grantPermissions / setPermission /
-// resetPermissions, keyed by permission name (e.g. "geolocation"). Read back
-// by navigator.permissions.query().
-permissions: std.StringHashMapUnmanaged(PermissionState) = .empty,
 
 // Identity tracking for the main world. All main-world contexts in this Page
 // share this, ensuring object identity works across same-origin frames.
@@ -193,10 +187,6 @@ pub fn deinit(self: *Page) void {
         self.origins = .empty;
     }
 
-    // Keys and values are duped into frame_arena, released just below; drop
-    // the map so we don't keep a dangling reference.
-    self.permissions = .empty;
-
     session.arena_pool.release(self.frame_arena);
 }
 
@@ -206,14 +196,6 @@ pub fn getArena(self: *Page, size_or_bucket: anytype, debug: []const u8) !Alloca
 
 pub fn releaseArena(self: *Page, allocator: Allocator) void {
     return self.session.releaseArena(allocator);
-}
-
-pub fn setPermission(self: *Page, name: []const u8, state: PermissionState) !void {
-    const gop = try self.permissions.getOrPut(self.frame_arena, name);
-    if (!gop.found_existing) {
-        gop.key_ptr.* = try self.frame_arena.dupe(u8, name);
-    }
-    gop.value_ptr.* = state;
 }
 
 pub fn getOrCreateOrigin(self: *Page, key_: ?[]const u8) !*js.Origin {

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -70,6 +70,12 @@ frame_arena: Allocator,
 // lifetime.
 origins: std.StringHashMapUnmanaged(*js.Origin) = .empty,
 
+// Permission state set via CDP Browser.grantPermissions / setPermission /
+// resetPermissions, keyed by permission name (e.g. "geolocation"). Read back
+// by navigator.permissions.query(). Keys and values are duped into
+// frame_arena, so they live for (and reset with) the Page.
+permissions: std.StringHashMapUnmanaged([]const u8) = .empty,
+
 // Identity tracking for the main world. All main-world contexts in this Page
 // share this, ensuring object identity works across same-origin frames.
 identity: js.Identity = .{},
@@ -187,6 +193,10 @@ pub fn deinit(self: *Page) void {
         self.origins = .empty;
     }
 
+    // Keys and values are duped into frame_arena, released just below; drop
+    // the map so we don't keep a dangling reference.
+    self.permissions = .empty;
+
     session.arena_pool.release(self.frame_arena);
 }
 
@@ -196,6 +206,16 @@ pub fn getArena(self: *Page, size_or_bucket: anytype, debug: []const u8) !Alloca
 
 pub fn releaseArena(self: *Page, allocator: Allocator) void {
     return self.session.releaseArena(allocator);
+}
+
+// Set (or overwrite) the stored state for a permission. Name and state are
+// duped into frame_arena. Used by CDP Browser.grantPermissions / setPermission.
+pub fn setPermission(self: *Page, name: []const u8, state: []const u8) !void {
+    const gop = try self.permissions.getOrPut(self.frame_arena, name);
+    if (!gop.found_existing) {
+        gop.key_ptr.* = try self.frame_arena.dupe(u8, name);
+    }
+    gop.value_ptr.* = try self.frame_arena.dupe(u8, state);
 }
 
 pub fn getOrCreateOrigin(self: *Page, key_: ?[]const u8) !*js.Origin {

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -25,6 +25,7 @@ const v8 = js.v8;
 const Frame = @import("Frame.zig");
 const Session = @import("Session.zig");
 const Factory = @import("Factory.zig");
+const PermissionState = @import("webapi/Permissions.zig").State;
 
 const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
@@ -72,9 +73,8 @@ origins: std.StringHashMapUnmanaged(*js.Origin) = .empty,
 
 // Permission state set via CDP Browser.grantPermissions / setPermission /
 // resetPermissions, keyed by permission name (e.g. "geolocation"). Read back
-// by navigator.permissions.query(). Keys and values are duped into
-// frame_arena, so they live for (and reset with) the Page.
-permissions: std.StringHashMapUnmanaged([]const u8) = .empty,
+// by navigator.permissions.query().
+permissions: std.StringHashMapUnmanaged(PermissionState) = .empty,
 
 // Identity tracking for the main world. All main-world contexts in this Page
 // share this, ensuring object identity works across same-origin frames.
@@ -208,14 +208,12 @@ pub fn releaseArena(self: *Page, allocator: Allocator) void {
     return self.session.releaseArena(allocator);
 }
 
-// Set (or overwrite) the stored state for a permission. Name and state are
-// duped into frame_arena. Used by CDP Browser.grantPermissions / setPermission.
-pub fn setPermission(self: *Page, name: []const u8, state: []const u8) !void {
+pub fn setPermission(self: *Page, name: []const u8, state: PermissionState) !void {
     const gop = try self.permissions.getOrPut(self.frame_arena, name);
     if (!gop.found_existing) {
         gop.key_ptr.* = try self.frame_arena.dupe(u8, name);
     }
-    gop.value_ptr.* = try self.frame_arena.dupe(u8, state);
+    gop.value_ptr.* = state;
 }
 
 pub fn getOrCreateOrigin(self: *Page, key_: ?[]const u8) !*js.Origin {

--- a/src/browser/webapi/Permissions.zig
+++ b/src/browser/webapi/Permissions.zig
@@ -37,15 +37,19 @@ _pad: bool = false,
 const QueryDescriptor = struct {
     name: []const u8,
 };
-// We always report 'prompt' (the default safe value — neither granted nor denied).
+
+// Report the state set via CDP Browser.grantPermissions / setPermission, or
+// 'prompt' (the default safe value — neither granted nor denied) when unset.
 pub fn query(_: *const Permissions, qd: QueryDescriptor, exec: *const Execution) !js.Promise {
     const arena = try exec.getArena(.tiny, "PermissionStatus");
     errdefer exec.releaseArena(arena);
 
+    const state = exec.page.permissions.get(qd.name) orelse "prompt";
+
     const status = try arena.create(PermissionStatus);
     status.* = .{
         ._arena = arena,
-        ._state = "prompt",
+        ._state = try arena.dupe(u8, state),
         ._name = try arena.dupe(u8, qd.name),
     };
     return exec.js.local.?.resolvePromise(status);

--- a/src/browser/webapi/Permissions.zig
+++ b/src/browser/webapi/Permissions.zig
@@ -29,6 +29,12 @@ pub fn registerTypes() []const type {
     return &.{ Permissions, PermissionStatus };
 }
 
+pub const State = enum {
+    granted,
+    prompt,
+    denied,
+};
+
 const Permissions = @This();
 
 // Padding to avoid zero-size struct pointer collisions
@@ -44,12 +50,11 @@ pub fn query(_: *const Permissions, qd: QueryDescriptor, exec: *const Execution)
     const arena = try exec.getArena(.tiny, "PermissionStatus");
     errdefer exec.releaseArena(arena);
 
-    const state = exec.page.permissions.get(qd.name) orelse "prompt";
-
+    const state = exec.page.permissions.get(qd.name) orelse .prompt;
     const status = try arena.create(PermissionStatus);
     status.* = .{
         ._arena = arena,
-        ._state = try arena.dupe(u8, state),
+        ._state = state,
         ._name = try arena.dupe(u8, qd.name),
     };
     return exec.js.local.?.resolvePromise(status);
@@ -59,7 +64,7 @@ const PermissionStatus = struct {
     _rc: lp.RC(u8) = .{},
     _arena: Allocator,
     _name: []const u8,
-    _state: []const u8,
+    _state: State,
 
     pub fn deinit(self: *PermissionStatus, page: *Page) void {
         page.releaseArena(self._arena);
@@ -78,7 +83,7 @@ const PermissionStatus = struct {
     }
 
     fn getState(self: *const PermissionStatus) []const u8 {
-        return self._state;
+        return @tagName(self._state);
     }
 
     pub const JsApi = struct {

--- a/src/browser/webapi/Permissions.zig
+++ b/src/browser/webapi/Permissions.zig
@@ -50,7 +50,7 @@ pub fn query(_: *const Permissions, qd: QueryDescriptor, exec: *const Execution)
     const arena = try exec.getArena(.tiny, "PermissionStatus");
     errdefer exec.releaseArena(arena);
 
-    const state = exec.page.permissions.get(qd.name) orelse .prompt;
+    const state = exec.session.browser.permissions.get(qd.name) orelse .prompt;
     const status = try arena.create(PermissionStatus);
     status.* = .{
         ._arena = arena,

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -17,7 +17,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 const CDP = @import("../CDP.zig");
+
+const log = lp.log;
+const PermissionState = @import("../../browser/webapi/Permissions.zig").State;
 
 // TODO: hard coded data
 const PROTOCOL_VERSION = "1.3";
@@ -97,7 +101,8 @@ fn setWindowBounds(cmd: *CDP.Command) !void {
 }
 
 // Grant the listed permissions so navigator.permissions.query() reports them
-// as "granted". State is stored on the active Page and resets on navigation.
+// as "granted". State is stored on the Browser, so it persists across page
+// navigations.
 fn grantPermissions(cmd: *CDP.Command) !void {
     const params = (try cmd.params(struct {
         permissions: []const []const u8,
@@ -105,10 +110,16 @@ fn grantPermissions(cmd: *CDP.Command) !void {
         browserContextId: ?[]const u8 = null,
     })) orelse return error.InvalidParams;
 
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    if (params.origin) |v| {
+        log.warn(.not_implemented, "Browser.grantPermissions", .{ .param = "origin", .value = v });
+    }
+    if (params.browserContextId) |v| {
+        log.warn(.not_implemented, "Browser.grantPermissions", .{ .param = "browserContextId", .value = v });
+    }
+
+    const browser = &cmd.cdp.browser;
     for (params.permissions) |name| {
-        try page.setPermission(name, .granted);
+        try browser.setPermission(name, .granted);
     }
 
     return cmd.sendResult(null, .{ .include_session_id = false });
@@ -124,25 +135,24 @@ fn setPermission(cmd: *CDP.Command) !void {
         browserContextId: ?[]const u8 = null,
     })) orelse return error.InvalidParams;
 
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    if (params.origin) |v| {
+        log.warn(.not_implemented, "Browser.setPermission", .{ .param = "origin", .value = v });
+    }
+    if (params.browserContextId) |v| {
+        log.warn(.not_implemented, "Browser.setPermission", .{ .param = "browserContextId", .value = v });
+    }
 
-    const PermissionState = @import("../../browser/webapi/Permissions.zig").State;
     const state = std.meta.stringToEnum(PermissionState, params.setting) orelse {
         return error.InvalidPermissionSetting;
     };
-    try page.setPermission(params.permission.name, state);
+    try cmd.cdp.browser.setPermission(params.permission.name, state);
     return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
 // Clear all granted permissions; navigator.permissions.query() falls back to
 // the default "prompt".
 fn resetPermissions(cmd: *CDP.Command) !void {
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    if (bc.session.currentPage()) |page| {
-        page.permissions.clearRetainingCapacity();
-    }
-
+    cmd.cdp.browser.clearPermissions();
     return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
@@ -187,17 +197,21 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{ .id = "BID-PERM", .url = "cdp/dom1.html" });
-    const page = bc.session.currentPage() orelse unreachable;
+    const browser = bc.session.browser;
 
-    // grantPermissions: each listed permission becomes "granted".
+    // grantPermissions: each listed permission becomes "granted". State lives
+    // on the Browser, not the Page.
     try ctx.processMessage(.{
         .id = 40,
         .method = "Browser.grantPermissions",
         .params = .{ .permissions = &[_][]const u8{ "geolocation", "notifications" } },
     });
     try ctx.expectSentResult(null, .{ .id = 40, .session_id = null });
-    try testing.expectEqual(.granted, page.permissions.get("geolocation").?);
-    try testing.expectEqual(.granted, page.permissions.get("notifications").?);
+    // State lives on the Browser, not the Page, so it persists for the whole
+    // CDP connection (across page navigations) rather than being lost when the
+    // page is replaced.
+    try testing.expectEqual(.granted, browser.permissions.get("geolocation").?);
+    try testing.expectEqual(.granted, browser.permissions.get("notifications").?);
 
     // setPermission: override a single permission to an explicit state.
     try ctx.processMessage(.{
@@ -206,7 +220,7 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
         .params = .{ .permission = .{ .name = "geolocation" }, .setting = "denied" },
     });
     try ctx.expectSentResult(null, .{ .id = 41, .session_id = null });
-    try testing.expectEqual(.denied, page.permissions.get("geolocation").?);
+    try testing.expectEqual(.denied, browser.permissions.get("geolocation").?);
 
     // resetPermissions: clears everything; query falls back to "prompt".
     try ctx.processMessage(.{
@@ -214,5 +228,5 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
         .method = "Browser.resetPermissions",
     });
     try ctx.expectSentResult(null, .{ .id = 42, .session_id = null });
-    try testing.expectEqual(@as(usize, 0), page.permissions.count());
+    try testing.expectEqual(@as(usize, 0), browser.permissions.count());
 }

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -96,19 +96,50 @@ fn setWindowBounds(cmd: *CDP.Command) !void {
     return cmd.sendResult(null, .{});
 }
 
-// TODO: noop method
+// Grant the listed permissions so navigator.permissions.query() reports them
+// as "granted". State is stored on the active Page and resets on navigation.
 fn grantPermissions(cmd: *CDP.Command) !void {
-    return cmd.sendResult(null, .{});
+    const params = (try cmd.params(struct {
+        permissions: []const []const u8,
+        origin: ?[]const u8 = null,
+        browserContextId: ?[]const u8 = null,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    for (params.permissions) |name| {
+        try page.setPermission(name, "granted");
+    }
+
+    return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
-// TODO: noop method
+// Set a single permission to an explicit state ("granted", "denied" or
+// "prompt"), reflected by navigator.permissions.query().
 fn setPermission(cmd: *CDP.Command) !void {
-    return cmd.sendResult(null, .{});
+    const params = (try cmd.params(struct {
+        permission: struct { name: []const u8 },
+        setting: []const u8,
+        origin: ?[]const u8 = null,
+        browserContextId: ?[]const u8 = null,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const page = bc.session.currentPage() orelse return error.PageNotLoaded;
+    try page.setPermission(params.permission.name, params.setting);
+
+    return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
-// TODO: noop method
+// Clear all granted permissions; navigator.permissions.query() falls back to
+// the default "prompt".
 fn resetPermissions(cmd: *CDP.Command) !void {
-    return cmd.sendResult(null, .{});
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    if (bc.session.currentPage()) |page| {
+        page.permissions.clearRetainingCapacity();
+    }
+
+    return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
 const testing = @import("../testing.zig");
@@ -145,4 +176,39 @@ test "cdp.browser: getWindowForTarget" {
         .windowId = DEV_TOOLS_WINDOW_ID,
         .bounds = .{ .windowState = "normal" },
     }, .{ .id = 33, .index = 0, .session_id = null });
+}
+
+test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-PERM", .url = "cdp/dom1.html" });
+    const page = bc.session.currentPage() orelse unreachable;
+
+    // grantPermissions: each listed permission becomes "granted".
+    try ctx.processMessage(.{
+        .id = 40,
+        .method = "Browser.grantPermissions",
+        .params = .{ .permissions = &[_][]const u8{ "geolocation", "notifications" } },
+    });
+    try ctx.expectSentResult(null, .{ .id = 40, .session_id = null });
+    try testing.expectEqualSlices(u8, "granted", page.permissions.get("geolocation").?);
+    try testing.expectEqualSlices(u8, "granted", page.permissions.get("notifications").?);
+
+    // setPermission: override a single permission to an explicit state.
+    try ctx.processMessage(.{
+        .id = 41,
+        .method = "Browser.setPermission",
+        .params = .{ .permission = .{ .name = "geolocation" }, .setting = "denied" },
+    });
+    try ctx.expectSentResult(null, .{ .id = 41, .session_id = null });
+    try testing.expectEqualSlices(u8, "denied", page.permissions.get("geolocation").?);
+
+    // resetPermissions: clears everything; query falls back to "prompt".
+    try ctx.processMessage(.{
+        .id = 42,
+        .method = "Browser.resetPermissions",
+    });
+    try ctx.expectSentResult(null, .{ .id = 42, .session_id = null });
+    try testing.expectEqual(@as(usize, 0), page.permissions.count());
 }

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -108,7 +108,7 @@ fn grantPermissions(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
     for (params.permissions) |name| {
-        try page.setPermission(name, "granted");
+        try page.setPermission(name, .granted);
     }
 
     return cmd.sendResult(null, .{ .include_session_id = false });
@@ -126,8 +126,12 @@ fn setPermission(cmd: *CDP.Command) !void {
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const page = bc.session.currentPage() orelse return error.PageNotLoaded;
-    try page.setPermission(params.permission.name, params.setting);
 
+    const PermissionState = @import("../../browser/webapi/Permissions.zig").State;
+    const state = std.meta.stringToEnum(PermissionState, params.setting) orelse {
+        return error.InvalidPermissionSetting;
+    };
+    try page.setPermission(params.permission.name, state);
     return cmd.sendResult(null, .{ .include_session_id = false });
 }
 
@@ -192,8 +196,8 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
         .params = .{ .permissions = &[_][]const u8{ "geolocation", "notifications" } },
     });
     try ctx.expectSentResult(null, .{ .id = 40, .session_id = null });
-    try testing.expectEqualSlices(u8, "granted", page.permissions.get("geolocation").?);
-    try testing.expectEqualSlices(u8, "granted", page.permissions.get("notifications").?);
+    try testing.expectEqual(.granted, page.permissions.get("geolocation").?);
+    try testing.expectEqual(.granted, page.permissions.get("notifications").?);
 
     // setPermission: override a single permission to an explicit state.
     try ctx.processMessage(.{
@@ -202,7 +206,7 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
         .params = .{ .permission = .{ .name = "geolocation" }, .setting = "denied" },
     });
     try ctx.expectSentResult(null, .{ .id = 41, .session_id = null });
-    try testing.expectEqualSlices(u8, "denied", page.permissions.get("geolocation").?);
+    try testing.expectEqual(.denied, page.permissions.get("geolocation").?);
 
     // resetPermissions: clears everything; query falls back to "prompt".
     try ctx.processMessage(.{


### PR DESCRIPTION
`Browser.grantPermissions`, `Browser.setPermission` and `Browser.resetPermissions` were noops, so a CDP automation client (Puppeteer's `browserContext.grantPermissions(['geolocation'])`, Playwright's `context.grantPermissions`) could not influence what `navigator.permissions.query()` returns. The query always reported `"prompt"` regardless. This is a gap for automation flows that need to pre-grant or deny permissions (geolocation, notifications, clipboard, etc.) before a page runs.

## Changes

- `src/browser/Page.zig`: store permission state on the Page, keyed by permission name, with a small `setPermission` helper. Keys and values are duped into the Page arena, so the state lives for (and resets with) the Page.
- `src/cdp/domains/browser.zig`: implement the three methods. `grantPermissions` sets each listed permission to `"granted"`; `setPermission` sets a single permission to an explicit `"granted"`/`"denied"`/`"prompt"` state; `resetPermissions` clears the map.
- `src/browser/webapi/Permissions.zig`: `navigator.permissions.query()` now reads the stored state and falls back to `"prompt"` when unset (previously hardcoded `"prompt"`).

## Scope note

Permission state is stored on the active `Page`, so it resets on navigation. CDP scopes these methods to a browser context (state persists across navigations); persisting across navigations would mean storing on the CDP `BrowserContext` and re-applying on each new Page, which I left as a follow-up to keep this change small. The `origin` / `browserContextId` parameters are accepted and ignored for now.

## Verified

- `make test` passes (796/796, no leaks); new test `cdp.browser: grant/set/reset permissions reach navigator.permissions` drives all three methods through `processMessage` and asserts the stored state.
- `zig fmt --check ./*.zig ./**/*.zig` clean.
- `make build` succeeds.