### PR TITLE
script: make goto async and support top-level await

### DIFF
--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -1,11 +1,12 @@
 # Agent JavaScript scripts
 
 `lightpanda agent <script.js>` runs a JavaScript file that drives a
-Lightpanda browser session. Navigation goes through a global `goto(url)` that
-returns a **page object**; every other browser action is a method on that page
-(`page.extract(...)`, `page.click(...)`, …). The format is intentionally plain
-JavaScript: use normal variables, functions, loops, objects, arrays,
-`JSON.parse`, `JSON.stringify`, and other standard ECMAScript built-ins.
+Lightpanda browser session. Pages are created with the global `Page` class —
+`new Page()` makes a page and `await page.goto(url)` navigates it; every other
+browser action is a method on that page (`page.extract(...)`, `page.click(...)`,
+…). The format is intentionally plain JavaScript: use normal variables,
+functions, loops, objects, arrays, `JSON.parse`, `JSON.stringify`, and other
+standard ECMAScript built-ins.
 
 ```console
 ./lightpanda agent session.js
@@ -33,10 +34,10 @@ web page's JavaScript context.
 - Agent variables persist for the lifetime of one script run, across
   navigations and primitive calls. A later `lightpanda agent script.js` run
   starts with a fresh agent context.
-- `goto(url)` is asynchronous — always use `await goto(...)`. Every page method
-  is synchronous; do not `await` them (`const data = page.extract({ ... })`, not
-  `await page.extract(...)`). The script body runs as an async function, so
-  top-level `await` is allowed.
+- `page.goto(url)` is asynchronous — always use `await page.goto(...)`. Every
+  other page method is synchronous; do not `await` them (`const data =
+  page.extract({ ... })`, not `await page.extract(...)`). The script body runs
+  as an async function, so top-level `await` is allowed.
 - Tool failures throw JavaScript `Error` exceptions (a `goto` failure rejects
   its Promise, so `await` throws) and stop execution unless you catch them.
 - The script's output is whatever it `return`s, printed automatically (objects
@@ -64,7 +65,8 @@ your schema — an object schema returns an object keyed by your fields (even wi
 a single field), and a bare array schema returns an array:
 
 ```js
-const page = await goto("https://news.ycombinator.com/");
+const page = new Page();
+await page.goto("https://news.ycombinator.com/");
 
 const data = page.extract({
   title: "title",
@@ -109,12 +111,15 @@ cyclic objects do not.
 
 ## Installed Primitives
 
-`goto` is the only global; it opens a page and resolves a page object. Every
-other browser primitive is a method on that page object:
+`Page` is the only global. `new Page()` makes a page object; every browser
+primitive is a method on it. `page.goto` navigates; `page.close` frees the
+page; everything else reads or acts on the loaded document:
 
 | Primitive | Arguments | Runs in |
 |-----------|-----------|---------|
-| `goto` | `await goto(url[, { timeout }])` (async; resolves a page object) | Browser session |
+| `Page` | `new Page()` (no navigation yet) | Agent context |
+| `page.goto` | `await page.goto(url[, { timeout }])` (async) | Browser session |
+| `page.close` | `page.close()` | Browser session |
 | `page.extract` | `page.extract(schema)` or `page.extract({ schema })` | Browser page via extractor; returns a JS object or array |
 | `page.evaluate` | `page.evaluate(script[, { url, timeout, save }])` | Browser page JS context |
 | `page.click` | `page.click(selector)` or `page.click({ selector })` | Browser page |
@@ -128,12 +133,12 @@ other browser primitive is a method on that page object:
 | `page.selectOption` | `page.selectOption(selector, value)` or `page.selectOption({ selector, value })` | Browser page |
 | `page.setChecked` | `page.setChecked(selector[, checked])` or `page.setChecked({ selector, checked })` | Browser page |
 
-`goto` returns at the `load` event (a fast snapshot). When a page's content is
-still loading (rendered by post-load JS), call `page.waitForState("networkidle")`
-before reading. `waitForState`'s `state` accepts `"load"`,
-`"domcontentloaded"`, `"networkalmostidle"`, `"networkidle"`, or `"done"`.
-`goto`'s `timeout` defaults to 10000 ms; the `waitFor*` timeouts default to
-5000 ms.
+`page.goto` returns at the `load` event (a fast snapshot). When a page's content
+is still loading (rendered by post-load JS), call
+`page.waitForState("networkidle")` before reading. `waitForState`'s `state`
+accepts `"load"`, `"domcontentloaded"`, `"networkalmostidle"`, `"networkidle"`,
+or `"done"`. `goto`'s `timeout` defaults to 10000 ms; the `waitFor*` timeouts
+default to 5000 ms.
 
 The `[, { … }]` is an optional trailing options object: leading arguments are
 positional (`page.waitForSelector("#row", { timeout: 2000 })`), and the options
@@ -143,7 +148,7 @@ that's the shape `/save` records into saved scripts. An option can't be a bare
 positional, though: `page.waitForSelector("#row", 2000)` is an error. A `null`
 positional omits that field (`page.press(null, "Enter")` presses on the focused
 element), and setting the same field positionally and in the options object
-(`goto(url, { url: ... })`) is an `invalid arguments` error.
+(`page.goto(url, { url: ... })`) is an `invalid arguments` error.
 
 Page methods address elements by CSS selector only. The tools that hand out
 `backendNodeId`s (`tree`, `findElement`, `nodeDetails`) aren't installed in the
@@ -154,55 +159,69 @@ get a durable CSS `selector`, then paste that into your script.
 
 ## Navigation
 
-Use `await goto(...)` to open a page (it is asynchronous). It returns a page
-object you call every other primitive on:
+Create a page with `new Page()`, then `await page.goto(...)` to navigate it (it
+is asynchronous). A fresh `new Page()` has no document yet — call `page.goto`
+before any other method, or you get `page is not navigated or has been closed`.
 
 ```js
-const page = await goto("https://example.com");
+const page = new Page();
+await page.goto("https://example.com");
 
-const page2 = await goto({
+await page.goto({
   url: "https://example.com/app",
   timeout: 15000
 });
 ```
 
-The Promise resolves to a **page object** and rejects if navigation fails. A
-timeout does **not** reject: the page stays in whatever state it reached, so
-follow with `page.waitForState(...)` / `page.waitForSelector(...)` when
-completeness matters.
+The Promise resolves to the page object (the same one) and rejects if navigation
+fails. A timeout does **not** reject: the page stays in whatever state it
+reached, so follow with `page.waitForState(...)` / `page.waitForSelector(...)`
+when completeness matters.
 
-A page object is bound to one loaded document. Navigating again — calling `goto`
-a second time — opens a fresh page and replaces the old one; re-navigate by
-calling `goto` again and rebinding your variable:
+**Re-navigating reuses the same page object.** Calling `page.goto` again moves
+the page to a new document; the object stays valid, so there's no rebind to
+track:
 
 ```js
-let page = await goto("https://example.com");
+const page = new Page();
+await page.goto("https://example.com");
 page.click("#next");
-page = await goto("https://example.com/step2"); // replaces; rebind `page`
+await page.goto("https://example.com/step2"); // same `page`, now on step2
 const data = page.extract({ title: "h1" });
 ```
 
-After a replacing `goto`, the previous page object is **stale**: calling a method
-on it throws `page handle is no longer valid`. Always read through the page
-object from the most recent `goto`.
-
-For **parallel** fetches, start several `goto`s at once with `Promise.all`. Those
-pages coexist (they open as popup frames) and each is read through its own page
-object:
+For **parallel** fetches, make several pages and navigate them together with
+`Promise.all`. Those pages coexist (they open as popup frames) and each is read
+through its own page object:
 
 ```js
-const [a, b] = await Promise.all([
-  goto("https://example.com/a"),
-  goto("https://example.com/b"),
+const a = new Page();
+const b = new Page();
+await Promise.all([
+  a.goto("https://example.com/a"),
+  b.goto("https://example.com/b"),
 ]);
 const da = a.extract({ title: "h1" }); // reads page a
 const db = b.extract({ title: "h1" }); // reads page b
 a.click("#more");                       // any method works on either
 ```
 
-Pages from a parallel batch stay alive until the next *sequential* `goto` (one
-with nothing else in flight), which replaces them. So read a batch's pages
-before your next standalone `goto` — don't stash one across it.
+A single page that re-navigates always stays valid. But a *new* page navigated
+sequentially (nothing else in flight) replaces the root page, so any earlier
+page goes **stale** — calling a method on it throws `page handle is no longer
+valid`:
+
+```js
+const a = new Page();
+await a.goto("https://example.com/a");
+const b = new Page();
+await b.goto("https://example.com/b"); // replaces the root; `a` is now stale
+a.extract({ title: "h1" });            // throws: page handle is no longer valid
+```
+
+Read a parallel batch's pages before your next standalone navigation, and call
+`page.close()` to free a page (a popup) you're done with mid-script. The root
+page is reclaimed at script end.
 
 ## Structured Extraction
 
@@ -255,9 +274,9 @@ wrong", not "the page is empty".
 
 `page.extract(...)` reads only that page. For list-to-detail scraping — capture
 a list, then visit each row for more — capture the list, then loop in the
-script: `goto` each row's URL and `extract` the detail. The local agent context
-keeps the data across navigations, so the assembly happens in plain JavaScript.
-See the [complete example](#complete-example) below.
+script: `await page.goto(...)` each row's URL and `extract` the detail. The
+local agent context keeps the data across navigations, so the assembly happens
+in plain JavaScript. See the [complete example](#complete-example) below.
 
 When passing an object directly to `page.extract(...)`, the runtime serializes
 it as the extractor schema. These forms are equivalent:
@@ -278,7 +297,8 @@ results in local variables instead.
 context. Its script string runs where `window` and `document` exist.
 
 ```js
-const page = await goto("https://example.com");
+const page = new Page();
+await page.goto("https://example.com");
 
 const title = page.evaluate("document.title");
 console.log(title);
@@ -314,7 +334,8 @@ The action methods operate on the page they're called on. Most take one object
 whose fields match the browser tool schema:
 
 ```js
-const page = await goto("https://example.com/login");
+const page = new Page();
+await page.goto("https://example.com/login");
 
 page.click({ selector: "a.login" });
 page.fill({ selector: "input[name='acct']", value: "$LP_HN_USERNAME" });
@@ -354,23 +375,25 @@ The REPL remains slash-command based:
 > /save
 ```
 
-`/save` writes JavaScript by default — binding `page` on each `goto` and calling
-every other tool as a method on it:
+`/save` writes JavaScript by default — making the page once up front, then
+calling every recorded tool as a method on it (`goto` awaited, the rest
+synchronous):
 
 ```js
-let page = await goto("https://example.com");
+const page = new Page();
+await page.goto("https://example.com");
 page.click({ selector: "a.login" });
 ```
 
-A later `/goto` in the same session reassigns the variable (`page = await
-goto(...)`), matching the REPL's replace-in-place navigation.
+A later `/goto` in the same session records as another `await page.goto(...)` on
+the same page, matching the REPL's replace-in-place navigation.
 
 Only replayable browser actions are recorded:
 
 - Recorded: `goto`, `click`, `fill`, `scroll`, `hover`, `press`,
   `selectOption`, `setChecked`, `waitForSelector`, `waitForScript`,
-  `waitForState`, `evaluate`, and `extract` — the same set installed as script
-  primitives.
+  `waitForState`, `evaluate`, and `extract` — the same set installed as page
+  methods.
 - Not recorded: read-only exploration tools such as `tree`, `markdown`, `html`,
   `links`, `findElement`, `consoleLogs`, `getUrl`, `getCookies`, and `getEnv`.
 - Natural-language prompts are written as `//` comments above the actions they
@@ -399,8 +422,9 @@ Common failures:
 |-------|---------|
 | `ReferenceError: document is not defined` | You tried to use browser DOM APIs in the agent context. Use `page.extract(...)` or `page.evaluate(...)`. |
 | `ReferenceError: require is not defined` | Agent scripts are not Node.js scripts. |
-| `this must be called as a method on a page returned by goto()` | A page primitive was called as a bare function. Call it on the page object: `page.click(...)`. |
-| `page handle is no longer valid` | The page object was used after a later `goto` replaced its page. Read through the most recent `goto`'s page object. |
+| `Page must be called with new` | `Page(...)` was called without `new`. Use `const page = new Page();`. |
+| `page is not navigated or has been closed` | A method ran on a fresh `new Page()` (or one already closed). Call `await page.goto(url)` first. |
+| `page handle is no longer valid` | The page was used after a later sequential navigation replaced the root page. Read through the current page. |
 | `no page loaded - run goto(url) first` | A page-dependent primitive ran before navigation. |
 | `invalid arguments` | A primitive received the wrong number or shape of arguments, or a non-JSON-serializable value. |
 | `extract: no schema selector matched any element` | Every field in the schema missed. Fix the selectors; an empty page section yields `null`/`[]` per field, not this error. |
@@ -414,7 +438,8 @@ the local agent script, not in the page.
 ```js
 const HN = "https://news.ycombinator.com";
 
-let page = await goto(HN);
+const page = new Page();
+await page.goto(HN);
 
 const { stories } = page.extract({
   stories: [{
@@ -432,7 +457,7 @@ for (const story of stories) {
   story.comments = [];
   if (!story.id) continue;
 
-  page = await goto(`${HN}/item?id=${story.id}`);
+  await page.goto(`${HN}/item?id=${story.id}`);
   const { comments } = page.extract({
     comments: [{
       selector: "tr.athing.comtr:has(.commtext)",

--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -32,12 +32,11 @@ web page's JavaScript context.
 - Agent variables persist for the lifetime of one script run, across
   navigations and primitive calls. A later `lightpanda agent script.js` run
   starts with a fresh agent context.
-- `goto(url)` is asynchronous and resolves to a **page handle** — always
-  `await goto(...)`. Every other primitive is synchronous; do not `await` them
-  (`const data = extract({ ... })`, not `await extract(...)`). The script body
-  runs as an async function, so top-level `await` is allowed. The read tools act
-  on the latest `goto` by default; pass a handle as their optional last argument
-  to target a specific page (needed only for parallel `Promise.all` fetches).
+- `goto(url)` is asynchronous — always use `await goto(...)`. Every other primitive
+  is synchronous; do not `await` them (`const data = extract({ ... })`, not
+  `await extract(...)`). The script body runs as an async function, so top-level
+  `await` is allowed. (`goto` returns a page handle for parallel fetches — see
+  Navigation below.)
 - Tool failures throw JavaScript `Error` exceptions (a `goto` failure rejects
   its Promise, so `await` throws) and stop execution unless you catch them.
 - The script's output is whatever it `return`s, printed automatically (objects

--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -273,10 +273,12 @@ without complaint (a page with zero comments is a valid result), but if
 wrong", not "the page is empty".
 
 `page.extract(...)` reads only that page. For list-to-detail scraping — capture
-a list, then visit each row for more — capture the list, then loop in the
-script: `await page.goto(...)` each row's URL and `extract` the detail. The
-local agent context keeps the data across navigations, so the assembly happens
-in plain JavaScript. See the [complete example](#complete-example) below.
+a list, then visit each row for more — extract the list, then fetch the detail
+pages in parallel: one `new Page()` per row gathered with `Promise.all`. Reuse a
+single page and a sequential `await page.goto(...)` loop instead when the steps
+depend on each other or share login state. Either way the local agent context
+keeps the data, so the assembly happens in plain JavaScript. See the
+[complete example](#complete-example) below.
 
 When passing an object directly to `page.extract(...)`, the runtime serializes
 it as the extractor schema. These forms are equivalent:
@@ -431,17 +433,17 @@ Common failures:
 
 ## Complete Example
 
-This script opens Hacker News, extracts five stories, visits each comments
-page, and prints one JSON object. The looping and object assembly happen in
-the local agent script, not in the page.
+This script opens Hacker News, extracts five stories, fetches each comments
+page **in parallel**, and prints one JSON object. The fan-out and object
+assembly happen in the local agent script, not in the page.
 
 ```js
 const HN = "https://news.ycombinator.com";
 
-const page = new Page();
-await page.goto(HN);
+const index = new Page();
+await index.goto(HN);
 
-const { stories } = page.extract({
+const { stories } = index.extract({
   stories: [{
     selector: "tr.athing",
     limit: 5,
@@ -453,10 +455,11 @@ const { stories } = page.extract({
   }]
 });
 
-for (const story of stories) {
-  story.comments = [];
-  if (!story.id) continue;
+// Each story's comments page loads concurrently.
+const results = await Promise.all(stories.map(async (story) => {
+  if (!story.id) return { ...story, comments: [] };
 
+  const page = new Page();
   await page.goto(`${HN}/item?id=${story.id}`);
   const { comments } = page.extract({
     comments: [{
@@ -468,8 +471,12 @@ for (const story of stories) {
       }
     }]
   });
-  story.comments = comments;
-}
+  page.close();
+  return { ...story, comments };
+}));
 
-return stories; // printed automatically as JSON
+return results; // printed automatically as JSON
 ```
+
+When the detail pages depend on each other or share login state, use a single
+reused `page` with a sequential `await page.goto(...)` loop instead.

--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -1,10 +1,11 @@
 # Agent JavaScript scripts
 
 `lightpanda agent <script.js>` runs a JavaScript file that drives a
-Lightpanda browser session through a small set of blocking global functions.
-The format is intentionally plain JavaScript: use normal variables, functions,
-loops, objects, arrays, `JSON.parse`, `JSON.stringify`, and other standard
-ECMAScript built-ins.
+Lightpanda browser session. Navigation goes through a global `goto(url)` that
+returns a **page object**; every other browser action is a method on that page
+(`page.extract(...)`, `page.click(...)`, …). The format is intentionally plain
+JavaScript: use normal variables, functions, loops, objects, arrays,
+`JSON.parse`, `JSON.stringify`, and other standard ECMAScript built-ins.
 
 ```console
 ./lightpanda agent session.js
@@ -21,27 +22,26 @@ web page's JavaScript context.
 
 - It is not the browser page environment. There is no `window`, `document`,
   DOM, `localStorage`, `navigator`, or page global state in the agent script.
-  Read page data with `extract(...)`, or explicitly run page JavaScript with
-  `evaluate(...)` when that is the right tool.
+  Read page data with `page.extract(...)`, or explicitly run page JavaScript
+  with `page.evaluate(...)` when that is the right tool.
 - It is not Node.js. There is no `require`, `process`, `fs`, `path`, npm
   package loading, command-line argument API, or Node network/filesystem API.
 - Page scripts cannot see agent variables or Lightpanda primitives. Agent
   scripts cannot directly see page variables.
-- The global `evaluate(...)` primitive runs JavaScript in the page context,
-  distinct from the agent context's own native `eval`.
+- `page.evaluate(...)` runs JavaScript in the page context, distinct from the
+  agent context's own native `eval`.
 - Agent variables persist for the lifetime of one script run, across
   navigations and primitive calls. A later `lightpanda agent script.js` run
   starts with a fresh agent context.
-- `goto(url)` is asynchronous — always use `await goto(...)`. Every other primitive
-  is synchronous; do not `await` them (`const data = extract({ ... })`, not
-  `await extract(...)`). The script body runs as an async function, so top-level
-  `await` is allowed. (`goto` returns a page handle for parallel fetches — see
-  Navigation below.)
+- `goto(url)` is asynchronous — always use `await goto(...)`. Every page method
+  is synchronous; do not `await` them (`const data = page.extract({ ... })`, not
+  `await page.extract(...)`). The script body runs as an async function, so
+  top-level `await` is allowed.
 - Tool failures throw JavaScript `Error` exceptions (a `goto` failure rejects
   its Promise, so `await` throws) and stop execution unless you catch them.
 - The script's output is whatever it `return`s, printed automatically (objects
   and arrays as JSON; other values coerced). End a script with `return
-  extract({ ... });` or `return results;`. A bare trailing expression is not
+  page.extract({ ... });` or `return results;`. A bare trailing expression is not
   printed. `console.log(...)` is for extra or debug output and does not
   JSON-format objects.
 
@@ -57,16 +57,16 @@ console.error("printed to stderr");
 
 ## Values And Return Types
 
-Most primitives return the browser tool's result text as a JavaScript string.
-`extract(...)` is the exception: it returns extracted data as a normal
+Most page methods return the browser tool's result text as a JavaScript string.
+`page.extract(...)` is the exception: it returns extracted data as a normal
 JavaScript value, so local script logic can use it directly. The result mirrors
 your schema — an object schema returns an object keyed by your fields (even with
 a single field), and a bare array schema returns an array:
 
 ```js
-await goto("https://news.ycombinator.com/");
+const page = await goto("https://news.ycombinator.com/");
 
-const data = extract({
+const data = page.extract({
   title: "title",
   stories: [{
     selector: "tr.athing",
@@ -84,7 +84,7 @@ return data; // printed automatically as JSON
 Destructure when a single field is all you need:
 
 ```js
-const { stories } = extract({
+const { stories } = page.extract({
   stories: [{
     selector: "tr.athing",
     limit: 5,
@@ -100,8 +100,8 @@ for (const story of stories) {
 }
 ```
 
-`evaluate(...)` still returns the page evaluate tool result text. When page `evaluate(...)`
-returns an object or array, that text is JSON.
+`page.evaluate(...)` returns the page evaluate tool result text. When page
+`evaluate(...)` returns an object or array, that text is JSON.
 
 Primitive arguments must be JSON-serializable. Strings, numbers, booleans,
 arrays, plain objects, and `null` work. `undefined`, functions, symbols, and
@@ -109,101 +109,109 @@ cyclic objects do not.
 
 ## Installed Primitives
 
-Only recorded browser primitives are installed globally:
+`goto` is the only global; it opens a page and resolves a page object. Every
+other browser primitive is a method on that page object:
 
 | Primitive | Arguments | Runs in |
 |-----------|-----------|---------|
-| `goto` | `await goto(url[, { timeout }])` (async; resolves a page handle) | Browser session |
-| `extract` | `extract(schema[, page])` or `extract({ schema })` | Browser page via extractor; returns a JS object or array |
-| `evaluate` | `evaluate(script[, { url, timeout, save }])` | Browser page JS context |
-| `click` | `click(selector)` or `click({ selector })` | Browser page |
-| `fill` | `fill(selector, value)` or `fill({ selector, value })` | Browser page |
-| `scroll` | `scroll()` or `scroll({ x, y })` | Browser page |
-| `waitForSelector` | `waitForSelector(selector[, { timeout }])` | Browser page |
-| `waitForScript` | `waitForScript(script[, { timeout }])` | Browser page JS context |
-| `waitForState` | `waitForState(state[, { timeout }])` | Browser page |
-| `hover` | `hover(selector)` or `hover({ selector })` | Browser page |
-| `press` | `press(selector, key)` or `press({ key[, selector] })` | Browser page |
-| `selectOption` | `selectOption(selector, value)` or `selectOption({ selector, value })` | Browser page |
-| `setChecked` | `setChecked(selector[, checked])` or `setChecked({ selector, checked })` | Browser page |
+| `goto` | `await goto(url[, { timeout }])` (async; resolves a page object) | Browser session |
+| `page.extract` | `page.extract(schema)` or `page.extract({ schema })` | Browser page via extractor; returns a JS object or array |
+| `page.evaluate` | `page.evaluate(script[, { url, timeout, save }])` | Browser page JS context |
+| `page.click` | `page.click(selector)` or `page.click({ selector })` | Browser page |
+| `page.fill` | `page.fill(selector, value)` or `page.fill({ selector, value })` | Browser page |
+| `page.scroll` | `page.scroll()` or `page.scroll({ x, y })` | Browser page |
+| `page.waitForSelector` | `page.waitForSelector(selector[, { timeout }])` | Browser page |
+| `page.waitForScript` | `page.waitForScript(script[, { timeout }])` | Browser page JS context |
+| `page.waitForState` | `page.waitForState(state[, { timeout }])` | Browser page |
+| `page.hover` | `page.hover(selector)` or `page.hover({ selector })` | Browser page |
+| `page.press` | `page.press(selector, key)` or `page.press({ key[, selector] })` | Browser page |
+| `page.selectOption` | `page.selectOption(selector, value)` or `page.selectOption({ selector, value })` | Browser page |
+| `page.setChecked` | `page.setChecked(selector[, checked])` or `page.setChecked({ selector, checked })` | Browser page |
 
 `goto` returns at the `load` event (a fast snapshot). When a page's content is
-still loading (rendered by post-load JS), call `waitForState("networkidle")`
+still loading (rendered by post-load JS), call `page.waitForState("networkidle")`
 before reading. `waitForState`'s `state` accepts `"load"`,
 `"domcontentloaded"`, `"networkalmostidle"`, `"networkidle"`, or `"done"`.
 `goto`'s `timeout` defaults to 10000 ms; the `waitFor*` timeouts default to
 5000 ms.
 
 The `[, { … }]` is an optional trailing options object: leading arguments are
-positional (`waitForSelector("#row", { timeout: 2000 })`), and the options ride
-in a final object. Passing a single object with everything
-(`waitForSelector({ selector: "#row", timeout: 2000 })`) is equivalent — that's
-the shape `/save` records into saved scripts. An option can't be a bare
-positional, though: `waitForSelector("#row", 2000)` is an error. A `null`
-positional omits that field (`press(null, "Enter")` presses on the focused
+positional (`page.waitForSelector("#row", { timeout: 2000 })`), and the options
+ride in a final object. Passing a single object with everything
+(`page.waitForSelector({ selector: "#row", timeout: 2000 })`) is equivalent —
+that's the shape `/save` records into saved scripts. An option can't be a bare
+positional, though: `page.waitForSelector("#row", 2000)` is an error. A `null`
+positional omits that field (`page.press(null, "Enter")` presses on the focused
 element), and setting the same field positionally and in the options object
 (`goto(url, { url: ... })`) is an `invalid arguments` error.
 
-Script primitives address elements by CSS selector only. The tools that hand
-out `backendNodeId`s (`tree`, `findElement`, `nodeDetails`) aren't installed in
-the script context, and a raw node ID wouldn't survive replay anyway. When
-you're exploring in the REPL and have a `backendNodeId` — e.g. the leading
-number on a `/tree` line, or a `/findElement` hit — run `/nodeDetails
-backendNodeId=<id>` to get a durable CSS `selector`, then paste that into your
-script.
+Page methods address elements by CSS selector only. The tools that hand out
+`backendNodeId`s (`tree`, `findElement`, `nodeDetails`) aren't installed in the
+script context, and a raw node ID wouldn't survive replay anyway. When you're
+exploring in the REPL and have a `backendNodeId` — e.g. the leading number on a
+`/tree` line, or a `/findElement` hit — run `/nodeDetails backendNodeId=<id>` to
+get a durable CSS `selector`, then paste that into your script.
 
 ## Navigation
 
-Use `await goto(...)` to open a page (it is asynchronous):
+Use `await goto(...)` to open a page (it is asynchronous). It returns a page
+object you call every other primitive on:
 
 ```js
-await goto("https://example.com");
+const page = await goto("https://example.com");
 
-await goto({
+const page2 = await goto({
   url: "https://example.com/app",
   timeout: 15000
 });
 ```
 
-The Promise resolves to a **page handle** and rejects if navigation fails. A
+The Promise resolves to a **page object** and rejects if navigation fails. A
 timeout does **not** reject: the page stays in whatever state it reached, so
-follow with `waitForState(...)` / `waitForSelector(...)` when completeness
-matters.
+follow with `page.waitForState(...)` / `page.waitForSelector(...)` when
+completeness matters.
 
-You only need the handle for **parallel** fetches: a single page at a time is
-implicit (the read tools act on the latest `goto`), but to load several at once
-and read each one, pass its handle as the optional last argument:
+A page object is bound to one loaded document. Navigating again — calling `goto`
+a second time — opens a fresh page and replaces the old one; re-navigate by
+calling `goto` again and rebinding your variable:
+
+```js
+let page = await goto("https://example.com");
+page.click("#next");
+page = await goto("https://example.com/step2"); // replaces; rebind `page`
+const data = page.extract({ title: "h1" });
+```
+
+After a replacing `goto`, the previous page object is **stale**: calling a method
+on it throws `page handle is no longer valid`. Always read through the page
+object from the most recent `goto`.
+
+For **parallel** fetches, start several `goto`s at once with `Promise.all`. Those
+pages coexist (they open as popup frames) and each is read through its own page
+object:
 
 ```js
 const [a, b] = await Promise.all([
   goto("https://example.com/a"),
   goto("https://example.com/b"),
 ]);
-const da = extract({ title: "h1" }, a);   // reads page a
-const db = extract({ title: "h1" }, b);   // reads page b
+const da = a.extract({ title: "h1" }); // reads page a
+const db = b.extract({ title: "h1" }); // reads page b
+a.click("#more");                       // any method works on either
 ```
 
-The handle works on any page tool — `click(sel, a)`, `evaluate(js, a)`, etc.
-
-Two limits to know:
-
-- **Handle lifetime.** Pages from a parallel batch stay alive until the next
-  *sequential* `goto` (one with nothing else in flight), which replaces them.
-  So read a batch's handles before your next standalone `goto` — don't stash a
-  handle across one.
-- **Combined navigate-and-read stays single-page.** The `url` option on
-  `markdown`/`html`/`tree`/`evaluate` (e.g. `markdown({ url })`) navigates the
-  one current page, so it does not take part in parallel fetching. Use
-  `await goto(url)` + a handle when you need concurrency.
+Pages from a parallel batch stay alive until the next *sequential* `goto` (one
+with nothing else in flight), which replaces them. So read a batch's pages
+before your next standalone `goto` — don't stash one across it.
 
 ## Structured Extraction
 
-Use `extract(...)` to read data from the current page without writing page-side
+Use `page.extract(...)` to read data from the page without writing page-side
 JavaScript. This is the preferred bridge from page content into local agent
 logic.
 
 ```js
-const result = extract({
+const result = page.extract({
   heading: "h1",
   links: [{
     selector: "a",
@@ -230,55 +238,49 @@ The schema forms are:
 
 Return shape follows the top-level schema:
 
-- `extract({ title: "h1" })` returns `{ title: "..." }`.
-- `extract({ title: "h1", links: [{ selector: "a" }] })` returns an object
+- `page.extract({ title: "h1" })` returns `{ title: "..." }`.
+- `page.extract({ title: "h1", links: [{ selector: "a" }] })` returns an object
   with both fields.
-- `extract({ links: [{ selector: "a" }] })` returns `{ links: [...] }` — an
+- `page.extract({ links: [{ selector: "a" }] })` returns `{ links: [...] }` — an
   object schema always returns an object, even with a single field.
-- `extract([{ selector: "a" }])` is shorthand for a single anonymous array
+- `page.extract([{ selector: "a" }])` is shorthand for a single anonymous array
   extraction and returns the array directly.
 
 Every value is a string (trimmed text or a raw attribute) or `null` — parse
 numbers in script logic. An array field that matches nothing yields `[]`
 without complaint (a page with zero comments is a valid result), but if
-*every* field in the schema misses, `extract(...)` throws
+*every* field in the schema misses, `page.extract(...)` throws
 `no schema selector matched any element` — treat that as "my selectors are
 wrong", not "the page is empty".
 
-`extract(...)` reads only the current page. For list-to-detail scraping —
-capture a list, then visit each row for more — capture the list, then loop in
-the script: `goto` each row's URL and `extract` the detail. The local agent
-context keeps the data across navigations, so the assembly happens in plain
-JavaScript. See the [complete example](#complete-example) below.
+`page.extract(...)` reads only that page. For list-to-detail scraping — capture
+a list, then visit each row for more — capture the list, then loop in the
+script: `goto` each row's URL and `extract` the detail. The local agent context
+keeps the data across navigations, so the assembly happens in plain JavaScript.
+See the [complete example](#complete-example) below.
 
-When passing an object directly to `extract(...)`, the runtime serializes it as
-the extractor schema. These forms are equivalent:
+When passing an object directly to `page.extract(...)`, the runtime serializes
+it as the extractor schema. These forms are equivalent:
 
 ```js
-extract({ title: "h1" });
-extract({ schema: { title: "h1" } });
-extract('{ "title": "h1" }');
+page.extract({ title: "h1" });
+page.extract({ schema: { title: "h1" } });
+page.extract('{ "title": "h1" }');
 ```
 
 The wrapped form accepts only `schema`: the REPL's `save=` option does not
-exist in scripts (`extract({ schema: ..., save: ... })` is rejected). Keep
+exist in scripts (`page.extract({ schema: ..., save: ... })` is rejected). Keep
 results in local variables instead.
-
-Use local variables to keep extracted data available to later script logic:
-
-```js
-const page = extract({ title: "title" });
-```
 
 ## Page JavaScript
 
-`evaluate(...)` is the explicit escape hatch into the current page's JavaScript
+`page.evaluate(...)` is the explicit escape hatch into the page's JavaScript
 context. Its script string runs where `window` and `document` exist.
 
 ```js
-await goto("https://example.com");
+const page = await goto("https://example.com");
 
-const title = evaluate("document.title");
+const title = page.evaluate("document.title");
 console.log(title);
 ```
 
@@ -288,52 +290,55 @@ Keep the boundary clear:
 const selector = "h1";
 
 // Good: local agent logic builds an extract schema.
-const data = extract({ heading: selector });
+const data = page.extract({ heading: selector });
 
 // Bad: page evaluate cannot see local agent variables.
-evaluate("document.querySelector(selector).textContent");
+page.evaluate("document.querySelector(selector).textContent");
 ```
 
 Page `evaluate(...)` cannot call `goto`, `extract`, or other agent primitives.
 Agent scripts cannot access `document` directly. If you need page DOM data,
-prefer `extract(...)`; use `evaluate(...)` only for page behavior that extraction
-cannot express.
+prefer `page.extract(...)`; use `page.evaluate(...)` only for page behavior that
+extraction cannot express.
 
-`waitForScript(...)` also evaluates in the page context, repeatedly, until the
-expression is truthy or the timeout expires:
+`page.waitForScript(...)` also evaluates in the page context, repeatedly, until
+the expression is truthy or the timeout expires:
 
 ```js
-waitForScript("document.querySelectorAll('.row').length >= 5");
+page.waitForScript("document.querySelectorAll('.row').length >= 5");
 ```
 
 ## Interaction Primitives
 
-The action primitives operate on the current page. Most take one object whose
-fields match the browser tool schema:
+The action methods operate on the page they're called on. Most take one object
+whose fields match the browser tool schema:
 
 ```js
-click({ selector: "a.login" });
-fill({ selector: "input[name='acct']", value: "$LP_HN_USERNAME" });
-fill({ selector: "input[name='pw']", value: "$LP_HN_PASSWORD" });
-press({ key: "Enter" });
+const page = await goto("https://example.com/login");
 
-waitForSelector("#logout");
+page.click({ selector: "a.login" });
+page.fill({ selector: "input[name='acct']", value: "$LP_HN_USERNAME" });
+page.fill({ selector: "input[name='pw']", value: "$LP_HN_PASSWORD" });
+page.press({ key: "Enter" });
 
-hover({ selector: "#menu" });
-selectOption({ selector: "select[name='country']", value: "FR" });
-setChecked({ selector: "input[name='terms']", checked: true });
-setChecked({ selector: "input[name='newsletter']", checked: false });
+page.waitForSelector("#logout");
 
-scroll({ y: 600 });
-scroll();
+page.hover({ selector: "#menu" });
+page.selectOption({ selector: "select[name='country']", value: "FR" });
+page.setChecked({ selector: "input[name='terms']", checked: true });
+page.setChecked({ selector: "input[name='newsletter']", checked: false });
+
+page.scroll({ y: 600 });
+page.scroll();
 ```
 
 `setChecked` defaults `checked` to `true` when the field is omitted
-(`setChecked("#chk")` checks the box). `press`'s leading positional is the
-optional `selector`, not `key`: a bare `press("Enter")` binds `"Enter"` to
+(`page.setChecked("#chk")` checks the box). `press`'s leading positional is the
+optional `selector`, not `key`: a bare `page.press("Enter")` binds `"Enter"` to
 `selector` and fails. Press on the focused element with
-`press({ key: "Enter" })` or `press(null, "Enter")`; target an element with
-`press("#search", "Enter")` or `press({ key: "Enter", selector: "#search" })`.
+`page.press({ key: "Enter" })` or `page.press(null, "Enter")`; target an element
+with `page.press("#search", "Enter")` or
+`page.press({ key: "Enter", selector: "#search" })`.
 
 `$LP_*` placeholders in string arguments are resolved inside the Lightpanda
 process. This keeps credentials out of recorded scripts and LLM prompts. In
@@ -349,12 +354,16 @@ The REPL remains slash-command based:
 > /save
 ```
 
-`/save` writes JavaScript by default:
+`/save` writes JavaScript by default — binding `page` on each `goto` and calling
+every other tool as a method on it:
 
 ```js
-await goto("https://example.com");
-click({ selector: "a.login" });
+let page = await goto("https://example.com");
+page.click({ selector: "a.login" });
 ```
+
+A later `/goto` in the same session reassigns the variable (`page = await
+goto(...)`), matching the REPL's replace-in-place navigation.
 
 Only replayable browser actions are recorded:
 
@@ -377,7 +386,7 @@ Primitive failures throw JavaScript exceptions:
 
 ```js
 try {
-  waitForSelector({ selector: "#dashboard", timeout: 1000 });
+  page.waitForSelector({ selector: "#dashboard", timeout: 1000 });
 } catch (err) {
   console.error("dashboard did not appear:", err.message);
   throw err;
@@ -388,8 +397,10 @@ Common failures:
 
 | Error | Meaning |
 |-------|---------|
-| `ReferenceError: document is not defined` | You tried to use browser DOM APIs in the agent context. Use `extract(...)` or page `evaluate(...)`. |
+| `ReferenceError: document is not defined` | You tried to use browser DOM APIs in the agent context. Use `page.extract(...)` or `page.evaluate(...)`. |
 | `ReferenceError: require is not defined` | Agent scripts are not Node.js scripts. |
+| `this must be called as a method on a page returned by goto()` | A page primitive was called as a bare function. Call it on the page object: `page.click(...)`. |
+| `page handle is no longer valid` | The page object was used after a later `goto` replaced its page. Read through the most recent `goto`'s page object. |
 | `no page loaded - run goto(url) first` | A page-dependent primitive ran before navigation. |
 | `invalid arguments` | A primitive received the wrong number or shape of arguments, or a non-JSON-serializable value. |
 | `extract: no schema selector matched any element` | Every field in the schema missed. Fix the selectors; an empty page section yields `null`/`[]` per field, not this error. |
@@ -403,9 +414,9 @@ the local agent script, not in the page.
 ```js
 const HN = "https://news.ycombinator.com";
 
-await goto(HN);
+let page = await goto(HN);
 
-const { stories } = extract({
+const { stories } = page.extract({
   stories: [{
     selector: "tr.athing",
     limit: 5,
@@ -421,8 +432,8 @@ for (const story of stories) {
   story.comments = [];
   if (!story.id) continue;
 
-  await goto(`${HN}/item?id=${story.id}`);
-  const { comments } = extract({
+  page = await goto(`${HN}/item?id=${story.id}`);
+  const { comments } = page.extract({
     comments: [{
       selector: "tr.athing.comtr:has(.commtext)",
       limit: 3,

--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -32,10 +32,12 @@ web page's JavaScript context.
 - Agent variables persist for the lifetime of one script run, across
   navigations and primitive calls. A later `lightpanda agent script.js` run
   starts with a fresh agent context.
-- `goto(url)` is asynchronous and returns a Promise — always `await goto(...)`.
-  Every other primitive is synchronous; do not `await` them (`const data =
-  extract({ ... })`, not `await extract(...)`). The script body runs as an
-  async function, so top-level `await` is allowed.
+- `goto(url)` is asynchronous and resolves to a **page handle** — always
+  `await goto(...)`. Every other primitive is synchronous; do not `await` them
+  (`const data = extract({ ... })`, not `await extract(...)`). The script body
+  runs as an async function, so top-level `await` is allowed. The read tools act
+  on the latest `goto` by default; pass a handle as their optional last argument
+  to target a specific page (needed only for parallel `Promise.all` fetches).
 - Tool failures throw JavaScript `Error` exceptions (a `goto` failure rejects
   its Promise, so `await` throws) and stop execution unless you catch them.
 - The script's output is whatever it `return`s, printed automatically (objects
@@ -112,8 +114,8 @@ Only recorded browser primitives are installed globally:
 
 | Primitive | Arguments | Runs in |
 |-----------|-----------|---------|
-| `goto` | `await goto(url[, { timeout }])` (async) | Browser session |
-| `extract` | `extract(schema)` or `extract({ schema })` | Browser page via extractor; returns a JS object or array |
+| `goto` | `await goto(url[, { timeout }])` (async; resolves a page handle) | Browser session |
+| `extract` | `extract(schema[, page])` or `extract({ schema })` | Browser page via extractor; returns a JS object or array |
 | `evaluate` | `evaluate(script[, { url, timeout, save }])` | Browser page JS context |
 | `click` | `click(selector)` or `click({ selector })` | Browser page |
 | `fill` | `fill(selector, value)` or `fill({ selector, value })` | Browser page |
@@ -164,11 +166,36 @@ await goto({
 });
 ```
 
-The Promise resolves to a status string and rejects if navigation fails. A
-timeout does **not** reject: it resolves to `"Navigation started but the page
-did not finish loading before the timeout."` and the page stays in whatever
-state it reached. Check the resolved value — or follow with `waitForState(...)`
-/ `waitForSelector(...)` — when completeness matters.
+The Promise resolves to a **page handle** and rejects if navigation fails. A
+timeout does **not** reject: the page stays in whatever state it reached, so
+follow with `waitForState(...)` / `waitForSelector(...)` when completeness
+matters.
+
+You only need the handle for **parallel** fetches: a single page at a time is
+implicit (the read tools act on the latest `goto`), but to load several at once
+and read each one, pass its handle as the optional last argument:
+
+```js
+const [a, b] = await Promise.all([
+  goto("https://example.com/a"),
+  goto("https://example.com/b"),
+]);
+const da = extract({ title: "h1" }, a);   // reads page a
+const db = extract({ title: "h1" }, b);   // reads page b
+```
+
+The handle works on any page tool — `click(sel, a)`, `evaluate(js, a)`, etc.
+
+Two limits to know:
+
+- **Handle lifetime.** Pages from a parallel batch stay alive until the next
+  *sequential* `goto` (one with nothing else in flight), which replaces them.
+  So read a batch's handles before your next standalone `goto` — don't stash a
+  handle across one.
+- **Combined navigate-and-read stays single-page.** The `url` option on
+  `markdown`/`html`/`tree`/`evaluate` (e.g. `markdown({ url })`) navigates the
+  one current page, so it does not take part in parallel fetching. Use
+  `await goto(url)` + a handle when you need concurrency.
 
 ## Structured Extraction
 

--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -32,18 +32,17 @@ web page's JavaScript context.
 - Agent variables persist for the lifetime of one script run, across
   navigations and primitive calls. A later `lightpanda agent script.js` run
   starts with a fresh agent context.
-- The installed primitives are synchronous and blocking. Do not write an
-  `async`/`await` automation contract around them. Scripts compile as classic
-  scripts, so top-level `await` is a `SyntaxError`; promise callbacks
-  (`.then`) only run after the script body finishes, never in between
-  primitive calls.
-- Tool failures throw JavaScript `Error` exceptions and stop execution unless
-  you catch them.
-- The script's completion value — its last top-level expression — is printed
-  automatically (objects and arrays as JSON; other values coerced). End a
-  script with the bare expression you want as output, e.g. a final
-  `extract({ ... });` or `results;`. `console.log(...)` is for extra or debug
-  output and does not JSON-format objects.
+- `goto(url)` is asynchronous and returns a Promise — always `await goto(...)`.
+  Every other primitive is synchronous; do not `await` them (`const data =
+  extract({ ... })`, not `await extract(...)`). The script body runs as an
+  async function, so top-level `await` is allowed.
+- Tool failures throw JavaScript `Error` exceptions (a `goto` failure rejects
+  its Promise, so `await` throws) and stop execution unless you catch them.
+- The script's output is whatever it `return`s, printed automatically (objects
+  and arrays as JSON; other values coerced). End a script with `return
+  extract({ ... });` or `return results;`. A bare trailing expression is not
+  printed. `console.log(...)` is for extra or debug output and does not
+  JSON-format objects.
 
 The agent context includes a small `console` object:
 
@@ -64,7 +63,7 @@ your schema — an object schema returns an object keyed by your fields (even wi
 a single field), and a bare array schema returns an array:
 
 ```js
-goto("https://news.ycombinator.com/");
+await goto("https://news.ycombinator.com/");
 
 const data = extract({
   title: "title",
@@ -78,7 +77,7 @@ const data = extract({
   }]
 });
 
-data; // printed automatically as JSON
+return data; // printed automatically as JSON
 ```
 
 Destructure when a single field is all you need:
@@ -113,7 +112,7 @@ Only recorded browser primitives are installed globally:
 
 | Primitive | Arguments | Runs in |
 |-----------|-----------|---------|
-| `goto` | `goto(url[, { timeout }])` | Browser session |
+| `goto` | `await goto(url[, { timeout }])` (async) | Browser session |
 | `extract` | `extract(schema)` or `extract({ schema })` | Browser page via extractor; returns a JS object or array |
 | `evaluate` | `evaluate(script[, { url, timeout, save }])` | Browser page JS context |
 | `click` | `click(selector)` or `click({ selector })` | Browser page |
@@ -154,22 +153,22 @@ script.
 
 ## Navigation
 
-Use `goto(...)` to open a page:
+Use `await goto(...)` to open a page (it is asynchronous):
 
 ```js
-goto("https://example.com");
+await goto("https://example.com");
 
-goto({
+await goto({
   url: "https://example.com/app",
   timeout: 15000
 });
 ```
 
-The call returns a status string and throws if navigation fails. A timeout
-does **not** throw: the call returns `"Navigation started but the page did not
-finish loading before the timeout."` and the page stays in whatever state it
-reached. Check the return value — or follow with `waitForState(...)` /
-`waitForSelector(...)` — when completeness matters.
+The Promise resolves to a status string and rejects if navigation fails. A
+timeout does **not** reject: it resolves to `"Navigation started but the page
+did not finish loading before the timeout."` and the page stays in whatever
+state it reached. Check the resolved value — or follow with `waitForState(...)`
+/ `waitForSelector(...)` — when completeness matters.
 
 ## Structured Extraction
 
@@ -251,7 +250,7 @@ const page = extract({ title: "title" });
 context. Its script string runs where `window` and `document` exist.
 
 ```js
-goto("https://example.com");
+await goto("https://example.com");
 
 const title = evaluate("document.title");
 console.log(title);
@@ -327,7 +326,7 @@ The REPL remains slash-command based:
 `/save` writes JavaScript by default:
 
 ```js
-goto("https://example.com");
+await goto("https://example.com");
 click({ selector: "a.login" });
 ```
 
@@ -378,7 +377,7 @@ the local agent script, not in the page.
 ```js
 const HN = "https://news.ycombinator.com";
 
-goto(HN);
+await goto(HN);
 
 const { stories } = extract({
   stories: [{
@@ -396,7 +395,7 @@ for (const story of stories) {
   story.comments = [];
   if (!story.id) continue;
 
-  goto(`${HN}/item?id=${story.id}`);
+  await goto(`${HN}/item?id=${story.id}`);
   const { comments } = extract({
     comments: [{
       selector: "tr.athing.comtr:has(.commtext)",
@@ -410,5 +409,5 @@ for (const story of stories) {
   story.comments = comments;
 }
 
-stories; // printed automatically as JSON
+return stories; // printed automatically as JSON
 ```

--- a/docs/agent-tutorial.md
+++ b/docs/agent-tutorial.md
@@ -165,13 +165,13 @@ With an LLM, it synthesizes an idiomatic script. The result is
 JavaScript:
 
 ```js
-goto("https://news.ycombinator.com/login");
+await goto("https://news.ycombinator.com/login");
 fill({ selector: "form[action=\"login\"] input[name=\"acct\"]", value: "$LP_HN_USERNAME" });
 fill({ selector: "form[action=\"login\"] input[name=\"pw\"]", value: "$LP_HN_PASSWORD" });
 click({ selector: "form[action=\"login\"] input[type=\"submit\"][value=\"login\"]" });
 waitForSelector("#logout");
-goto("https://news.ycombinator.com");
-extract({ topStories: [{ selector: ".athing", fields: { rank: ".rank", title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
+await goto("https://news.ycombinator.com");
+return extract({ topStories: [{ selector: ".athing", fields: { rank: ".rank", title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
 ```
 
 Only state-mutating commands are recorded; read-only ones (`/tree`,
@@ -223,7 +223,7 @@ Use `extract(...)` to move page data into local logic, then process it
 with normal JavaScript:
 
 ```js
-goto("https://news.ycombinator.com");
+await goto("https://news.ycombinator.com");
 
 const topStories = extract({
   topStories: [{
@@ -237,7 +237,7 @@ const topStories = extract({
   }]
 });
 
-topStories.map((s) => ({ rank: s.rank, title: s.title, url: s.url }));
+return topStories.map((s) => ({ rank: s.rank, title: s.title, url: s.url }));
 ```
 
 Use `evaluate(...)` only when you intentionally want a string to run in
@@ -269,7 +269,7 @@ Drive the browser with the usual tools (`goto`, `fill`, `click`,
   "tool": "save",
   "args": {
     "path": "hn_login.js",
-    "script": "goto(\"...\");\n..."
+    "script": "await goto(\"...\");\n..."
   }
 }
 ```

--- a/docs/agent-tutorial.md
+++ b/docs/agent-tutorial.md
@@ -165,13 +165,14 @@ With an LLM, it synthesizes an idiomatic script. The result is
 JavaScript:
 
 ```js
-await goto("https://news.ycombinator.com/login");
-fill({ selector: "form[action=\"login\"] input[name=\"acct\"]", value: "$LP_HN_USERNAME" });
-fill({ selector: "form[action=\"login\"] input[name=\"pw\"]", value: "$LP_HN_PASSWORD" });
-click({ selector: "form[action=\"login\"] input[type=\"submit\"][value=\"login\"]" });
-waitForSelector("#logout");
-await goto("https://news.ycombinator.com");
-return extract({ topStories: [{ selector: ".athing", fields: { rank: ".rank", title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
+const page = new Page();
+await page.goto("https://news.ycombinator.com/login");
+page.fill({ selector: "form[action=\"login\"] input[name=\"acct\"]", value: "$LP_HN_USERNAME" });
+page.fill({ selector: "form[action=\"login\"] input[name=\"pw\"]", value: "$LP_HN_PASSWORD" });
+page.click({ selector: "form[action=\"login\"] input[type=\"submit\"][value=\"login\"]" });
+page.waitForSelector("#logout");
+await page.goto("https://news.ycombinator.com");
+return page.extract({ topStories: [{ selector: ".athing", fields: { rank: ".rank", title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
 ```
 
 Only state-mutating commands are recorded; read-only ones (`/tree`,
@@ -186,7 +187,7 @@ what the script returns.
 
 No `--provider`, no API key, no token spend. The script's last
 expression is printed automatically as JSON. Because the saved script
-ends with `extract(...)`, you get clean JSON on stdout:
+ends with `page.extract(...)`, you get clean JSON on stdout:
 
 ```console
 ./lightpanda agent hn_login.js > stories.json
@@ -199,7 +200,7 @@ To reshape the output, assign the result and end with a bare expression
 (the final value is what prints):
 
 ```js
-const topStories = extract({
+const topStories = page.extract({
   topStories: [{
     selector: ".athing",
     fields: {
@@ -219,13 +220,14 @@ Agent scripts run in a separate JavaScript context from the page. No
 `window`, `document`, DOM API, `require`, or `process`. Browser
 interaction happens through the installed primitives.
 
-Use `extract(...)` to move page data into local logic, then process it
+Use `page.extract(...)` to move page data into local logic, then process it
 with normal JavaScript:
 
 ```js
-await goto("https://news.ycombinator.com");
+const page = new Page();
+await page.goto("https://news.ycombinator.com");
 
-const topStories = extract({
+const topStories = page.extract({
   topStories: [{
     selector: ".athing",
     limit: 5,
@@ -240,20 +242,23 @@ const topStories = extract({
 return topStories.map((s) => ({ rank: s.rank, title: s.title, url: s.url }));
 ```
 
-`await goto(...)` resolves to a **page handle**. You don't need it for one
-page at a time, but to fetch several at once, hand each handle to `extract`:
+`new Page()` makes a page and `await page.goto(...)` navigates it. You don't
+need more than one for a single page, but to fetch several at once, make a page
+each and navigate them together:
 
 ```js
-const [hn, lobsters] = await Promise.all([
-  goto("https://news.ycombinator.com"),
-  goto("https://lobste.rs"),
+const a = new Page();
+const b = new Page();
+await Promise.all([
+  a.goto("https://news.ycombinator.com"),
+  b.goto("https://lobste.rs"),
 ]);
-const a = extract({ top: ".titleline > a" }, hn);       // reads HN
-const b = extract({ top: ".story .u-url" }, lobsters);  // reads Lobsters
-return { hn: a.top, lobsters: b.top };
+const hn = a.extract({ top: ".titleline > a" });       // reads HN
+const lobsters = b.extract({ top: ".story .u-url" });  // reads Lobsters
+return { hn: hn.top, lobsters: lobsters.top };
 ```
 
-Use `evaluate(...)` only when you intentionally want a string to run in
+Use `page.evaluate(...)` only when you intentionally want a string to run in
 the page's JavaScript context. Page evaluate cannot see agent
 variables or call agent primitives.
 
@@ -282,7 +287,7 @@ Drive the browser with the usual tools (`goto`, `fill`, `click`,
   "tool": "save",
   "args": {
     "path": "hn_login.js",
-    "script": "await goto(\"...\");\n..."
+    "script": "const page = new Page();\nawait page.goto(\"...\");\n..."
   }
 }
 ```

--- a/docs/agent-tutorial.md
+++ b/docs/agent-tutorial.md
@@ -240,6 +240,19 @@ const topStories = extract({
 return topStories.map((s) => ({ rank: s.rank, title: s.title, url: s.url }));
 ```
 
+`await goto(...)` resolves to a **page handle**. You don't need it for one
+page at a time, but to fetch several at once, hand each handle to `extract`:
+
+```js
+const [hn, lobsters] = await Promise.all([
+  goto("https://news.ycombinator.com"),
+  goto("https://lobste.rs"),
+]);
+const a = extract({ top: ".titleline > a" }, hn);       // reads HN
+const b = extract({ top: ".story .u-url" }, lobsters);  // reads Lobsters
+return { hn: a.top, lobsters: b.top };
+```
+
 Use `evaluate(...)` only when you intentionally want a string to run in
 the page's JavaScript context. Page evaluate cannot see agent
 variables or call agent primitives.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -361,13 +361,14 @@ click({ selector: "a.login" });
 return evaluate("document.title");
 ```
 
-`goto(url)` is **asynchronous** and resolves to a **page handle** — always
-`await goto(...)`. Every other primitive is **synchronous**: each returns its
-result directly, so write `const data = extract(…)`, not `await extract(…)`.
-The script body runs as an async function, so top-level `await` is allowed.
-The read tools act on the latest `goto` by default; to fetch several pages at
-once, `await Promise.all([goto(a), goto(b)])` and pass each handle as the
-optional last argument of a tool — `extract(schema, a)`.
+`goto(url)` is **asynchronous** — always use `await goto(...)`. Every other
+primitive is **synchronous**: each returns its result directly, so write
+`const data = extract(…)`, not `await extract(…)`. The script body runs as an
+async function, so top-level `await` is allowed.
+
+`await goto(...)` resolves to a **page handle**. You don't need it for one page
+at a time, but to fetch several at once, `await Promise.all([goto(a), goto(b)])`
+and pass each handle as a tool's optional last argument — `extract(schema, a)`.
 
 It's not Node.js. There's no `require`, `process`, `fs`, npm package
 loading, or Node standard library. The `evaluate(...)` primitive runs its

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -361,10 +361,13 @@ click({ selector: "a.login" });
 return evaluate("document.title");
 ```
 
-`goto(url)` is **asynchronous** — always `await goto(...)`. Every other
-primitive is **synchronous**: each returns its result directly, so write
-`const data = extract(…)`, not `await extract(…)`. The script body runs as
-an async function, so top-level `await` is allowed.
+`goto(url)` is **asynchronous** and resolves to a **page handle** — always
+`await goto(...)`. Every other primitive is **synchronous**: each returns its
+result directly, so write `const data = extract(…)`, not `await extract(…)`.
+The script body runs as an async function, so top-level `await` is allowed.
+The read tools act on the latest `goto` by default; to fetch several pages at
+once, `await Promise.all([goto(a), goto(b)])` and pass each handle as the
+optional last argument of a tool — `extract(schema, a)`.
 
 It's not Node.js. There's no `require`, `process`, `fs`, npm package
 loading, or Node standard library. The `evaluate(...)` primitive runs its

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -356,22 +356,26 @@ session).
 are plain JavaScript plus the installed Lightpanda primitives:
 
 ```js
-await goto("https://example.com");
-click({ selector: "a.login" });
-return evaluate("document.title");
+const page = new Page();
+await page.goto("https://example.com");
+page.click({ selector: "a.login" });
+return page.evaluate("document.title");
 ```
 
-`goto(url)` is **asynchronous** — always use `await goto(...)`. Every other
-primitive is **synchronous**: each returns its result directly, so write
-`const data = extract(…)`, not `await extract(…)`. The script body runs as an
-async function, so top-level `await` is allowed.
+`Page` is the only global: `new Page()` makes a page and `await page.goto(url)`
+navigates it. `page.goto(url)` is **asynchronous** — always `await` it. Every
+other method is **synchronous**: each returns its result directly, so write
+`const data = page.extract(…)`, not `await page.extract(…)`. The script body
+runs as an async function, so top-level `await` is allowed.
 
-`await goto(...)` resolves to a **page handle**. You don't need it for one page
-at a time, but to fetch several at once, `await Promise.all([goto(a), goto(b)])`
-and pass each handle as a tool's optional last argument — `extract(schema, a)`.
+Re-navigating reuses the same page object (`await page.goto(url2)`). To fetch
+several pages at once, make a page each and navigate them together:
+`const a = new Page(), b = new Page(); await Promise.all([a.goto(x), b.goto(y)])`,
+then read each through its own object (`a.extract(schema)`). Free a page you no
+longer need with `page.close()`.
 
 It's not Node.js. There's no `require`, `process`, `fs`, npm package
-loading, or Node standard library. The `evaluate(...)` primitive runs its
+loading, or Node standard library. The `page.evaluate(...)` primitive runs its
 string in the current page context; page scripts can't see agent variables
 or agent primitives.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -353,27 +353,29 @@ session).
 ## JavaScript scripts
 
 `./lightpanda agent script.js` runs a script without any LLM call. Scripts
-are plain synchronous JavaScript plus the installed Lightpanda primitives:
+are plain JavaScript plus the installed Lightpanda primitives:
 
 ```js
-goto("https://example.com");
+await goto("https://example.com");
 click({ selector: "a.login" });
-evaluate("document.title");
+return evaluate("document.title");
 ```
 
-The primitives are **synchronous and blocking**: each returns its
-result directly, so write `const data = extract(…)`, not
-`await extract(…)`. (`evaluate(...)` can run async JS inside the page,
-but the `evaluate(...)` call itself still returns synchronously.)
+`goto(url)` is **asynchronous** — always `await goto(...)`. Every other
+primitive is **synchronous**: each returns its result directly, so write
+`const data = extract(…)`, not `await extract(…)`. The script body runs as
+an async function, so top-level `await` is allowed.
 
 It's not Node.js. There's no `require`, `process`, `fs`, npm package
 loading, or Node standard library. The `evaluate(...)` primitive runs its
 string in the current page context; page scripts can't see agent variables
 or agent primitives.
 
-The last expression in the script is printed automatically, so a script
-that ends with `extract({...})` will print the extraction result to stdout.
-Tool errors throw JavaScript exceptions and stop execution.
+A script's output is whatever it `return`s, printed automatically, so a
+script that ends with `return extract({...})` prints the extraction result
+to stdout. A bare trailing expression is not printed. Tool errors throw
+JavaScript exceptions (a `goto` failure rejects, so `await` throws) and stop
+execution.
 
 See [agent-script.md](agent-script.md) for the full script format reference.
 
@@ -404,8 +406,8 @@ no resolved provider) you get the deterministic transcription:
 - **With an LLM** it synthesizes an idiomatic script from the whole
   session. The synthesis prompt asks for JavaScript only ("no commentary"),
   so the result generally has no such comments: the model folds intent
-  into the code and drops dead-ends. Returned data is the last expression,
-  which prints automatically on replay.
+  into the code and drops dead-ends. Output is whatever the script
+  `return`s, which prints automatically on replay.
 
 ## One-shot mode (`--task`)
 

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -92,31 +92,34 @@ const script_skill =
     \\
     \\The script runs in its **own V8 context** — neither the page nor Node.js:
     \\
-    \\- No `window`, `document`, DOM, `localStorage` — read pages with `extract(...)`, run page-side JS only via `evaluate("...")`.
+    \\- `goto(url)` is the only global. It opens a page and **resolves a page object**; every other primitive is a **method on that page**: `const page = await goto(url); page.extract({...}); page.click(sel);`.
+    \\- No `window`, `document`, DOM, `localStorage` — read pages with `page.extract(...)`, run page-side JS only via `page.evaluate("...")`.
     \\- No `require`, `process`, `fs`, npm. Standard ECMAScript built-ins only (`JSON`, `Map`, template literals, …).
-    \\- `goto(...)` is **async — always `await` it**; it resolves to a **page handle**. Every other primitive is **synchronous**: `const data = extract({...})`, never `await extract(...)`. The script body runs as an async function, so top-level `await` is allowed.
-    \\- A single page needs no handle — tools act on the latest `goto`'s page. To fetch in **parallel**, `await Promise.all([goto(a), goto(b)])` and pass each handle to read it: `extract(schema, a)`. The handle is the optional last argument of any page tool (`click(sel, a)`, …).
+    \\- `goto(...)` is **async — always `await` it**. Page methods are **synchronous**: `const data = page.extract({...})`, never `await page.extract(...)`. The script body runs as an async function, so top-level `await` is allowed.
+    \\- **Re-navigating replaces the page**: call `goto` again and rebind — `page = await goto(url2)`; the old object is then stale (`page handle is no longer valid`). To fetch in **parallel**, `const [a, b] = await Promise.all([goto(x), goto(y)])` — these pages coexist; read each through its own object: `a.extract(schema)`, `b.click(sel)`.
     \\- Page `evaluate("...")` cannot see script variables — interpolate values into the string. Script code cannot see page variables.
     \\- Variables persist across navigations within one run, so cross-page aggregation is plain JS.
-    \\- **`return <value>` is the script's output**, printed automatically (objects/arrays as JSON). End with `return extract({...});` or `return results;`. A bare trailing expression is NOT printed; neither is `console.log(JSON.stringify(...))`.
+    \\- **`return <value>` is the script's output**, printed automatically (objects/arrays as JSON). End with `return page.extract({...});` or `return results;`. A bare trailing expression is NOT printed; neither is `console.log(JSON.stringify(...))`.
     \\
     \\## Primitives
     \\
+    \\`goto` is global; everything else is a method on the page object it resolves.
+    \\
     \\| Call | Notes |
     \\|------|-------|
-    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed; resolves to a page handle.** Waits for `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** (the page may still be usable). |
-    \\| `extract(schema[, page])` | The only primitive returning a real JS value (object/array). Optional `page` handle targets a specific page. See schema below. |
-    \\| `evaluate(script[, { url, timeout, save }])` | Page-side JS escape hatch; returns text (JSON for objects/arrays). |
-    \\| `click(sel)` / `hover(sel)` | |
-    \\| `fill(sel, value)` / `selectOption(sel, value)` | |
-    \\| `setChecked(sel[, checked])` | `checked` defaults to `true`. |
-    \\| `press(sel, key)` / `press(null, key)` / `press({ key })` | Selector first! `press("Enter")` binds "Enter" to `selector` and fails. |
-    \\| `scroll()` / `scroll({ x, y })` | |
-    \\| `waitForSelector(sel[, { timeout }])` | `waitFor*` default timeout 5000 ms. |
-    \\| `waitForScript(js[, { timeout }])` | Re-evaluates page JS until truthy. |
-    \\| `waitForState(state[, { timeout }])` | `"load"`, `"domcontentloaded"`, `"networkalmostidle"`, `"networkidle"`, `"done"`. |
+    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed; resolves a page object.** Waits for `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** (the page may still be usable). |
+    \\| `page.extract(schema)` | The only primitive returning a real JS value (object/array). See schema below. |
+    \\| `page.evaluate(script[, { url, timeout, save }])` | Page-side JS escape hatch; returns text (JSON for objects/arrays). |
+    \\| `page.click(sel)` / `page.hover(sel)` | |
+    \\| `page.fill(sel, value)` / `page.selectOption(sel, value)` | |
+    \\| `page.setChecked(sel[, checked])` | `checked` defaults to `true`. |
+    \\| `page.press(sel, key)` / `page.press(null, key)` / `page.press({ key })` | Selector first! `page.press("Enter")` binds "Enter" to `selector` and fails. |
+    \\| `page.scroll()` / `page.scroll({ x, y })` | |
+    \\| `page.waitForSelector(sel[, { timeout }])` | `waitFor*` default timeout 5000 ms. |
+    \\| `page.waitForScript(js[, { timeout }])` | Re-evaluates page JS until truthy. |
+    \\| `page.waitForState(state[, { timeout }])` | `"load"`, `"domcontentloaded"`, `"networkalmostidle"`, `"networkidle"`, `"done"`. |
     \\
-    \\Calling convention: leading positionals + optional trailing options object, or one object with everything (`waitForSelector("#row", { timeout: 2000 })` ≡ `waitForSelector({ selector: "#row", timeout: 2000 })`). A bare option positional (`waitForSelector("#row", 2000)`) and a field passed both ways are `invalid arguments`. `null` skips a positional. Arguments must be JSON-serializable.
+    \\Calling convention: leading positionals + optional trailing options object, or one object with everything (`page.waitForSelector("#row", { timeout: 2000 })` ≡ `page.waitForSelector({ selector: "#row", timeout: 2000 })`). A bare option positional (`page.waitForSelector("#row", 2000)`) and a field passed both ways are `invalid arguments`. `null` skips a positional. Arguments must be JSON-serializable.
     \\
     \\CSS selectors only — `backendNodeId`s don't exist here. Standard CSS only: no jQuery `:contains()` or Playwright `:has-text()`.
     \\
@@ -125,7 +128,7 @@ const script_skill =
     \\Keys = output field names; values pick what to lift (not a JSON Schema):
     \\
     \\```js
-    \\const { stories } = extract({
+    \\const { stories } = page.extract({
     \\  stories: [{
     \\    selector: "tr.athing",          // one record per match
     \\    limit: 5,
@@ -146,13 +149,13 @@ const script_skill =
     \\
     \\## Best practices
     \\
-    \\1. **Navigate, settle, read.** After `await goto` on a dynamic page (feeds, search results, comment threads), call `waitForState("networkidle")` or `waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
-    \\2. **Fetch in parallel when the pages are independent.** `const [a, b] = await Promise.all([goto(x), goto(y)]);` then read each by handle (`extract(schema, a)`). Sequential is fine too — see #3.
-    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `await goto`/`extract` per item, assembling plain JS objects.
-    \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `evaluate` block is always wrong: lift the raw strings with `extract`, then trim/split/parse them in top-level JS. Reserve `evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every `goto`/reload, while script variables persist.
-    \\5. **Credentials via `$LP_*` placeholders** in any string argument (`fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.
+    \\1. **Navigate, settle, read.** After `await goto` on a dynamic page (feeds, search results, comment threads), call `page.waitForState("networkidle")` or `page.waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
+    \\2. **Fetch in parallel when the pages are independent.** `const [a, b] = await Promise.all([goto(x), goto(y)]);` then read each through its object (`a.extract(schema)`). Sequential is fine too — see #3.
+    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `page = await goto(...)`/`page.extract(...)` per item, assembling plain JS objects.
+    \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `page.evaluate` block is always wrong: lift the raw strings with `page.extract`, then trim/split/parse them in top-level JS. Reserve `page.evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every `goto`/reload, while script variables persist.
+    \\5. **Credentials via `$LP_*` placeholders** in any string argument (`page.fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.
     \\6. **Unique selectors.** Disambiguate with attributes/position: `input[type="submit"][value="login"]`, not `input[type="submit"]`.
-    \\7. **Let failures fail.** Primitives throw on error and stop the script — only `try/catch` where you have a real fallback (e.g. optional cookie banner: `try { click("#accept") } catch {}`).
+    \\7. **Let failures fail.** Primitives throw on error and stop the script — only `try/catch` where you have a real fallback (e.g. optional cookie banner: `try { page.click("#accept") } catch {}`).
     \\8. **End with `return <result>`.** `console.log` is for debug output only and doesn't JSON-format objects.
     \\9. Modern, readable JS: `const`/`let`, `for (const x of xs)`, template literals, destructuring, 2-space indent.
     \\
@@ -160,12 +163,14 @@ const script_skill =
     \\
     \\| Error | Cause / fix |
     \\|-------|-------------|
-    \\| `document is not defined` | DOM API in script context → use `extract` or `evaluate` |
+    \\| `extract is not defined` (or click/fill/…) | These are methods on the page object, not globals → `const page = await goto(url); page.extract(...)` |
+    \\| `page handle is no longer valid` | Used a page object after a later `goto` replaced it → read through the most recent `goto`'s object |
+    \\| `document is not defined` | DOM API in script context → use `page.extract` or `page.evaluate` |
     \\| `require is not defined` | Not Node.js |
     \\| `no page loaded - run goto(url) first` | Page primitive before navigation |
     \\| `invalid arguments` | Wrong arity/shape, non-JSON value, or a field set both positionally and in options |
     \\| `extract: no schema selector matched any element` | All schema fields missed → fix selectors |
-    \\| `press` fails with one string arg | Selector-first: use `press(null, "Enter")` or `press({ key: "Enter" })` |
+    \\| `press` fails with one string arg | Selector-first: use `page.press(null, "Enter")` or `page.press({ key: "Enter" })` |
 ;
 
 // Sytem prompt of the `/save` command
@@ -675,7 +680,9 @@ fn runRepl(self: *Agent) void {
                 self.terminal.endTool();
                 self.printCommandResult(cmd, result);
                 if (!result.is_error) {
-                    self.recordSaveCommand(cmd);
+                    // A navigating read tool records as the `goto` it performed;
+                    // every other tool records itself (read-only ones no-op).
+                    self.recordSaveCommand(navigationGoto(aa, tc.tool, tc.args) orelse cmd);
                 }
                 self.recordSlashToolCall(trimmed, tc.name(), tc.args, result) catch |err| {
                     self.terminal.printWarning("LLM conversation out of sync (/{s}: {s}); next prompt may not see this action", .{ tc.name(), @errorName(err) });
@@ -1160,6 +1167,22 @@ fn recordSaveCommand(self: *Agent, cmd: Command) void {
     self.save_buffer.record(cmd) catch |err| self.logSaveBufferError(err);
 }
 
+/// A navigating read tool (`markdown {url}`, `tree {url}`, …) loads a page but
+/// isn't itself recorded; the navigation it performed is the replayable part, so
+/// `/save` captures it as a `goto`. Returns that synthetic command, or null when
+/// the call did not navigate (not such a tool, or no `url`). The returned
+/// command borrows `args`/`arena`, so record it before either is freed.
+fn navigationGoto(arena: std.mem.Allocator, tool: BrowserTool, args: ?std.json.Value) ?Command {
+    if (!tool.navigatesToUrl()) return null;
+    const a = args orelse return null;
+    if (a != .object) return null;
+    const url = a.object.get("url") orelse return null;
+    if (url != .string or url.string.len == 0) return null;
+    var obj: std.json.ObjectMap = .init(arena);
+    obj.put("url", url) catch return null;
+    return Command.fromToolCall(.goto, .{ .object = obj });
+}
+
 fn recordSaveComment(self: *Agent, comment: []const u8) void {
     self.save_buffer.recordComment(comment) catch |err| self.logSaveBufferError(err);
 }
@@ -1491,13 +1514,19 @@ fn processUserMessage(self: *Agent, input: TurnInput) !?[]const u8 {
                 if (tool == .extract and idx != i) continue;
             }
             const args = browser_tools.normalizeArgKeys(self.conversation.arena.allocator(), tool, tc.arguments) catch tc.arguments;
+            // Record the tool itself, or — for a navigating read tool the model
+            // used in place of `goto` — the navigation it performed. Without this
+            // a markdown/tree-driven turn records nothing and `/save` has nothing.
             const cmd = Command.fromToolCall(tool, args);
-            if (!cmd.isRecorded()) continue;
+            const to_record = if (cmd.isRecorded())
+                cmd
+            else
+                navigationGoto(self.conversation.arena.allocator(), tool, args) orelse continue;
             if (!recorded_any) {
                 if (input.record_comment) |c| self.recordSaveComment(c);
                 recorded_any = true;
             }
-            self.recordSaveCommand(cmd);
+            self.recordSaveCommand(to_record);
         }
     }
 

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -152,8 +152,18 @@ const script_skill =
     \\## Best practices
     \\
     \\1. **Navigate, settle, read.** After `await page.goto` on a dynamic page (feeds, search results, comment threads), call `page.waitForState("networkidle")` or `page.waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
-    \\2. **Fetch in parallel when the pages are independent.** `const a = new Page(), b = new Page(); await Promise.all([a.goto(x), b.goto(y)]);` then read each through its object (`a.extract(schema)`). Sequential is fine too — see #3.
-    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `await page.goto(...)`/`page.extract(...)` per item, assembling plain JS objects.
+    \\2. **Fetch in parallel when the pages are independent.** `const a = new Page(), b = new Page(); await Promise.all([a.goto(x), b.goto(y)]);` then read each through its object (`a.extract(schema)`). Parallel pages share one cookie jar and run JS serially, so this speeds up independent, read-only fetches — not login or stateful flows.
+    \\3. **List-to-detail: fan out, don't crawl.** Extract the list, then fetch the detail pages in parallel — one `new Page()` per item, gathered with `Promise.all` — assembling plain JS objects. This is where async `goto` pays off:
+    \\   ```js
+    \\   const details = await Promise.all(items.map(async (it) => {
+    \\     const p = new Page();
+    \\     await p.goto(it.url);
+    \\     const data = p.extract({ /* schema */ });
+    \\     p.close();
+    \\     return { ...it, ...data };
+    \\   }));
+    \\   ```
+    \\   Reuse a single sequential `page` (`await page.goto(...)` per item) instead only when the steps depend on each other or share login state; for long lists, fan out in chunks of ~5–10.
     \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `page.evaluate` block is always wrong: lift the raw strings with `page.extract`, then trim/split/parse them in top-level JS. Reserve `page.evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every navigation/reload, while script variables persist.
     \\5. **Credentials via `$LP_*` placeholders** in any string argument (`page.fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.
     \\6. **Unique selectors.** Disambiguate with attributes/position: `input[type="submit"][value="login"]`, not `input[type="submit"]`.

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -92,22 +92,24 @@ const script_skill =
     \\
     \\The script runs in its **own V8 context** — neither the page nor Node.js:
     \\
-    \\- `goto(url)` is the only global. It opens a page and **resolves a page object**; every other primitive is a **method on that page**: `const page = await goto(url); page.extract({...}); page.click(sel);`.
+    \\- `Page` is the only global. `new Page()` makes a page and `await page.goto(url)` navigates it; every other primitive is a **method on that page**: `const page = new Page(); await page.goto(url); page.extract({...}); page.click(sel);`.
     \\- No `window`, `document`, DOM, `localStorage` — read pages with `page.extract(...)`, run page-side JS only via `page.evaluate("...")`.
     \\- No `require`, `process`, `fs`, npm. Standard ECMAScript built-ins only (`JSON`, `Map`, template literals, …).
-    \\- `goto(...)` is **async — always `await` it**. Page methods are **synchronous**: `const data = page.extract({...})`, never `await page.extract(...)`. The script body runs as an async function, so top-level `await` is allowed.
-    \\- **Re-navigating replaces the page**: call `goto` again and rebind — `page = await goto(url2)`; the old object is then stale (`page handle is no longer valid`). To fetch in **parallel**, `const [a, b] = await Promise.all([goto(x), goto(y)])` — these pages coexist; read each through its own object: `a.extract(schema)`, `b.click(sel)`.
+    \\- `page.goto(...)` is **async — always `await` it**. Page methods are **synchronous**: `const data = page.extract({...})`, never `await page.extract(...)`. The script body runs as an async function, so top-level `await` is allowed.
+    \\- **Re-navigating reuses the same page**: `await page.goto(url2)` keeps `page` valid. To fetch in **parallel**, make several pages and navigate them together: `const a = new Page(), b = new Page(); await Promise.all([a.goto(x), b.goto(y)])` — these pages coexist; read each through its own object: `a.extract(schema)`, `b.click(sel)`. Free a page you're done with via `page.close()`.
     \\- Page `evaluate("...")` cannot see script variables — interpolate values into the string. Script code cannot see page variables.
     \\- Variables persist across navigations within one run, so cross-page aggregation is plain JS.
     \\- **`return <value>` is the script's output**, printed automatically (objects/arrays as JSON). End with `return page.extract({...});` or `return results;`. A bare trailing expression is NOT printed; neither is `console.log(JSON.stringify(...))`.
     \\
     \\## Primitives
     \\
-    \\`goto` is global; everything else is a method on the page object it resolves.
+    \\`Page` is the only global; `new Page()` makes a page and everything else is a method on it.
     \\
     \\| Call | Notes |
     \\|------|-------|
-    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed; resolves a page object.** Waits for `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** (the page may still be usable). |
+    \\| `new Page()` | Makes a page object. No navigation yet — call `page.goto(url)` before any other method. |
+    \\| `await page.goto(url[, { timeout }])` | **Async — must be `await`ed.** Navigates the page (re-navigating reuses the same object). Waits for `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** (the page may still be usable). |
+    \\| `page.close()` | Free a page's resources (parallel/popup pages). The root page is reclaimed at script end. |
     \\| `page.extract(schema)` | The only primitive returning a real JS value (object/array). See schema below. |
     \\| `page.evaluate(script[, { url, timeout, save }])` | Page-side JS escape hatch; returns text (JSON for objects/arrays). |
     \\| `page.click(sel)` / `page.hover(sel)` | |
@@ -149,10 +151,10 @@ const script_skill =
     \\
     \\## Best practices
     \\
-    \\1. **Navigate, settle, read.** After `await goto` on a dynamic page (feeds, search results, comment threads), call `page.waitForState("networkidle")` or `page.waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
-    \\2. **Fetch in parallel when the pages are independent.** `const [a, b] = await Promise.all([goto(x), goto(y)]);` then read each through its object (`a.extract(schema)`). Sequential is fine too — see #3.
-    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `page = await goto(...)`/`page.extract(...)` per item, assembling plain JS objects.
-    \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `page.evaluate` block is always wrong: lift the raw strings with `page.extract`, then trim/split/parse them in top-level JS. Reserve `page.evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every `goto`/reload, while script variables persist.
+    \\1. **Navigate, settle, read.** After `await page.goto` on a dynamic page (feeds, search results, comment threads), call `page.waitForState("networkidle")` or `page.waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
+    \\2. **Fetch in parallel when the pages are independent.** `const a = new Page(), b = new Page(); await Promise.all([a.goto(x), b.goto(y)]);` then read each through its object (`a.extract(schema)`). Sequential is fine too — see #3.
+    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `await page.goto(...)`/`page.extract(...)` per item, assembling plain JS objects.
+    \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `page.evaluate` block is always wrong: lift the raw strings with `page.extract`, then trim/split/parse them in top-level JS. Reserve `page.evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every navigation/reload, while script variables persist.
     \\5. **Credentials via `$LP_*` placeholders** in any string argument (`page.fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.
     \\6. **Unique selectors.** Disambiguate with attributes/position: `input[type="submit"][value="login"]`, not `input[type="submit"]`.
     \\7. **Let failures fail.** Primitives throw on error and stop the script — only `try/catch` where you have a real fallback (e.g. optional cookie banner: `try { page.click("#accept") } catch {}`).
@@ -163,8 +165,10 @@ const script_skill =
     \\
     \\| Error | Cause / fix |
     \\|-------|-------------|
-    \\| `extract is not defined` (or click/fill/…) | These are methods on the page object, not globals → `const page = await goto(url); page.extract(...)` |
-    \\| `page handle is no longer valid` | Used a page object after a later `goto` replaced it → read through the most recent `goto`'s object |
+    \\| `extract is not defined` (or click/fill/…) | These are methods on the page object, not globals → `const page = new Page(); await page.goto(url); page.extract(...)` |
+    \\| `Page must be called with new` | `Page(...)` called without `new` → `const page = new Page();` |
+    \\| `page is not navigated or has been closed` | A method on a fresh `new Page()` (or a closed page) → `await page.goto(url)` first |
+    \\| `page handle is no longer valid` | Used a page after a later `goto` replaced it (a sequential `new Page()`+goto replaces the root) → read through the current page |
     \\| `document is not defined` | DOM API in script context → use `page.extract` or `page.evaluate` |
     \\| `require is not defined` | Not Node.js |
     \\| `no page loaded - run goto(url) first` | Page primitive before navigation |

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -680,8 +680,6 @@ fn runRepl(self: *Agent) void {
                 self.terminal.endTool();
                 self.printCommandResult(cmd, result);
                 if (!result.is_error) {
-                    // A navigating read tool records as the `goto` it performed;
-                    // every other tool records itself (read-only ones no-op).
                     self.recordSaveCommand(navigationGoto(aa, tc.tool, tc.args) orelse cmd);
                 }
                 self.recordSlashToolCall(trimmed, tc.name(), tc.args, result) catch |err| {
@@ -1167,11 +1165,9 @@ fn recordSaveCommand(self: *Agent, cmd: Command) void {
     self.save_buffer.record(cmd) catch |err| self.logSaveBufferError(err);
 }
 
-/// A navigating read tool (`markdown {url}`, `tree {url}`, …) loads a page but
-/// isn't itself recorded; the navigation it performed is the replayable part, so
-/// `/save` captures it as a `goto`. Returns that synthetic command, or null when
-/// the call did not navigate (not such a tool, or no `url`). The returned
-/// command borrows `args`/`arena`, so record it before either is freed.
+/// A navigating read tool (`markdown {url}`, …) isn't recorded, but the
+/// navigation it performed is, so capture it as a `goto`; null when it didn't
+/// navigate. The result borrows `args`/`arena` — record it before they're freed.
 fn navigationGoto(arena: std.mem.Allocator, tool: BrowserTool, args: ?std.json.Value) ?Command {
     if (!tool.navigatesToUrl()) return null;
     const a = args orelse return null;
@@ -1514,9 +1510,8 @@ fn processUserMessage(self: *Agent, input: TurnInput) !?[]const u8 {
                 if (tool == .extract and idx != i) continue;
             }
             const args = browser_tools.normalizeArgKeys(self.conversation.arena.allocator(), tool, tc.arguments) catch tc.arguments;
-            // Record the tool itself, or — for a navigating read tool the model
-            // used in place of `goto` — the navigation it performed. Without this
-            // a markdown/tree-driven turn records nothing and `/save` has nothing.
+            // Without this, a turn that navigated via read tools (`markdown {url}`)
+            // instead of `goto` records nothing.
             const cmd = Command.fromToolCall(tool, args);
             const to_record = if (cmd.isRecorded())
                 cmd

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -94,7 +94,8 @@ const script_skill =
     \\
     \\- No `window`, `document`, DOM, `localStorage` — read pages with `extract(...)`, run page-side JS only via `evaluate("...")`.
     \\- No `require`, `process`, `fs`, npm. Standard ECMAScript built-ins only (`JSON`, `Map`, template literals, …).
-    \\- `goto(...)` is **async — always `await` it**. Every other primitive is **synchronous**: `const data = extract({...})`, never `await extract(...)`. The script body runs as an async function, so top-level `await` is allowed (and required for `goto`).
+    \\- `goto(...)` is **async — always `await` it**; it resolves to a **page handle**. Every other primitive is **synchronous**: `const data = extract({...})`, never `await extract(...)`. The script body runs as an async function, so top-level `await` is allowed.
+    \\- A single page needs no handle — tools act on the latest `goto`'s page. To fetch in **parallel**, `await Promise.all([goto(a), goto(b)])` and pass each handle to read it: `extract(schema, a)`. The handle is the optional last argument of any page tool (`click(sel, a)`, …).
     \\- Page `evaluate("...")` cannot see script variables — interpolate values into the string. Script code cannot see page variables.
     \\- Variables persist across navigations within one run, so cross-page aggregation is plain JS.
     \\- **`return <value>` is the script's output**, printed automatically (objects/arrays as JSON). End with `return extract({...});` or `return results;`. A bare trailing expression is NOT printed; neither is `console.log(JSON.stringify(...))`.
@@ -103,8 +104,8 @@ const script_skill =
     \\
     \\| Call | Notes |
     \\|------|-------|
-    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed.** Resolves at `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** — it resolves to a "did not finish loading" status string. |
-    \\| `extract(schema)` | The only primitive returning a real JS value (object/array). See schema below. |
+    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed; resolves to a page handle.** Waits for `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** (the page may still be usable). |
+    \\| `extract(schema[, page])` | The only primitive returning a real JS value (object/array). Optional `page` handle targets a specific page. See schema below. |
     \\| `evaluate(script[, { url, timeout, save }])` | Page-side JS escape hatch; returns text (JSON for objects/arrays). |
     \\| `click(sel)` / `hover(sel)` | |
     \\| `fill(sel, value)` / `selectOption(sel, value)` | |
@@ -146,7 +147,7 @@ const script_skill =
     \\## Best practices
     \\
     \\1. **Navigate, settle, read.** After `await goto` on a dynamic page (feeds, search results, comment threads), call `waitForState("networkidle")` or `waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
-    \\2. **Check the `await goto` result when completeness matters** — it resolves to a status string instead of rejecting on timeout.
+    \\2. **Fetch in parallel when the pages are independent.** `const [a, b] = await Promise.all([goto(x), goto(y)]);` then read each by handle (`extract(schema, a)`). Sequential is fine too — see #3.
     \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `await goto`/`extract` per item, assembling plain JS objects.
     \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `evaluate` block is always wrong: lift the raw strings with `extract`, then trim/split/parse them in top-level JS. Reserve `evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every `goto`/reload, while script variables persist.
     \\5. **Credentials via `$LP_*` placeholders** in any string argument (`fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -94,16 +94,16 @@ const script_skill =
     \\
     \\- No `window`, `document`, DOM, `localStorage` — read pages with `extract(...)`, run page-side JS only via `evaluate("...")`.
     \\- No `require`, `process`, `fs`, npm. Standard ECMAScript built-ins only (`JSON`, `Map`, template literals, …).
-    \\- All primitives are **synchronous and blocking**. Never wrap them in `async`/`await`/`.then` — `const data = extract({...})`, not `await extract(...)`. Top-level `await` is a `SyntaxError` (classic script); promise callbacks only run after the script body ends.
+    \\- `goto(...)` is **async — always `await` it**. Every other primitive is **synchronous**: `const data = extract({...})`, never `await extract(...)`. The script body runs as an async function, so top-level `await` is allowed (and required for `goto`).
     \\- Page `evaluate("...")` cannot see script variables — interpolate values into the string. Script code cannot see page variables.
     \\- Variables persist across navigations within one run, so cross-page aggregation is plain JS.
-    \\- The **last top-level expression is the script's output**, printed automatically (objects/arrays as JSON). End with the bare result: `extract({...});` or `results;`. No `console.log(JSON.stringify(...))`, no top-level `return` (illegal).
+    \\- **`return <value>` is the script's output**, printed automatically (objects/arrays as JSON). End with `return extract({...});` or `return results;`. A bare trailing expression is NOT printed; neither is `console.log(JSON.stringify(...))`.
     \\
     \\## Primitives
     \\
     \\| Call | Notes |
     \\|------|-------|
-    \\| `goto(url[, { timeout }])` | Returns at `load`. Default timeout 10000 ms. Throws on failure; a **timeout does NOT throw** — it returns a "did not finish loading" status string. |
+    \\| `await goto(url[, { timeout }])` | **Async — must be `await`ed.** Resolves at `load`. Default timeout 10000 ms. Rejects on navigation failure; a **timeout does NOT reject** — it resolves to a "did not finish loading" status string. |
     \\| `extract(schema)` | The only primitive returning a real JS value (object/array). See schema below. |
     \\| `evaluate(script[, { url, timeout, save }])` | Page-side JS escape hatch; returns text (JSON for objects/arrays). |
     \\| `click(sel)` / `hover(sel)` | |
@@ -145,14 +145,14 @@ const script_skill =
     \\
     \\## Best practices
     \\
-    \\1. **Navigate, settle, read.** After `goto` on a dynamic page (feeds, search results, comment threads), call `waitForState("networkidle")` or `waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
-    \\2. **Check `goto` when completeness matters** — it returns a status string instead of throwing on timeout.
-    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `goto`/`extract` per item, assembling plain JS objects.
+    \\1. **Navigate, settle, read.** After `await goto` on a dynamic page (feeds, search results, comment threads), call `waitForState("networkidle")` or `waitForSelector(...)` before extracting. Most static pages are complete at `load` — don't wait blindly.
+    \\2. **Check the `await goto` result when completeness matters** — it resolves to a status string instead of rejecting on timeout.
+    \\3. **Aggregate in the script, not the page.** List-to-detail: extract the list, then loop `await goto`/`extract` per item, assembling plain JS objects.
     \\4. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `evaluate` block is always wrong: lift the raw strings with `extract`, then trim/split/parse them in top-level JS. Reserve `evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every `goto`/reload, while script variables persist.
     \\5. **Credentials via `$LP_*` placeholders** in any string argument (`fill("#pw", "$LP_HN_PASSWORD")`). Never inline a real secret; placeholders resolve inside the Lightpanda process.
     \\6. **Unique selectors.** Disambiguate with attributes/position: `input[type="submit"][value="login"]`, not `input[type="submit"]`.
     \\7. **Let failures fail.** Primitives throw on error and stop the script — only `try/catch` where you have a real fallback (e.g. optional cookie banner: `try { click("#accept") } catch {}`).
-    \\8. **End with the bare result expression.** `console.log` is for debug output only and doesn't JSON-format objects.
+    \\8. **End with `return <result>`.** `console.log` is for debug output only and doesn't JSON-format objects.
     \\9. Modern, readable JS: `const`/`let`, `for (const x of xs)`, template literals, destructuring, 2-space indent.
     \\
     \\## Common errors

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -363,6 +363,54 @@ pub fn removePage(self: *Session) void {
     }
 }
 
+/// Tear down a single script-opened popup: detach it from its page and queue
+/// its frame for destruction. Returns false (tearing nothing down) when `frame`
+/// is not a popup — e.g. the root frame, which has no single-page teardown.
+/// Shared by `Window.close` and the agent script runtime's `page.close()`.
+pub fn closePopup(self: *Session, frame: *Frame) bool {
+    const page = frame._page;
+    const window = frame.window;
+
+    var popup_index: usize = 0;
+    while (popup_index < page.popups.items.len) : (popup_index += 1) {
+        if (page.popups.items[popup_index] == frame) {
+            break;
+        }
+    } else return false;
+
+    // Any live Window holding this one as its opener must drop the reference —
+    // the Frame is about to go away, and a stale `_frame` deref would crash.
+    for (page.popups.items) |popup| {
+        if (popup.window._opener == window) {
+            popup.window._opener = null;
+        }
+    }
+    if (page.frame.window._opener == window) {
+        page.frame.window._opener = null;
+    }
+
+    _ = page.popups.swapRemove(popup_index);
+
+    // Drop any pending queued navigation for this frame; Frame.deinit releases
+    // the QueuedNavigation arena, so a leftover entry would be re-deinited.
+    if (frame._queued_navigation != null) {
+        for (page.queued_navigation.items, 0..) |f, i| {
+            if (f == frame) {
+                _ = page.queued_navigation.swapRemove(i);
+                break;
+            }
+        }
+    }
+
+    frame.js.scheduler.reset();
+
+    // Defer the actual teardown: a popup closed from its own running script sits
+    // on top of the Frame's V8 context, so destroying it now leaves dangling
+    // pointers in the unwinding eval. Page.deinit drains the queue.
+    self.queueFrameDestruction(frame);
+    return true;
+}
+
 pub fn getArena(self: *Session, size_or_bucket: anytype, debug: []const u8) !Allocator {
     return self.arena_pool.acquire(size_or_bucket, debug);
 }

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -75,6 +75,11 @@ _pending: ?*Page = null,
 _page_destruction_queue: std.ArrayList(*Page) = .{},
 _frame_destruction_queue: std.ArrayList(*Frame) = .{},
 
+// When set, page tools act on this frame instead of the active page's root —
+// the script runtime aims them at a popup so concurrent `goto`s are readable by
+// handle. Only `toolFrame()` consults it; CDP/runner use `currentFrame()`.
+_tool_frame_override: ?*Frame = null,
+
 // Loader IDs are scoped to the Session: each new BrowserContext gets a
 // fresh counter. Frame IDs (`frame_id_gen`) live on `Browser` instead so
 // CDP target IDs stay unique across BrowserContext lifecycle on a single
@@ -390,6 +395,11 @@ pub fn pendingOrCurrentFrame(self: *Session) ?*Frame {
 pub fn currentFrame(self: *Session) ?*Frame {
     const page = self.currentPage() orelse return null;
     return &page.frame;
+}
+
+/// Frame page tools act on: the override if set, else the active page's root.
+pub fn toolFrame(self: *Session) ?*Frame {
+    return self._tool_frame_override orelse self.currentFrame();
 }
 
 pub fn findFrameByFrameId(self: *Session, frame_id: u32) ?*Frame {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -478,6 +478,7 @@ fn getGlobalArg(comptime T: type, ctx: *Context) T {
         return switch (ctx.global) {
             .frame => |frame| frame,
             .worker => unreachable,
+            .bare => unreachable,
         };
     }
 
@@ -633,6 +634,7 @@ pub const Function = struct {
         const ce_frame: ?*Frame = if (comptime opts.ce_reactions) switch (ctx.global) {
             .frame => |frame| frame,
             .worker => null,
+            .bare => null,
         } else null;
 
         if (comptime opts.ce_reactions) {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -520,7 +520,7 @@ pub const FunctionCallbackInfo = struct {
         return .{ .handle = rv };
     }
 
-    fn isConstructCall(self: FunctionCallbackInfo) bool {
+    pub fn isConstructCall(self: FunctionCallbackInfo) bool {
         return v8.v8__FunctionCallbackInfo__IsConstructCall(self.handle);
     }
 };

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -42,8 +42,7 @@ const Context = @This();
 pub const GlobalScope = union(enum) {
     frame: *Frame,
     worker: *WorkerGlobalScope,
-    // The agent script runtime: a page-less, WebAPI-less context. Carries a
-    // back-pointer to its own Context (frames/workers store theirs in `.js`).
+    // Agent script runtime; back-points to its own Context (frames/workers store theirs in `.js`).
     bare: *Context,
 
     pub fn base(self: GlobalScope) [:0]const u8 {
@@ -66,8 +65,7 @@ pub const GlobalScope = union(enum) {
         switch (self) {
             .frame => |frame| frame.js = ctx,
             .worker => |worker| worker.js = ctx,
-            // The bare context is fixed; nothing to re-point.
-            .bare => {},
+            .bare => {}, // no separate storage to re-point
         }
     }
 };
@@ -222,7 +220,7 @@ pub fn deinit(self: *Context) void {
     }
 
     switch (self.global) {
-        // The bare agent context owns a standalone origin (no page to release to).
+        // Standalone origin; no page to release it back to.
         .bare => self.origin.deinit(env.app),
         else => self.page.releaseOrigin(self.origin),
     }

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -42,11 +42,15 @@ const Context = @This();
 pub const GlobalScope = union(enum) {
     frame: *Frame,
     worker: *WorkerGlobalScope,
+    // The agent script runtime: a page-less, WebAPI-less context. Carries a
+    // back-pointer to its own Context (frames/workers store theirs in `.js`).
+    bare: *Context,
 
     pub fn base(self: GlobalScope) [:0]const u8 {
         return switch (self) {
             .frame => |frame| frame.base(),
             .worker => |worker| worker.base(),
+            .bare => "about:blank",
         };
     }
 
@@ -54,6 +58,7 @@ pub const GlobalScope = union(enum) {
         return switch (self) {
             .frame => |frame| frame.js,
             .worker => |worker| worker.js,
+            .bare => |ctx| ctx,
         };
     }
 
@@ -61,6 +66,8 @@ pub const GlobalScope = union(enum) {
         switch (self) {
             .frame => |frame| frame.js = ctx,
             .worker => |worker| worker.js = ctx,
+            // The bare context is fixed; nothing to re-point.
+            .bare => {},
         }
     }
 };
@@ -214,7 +221,11 @@ pub fn deinit(self: *Context) void {
         v8.v8__Global__Reset(global);
     }
 
-    self.page.releaseOrigin(self.origin);
+    switch (self.global) {
+        // The bare agent context owns a standalone origin (no page to release to).
+        .bare => self.origin.deinit(env.app),
+        else => self.page.releaseOrigin(self.origin),
+    }
 
     // Clear the embedder data so that if V8 keeps this context alive
     // (because objects created in it are still referenced), we don't
@@ -306,6 +317,7 @@ pub fn getIncumbent(self: *Context) *Frame {
     return switch (ctx.global) {
         .frame => |frame| frame,
         .worker => unreachable,
+        .bare => unreachable,
     };
 }
 
@@ -1036,6 +1048,7 @@ pub fn queueMutationDelivery(self: *Context) !void {
             switch (ctx.global) {
                 .frame => |frame| frame.deliverMutations(),
                 .worker => unreachable,
+                .bare => unreachable,
             }
         }
     }.run);
@@ -1047,6 +1060,7 @@ pub fn queueIntersectionChecks(self: *Context) !void {
             switch (ctx.global) {
                 .frame => |frame| frame.performScheduledIntersectionChecks(),
                 .worker => unreachable,
+                .bare => unreachable,
             }
         }
     }.run);
@@ -1058,6 +1072,7 @@ pub fn queueIntersectionDelivery(self: *Context) !void {
             switch (ctx.global) {
                 .frame => |frame| frame.deliverIntersections(),
                 .worker => unreachable,
+                .bare => unreachable,
             }
         }
     }.run);
@@ -1069,6 +1084,7 @@ pub fn queueSlotchangeDelivery(self: *Context) !void {
             switch (ctx.global) {
                 .frame => |frame| frame.deliverSlotchangeEvents(),
                 .worker => unreachable,
+                .bare => unreachable,
             }
         }
     }.run);
@@ -1080,6 +1096,7 @@ pub fn queueCustomElementBackupDrain(self: *Context) !void {
             switch (ctx.global) {
                 .frame => |frame| frame._ce_reactions.drainBackup(frame),
                 .worker => unreachable,
+                .bare => unreachable,
             }
         }
     }.run);

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 const builtin = @import("builtin");
 
 const js = @import("js.zig");
+const Origin = @import("Origin.zig");
 const bridge = @import("bridge.zig");
 const Context = @import("Context.zig");
 const Isolate = @import("Isolate.zig");
@@ -236,6 +237,72 @@ pub fn createContext(self: *Env, frame: *Frame, params: ContextParams) !*Context
 
 pub fn createWorkerContext(self: *Env, worker: *WorkerGlobalScope, params: ContextParams) !*Context {
     return self._createContext(worker, params);
+}
+
+/// A page-less, WebAPI-less `Context` for the agent script runtime. Only realm
+/// fields are populated; the page-coupled ones (`page`/`script_manager`/
+/// `execution`) are left `undefined` and never read, because the agent installs
+/// no WebAPI functions — every WebAPI path's `GlobalScope` switch has a
+/// `.bare => unreachable` arm. Microtasks drain via `performIsolateMicrotasks`
+/// (the bare context uses the isolate-default queue, not a per-context one).
+pub fn createAgentContext(self: *Env, call_arena: Allocator) !*Context {
+    const context_arena = try self.app.arena_pool.acquire(.medium, "AgentContext");
+    errdefer self.app.arena_pool.release(context_arena);
+
+    const isolate = self.isolate;
+    var hs: js.HandleScope = undefined;
+    hs.init(isolate);
+    defer hs.deinit();
+
+    // `Context.deinit` deletes `microtask_queue`, so it must not be the shared
+    // isolate-default queue. This dedicated one stays unused (a bare context
+    // created via `v8__Context__New` can't be handed an explicit queue).
+    const microtask_queue = v8.v8__MicrotaskQueue__New(isolate.handle, v8.kExplicit).?;
+    errdefer v8.v8__MicrotaskQueue__DELETE(microtask_queue);
+
+    // Bare v8 context: no snapshot, no WebAPI globals.
+    const v8_context = v8.v8__Context__New(isolate.handle, null, null).?;
+    var context_global: v8.Global = undefined;
+    v8.v8__Global__New(isolate.handle, v8_context, &context_global);
+
+    const context_id = self.context_id;
+    self.context_id = context_id + 1;
+
+    const origin = try Origin.init(self.app, isolate, "agent");
+    errdefer origin.deinit(self.app);
+
+    const identity = try context_arena.create(js.Identity);
+    identity.* = .{};
+
+    if (self.contexts.items.len >= MAX_CONTEXTS) {
+        return error.TooManyContexts;
+    }
+
+    const context = try context_arena.create(Context);
+    context.* = .{
+        .env = self,
+        .global = .{ .bare = context },
+        .origin = origin,
+        .id = context_id,
+        .page = undefined,
+        .isolate = isolate,
+        .arena = context_arena,
+        .handle = context_global,
+        .templates = self.templates,
+        .call_arena = call_arena,
+        .microtask_queue = microtask_queue,
+        .script_manager = undefined,
+        .scheduler = .init(context_arena),
+        .identity = identity,
+        .identity_arena = context_arena,
+        .execution = undefined,
+    };
+
+    // Caller and the promise-reject callback recover the Context from slot 1.
+    v8.v8__Context__SetAlignedPointerInEmbedderData(v8_context, 1, @ptrCast(context));
+
+    try self.contexts.append(self.allocator, context);
+    return context;
 }
 
 fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context {
@@ -584,6 +651,9 @@ fn promiseRejectCallback(message_handle: v8.PromiseRejectMessage) callconv(.c) v
 
     const no_handler = promise_event == v8.kPromiseRejectWithNoHandler;
     switch (ctx.global) {
+        // Agent scripts surface rejections via runSource's own state check; no
+        // window/worker to dispatch to.
+        .bare => {},
         .frame => |frame| {
             frame.window.unhandledPromiseRejection(no_handler, .{
                 .local = &local,

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -239,12 +239,12 @@ pub fn createWorkerContext(self: *Env, worker: *WorkerGlobalScope, params: Conte
     return self._createContext(worker, params);
 }
 
-/// A page-less, WebAPI-less `Context` for the agent script runtime. Only realm
-/// fields are populated; the page-coupled ones (`page`/`script_manager`/
-/// `execution`) are left `undefined` and never read, because the agent installs
-/// no WebAPI functions — every WebAPI path's `GlobalScope` switch has a
-/// `.bare => unreachable` arm. Microtasks drain via `performIsolateMicrotasks`
-/// (the bare context uses the isolate-default queue, not a per-context one).
+/// A page-less, WebAPI-less `Context` for the agent script runtime. The
+/// page-coupled fields (`page`/`script_manager`/`execution`) are left `undefined`
+/// and never read — the agent installs no WebAPI functions, so every WebAPI
+/// path's `GlobalScope` switch has a `.bare => unreachable` arm. Microtasks drain
+/// via `performIsolateMicrotasks` (the bare context uses the isolate-default
+/// queue, not a per-context one).
 pub fn createAgentContext(self: *Env, call_arena: Allocator) !*Context {
     const context_arena = try self.app.arena_pool.acquire(.medium, "AgentContext");
     errdefer self.app.arena_pool.release(context_arena);
@@ -260,7 +260,6 @@ pub fn createAgentContext(self: *Env, call_arena: Allocator) !*Context {
     const microtask_queue = v8.v8__MicrotaskQueue__New(isolate.handle, v8.kExplicit).?;
     errdefer v8.v8__MicrotaskQueue__DELETE(microtask_queue);
 
-    // Bare v8 context: no snapshot, no WebAPI globals.
     const v8_context = v8.v8__Context__New(isolate.handle, null, null).?;
     var context_global: v8.Global = undefined;
     v8.v8__Global__New(isolate.handle, v8_context, &context_global);

--- a/src/browser/js/Execution.zig
+++ b/src/browser/js/Execution.zig
@@ -85,18 +85,21 @@ pub fn releaseArena(self: *const Execution, allocator: Allocator) void {
 
 pub fn headersForRequest(self: *const Execution, headers: *HttpClient.Headers) !void {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.headersForRequest(headers),
     };
 }
 
 pub fn isSameOrigin(self: *const Execution, url: [:0]const u8) bool {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.isSameOrigin(url),
     };
 }
 
 pub fn makeRequest(self: *const Execution, req: HttpClient.Request) !void {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.makeRequest(req),
     };
 }
@@ -107,6 +110,7 @@ pub fn makeRequest(self: *const Execution, req: HttpClient.Request) !void {
 // WebSocket.init appending to `.websockets`.
 pub fn httpOwner(self: *const Execution) *HttpClient.Owner {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| &g._http_owner,
     };
 }
@@ -119,30 +123,35 @@ pub fn dispatch(
     comptime opts: EventManagerBase.DispatchDirectOptions,
 ) !void {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.dispatch(target, event, handler, opts),
     };
 }
 
 pub fn hasDirectListeners(self: *const Execution, target: *EventTarget, typ: []const u8, handler: anytype) bool {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.hasDirectListeners(target, typ, handler),
     };
 }
 
 pub fn performance(self: *const Execution) *Performance {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g.performance(),
     };
 }
 
 pub fn frameId(self: *const Execution) u32 {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g._frame_id,
     };
 }
 
 pub fn loaderId(self: *const Execution) u32 {
     return switch (self.js.global) {
+        .bare => unreachable,
         inline else => |g| g._loader_id,
     };
 }

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -36,6 +36,13 @@ pub const Result = struct {
     exception: []const u8,
 };
 
+pub fn toValue(self: *const Function) js.Value {
+    return .{
+        .local = self.local,
+        .handle = @ptrCast(self.handle),
+    };
+}
+
 pub fn withThis(self: *const Function, value: anytype) !Function {
     const local = self.local;
     const this_obj = if (@TypeOf(value) == js.Object)

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -109,6 +109,27 @@ pub fn newCallback(
     return .{ .local = self, .handle = handle };
 }
 
+/// The argument bundle passed to a `RawCallback` by the engine; decode it with
+/// `Caller.FunctionCallbackInfo`.
+pub const RawCallbackInfo = v8.FunctionCallbackInfo;
+
+/// Signature of a raw C callback installed via `newRawCallback`.
+pub const RawCallback = *const fn (?*const RawCallbackInfo) callconv(.c) void;
+
+/// Install a native function backed by a raw C callback — for callers (e.g. the
+/// agent runtime) that decode args themselves via `Caller.FunctionCallbackInfo`
+/// instead of the typed bridge dispatch. `data` becomes the function's External.
+pub fn newRawCallback(self: *const Local, callback: RawCallback, data: *anyopaque) js.Function {
+    const external = self.isolate.createExternal(data);
+    const handle = v8.v8__Function__New__DEFAULT2(self.handle, callback, @ptrCast(external)).?;
+    return .{ .local = self, .handle = handle };
+}
+
+/// The context's global object, as a `js.Object` (e.g. to install globals on).
+pub fn globalObject(self: *const Local) js.Object {
+    return .{ .local = self, .handle = v8.v8__Context__Global(self.handle).? };
+}
+
 pub fn runMacrotasks(self: *const Local) void {
     const env = self.ctx.env;
     env.pumpMessageLoop();

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -125,7 +125,7 @@ pub fn newRawCallback(self: *const Local, callback: RawCallback, data: *anyopaqu
     return .{ .local = self, .handle = handle };
 }
 
-/// The context's global object, as a `js.Object` (e.g. to install globals on).
+/// The context's global object, as a `js.Object`.
 pub fn globalObject(self: *const Local) js.Object {
     return .{ .local = self, .handle = v8.v8__Context__Global(self.handle).? };
 }

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -386,6 +386,7 @@ pub fn zigValueToJs(self: *const Local, value: anytype, comptime opts: CallOpts)
                 if (@typeInfo(ptr.child) == .@"struct" and @hasDecl(ptr.child, "runtimeGenericWrap")) {
                     const frame = switch (self.ctx.global) {
                         .frame => |f| f,
+                        .bare => unreachable,
                         .worker => {
                             // No Worker-related API currently uses this, so haven't
                             // added support for it
@@ -473,6 +474,7 @@ pub fn zigValueToJs(self: *const Local, value: anytype, comptime opts: CallOpts)
 
             if (@hasDecl(T, "runtimeGenericWrap")) {
                 const frame = switch (self.ctx.global) {
+                    .bare => unreachable,
                     .frame => |f| f,
                     .worker => {
                         // No Worker-related API currently uses this, so haven't

--- a/src/browser/js/Object.zig
+++ b/src/browser/js/Object.zig
@@ -102,6 +102,16 @@ pub fn persist(self: Object) !Global {
     return .{ .handle = global };
 }
 
+/// Like `persist`, but the returned `Global` is owned by the caller (not tracked
+/// by the context) and must be `deinit`ed. For objects with a lifetime shorter
+/// than the context, or contexts (e.g. the bare agent context) that have no
+/// page-scoped global tracking.
+pub fn persistOwned(self: Object) Global {
+    var global: v8.Global = undefined;
+    v8.v8__Global__New(self.local.isolate.handle, self.handle, &global);
+    return .{ .handle = global };
+}
+
 pub fn getFunction(self: Object, name: []const u8) !?js.Function {
     if (self.isNullOrUndefined()) {
         return null;

--- a/src/browser/js/PromiseResolver.zig
+++ b/src/browser/js/PromiseResolver.zig
@@ -125,6 +125,15 @@ pub fn persist(self: PromiseResolver) !Global {
     return .{ .handle = global };
 }
 
+/// Like `persist`, but the returned `Global` is owned by the caller (not tracked
+/// by the context) and must be `deinit`ed. For resolvers with a lifetime shorter
+/// than the context that are settled and freed individually.
+pub fn persistOwned(self: PromiseResolver) Global {
+    var global: v8.Global = undefined;
+    v8.v8__Global__New(self.local.isolate.handle, self.handle, &global);
+    return .{ .handle = global };
+}
+
 pub const Global = struct {
     handle: v8.Global,
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -137,6 +137,7 @@ pub const Constructor = struct {
                     const ce_frame: ?*Frame = switch (caller.local.ctx.global) {
                         .frame => |frame| frame,
                         .worker => null,
+                        .bare => null,
                     };
                     const ce_checkpoint: usize = if (ce_frame) |frame| frame._ce_reactions.push() else 0;
                     defer if (ce_frame) |frame| frame._ce_reactions.popAndInvoke(ce_checkpoint, frame);
@@ -348,6 +349,7 @@ pub const NamedIndexed = struct {
                 const ce_frame: ?*Frame = if (comptime opts.ce_reactions) switch (caller.local.ctx.global) {
                     .frame => |frame| frame,
                     .worker => null,
+                    .bare => null,
                 } else null;
                 var ce_checkpoint: usize = undefined;
                 if (comptime opts.ce_reactions) {
@@ -376,6 +378,7 @@ pub const NamedIndexed = struct {
                 const ce_frame: ?*Frame = if (comptime opts.ce_reactions) switch (caller.local.ctx.global) {
                     .frame => |frame| frame,
                     .worker => null,
+                    .bare => null,
                 } else null;
                 var ce_checkpoint: usize = undefined;
                 if (comptime opts.ce_reactions) {
@@ -515,6 +518,7 @@ pub fn unknownWindowPropertyCallback(c_name: ?*const v8.Name, handle: ?*const v8
             }
         },
         .worker => {}, // no global lookup in a worker
+        .bare => {}, // nor in the agent runtime
     }
 
     if (comptime IS_DEBUG) {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -177,9 +177,9 @@ pub const save_synthesis_prompt =
 /// script. The agent's `/save` covers all of this via its skill doc instead.
 pub const save_script_rules =
     \\Script rules:
-    \\- The builtins are synchronous and the file runs as a classic script:
-    \\  `const data = extract({...})` — never async/await/.then. Top-level
-    \\  `await` is a SyntaxError; top-level `return` is illegal.
+    \\- The file runs as an async script, so top-level `await` is allowed.
+    \\  `goto(url)` is async — always `await goto(...)`. Every other builtin
+    \\  is synchronous: `const data = extract({...})`, never `await extract`.
     \\- Read pages with extract(schema); all processing of the returned
     \\  strings (trim, split, parse, merge, loops, cross-page aggregation)
     \\  is plain top-level JavaScript in the script context. evaluate(...)
@@ -187,9 +187,10 @@ pub const save_script_rules =
     \\  never a querySelector-and-parse block. It cannot see script
     \\  variables (interpolate values into its string), and page state is
     \\  wiped by every goto/reload while script variables persist.
-    \\- The last top-level expression is the script's output, printed
-    \\  automatically (objects/arrays as JSON). End with the bare result —
-    \\  `extract({...});` or `results;` — no console.log or JSON.stringify.
+    \\- `return <value>` is the script's output, printed automatically
+    \\  (objects/arrays as JSON). End with `return extract({...});` or
+    \\  `return results;` — a bare trailing expression is not printed, and
+    \\  neither is console.log or JSON.stringify.
     \\- Modern, readable JS: `const`/`let`, `for (const x of xs)`, template
     \\  literals, destructuring, 2-space indent.
 ;
@@ -251,6 +252,14 @@ pub const Tool = enum {
             .goto, .evaluate, .extract, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked => true,
             .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
+    }
+
+    /// Tool exposed to scripts as an async (Promise-returning) builtin, so the
+    /// recorder emits `await tool(...)`. Only `goto` navigates and must be
+    /// awaited before the next primitive reads the page; everything else is
+    /// synchronous.
+    pub fn isAsync(self: Tool) bool {
+        return self == .goto;
     }
 
     /// Tool requires a target element (selector or backendNodeId) at
@@ -1791,16 +1800,25 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
 /// network from ever fully idling, so it just rides the timeout.
 const default_nav_wait: lp.Config.WaitUntil = .load;
 
-fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32) ToolError!lp.Session.Runner.WaitResult {
+/// Kick off a root navigation without waiting for it to finish. Returns the
+/// new frame so a caller can match its `_frame_id` against a later load
+/// notification. `performGoto` is the blocking counterpart; the async `goto`
+/// script primitive drives the wait itself off this same setup.
+pub fn startGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8) ToolError!*lp.Frame {
     if (session.hasPage()) {
         registry.reset();
         session.removePage();
     }
-    const page = session.createPage() catch return ToolError.NavigationFailed;
-    _ = page.navigate(url, .{
+    const frame = session.createPage() catch return ToolError.NavigationFailed;
+    _ = frame.navigate(url, .{
         .reason = .address_bar,
         .kind = .{ .push = null },
     }) catch return ToolError.NavigationFailed;
+    return frame;
+}
+
+fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32) ToolError!lp.Session.Runner.WaitResult {
+    _ = try startGoto(session, registry, url);
 
     var runner = session.runner(.{}) catch return ToolError.NavigationFailed;
     const result = runner.waitResult(.{

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -156,14 +156,15 @@ pub const save_synthesis_prompt =
     \\- Reasoning you did between tool calls — comparing, filtering, picking,
     \\  aggregating across pages — becomes plain top-level JavaScript, so the
     \\  script reaches the result without you.
-    \\- `goto(url)` resolves a page object; every other primitive is a method on
-    \\  it (`const page = await goto(url); page.extract({...})`). Read pages with
+    \\- `new Page()` makes a page and `await page.goto(url)` navigates it; every
+    \\  other primitive is a method on the page (`const page = new Page();
+    \\  await page.goto(url); page.extract({...})`). Read pages with
     \\  page.extract(schema): CSS selectors lift text and attributes as strings,
     \\  and every trim/split/regex/parse/merge on those strings is top-level
     \\  JavaScript. Do NOT write a page.evaluate(...) that querySelects the page
     \\  and massages the result — that is page.extract + top-level JS.
     \\  page.evaluate is ONLY for what must execute inside the page and no builtin
-    \\  can do. Top-level variables also persist across goto/reload; everything in
+    \\  can do. Top-level variables also persist across navigations; everything in
     \\  the page context is wiped.
     \\Stay faithful to the calls that worked: same arguments and options each
     \\one actually used. Do NOT add a `timeout` (or any option) the session
@@ -180,14 +181,16 @@ pub const save_synthesis_prompt =
 pub const save_script_rules =
     \\Script rules:
     \\- The file runs as an async script, so top-level `await` is allowed.
-    \\  `goto(url)` is the only global and is async — always `await goto(...)`; it
-    \\  resolves a page object. Every other builtin is a synchronous method on
-    \\  that object: `const page = await goto(url); const data = page.extract({...})`,
-    \\  never `await page.extract`.
-    \\- Re-navigating replaces the page: `page = await goto(url2)` and rebind; the
-    \\  old object is then stale. To fetch in parallel,
-    \\  `const [a, b] = await Promise.all([goto(x), goto(y)])` — these coexist;
-    \\  read each through its own object: `a.extract(schema)`, `b.click(sel)`.
+    \\  Make a page with `new Page()`; `page.goto(url)` is async — always
+    \\  `await page.goto(...)`. Every other builtin is a synchronous method on
+    \\  the page: `const page = new Page(); await page.goto(url);
+    \\  const data = page.extract({...})`, never `await page.extract`.
+    \\- Re-navigating reuses the same page object: `await page.goto(url2)` keeps
+    \\  `page` valid. To fetch in parallel, make several pages and navigate them
+    \\  together: `const a = new Page(), b = new Page();
+    \\  await Promise.all([a.goto(x), b.goto(y)])` — these coexist; read each
+    \\  through its own object: `a.extract(schema)`, `b.click(sel)`. Free a page
+    \\  you no longer need with `page.close()`.
     \\- Read pages with page.extract(schema); all processing of the returned
     \\  strings (trim, split, parse, merge, loops, cross-page aggregation)
     \\  is plain top-level JavaScript in the script context. page.evaluate(...)

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -156,17 +156,19 @@ pub const save_synthesis_prompt =
     \\- Reasoning you did between tool calls — comparing, filtering, picking,
     \\  aggregating across pages — becomes plain top-level JavaScript, so the
     \\  script reaches the result without you.
-    \\- Read pages with extract(schema): CSS selectors lift text and
-    \\  attributes as strings, and every trim/split/regex/parse/merge on
-    \\  those strings is top-level JavaScript. Do NOT write an evaluate(...)
-    \\  that querySelects the page and massages the result — that is
-    \\  extract + top-level JS. evaluate is ONLY for what must execute
-    \\  inside the page and no builtin can do. Top-level variables also
-    \\  persist across goto/reload; everything in the page context is wiped.
+    \\- `goto(url)` resolves a page object; every other primitive is a method on
+    \\  it (`const page = await goto(url); page.extract({...})`). Read pages with
+    \\  page.extract(schema): CSS selectors lift text and attributes as strings,
+    \\  and every trim/split/regex/parse/merge on those strings is top-level
+    \\  JavaScript. Do NOT write a page.evaluate(...) that querySelects the page
+    \\  and massages the result — that is page.extract + top-level JS.
+    \\  page.evaluate is ONLY for what must execute inside the page and no builtin
+    \\  can do. Top-level variables also persist across goto/reload; everything in
+    \\  the page context is wiped.
     \\Stay faithful to the calls that worked: same arguments and options each
     \\one actually used. Do NOT add a `timeout` (or any option) the session
     \\didn't use. Never round-trip a result through `lp.*`, and never append
-    \\no-op extract(...) probes or `evaluate("return lp....")` tails to
+    \\no-op page.extract(...) probes or `page.evaluate("return lp....")` tails to
     \\surface output.
     \\Output ONLY JavaScript source — no markdown fences, no commentary.
 ;
@@ -178,21 +180,23 @@ pub const save_synthesis_prompt =
 pub const save_script_rules =
     \\Script rules:
     \\- The file runs as an async script, so top-level `await` is allowed.
-    \\  `goto(url)` is async — always `await goto(...)`; it resolves to a page
-    \\  handle. Every other builtin is synchronous: `const data = extract({...})`,
-    \\  never `await extract`.
-    \\- One page needs no handle (tools act on the latest goto). To fetch in
-    \\  parallel, `await Promise.all([goto(a), goto(b)])` and pass each handle
-    \\  to read it: `extract(schema, a)` — the handle is the optional last arg.
-    \\- Read pages with extract(schema); all processing of the returned
+    \\  `goto(url)` is the only global and is async — always `await goto(...)`; it
+    \\  resolves a page object. Every other builtin is a synchronous method on
+    \\  that object: `const page = await goto(url); const data = page.extract({...})`,
+    \\  never `await page.extract`.
+    \\- Re-navigating replaces the page: `page = await goto(url2)` and rebind; the
+    \\  old object is then stale. To fetch in parallel,
+    \\  `const [a, b] = await Promise.all([goto(x), goto(y)])` — these coexist;
+    \\  read each through its own object: `a.extract(schema)`, `b.click(sel)`.
+    \\- Read pages with page.extract(schema); all processing of the returned
     \\  strings (trim, split, parse, merge, loops, cross-page aggregation)
-    \\  is plain top-level JavaScript in the script context. evaluate(...)
+    \\  is plain top-level JavaScript in the script context. page.evaluate(...)
     \\  is ONLY for JS that must run inside the page and no builtin covers —
     \\  never a querySelector-and-parse block. It cannot see script
     \\  variables (interpolate values into its string), and page state is
     \\  wiped by every goto/reload while script variables persist.
     \\- `return <value>` is the script's output, printed automatically
-    \\  (objects/arrays as JSON). End with `return extract({...});` or
+    \\  (objects/arrays as JSON). End with `return page.extract({...});` or
     \\  `return results;` — a bare trailing expression is not printed, and
     \\  neither is console.log or JSON.stringify.
     \\- Modern, readable JS: `const`/`let`, `for (const x of xs)`, template
@@ -262,6 +266,19 @@ pub const Tool = enum {
     /// `await tool(...)` — only `goto`, which must finish before the next read.
     pub fn isAsync(self: Tool) bool {
         return self == .goto;
+    }
+
+    /// A read tool that navigates when handed a `url` (via `ensurePage`). The
+    /// read itself isn't recorded, but its navigation is the replayable part, so
+    /// the recorder captures it as a `goto`. Excludes `goto` (the navigation
+    /// itself), `evaluate` (recorded, carries its own `url`), `search` (its goto
+    /// targets a derived engine URL, not a user one), and `getCookies` (whose
+    /// `url` filters, not navigates).
+    pub fn navigatesToUrl(self: Tool) bool {
+        return switch (self) {
+            .markdown, .html, .links, .tree, .interactiveElements, .structuredData, .detectForms => true,
+            .goto, .search, .evaluate, .extract, .nodeDetails, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+        };
     }
 
     /// Tool requires a target element (selector or backendNodeId) at

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -178,8 +178,12 @@ pub const save_synthesis_prompt =
 pub const save_script_rules =
     \\Script rules:
     \\- The file runs as an async script, so top-level `await` is allowed.
-    \\  `goto(url)` is async — always `await goto(...)`. Every other builtin
-    \\  is synchronous: `const data = extract({...})`, never `await extract`.
+    \\  `goto(url)` is async — always `await goto(...)`; it resolves to a page
+    \\  handle. Every other builtin is synchronous: `const data = extract({...})`,
+    \\  never `await extract`.
+    \\- One page needs no handle (tools act on the latest goto). To fetch in
+    \\  parallel, `await Promise.all([goto(a), goto(b)])` and pass each handle
+    \\  to read it: `extract(schema, a)` — the handle is the optional last arg.
     \\- Read pages with extract(schema); all processing of the returned
     \\  strings (trim, split, parse, merge, loops, cross-page aggregation)
     \\  is plain top-level JavaScript in the script context. evaluate(...)
@@ -1772,7 +1776,7 @@ fn execGetCookies(arena: std.mem.Allocator, session: *lp.Session, arguments: ?st
 }
 
 fn requireFrame(session: *lp.Session) ToolError!*lp.Frame {
-    return session.currentFrame() orelse ToolError.FrameNotLoaded;
+    return session.toolFrame() orelse ToolError.FrameNotLoaded;
 }
 
 fn renderJson(arena: std.mem.Allocator, value: anytype) ToolError![]const u8 {
@@ -1788,7 +1792,7 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
         }
         _ = try performGoto(session, registry, u, timeout);
     }
-    return session.currentFrame() orelse ToolError.FrameNotLoaded;
+    return session.toolFrame() orelse ToolError.FrameNotLoaded;
 }
 
 /// Navigations wait only for `load` — the fast snapshot. Content rendered by
@@ -1811,6 +1815,17 @@ pub fn startGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]con
         .kind = .{ .push = null },
     }) catch return ToolError.NavigationFailed;
     return frame;
+}
+
+/// `fork` (another goto in flight) opens a popup so navigations coexist;
+/// otherwise replaces the single page, keeping sequential gotos bounded.
+pub fn openGotoFrame(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, fork: bool) ToolError!*lp.Frame {
+    if (fork) {
+        if (session.currentFrame()) |root| {
+            return root.openPopup(.{ .url = url, .name = "", .opener = null }) catch ToolError.NavigationFailed;
+        }
+    }
+    return startGoto(session, registry, url);
 }
 
 fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32) ToolError!lp.Session.Runner.WaitResult {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -268,12 +268,11 @@ pub const Tool = enum {
         return self == .goto;
     }
 
-    /// A read tool that navigates when handed a `url` (via `ensurePage`). The
-    /// read itself isn't recorded, but its navigation is the replayable part, so
-    /// the recorder captures it as a `goto`. Excludes `goto` (the navigation
-    /// itself), `evaluate` (recorded, carries its own `url`), `search` (its goto
-    /// targets a derived engine URL, not a user one), and `getCookies` (whose
-    /// `url` filters, not navigates).
+    /// A read tool that navigates when handed a `url` (via `ensurePage`), so the
+    /// recorder can capture that navigation as a `goto`. Excludes `goto` (the
+    /// navigation itself), `evaluate` (recorded, carries its own `url`), `search`
+    /// (navigates to a derived engine URL, not a user one), and `getCookies`
+    /// (`url` filters, not navigates).
     pub fn navigatesToUrl(self: Tool) bool {
         return switch (self) {
             .markdown, .html, .links, .tree, .interactiveElements, .structuredData, .detectForms => true,

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -166,6 +166,10 @@ pub const save_synthesis_prompt =
     \\  page.evaluate is ONLY for what must execute inside the page and no builtin
     \\  can do. Top-level variables also persist across navigations; everything in
     \\  the page context is wiped.
+    \\- For list-to-detail, fetch independent detail pages in parallel — one
+    \\  `new Page()` per item gathered with `Promise.all`, `page.close()` each
+    \\  when done — rather than a serial goto loop. Reuse one sequential `page`
+    \\  only when steps depend on each other or share login state.
     \\Stay faithful to the calls that worked: same arguments and options each
     \\one actually used. Do NOT add a `timeout` (or any option) the session
     \\didn't use. Never round-trip a result through `lp.*`, and never append

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -254,10 +254,8 @@ pub const Tool = enum {
         };
     }
 
-    /// Tool exposed to scripts as an async (Promise-returning) builtin, so the
-    /// recorder emits `await tool(...)`. Only `goto` navigates and must be
-    /// awaited before the next primitive reads the page; everything else is
-    /// synchronous.
+    /// Async (Promise-returning) script builtin, so the recorder emits
+    /// `await tool(...)` — only `goto`, which must finish before the next read.
     pub fn isAsync(self: Tool) bool {
         return self == .goto;
     }
@@ -1800,10 +1798,8 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
 /// network from ever fully idling, so it just rides the timeout.
 const default_nav_wait: lp.Config.WaitUntil = .load;
 
-/// Kick off a root navigation without waiting for it to finish. Returns the
-/// new frame so a caller can match its `_frame_id` against a later load
-/// notification. `performGoto` is the blocking counterpart; the async `goto`
-/// script primitive drives the wait itself off this same setup.
+/// Kick off a root navigation without waiting; returns the new frame. The
+/// blocking `performGoto` and the async `goto` primitive share this setup.
 pub fn startGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8) ToolError!*lp.Frame {
     if (session.hasPage()) {
         registry.reset();

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -131,6 +131,7 @@ fn dispatchAbortEvent(self: *AbortSignal, exec: *const Execution) !void {
     const target = self.asEventTarget();
     const on_abort = self._on_abort;
     switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| {
             if (g._event_manager.hasDirectListeners(target, "abort", on_abort)) {
                 const event = try Event.initTrusted(comptime .wrap("abort"), .{}, g._page);

--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -341,6 +341,7 @@ pub fn composedPath(self: *Event, exec: *Execution) ![]const *EventTarget {
         if (root_is_document) {
             if (path_len < path_buffer.len) {
                 switch (exec.js.global) {
+                    .bare => unreachable,
                     .worker => {},
                     .frame => |frame| {
                         path_buffer[path_len] = frame.window.asEventTarget();

--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -66,6 +66,7 @@ pub fn dispatchEvent(self: *EventTarget, event: *Event, exec: *js.Execution) !bo
     event._is_trusted = false;
 
     switch (exec.js.global) {
+        .bare => unreachable,
         .frame => |frame| {
             event.acquireRef();
             defer _ = event.releaseRef(frame._page);
@@ -102,6 +103,7 @@ pub fn addEventListener(self: *EventTarget, typ: []const u8, callback_: ?EventLi
     };
 
     switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| _ = try g._event_manager.register(self, typ, em_callback, options),
     }
 }
@@ -138,6 +140,7 @@ pub fn removeEventListener(self: *EventTarget, typ: []const u8, callback_: ?Even
     };
 
     switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| g._event_manager.remove(self, typ, em_callback, use_capture),
     }
 }

--- a/src/browser/webapi/ModelContext.zig
+++ b/src/browser/webapi/ModelContext.zig
@@ -122,6 +122,7 @@ pub fn registerTool(
     const event: Notification.ModelContextToolEvent = .{ .exec = exec, .tool = entry };
 
     const session = switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| g._session,
     };
 
@@ -148,6 +149,7 @@ pub fn findTool(self: *ModelContext, name: []const u8) ?*Tool {
 /// signals fired (which is the common case).
 fn markAborted(self: *ModelContext, tool: *Tool, exec: *const Execution) !void {
     const session = switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| g._session,
     };
 

--- a/src/browser/webapi/Timers.zig
+++ b/src/browser/webapi/Timers.zig
@@ -196,6 +196,7 @@ const ScheduleCallback = struct {
                 // requestAnimationFrame is window-only; if a worker ever
                 // schedules with this mode it's a programming error.
                 const window = switch (self.exec.js.global) {
+                    .bare => unreachable,
                     .frame => |frame| frame.window,
                     .worker => unreachable,
                 };

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -332,6 +332,7 @@ pub fn createObjectURL(blob: *Blob, exec: *const Execution) ![]const u8 {
     @import("../../id.zig").uuidv4(&uuid_buf);
 
     switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| {
             const blob_url = try std.fmt.allocPrint(
                 g.arena,
@@ -352,6 +353,7 @@ pub fn revokeObjectURL(url: []const u8, exec: *const Execution) void {
     }
 
     switch (exec.js.global) {
+        .bare => unreachable,
         inline else => |g| {
             if (g._blob_urls.fetchRemove(url)) |entry| {
                 entry.value.releaseRef(g._page);

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -573,54 +573,12 @@ pub fn close(self: *Window) void {
         return;
     }
 
-    // Per spec, close() is only honored on script-opened windows. That
-    // maps exactly to membership in page.popups.
+    // Per spec, close() is only honored on script-opened windows — exactly the
+    // popup case `Session.closePopup` tears down (it no-ops on the root frame).
     const frame = self._frame;
-    const page = frame._page;
-
-    var popup_index: usize = 0;
-    while (popup_index < page.popups.items.len) : (popup_index += 1) {
-        if (page.popups.items[popup_index] == frame) {
-            break;
-        }
-    } else return;
-
-    self._closed = true;
-
-    // Any live Window holding us as its opener must drop the reference —
-    // our Frame is about to go away, and a stale _frame deref on their
-    // side would crash.
-    for (page.popups.items) |popup| {
-        if (popup.window._opener == self) {
-            popup.window._opener = null;
-        }
+    if (frame._page.session.closePopup(frame)) {
+        self._closed = true;
     }
-    if (page.frame.window._opener == self) {
-        page.frame.window._opener = null;
-    }
-
-    _ = page.popups.swapRemove(popup_index);
-
-    // Drop any pending queued navigation for this frame. Frame.deinit will
-    // release the QueuedNavigation arena, but the entry in page.queued_navigation
-    // would otherwise have processQueuedNavigation re-deinit the popup.
-    if (frame._queued_navigation != null) {
-        for (page.queued_navigation.items, 0..) |f, i| {
-            if (f == frame) {
-                _ = page.queued_navigation.swapRemove(i);
-                break;
-            }
-        }
-    }
-
-    frame.js.scheduler.reset();
-
-    // We can't tear the Frame down here — close() is invoked from JS still
-    // running on top of this Frame's V8 context, often deep inside a script
-    // eval whose parser is still holding the Frame. Destroying the context
-    // now leaves dangling pointers in the unwinding script eval (load event
-    // dispatch, runMacrotasks, etc.). Defer to Page.deinit instead.
-    page.session.queueFrameDestruction(frame);
 }
 
 pub fn postMessage(self: *Window, message: js.Value.Temp, target_origin: ?[]const u8, transfer: ?[]const *MessagePort, frame: *Frame) !void {

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -85,6 +85,7 @@ pub fn init(form_: ?*Form, submitter: ?*Element, exec: *const Execution) !*FormD
     const form = form_ orelse return form_data;
 
     const frame = switch (exec.js.global) {
+        .bare => unreachable,
         .frame => |f| f,
         .worker => lp.assert(false, "FormData worker form", .{}),
     };

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -396,6 +396,7 @@ pub fn getResponse(self: *XMLHttpRequest, exec: *const Execution) !?Response {
             // otherwise. We only have an HTML parser today, so the body is
             // always parsed as HTML regardless of the override.
             switch (exec.js.global) {
+                .bare => unreachable,
                 .frame => |frame| {
                     const document = try exec._factory.node(Node.Document{ ._proto = undefined, ._type = .generic });
                     try frame.parseHtmlAsChildren(document.asNode(), data);
@@ -439,6 +440,7 @@ pub fn getResponseXML(self: *XMLHttpRequest, exec: *const Execution) !?*Node.Doc
     if (final.content_type != .text_xml) return null;
 
     switch (exec.js.global) {
+        .bare => unreachable,
         .frame => |frame| {
             const document = try exec._factory.node(Node.Document{ ._proto = undefined, ._type = .generic });
             try frame.parseHtmlAsChildren(document.asNode(), self._response_data.items);

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -323,6 +323,7 @@ fn resolveQueryUrl(exec: *const Execution, _override: ?[]const u8) ![:0]const u8
     if (!exec.isSameOrigin(resolved)) return error.SecurityError;
 
     switch (exec.js.global) {
+        .bare => unreachable,
         .frame => {
             if (!std.mem.eql(u8, resolved, current)) return error.InvalidUrl;
         },

--- a/src/cdp/domains/webmcp.zig
+++ b/src/cdp/domains/webmcp.zig
@@ -261,6 +261,7 @@ pub fn onToolAdded(
     defer ls.deinit();
 
     const frame_id = switch (global) {
+        .bare => unreachable,
         inline else => |g| g._frame_id,
     };
 
@@ -279,6 +280,7 @@ pub fn onToolRemoved(
     event: *const Notification.ModelContextToolEvent,
 ) !void {
     const frame_id = switch (event.exec.js.global) {
+        .bare => unreachable,
         inline else => |g| g._frame_id,
     };
     try bc.cdp.sendEvent("WebMCP.toolsRemoved", .{

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -815,13 +815,13 @@ test "MCP - save writes the script to disk" {
     defer std.fs.cwd().deleteFile(path) catch {};
 
     const msg =
-        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"save","arguments":{"path":"mcp-save-test-script.js","script":"goto(\"https://example.com\");"}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"save","arguments":{"path":"mcp-save-test-script.js","script":"await goto(\"https://example.com\");"}}}
     ;
     try router.handleMessage(server, testing.arena_allocator, msg);
     try testing.expect(std.mem.indexOf(u8, out.written(), "saved 1 line") != null);
 
     const written = try std.fs.cwd().readFileAlloc(testing.arena_allocator, path, 4096);
-    try std.testing.expectEqualStrings("goto(\"https://example.com\");\n", written);
+    try std.testing.expectEqualStrings("await goto(\"https://example.com\");\n", written);
 }
 
 test "MCP - tree rejects stale backendNodeId instead of dumping whole document" {

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -815,13 +815,13 @@ test "MCP - save writes the script to disk" {
     defer std.fs.cwd().deleteFile(path) catch {};
 
     const msg =
-        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"save","arguments":{"path":"mcp-save-test-script.js","script":"await goto(\"https://example.com\");"}}}
+        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"save","arguments":{"path":"mcp-save-test-script.js","script":"const page = new Page();\nawait page.goto(\"https://example.com\");"}}}
     ;
     try router.handleMessage(server, testing.arena_allocator, msg);
-    try testing.expect(std.mem.indexOf(u8, out.written(), "saved 1 line") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "saved 2 line") != null);
 
     const written = try std.fs.cwd().readFileAlloc(testing.arena_allocator, path, 4096);
-    try std.testing.expectEqualStrings("await goto(\"https://example.com\");\n", written);
+    try std.testing.expectEqualStrings("const page = new Page();\nawait page.goto(\"https://example.com\");\n", written);
 }
 
 test "MCP - tree rejects stale backendNodeId instead of dumping whole document" {

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -130,7 +130,7 @@ test "record filters state-mutating commands and comments" {
     try recorder.recordComment("search for login");
 
     try std.testing.expectEqualStrings(
-        "goto(\"https://example.com\");\nclick({ selector: \"Login\" });\n// search for login\n",
+        "await goto(\"https://example.com\");\nclick({ selector: \"Login\" });\n// search for login\n",
         recorder.bytes(),
     );
     try std.testing.expectEqual(@as(u32, 3), recorder.lines);

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -29,6 +29,10 @@ const Recorder = @This();
 allocator: std.mem.Allocator,
 /// Number of lines appended since the last reset. Bumped only on success.
 lines: u32,
+/// Whether a `page` binding has been emitted yet. `goto` declares it on the
+/// first navigation (`let page = …`) and rebinds it after (`page = …`); every
+/// other tool is recorded as a method on it (`page.click(…)`).
+page_declared: bool,
 /// Accumulated JavaScript, returned verbatim by `bytes()`.
 content: std.Io.Writer.Allocating,
 /// Reused between writes so each line doesn't alloc/free.
@@ -40,6 +44,7 @@ pub fn init(allocator: std.mem.Allocator) Recorder {
     return .{
         .allocator = allocator,
         .lines = 0,
+        .page_declared = false,
         .content = .init(allocator),
         .buf = .init(allocator),
         .arena = .init(allocator),
@@ -58,6 +63,7 @@ pub fn bytes(self: *Recorder) []const u8 {
 
 pub fn reset(self: *Recorder) void {
     self.lines = 0;
+    self.page_declared = false;
     self.content.clearRetainingCapacity();
     self.buf.clearRetainingCapacity();
     _ = self.arena.reset(.retain_capacity);
@@ -67,6 +73,17 @@ pub fn record(self: *Recorder, cmd: Command) !void {
     if (!cmd.isRecorded()) return;
     self.buf.clearRetainingCapacity();
     _ = self.arena.reset(.retain_capacity);
+    // Bind the page on `goto`, call every other tool as a method on it. `goto`
+    // already renders with a leading `await ` (it's the lone async builtin), so
+    // the binding prefix lands before it: `let page = await goto(…)`.
+    if (cmd == .tool_call) {
+        if (cmd.tool_call.tool == .goto) {
+            try self.buf.writer.writeAll(if (self.page_declared) "page = " else "let page = ");
+            self.page_declared = true;
+        } else {
+            try self.buf.writer.writeAll("page.");
+        }
+    }
     try cmd.formatJs(self.arena.allocator(), &self.buf.writer);
     try self.buf.writer.writeByte('\n');
     try self.appendScrubbed();
@@ -130,7 +147,7 @@ test "record filters state-mutating commands and comments" {
     try recorder.recordComment("search for login");
 
     try std.testing.expectEqualStrings(
-        "await goto(\"https://example.com\");\nclick({ selector: \"Login\" });\n// search for login\n",
+        "let page = await goto(\"https://example.com\");\npage.click({ selector: \"Login\" });\n// search for login\n",
         recorder.bytes(),
     );
     try std.testing.expectEqual(@as(u32, 3), recorder.lines);
@@ -140,7 +157,7 @@ test "record filters state-mutating commands and comments" {
     try std.testing.expectEqual(@as(u32, 0), recorder.lines);
 
     try recorder.record(parseLine(aa, "/scroll y=200"));
-    try std.testing.expectEqualStrings("scroll({ y: 200 });\n", recorder.bytes());
+    try std.testing.expectEqualStrings("page.scroll({ y: 200 });\n", recorder.bytes());
     try std.testing.expectEqual(@as(u32, 1), recorder.lines);
 }
 
@@ -166,7 +183,7 @@ test "record emits multi-line extract as JavaScript" {
     try recorder.record(parseLine(aa, cmd_str));
 
     try std.testing.expectEqualStrings(
-        "extract({ title: \"span.title\", desc: \"p.description\" });\n",
+        "page.extract({ title: \"span.title\", desc: \"p.description\" });\n",
         recorder.bytes(),
     );
 }
@@ -217,7 +234,7 @@ test "record scrubs literal LP_* values in JavaScript calls" {
 
     try recorder.record(parseLine(aa, "/fill selector='#user' value='secret-user'"));
     try std.testing.expectEqualStrings(
-        "fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
+        "page.fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
         recorder.bytes(),
     );
 }

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -29,8 +29,8 @@ const Recorder = @This();
 allocator: std.mem.Allocator,
 /// Number of lines appended since the last reset. Bumped only on success.
 lines: u32,
-/// Whether the `page` binding was emitted yet: `goto` declares it (`let page =`),
-/// later gotos rebind it (`page =`).
+/// Whether `const page = new Page();` has been emitted yet. The first recorded
+/// command emits it, then every call is a method on `page`.
 page_declared: bool,
 /// Accumulated JavaScript, returned verbatim by `bytes()`.
 content: std.Io.Writer.Allocating,
@@ -72,14 +72,14 @@ pub fn record(self: *Recorder, cmd: Command) !void {
     if (!cmd.isRecorded()) return;
     self.buf.clearRetainingCapacity();
     _ = self.arena.reset(.retain_capacity);
-    // `isRecorded` guarantees `.tool_call`. `goto` renders with a leading
-    // `await `, so the binding prefix lands before it: `let page = await goto(…)`.
-    if (cmd.tool_call.tool == .goto) {
-        try self.buf.writer.writeAll(if (self.page_declared) "page = " else "let page = ");
+    // `isRecorded` guarantees `.tool_call`. The page is born once, up front; every
+    // recorded call is then a method on it — `goto` async, the rest sync.
+    if (!self.page_declared) {
+        try self.buf.writer.writeAll("const page = new Page();\n");
         self.page_declared = true;
-    } else {
-        try self.buf.writer.writeAll("page.");
     }
+    if (cmd.tool_call.tool.isAsync()) try self.buf.writer.writeAll("await ");
+    try self.buf.writer.writeAll("page.");
     try cmd.formatJs(self.arena.allocator(), &self.buf.writer);
     try self.buf.writer.writeByte('\n');
     try self.appendScrubbed();
@@ -143,18 +143,18 @@ test "record filters state-mutating commands and comments" {
     try recorder.recordComment("search for login");
 
     try std.testing.expectEqualStrings(
-        "let page = await goto(\"https://example.com\");\npage.click({ selector: \"Login\" });\n// search for login\n",
+        "const page = new Page();\nawait page.goto(\"https://example.com\");\npage.click({ selector: \"Login\" });\n// search for login\n",
         recorder.bytes(),
     );
-    try std.testing.expectEqual(@as(u32, 3), recorder.lines);
+    try std.testing.expectEqual(@as(u32, 4), recorder.lines);
 
     recorder.reset();
     try std.testing.expectEqualStrings("", recorder.bytes());
     try std.testing.expectEqual(@as(u32, 0), recorder.lines);
 
     try recorder.record(parseLine(aa, "/scroll y=200"));
-    try std.testing.expectEqualStrings("page.scroll({ y: 200 });\n", recorder.bytes());
-    try std.testing.expectEqual(@as(u32, 1), recorder.lines);
+    try std.testing.expectEqualStrings("const page = new Page();\npage.scroll({ y: 200 });\n", recorder.bytes());
+    try std.testing.expectEqual(@as(u32, 2), recorder.lines);
 }
 
 test "recordRaw writes the JS line verbatim" {
@@ -179,7 +179,7 @@ test "record emits multi-line extract as JavaScript" {
     try recorder.record(parseLine(aa, cmd_str));
 
     try std.testing.expectEqualStrings(
-        "page.extract({ title: \"span.title\", desc: \"p.description\" });\n",
+        "const page = new Page();\npage.extract({ title: \"span.title\", desc: \"p.description\" });\n",
         recorder.bytes(),
     );
 }
@@ -230,7 +230,7 @@ test "record scrubs literal LP_* values in JavaScript calls" {
 
     try recorder.record(parseLine(aa, "/fill selector='#user' value='secret-user'"));
     try std.testing.expectEqualStrings(
-        "page.fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
+        "const page = new Page();\npage.fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
         recorder.bytes(),
     );
 }

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -29,9 +29,8 @@ const Recorder = @This();
 allocator: std.mem.Allocator,
 /// Number of lines appended since the last reset. Bumped only on success.
 lines: u32,
-/// Whether a `page` binding has been emitted yet. `goto` declares it on the
-/// first navigation (`let page = …`) and rebinds it after (`page = …`); every
-/// other tool is recorded as a method on it (`page.click(…)`).
+/// Whether the `page` binding was emitted yet: `goto` declares it (`let page =`),
+/// later gotos rebind it (`page =`).
 page_declared: bool,
 /// Accumulated JavaScript, returned verbatim by `bytes()`.
 content: std.Io.Writer.Allocating,
@@ -73,16 +72,13 @@ pub fn record(self: *Recorder, cmd: Command) !void {
     if (!cmd.isRecorded()) return;
     self.buf.clearRetainingCapacity();
     _ = self.arena.reset(.retain_capacity);
-    // Bind the page on `goto`, call every other tool as a method on it. `goto`
-    // already renders with a leading `await ` (it's the lone async builtin), so
-    // the binding prefix lands before it: `let page = await goto(…)`.
-    if (cmd == .tool_call) {
-        if (cmd.tool_call.tool == .goto) {
-            try self.buf.writer.writeAll(if (self.page_declared) "page = " else "let page = ");
-            self.page_declared = true;
-        } else {
-            try self.buf.writer.writeAll("page.");
-        }
+    // `isRecorded` guarantees `.tool_call`. `goto` renders with a leading
+    // `await `, so the binding prefix lands before it: `let page = await goto(…)`.
+    if (cmd.tool_call.tool == .goto) {
+        try self.buf.writer.writeAll(if (self.page_declared) "page = " else "let page = ");
+        self.page_declared = true;
+    } else {
+        try self.buf.writer.writeAll("page.");
     }
     try cmd.formatJs(self.arena.allocator(), &self.buf.writer);
     try self.buf.writer.writeByte('\n');

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -43,6 +43,12 @@ console_data: [std.enums.values(ConsoleMethod).len]ConsoleData,
 /// of colliding with the indicator; the line still goes to stdout/stderr.
 console_observer: ?ConsoleObserver = null,
 
+/// In-flight `goto` navigations awaiting completion. Each holds a persisted
+/// resolver for the Promise handed back to the script; `runSource`'s driver
+/// loop settles them as their frame loads. A list (not a single slot) so the
+/// shape already supports Phase 2 multi-page — Phase 1 just caps it at one.
+pending_gotos: std.ArrayListUnmanaged(PendingGoto) = .empty,
+
 /// The runtime installs exactly the recorded browser tools as script
 /// primitives — the same set the recorder writes — so every recorded call
 /// replays. `buildArgs` adapts each tool's JS calling convention to the JSON
@@ -58,6 +64,12 @@ const recorded_tool_count = blk: {
 const PrimitiveData = struct {
     runtime: *Runtime,
     tool: BrowserTool,
+};
+
+const PendingGoto = struct {
+    frame_id: u32,
+    resolver: v8.Global,
+    deadline_ms: i64,
 };
 
 const ConsoleMethod = enum {
@@ -130,11 +142,23 @@ pub fn init(
 }
 
 pub fn deinit(self: *Runtime) void {
+    self.clearPendingGotos();
+    self.pending_gotos.deinit(self.allocator);
     self.resetContext();
     self.env.deinit();
     self.call_arena.deinit();
     const allocator = self.allocator;
     allocator.destroy(self);
+}
+
+/// Reset every persisted goto resolver and empty the list. Called when a run
+/// finishes (settled or not) and at teardown — a leftover `v8.Global` would
+/// leak past the isolate it belongs to.
+fn clearPendingGotos(self: *Runtime) void {
+    for (self.pending_gotos.items) |*entry| {
+        v8.v8__Global__Reset(&entry.resolver);
+    }
+    self.pending_gotos.clearRetainingCapacity();
 }
 
 pub fn terminate(self: *Runtime) void {
@@ -157,6 +181,13 @@ fn createContext(self: *Runtime) InitError!void {
 
     v8.v8__Context__Enter(context);
     defer v8.v8__Context__Exit(context);
+
+    // The promise-reject callback every `Env` installs reads a browser
+    // `Context` from embedder slot 1; this bare context has none. Pin the slot
+    // to null so `Context.fromC` returns null and the callback no-ops, instead
+    // of aligncasting garbage when a script's promise rejects unhandled (which
+    // now happens routinely — the script body runs inside an async wrapper).
+    v8.v8__Context__SetAlignedPointerInEmbedderData(context, 1, null);
 
     const global = v8.v8__Context__Global(context) orelse return error.RuntimeInitFailed;
     var i: usize = 0;
@@ -254,7 +285,14 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     defer v8.v8__TryCatch__DESTRUCT(&try_catch);
 
     const script_name = self.env.isolate.initStringHandle(name);
-    const script_source = self.env.isolate.initStringHandle(source);
+    // Wrap in an async IIFE so the source can use top-level `await` (e.g.
+    // `await goto(...)`). The wrapper evaluates to a Promise; a top-level
+    // `return <expr>` in the source becomes that Promise's value, which is what
+    // we echo. (A bare trailing expression no longer auto-prints — `await` and
+    // a script completion value are mutually exclusive in JS.)
+    const wrapped = std.fmt.allocPrint(self.call_arena.allocator(), "(async () => {{\n{s}\n}})()", .{source}) catch
+        return try self.dupeError("out of memory");
+    const script_source = self.env.isolate.initStringHandle(wrapped);
 
     var origin: v8.ScriptOrigin = undefined;
     v8.v8__ScriptOrigin__CONSTRUCT(&origin, script_name);
@@ -273,19 +311,76 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     const completion = v8.v8__Script__Run(script, context) orelse
         return try self.formatCaught(context, &try_catch, "script failed");
 
-    // Explicit microtask policy: promise continuations only run once drained.
+    // Any pending goto whose Promise outlives this run (e.g. rejected by the
+    // single-page guard while still navigating) must not leak its resolver.
+    defer self.clearPendingGotos();
+
+    const root: *const v8.Promise = @ptrCast(completion);
     self.env.performIsolateMicrotasks();
+    if (try self.driveToCompletion(context, root)) |interrupted| {
+        return interrupted;
+    }
     if (v8.v8__TryCatch__HasCaught(&try_catch)) {
         return try self.formatCaught(context, &try_catch, "script failed");
     }
 
-    self.printCompletion(context, completion);
+    switch (promiseState(root)) {
+        v8.kFulfilled => self.printCompletion(context, v8.v8__Promise__Result(root) orelse return null),
+        v8.kRejected => return try self.formatRejection(context, v8.v8__Promise__Result(root)),
+        else => {}, // still pending: the script awaited something we can't settle
+    }
     return null;
 }
 
-/// Echo a script's completion value (its last-evaluated expression) so a script
-/// ending in `extract(...)` or a bare `results;` prints without `console.log`.
-/// `undefined` — declarations, assignments, control flow — stays silent.
+/// `v8__Promise__State` returns the `c_uint` `PromiseState`, but the `k*`
+/// constants are `c_int`; normalize so comparisons and switches type-check.
+fn promiseState(promise: *const v8.Promise) c_int {
+    return @intCast(v8.v8__Promise__State(promise));
+}
+
+/// Tick the browser event loop and settle pending gotos until the root Promise
+/// leaves the pending state. Returns a message if the run was interrupted
+/// (SIGINT cancel or terminate); otherwise null once it settles — or stalls,
+/// when no in-flight navigation can advance it further.
+fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8.Promise) RunError!?[]const u8 {
+    var runner: ?lp.Session.Runner = null;
+    while (promiseState(root) == v8.kPending) {
+        if (self.session.isCancelled()) return try self.dupeError("cancelled");
+        if (self.env.terminatePending()) return try self.dupeError("terminated");
+
+        // `goto` is the only async source we drive. With nothing in flight, the
+        // script is awaiting a value we cannot settle — stop rather than spin.
+        if (self.pending_gotos.items.len == 0) break;
+
+        {
+            self.session.browser.env.isolate.enter();
+            defer self.session.browser.env.isolate.exit();
+            if (runner == null) {
+                runner = self.session.runner(.{}) catch null;
+            }
+            if (runner) |*r| {
+                // A failed tick (page JS error, etc.) must not abort the wait —
+                // the per-goto deadline still bounds it. Ignore result and error.
+                if (r.tick(.{ .ms = 100 })) |_| {} else |_| {}
+            }
+        }
+
+        self.resolveReadyGotos(context);
+        self.env.performIsolateMicrotasks();
+    }
+    return null;
+}
+
+fn formatRejection(self: *Runtime, context: *const v8.Context, reason: ?*const v8.Value) RunError![]const u8 {
+    const value = reason orelse return try self.dupeError("script rejected");
+    const text = self.valueToString(self.call_arena.allocator(), context, value) catch
+        return try self.dupeError("script failed");
+    return try self.dupeError(text);
+}
+
+/// Echo a script's output — the value it `return`s from the async wrapper, so a
+/// script ending in `return extract(...)` prints without `console.log`.
+/// `undefined` — no `return`, or a bare trailing expression — stays silent.
 fn printCompletion(self: *Runtime, context: *const v8.Context, value: *const v8.Value) void {
     if (v8.v8__Value__IsUndefined(value)) return;
 
@@ -327,6 +422,10 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
         error.InvalidArguments => return self.throwTypeError("invalid arguments"),
     };
 
+    // `goto` is the one async primitive: it returns a Promise resolved by the
+    // `runSource` driver loop when navigation settles, rather than blocking.
+    if (tool == .goto) return self.invokeGoto(arena, context, info, args);
+
     const result = self.callTool(arena, tool, args) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
     };
@@ -342,6 +441,91 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
             else => self.setReturnString(info, text),
         },
         .fail => |message| self.throwError(message),
+    }
+}
+
+/// Start a navigation and hand the script a Promise that settles when the page
+/// loads. The resolver is persisted as a `v8.Global` and parked in
+/// `pending_gotos`; the `runSource` driver loop ticks the browser and resolves
+/// it. Phase 1 allows one navigation at a time — a concurrent `goto` rejects.
+fn invokeGoto(
+    self: *Runtime,
+    arena: std.mem.Allocator,
+    context: *const v8.Context,
+    info: *const v8.FunctionCallbackInfo,
+    args: ?std.json.Value,
+) void {
+    const resolver = v8.v8__Promise__Resolver__New(context) orelse return self.throwError("internal: resolver alloc failed");
+    const promise = v8.v8__Promise__Resolver__GetPromise(resolver) orelse return self.throwError("internal: promise alloc failed");
+    self.setReturnValue(info, @ptrCast(promise));
+
+    const params = browser_tools.parseArgs(browser_tools.GotoParams, arena, args) catch |err| switch (err) {
+        error.OutOfMemory => return self.rejectResolver(context, resolver, "out of memory"),
+        error.InvalidParams => return self.rejectResolver(context, resolver, "goto requires a url"),
+    };
+    const url = params.url;
+    const timeout = params.timeout orelse 10000;
+
+    // Phase-1 guard: one navigation at a time. Reject before touching the
+    // session so `Session.createPage`'s single-page assert is never reached.
+    if (self.pending_gotos.items.len != 0) {
+        return self.rejectResolver(context, resolver, "a navigation is already in progress");
+    }
+
+    const frame = frame: {
+        self.session.browser.env.isolate.enter();
+        defer self.session.browser.env.isolate.exit();
+        break :frame browser_tools.startGoto(self.session, self.registry, url) catch
+            return self.rejectResolver(context, resolver, "navigation failed to start");
+    };
+
+    var global: v8.Global = undefined;
+    v8.v8__Global__New(self.env.isolate.handle, resolver, &global);
+    self.pending_gotos.append(self.allocator, .{
+        .frame_id = frame._frame_id,
+        .resolver = global,
+        .deadline_ms = std.time.milliTimestamp() + @as(i64, timeout),
+    }) catch {
+        v8.v8__Global__Reset(&global);
+        return self.rejectResolver(context, resolver, "out of memory");
+    };
+}
+
+fn resolveResolver(self: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, text: []const u8) void {
+    var out: v8.MaybeBool = undefined;
+    v8.v8__Promise__Resolver__Resolve(resolver, context, @ptrCast(self.env.isolate.initStringHandle(text)), &out);
+}
+
+fn rejectResolver(self: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, message: []const u8) void {
+    var out: v8.MaybeBool = undefined;
+    v8.v8__Promise__Resolver__Reject(resolver, context, self.env.isolate.createError(message), &out);
+}
+
+/// Settle each pending goto whose frame has finished (or errored, or run past
+/// its deadline). Mirrors the blocking `performGoto`/`execGoto` outcomes: a
+/// reached load resolves, a soft timeout resolves with a notice (the page may
+/// still be usable), only a real navigation error rejects. Runs on the script
+/// isolate (the resolvers live there); the caller drains microtasks after.
+fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
+    var i: usize = 0;
+    while (i < self.pending_gotos.items.len) {
+        const entry = &self.pending_gotos.items[i];
+        const resolver: *const v8.PromiseResolver = @ptrCast(v8.v8__Global__Get(&entry.resolver, self.env.isolate.handle));
+
+        const frame = self.session.findFrameByFrameId(entry.frame_id);
+        if (frame == null or frame.?._last_navigate_error != null) {
+            self.rejectResolver(context, resolver, "navigation failed");
+        } else if (frame.?._load_state == .load or frame.?._load_state == .complete) {
+            self.resolveResolver(context, resolver, "Navigated successfully.");
+        } else if (std.time.milliTimestamp() >= entry.deadline_ms) {
+            self.resolveResolver(context, resolver, "Navigation started but the page did not finish loading before the timeout.");
+        } else {
+            i += 1;
+            continue;
+        }
+
+        var settled = self.pending_gotos.swapRemove(i);
+        v8.v8__Global__Reset(&settled.resolver);
     }
 }
 
@@ -684,7 +868,7 @@ test "agent script runtime: goto and evaluate dispatch through browser tools" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const nav = goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\if (!nav.includes("Navigated")) throw new Error("unexpected goto result: " + nav);
         \\const text = evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("evaluate ran in the wrong context: " + text);
@@ -705,7 +889,7 @@ test "agent script runtime: extract returns a JavaScript object" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\const data = extract({
         \\  button: "#btn",
         \\  options: [{
@@ -759,7 +943,7 @@ test "agent script runtime: extract tolerates list selectors that match nothing"
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\const empty = extract({ comments: [{ selector: ".no-such-element", fields: { text: "" } }] });
         \\if (!Array.isArray(empty.comments) || empty.comments.length !== 0) throw new Error("empty list selector should yield an empty array, not throw");
         \\const bare = extract([".no-such-element"]);
@@ -788,7 +972,7 @@ test "agent script runtime: strict-mode scripts can call primitives" {
 
     try runTestScript(runtime,
         \\"use strict";
-        \\const nav = goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\if (!nav.includes("Navigated")) throw new Error("strict-mode goto failed: " + nav);
         \\const text = evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("strict-mode evaluate failed: " + text);
@@ -805,13 +989,13 @@ test "agent script runtime: promise microtasks run to completion" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\let microtaskRan = false;
-        \\Promise.resolve().then(() => { microtaskRan = true; });
-        \\if (microtaskRan) throw new Error("microtask ran before the checkpoint");
+        \\globalThis.microtaskRan = false;
+        \\Promise.resolve().then(() => { globalThis.microtaskRan = true; });
+        \\if (globalThis.microtaskRan) throw new Error("microtask ran before the checkpoint");
     );
 
     try runTestScript(runtime,
-        \\if (!microtaskRan) throw new Error("microtask did not run after the script");
+        \\if (!globalThis.microtaskRan) throw new Error("microtask did not run after the script");
     );
 }
 
@@ -826,7 +1010,7 @@ test "agent script runtime: primitives re-entered from argument callbacks stay i
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\// toJSON re-enters evaluate mid-marshal; the outer extract must still see "#btn".
         \\const data = extract({ button: { toJSON() { return evaluate("'#btn'"); } } });
         \\if (data.button !== "Click Me") throw new Error("re-entrant extract corrupted: " + JSON.stringify(data));
@@ -866,17 +1050,17 @@ test "agent script runtime: agent variables persist and page globals are isolate
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\let counter = 1;
+        \\globalThis.counter = 1;
         \\if (typeof window !== "undefined") throw new Error("window leaked into agent runtime");
         \\if (typeof document !== "undefined") throw new Error("document leaked into agent runtime");
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\counter += 1;
-        \\if (counter !== 2) throw new Error("agent global state did not persist");
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\globalThis.counter += 1;
+        \\if (globalThis.counter !== 2) throw new Error("agent global state did not persist");
     );
 
     try runTestScript(runtime,
-        \\counter += 1;
-        \\if (counter !== 3) throw new Error("agent global state was reset between scripts");
+        \\globalThis.counter += 1;
+        \\if (globalThis.counter !== 3) throw new Error("agent global state was reset between scripts");
     );
 }
 
@@ -892,7 +1076,7 @@ test "agent script runtime: page evaluate cannot see agent primitives or binding
 
     try runTestScript(runtime,
         \\const agentOnly = "secret";
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\if (evaluate("typeof goto") !== "undefined") throw new Error("agent primitive leaked to page evaluate");
         \\if (evaluate("typeof agentOnly") !== "undefined") throw new Error("agent binding leaked to page evaluate");
         \\if (evaluate("typeof document") !== "object") throw new Error("page evaluate did not run in the page context");
@@ -926,10 +1110,10 @@ test "agent script runtime: tool errors throw and stop execution" {
     defer runtime.deinit();
 
     const message = (try runtime.runSource(
-        \\let marker = "before";
-        \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\globalThis.marker = "before";
+        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\click({ selector: "#does-not-exist" });
-        \\marker = "after";
+        \\globalThis.marker = "after";
     , "agent-runtime-failure.js")).?;
 
     try testing.expect(std.mem.indexOf(u8, message, "click") != null or
@@ -937,7 +1121,7 @@ test "agent script runtime: tool errors throw and stop execution" {
         std.mem.indexOf(u8, message, "#does-not-exist") != null);
 
     try runTestScript(runtime,
-        \\if (marker !== "before") throw new Error("script continued after tool failure");
+        \\if (globalThis.marker !== "before") throw new Error("script continued after tool failure");
     );
 }
 
@@ -953,12 +1137,12 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
 
     try runTestScript(runtime,
         \\// The reported bug: Playwright-style goto(url, options) must merge, not throw.
-        \\const nav = goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
+        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
         \\if (!nav.includes("Navigated")) throw new Error("two-arg goto failed: " + nav);
         \\// waitForState: single required param, positional like waitForSelector.
         \\if (!waitForState("load").includes("reached")) throw new Error("waitForState positional failed");
         \\// Object form still works.
-        \\goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
+        \\await goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
         \\// Single selector positional.
         \\click("#btn");
         \\if (evaluate("String(window.clicked)") !== "true") throw new Error("click positional failed");
@@ -981,7 +1165,7 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
     // A field set by both a positional and the options object is a conflict.
     {
         const message = (try runtime.runSource(
-            \\goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { url: "http://other" });
+            \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { url: "http://other" });
         , "agent-runtime-conflict.js")).?;
         try testing.expect(std.mem.indexOf(u8, message, "invalid arguments") != null);
     }
@@ -993,4 +1177,50 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
         , "agent-runtime-arity.js")).?;
         try testing.expect(std.mem.indexOf(u8, message, "invalid arguments") != null);
     }
+}
+
+test "agent script runtime: top-level await runs in an async wrapper" {
+    defer testing.reset();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    // `await` on a non-goto promise resolves without touching the browser, and
+    // a top-level `return` surfaces as the (otherwise un-echoed) result.
+    try runTestScript(runtime,
+        \\const x = await Promise.resolve(40);
+        \\if (x + 2 !== 42) throw new Error("top-level await did not resolve: " + x);
+        \\return x + 2;
+    );
+}
+
+test "agent script runtime: a second concurrent goto rejects (phase-1 single page)" {
+    defer testing.reset();
+    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    // Phase 1 holds one page at a time: firing two navigations at once must
+    // reject the second rather than trip Session.createPage's assert.
+    try runTestScript(runtime,
+        \\let rejected = null;
+        \\try {
+        \\  await Promise.all([
+        \\    goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
+        \\    goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
+        \\  ]);
+        \\} catch (err) {
+        \\  rejected = String(err);
+        \\}
+        \\if (!rejected || !rejected.includes("already in progress")) {
+        \\  throw new Error("expected a concurrent-goto rejection, got: " + rejected);
+        \\}
+    );
 }

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -68,6 +68,9 @@ const PrimitiveData = struct {
 const PendingGoto = struct {
     frame_id: u32,
     resolver: lp.js.PromiseResolver.Global,
+    // The receiver `page.goto` was called on, persisted across the async wait so
+    // the settle rebinds `__lpFrameId` on the same object — the page stays valid.
+    page: lp.js.Object.Global,
     deadline_ms: i64,
 };
 
@@ -151,10 +154,11 @@ pub fn deinit(self: *Runtime) void {
     allocator.destroy(self);
 }
 
-/// A leftover persisted resolver handle would leak past its isolate.
+/// Leftover persisted handles (resolver + page) would leak past their isolate.
 fn clearPendingGotos(self: *Runtime) void {
     for (self.pending_gotos.items) |*entry| {
         entry.resolver.deinit();
+        entry.page.deinit();
     }
     self.pending_gotos.clearRetainingCapacity();
 }
@@ -177,18 +181,19 @@ fn createContext(self: *Runtime) InitError!void {
     const local = &ls.local;
     const global = local.globalObject();
 
-    // Only `goto` is a global; the rest become page methods via `makePage`,
-    // which reuses these `primitive_data` entries — so fill them all here.
+    // `Page` is the only global verb; `new Page()` (`pageConstructor`) attaches a
+    // method for each recorded tool, reusing these `primitive_data` entries — so
+    // fill them all here.
     var i: usize = 0;
     for (std.enums.values(BrowserTool)) |t| {
         if (!t.isRecorded()) continue;
         self.primitive_data[i] = .{ .runtime = self, .tool = t };
-        if (t == .goto) {
-            const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
-            _ = global.set(@tagName(t), func.toValue(), .{}) catch return error.RuntimeInitFailed;
-        }
         i += 1;
     }
+
+    const page_ctor = local.newRawCallback(pageConstructor, self);
+    _ = global.set("Page", page_ctor.toValue(), .{}) catch return error.RuntimeInitFailed;
+
     try self.installConsole(local, global);
 }
 
@@ -339,6 +344,26 @@ fn consoleCallback(info_handle: ?*const lp.js.Local.RawCallbackInfo) callconv(.c
     data.runtime.invokeConsole(&caller.local, data.method, fci);
 }
 
+fn pageConstructor(info_handle: ?*const lp.js.Local.RawCallbackInfo) callconv(.c) void {
+    const info = info_handle orelse return;
+    var caller: lp.js.Caller = undefined;
+    if (!caller.initFromHandle(info)) return;
+    defer caller.deinit();
+    const fci = lp.js.Caller.FunctionCallbackInfo{ .handle = info };
+    const self: *Runtime = @ptrCast(@alignCast(fci.getData() orelse return));
+    self.construct(&caller.local, fci);
+}
+
+fn closeCallback(info_handle: ?*const lp.js.Local.RawCallbackInfo) callconv(.c) void {
+    const info = info_handle orelse return;
+    var caller: lp.js.Caller = undefined;
+    if (!caller.initFromHandle(info)) return;
+    defer caller.deinit();
+    const fci = lp.js.Caller.FunctionCallbackInfo{ .handle = info };
+    const self: *Runtime = @ptrCast(@alignCast(fci.getData() orelse return));
+    self.invokeClose(&caller.local, fci);
+}
+
 const Fci = lp.js.Caller.FunctionCallbackInfo;
 
 fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci) void {
@@ -362,7 +387,7 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
 
     // Non-goto primitives are page methods; the receiver names the target frame.
     const frame_id = receiverFrameId(local, fci) orelse
-        return self.throwError("this must be called as a method on a page returned by goto()");
+        return self.throwError("page is not navigated or has been closed; call page.goto(url) first");
     self.session._tool_frame_override = self.session.findFrameByFrameId(frame_id) orelse
         return self.throwError("page handle is no longer valid; the page was closed or replaced");
 
@@ -384,8 +409,9 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
     }
 }
 
-/// Open a navigation; resolves a Page object whose methods target this page.
-/// Concurrent gotos fork popups, so `Promise.all` fetches in parallel.
+/// Navigate the receiver Page. Settles by rebinding the same object's
+/// `__lpFrameId` (re-navigation keeps the page valid). Concurrent gotos fork
+/// popups, so `Promise.all` fetches in parallel.
 fn invokeGoto(
     self: *Runtime,
     arena: std.mem.Allocator,
@@ -412,29 +438,50 @@ fn invokeGoto(
             return resolver.rejectError("goto", .{ .generic_error = "navigation failed to start" });
     };
 
+    const this: lp.js.Object = .{ .local = local, .handle = fci.getThis() };
+    var page = this.persistOwned();
     var global = resolver.persistOwned();
     self.pending_gotos.append(self.allocator, .{
         .frame_id = frame._frame_id,
         .resolver = global,
+        .page = page,
         .deadline_ms = std.time.milliTimestamp() + @as(i64, timeout),
     }) catch {
+        page.deinit();
         global.deinit();
         return resolver.rejectError("goto", .{ .generic_error = "out of memory" });
     };
 }
 
-/// The Page object `goto` resolves: `__lpFrameId` plus a method for every
-/// recorded tool except `goto`.
-fn makePage(self: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
-    const obj = local.newObject();
-    _ = obj.set("__lpFrameId", frame_id, .{}) catch return null;
+/// `new Page()`: attach a method for every recorded tool (including `goto`) plus
+/// `close`. `__lpFrameId` is left unset until the first `goto` navigates the page.
+fn construct(self: *Runtime, local: *const lp.js.Local, fci: Fci) void {
+    if (!fci.isConstructCall()) return self.throwTypeError("Page must be called with new");
 
+    const this: lp.js.Object = .{ .local = local, .handle = fci.getThis() };
     for (&self.primitive_data) |*data| {
-        if (data.tool == .goto) continue;
         const func = local.newRawCallback(primitiveCallback, data);
-        _ = obj.set(@tagName(data.tool), func.toValue(), .{}) catch return null;
+        _ = this.set(@tagName(data.tool), func.toValue(), .{}) catch
+            return self.throwError("failed to construct page");
     }
-    return obj.toValue();
+    const close = local.newRawCallback(closeCallback, self);
+    _ = this.set("close", close.toValue(), .{}) catch
+        return self.throwError("failed to construct page");
+}
+
+/// `page.close()`: free a popup page's resources via `Session.closePopup` (a
+/// no-op on the root, which is reclaimed on the next root goto / at script end),
+/// then stale the wrapper so later method calls error.
+fn invokeClose(self: *Runtime, local: *const lp.js.Local, fci: Fci) void {
+    if (receiverFrameId(local, fci)) |frame_id| {
+        if (self.session.findFrameByFrameId(frame_id)) |frame| {
+            self.session.browser.env.isolate.enter();
+            defer self.session.browser.env.isolate.exit();
+            _ = self.session.closePopup(frame);
+        }
+    }
+    const this: lp.js.Object = .{ .local = local, .handle = fci.getThis() };
+    _ = this.set("__lpFrameId", null, .{}) catch {};
 }
 
 /// Frame id from a method's receiver (`this.__lpFrameId`), or null for a bare
@@ -462,10 +509,11 @@ fn resolveReadyGotos(self: *Runtime, local: *const lp.js.Local) void {
         if (frame == null or frame.?._last_navigate_error != null) {
             resolver.rejectError("goto", .{ .generic_error = "navigation failed" });
         } else if (ls == .load or ls == .complete or std.time.milliTimestamp() >= entry.deadline_ms) {
-            if (self.makePage(local, entry.frame_id)) |page| {
-                resolver.resolve("goto", page);
-            } else {
-                resolver.rejectError("goto", .{ .generic_error = "internal: page alloc failed" });
+            const page = entry.page.local(local);
+            if (page.set("__lpFrameId", entry.frame_id, .{})) |_| {
+                resolver.resolve("goto", page.toValue());
+            } else |_| {
+                resolver.rejectError("goto", .{ .generic_error = "internal: page bind failed" });
             }
         } else {
             i += 1;
@@ -474,6 +522,7 @@ fn resolveReadyGotos(self: *Runtime, local: *const lp.js.Local) void {
 
         var settled = self.pending_gotos.swapRemove(i);
         settled.resolver.deinit();
+        settled.page.deinit();
     }
 }
 
@@ -725,14 +774,44 @@ test "agent script runtime: goto and evaluate dispatch through browser tools" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (typeof page !== "object" || page === null) throw new Error("goto should resolve a page object: " + page);
+        \\const page = new Page();
+        \\const same = await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\if (same !== page) throw new Error("page.goto should resolve the same page object");
         \\const text = page.evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("evaluate ran in the wrong context: " + text);
     );
 
     const frame = testing.test_session.currentFrame().?;
     try testing.expect(std.mem.indexOf(u8, frame.url, "/src/browser/tests/mcp_actions.html") != null);
+}
+
+test "agent script runtime: Page must be called with new" {
+    defer testing.reset();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    const message = (try runtime.runSource("Page();", "agent-runtime-page-no-new.js")).?;
+    try testing.expect(std.mem.indexOf(u8, message, "must be called with new") != null);
+}
+
+test "agent script runtime: a method on an un-navigated page errors" {
+    defer testing.reset();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    const message = (try runtime.runSource(
+        \\const page = new Page();
+        \\page.extract({ btn: "#btn" });
+    , "agent-runtime-not-navigated.js")).?;
+    try testing.expect(std.mem.indexOf(u8, message, "not navigated") != null);
 }
 
 test "agent script runtime: extract returns a JavaScript object" {
@@ -746,7 +825,8 @@ test "agent script runtime: extract returns a JavaScript object" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\const data = page.extract({
         \\  button: "#btn",
         \\  options: [{
@@ -800,7 +880,8 @@ test "agent script runtime: extract tolerates list selectors that match nothing"
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\const empty = page.extract({ comments: [{ selector: ".no-such-element", fields: { text: "" } }] });
         \\if (!Array.isArray(empty.comments) || empty.comments.length !== 0) throw new Error("empty list selector should yield an empty array, not throw");
         \\const bare = page.extract([".no-such-element"]);
@@ -829,8 +910,8 @@ test "agent script runtime: strict-mode scripts can call primitives" {
 
     try runTestScript(runtime,
         \\"use strict";
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (typeof page !== "object" || page === null) throw new Error("strict-mode goto failed: " + page);
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\const text = page.evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("strict-mode evaluate failed: " + text);
     );
@@ -867,7 +948,8 @@ test "agent script runtime: primitives re-entered from argument callbacks stay i
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\// toJSON re-enters evaluate mid-marshal; the outer extract must still see "#btn".
         \\const data = page.extract({ button: { toJSON() { return page.evaluate("'#btn'"); } } });
         \\if (data.button !== "Click Me") throw new Error("re-entrant extract corrupted: " + JSON.stringify(data));
@@ -910,7 +992,7 @@ test "agent script runtime: agent variables persist and page globals are isolate
         \\globalThis.counter = 1;
         \\if (typeof window !== "undefined") throw new Error("window leaked into agent runtime");
         \\if (typeof document !== "undefined") throw new Error("document leaked into agent runtime");
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await new Page().goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\globalThis.counter += 1;
         \\if (globalThis.counter !== 2) throw new Error("agent global state did not persist");
     );
@@ -933,8 +1015,9 @@ test "agent script runtime: page evaluate cannot see agent primitives or binding
 
     try runTestScript(runtime,
         \\const agentOnly = "secret";
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (page.evaluate("typeof goto") !== "undefined") throw new Error("agent primitive leaked to page evaluate");
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\if (page.evaluate("typeof Page") !== "undefined") throw new Error("agent primitive leaked to page evaluate");
         \\if (page.evaluate("typeof agentOnly") !== "undefined") throw new Error("agent binding leaked to page evaluate");
         \\if (page.evaluate("typeof document") !== "object") throw new Error("page evaluate did not run in the page context");
     );
@@ -968,7 +1051,8 @@ test "agent script runtime: tool errors throw and stop execution" {
 
     const message = (try runtime.runSource(
         \\globalThis.marker = "before";
-        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\page.click({ selector: "#does-not-exist" });
         \\globalThis.marker = "after";
     , "agent-runtime-failure.js")).?;
@@ -994,12 +1078,12 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
 
     try runTestScript(runtime,
         \\// The reported bug: Playwright-style goto(url, options) must merge, not throw.
-        \\let page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
-        \\if (typeof page !== "object" || page === null) throw new Error("two-arg goto failed: " + page);
+        \\const page = new Page();
+        \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
         \\// waitForState: single required param, positional like waitForSelector.
         \\if (!page.waitForState("load").includes("reached")) throw new Error("waitForState positional failed");
-        \\// Object form still works.
-        \\page = await goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
+        \\// Object form still works; re-navigation rebinds the same page object.
+        \\await page.goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
         \\// Single selector positional.
         \\page.click("#btn");
         \\if (page.evaluate("String(window.clicked)") !== "true") throw new Error("click positional failed");
@@ -1022,7 +1106,7 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
     // A field set by both a positional and the options object is a conflict.
     {
         const message = (try runtime.runSource(
-            \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { url: "http://other" });
+            \\await new Page().goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { url: "http://other" });
         , "agent-runtime-conflict.js")).?;
         try testing.expect(std.mem.indexOf(u8, message, "invalid arguments") != null);
     }
@@ -1030,7 +1114,8 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
     // More positionals than the tool has fields throws.
     {
         const message = (try runtime.runSource(
-            \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+            \\const page = new Page();
+            \\await page.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
             \\page.click("#btn", "#extra");
         , "agent-runtime-arity.js")).?;
         try testing.expect(std.mem.indexOf(u8, message, "invalid arguments") != null);
@@ -1066,17 +1151,46 @@ test "agent script runtime: parallel goto fetches concurrent pages, read per pag
     defer runtime.deinit();
 
     // Two gotos in flight at once open distinct frames (root + popup) that load
-    // concurrently in one Page; each is read back through the Page object goto resolved.
+    // concurrently in one Page; each is read back through its own Page object.
     try runTestScript(runtime,
-        \\const [a, b] = await Promise.all([
-        \\  goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
-        \\  goto("http://localhost:9582/src/browser/tests/runner/runner1.html"),
+        \\const a = new Page();
+        \\const b = new Page();
+        \\await Promise.all([
+        \\  a.goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
+        \\  b.goto("http://localhost:9582/src/browser/tests/runner/runner1.html"),
         \\]);
-        \\if (typeof a !== "object" || typeof b !== "object") throw new Error("goto should resolve page objects");
         \\const da = a.extract({ btn: "#btn" });
         \\if (da.btn !== "Click Me") throw new Error("page a read wrong: " + JSON.stringify(da));
         \\const db = b.extract({ sel: "#sel1" });
         \\if (db.sel !== "selector-1-content") throw new Error("page b read wrong: " + JSON.stringify(db));
+    );
+}
+
+test "agent script runtime: page.close frees a popup and stales its wrapper" {
+    defer testing.reset();
+    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    // b is a popup (second concurrent goto). Closing it stales its wrapper while
+    // the root page a keeps working.
+    try runTestScript(runtime,
+        \\const a = new Page();
+        \\const b = new Page();
+        \\await Promise.all([
+        \\  a.goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
+        \\  b.goto("http://localhost:9582/src/browser/tests/runner/runner1.html"),
+        \\]);
+        \\b.close();
+        \\let closed = false;
+        \\try { b.extract({ sel: "#sel1" }); } catch (e) { closed = true; }
+        \\if (!closed) throw new Error("a closed page should error on use");
+        \\const da = a.extract({ btn: "#btn" });
+        \\if (da.btn !== "Click Me") throw new Error("root page should survive a popup close");
     );
 }
 
@@ -1093,8 +1207,9 @@ test "agent script runtime: a stale page handle is a hard error" {
     // The first page goes stale once the second (non-forked) goto replaces the
     // page; reading through it must throw, not silently hit the current page.
     const message = (try runtime.runSource(
-        \\const a = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\await goto("http://localhost:9582/src/browser/tests/runner/runner1.html");
+        \\const a = new Page();
+        \\await a.goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await new Page().goto("http://localhost:9582/src/browser/tests/runner/runner1.html");
         \\a.extract({ btn: "#btn" });
     , "agent-runtime-stale-handle.js")).?;
 

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -361,11 +361,16 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
 
     if (tool == .goto) return self.invokeGoto(arena, local, fci, args);
 
-    // Aim page tools at the handle's frame, else the most-recent goto.
-    if (handle_id orelse self.current_frame_id) |target_id| {
-        self.session._tool_frame_override = self.session.findFrameByFrameId(target_id);
-    }
     defer self.session._tool_frame_override = null;
+
+    // An explicit handle that no longer resolves is a hard error; with no
+    // handle we aim at the most-recent goto (best-effort, may be current).
+    if (handle_id) |id| {
+        self.session._tool_frame_override = self.session.findFrameByFrameId(id) orelse
+            return self.throwError("page handle is no longer valid; the page was closed or replaced");
+    } else if (self.current_frame_id) |id| {
+        self.session._tool_frame_override = self.session.findFrameByFrameId(id);
+    }
 
     const result = self.callTool(arena, tool, args) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
@@ -1075,4 +1080,25 @@ test "agent script runtime: parallel goto fetches concurrent pages, read by hand
         \\const db = extract({ sel: "#sel1" }, b);
         \\if (db.sel !== "selector-1-content") throw new Error("handle b read wrong: " + JSON.stringify(db));
     );
+}
+
+test "agent script runtime: a stale page handle is a hard error" {
+    defer testing.reset();
+    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+
+    var registry = CDPNode.Registry.init(testing.allocator);
+    defer registry.deinit();
+
+    const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
+    defer runtime.deinit();
+
+    // The first handle goes stale once the second (non-forked) goto replaces the
+    // page; reading through it must throw, not silently hit the current page.
+    const message = (try runtime.runSource(
+        \\const a = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\await goto("http://localhost:9582/src/browser/tests/runner/runner1.html");
+        \\extract({ btn: "#btn" }, a);
+    , "agent-runtime-stale-handle.js")).?;
+
+    try testing.expect(std.mem.indexOf(u8, message, "no longer valid") != null);
 }

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const TickResult = lp.Session.Runner.TickResult;
 
 const browser_tools = lp.tools;
 const BrowserTool = browser_tools.Tool;
@@ -43,10 +44,8 @@ console_data: [std.enums.values(ConsoleMethod).len]ConsoleData,
 /// of colliding with the indicator; the line still goes to stdout/stderr.
 console_observer: ?ConsoleObserver = null,
 
-/// In-flight `goto` navigations awaiting completion. Each holds a persisted
-/// resolver for the Promise handed back to the script; `runSource`'s driver
-/// loop settles them as their frame loads. A list (not a single slot) so the
-/// shape already supports Phase 2 multi-page — Phase 1 just caps it at one.
+/// In-flight `goto` navigations the driver loop settles. A list, not one slot,
+/// so the shape already fits Phase 2 multi-page; Phase 1 caps it at one.
 pending_gotos: std.ArrayListUnmanaged(PendingGoto) = .empty,
 
 /// The runtime installs exactly the recorded browser tools as script
@@ -151,9 +150,7 @@ pub fn deinit(self: *Runtime) void {
     allocator.destroy(self);
 }
 
-/// Reset every persisted goto resolver and empty the list. Called when a run
-/// finishes (settled or not) and at teardown — a leftover `v8.Global` would
-/// leak past the isolate it belongs to.
+/// A leftover `v8.Global` resolver would leak past its isolate.
 fn clearPendingGotos(self: *Runtime) void {
     for (self.pending_gotos.items) |*entry| {
         v8.v8__Global__Reset(&entry.resolver);
@@ -182,11 +179,9 @@ fn createContext(self: *Runtime) InitError!void {
     v8.v8__Context__Enter(context);
     defer v8.v8__Context__Exit(context);
 
-    // The promise-reject callback every `Env` installs reads a browser
-    // `Context` from embedder slot 1; this bare context has none. Pin the slot
-    // to null so `Context.fromC` returns null and the callback no-ops, instead
-    // of aligncasting garbage when a script's promise rejects unhandled (which
-    // now happens routinely — the script body runs inside an async wrapper).
+    // The promise-reject callback aligncasts embedder slot 1 to a browser
+    // `Context`; this bare context has none. Pin it to null so `Context.fromC`
+    // returns null and the callback no-ops instead of crashing on a rejection.
     v8.v8__Context__SetAlignedPointerInEmbedderData(context, 1, null);
 
     const global = v8.v8__Context__Global(context) orelse return error.RuntimeInitFailed;
@@ -285,11 +280,9 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     defer v8.v8__TryCatch__DESTRUCT(&try_catch);
 
     const script_name = self.env.isolate.initStringHandle(name);
-    // Wrap in an async IIFE so the source can use top-level `await` (e.g.
-    // `await goto(...)`). The wrapper evaluates to a Promise; a top-level
-    // `return <expr>` in the source becomes that Promise's value, which is what
-    // we echo. (A bare trailing expression no longer auto-prints — `await` and
-    // a script completion value are mutually exclusive in JS.)
+    // Wrap in an async IIFE so the source can use top-level `await`. A top-level
+    // `return <expr>` becomes the Promise's value, which we echo; a bare trailing
+    // expression can't (`await` and a completion value are mutually exclusive in JS).
     const wrapped = std.fmt.allocPrint(self.call_arena.allocator(), "(async () => {{\n{s}\n}})()", .{source}) catch
         return try self.dupeError("out of memory");
     const script_source = self.env.isolate.initStringHandle(wrapped);
@@ -311,8 +304,6 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     const completion = v8.v8__Script__Run(script, context) orelse
         return try self.formatCaught(context, &try_catch, "script failed");
 
-    // Any pending goto whose Promise outlives this run (e.g. rejected by the
-    // single-page guard while still navigating) must not leak its resolver.
     defer self.clearPendingGotos();
 
     const root: *const v8.Promise = @ptrCast(completion);
@@ -338,20 +329,18 @@ fn promiseState(promise: *const v8.Promise) c_int {
     return @intCast(v8.v8__Promise__State(promise));
 }
 
-/// Tick the browser event loop and settle pending gotos until the root Promise
-/// leaves the pending state. Returns a message if the run was interrupted
-/// (SIGINT cancel or terminate); otherwise null once it settles — or stalls,
-/// when no in-flight navigation can advance it further.
+/// Drives the browser until the root Promise settles. Returns an interrupt
+/// message (SIGINT/terminate), or null once it settles or stalls.
 fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8.Promise) RunError!?[]const u8 {
     var runner: ?lp.Session.Runner = null;
     while (promiseState(root) == v8.kPending) {
         if (self.session.isCancelled()) return try self.dupeError("cancelled");
         if (self.env.terminatePending()) return try self.dupeError("terminated");
 
-        // `goto` is the only async source we drive. With nothing in flight, the
-        // script is awaiting a value we cannot settle — stop rather than spin.
+        // Nothing in flight → the script awaits something we can't settle.
         if (self.pending_gotos.items.len == 0) break;
 
+        var next_tick_ms: u32 = 0;
         {
             self.session.browser.env.isolate.enter();
             defer self.session.browser.env.isolate.exit();
@@ -359,14 +348,21 @@ fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8
                 runner = self.session.runner(.{}) catch null;
             }
             if (runner) |*r| {
-                // A failed tick (page JS error, etc.) must not abort the wait —
-                // the per-goto deadline still bounds it. Ignore result and error.
-                if (r.tick(.{ .ms = 100 })) |_| {} else |_| {}
+                // A failed tick must not abort the wait; the deadline bounds it.
+                const tick: TickResult = r.tick(.{ .ms = 100 }) catch .{ .done = {} };
+                next_tick_ms = switch (tick) {
+                    .ok => |ms| ms,
+                    .done => 0,
+                };
             }
         }
 
         self.resolveReadyGotos(context);
         self.env.performIsolateMicrotasks();
+
+        // Honor the runner's pacing hint so a timer-only wait (no network I/O,
+        // which `tick` would otherwise block on) doesn't busy-spin.
+        if (next_tick_ms > 0) std.Thread.sleep(next_tick_ms * std.time.ns_per_ms);
     }
     return null;
 }
@@ -422,8 +418,6 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
         error.InvalidArguments => return self.throwTypeError("invalid arguments"),
     };
 
-    // `goto` is the one async primitive: it returns a Promise resolved by the
-    // `runSource` driver loop when navigation settles, rather than blocking.
     if (tool == .goto) return self.invokeGoto(arena, context, info, args);
 
     const result = self.callTool(arena, tool, args) catch |err| switch (err) {
@@ -445,9 +439,7 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
 }
 
 /// Start a navigation and hand the script a Promise that settles when the page
-/// loads. The resolver is persisted as a `v8.Global` and parked in
-/// `pending_gotos`; the `runSource` driver loop ticks the browser and resolves
-/// it. Phase 1 allows one navigation at a time — a concurrent `goto` rejects.
+/// loads. Phase 1 allows one navigation at a time — a concurrent `goto` rejects.
 fn invokeGoto(
     self: *Runtime,
     arena: std.mem.Allocator,
@@ -466,8 +458,8 @@ fn invokeGoto(
     const url = params.url;
     const timeout = params.timeout orelse 10000;
 
-    // Phase-1 guard: one navigation at a time. Reject before touching the
-    // session so `Session.createPage`'s single-page assert is never reached.
+    // Phase-1: one navigation at a time. Reject before `startGoto` so
+    // `Session.createPage`'s single-page assert is never hit.
     if (self.pending_gotos.items.len != 0) {
         return self.rejectResolver(context, resolver, "a navigation is already in progress");
     }
@@ -501,11 +493,9 @@ fn rejectResolver(self: *Runtime, context: *const v8.Context, resolver: *const v
     v8.v8__Promise__Resolver__Reject(resolver, context, self.env.isolate.createError(message), &out);
 }
 
-/// Settle each pending goto whose frame has finished (or errored, or run past
-/// its deadline). Mirrors the blocking `performGoto`/`execGoto` outcomes: a
-/// reached load resolves, a soft timeout resolves with a notice (the page may
-/// still be usable), only a real navigation error rejects. Runs on the script
-/// isolate (the resolvers live there); the caller drains microtasks after.
+/// Mirrors `execGoto`: a reached load resolves, a soft timeout resolves with a
+/// notice (the page may still be usable), a real error rejects. Runs on the
+/// script isolate where the resolvers live; the caller drains microtasks after.
 fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
     var i: usize = 0;
     while (i < self.pending_gotos.items.len) {

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -34,9 +34,12 @@ app: *lp.App,
 session: *lp.Session,
 registry: *CDPNode.Registry,
 env: lp.js.Env,
-context: v8.Global,
+context: *lp.js.Context,
 has_context: bool,
 call_arena: std.heap.ArenaAllocator,
+// Backs the bare context's `call_arena` (reset by `js.Caller` per top-level
+// callback) — kept separate from `call_arena`, which holds run-scoped data.
+ctx_call_arena: std.heap.ArenaAllocator,
 primitive_data: [recorded_tool_count]PrimitiveData,
 console_data: [std.enums.values(ConsoleMethod).len]ConsoleData,
 /// Notified before each `console.*` line is written. The REPL uses it to
@@ -127,10 +130,12 @@ pub fn init(
         .context = undefined,
         .has_context = false,
         .call_arena = .init(allocator),
+        .ctx_call_arena = .init(allocator),
         .primitive_data = undefined,
         .console_data = undefined,
     };
     errdefer self.call_arena.deinit();
+    errdefer self.ctx_call_arena.deinit();
 
     // Separate isolate from the page. The full `Env` is used only as an isolate
     // + terminate/microtask carrier; the agent context is bare (no WebAPIs).
@@ -149,6 +154,7 @@ pub fn deinit(self: *Runtime) void {
     self.resetContext();
     self.env.deinit();
     self.call_arena.deinit();
+    self.ctx_call_arena.deinit();
     const allocator = self.allocator;
     allocator.destroy(self);
 }
@@ -170,22 +176,17 @@ pub fn cancelTerminate(self: *Runtime) void {
 }
 
 fn createContext(self: *Runtime) InitError!void {
+    self.context = self.env.createAgentContext(self.ctx_call_arena.allocator()) catch return error.RuntimeInitFailed;
+    self.has_context = true;
+
     var hs: lp.js.HandleScope = undefined;
     hs.init(self.env.isolate);
     defer hs.deinit();
 
-    const context = v8.v8__Context__New(self.env.isolate.handle, null, null) orelse
-        return error.RuntimeInitFailed;
-    v8.v8__Global__New(self.env.isolate.handle, context, &self.context);
-    self.has_context = true;
-
+    const context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.context.handle, self.env.isolate.handle) orelse
+        return error.RuntimeInitFailed);
     v8.v8__Context__Enter(context);
     defer v8.v8__Context__Exit(context);
-
-    // The promise-reject callback aligncasts embedder slot 1 to a browser
-    // `Context`; this bare context has none. Pin it to null so `Context.fromC`
-    // returns null and the callback no-ops instead of crashing on a rejection.
-    v8.v8__Context__SetAlignedPointerInEmbedderData(context, 1, null);
 
     const global = v8.v8__Context__Global(context) orelse return error.RuntimeInitFailed;
     var i: usize = 0;
@@ -200,8 +201,7 @@ fn createContext(self: *Runtime) InitError!void {
 
 fn resetContext(self: *Runtime) void {
     if (!self.has_context) return;
-    v8.v8__Global__Reset(&self.context);
-    self.env.isolate.notifyContextDisposed();
+    self.env.destroyContext(self.context);
     self.has_context = false;
 }
 
@@ -273,7 +273,7 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     hs.init(self.env.isolate);
     defer hs.deinit();
 
-    const context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.context, self.env.isolate.handle) orelse
+    const context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.context.handle, self.env.isolate.handle) orelse
         return try self.dupeError("agent script context is not available"));
     v8.v8__Context__Enter(context);
     defer v8.v8__Context__Exit(context);

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -335,7 +335,6 @@ fn promiseState(promise: *const v8.Promise) c_int {
 /// Drives the browser until the root Promise settles. Returns an interrupt
 /// message (SIGINT/terminate), or null once it settles or stalls.
 fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8.Promise) RunError!?[]const u8 {
-    var runner: ?lp.Session.Runner = null;
     while (promiseState(root) == v8.kPending) {
         if (self.session.isCancelled()) return try self.dupeError("cancelled");
         if (self.env.terminatePending()) return try self.dupeError("terminated");
@@ -347,17 +346,15 @@ fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8
         {
             self.session.browser.env.isolate.enter();
             defer self.session.browser.env.isolate.exit();
-            if (runner == null) {
-                runner = self.session.runner(.{}) catch null;
-            }
-            if (runner) |*r| {
-                // A failed tick must not abort the wait; the deadline bounds it.
-                const tick: TickResult = r.tick(.{ .ms = 100 }) catch .{ .done = {} };
-                next_tick_ms = switch (tick) {
-                    .ok => |ms| ms,
-                    .done => 0,
-                };
-            }
+            // A goto is in flight, so a page exists; `catch break` only guards
+            // the impossible no-page case against an endless loop.
+            var runner = self.session.runner(.{}) catch break;
+            // A failed tick must not abort the wait; the deadline bounds it.
+            const tick: TickResult = runner.tick(.{ .ms = 100 }) catch .{ .done = {} };
+            next_tick_ms = switch (tick) {
+                .ok => |ms| ms,
+                .done => 0,
+            };
         }
 
         self.resolveReadyGotos(context);

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -25,8 +25,6 @@ const BrowserTool = browser_tools.Tool;
 const CDPNode = @import("../cdp/Node.zig");
 const Schema = @import("Schema.zig");
 
-const v8 = lp.js.v8;
-
 const Runtime = @This();
 
 allocator: std.mem.Allocator,
@@ -73,7 +71,7 @@ const PrimitiveData = struct {
 
 const PendingGoto = struct {
     frame_id: u32,
-    resolver: v8.Global,
+    resolver: lp.js.PromiseResolver.Global,
     deadline_ms: i64,
 };
 
@@ -159,10 +157,10 @@ pub fn deinit(self: *Runtime) void {
     allocator.destroy(self);
 }
 
-/// A leftover `v8.Global` resolver would leak past its isolate.
+/// A leftover persisted resolver handle would leak past its isolate.
 fn clearPendingGotos(self: *Runtime) void {
     for (self.pending_gotos.items) |*entry| {
-        v8.v8__Global__Reset(&entry.resolver);
+        entry.resolver.deinit();
     }
     self.pending_gotos.clearRetainingCapacity();
 }
@@ -179,24 +177,21 @@ fn createContext(self: *Runtime) InitError!void {
     self.context = self.env.createAgentContext(self.ctx_call_arena.allocator()) catch return error.RuntimeInitFailed;
     self.has_context = true;
 
-    var hs: lp.js.HandleScope = undefined;
-    hs.init(self.env.isolate);
-    defer hs.deinit();
+    var ls: lp.js.Local.Scope = undefined;
+    self.context.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+    const global = local.globalObject();
 
-    const context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.context.handle, self.env.isolate.handle) orelse
-        return error.RuntimeInitFailed);
-    v8.v8__Context__Enter(context);
-    defer v8.v8__Context__Exit(context);
-
-    const global = v8.v8__Context__Global(context) orelse return error.RuntimeInitFailed;
     var i: usize = 0;
     for (std.enums.values(BrowserTool)) |t| {
         if (!t.isRecorded()) continue;
         self.primitive_data[i] = .{ .runtime = self, .tool = t };
-        try self.installPrimitive(context, global, @tagName(t), &self.primitive_data[i]);
+        const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
+        _ = global.set(@tagName(t), func.toValue(), .{}) catch return error.RuntimeInitFailed;
         i += 1;
     }
-    try self.installConsole(context, global);
+    try self.installConsole(local, global);
 }
 
 fn resetContext(self: *Runtime) void {
@@ -205,62 +200,14 @@ fn resetContext(self: *Runtime) void {
     self.has_context = false;
 }
 
-fn installPrimitive(
-    self: *Runtime,
-    context: *const v8.Context,
-    global: *const v8.Object,
-    name: []const u8,
-    data: *PrimitiveData,
-) InitError!void {
-    const external = self.env.isolate.createExternal(data);
-    const func = v8.v8__Function__New__DEFAULT2(context, primitiveCallback, external) orelse
-        return error.RuntimeInitFailed;
-    var out: v8.MaybeBool = undefined;
-    v8.v8__Object__Set(
-        global,
-        context,
-        @ptrCast(self.env.isolate.initStringHandle(name)),
-        @ptrCast(func),
-        &out,
-    );
-    if (!out.has_value or !out.value) return error.RuntimeInitFailed;
-}
-
-fn installConsole(
-    self: *Runtime,
-    context: *const v8.Context,
-    global: *const v8.Object,
-) InitError!void {
-    const console = v8.v8__Object__New(self.env.isolate.handle) orelse
-        return error.RuntimeInitFailed;
-
+fn installConsole(self: *Runtime, local: *const lp.js.Local, global: lp.js.Object) InitError!void {
+    const console = local.newObject();
     for (std.enums.values(ConsoleMethod), 0..) |method, i| {
         self.console_data[i] = .{ .runtime = self, .method = method };
-        const external = self.env.isolate.createExternal(&self.console_data[i]);
-        const func = v8.v8__Function__New__DEFAULT2(context, consoleCallback, external) orelse
-            return error.RuntimeInitFailed;
-        try setObjectProperty(self, context, console, @tagName(method), @ptrCast(func));
+        const func = local.newRawCallback(consoleCallback, &self.console_data[i]);
+        _ = console.set(@tagName(method), func.toValue(), .{}) catch return error.RuntimeInitFailed;
     }
-
-    try setObjectProperty(self, context, global, "console", @ptrCast(console));
-}
-
-fn setObjectProperty(
-    self: *Runtime,
-    context: *const v8.Context,
-    object: *const v8.Object,
-    name: []const u8,
-    value: *const v8.Value,
-) InitError!void {
-    var out: v8.MaybeBool = undefined;
-    v8.v8__Object__Set(
-        object,
-        context,
-        @ptrCast(self.env.isolate.initStringHandle(name)),
-        value,
-        &out,
-    );
-    if (!out.has_value or !out.value) return error.RuntimeInitFailed;
+    _ = global.set("console", console.toValue(), .{}) catch return error.RuntimeInitFailed;
 }
 
 /// Run script source in the agent context. Returns null on success; on a JS
@@ -273,7 +220,6 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     self.context.localScope(&ls);
     defer ls.deinit();
     const local = &ls.local;
-    const context = local.handle;
 
     var tc: lp.js.TryCatch = undefined;
     tc.init(local);
@@ -292,7 +238,7 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
 
     const root = completion.toPromise();
     self.env.performIsolateMicrotasks();
-    if (try self.driveToCompletion(context, root.handle)) |interrupted| {
+    if (try self.driveToCompletion(local, root)) |interrupted| {
         return interrupted;
     }
     if (tc.hasCaught()) {
@@ -300,8 +246,8 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     }
 
     switch (root.state()) {
-        .fulfilled => self.printCompletion(context, root.result().handle),
-        .rejected => return try self.formatRejection(context, root.result().handle),
+        .fulfilled => self.printCompletion(root.result()),
+        .rejected => return try self.formatRejection(root.result()),
         .pending => {}, // the script awaited something we can't settle
     }
     return null;
@@ -322,16 +268,10 @@ fn formatTryCatch(self: *Runtime, tc: lp.js.TryCatch, err: anyerror) RunError![]
     return try self.dupeError(exception);
 }
 
-/// `v8__Promise__State` returns the `c_uint` `PromiseState`, but the `k*`
-/// constants are `c_int`; normalize so comparisons and switches type-check.
-fn promiseState(promise: *const v8.Promise) c_int {
-    return @intCast(v8.v8__Promise__State(promise));
-}
-
 /// Drives the browser until the root Promise settles. Returns an interrupt
 /// message (SIGINT/terminate), or null once it settles or stalls.
-fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8.Promise) RunError!?[]const u8 {
-    while (promiseState(root) == v8.kPending) {
+fn driveToCompletion(self: *Runtime, local: *const lp.js.Local, root: lp.js.Promise) RunError!?[]const u8 {
+    while (root.state() == .pending) {
         if (self.session.isCancelled()) return try self.dupeError("cancelled");
         if (self.env.terminatePending()) return try self.dupeError("terminated");
 
@@ -353,7 +293,7 @@ fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8
             };
         }
 
-        self.resolveReadyGotos(context);
+        self.resolveReadyGotos(local);
         self.env.performIsolateMicrotasks();
 
         // Honor the runner's pacing hint so a timer-only wait (no network I/O,
@@ -363,9 +303,8 @@ fn driveToCompletion(self: *Runtime, context: *const v8.Context, root: *const v8
     return null;
 }
 
-fn formatRejection(self: *Runtime, context: *const v8.Context, reason: ?*const v8.Value) RunError![]const u8 {
-    const value = reason orelse return try self.dupeError("script rejected");
-    const text = self.valueToString(self.call_arena.allocator(), context, value) catch
+fn formatRejection(self: *Runtime, value: lp.js.Value) RunError![]const u8 {
+    const text = value.toStringSliceWithAlloc(self.call_arena.allocator()) catch
         return try self.dupeError("script failed");
     return try self.dupeError(text);
 }
@@ -373,54 +312,57 @@ fn formatRejection(self: *Runtime, context: *const v8.Context, reason: ?*const v
 /// Echo a script's output — the value it `return`s from the async wrapper, so a
 /// script ending in `return extract(...)` prints without `console.log`.
 /// `undefined` — no `return`, or a bare trailing expression — stays silent.
-fn printCompletion(self: *Runtime, context: *const v8.Context, value: *const v8.Value) void {
-    if (v8.v8__Value__IsUndefined(value)) return;
+fn printCompletion(self: *Runtime, value: lp.js.Value) void {
+    if (value.isUndefined()) return;
 
     var arena_state: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena_state.deinit();
-    const text = self.displayString(arena_state.allocator(), context, value) catch return;
+    const text = self.displayString(arena_state.allocator(), value) catch return;
     self.writeConsoleLine(.log, text);
 }
 
-fn primitiveCallback(info_handle: ?*const v8.FunctionCallbackInfo) callconv(.c) void {
+fn primitiveCallback(info_handle: ?*const lp.js.Local.RawCallbackInfo) callconv(.c) void {
     const info = info_handle orelse return;
-    const raw_data = v8.v8__FunctionCallbackInfo__Data(info) orelse return;
-    const data: *PrimitiveData = @ptrCast(@alignCast(v8.v8__External__Value(@ptrCast(raw_data)) orelse return));
-    data.runtime.invoke(data.tool, info);
+    var caller: lp.js.Caller = undefined;
+    if (!caller.initFromHandle(info)) return;
+    defer caller.deinit();
+    const fci = lp.js.Caller.FunctionCallbackInfo{ .handle = info };
+    const data: *PrimitiveData = @ptrCast(@alignCast(fci.getData() orelse return));
+    data.runtime.invoke(&caller.local, data.tool, fci);
 }
 
-fn consoleCallback(info_handle: ?*const v8.FunctionCallbackInfo) callconv(.c) void {
+fn consoleCallback(info_handle: ?*const lp.js.Local.RawCallbackInfo) callconv(.c) void {
     const info = info_handle orelse return;
-    const raw_data = v8.v8__FunctionCallbackInfo__Data(info) orelse return;
-    const data: *ConsoleData = @ptrCast(@alignCast(v8.v8__External__Value(@ptrCast(raw_data)) orelse return));
-    data.runtime.invokeConsole(data.method, info);
+    var caller: lp.js.Caller = undefined;
+    if (!caller.initFromHandle(info)) return;
+    defer caller.deinit();
+    const fci = lp.js.Caller.FunctionCallbackInfo{ .handle = info };
+    const data: *ConsoleData = @ptrCast(@alignCast(fci.getData() orelse return));
+    data.runtime.invokeConsole(&caller.local, data.method, fci);
 }
 
-fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInfo) void {
+const Fci = lp.js.Caller.FunctionCallbackInfo;
+
+fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci) void {
     // Owned, not shared: marshalling runs JS (`toJSON`) that can re-enter a
     // primitive; a shared arena would let the nested call reset ours mid-flight.
     var arena_state: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const context = v8.v8__Isolate__GetCurrentContext(self.env.isolate.handle) orelse {
-        self.throwError("internal: missing callback context");
-        return;
-    };
-
-    var argc: usize = @intCast(v8.v8__FunctionCallbackInfo__Length(info));
+    var argc: usize = fci.length();
 
     // Peel a trailing page handle (from `goto`) out of the args; goto has none.
-    const handle_id = if (tool == .goto) null else self.peelHandle(context, info, argc);
+    const handle_id = if (tool == .goto) null else self.peelHandle(local, fci, argc);
     if (handle_id != null) argc -= 1;
 
-    const args = self.buildArgs(arena, context, tool, info, argc) catch |err| switch (err) {
+    const args = self.buildArgs(arena, local, tool, fci, argc) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
         error.JsException => return,
         error.InvalidArguments => return self.throwTypeError("invalid arguments"),
     };
 
-    if (tool == .goto) return self.invokeGoto(arena, context, info, args);
+    if (tool == .goto) return self.invokeGoto(arena, local, fci, args);
 
     // Aim page tools at the handle's frame, else the most-recent goto.
     if (handle_id orelse self.current_frame_id) |target_id| {
@@ -438,9 +380,9 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
                 const normalized = self.normalizeExtractReturnJson(arena, text) catch |err| switch (err) {
                     error.OutOfMemory => return self.throwError("out of memory"),
                 };
-                self.setReturnJson(context, info, normalized);
+                self.setReturnJson(local, fci, normalized);
             },
-            else => self.setReturnString(info, text),
+            else => fci.getReturnValue().set(local.newString(text).toValue()),
         },
         .fail => |message| self.throwError(message),
     }
@@ -451,17 +393,16 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
 fn invokeGoto(
     self: *Runtime,
     arena: std.mem.Allocator,
-    context: *const v8.Context,
-    info: *const v8.FunctionCallbackInfo,
+    local: *const lp.js.Local,
+    fci: Fci,
     args: ?std.json.Value,
 ) void {
-    const resolver = v8.v8__Promise__Resolver__New(context) orelse return self.throwError("internal: resolver alloc failed");
-    const promise = v8.v8__Promise__Resolver__GetPromise(resolver) orelse return self.throwError("internal: promise alloc failed");
-    self.setReturnValue(info, @ptrCast(promise));
+    const resolver = local.createPromiseResolver();
+    fci.getReturnValue().set(resolver.promise().toValue());
 
     const params = browser_tools.parseArgs(browser_tools.GotoParams, arena, args) catch |err| switch (err) {
-        error.OutOfMemory => return self.rejectResolver(context, resolver, "out of memory"),
-        error.InvalidParams => return self.rejectResolver(context, resolver, "goto requires a url"),
+        error.OutOfMemory => return resolver.rejectError("goto", .{ .generic_error = "out of memory" }),
+        error.InvalidParams => return resolver.rejectError("goto", .{ .generic_error = "goto requires a url" }),
     };
     const url = params.url;
     const timeout = params.timeout orelse 10000;
@@ -472,73 +413,60 @@ fn invokeGoto(
         self.session.browser.env.isolate.enter();
         defer self.session.browser.env.isolate.exit();
         break :frame browser_tools.openGotoFrame(self.session, self.registry, url, fork) catch
-            return self.rejectResolver(context, resolver, "navigation failed to start");
+            return resolver.rejectError("goto", .{ .generic_error = "navigation failed to start" });
     };
     self.current_frame_id = frame._frame_id;
 
-    var global: v8.Global = undefined;
-    v8.v8__Global__New(self.env.isolate.handle, resolver, &global);
+    var global = resolver.persistOwned();
     self.pending_gotos.append(self.allocator, .{
         .frame_id = frame._frame_id,
         .resolver = global,
         .deadline_ms = std.time.milliTimestamp() + @as(i64, timeout),
     }) catch {
-        v8.v8__Global__Reset(&global);
-        return self.rejectResolver(context, resolver, "out of memory");
+        global.deinit();
+        return resolver.rejectError("goto", .{ .generic_error = "out of memory" });
     };
 }
 
 /// A page handle: `{ __lpFrameId: <id> }`, peeled back by `peelHandle`.
-fn makeHandle(self: *Runtime, context: *const v8.Context, frame_id: u32) ?*const v8.Value {
-    const obj = v8.v8__Object__New(self.env.isolate.handle) orelse return null;
-    const value = v8.v8__Integer__NewFromUnsigned(self.env.isolate.handle, frame_id) orelse return null;
-    var out: v8.MaybeBool = undefined;
-    v8.v8__Object__Set(obj, context, @ptrCast(self.env.isolate.initStringHandle("__lpFrameId")), @ptrCast(value), &out);
-    return @ptrCast(obj);
+fn makeHandle(_: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
+    const obj = local.newObject();
+    _ = obj.set("__lpFrameId", frame_id, .{}) catch return null;
+    return obj.toValue();
 }
 
 /// Frame id if the last arg is a page handle (`{ __lpFrameId }`), else null —
 /// unambiguous since no real tool arg carries that key.
-fn peelHandle(self: *Runtime, context: *const v8.Context, info: *const v8.FunctionCallbackInfo, argc: usize) ?u32 {
+fn peelHandle(_: *Runtime, local: *const lp.js.Local, fci: Fci, argc: usize) ?u32 {
     if (argc == 0) return null;
-    const last = v8.v8__FunctionCallbackInfo__INDEX(info, @intCast(argc - 1)) orelse return null;
-    if (!v8.v8__Value__IsObject(last)) return null;
-    const prop = v8.v8__Object__Get(@ptrCast(last), context, @ptrCast(self.env.isolate.initStringHandle("__lpFrameId"))) orelse return null;
-    if (!v8.v8__Value__IsNumber(prop)) return null;
-    var out: v8.MaybeU32 = undefined;
-    v8.v8__Value__Uint32Value(prop, context, &out);
-    return if (out.has_value) out.value else null;
-}
-
-fn resolveResolver(_: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, value: *const v8.Value) void {
-    var out: v8.MaybeBool = undefined;
-    v8.v8__Promise__Resolver__Resolve(resolver, context, value, &out);
-}
-
-fn rejectResolver(self: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, message: []const u8) void {
-    var out: v8.MaybeBool = undefined;
-    v8.v8__Promise__Resolver__Reject(resolver, context, self.env.isolate.createError(message), &out);
+    const last = fci.getArg(@intCast(argc - 1), local);
+    if (!last.isObject()) return null;
+    const obj = last.toObject();
+    if (obj.has("__lpFrameId") == false) return null;
+    const prop = obj.get("__lpFrameId") catch return null;
+    if (!prop.isNumber()) return null;
+    return prop.toU32() catch null;
 }
 
 /// Settle each pending goto: a reached load — or a soft timeout (the page may
 /// still be usable) — resolves the page handle; a real navigation error
 /// rejects. Runs on the script isolate where the resolvers live; the caller
 /// drains microtasks after.
-fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
+fn resolveReadyGotos(self: *Runtime, local: *const lp.js.Local) void {
     var i: usize = 0;
     while (i < self.pending_gotos.items.len) {
         const entry = &self.pending_gotos.items[i];
-        const resolver: *const v8.PromiseResolver = @ptrCast(v8.v8__Global__Get(&entry.resolver, self.env.isolate.handle));
+        const resolver = entry.resolver.local(local);
 
         const frame = self.session.findFrameByFrameId(entry.frame_id);
         const ls = if (frame) |f| f._load_state else .waiting;
         if (frame == null or frame.?._last_navigate_error != null) {
-            self.rejectResolver(context, resolver, "navigation failed");
+            resolver.rejectError("goto", .{ .generic_error = "navigation failed" });
         } else if (ls == .load or ls == .complete or std.time.milliTimestamp() >= entry.deadline_ms) {
-            if (self.makeHandle(context, entry.frame_id)) |handle| {
-                self.resolveResolver(context, resolver, handle);
+            if (self.makeHandle(local, entry.frame_id)) |handle| {
+                resolver.resolve("goto", handle);
             } else {
-                self.rejectResolver(context, resolver, "internal: handle alloc failed");
+                resolver.rejectError("goto", .{ .generic_error = "internal: handle alloc failed" });
             }
         } else {
             i += 1;
@@ -546,25 +474,21 @@ fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
         }
 
         var settled = self.pending_gotos.swapRemove(i);
-        v8.v8__Global__Reset(&settled.resolver);
+        settled.resolver.deinit();
     }
 }
 
-fn invokeConsole(self: *Runtime, method: ConsoleMethod, info: *const v8.FunctionCallbackInfo) void {
+fn invokeConsole(self: *Runtime, local: *const lp.js.Local, method: ConsoleMethod, fci: Fci) void {
     // Owned arena (see `invoke`): an argument's `toString` can re-enter a
     // primitive mid-loop and must not reset the buffer we're accumulating.
     var arena_state: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const context = v8.v8__Isolate__GetCurrentContext(self.env.isolate.handle) orelse return;
-    const argc: usize = @intCast(v8.v8__FunctionCallbackInfo__Length(info));
-
     var aw: std.Io.Writer.Allocating = .init(arena);
-    for (0..argc) |i| {
+    for (0..fci.length()) |i| {
         if (i > 0) aw.writer.writeByte(' ') catch return;
-        const value = v8.v8__FunctionCallbackInfo__INDEX(info, @intCast(i)) orelse continue;
-        const text = self.valueToString(arena, context, value) catch "<unprintable>";
+        const text = fci.getArg(@intCast(i), local).toStringSliceWithAlloc(arena) catch "<unprintable>";
         aw.writer.writeAll(text) catch return;
     }
 
@@ -613,14 +537,14 @@ const BuildArgsError = error{
 fn buildArgs(
     self: *Runtime,
     arena: std.mem.Allocator,
-    context: *const v8.Context,
+    local: *const lp.js.Local,
     tool: BrowserTool,
-    info: *const v8.FunctionCallbackInfo,
+    fci: Fci,
     argc: usize,
 ) BuildArgsError!?std.json.Value {
     return switch (tool) {
-        .extract => try self.extractArgs(arena, context, info, argc),
-        else => try self.marshalArgs(arena, context, info, argc, Schema.positionalFor(tool)),
+        .extract => try self.extractArgs(arena, local, fci, argc),
+        else => try self.marshalArgs(arena, local, fci, argc, Schema.positionalFor(tool)),
     };
 }
 
@@ -631,13 +555,13 @@ fn buildArgs(
 fn marshalArgs(
     self: *Runtime,
     arena: std.mem.Allocator,
-    context: *const v8.Context,
-    info: *const v8.FunctionCallbackInfo,
+    local: *const lp.js.Local,
+    fci: Fci,
     argc: usize,
     positional: []const []const u8,
 ) BuildArgsError!std.json.Value {
     const values = try arena.alloc(std.json.Value, argc);
-    for (values, 0..) |*v, i| v.* = try self.argJson(arena, context, info, @intCast(i));
+    for (values, 0..) |*v, i| v.* = try self.argJson(arena, local, fci, @intCast(i));
 
     if (argc == 1 and values[0] == .object) return values[0];
 
@@ -671,12 +595,12 @@ fn marshalArgs(
 fn extractArgs(
     self: *Runtime,
     arena: std.mem.Allocator,
-    context: *const v8.Context,
-    info: *const v8.FunctionCallbackInfo,
+    local: *const lp.js.Local,
+    fci: Fci,
     argc: usize,
 ) BuildArgsError!std.json.Value {
     if (argc != 1) return error.InvalidArguments;
-    const value = try self.argJson(arena, context, info, 0);
+    const value = try self.argJson(arena, local, fci, 0);
     const schema = switch (value) {
         .string, .array => try extractSchemaString(arena, value),
         .object => |obj| if (obj.get("schema")) |inner| blk: {
@@ -708,22 +632,16 @@ fn normalizeExtractSchemaString(arena: std.mem.Allocator, schema: []const u8) er
 fn argJson(
     self: *Runtime,
     arena: std.mem.Allocator,
-    context: *const v8.Context,
-    info: *const v8.FunctionCallbackInfo,
+    local: *const lp.js.Local,
+    fci: Fci,
     index: u32,
 ) BuildArgsError!std.json.Value {
-    const value = v8.v8__FunctionCallbackInfo__INDEX(info, @intCast(index)) orelse return error.InvalidArguments;
-    return self.valueToJson(arena, context, value);
+    return self.valueToJson(arena, fci.getArg(index, local));
 }
 
-fn valueToJson(
-    self: *Runtime,
-    arena: std.mem.Allocator,
-    context: *const v8.Context,
-    value: *const v8.Value,
-) BuildArgsError!std.json.Value {
-    const json_string = v8.v8__JSON__Stringify(context, value, null) orelse return error.JsException;
-    const json = try self.stringToOwned(arena, json_string);
+fn valueToJson(_: *Runtime, arena: std.mem.Allocator, value: lp.js.Value) BuildArgsError!std.json.Value {
+    const json = value.toJson(arena) catch |err|
+        return if (err == error.OutOfMemory) error.OutOfMemory else error.JsException;
     if (std.mem.eql(u8, json, "undefined")) return error.InvalidArguments;
     return std.json.parseFromSliceLeaky(std.json.Value, arena, json, .{}) catch error.InvalidArguments;
 }
@@ -751,85 +669,32 @@ fn normalizeExtractReturnJson(_: *Runtime, arena: std.mem.Allocator, value: []co
     return try std.json.Stringify.valueAlloc(arena, entry.value_ptr.*, .{});
 }
 
-fn setReturnString(self: *Runtime, info: *const v8.FunctionCallbackInfo, value: []const u8) void {
-    self.setReturnValue(info, @ptrCast(self.env.isolate.initStringHandle(value)));
-}
-
-fn setReturnJson(self: *Runtime, context: *const v8.Context, info: *const v8.FunctionCallbackInfo, value: []const u8) void {
-    if (value.len == 0) {
-        self.setReturnValue(info, self.env.isolate.initUndefined());
-        return;
-    }
-    const json = self.env.isolate.initStringHandle(value);
-    const parsed = v8.v8__JSON__Parse(context, json) orelse {
-        self.throwError("extract returned invalid JSON");
-        return;
-    };
-    self.setReturnValue(info, parsed);
-}
-
-fn setReturnValue(_: *Runtime, info: *const v8.FunctionCallbackInfo, value: *const v8.Value) void {
-    var rv: v8.ReturnValue = undefined;
-    v8.v8__FunctionCallbackInfo__GetReturnValue(info, &rv);
-    v8.v8__ReturnValue__Set(rv, value);
+fn setReturnJson(self: *Runtime, local: *const lp.js.Local, fci: Fci, value: []const u8) void {
+    if (value.len == 0) return; // leave the return value as undefined
+    const parsed = local.parseJSON(value) catch return self.throwError("extract returned invalid JSON");
+    fci.getReturnValue().set(parsed);
 }
 
 fn throwError(self: *Runtime, message: []const u8) void {
-    _ = v8.v8__Isolate__ThrowException(self.env.isolate.handle, self.env.isolate.createError(message));
+    _ = self.env.isolate.throwException(self.env.isolate.createError(message));
 }
 
 fn throwTypeError(self: *Runtime, message: []const u8) void {
-    _ = v8.v8__Isolate__ThrowException(self.env.isolate.handle, self.env.isolate.createTypeError(message));
-}
-
-fn valueToString(
-    self: *Runtime,
-    arena: std.mem.Allocator,
-    context: *const v8.Context,
-    value: *const v8.Value,
-) error{ OutOfMemory, JsException }![]const u8 {
-    const string = v8.v8__Value__ToString(value, context) orelse return error.JsException;
-    return self.stringToOwned(arena, string);
+    _ = self.env.isolate.throwException(self.env.isolate.createTypeError(message));
 }
 
 /// Display form for the script's completion value: objects and arrays as JSON
-/// (plain coercion gives a useless `[object Object]`), every other value via that
-/// coercion. Falls back to coercion when JSON.stringify yields no string — a
-/// thrown circular reference, or a value (e.g. a function) that stringifies to
-/// `undefined`; the nested TryCatch keeps such a throw from leaking into the
-/// caller's scope.
-fn displayString(
-    self: *Runtime,
-    arena: std.mem.Allocator,
-    context: *const v8.Context,
-    value: *const v8.Value,
-) error{ OutOfMemory, JsException }![]const u8 {
-    if (v8.v8__Value__IsObject(value)) {
-        var try_catch: v8.TryCatch = undefined;
-        v8.v8__TryCatch__CONSTRUCT(&try_catch, self.env.isolate.handle);
-        defer v8.v8__TryCatch__DESTRUCT(&try_catch);
-        if (v8.v8__JSON__Stringify(context, value, null)) |json| {
-            return self.stringToOwned(arena, json);
-        }
+/// (plain coercion gives a useless `[object Object]`), every other value via
+/// `toString`. Falls back to coercion when JSON.stringify fails (e.g. a circular
+/// reference) — the `TryCatch` swallows that throw on `deinit`.
+fn displayString(_: *Runtime, arena: std.mem.Allocator, value: lp.js.Value) ![]const u8 {
+    if (value.isObject()) {
+        var tc: lp.js.TryCatch = undefined;
+        tc.init(value.local);
+        defer tc.deinit();
+        if (value.toJson(arena)) |json| return json else |_| {}
     }
-    return self.valueToString(arena, context, value);
-}
-
-fn stringToOwned(
-    self: *Runtime,
-    arena: std.mem.Allocator,
-    string: *const v8.String,
-) error{OutOfMemory}![]const u8 {
-    const len: usize = @intCast(v8.v8__String__Utf8Length(string, self.env.isolate.handle));
-    const buf = try arena.alloc(u8, len);
-    const written = v8.v8__String__WriteUtf8(
-        string,
-        self.env.isolate.handle,
-        buf.ptr,
-        buf.len,
-        v8.NO_NULL_TERMINATION | v8.REPLACE_INVALID_UTF8,
-    );
-    return buf[0..written];
+    return value.toStringSliceWithAlloc(arena);
 }
 
 fn dupeError(self: *Runtime, message: []const u8) RunError![]const u8 {

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -269,61 +269,57 @@ fn setObjectProperty(
 pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!?[]const u8 {
     _ = self.call_arena.reset(.retain_capacity);
 
-    var hs: lp.js.HandleScope = undefined;
-    hs.init(self.env.isolate);
-    defer hs.deinit();
+    var ls: lp.js.Local.Scope = undefined;
+    self.context.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+    const context = local.handle;
 
-    const context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.context.handle, self.env.isolate.handle) orelse
-        return try self.dupeError("agent script context is not available"));
-    v8.v8__Context__Enter(context);
-    defer v8.v8__Context__Exit(context);
+    var tc: lp.js.TryCatch = undefined;
+    tc.init(local);
+    defer tc.deinit();
 
-    var try_catch: v8.TryCatch = undefined;
-    v8.v8__TryCatch__CONSTRUCT(&try_catch, self.env.isolate.handle);
-    defer v8.v8__TryCatch__DESTRUCT(&try_catch);
-
-    const script_name = self.env.isolate.initStringHandle(name);
     // Wrap in an async IIFE so the source can use top-level `await`. A top-level
     // `return <expr>` becomes the Promise's value, which we echo; a bare trailing
     // expression can't (`await` and a completion value are mutually exclusive in JS).
     const wrapped = std.fmt.allocPrint(self.call_arena.allocator(), "(async () => {{\n{s}\n}})()", .{source}) catch
         return try self.dupeError("out of memory");
-    const script_source = self.env.isolate.initStringHandle(wrapped);
 
-    var origin: v8.ScriptOrigin = undefined;
-    v8.v8__ScriptOrigin__CONSTRUCT(&origin, script_name);
-
-    var compiler_source: v8.ScriptCompilerSource = undefined;
-    v8.v8__ScriptCompiler__Source__CONSTRUCT2(script_source, &origin, null, &compiler_source);
-    defer v8.v8__ScriptCompiler__Source__DESTRUCT(&compiler_source);
-
-    const script = v8.v8__ScriptCompiler__Compile(
-        context,
-        &compiler_source,
-        v8.kNoCompileOptions,
-        v8.kNoCacheNoReason,
-    ) orelse return try self.formatCaught(context, &try_catch, "compile failed");
-
-    const completion = v8.v8__Script__Run(script, context) orelse
-        return try self.formatCaught(context, &try_catch, "script failed");
+    const completion = local.compileAndRun(wrapped, name) catch |err|
+        return try self.formatTryCatch(tc, err);
 
     defer self.clearPendingGotos();
 
-    const root: *const v8.Promise = @ptrCast(completion);
+    const root = completion.toPromise();
     self.env.performIsolateMicrotasks();
-    if (try self.driveToCompletion(context, root)) |interrupted| {
+    if (try self.driveToCompletion(context, root.handle)) |interrupted| {
         return interrupted;
     }
-    if (v8.v8__TryCatch__HasCaught(&try_catch)) {
-        return try self.formatCaught(context, &try_catch, "script failed");
+    if (tc.hasCaught()) {
+        return try self.formatTryCatch(tc, error.JsException);
     }
 
-    switch (promiseState(root)) {
-        v8.kFulfilled => self.printCompletion(context, v8.v8__Promise__Result(root) orelse return null),
-        v8.kRejected => return try self.formatRejection(context, v8.v8__Promise__Result(root)),
-        else => {}, // still pending: the script awaited something we can't settle
+    switch (root.state()) {
+        .fulfilled => self.printCompletion(context, root.result().handle),
+        .rejected => return try self.formatRejection(context, root.result().handle),
+        .pending => {}, // the script awaited something we can't settle
     }
     return null;
+}
+
+/// Format a caught JS exception (compile or run) into a run-arena message,
+/// mirroring the old raw `formatCaught`: prefer the stack, else `line N: msg`.
+fn formatTryCatch(self: *Runtime, tc: lp.js.TryCatch, err: anyerror) RunError![]const u8 {
+    const arena = self.call_arena.allocator();
+    const c = tc.caughtOrError(arena, err);
+    if (c.stack) |stack| {
+        if (stack.len > 0) return try self.dupeError(stack);
+    }
+    const exception = c.exception orelse "script failed";
+    if (c.line) |line| {
+        return std.fmt.allocPrint(arena, "line {d}: {s}", .{ line, exception }) catch return error.OutOfMemory;
+    }
+    return try self.dupeError(exception);
 }
 
 /// `v8__Promise__State` returns the `c_uint` `PromiseState`, but the `k*`
@@ -784,34 +780,6 @@ fn throwError(self: *Runtime, message: []const u8) void {
 
 fn throwTypeError(self: *Runtime, message: []const u8) void {
     _ = v8.v8__Isolate__ThrowException(self.env.isolate.handle, self.env.isolate.createTypeError(message));
-}
-
-fn formatCaught(
-    self: *Runtime,
-    context: *const v8.Context,
-    try_catch: *const v8.TryCatch,
-    fallback: []const u8,
-) RunError![]const u8 {
-    const arena = self.call_arena.allocator();
-    if (v8.v8__TryCatch__StackTrace(try_catch, context)) |stack_value| {
-        const stack = self.valueToString(arena, context, stack_value) catch "";
-        if (stack.len > 0) return stack;
-    }
-
-    const exception = if (v8.v8__TryCatch__Exception(try_catch)) |exception_value|
-        self.valueToString(arena, context, exception_value) catch fallback
-    else
-        fallback;
-
-    const line: ?u32 = blk: {
-        const msg = v8.v8__TryCatch__Message(try_catch) orelse break :blk null;
-        const n = v8.v8__Message__GetLineNumber(msg, context);
-        break :blk if (n < 0) null else @as(u32, @intCast(n));
-    };
-    if (line) |n| {
-        return std.fmt.allocPrint(arena, "line {d}: {s}", .{ n, exception }) catch return error.OutOfMemory;
-    }
-    return try self.dupeError(exception);
 }
 
 fn valueToString(

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -46,7 +46,7 @@ console_observer: ?ConsoleObserver = null,
 
 /// In-flight `goto` navigations the driver loop settles. Concurrent gotos open
 /// popup frames so they coexist; a sequential goto replaces the page.
-pending_gotos: std.ArrayListUnmanaged(PendingGoto) = .empty,
+pending_gotos: std.ArrayList(PendingGoto) = .empty,
 
 /// Most-recent `goto`'s frame — the default target when no handle is passed.
 current_frame_id: ?u32 = null,

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -177,10 +177,8 @@ fn createContext(self: *Runtime) InitError!void {
     const local = &ls.local;
     const global = local.globalObject();
 
-    // `goto` is the only global: it opens a page and resolves a Page object
-    // whose methods (every other recorded tool) `makePage` attaches. The
-    // `primitive_data` entry for each recorded tool is filled here regardless,
-    // so `makePage` can hand the same shared data to its method callbacks.
+    // Only `goto` is a global; the rest become page methods via `makePage`,
+    // which reuses these `primitive_data` entries — so fill them all here.
     var i: usize = 0;
     for (std.enums.values(BrowserTool)) |t| {
         if (!t.isRecorded()) continue;
@@ -362,9 +360,7 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
 
     defer self.session._tool_frame_override = null;
 
-    // Every non-goto primitive is a method on the Page object `goto` resolved;
-    // the receiver carries the target frame. A bare call (no page receiver) or a
-    // frame that no longer resolves (page closed or replaced) is a hard error.
+    // Non-goto primitives are page methods; the receiver names the target frame.
     const frame_id = receiverFrameId(local, fci) orelse
         return self.throwError("this must be called as a method on a page returned by goto()");
     self.session._tool_frame_override = self.session.findFrameByFrameId(frame_id) orelse
@@ -427,26 +423,22 @@ fn invokeGoto(
     };
 }
 
-/// The Page object `goto` resolves: `__lpFrameId` plus a method for every recorded
-/// tool except `goto`. Methods share `createContext`'s `primitive_data` entries, so
-/// the tool iteration order here must match it for the indices to line up.
+/// The Page object `goto` resolves: `__lpFrameId` plus a method for every
+/// recorded tool except `goto`.
 fn makePage(self: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
     const obj = local.newObject();
     _ = obj.set("__lpFrameId", frame_id, .{}) catch return null;
 
-    var i: usize = 0;
-    for (std.enums.values(BrowserTool)) |t| {
-        if (!t.isRecorded()) continue;
-        defer i += 1;
-        if (t == .goto) continue;
-        const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
-        _ = obj.set(@tagName(t), func.toValue(), .{}) catch return null;
+    for (&self.primitive_data) |*data| {
+        if (data.tool == .goto) continue;
+        const func = local.newRawCallback(primitiveCallback, data);
+        _ = obj.set(@tagName(data.tool), func.toValue(), .{}) catch return null;
     }
     return obj.toValue();
 }
 
-/// Frame id from a method's receiver (`this.__lpFrameId`), else null — a bare
-/// call with no page receiver. Mirrors the old `peelHandle`, reading `getThis()`.
+/// Frame id from a method's receiver (`this.__lpFrameId`), or null for a bare
+/// call with no page receiver.
 fn receiverFrameId(local: *const lp.js.Local, fci: Fci) ?u32 {
     const this: lp.js.Object = .{ .local = local, .handle = fci.getThis() };
     if (this.has("__lpFrameId") == false) return null;

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -32,8 +32,7 @@ app: *lp.App,
 session: *lp.Session,
 registry: *CDPNode.Registry,
 env: lp.js.Env,
-context: *lp.js.Context,
-has_context: bool,
+context: ?*lp.js.Context = null,
 call_arena: std.heap.ArenaAllocator,
 // Backs the bare context's `call_arena` (reset by `js.Caller` per top-level
 // callback) — kept separate from `call_arena`, which holds run-scoped data.
@@ -125,8 +124,6 @@ pub fn init(
         .session = session,
         .registry = registry,
         .env = undefined,
-        .context = undefined,
-        .has_context = false,
         .call_arena = .init(allocator),
         .ctx_call_arena = .init(allocator),
         .primitive_data = undefined,
@@ -174,11 +171,11 @@ pub fn cancelTerminate(self: *Runtime) void {
 }
 
 fn createContext(self: *Runtime) InitError!void {
-    self.context = self.env.createAgentContext(self.ctx_call_arena.allocator()) catch return error.RuntimeInitFailed;
-    self.has_context = true;
+    const context = self.env.createAgentContext(self.ctx_call_arena.allocator()) catch return error.RuntimeInitFailed;
+    self.context = context;
 
     var ls: lp.js.Local.Scope = undefined;
-    self.context.localScope(&ls);
+    context.localScope(&ls);
     defer ls.deinit();
     const local = &ls.local;
     const global = local.globalObject();
@@ -195,9 +192,9 @@ fn createContext(self: *Runtime) InitError!void {
 }
 
 fn resetContext(self: *Runtime) void {
-    if (!self.has_context) return;
-    self.env.destroyContext(self.context);
-    self.has_context = false;
+    const context = self.context orelse return;
+    self.env.destroyContext(context);
+    self.context = null;
 }
 
 fn installConsole(self: *Runtime, local: *const lp.js.Local, global: lp.js.Object) InitError!void {
@@ -217,7 +214,7 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     _ = self.call_arena.reset(.retain_capacity);
 
     var ls: lp.js.Local.Scope = undefined;
-    self.context.localScope(&ls);
+    self.context.?.localScope(&ls);
     defer ls.deinit();
     const local = &ls.local;
 
@@ -253,8 +250,8 @@ pub fn runSource(self: *Runtime, source: []const u8, name: []const u8) RunError!
     return null;
 }
 
-/// Format a caught JS exception (compile or run) into a run-arena message,
-/// mirroring the old raw `formatCaught`: prefer the stack, else `line N: msg`.
+/// Format a caught JS exception (compile or run) into a run-arena message:
+/// prefer the stack, else `line N: msg`.
 fn formatTryCatch(self: *Runtime, tc: lp.js.TryCatch, err: anyerror) RunError![]const u8 {
     const arena = self.call_arena.allocator();
     const c = tc.caughtOrError(arena, err);
@@ -317,7 +314,7 @@ fn printCompletion(self: *Runtime, value: lp.js.Value) void {
 
     var arena_state: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena_state.deinit();
-    const text = self.displayString(arena_state.allocator(), value) catch return;
+    const text = displayString(arena_state.allocator(), value) catch return;
     self.writeConsoleLine(.log, text);
 }
 
@@ -353,7 +350,7 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
     var argc: usize = fci.length();
 
     // Peel a trailing page handle (from `goto`) out of the args; goto has none.
-    const handle_id = if (tool == .goto) null else self.peelHandle(local, fci, argc);
+    const handle_id = if (tool == .goto) null else peelHandle(local, fci, argc);
     if (handle_id != null) argc -= 1;
 
     const args = self.buildArgs(arena, local, tool, fci, argc) catch |err| switch (err) {
@@ -429,7 +426,7 @@ fn invokeGoto(
 }
 
 /// A page handle: `{ __lpFrameId: <id> }`, peeled back by `peelHandle`.
-fn makeHandle(_: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
+fn makeHandle(local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
     const obj = local.newObject();
     _ = obj.set("__lpFrameId", frame_id, .{}) catch return null;
     return obj.toValue();
@@ -437,7 +434,7 @@ fn makeHandle(_: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Valu
 
 /// Frame id if the last arg is a page handle (`{ __lpFrameId }`), else null —
 /// unambiguous since no real tool arg carries that key.
-fn peelHandle(_: *Runtime, local: *const lp.js.Local, fci: Fci, argc: usize) ?u32 {
+fn peelHandle(local: *const lp.js.Local, fci: Fci, argc: usize) ?u32 {
     if (argc == 0) return null;
     const last = fci.getArg(@intCast(argc - 1), local);
     if (!last.isObject()) return null;
@@ -463,7 +460,7 @@ fn resolveReadyGotos(self: *Runtime, local: *const lp.js.Local) void {
         if (frame == null or frame.?._last_navigate_error != null) {
             resolver.rejectError("goto", .{ .generic_error = "navigation failed" });
         } else if (ls == .load or ls == .complete or std.time.milliTimestamp() >= entry.deadline_ms) {
-            if (self.makeHandle(local, entry.frame_id)) |handle| {
+            if (makeHandle(local, entry.frame_id)) |handle| {
                 resolver.resolve("goto", handle);
             } else {
                 resolver.rejectError("goto", .{ .generic_error = "internal: handle alloc failed" });
@@ -687,7 +684,7 @@ fn throwTypeError(self: *Runtime, message: []const u8) void {
 /// (plain coercion gives a useless `[object Object]`), every other value via
 /// `toString`. Falls back to coercion when JSON.stringify fails (e.g. a circular
 /// reference) — the `TryCatch` swallows that throw on `deinit`.
-fn displayString(_: *Runtime, arena: std.mem.Allocator, value: lp.js.Value) ![]const u8 {
+fn displayString(arena: std.mem.Allocator, value: lp.js.Value) ![]const u8 {
     if (value.isObject()) {
         var tc: lp.js.TryCatch = undefined;
         tc.init(value.local);

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -44,9 +44,12 @@ console_data: [std.enums.values(ConsoleMethod).len]ConsoleData,
 /// of colliding with the indicator; the line still goes to stdout/stderr.
 console_observer: ?ConsoleObserver = null,
 
-/// In-flight `goto` navigations the driver loop settles. A list, not one slot,
-/// so the shape already fits Phase 2 multi-page; Phase 1 caps it at one.
+/// In-flight `goto` navigations the driver loop settles. Concurrent gotos open
+/// popup frames so they coexist; a sequential goto replaces the page.
 pending_gotos: std.ArrayListUnmanaged(PendingGoto) = .empty,
+
+/// Most-recent `goto`'s frame — the default target when no handle is passed.
+current_frame_id: ?u32 = null,
 
 /// The runtime installs exactly the recorded browser tools as script
 /// primitives — the same set the recorder writes — so every recorded call
@@ -412,13 +415,25 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
         return;
     };
 
-    const args = self.buildArgs(arena, context, tool, info) catch |err| switch (err) {
+    var argc: usize = @intCast(v8.v8__FunctionCallbackInfo__Length(info));
+
+    // Peel a trailing page handle (from `goto`) out of the args; goto has none.
+    const handle_id = if (tool == .goto) null else self.peelHandle(context, info, argc);
+    if (handle_id != null) argc -= 1;
+
+    const args = self.buildArgs(arena, context, tool, info, argc) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
         error.JsException => return,
         error.InvalidArguments => return self.throwTypeError("invalid arguments"),
     };
 
     if (tool == .goto) return self.invokeGoto(arena, context, info, args);
+
+    // Aim page tools at the handle's frame, else the most-recent goto.
+    if (handle_id orelse self.current_frame_id) |target_id| {
+        self.session._tool_frame_override = self.session.findFrameByFrameId(target_id);
+    }
+    defer self.session._tool_frame_override = null;
 
     const result = self.callTool(arena, tool, args) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
@@ -438,8 +453,8 @@ fn invoke(self: *Runtime, tool: BrowserTool, info: *const v8.FunctionCallbackInf
     }
 }
 
-/// Start a navigation and hand the script a Promise that settles when the page
-/// loads. Phase 1 allows one navigation at a time — a concurrent `goto` rejects.
+/// Open a navigation; resolves a page handle the read tools accept to target
+/// this page. Concurrent gotos fork popups, so `Promise.all` fetches in parallel.
 fn invokeGoto(
     self: *Runtime,
     arena: std.mem.Allocator,
@@ -458,18 +473,15 @@ fn invokeGoto(
     const url = params.url;
     const timeout = params.timeout orelse 10000;
 
-    // Phase-1: one navigation at a time. Reject before `startGoto` so
-    // `Session.createPage`'s single-page assert is never hit.
-    if (self.pending_gotos.items.len != 0) {
-        return self.rejectResolver(context, resolver, "a navigation is already in progress");
-    }
-
+    // Another goto in flight → fork a popup rather than tear down its page.
+    const fork = self.pending_gotos.items.len != 0;
     const frame = frame: {
         self.session.browser.env.isolate.enter();
         defer self.session.browser.env.isolate.exit();
-        break :frame browser_tools.startGoto(self.session, self.registry, url) catch
+        break :frame browser_tools.openGotoFrame(self.session, self.registry, url, fork) catch
             return self.rejectResolver(context, resolver, "navigation failed to start");
     };
+    self.current_frame_id = frame._frame_id;
 
     var global: v8.Global = undefined;
     v8.v8__Global__New(self.env.isolate.handle, resolver, &global);
@@ -483,9 +495,31 @@ fn invokeGoto(
     };
 }
 
-fn resolveResolver(self: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, text: []const u8) void {
+/// A page handle: `{ __lpFrameId: <id> }`, peeled back by `peelHandle`.
+fn makeHandle(self: *Runtime, context: *const v8.Context, frame_id: u32) ?*const v8.Value {
+    const obj = v8.v8__Object__New(self.env.isolate.handle) orelse return null;
+    const value = v8.v8__Integer__NewFromUnsigned(self.env.isolate.handle, frame_id) orelse return null;
     var out: v8.MaybeBool = undefined;
-    v8.v8__Promise__Resolver__Resolve(resolver, context, @ptrCast(self.env.isolate.initStringHandle(text)), &out);
+    v8.v8__Object__Set(obj, context, @ptrCast(self.env.isolate.initStringHandle("__lpFrameId")), @ptrCast(value), &out);
+    return @ptrCast(obj);
+}
+
+/// Frame id if the last arg is a page handle (`{ __lpFrameId }`), else null —
+/// unambiguous since no real tool arg carries that key.
+fn peelHandle(self: *Runtime, context: *const v8.Context, info: *const v8.FunctionCallbackInfo, argc: usize) ?u32 {
+    if (argc == 0) return null;
+    const last = v8.v8__FunctionCallbackInfo__INDEX(info, @intCast(argc - 1)) orelse return null;
+    if (!v8.v8__Value__IsObject(last)) return null;
+    const prop = v8.v8__Object__Get(@ptrCast(last), context, @ptrCast(self.env.isolate.initStringHandle("__lpFrameId"))) orelse return null;
+    if (!v8.v8__Value__IsNumber(prop)) return null;
+    var out: v8.MaybeU32 = undefined;
+    v8.v8__Value__Uint32Value(prop, context, &out);
+    return if (out.has_value) out.value else null;
+}
+
+fn resolveResolver(_: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, value: *const v8.Value) void {
+    var out: v8.MaybeBool = undefined;
+    v8.v8__Promise__Resolver__Resolve(resolver, context, value, &out);
 }
 
 fn rejectResolver(self: *Runtime, context: *const v8.Context, resolver: *const v8.PromiseResolver, message: []const u8) void {
@@ -493,9 +527,10 @@ fn rejectResolver(self: *Runtime, context: *const v8.Context, resolver: *const v
     v8.v8__Promise__Resolver__Reject(resolver, context, self.env.isolate.createError(message), &out);
 }
 
-/// Mirrors `execGoto`: a reached load resolves, a soft timeout resolves with a
-/// notice (the page may still be usable), a real error rejects. Runs on the
-/// script isolate where the resolvers live; the caller drains microtasks after.
+/// Settle each pending goto: a reached load — or a soft timeout (the page may
+/// still be usable) — resolves the page handle; a real navigation error
+/// rejects. Runs on the script isolate where the resolvers live; the caller
+/// drains microtasks after.
 fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
     var i: usize = 0;
     while (i < self.pending_gotos.items.len) {
@@ -503,12 +538,15 @@ fn resolveReadyGotos(self: *Runtime, context: *const v8.Context) void {
         const resolver: *const v8.PromiseResolver = @ptrCast(v8.v8__Global__Get(&entry.resolver, self.env.isolate.handle));
 
         const frame = self.session.findFrameByFrameId(entry.frame_id);
+        const ls = if (frame) |f| f._load_state else .waiting;
         if (frame == null or frame.?._last_navigate_error != null) {
             self.rejectResolver(context, resolver, "navigation failed");
-        } else if (frame.?._load_state == .load or frame.?._load_state == .complete) {
-            self.resolveResolver(context, resolver, "Navigated successfully.");
-        } else if (std.time.milliTimestamp() >= entry.deadline_ms) {
-            self.resolveResolver(context, resolver, "Navigation started but the page did not finish loading before the timeout.");
+        } else if (ls == .load or ls == .complete or std.time.milliTimestamp() >= entry.deadline_ms) {
+            if (self.makeHandle(context, entry.frame_id)) |handle| {
+                self.resolveResolver(context, resolver, handle);
+            } else {
+                self.rejectResolver(context, resolver, "internal: handle alloc failed");
+            }
         } else {
             i += 1;
             continue;
@@ -585,8 +623,8 @@ fn buildArgs(
     context: *const v8.Context,
     tool: BrowserTool,
     info: *const v8.FunctionCallbackInfo,
+    argc: usize,
 ) BuildArgsError!?std.json.Value {
-    const argc: usize = @intCast(v8.v8__FunctionCallbackInfo__Length(info));
     return switch (tool) {
         .extract => try self.extractArgs(arena, context, info, argc),
         else => try self.marshalArgs(arena, context, info, argc, Schema.positionalFor(tool)),
@@ -859,7 +897,7 @@ test "agent script runtime: goto and evaluate dispatch through browser tools" {
 
     try runTestScript(runtime,
         \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (!nav.includes("Navigated")) throw new Error("unexpected goto result: " + nav);
+        \\if (typeof nav !== "object" || nav === null) throw new Error("goto should resolve a page handle: " + nav);
         \\const text = evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("evaluate ran in the wrong context: " + text);
     );
@@ -963,7 +1001,7 @@ test "agent script runtime: strict-mode scripts can call primitives" {
     try runTestScript(runtime,
         \\"use strict";
         \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (!nav.includes("Navigated")) throw new Error("strict-mode goto failed: " + nav);
+        \\if (typeof nav !== "object" || nav === null) throw new Error("strict-mode goto failed: " + nav);
         \\const text = evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("strict-mode evaluate failed: " + text);
     );
@@ -1128,7 +1166,7 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
     try runTestScript(runtime,
         \\// The reported bug: Playwright-style goto(url, options) must merge, not throw.
         \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
-        \\if (!nav.includes("Navigated")) throw new Error("two-arg goto failed: " + nav);
+        \\if (typeof nav !== "object" || nav === null) throw new Error("two-arg goto failed: " + nav);
         \\// waitForState: single required param, positional like waitForSelector.
         \\if (!waitForState("load").includes("reached")) throw new Error("waitForState positional failed");
         \\// Object form still works.
@@ -1187,7 +1225,7 @@ test "agent script runtime: top-level await runs in an async wrapper" {
     );
 }
 
-test "agent script runtime: a second concurrent goto rejects (phase-1 single page)" {
+test "agent script runtime: parallel goto fetches concurrent pages, read by handle" {
     defer testing.reset();
     defer if (testing.test_session.hasPage()) testing.test_session.removePage();
 
@@ -1197,20 +1235,17 @@ test "agent script runtime: a second concurrent goto rejects (phase-1 single pag
     const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
     defer runtime.deinit();
 
-    // Phase 1 holds one page at a time: firing two navigations at once must
-    // reject the second rather than trip Session.createPage's assert.
+    // Two gotos in flight at once open distinct frames (root + popup) that load
+    // concurrently in one Page; each is read back via the handle goto resolved.
     try runTestScript(runtime,
-        \\let rejected = null;
-        \\try {
-        \\  await Promise.all([
-        \\    goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
-        \\    goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
-        \\  ]);
-        \\} catch (err) {
-        \\  rejected = String(err);
-        \\}
-        \\if (!rejected || !rejected.includes("already in progress")) {
-        \\  throw new Error("expected a concurrent-goto rejection, got: " + rejected);
-        \\}
+        \\const [a, b] = await Promise.all([
+        \\  goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
+        \\  goto("http://localhost:9582/src/browser/tests/runner/runner1.html"),
+        \\]);
+        \\if (typeof a !== "object" || typeof b !== "object") throw new Error("goto should resolve page handles");
+        \\const da = extract({ btn: "#btn" }, a);
+        \\if (da.btn !== "Click Me") throw new Error("handle a read wrong: " + JSON.stringify(da));
+        \\const db = extract({ sel: "#sel1" }, b);
+        \\if (db.sel !== "selector-1-content") throw new Error("handle b read wrong: " + JSON.stringify(db));
     );
 }

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -48,9 +48,6 @@ console_observer: ?ConsoleObserver = null,
 /// popup frames so they coexist; a sequential goto replaces the page.
 pending_gotos: std.ArrayList(PendingGoto) = .empty,
 
-/// Most-recent `goto`'s frame — the default target when no handle is passed.
-current_frame_id: ?u32 = null,
-
 /// The runtime installs exactly the recorded browser tools as script
 /// primitives — the same set the recorder writes — so every recorded call
 /// replays. `buildArgs` adapts each tool's JS calling convention to the JSON
@@ -180,12 +177,18 @@ fn createContext(self: *Runtime) InitError!void {
     const local = &ls.local;
     const global = local.globalObject();
 
+    // `goto` is the only global: it opens a page and resolves a Page object
+    // whose methods (every other recorded tool) `makePage` attaches. The
+    // `primitive_data` entry for each recorded tool is filled here regardless,
+    // so `makePage` can hand the same shared data to its method callbacks.
     var i: usize = 0;
     for (std.enums.values(BrowserTool)) |t| {
         if (!t.isRecorded()) continue;
         self.primitive_data[i] = .{ .runtime = self, .tool = t };
-        const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
-        _ = global.set(@tagName(t), func.toValue(), .{}) catch return error.RuntimeInitFailed;
+        if (t == .goto) {
+            const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
+            _ = global.set(@tagName(t), func.toValue(), .{}) catch return error.RuntimeInitFailed;
+        }
         i += 1;
     }
     try self.installConsole(local, global);
@@ -347,11 +350,7 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    var argc: usize = fci.length();
-
-    // Peel a trailing page handle (from `goto`) out of the args; goto has none.
-    const handle_id = if (tool == .goto) null else peelHandle(local, fci, argc);
-    if (handle_id != null) argc -= 1;
+    const argc: usize = fci.length();
 
     const args = self.buildArgs(arena, local, tool, fci, argc) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
@@ -363,14 +362,13 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
 
     defer self.session._tool_frame_override = null;
 
-    // An explicit handle that no longer resolves is a hard error; with no
-    // handle we aim at the most-recent goto (best-effort, may be current).
-    if (handle_id) |id| {
-        self.session._tool_frame_override = self.session.findFrameByFrameId(id) orelse
-            return self.throwError("page handle is no longer valid; the page was closed or replaced");
-    } else if (self.current_frame_id) |id| {
-        self.session._tool_frame_override = self.session.findFrameByFrameId(id);
-    }
+    // Every non-goto primitive is a method on the Page object `goto` resolved;
+    // the receiver carries the target frame. A bare call (no page receiver) or a
+    // frame that no longer resolves (page closed or replaced) is a hard error.
+    const frame_id = receiverFrameId(local, fci) orelse
+        return self.throwError("this must be called as a method on a page returned by goto()");
+    self.session._tool_frame_override = self.session.findFrameByFrameId(frame_id) orelse
+        return self.throwError("page handle is no longer valid; the page was closed or replaced");
 
     const result = self.callTool(arena, tool, args) catch |err| switch (err) {
         error.OutOfMemory => return self.throwError("out of memory"),
@@ -390,8 +388,8 @@ fn invoke(self: *Runtime, local: *const lp.js.Local, tool: BrowserTool, fci: Fci
     }
 }
 
-/// Open a navigation; resolves a page handle the read tools accept to target
-/// this page. Concurrent gotos fork popups, so `Promise.all` fetches in parallel.
+/// Open a navigation; resolves a Page object whose methods target this page.
+/// Concurrent gotos fork popups, so `Promise.all` fetches in parallel.
 fn invokeGoto(
     self: *Runtime,
     arena: std.mem.Allocator,
@@ -417,7 +415,6 @@ fn invokeGoto(
         break :frame browser_tools.openGotoFrame(self.session, self.registry, url, fork) catch
             return resolver.rejectError("goto", .{ .generic_error = "navigation failed to start" });
     };
-    self.current_frame_id = frame._frame_id;
 
     var global = resolver.persistOwned();
     self.pending_gotos.append(self.allocator, .{
@@ -430,22 +427,30 @@ fn invokeGoto(
     };
 }
 
-/// A page handle: `{ __lpFrameId: <id> }`, peeled back by `peelHandle`.
-fn makeHandle(local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
+/// The Page object `goto` resolves: `__lpFrameId` plus a method for every recorded
+/// tool except `goto`. Methods share `createContext`'s `primitive_data` entries, so
+/// the tool iteration order here must match it for the indices to line up.
+fn makePage(self: *Runtime, local: *const lp.js.Local, frame_id: u32) ?lp.js.Value {
     const obj = local.newObject();
     _ = obj.set("__lpFrameId", frame_id, .{}) catch return null;
+
+    var i: usize = 0;
+    for (std.enums.values(BrowserTool)) |t| {
+        if (!t.isRecorded()) continue;
+        defer i += 1;
+        if (t == .goto) continue;
+        const func = local.newRawCallback(primitiveCallback, &self.primitive_data[i]);
+        _ = obj.set(@tagName(t), func.toValue(), .{}) catch return null;
+    }
     return obj.toValue();
 }
 
-/// Frame id if the last arg is a page handle (`{ __lpFrameId }`), else null —
-/// unambiguous since no real tool arg carries that key.
-fn peelHandle(local: *const lp.js.Local, fci: Fci, argc: usize) ?u32 {
-    if (argc == 0) return null;
-    const last = fci.getArg(@intCast(argc - 1), local);
-    if (!last.isObject()) return null;
-    const obj = last.toObject();
-    if (obj.has("__lpFrameId") == false) return null;
-    const prop = obj.get("__lpFrameId") catch return null;
+/// Frame id from a method's receiver (`this.__lpFrameId`), else null — a bare
+/// call with no page receiver. Mirrors the old `peelHandle`, reading `getThis()`.
+fn receiverFrameId(local: *const lp.js.Local, fci: Fci) ?u32 {
+    const this: lp.js.Object = .{ .local = local, .handle = fci.getThis() };
+    if (this.has("__lpFrameId") == false) return null;
+    const prop = this.get("__lpFrameId") catch return null;
     if (!prop.isNumber()) return null;
     return prop.toU32() catch null;
 }
@@ -465,10 +470,10 @@ fn resolveReadyGotos(self: *Runtime, local: *const lp.js.Local) void {
         if (frame == null or frame.?._last_navigate_error != null) {
             resolver.rejectError("goto", .{ .generic_error = "navigation failed" });
         } else if (ls == .load or ls == .complete or std.time.milliTimestamp() >= entry.deadline_ms) {
-            if (makeHandle(local, entry.frame_id)) |handle| {
-                resolver.resolve("goto", handle);
+            if (self.makePage(local, entry.frame_id)) |page| {
+                resolver.resolve("goto", page);
             } else {
-                resolver.rejectError("goto", .{ .generic_error = "internal: handle alloc failed" });
+                resolver.rejectError("goto", .{ .generic_error = "internal: page alloc failed" });
             }
         } else {
             i += 1;
@@ -728,9 +733,9 @@ test "agent script runtime: goto and evaluate dispatch through browser tools" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (typeof nav !== "object" || nav === null) throw new Error("goto should resolve a page handle: " + nav);
-        \\const text = evaluate("document.getElementById('btn').textContent");
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\if (typeof page !== "object" || page === null) throw new Error("goto should resolve a page object: " + page);
+        \\const text = page.evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("evaluate ran in the wrong context: " + text);
     );
 
@@ -749,8 +754,8 @@ test "agent script runtime: extract returns a JavaScript object" {
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\const data = extract({
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const data = page.extract({
         \\  button: "#btn",
         \\  options: [{
         \\    selector: "#sel option",
@@ -765,7 +770,7 @@ test "agent script runtime: extract returns a JavaScript object" {
         \\if (data.button !== "Click Me") throw new Error("unexpected button text: " + data.button);
         \\if (data.options.length !== 2) throw new Error("unexpected option count: " + data.options.length);
         \\if (data.options[1].value !== "opt2") throw new Error("unexpected option value: " + data.options[1].value);
-        \\const options = extract({
+        \\const options = page.extract({
         \\  options: [{
         \\    selector: "#sel option",
         \\    limit: 2,
@@ -777,14 +782,14 @@ test "agent script runtime: extract returns a JavaScript object" {
         \\});
         \\if (typeof options !== "object" || options === null || Array.isArray(options)) throw new Error("single object field should stay an object");
         \\if (options.options[0].text !== "Option 1") throw new Error("unexpected option text: " + options.options[0].text);
-        \\const direct = extract([{ selector: "#sel option", limit: 1 }]);
+        \\const direct = page.extract([{ selector: "#sel option", limit: 1 }]);
         \\if (!Array.isArray(direct)) throw new Error("array schema should return an array");
         \\if (direct[0] !== "Option 1") throw new Error("unexpected direct array extract: " + direct[0]);
-        \\const saveField = extract({ save: "#btn" });
+        \\const saveField = page.extract({ save: "#btn" });
         \\if (saveField.save !== "Click Me") throw new Error("top-level save field should be schema data");
         \\let rejectedSaveOption = false;
         \\try {
-        \\  extract({ schema: { button: "#btn" }, save: "snap" });
+        \\  page.extract({ schema: { button: "#btn" }, save: "snap" });
         \\} catch (err) {
         \\  rejectedSaveOption = true;
         \\}
@@ -803,16 +808,16 @@ test "agent script runtime: extract tolerates list selectors that match nothing"
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\const empty = extract({ comments: [{ selector: ".no-such-element", fields: { text: "" } }] });
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const empty = page.extract({ comments: [{ selector: ".no-such-element", fields: { text: "" } }] });
         \\if (!Array.isArray(empty.comments) || empty.comments.length !== 0) throw new Error("empty list selector should yield an empty array, not throw");
-        \\const bare = extract([".no-such-element"]);
+        \\const bare = page.extract([".no-such-element"]);
         \\if (!Array.isArray(bare) || bare.length !== 0) throw new Error("bare empty array schema should yield an empty array");
-        \\const mixed = extract({ button: "#btn", comments: [".no-such-element"] });
+        \\const mixed = page.extract({ button: "#btn", comments: [".no-such-element"] });
         \\if (mixed.button !== "Click Me" || mixed.comments.length !== 0) throw new Error("a matched scalar beside an empty list should still resolve");
         \\let threwOnAllNull = false;
         \\try {
-        \\  extract({ missing: "#does-not-exist" });
+        \\  page.extract({ missing: "#does-not-exist" });
         \\} catch (err) {
         \\  threwOnAllNull = true;
         \\}
@@ -832,9 +837,9 @@ test "agent script runtime: strict-mode scripts can call primitives" {
 
     try runTestScript(runtime,
         \\"use strict";
-        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (typeof nav !== "object" || nav === null) throw new Error("strict-mode goto failed: " + nav);
-        \\const text = evaluate("document.getElementById('btn').textContent");
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\if (typeof page !== "object" || page === null) throw new Error("strict-mode goto failed: " + page);
+        \\const text = page.evaluate("document.getElementById('btn').textContent");
         \\if (text !== "Click Me") throw new Error("strict-mode evaluate failed: " + text);
     );
 }
@@ -870,13 +875,13 @@ test "agent script runtime: primitives re-entered from argument callbacks stay i
     defer runtime.deinit();
 
     try runTestScript(runtime,
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\// toJSON re-enters evaluate mid-marshal; the outer extract must still see "#btn".
-        \\const data = extract({ button: { toJSON() { return evaluate("'#btn'"); } } });
+        \\const data = page.extract({ button: { toJSON() { return page.evaluate("'#btn'"); } } });
         \\if (data.button !== "Click Me") throw new Error("re-entrant extract corrupted: " + JSON.stringify(data));
         \\// toString re-enters a primitive mid-loop; the console buffer must survive.
         \\let probed = 0;
-        \\console.log("value", { toString() { probed += 1; return evaluate("'ok'"); } }, "tail");
+        \\console.log("value", { toString() { probed += 1; return page.evaluate("'ok'"); } }, "tail");
         \\if (probed !== 1) throw new Error("console toString re-entry not exercised");
     );
 }
@@ -936,10 +941,10 @@ test "agent script runtime: page evaluate cannot see agent primitives or binding
 
     try runTestScript(runtime,
         \\const agentOnly = "secret";
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\if (evaluate("typeof goto") !== "undefined") throw new Error("agent primitive leaked to page evaluate");
-        \\if (evaluate("typeof agentOnly") !== "undefined") throw new Error("agent binding leaked to page evaluate");
-        \\if (evaluate("typeof document") !== "object") throw new Error("page evaluate did not run in the page context");
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\if (page.evaluate("typeof goto") !== "undefined") throw new Error("agent primitive leaked to page evaluate");
+        \\if (page.evaluate("typeof agentOnly") !== "undefined") throw new Error("agent binding leaked to page evaluate");
+        \\if (page.evaluate("typeof document") !== "object") throw new Error("page evaluate did not run in the page context");
     );
 }
 
@@ -971,8 +976,8 @@ test "agent script runtime: tool errors throw and stop execution" {
 
     const message = (try runtime.runSource(
         \\globalThis.marker = "before";
-        \\await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
-        \\click({ selector: "#does-not-exist" });
+        \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+        \\page.click({ selector: "#does-not-exist" });
         \\globalThis.marker = "after";
     , "agent-runtime-failure.js")).?;
 
@@ -997,29 +1002,29 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
 
     try runTestScript(runtime,
         \\// The reported bug: Playwright-style goto(url, options) must merge, not throw.
-        \\const nav = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
-        \\if (typeof nav !== "object" || nav === null) throw new Error("two-arg goto failed: " + nav);
+        \\let page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html", { timeout: 5000 });
+        \\if (typeof page !== "object" || page === null) throw new Error("two-arg goto failed: " + page);
         \\// waitForState: single required param, positional like waitForSelector.
-        \\if (!waitForState("load").includes("reached")) throw new Error("waitForState positional failed");
+        \\if (!page.waitForState("load").includes("reached")) throw new Error("waitForState positional failed");
         \\// Object form still works.
-        \\await goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
+        \\page = await goto({ url: "http://localhost:9582/src/browser/tests/mcp_actions.html", timeout: 5000 });
         \\// Single selector positional.
-        \\click("#btn");
-        \\if (evaluate("String(window.clicked)") !== "true") throw new Error("click positional failed");
+        \\page.click("#btn");
+        \\if (page.evaluate("String(window.clicked)") !== "true") throw new Error("click positional failed");
         \\// Two positionals: selector, value.
-        \\fill("#inp", "hello");
-        \\if (evaluate("window.inputVal") !== "hello") throw new Error("fill two-positional failed");
-        \\selectOption("#sel", "opt2");
-        \\if (evaluate("window.selChanged") !== "opt2") throw new Error("selectOption two-positional failed");
+        \\page.fill("#inp", "hello");
+        \\if (page.evaluate("window.inputVal") !== "hello") throw new Error("fill two-positional failed");
+        \\page.selectOption("#sel", "opt2");
+        \\if (page.evaluate("window.selChanged") !== "opt2") throw new Error("selectOption two-positional failed");
         \\// Bool positional, and the default-true shorthand when omitted. Assert via the
         \\// tool's own report (the synthetic click toggles the DOM state, so .checked is
         \\// not a reliable observation of the `checked` argument).
-        \\if (!setChecked("#chk").includes("to checked")) throw new Error("setChecked default-true failed");
-        \\if (!setChecked("#chk", false).includes("to unchecked")) throw new Error("setChecked bool positional failed");
+        \\if (!page.setChecked("#chk").includes("to checked")) throw new Error("setChecked default-true failed");
+        \\if (!page.setChecked("#chk", false).includes("to unchecked")) throw new Error("setChecked bool positional failed");
         \\// Selector-first press, and a null selector for a page/focused key press.
-        \\press("#keyTarget", "Enter");
-        \\if (evaluate("window.keyPressed") !== "Enter") throw new Error("selector-first press failed");
-        \\press(null, "a");
+        \\page.press("#keyTarget", "Enter");
+        \\if (page.evaluate("window.keyPressed") !== "Enter") throw new Error("selector-first press failed");
+        \\page.press(null, "a");
     );
 
     // A field set by both a positional and the options object is a conflict.
@@ -1033,7 +1038,8 @@ test "agent script runtime: builtin argument marshalling (positional + options)"
     // More positionals than the tool has fields throws.
     {
         const message = (try runtime.runSource(
-            \\click("#btn", "#extra");
+            \\const page = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
+            \\page.click("#btn", "#extra");
         , "agent-runtime-arity.js")).?;
         try testing.expect(std.mem.indexOf(u8, message, "invalid arguments") != null);
     }
@@ -1057,7 +1063,7 @@ test "agent script runtime: top-level await runs in an async wrapper" {
     );
 }
 
-test "agent script runtime: parallel goto fetches concurrent pages, read by handle" {
+test "agent script runtime: parallel goto fetches concurrent pages, read per page object" {
     defer testing.reset();
     defer if (testing.test_session.hasPage()) testing.test_session.removePage();
 
@@ -1068,17 +1074,17 @@ test "agent script runtime: parallel goto fetches concurrent pages, read by hand
     defer runtime.deinit();
 
     // Two gotos in flight at once open distinct frames (root + popup) that load
-    // concurrently in one Page; each is read back via the handle goto resolved.
+    // concurrently in one Page; each is read back through the Page object goto resolved.
     try runTestScript(runtime,
         \\const [a, b] = await Promise.all([
         \\  goto("http://localhost:9582/src/browser/tests/mcp_actions.html"),
         \\  goto("http://localhost:9582/src/browser/tests/runner/runner1.html"),
         \\]);
-        \\if (typeof a !== "object" || typeof b !== "object") throw new Error("goto should resolve page handles");
-        \\const da = extract({ btn: "#btn" }, a);
-        \\if (da.btn !== "Click Me") throw new Error("handle a read wrong: " + JSON.stringify(da));
-        \\const db = extract({ sel: "#sel1" }, b);
-        \\if (db.sel !== "selector-1-content") throw new Error("handle b read wrong: " + JSON.stringify(db));
+        \\if (typeof a !== "object" || typeof b !== "object") throw new Error("goto should resolve page objects");
+        \\const da = a.extract({ btn: "#btn" });
+        \\if (da.btn !== "Click Me") throw new Error("page a read wrong: " + JSON.stringify(da));
+        \\const db = b.extract({ sel: "#sel1" });
+        \\if (db.sel !== "selector-1-content") throw new Error("page b read wrong: " + JSON.stringify(db));
     );
 }
 
@@ -1092,12 +1098,12 @@ test "agent script runtime: a stale page handle is a hard error" {
     const runtime = try Runtime.init(testing.allocator, testing.test_app, testing.test_session, &registry);
     defer runtime.deinit();
 
-    // The first handle goes stale once the second (non-forked) goto replaces the
+    // The first page goes stale once the second (non-forked) goto replaces the
     // page; reading through it must throw, not silently hit the current page.
     const message = (try runtime.runSource(
         \\const a = await goto("http://localhost:9582/src/browser/tests/mcp_actions.html");
         \\await goto("http://localhost:9582/src/browser/tests/runner/runner1.html");
-        \\extract({ btn: "#btn" }, a);
+        \\a.extract({ btn: "#btn" });
     , "agent-runtime-stale-handle.js")).?;
 
     try testing.expect(std.mem.indexOf(u8, message, "no longer valid") != null);

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -191,6 +191,9 @@ pub const Command = union(enum) {
 
 fn formatJsToolCall(tc: Command.ToolCall, arena: std.mem.Allocator, writer: *std.Io.Writer) (std.Io.Writer.Error || error{OutOfMemory})!void {
     const s = tc.schema();
+    // Async builtins (goto) must be awaited so a replayed script waits for the
+    // navigation before the next primitive reads the page.
+    if (tc.tool.isAsync()) try writer.writeAll("await ");
     const args_val = tc.args orelse {
         try writer.print("{s}();", .{s.tool_name});
         return;
@@ -419,7 +422,7 @@ test "formatJs: positional and object arguments" {
     const aa = arena.allocator();
 
     const cases = [_]struct { input: []const u8, expected: []const u8 }{
-        .{ .input = "/goto https://example.com", .expected = "goto(\"https://example.com\");" },
+        .{ .input = "/goto https://example.com", .expected = "await goto(\"https://example.com\");" },
         .{ .input = "/click selector='Login'", .expected = "click({ selector: \"Login\" });" },
         .{ .input = "/scroll y=200", .expected = "scroll({ y: 200 });" },
         .{ .input = "/setChecked selector='#x' checked=false", .expected = "setChecked({ selector: \"#x\", checked: false });" },

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -191,8 +191,7 @@ pub const Command = union(enum) {
 
 fn formatJsToolCall(tc: Command.ToolCall, arena: std.mem.Allocator, writer: *std.Io.Writer) (std.Io.Writer.Error || error{OutOfMemory})!void {
     const s = tc.schema();
-    // Async builtins must be awaited so a replay waits for navigation.
-    if (tc.tool.isAsync()) try writer.writeAll("await ");
+    // The bare call only; the recorder adds the `page.` receiver and any `await`.
     const args_val = tc.args orelse {
         try writer.print("{s}();", .{s.tool_name});
         return;
@@ -421,7 +420,7 @@ test "formatJs: positional and object arguments" {
     const aa = arena.allocator();
 
     const cases = [_]struct { input: []const u8, expected: []const u8 }{
-        .{ .input = "/goto https://example.com", .expected = "await goto(\"https://example.com\");" },
+        .{ .input = "/goto https://example.com", .expected = "goto(\"https://example.com\");" },
         .{ .input = "/click selector='Login'", .expected = "click({ selector: \"Login\" });" },
         .{ .input = "/scroll y=200", .expected = "scroll({ y: 200 });" },
         .{ .input = "/setChecked selector='#x' checked=false", .expected = "setChecked({ selector: \"#x\", checked: false });" },

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -191,8 +191,7 @@ pub const Command = union(enum) {
 
 fn formatJsToolCall(tc: Command.ToolCall, arena: std.mem.Allocator, writer: *std.Io.Writer) (std.Io.Writer.Error || error{OutOfMemory})!void {
     const s = tc.schema();
-    // Async builtins (goto) must be awaited so a replayed script waits for the
-    // navigation before the next primitive reads the page.
+    // Async builtins must be awaited so a replay waits for navigation.
     if (tc.tool.isAsync()) try writer.writeAll("await ");
     const args_val = tc.args orelse {
         try writer.print("{s}();", .{s.tool_name});


### PR DESCRIPTION
Wraps agent scripts in an async IIFE to allow top-level `await` and explicit `return` statements for output. The `goto` primitive is now asynchronous, returning a Promise that is settled by driving the browser event loop. All other primitives remain synchronous.