### PR TITLE
tools: update save script prompts for Page API

### DIFF
--- a/docs/agent-script.md
+++ b/docs/agent-script.md
@@ -392,7 +392,7 @@ Common failures:
 | `page handle is no longer valid` | A page was used after a later `goto` replaced it. Read a page before navigating away. |
 | `ReferenceError: document is not defined` | You tried to use browser DOM APIs in the agent context. Use `page.extract(...)` or `page.evaluate(...)`. |
 | `ReferenceError: require is not defined` | Agent scripts are not Node.js scripts. |
-| `no page loaded - run goto(url) first` | A page-dependent primitive ran before navigation. |
+| `no page loaded - run page.goto(url) first` | A page method ran before navigation. |
 | `invalid arguments` | A method received the wrong number or shape of arguments, or a non-JSON-serializable value. |
 | `extract: no schema selector matched any element` | Every field in the schema missed. Fix the selectors; an empty page section yields `null`/`[]` per field, not this error. |
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -95,11 +95,11 @@ The whole value of a saved script is that it keeps working after you walk away.
 - **Ask for the data you want, not the conversation about it.** "Get me the
   top 5 HN story titles and points, print them to stdout" beats "show me
   what's on Hacker News today." The synthesizer captures the data you asked
-  for as an `extract()` call; vague prompts produce vague recordings.
+  for as a `page.extract()` call; vague prompts produce vague recordings.
 - **Be specific about the page.** "Go to news.ycombinator.com" is much
   better than "find me what's on Hacker News".
 - **Check the file with `cat your-script.js` before running it.** The
-  script holds the *calls*, not the data, so look for an `extract(...)`
+  script holds the *calls*, not the data, so look for a `page.extract(...)`
   whose schema covers the fields you asked for. If there isn't one, the
   recording missed something — try rewording your prompt.
 - **When the page changes and a saved script breaks**, re-run with the LLM,

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -181,7 +181,7 @@ const script_skill =
     \\| `page handle is no longer valid` | Used a page after a later `goto` replaced it → read a page before navigating away |
     \\| `document is not defined` | DOM API in script context → use `page.extract` or `page.evaluate` |
     \\| `require is not defined` | Not Node.js |
-    \\| `no page loaded - run goto(url) first` | Page primitive before navigation |
+    \\| `no page loaded - run page.goto(url) first` | Page method before navigation |
     \\| `invalid arguments` | Wrong arity/shape, non-JSON value, or a field set both positionally and in options |
     \\| `extract: no schema selector matched any element` | All schema fields missed → fix selectors |
     \\| `press` fails with one string arg | Selector-first: use `page.press(null, "Enter")` or `page.press({ key: "Enter" })` |

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -156,17 +156,18 @@ pub const save_synthesis_prompt =
     \\- Reasoning you did between tool calls — comparing, filtering, picking,
     \\  aggregating across pages — becomes plain top-level JavaScript, so the
     \\  script reaches the result without you.
-    \\- Read pages with extract(schema): CSS selectors lift text and
-    \\  attributes as strings, and every trim/split/regex/parse/merge on
-    \\  those strings is top-level JavaScript. Do NOT write an evaluate(...)
-    \\  that querySelects the page and massages the result — that is
-    \\  extract + top-level JS. evaluate is ONLY for what must execute
-    \\  inside the page and no builtin can do. Top-level variables also
-    \\  persist across goto/reload; everything in the page context is wiped.
+    \\- Read pages with page.extract(schema) — `const page = new Page(); await
+    \\  page.goto(url); page.extract({...})`. CSS selectors lift text and
+    \\  attributes as strings, and every trim/split/regex/parse/merge on those
+    \\  strings is top-level JavaScript. Do NOT write a page.evaluate(...) that
+    \\  querySelects the page and massages the result — that is page.extract +
+    \\  top-level JS. page.evaluate is ONLY for what must execute inside the page
+    \\  and no builtin can do. Top-level variables also persist across navigation;
+    \\  everything in the page context is wiped.
     \\Stay faithful to the calls that worked: same arguments and options each
     \\one actually used. Do NOT add a `timeout` (or any option) the session
     \\didn't use. Never round-trip a result through `lp.*`, and never append
-    \\no-op extract(...) probes or `evaluate("return lp....")` tails to
+    \\no-op page.extract(...) probes or `page.evaluate("return lp....")` tails to
     \\surface output.
     \\Output ONLY JavaScript source — no markdown fences, no commentary.
 ;
@@ -177,19 +178,22 @@ pub const save_synthesis_prompt =
 /// script. The agent's `/save` covers all of this via its skill doc instead.
 pub const save_script_rules =
     \\Script rules:
-    \\- The builtins are synchronous and the file runs as a classic script:
-    \\  `const data = extract({...})` — never async/await/.then. Top-level
-    \\  `await` is a SyntaxError; top-level `return` is illegal.
-    \\- Read pages with extract(schema); all processing of the returned
+    \\- `Page` is the only global. `new Page()` makes a page; `await page.goto(url)`
+    \\  navigates it (async — always `await`). Every other builtin is a synchronous
+    \\  method on that page: `const data = page.extract({...})`, never `await
+    \\  page.extract`. The file runs as an async script, so top-level `await` is
+    \\  allowed.
+    \\- Read pages with page.extract(schema); all processing of the returned
     \\  strings (trim, split, parse, merge, loops, cross-page aggregation)
-    \\  is plain top-level JavaScript in the script context. evaluate(...)
+    \\  is plain top-level JavaScript in the script context. page.evaluate(...)
     \\  is ONLY for JS that must run inside the page and no builtin covers —
     \\  never a querySelector-and-parse block. It cannot see script
     \\  variables (interpolate values into its string), and page state is
-    \\  wiped by every goto/reload while script variables persist.
-    \\- The last top-level expression is the script's output, printed
-    \\  automatically (objects/arrays as JSON). End with the bare result —
-    \\  `extract({...});` or `results;` — no console.log or JSON.stringify.
+    \\  wiped by every navigation while script variables persist.
+    \\- `return <value>` is the script's output, printed automatically
+    \\  (objects/arrays as JSON). End with `return page.extract({...});` or
+    \\  `return results;` — a bare trailing expression is not printed, and
+    \\  neither is console.log or JSON.stringify.
     \\- Modern, readable JS: `const`/`let`, `for (const x of xs)`, template
     \\  literals, destructuring, 2-space indent.
 ;

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -39,7 +39,7 @@ const save_schema = browser_tools.minify(
 const extra_tools = [_]McpTool{
     .{
         .name = "save",
-        .description = "Save the session as a reusable Lightpanda agent script. You hold the conversation, so synthesize the `script` yourself — call the builtins you used as tools (goto, click, fill, extract, …) as JavaScript functions with the same object arguments. Keep `$LP_*` placeholders; never inline a resolved secret.\n\n" ++ browser_tools.save_synthesis_prompt ++ "\n\n" ++ browser_tools.save_script_rules,
+        .description = "Save the session as a reusable Lightpanda agent script. You hold the conversation, so synthesize the `script` yourself — `const page = new Page(); await page.goto(url);` then call the builtins you used as tools (extract, click, fill, …) as methods on `page` with the same object arguments. Keep `$LP_*` placeholders; never inline a resolved secret.\n\n" ++ browser_tools.save_synthesis_prompt ++ "\n\n" ++ browser_tools.save_script_rules,
         .inputSchema = save_schema,
     },
 };

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -562,7 +562,7 @@ fn callTool(
 
     const result = browser_tools.call(arena, self.session, self.registry, @tagName(tool), args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
-        error.FrameNotLoaded => return .{ .fail = "no page loaded - run goto(url) first" },
+        error.FrameNotLoaded => return .{ .fail = "no page loaded - run page.goto(url) first" },
         else => return .{ .fail = std.fmt.allocPrint(arena, "{s} failed: {s}", .{ @tagName(tool), @errorName(err) }) catch return error.OutOfMemory },
     };
 


### PR DESCRIPTION
Updates the synthesis prompts and rules for the `save` tool to reflect the new `Page` class API. Scripts now instantiate `Page`, use async `await page.goto()`, call other builtins as synchronous methods on `page`, and use `return` to output results.