### PR TITLE
debug: Use normal crash report assertion in debug

### DIFF
--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -273,9 +273,6 @@ fn dumpWPT(frame: *Frame, writer: *std.Io.Writer) !void {
 
 pub inline fn assert(ok: bool, comptime ctx: []const u8, args: anytype) void {
     if (!ok) {
-        if (comptime IS_DEBUG) {
-            unreachable;
-        }
         assertionFailure(ctx, args);
     }
 }


### PR DESCRIPTION
I don't know why I thought debug should `unreahcable` while release should generate a crash report. The crash report always contains more info and whenever I encounter a failed assertion in debug, the first thing I do is remove the unreachable to get the more complete crash report.

(The crash report path skips sending the crash report in debug builds already)