### PR TITLE
agent: reset save destination on /clear and /reset

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -742,11 +742,13 @@ fn handleUsage(self: *Agent) void {
 }
 
 /// Drop everything tied to the conversation: history (system prompt re-seeds
-/// lazily next turn), cumulative usage, the recorded action buffer, and DOM
-/// node IDs. Shared by `/clear` and `/reset`.
+/// lazily next turn), cumulative usage, the recorded action buffer and its save
+/// destination, and DOM node IDs. Shared by `/clear` and `/reset`.
 fn clearConversation(self: *Agent) void {
     self.conversation.rollback(0);
     self.save_buffer.reset();
+    if (self.save_path) |p| self.allocator.free(p);
+    self.save_path = null;
     self.total_usage = .{};
     self.node_registry.reset();
 }


### PR DESCRIPTION
clearConversation reset the recorded action buffer but left save_path set, so after /clear or /reset a /save <newfile> was rejected with "already saving to <oldfile>". Free and clear save_path alongside the buffer so a cleared session can save to a fresh file.