### PR TITLE
fix(cdp): allow setting a browser User-Agent via CDP

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -592,8 +592,4 @@ pub fn validateUserAgent(ua: []const u8) !void {
             return error.NonPrintable;
         }
     }
-
-    if (std.ascii.indexOfIgnoreCase(ua, "mozilla") != null) {
-        return error.Reserved;
-    }
 }

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -24,6 +24,13 @@ const Config = @import("../../Config.zig");
 
 const log = lp.log;
 
+// go-rod activates device emulation by default (Devices.LaptopWithMDPIScreen)
+// and pushes that device's User-Agent over CDP on every connect. Honoring it
+// would make every go-rod session silently impersonate Chrome, so we ignore
+// this one exact value while accepting any other UA a client deliberately sets.
+// See https://github.com/lightpanda-io/browser/issues/2704.
+const gorod_default_user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
+
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
         setEmulatedMedia,
@@ -91,11 +98,12 @@ pub fn setUserAgentOverride(cmd: *CDP.Command) !void {
     const ua = params.userAgent;
     Config.validateUserAgent(ua) catch |err| switch (err) {
         error.NonPrintable => return cmd.sendError(-32602, "User agent contains non-printable characters", .{}),
-        error.Reserved => {
-            log.warn(.not_implemented, "Emulation.setUserAgentOverride", .{ .param = "userAgent", .value = ua, .info = "User agent must not contain Mozilla" });
-            return cmd.sendResult(null, .{});
-        },
     };
+
+    if (std.mem.eql(u8, ua, gorod_default_user_agent)) {
+        log.warn(.not_implemented, "Emulation.setUserAgentOverride", .{ .param = "userAgent", .value = ua, .info = "ignoring go-rod default user agent" });
+        return cmd.sendResult(null, .{});
+    }
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const http_client = &cmd.cdp.browser.http_client;
@@ -121,10 +129,7 @@ test "cdp.Emulation: setUserAgentOverride with valid user agent" {
     try ctx.expectSentResult(null, .{ .id = 1 });
 }
 
-test "cdp.Emulation: setUserAgentOverride ignores mozilla" {
-    const filter: testing.LogFilter = .init(&.{.not_implemented});
-    defer filter.deinit();
-
+test "cdp.Emulation: setUserAgentOverride honors a deliberate Mozilla user agent" {
     var ctx = try testing.context();
     defer ctx.deinit();
     _ = try ctx.loadBrowserContext(.{ .id = "BID-UA2" });
@@ -135,11 +140,11 @@ test "cdp.Emulation: setUserAgentOverride ignores mozilla" {
         .params = .{ .userAgent = "Mozilla/5.0 (Windows NT 10.0)" },
     });
 
-    try ctx.expectSentResult(null, .{});
-    try testing.expectEqual(false, ctx.cdp().browser_context.?.user_agent_changed);
+    try ctx.expectSentResult(null, .{ .id = 2 });
+    try testing.expectEqual(true, ctx.cdp().browser_context.?.user_agent_changed);
 }
 
-test "cdp.Emulation: setUserAgentOverride ignores mozilla case insensitive" {
+test "cdp.Emulation: setUserAgentOverride ignores the go-rod default user agent" {
     const filter: testing.LogFilter = .init(&.{.not_implemented});
     defer filter.deinit();
 
@@ -150,7 +155,7 @@ test "cdp.Emulation: setUserAgentOverride ignores mozilla case insensitive" {
     try ctx.processMessage(.{
         .id = 3,
         .method = "Emulation.setUserAgentOverride",
-        .params = .{ .userAgent = "MOZILLA/5.0 test" },
+        .params = .{ .userAgent = gorod_default_user_agent },
     });
 
     try ctx.expectSentResult(null, .{});

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -307,9 +307,11 @@ pub fn httpRequestStart(bc: *CDP.BrowserContext, msg: *const Notification.Reques
     const frame_id = req.frame_id;
     const frame = bc.session.findFrameByFrameId(frame_id) orelse return;
 
-    // Modify request with extra CDP headers
+    // Modify request with extra CDP headers. Use `set` so a caller-supplied
+    // header (e.g. User-Agent) overrides the request's default instead of
+    // producing a duplicate that curl would silently drop.
     for (bc.extra_headers.items) |extra| {
-        try req.headers.add(extra);
+        try req.headers.set(extra);
     }
 
     // We're missing a bunch of fields, but, for now, this eems like enough

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -99,6 +99,38 @@ pub const Headers = struct {
         self.headers = updated_headers;
     }
 
+    // Append `header`, first dropping any existing header with the same
+    // (case-insensitive) name. Unlike `add`, this guarantees a single entry
+    // for that name: curl keeps the first of duplicate headers, so a plain
+    // `add` of e.g. "User-Agent: X" on top of the default would be silently
+    // ignored. Used for CDP extra headers, which must override request defaults.
+    pub fn set(self: *Headers, header: [*c]const u8) !void {
+        const header_str = std.mem.span(@as([*:0]const u8, @ptrCast(header)));
+        const parsed = parseHeader(header_str) orelse return self.add(header);
+
+        var new_list: ?*libcurl.CurlSList = null;
+        errdefer if (new_list) |list| libcurl.curl_slist_free_all(list);
+
+        var node = self.headers;
+        while (node) |h| : (node = h.*.next) {
+            const data = h.*.data;
+            if (parseHeader(std.mem.span(@as([*:0]const u8, @ptrCast(data))))) |existing| {
+                if (std.ascii.eqlIgnoreCase(existing.name, parsed.name)) {
+                    // Drop the default we're overriding.
+                    continue;
+                }
+            }
+            new_list = libcurl.curl_slist_append(new_list, data) orelse return error.OutOfMemory;
+        }
+
+        new_list = libcurl.curl_slist_append(new_list, header) orelse return error.OutOfMemory;
+
+        if (self.headers) |old| {
+            libcurl.curl_slist_free_all(old);
+        }
+        self.headers = new_list;
+    }
+
     pub fn parseHeader(header_str: []const u8) ?Header {
         const colon_pos = std.mem.indexOfScalar(u8, header_str, ':') orelse return null;
 
@@ -725,4 +757,38 @@ test "opensocketCallback: block_private=false allows private IP" {
     defer posix.close(fd);
 
     try testing.expect(fd >= 0);
+}
+
+test "Headers.set replaces a same-name header instead of duplicating" {
+    var headers = try Headers.init("User-Agent: Lightpanda/1.0");
+    defer headers.deinit();
+
+    // Override the seeded default User-Agent...
+    try headers.set("User-Agent: Custom/2.0");
+    // ...and append a brand-new header (no existing match -> plain append).
+    try headers.set("X-Custom: yes");
+
+    var ua_count: usize = 0;
+    var ua_value: []const u8 = "";
+    var saw_custom = false;
+    var accept_language: []const u8 = "";
+    var it = headers.iterator();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "User-Agent")) {
+            ua_count += 1;
+            ua_value = h.value;
+        } else if (std.ascii.eqlIgnoreCase(h.name, "X-Custom")) {
+            saw_custom = true;
+        } else if (std.ascii.eqlIgnoreCase(h.name, "Accept-Language")) {
+            accept_language = h.value;
+        }
+    }
+
+    // Exactly one User-Agent, carrying the overriding value (curl keeps the
+    // first of duplicates, so a leftover default would have shadowed it).
+    try testing.expectEqual(@as(usize, 1), ua_count);
+    try testing.expectString("Custom/2.0", ua_value);
+    try testing.expect(saw_custom);
+    // Unrelated defaults seeded by init() are preserved.
+    try testing.expectString("en-US,en;q=0.9", accept_language);
 }


### PR DESCRIPTION
## What

Fixes #2704: a CDP client cannot set a realistic browser `User-Agent`. Both Playwright mechanisms are broken, so any UA beginning with `Mozilla/5.0` (i.e. every real Chrome/Firefox/Safari UA) is silently dropped and origins always receive `User-Agent: Lightpanda/1.0`.

There are two independent bugs; this addresses both.

### Bug 1: `Emulation.setUserAgentOverride` blanket-ignores any "Mozilla" UA

`Config.validateUserAgent` returned `error.Reserved` for any UA containing `"mozilla"` (case-insensitive), and `setUserAgentOverride` turned that into a warning + `sendResult(null)` without applying the UA. The intent (commit 920ae57f) was narrow: go-rod activates device emulation by default (`Devices.LaptopWithMDPIScreen`) and pushes that device's `Mozilla/...` UA over CDP on every connect, so the maintainers chose to ignore it rather than error (erroring breaks go-rod). But a blanket substring match also discards every legitimate `newContext({ userAgent })` call.

Fix: scope the workaround to go-rod's **exact** default device UA string instead of any UA containing `"Mozilla"`. go-rod's `LaptopWithMDPIScreen` UA is a hardcoded constant (`...Chrome/114.0.0.0 Safari/537.36`), so go-rod keeps working while any other deliberately-set UA is honored. The non-printable-character rejection is unchanged.

### Bug 2: `Network.setExtraHTTPHeaders` appends `User-Agent` instead of replacing it

Each request's header list is seeded with the default `User-Agent: Lightpanda/1.0` in `http.Headers.init`. `httpRequestStart` then applied the CDP extra headers with `req.headers.add`, a plain `curl_slist_append`. The result was two `User-Agent` entries; curl keeps the first (`Lightpanda/1.0`), so the caller's value was silently dropped (every other extra header worked, since they had no default to collide with).

Fix: add `Headers.set`, which drops any existing same-name (case-insensitive) header before appending, and use it for CDP extra headers. Extra headers now override request defaults instead of producing a duplicate curl discards. This restores the documented `setExtraHTTPHeaders({ "User-Agent": ... })` fallback.

## Why it matters

For a drop-in Chrome/Chromium replacement, presenting a normal browser User-Agent to origins is essential, and keeps `navigator.userAgent`, the outbound header, and the TLS fingerprint mutually consistent. With both fixes, the natural `newContext({ userAgent })` path and the `setExtraHTTPHeaders` fallback both work for realistic UAs; go-rod's auto-injected UA is still ignored.

## Tests

- `cdp.Emulation: setUserAgentOverride honors a deliberate Mozilla user agent` (was "ignores mozilla", inverted to assert the new behavior).
- `cdp.Emulation: setUserAgentOverride ignores the go-rod default user agent` (asserts the scoped workaround still fires for go-rod's exact UA).
- `Headers.set replaces a same-name header instead of duplicating` (one `User-Agent` entry carrying the overriding value; unrelated seeded defaults preserved).

Full suite green: `797 of 797 tests passed`; `zig fmt --check` clean.