### PR TITLE
cdp: answer Page.navigate with errorText when navigation fails

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -76,6 +76,7 @@ const EventListeners = struct {
     frame_created: List = .{},
     frame_navigate: List = .{},
     frame_navigated: List = .{},
+    frame_navigate_failed: List = .{},
     frame_network_idle: List = .{},
     frame_network_almost_idle: List = .{},
     frame_child_frame_created: List = .{},
@@ -102,6 +103,7 @@ const Events = union(enum) {
     frame_created: *Frame,
     frame_navigate: *const FrameNavigate,
     frame_navigated: *const FrameNavigated,
+    frame_navigate_failed: *const FrameNavigateFailed,
     frame_network_idle: *const FrameNetworkIdle,
     frame_network_almost_idle: *const FrameNetworkAlmostIdle,
     frame_child_frame_created: *const FrameChildFrameCreated,
@@ -146,6 +148,19 @@ pub const FrameNavigated = struct {
     loader_id: u32,
     timestamp: u64,
     url: [:0]const u8,
+    opts: Frame.NavigatedOpts,
+};
+
+// A root navigation that failed before commit (DNS failure, connection
+// refused, malformed response, ...). Dispatched so CDP can answer the
+// pending Page.navigate command with an errorText instead of leaving the
+// command id unanswered forever.
+pub const FrameNavigateFailed = struct {
+    frame_id: u32,
+    loader_id: u32,
+    timestamp: u64,
+    url: [:0]const u8,
+    err: anyerror,
     opts: Frame.NavigatedOpts,
 };
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1325,6 +1325,23 @@ fn frameErrorCallback(ctx: *anyopaque, err: anyerror) void {
 
     log.err(.frame, "navigate failed", .{ .err = err, .type = self._type, .url = self.url });
 
+    // A navigation that fails before any response headers arrive never
+    // reaches the frame_navigated dispatch in frameHeaderCallback, so the
+    // Page.navigate command that initiated it would stay unanswered forever.
+    // Tell CDP so it can answer with an errorText (Chrome semantics).
+    // _http_status is set as soon as headers are processed; non-null means
+    // frameHeaderCallback already answered the command — don't answer twice.
+    if (self._http_status == null) {
+        self._session.notification.dispatch(.frame_navigate_failed, &.{
+            .frame_id = self._frame_id,
+            .loader_id = self._loader_id,
+            .timestamp = timestamp(.monotonic),
+            .url = self.url,
+            .err = err,
+            .opts = self._navigated_options orelse .{},
+        });
+    }
+
     // A pending root navigation that failed before commit: discard the
     // pending Page; the OLD active Page (and its V8 context) is untouched.
     // We do NOT run frameDoneCallback against the pending frame — the frame

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -600,6 +600,7 @@ pub const BrowserContext = struct {
         try notification.register(.frame_created, self, onFrameCreated);
         try notification.register(.frame_navigate, self, onFrameNavigate);
         try notification.register(.frame_navigated, self, onFrameNavigated);
+        try notification.register(.frame_navigate_failed, self, onFrameNavigateFailed);
         try notification.register(.frame_child_frame_created, self, onFrameChildFrameCreated);
         try notification.register(.frame_dom_content_loaded, self, onFrameDOMContentLoaded);
         try notification.register(.frame_loaded, self, onFrameLoaded);
@@ -835,6 +836,11 @@ pub const BrowserContext = struct {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         defer self.resetNotificationArena();
         return @import("domains/page.zig").frameNavigated(self.notification_arena, self, msg);
+    }
+
+    pub fn onFrameNavigateFailed(ctx: *anyopaque, msg: *const Notification.FrameNavigateFailed) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/page.zig").frameNavigateFailed(self, msg);
     }
 
     pub fn onFrameChildFrameCreated(ctx: *anyopaque, msg: *const Notification.FrameChildFrameCreated) !void {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -551,6 +551,26 @@ pub fn frameCreated(bc: *CDP.BrowserContext, frame: *Frame) !void {
     }
 }
 
+// A root navigation failed before commit — the pending Page is being
+// discarded and no frameNavigated will ever fire, but the Page.navigate
+// command that initiated it is still awaiting its response. Answer it with
+// an errorText (Chrome semantics: "present if and only if navigation has
+// failed") so the client isn't left waiting on the command id forever.
+pub fn frameNavigateFailed(bc: *CDP.BrowserContext, event: *const Notification.FrameNavigateFailed) !void {
+    const session_id = bc.session_id orelse return;
+
+    const input_id = event.opts.cdp_id orelse return;
+    try bc.cdp.sendJSON(.{
+        .id = input_id,
+        .result = .{
+            .frameId = &id.toFrameId(event.frame_id),
+            .loaderId = &id.toLoaderId(event.loader_id),
+            .errorText = @errorName(event.err),
+        },
+        .sessionId = session_id,
+    });
+}
+
 pub fn frameChildFrameCreated(bc: *CDP.BrowserContext, event: *const Notification.FrameChildFrameCreated) !void {
     const session_id = bc.session_id orelse return;
 
@@ -1366,6 +1386,37 @@ test "cdp.frame: navigate does not follow Location on a non-redirect 3xx" {
     defer ls.deinit();
     const v = try ls.local.exec("document.title === 'choices' && document.body.innerText.includes('multiple choices body')", null);
     try testing.expect(v.toBool());
+}
+
+test "cdp.frame: navigate answers with errorText when the navigation fails" {
+    // A root navigation that fails before commit (here: connection refused —
+    // nothing listens on port 1) must still answer the Page.navigate command.
+    // Chrome resolves it with an errorText field ("present if and only if
+    // navigation has failed"); leaving the command id unanswered forever
+    // deadlocks clients that await the response.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-NAVF", .url = "hi.html", .target_id = "FID-000000NAVF".* });
+
+    try ctx.processMessage(.{
+        .id = 52,
+        .method = "Page.navigate",
+        .params = .{ .url = "http://127.0.0.1:1/unreachable" },
+    });
+
+    var runner = try bc.session.runner(.{});
+    try runner.wait(.{ .ms = 2000 });
+
+    // The pending page was discarded; the active document is untouched.
+    const frame = bc.session.currentFrame() orelse unreachable;
+    try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html", frame.url);
+
+    try ctx.expectSentResult(.{
+        .frameId = "FID-0000000001",
+        .loaderId = "LID-0000000002",
+        .errorText = "CouldntConnect",
+    }, .{ .id = 52 });
 }
 
 test "cdp.frame: navigate to about:blank replaces a non-blank document" {


### PR DESCRIPTION
## What

A root navigation that fails before any response headers arrive (connection refused, DNS failure, TLS error) never answers the `Page.navigate` command — the command id stays unanswered forever and any CDP client awaiting the response deadlocks until its own timeout. This PR routes the already-detected failure back to the CDP connection and answers the pending command with `{frameId, loaderId, errorText}`, matching Chrome ("errorText — present if and only if navigation has failed", [CDP reference](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate)).

Closes #2728.

## Root cause

The `Page.navigate` reply is only sent from the response-header path: `frameHeaderCallback` dispatches `frame_navigated`, whose CDP handler answers the stored `cdp_id`. When the transfer fails before headers, `frameErrorCallback` runs instead — it logs `navigate failed` and either discards the pending Page (navigation away from a committed page) or renders the internal error page (fresh target), but in both paths the stored `cdp_id` is dropped without ever reaching the CDP layer.

```mermaid
flowchart LR
    A[Page.navigate id:5] --> B[HTTP transfer fails<br/>before headers]
    B --> C[frameErrorCallback:<br/>log + discard pending Page]
    C --> D[cdp_id 5 dropped —<br/>client waits forever]
    style C fill:#fdd
    style D fill:#fdd
```

## Fix

- `src/Notification.zig` — new `frame_navigate_failed` event carrying `frame_id`, `loader_id`, the failure `err`, and the navigation's `NavigatedOpts` (which holds the `cdp_id`).
- `src/browser/Frame.zig` — `frameErrorCallback`: dispatch `frame_navigate_failed` when `_http_status == null` (no response headers were processed, so `frame_navigated` never answered the command — the guard prevents double-answering mid-body failures).
- `src/cdp/CDP.zig` — register the new notification for browser contexts.
- `src/cdp/domains/page.zig` — `frameNavigateFailed`: answer the pending command id with `{frameId, loaderId, errorText: @errorName(err)}`.

```mermaid
flowchart LR
    A[Page.navigate id:5] --> B[HTTP transfer fails<br/>before headers]
    B --> C[frameErrorCallback dispatches<br/>frame_navigate_failed]
    C --> D["reply: {id:5, result: {frameId,<br/>loaderId, errorText}}"]
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- **Unit test**: `src/cdp/domains/page.zig` — `cdp.frame: navigate answers with errorText when the navigation fails` (navigates a committed page to a refused port, asserts the command id is answered with `errorText: "CouldntConnect"` and the active document is untouched). Fails on `main`, passes with this commit. Full suite: 796/796.
- **Reproducer**: the `repro.sh` from #2728 exits 1 on `main` / nightly 6736, exits 0 with this commit — it asserts the `Page.navigate` command id receives a response within 5s. Verified on both root-navigation paths (fresh target and navigation away from a committed page).

## Notes

- `errorText` uses the Zig error name (e.g. `CouldntConnect`) rather than Chrome's `net::ERR_*` strings — the CDP contract is "user friendly error message", and the field's presence (not its exact wording) is what clients key on. Happy to add a mapping if you'd prefer Chrome-compatible strings.
- Subframe (iframe) load failures pass through the same dispatch but carry no `cdp_id`, so the CDP handler ignores them — behavior there is unchanged.
- Failures *after* headers arrived (mid-body) were already answered by `frame_navigated`; the `_http_status == null` guard keeps them single-answer.
