### PR TITLE
webapi: implement HTMLSelectElement.type and HTMLOptionElement.label

### DIFF
--- a/src/browser/tests/element/html/option.html
+++ b/src/browser/tests/element/html/option.html
@@ -29,6 +29,23 @@
   testing.expectEqual('Text 3', $('#opt3').text)
 </script>
 
+<option id="opt_labelled" label="Explicit Label">Inner Text</option>
+
+<script id="label">
+  // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-label
+  // No label attribute: falls back to the text.
+  testing.expectEqual('Text 1', $('#opt1').label)
+  // label attribute present and non-empty: returned as-is.
+  testing.expectEqual('Explicit Label', $('#opt_labelled').label)
+  // Setting reflects to the label content attribute.
+  $('#opt1').label = 'Set Label'
+  testing.expectEqual('Set Label', $('#opt1').label)
+  testing.expectEqual('Set Label', $('#opt1').getAttribute('label'))
+  // An empty label attribute falls back to the text, per spec.
+  $('#opt1').setAttribute('label', '')
+  testing.expectEqual('Text 1', $('#opt1').label)
+</script>
+
 <script id="text_set">
   $('#opt1').text = 'New Text 1'
   testing.expectEqual('New Text 1', $('#opt1').text)

--- a/src/browser/tests/element/html/select.html
+++ b/src/browser/tests/element/html/select.html
@@ -142,6 +142,20 @@
   }
 </script>
 
+<script id="type_reflects_multiple">
+  {
+    // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-type
+    testing.expectEqual('select-one', $('#select1').type)
+    testing.expectEqual('select-multiple', $('#select_multi').type)
+
+    // type tracks the multiple attribute, it is not stored independently
+    const sel = document.createElement('select')
+    testing.expectEqual('select-one', sel.type)
+    sel.multiple = true
+    testing.expectEqual('select-multiple', sel.type)
+  }
+</script>
+
 <script id="multiple_setValue">
   {
     const sel = $('#select_multi')

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -108,6 +108,21 @@ pub fn setName(self: *Option, name: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
 }
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-label
+// On getting, return the `label` content attribute if present and non-empty,
+// otherwise the value of the `text` IDL attribute. On setting, reflect to the
+// `label` content attribute.
+pub fn getLabel(self: *const Option, frame: *Frame) []const u8 {
+    if (self.asConstElement().getAttributeSafe(comptime .wrap("label"))) |label| {
+        if (label.len != 0) return label;
+    }
+    return self.getText(frame);
+}
+
+pub fn setLabel(self: *Option, label: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("label"), .wrap(label), frame);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Option);
 
@@ -119,6 +134,7 @@ pub const JsApi = struct {
 
     pub const value = bridge.accessor(Option.getValue, Option.setValue, .{ .ce_reactions = true });
     pub const text = bridge.accessor(Option.getText, Option.setText, .{ .ce_reactions = true });
+    pub const label = bridge.accessor(Option.getLabel, Option.setLabel, .{ .ce_reactions = true });
     pub const selected = bridge.accessor(Option.getSelected, Option.setSelected, .{});
     pub const defaultSelected = bridge.accessor(Option.getDefaultSelected, null, .{});
     pub const disabled = bridge.accessor(Option.getDisabled, Option.setDisabled, .{ .ce_reactions = true });

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -129,6 +129,13 @@ pub fn getMultiple(self: *const Select) bool {
     return self.asConstElement().getAttributeSafe(comptime .wrap("multiple")) != null;
 }
 
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-type
+// The `type` IDL attribute reflects the element's mode: "select-multiple" when
+// the `multiple` attribute is present, "select-one" otherwise.
+pub fn getType(self: *const Select) []const u8 {
+    return if (self.getMultiple()) "select-multiple" else "select-one";
+}
+
 pub fn setMultiple(self: *Select, multiple: bool, frame: *Frame) !void {
     if (multiple) {
         try self.asElement().setAttributeSafe(comptime .wrap("multiple"), .wrap(""), frame);
@@ -318,6 +325,7 @@ pub const JsApi = struct {
     };
 
     pub const value = bridge.accessor(Select.getValue, Select.setValue, .{});
+    pub const @"type" = bridge.accessor(Select.getType, null, .{});
     pub const selectedIndex = bridge.accessor(Select.getSelectedIndex, Select.setSelectedIndex, .{});
     pub const multiple = bridge.accessor(Select.getMultiple, Select.setMultiple, .{ .ce_reactions = true });
     pub const disabled = bridge.accessor(Select.getDisabled, Select.setDisabled, .{ .ce_reactions = true });


### PR DESCRIPTION
## What

`HTMLSelectElement.type` and `HTMLOptionElement.label` were unimplemented and evaluated to `undefined` in V8. Both are required IDL attributes in the HTML Living Standard. This implements them: `select.type` derived from the `multiple` attribute, `option.label` from the `label` attribute with a text fallback.

Closes #2738.

## Root cause

Neither `Select.zig` nor `Option.zig` exposed a `type` / `label` accessor in their `JsApi` block, so V8 found no property on the prototype and returned `undefined`. Every sibling attribute (`multiple`, `value`, `text`, `selected`, …) is implemented — these two were simply missing. Select-enhancement libraries branch on `select.type` to pick single- vs multi-select handling; reading `undefined` made them take a dead path and throw during init.

```mermaid
flowchart LR
    A["JS: select.type"] --> B["HTMLSelectElement prototype<br/>no `type` accessor"]
    B --> C["undefined"]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/browser/webapi/element/html/Select.zig` — add `getType()` returning `"select-multiple"` if `getMultiple()` else `"select-one"`; bind as `type`.
- `src/browser/webapi/element/html/Option.zig` — add `getLabel()` returning the `label` attribute when present and non-empty, else `getText()`; add `setLabel()` reflecting to the `label` attribute; bind as `label`.

```mermaid
flowchart LR
    A["JS: select.type"] --> B["Select.getType()<br/>reads multiple attribute"]
    B --> C["select-one / select-multiple"]
    style B fill:#dfd
    style C fill:#dfd
```

## Test

- **Fixtures**: `src/browser/tests/element/html/select.html` (`type_reflects_multiple`) and `option.html` (`label`) — both fail on `main` (`got undefined`) and pass with this commit. Verified by reverting just the production `.zig` files and re-running. Full suite: `796 of 796 tests passed`.
- **Reproducer** (from #2738): a CDP client reads `select.type` / `option.label` over `Runtime.evaluate`. Exits 1 on `main` (all three `undefined`), exits 0 with this commit (`select-one` / `select-multiple` / text-fallback label).

## Notes

- `select.type` is intentionally derived from `multiple` rather than stored — it has no backing content attribute, matching the spec and Chrome.
- `option.label`'s empty-attribute case falls back to text per spec (`<option label="">Foo</option>` → `"Foo"`), covered by the fixture.
