### PR TITLE
webapi; WPT domparsing improvements

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -99,6 +99,12 @@ _event_manager: EventManager,
 
 _parse_mode: enum { document, fragment, document_write } = .document,
 
+// While fragment-parsing (e.g. innerHTML), scripts are normally marked
+// "already started" so they never run. The one exception is
+// Range.createContextualFragment(), whose scripts DO run when the fragment is
+// inserted into a document
+_fragment_scripts_runnable: bool = false,
+
 // See Attribute.List for what this is. TL;DR: proper DOM Attribute Nodes are
 // fat yet rarely needed. We only create them on-demand, but still need proper
 // identity (a given attribute should return the same *Attribute), so we do
@@ -3617,15 +3623,26 @@ pub fn updateRangesForNodeRemoval(self: *Frame, parent: *Node, child: *Node, chi
 
 // TODO: optimize and cleanup, this is called a lot (e.g., innerHTML = '')
 pub fn parseHtmlAsChildren(self: *Frame, node: *Node, html: []const u8) !void {
-    return self.parseHtmlAsChildrenInner(node, html, false);
+    return self.parseHtmlAsChildrenInner(node, html, .{});
 }
 
 // setHTMLUnsafe variant: parse a fragment that may contain declarative shadow node
 pub fn parseHtmlUnsafeAsChildren(self: *Frame, node: *Node, html: []const u8) !void {
-    return self.parseHtmlAsChildrenInner(node, html, true);
+    return self.parseHtmlAsChildrenInner(node, html, .{ .allow_declarative_shadow = true });
 }
 
-fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, allow_declarative_shadow: bool) !void {
+// Range.createContextualFragment variant: unlike innerHTML et al., its scripts
+// are run when the fragment is inserted into a document.
+pub fn parseContextualFragment(self: *Frame, node: *Node, html: []const u8) !void {
+    return self.parseHtmlAsChildrenInner(node, html, .{ .scripts_runnable = true });
+}
+
+const FragmentParseOpts = struct {
+    scripts_runnable: bool = false,
+    allow_declarative_shadow: bool = false,
+};
+
+fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, opts: FragmentParseOpts) !void {
     const previous_parse_mode = self._parse_mode;
     self._parse_mode = .fragment;
     defer self._parse_mode = previous_parse_mode;
@@ -3645,7 +3662,11 @@ fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, allow_d
         }
     };
 
-    var parser = Parser.init(self.call_arena, node, self, .{ .allow_declarative_shadow = allow_declarative_shadow });
+    const previous_scripts_runnable = self._fragment_scripts_runnable;
+    self._fragment_scripts_runnable = opts.scripts_runnable;
+    defer self._fragment_scripts_runnable = previous_scripts_runnable;
+
+    var parser = Parser.init(self.call_arena, node, self, .{ .allow_declarative_shadow = opts.allow_declarative_shadow });
     parser.parseFragment(html);
 
     // html5ever wraps fragment output in an <html> element; unwrap so its
@@ -3680,7 +3701,14 @@ fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, allow_d
 
 fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {
     if ((comptime from_parser) and self._parse_mode == .fragment) {
-        // we don't execute scripts added via innerHTML = '<script...';
+        if (self._fragment_scripts_runnable == false) {
+            // We don't execute scripts added via innerHTML = '<script...'. Mark
+            // them "already started" so they stay inert even after the parsed
+            // nodes are inserted into a connected document.
+            if (node.is(Element.Html.Script)) |script| {
+                script._executed = true;
+            }
+        }
         return;
     }
     // A node's "ready" work (running a <script>, loading an <iframe> / <link> /

--- a/src/browser/webapi/DocumentFragment.zig
+++ b/src/browser/webapi/DocumentFragment.zig
@@ -237,12 +237,16 @@ pub const JsApi = struct {
     pub const append = bridge.function(DocumentFragment.append, .{ .dom_exception = true, .ce_reactions = true });
     pub const prepend = bridge.function(DocumentFragment.prepend, .{ .dom_exception = true, .ce_reactions = true });
     pub const replaceChildren = bridge.function(DocumentFragment.replaceChildren, .{ .dom_exception = true, .ce_reactions = true });
-    pub const innerHTML = bridge.accessor(_innerHTML, DocumentFragment.setInnerHTML, .{ .ce_reactions = true });
 
-    fn _innerHTML(self: *DocumentFragment, frame: *Frame) ![]const u8 {
+    pub const innerHTML = bridge.accessor(_getInnerHTML, _setInnerHTML, .{ .ce_reactions = true });
+    fn _getInnerHTML(self: *DocumentFragment, frame: *Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);
         try self.getInnerHTML(&buf.writer, frame);
         return buf.written();
+    }
+    fn _setInnerHTML(self: *DocumentFragment, value: js.Value, frame: *Frame) !void {
+        // `[LegacyNullToEmptyString] DOMString`: a JS null becomes "", not "null".
+        return self.setInnerHTML(if (value.isNull()) "" else try value.toZig([]const u8), frame);
     }
 };
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1935,18 +1935,26 @@ pub const JsApi = struct {
         return buf.written();
     }
 
-    pub const outerHTML = bridge.accessor(_outerHTML, Element.setOuterHTML, .{ .ce_reactions = true });
-    fn _outerHTML(self: *Element, frame: *Frame) ![]const u8 {
+    pub const outerHTML = bridge.accessor(_getOuterHTML, _setOuterHTML, .{ .ce_reactions = true });
+    fn _getOuterHTML(self: *Element, frame: *Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);
         try self.getOuterHTML(&buf.writer, frame);
         return buf.written();
     }
+    fn _setOuterHTML(self: *Element, value: js.Value, frame: *Frame) !void {
+        // `[LegacyNullToEmptyString] DOMString`: a JS null becomes "", not "null".
+        return self.setOuterHTML(if (value.isNull()) "" else try value.toZig([]const u8), frame);
+    }
 
-    pub const innerHTML = bridge.accessor(_innerHTML, Element.setInnerHTML, .{ .ce_reactions = true });
-    fn _innerHTML(self: *Element, frame: *Frame) ![]const u8 {
+    pub const innerHTML = bridge.accessor(_getInnerHTML, _setInnerHTML, .{ .ce_reactions = true });
+    fn _getInnerHTML(self: *Element, frame: *Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);
         try self.getInnerHTML(&buf.writer, frame);
         return buf.written();
+    }
+    fn _setInnerHTML(self: *Element, value: js.Value, frame: *Frame) !void {
+        // `[LegacyNullToEmptyString] DOMString`: a JS null becomes "", not "null".
+        return self.setInnerHTML(if (value.isNull()) "" else try value.toZig([]const u8), frame);
     }
 
     pub const prefix = bridge.accessor(Element._prefix, null, .{});

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -554,7 +554,7 @@ pub fn createContextualFragment(self: *const Range, html: []const u8, frame: *Fr
     else
         try frame.createElementNS(.html, "div", null);
 
-    try frame.parseHtmlAsChildren(temp_node, html);
+    try frame.parseContextualFragment(temp_node, html);
 
     // Move all parsed children to the fragment
     // Keep removing first child until temp element is empty

--- a/src/browser/webapi/element/html/Template.zig
+++ b/src/browser/webapi/element/html/Template.zig
@@ -105,42 +105,49 @@ pub const JsApi = struct {
     };
 
     pub const content = bridge.accessor(Template.getContent, null, .{});
-    pub const innerHTML = bridge.accessor(_getInnerHTML, Template.setInnerHTML, .{ .ce_reactions = true });
-    pub const outerHTML = bridge.accessor(_getOuterHTML, null, .{});
-    pub const shadowRootMode = bridge.accessor(Template.getShadowRootMode, Template.setShadowRootMode, .{ .ce_reactions = true });
-    pub const shadowRootDelegatesFocus = bridge.accessor(_getShadowRootDelegatesFocus, _setShadowRootDelegatesFocus, .{ .ce_reactions = true });
-    pub const shadowRootClonable = bridge.accessor(_getShadowRootClonable, _setShadowRootClonable, .{ .ce_reactions = true });
-    pub const shadowRootSerializable = bridge.accessor(_getShadowRootSerializable, _setShadowRootSerializable, .{ .ce_reactions = true });
-
-    fn _getShadowRootDelegatesFocus(self: *const Template) bool {
-        return self.getBoolAttribute(.wrap("shadowrootdelegatesfocus"));
-    }
-    fn _setShadowRootDelegatesFocus(self: *Template, value: bool, frame: *Frame) !void {
-        try self.setBoolAttribute(.wrap("shadowrootdelegatesfocus"), value, frame);
-    }
-    fn _getShadowRootClonable(self: *const Template) bool {
-        return self.getBoolAttribute(.wrap("shadowrootclonable"));
-    }
-    fn _setShadowRootClonable(self: *Template, value: bool, frame: *Frame) !void {
-        try self.setBoolAttribute(.wrap("shadowrootclonable"), value, frame);
-    }
-    fn _getShadowRootSerializable(self: *const Template) bool {
-        return self.getBoolAttribute(.wrap("shadowrootserializable"));
-    }
-    fn _setShadowRootSerializable(self: *Template, value: bool, frame: *Frame) !void {
-        try self.setBoolAttribute(.wrap("shadowrootserializable"), value, frame);
-    }
+    pub const innerHTML = bridge.accessor(_getInnerHTML, _setInnerHTML, .{ .ce_reactions = true });
 
     fn _getInnerHTML(self: *Template, frame: *Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);
         try self._content.getInnerHTML(&buf.writer, frame);
         return buf.written();
     }
+    fn _setInnerHTML(self: *Template, value: js.Value, frame: *Frame) !void {
+        // `[LegacyNullToEmptyString] DOMString`: a JS null becomes "", not "null".
+        return self.setInnerHTML(if (value.isNull()) "" else try value.toZig([]const u8), frame);
+    }
 
+    pub const outerHTML = bridge.accessor(_getOuterHTML, null, .{});
     fn _getOuterHTML(self: *Template, frame: *Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);
         try self.getOuterHTML(&buf.writer, frame);
         return buf.written();
+    }
+
+    pub const shadowRootMode = bridge.accessor(Template.getShadowRootMode, Template.setShadowRootMode, .{ .ce_reactions = true });
+
+    pub const shadowRootDelegatesFocus = bridge.accessor(_getShadowRootDelegatesFocus, _setShadowRootDelegatesFocus, .{ .ce_reactions = true });
+    fn _getShadowRootDelegatesFocus(self: *const Template) bool {
+        return self.getBoolAttribute(.wrap("shadowrootdelegatesfocus"));
+    }
+    fn _setShadowRootDelegatesFocus(self: *Template, value: bool, frame: *Frame) !void {
+        try self.setBoolAttribute(.wrap("shadowrootdelegatesfocus"), value, frame);
+    }
+
+    pub const shadowRootClonable = bridge.accessor(_getShadowRootClonable, _setShadowRootClonable, .{ .ce_reactions = true });
+    fn _getShadowRootClonable(self: *const Template) bool {
+        return self.getBoolAttribute(.wrap("shadowrootclonable"));
+    }
+    fn _setShadowRootClonable(self: *Template, value: bool, frame: *Frame) !void {
+        try self.setBoolAttribute(.wrap("shadowrootclonable"), value, frame);
+    }
+
+    pub const shadowRootSerializable = bridge.accessor(_getShadowRootSerializable, _setShadowRootSerializable, .{ .ce_reactions = true });
+    fn _getShadowRootSerializable(self: *const Template) bool {
+        return self.getBoolAttribute(.wrap("shadowrootserializable"));
+    }
+    fn _setShadowRootSerializable(self: *Template, value: bool, frame: *Frame) !void {
+        try self.setBoolAttribute(.wrap("shadowrootserializable"), value, frame);
     }
 };
 


### PR DESCRIPTION
A few APIs already support [LegacyNullToEmptyString], this extends it to various setInnerHTML (Element, DocumentFragment, Template) and a few other places.

Also changes how Range.createContextualFragment. Unlike other fragment parsers (e.g. setInnerHTML) this one _does_ run scripts.