### PR TITLE
uaf, webapi: Window reuse

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.4.7'
+    default: 'v0.4.8'
   v8:
     description: 'v8 version to install'
     required: false

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig-v8 release tag the prebuilt lib came from'
     required: false
-    default: 'v0.4.7'
+    default: 'v0.4.8'
 
 runs:
   using: "composite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.0.365.4
-ARG ZIG_V8=v0.4.7
+ARG ZIG_V8=v0.4.8
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.7.tar.gz",
-            .hash = "v8-0.0.0-xddH63edBADvfTFAnAlB6WutVta1yhsLuyPdXXt_BnKK",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/a7556bba1f2e49cd179ab4d5eb8a10cfd73660bc.tar.gz",
+            .hash = "v8-0.0.0-xddH65qdBAA1hmB-gqEmhEzO0-aXKyEsmo1s34mssemb",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/a7556bba1f2e49cd179ab4d5eb8a10cfd73660bc.tar.gz",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.8.tar.gz",
             .hash = "v8-0.0.0-xddH65qdBAA1hmB-gqEmhEzO0-aXKyEsmo1s34mssemb",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -288,10 +288,23 @@ pub const HttpHeader = struct {
     value: []const u8,
 };
 
-pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
+pub const InitOpts = struct {
+    parent: ?*Frame = null,
+
+    // When a frame/popup re-navigates, we should preserve the same window.
+    // There are a couple reasons for this. First, iframe.contentWindow should
+    // maintain the same identity (which we don't correctly do now, but this
+    // is a first step). Secondly, a reference to the window can be acquired
+    // prior to navigation, and then used after. So it should remain valid.
+    reuse_window: ?*Window = null,
+};
+
+pub fn init(self: *Frame, frame_id: u32, page: *Page, opts: InitOpts) !void {
     if (comptime IS_DEBUG) {
         log.debug(.frame, "frame.init", .{});
     }
+
+    const parent = opts.parent;
 
     const session = page.session;
     const call_arena = try session.getArena(.medium, "call_arena");
@@ -341,7 +354,7 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
         });
     }
 
-    self.window = try factory.eventTarget(Window{
+    const window_template = Window{
         ._frame = self,
         ._proto = undefined,
         ._document = self.document,
@@ -350,7 +363,16 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, parent: ?*Frame) !void {
         ._screen = screen,
         ._visual_viewport = visual_viewport,
         ._cross_origin_wrapper = undefined,
-    });
+    };
+
+    if (opts.reuse_window) |w| {
+        const proto = w._proto;
+        w.* = window_template;
+        w._proto = proto;
+        self.window = w;
+    } else {
+        self.window = try factory.eventTarget(window_template);
+    }
     self.window._cross_origin_wrapper = .{ .window = self.window };
 
     self._style_manager = try StyleManager.init(self);
@@ -1463,7 +1485,7 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
     const new_frame = try self.arena.create(Frame);
     const frame_id = session.nextFrameId();
 
-    try Frame.init(new_frame, frame_id, self._page, self);
+    try Frame.init(new_frame, frame_id, self._page, .{ .parent = self });
     errdefer new_frame.deinit();
 
     self._pending_loads += 1;
@@ -1587,7 +1609,7 @@ pub fn openPopup(self: *Frame, opts: OpenPopupOpts) !*Frame {
     errdefer page.frame_arena.destroy(popup);
 
     const frame_id = session.nextFrameId();
-    try Frame.init(popup, frame_id, page, null);
+    try Frame.init(popup, frame_id, page, .{});
     errdefer popup.deinit();
 
     popup.window._opener = opts.opener;

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -293,9 +293,8 @@ pub const InitOpts = struct {
 
     // When a frame/popup re-navigates, we should preserve the same window.
     // There are a couple reasons for this. First, iframe.contentWindow should
-    // maintain the same identity (which we don't correctly do now, but this
-    // is a first step). Secondly, a reference to the window can be acquired
-    // prior to navigation, and then used after. So it should remain valid.
+    // maintain the same identity. Secondly, a reference to the window can be
+    // acquired prior to navigation, and then used after. So it should remain valid.
     reuse_window: ?*Window = null,
 };
 

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -126,7 +126,7 @@ pub fn init(self: *Page, session: *Session, frame_id: u32) !void {
     };
     self.queued_navigation = &self.queued_navigation_1;
 
-    try Frame.init(&self.frame, frame_id, self, null);
+    try Frame.init(&self.frame, frame_id, self, .{});
 }
 
 // Tear down the Page and its root Frame. Equivalent to the old

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -530,6 +530,7 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
     }
 
     const frame_id = frame._frame_id;
+    const reuse_window = frame.window;
     const page = self.currentPage().?;
     frame.deinit();
     frame.* = undefined;
@@ -546,7 +547,7 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
         }
     }
 
-    try Frame.init(frame, frame_id, page, parent);
+    try Frame.init(frame, frame_id, page, .{ .parent = parent, .reuse_window = reuse_window });
     errdefer {
         if (parent_notified) {
             parent._pending_loads -= 1;
@@ -563,14 +564,16 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
     };
 }
 
-// Re-navigates a popup Frame in place. The Frame pointer stays stable
-// (scripts in the opener may hold a cached Window ref — though the Window
-// object inside is replaced, matching how iframes behave on navigation).
+// Re-navigates a popup Frame in place. Both the Frame pointer and its Window
+// stay stable across the re-init, so a cached `window.open()` return value keeps
+// a valid `.location` instead of dangling against the freed one.
 fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) !void {
     // Preserve popup identity fields. _name lives in the Page arena and
     // survives Frame.deinit; _opener is just a pointer.
-    const saved_name = frame.window._name;
-    const saved_opener = frame.window._opener;
+
+    const reuse_window = frame.window;
+    const saved_name = reuse_window._name;
+    const saved_opener = reuse_window._opener;
     const frame_id = frame._frame_id;
     const page = self.currentPage().?;
 
@@ -587,7 +590,7 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
         }
     }
 
-    try Frame.init(frame, frame_id, page, null);
+    try Frame.init(frame, frame_id, page, .{ .reuse_window = reuse_window });
     errdefer frame.deinit();
 
     frame.window._name = saved_name;

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -221,20 +221,6 @@ pub fn deinit(self: *Context) void {
     // have a dangling pointer to our freed Context struct.
     v8.v8__Context__SetAlignedPointerInEmbedderData(entered.handle, 1, null);
 
-    // Evict the window's entry from the identity map. The window pointer is the
-    // identity-map key (see Env.createContext), and an in-place navigation
-    // reuses the same Window address — a lingering entry would make the next
-    // context's getOrPut see `found_existing` and skip registering its global.
-    switch (self.global) {
-        .frame => |frame| {
-            if (self.identity.identity_map.fetchRemove(@intFromPtr(frame.window))) |kv| {
-                var global = kv.value;
-                v8.v8__Global__Reset(&global);
-            }
-        },
-        .worker => {},
-    }
-
     v8.v8__Global__Reset(&self.handle);
     env.isolate.notifyContextDisposed();
     // There can be other tasks associated with this context that we need to

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -221,6 +221,20 @@ pub fn deinit(self: *Context) void {
     // have a dangling pointer to our freed Context struct.
     v8.v8__Context__SetAlignedPointerInEmbedderData(entered.handle, 1, null);
 
+    // Evict the window's entry from the identity map. The window pointer is the
+    // identity-map key (see Env.createContext), and an in-place navigation
+    // reuses the same Window address — a lingering entry would make the next
+    // context's getOrPut see `found_existing` and skip registering its global.
+    switch (self.global) {
+        .frame => |frame| {
+            if (self.identity.identity_map.fetchRemove(@intFromPtr(frame.window))) |kv| {
+                var global = kv.value;
+                v8.v8__Global__Reset(&global);
+            }
+        },
+        .worker => {},
+    }
+
     v8.v8__Global__Reset(&self.handle);
     env.isolate.notifyContextDisposed();
     // There can be other tasks associated with this context that we need to

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -254,11 +254,20 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
     const microtask_queue = v8.v8__MicrotaskQueue__New(isolate.handle, v8.kExplicit).?;
     errdefer v8.v8__MicrotaskQueue__DELETE(microtask_queue);
 
+    // Reuse the window's existing global proxy across an in-place navigation.
+    // The same *Window keeps its identity_map entry so reattaching it to the
+    // new context preserves WindowProxy identity
+    const reuse_global_object: ?*const v8.Value = blk: {
+        if (comptime !is_frame) break :blk null;
+        const existing = params.identity.identity_map.getPtr(@intFromPtr(global.window)) orelse break :blk null;
+        break :blk @ptrCast(v8.v8__Global__Get(existing, isolate.handle));
+    };
+
     // Restore the context from the snapshot (0 = Page, 1 = Worker)
     const snapshot_index: u32 = if (comptime is_frame) 0 else 1;
     const v8_context = v8.v8__Context__FromSnapshot__Config(isolate.handle, snapshot_index, &.{
         .global_template = null,
-        .global_object = null,
+        .global_object = reuse_global_object,
         .microtask_queue = microtask_queue,
     }).?;
 

--- a/src/browser/tests/frames/support/win_a.html
+++ b/src/browser/tests/frames/support/win_a.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>win_a</title>

--- a/src/browser/tests/frames/support/win_b.html
+++ b/src/browser/tests/frames/support/win_b.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>win_b</title>

--- a/src/browser/tests/frames/window_reuse.html
+++ b/src/browser/tests/frames/window_reuse.html
@@ -38,7 +38,10 @@ reuse and is tracked separately. This test guards the UAF, not the identity.
 
   state.resolve();
   await state.done(() => {
-    // Reading the cached window's location returns the new, valid location
+    // Same Window object across the navigation: the v8 global proxy is reused
+    // (WindowProxy identity).
+    testing.expectEqual(true, w === iframe.contentWindow);
+    // And reading the cached window's location returns the new, valid location
     // (previously a UAF double-free on the freed Location).
     testing.expectEqual(true, w.location.href.endsWith('/support/win_b.html'));
   });

--- a/src/browser/tests/frames/window_reuse.html
+++ b/src/browser/tests/frames/window_reuse.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<head></head>
+<body>
+<script src="../testing.js"></script>
+
+<!--
+Navigating a browsing context in place (iframe.src change / popup re-nav) reuses
+the same Window object, so a cached `iframe.contentWindow` / `window.open()`
+return value keeps a VALID `.location` across the navigation. Previously the
+in-place Frame re-init built a brand-new Window and freed the old one's
+Location, so the cached reference dangled — reading `.location` re-wrapped the
+freed Location into a double-free (URL.zig release-overflow).
+
+Note: strict WindowProxy identity (`w === iframe.contentWindow` across the
+navigation) is NOT yet provided — a Window is a v8 context's global object and
+the context is recreated per navigation. Achieving that needs v8 global-proxy
+reuse and is tracked separately. This test guards the UAF, not the identity.
+-->
+
+<script id=iframe_contentwindow_location_survives_navigation type=module>
+  const state = await testing.async();
+
+  const iframe = document.createElement('iframe');
+  const onceLoad = () => new Promise((r) => { iframe.onload = () => r(); });
+
+  let loaded = onceLoad();
+  iframe.src = 'support/win_a.html';
+  document.body.appendChild(iframe);
+  await loaded;
+
+  // Cache the window WITHOUT reading .location first, so its initial Location
+  // never gets a JS wrapper pinning it (the original crash condition).
+  const w = iframe.contentWindow;
+
+  loaded = onceLoad();
+  iframe.src = 'support/win_b.html';   // in-place re-init; Window is reused
+  await loaded;
+
+  state.resolve();
+  await state.done(() => {
+    // Reading the cached window's location returns the new, valid location
+    // (previously a UAF double-free on the freed Location).
+    testing.expectEqual(true, w.location.href.endsWith('/support/win_b.html'));
+  });
+</script>
+
+<!--
+The popup re-navigation path (Session.processPopupNavigation) reuses the Window
+the same way; it's exercised by the manual repro at wpt/_lprepro/opener.html
+(real HTTP popup load + postMessage aren't driven by this htmlRunner harness).
+-->
+</body>


### PR DESCRIPTION
Depends on https://github.com/lightpanda-io/zig-v8-fork/pull/182

This PR addresses 1 of 2 UAFs.

A few things going on. The simpler change is that a Window maintains its identity even when an iframe/popup navigates. So the Window of an iframe before and after a navigation is the same window (both in Zig and in JS).

While this is correct on the JS side, I think it's a minor compliance win and, on its own, possibly not worth the complexity. However, it also addresses 1 UAF bug.

After [rust-url integration](https://github.com/lightpanda-io/browser/pull/2658) was merged, I started to investigate new WPT crashes. It's a bit complicated. Fundamentally, we have 2 memory models: things live forever (until page end) or are reference counted. Because these are bi-directional graphs, you can't really mix the two memory models. If you do RC, then you need to do RC across everything in that graph. 

For that reason, most things don't do RC. It's just so much easier to lean on the page's arena. `Window` doesn't do RC. And that used to mean that if we did something like:

```
var w = iframe.contentWindow.
iframe.src = 'spice';
console.log(w.location)
```

Everything would work. Although we "destroy" the Frame, that Window continues to exist and can be reached from JS. 

The rust-url integration broke this by making URL reference counted. This is fine for JavaScript created URLs, but it breaks for window.location which is Zig-owned. In the above example, that abandoned Window, which is still valid, references a freed rust-url (freed in Page.deinit). 

One approach might have been to try to detach the URL's lifetime from the frame. I believe this would have fixed the UAF, but it would have resulted in incorrect data. e.g. the above snippet should print the new url, not the old one.

This PR addresses UAF caused by a navigation. It does not address the UAF from a `popup.close()`. I'll address that separately, likely after this is merged.