### PR TITLE
cdp: report console.log/console.warn with their own consoleAPICalled types

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -265,9 +265,10 @@ pub const DialogResponse = struct {
 };
 
 pub const ConsoleMessageType = enum {
+    log,
     debug,
     info,
-    warn,
+    warning,
     @"error",
     fatal,
     trace,

--- a/src/browser/webapi/Console.zig
+++ b/src/browser/webapi/Console.zig
@@ -71,12 +71,12 @@ pub fn info(_: *const Console, values: []js.Value, exec: *js.Execution) void {
 
 pub fn log(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.info(.js, "console.log", .{ValueWriter{ .values = values }});
-    dispatchConsoleMessage(values, .info, exec);
+    dispatchConsoleMessage(values, .log, exec);
 }
 
 pub fn warn(_: *const Console, values: []js.Value, exec: *js.Execution) void {
     logger.warn(.js, "console.warn", .{ValueWriter{ .values = values }});
-    dispatchConsoleMessage(values, .info, exec);
+    dispatchConsoleMessage(values, .warning, exec);
 }
 
 pub fn clear(_: *const Console) void {}

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -163,3 +163,28 @@ pub fn consoleMessage(arena: Allocator, bc: *CDP.BrowserContext, event: *const N
         .args = args.items,
     }, .{ .session_id = session_id });
 }
+
+const testing = @import("../testing.zig");
+
+test "cdp.runtime: consoleAPICalled type matches the console method" {
+    // Wire types per the CDP protocol: console.log -> "log",
+    // console.warn -> "warning" (not "warn"), console.info -> "info",
+    // console.error -> "error", console.debug -> "debug".
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-CONS", .url = "hi.html", .target_id = "FID-0000000CON".* });
+    try ctx.processMessage(.{ .id = 60, .method = "Runtime.enable" });
+
+    const frame = bc.session.currentFrame() orelse unreachable;
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    _ = try ls.local.exec("console.log('l'); console.warn('w'); console.info('i'); console.error('e'); console.debug('d');", null);
+
+    try ctx.expectSentEvent("Runtime.consoleAPICalled", .{ .type = "log" }, .{});
+    try ctx.expectSentEvent("Runtime.consoleAPICalled", .{ .type = "warning" }, .{});
+    try ctx.expectSentEvent("Runtime.consoleAPICalled", .{ .type = "info" }, .{});
+    try ctx.expectSentEvent("Runtime.consoleAPICalled", .{ .type = "error" }, .{});
+    try ctx.expectSentEvent("Runtime.consoleAPICalled", .{ .type = "debug" }, .{});
+}


### PR DESCRIPTION
## What

`console.log` and `console.warn` were both reported as `type: "info"` in `Runtime.consoleAPICalled` (and as `level: "info"` in `Console.messageAdded`). Per the [CDP protocol](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-consoleAPICalled), Chrome emits `"log"` and `"warning"` respectively — clients filtering console output by severity saw logs, infos and warnings collapsed into one bucket. This PR gives each method its own wire type.

Closes #2730.

## Root cause

`src/browser/webapi/Console.zig` dispatched both `log()` and `warn()` with `.info`. The shared `ConsoleMessageType` enum (`src/Notification.zig`) had a `warn` member that nothing used — and which wouldn't have been a valid wire value anyway (the protocol's value is `"warning"`, not `"warn"`) — and no `log` member at all. Both CDP surfaces serialize the enum tag directly via `@tagName`.

```mermaid
flowchart LR
    A[console.log / console.warn] --> B[dispatchConsoleMessage .info]
    B --> C["consoleAPICalled {type: 'info'}<br/>for log, info AND warn"]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/Notification.zig` — `ConsoleMessageType`: add `log`, rename the unused `warn` to `warning` (the protocol's wire value, shared by `Runtime.consoleAPICalled` `type` and `Console.messageAdded` `level`).
- `src/browser/webapi/Console.zig` — `log()` dispatches `.log`, `warn()` dispatches `.warning`. `info`/`error`/`debug`/`trace` were already correct and are unchanged.

```mermaid
flowchart LR
    A[console.log] --> B[dispatch .log] --> C["consoleAPICalled {type: 'log'}"]
    D[console.warn] --> E[dispatch .warning] --> F["consoleAPICalled {type: 'warning'}"]
    style B fill:#dfd
    style C fill:#dfd
    style E fill:#dfd
    style F fill:#dfd
```

## Test

- **Unit test**: `src/cdp/domains/runtime.zig` — `cdp.runtime: consoleAPICalled type matches the console method` (evaluates the five console methods in page JS, asserts the five wire types `log`/`warning`/`info`/`error`/`debug` are each emitted). Fails on `main`, passes with this commit. Full suite: 796/796.
- **Reproducer**: the `repro.sh` from #2730 prints `observed: ["info","info","info","error","debug"]` and exits 1 on `main` / nightly 6736; prints `observed: ["log","warning","info","error","debug"]` and exits 0 with this commit.

## Notes

- `console.trace` keeps emitting `"trace"` — that already matches Chrome's `consoleAPICalled` value. The deprecated `Console.messageAdded` `level` technically has no `trace` value (Chrome maps trace to `log` there), but changing it would desync the two surfaces for little gain; happy to follow up if you'd like that aligned too.
