### PR TITLE
webapi: fire iframe load on next tick

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -939,6 +939,19 @@ pub fn scriptsCompletedLoading(self: *Frame) void {
 }
 
 pub fn iframeCompletedLoading(self: *Frame, iframe: *IFrame) void {
+    // When parsing HTML, fire any load event for an iframe on the next tick.
+    const parsing_html = switch (self._parse_state) {
+        .html => true,
+        else => false,
+    };
+    if (parsing_html and iframe._src.len > 0) {
+        self.queueElementEvent(iframe._proto, .load) catch |err| {
+            log.err(.frame, "iframe queue load", .{ .err = err, .url = iframe._src });
+        };
+        self.pendingLoadCompleted();
+        return;
+    }
+
     var ls: JS.Local.Scope = undefined;
     self.js.localScope(&ls);
     defer ls.deinit();


### PR DESCRIPTION
Depends on: https://github.com/lightpanda-io/browser/pull/2724

Unblocks some WPT tests, but more generally, adds correctness so that the onload on an iframe doesn't fire before subsequent scripts. Imagine something like:

```
<iframe src=blah onload=done>
<script>
function done() {
 //...
}
</script>
```

(Which is an approximation of what some WPT tests do)...kind of important that we don't fire the onload while we're still parsing.