### PR TITLE
ops: Add "note" log level for CDP "server running" message

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -57,7 +57,7 @@ pub fn init(app: *App, address: net.Address) !*Server {
     // Bind first so /json/version can advertise the OS-assigned port (--port 0).
     var bound_address = address;
     try app.network.bind(&bound_address, self, onAccept);
-    log.info(.app, "server running", .{ .address = bound_address });
+    log.note(.app, "server running", .{ .address = bound_address });
 
     self.json_version_response = try buildJSONVersionResponse(app, bound_address.getPort());
     return self;

--- a/src/log.zig
+++ b/src/log.zig
@@ -89,6 +89,7 @@ pub const Level = enum {
     warn,
     err,
     fatal,
+    note,
 };
 
 pub const Format = enum {
@@ -114,6 +115,10 @@ pub fn err(scope: Scope, msg: []const u8, data: anytype) void {
 
 pub fn fatal(scope: Scope, msg: []const u8, data: anytype) void {
     log(scope, .fatal, msg, data);
+}
+
+pub fn note(scope: Scope, msg: []const u8, data: anytype) void {
+    log(scope, .note, msg, data);
 }
 
 pub fn log(scope: Scope, level: Level, msg: []const u8, data: anytype) void {
@@ -229,6 +234,7 @@ fn logPrettyPrefix(scope: Scope, level: Level, msg: []const u8, writer: *std.Io.
             .warn => "\x1b[0;33mWARN\x1b[0m  ",
             .err => "\x1b[0;31mERROR ",
             .fatal => "\x1b[0;35mFATAL ",
+            .note => "\x1b[0;32mNOTE\x1b[0m  ",
         });
     }
 


### PR DESCRIPTION
`note` is the highest log level (e.g. cannot be turned off), and thus will always be displayed. The purpose is to make sure that people who use --port 0 can see the listening port WITHOUT giving up log-level filtering (e.g. having to use --log-level info JUST to see the listening port).

I'm personally a fan of using .note only when (port == 0), but we can tweak it later if people complain about it showing up despite using a warn/error/fatal log level.