### PR TITLE
webapi: implement node.isNodeEqual when comparing document

### DIFF
--- a/src/browser/webapi/DocumentFragment.zig
+++ b/src/browser/webapi/DocumentFragment.zig
@@ -181,29 +181,6 @@ pub fn cloneFragment(self: *DocumentFragment, deep: bool, frame: *Frame) !*Node 
     return fragment_node;
 }
 
-pub fn isEqualNode(self: *DocumentFragment, other: *DocumentFragment) bool {
-    var self_iter = self.asNode().childrenIterator();
-    var other_iter = other.asNode().childrenIterator();
-
-    while (true) {
-        const self_child = self_iter.next();
-        const other_child = other_iter.next();
-
-        if ((self_child == null) != (other_child == null)) {
-            return false;
-        }
-
-        if (self_child == null) {
-            // We've reached the end
-            return true;
-        }
-
-        if (!self_child.?.isEqualNode(other_child.?)) {
-            return false;
-        }
-    }
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(DocumentFragment);
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -174,23 +174,7 @@ pub fn isEqualNode(self: *Element, other: *Element) bool {
         return false;
     }
 
-    // Compare children.
-    var self_iter = self.asNode().childrenIterator();
-    var other_iter = other.asNode().childrenIterator();
-    var self_count: usize = 0;
-    var other_count: usize = 0;
-    while (self_iter.next()) |self_node| : (self_count += 1) {
-        const other_node = other_iter.next() orelse return false;
-        other_count += 1;
-        if (self_node.isEqualNode(other_node)) {
-            continue;
-        }
-
-        return false;
-    }
-
-    // Make sure both have equal number of children.
-    return self_count == other_count;
+    return self.asNode().isEqualChildren(other.asNode());
 }
 
 pub fn getTagNameLower(self: *const Element) []const u8 {

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -427,16 +427,30 @@ pub fn isEqualNode(self: *Node, other: *Node) bool {
         .element => self.as(Element).isEqualNode(other.as(Element)),
         .attribute => self.as(Element.Attribute).isEqualNode(other.as(Element.Attribute)),
         .cdata => self.as(CData).isEqualNode(other.as(CData)),
-        .document_fragment => self.as(DocumentFragment).isEqualNode(other.as(DocumentFragment)),
         .document_type => self.as(DocumentType).isEqualNode(other.as(DocumentType)),
-        .document => {
-            // Document comparison is complex and rarely used in practice
-            log.warn(.not_implemented, "Node.isEqualNode", .{
-                .type = "document",
-            });
-            return false;
-        },
+        .document_fragment, .document => self.isEqualChildren(other),
     };
+}
+
+pub fn isEqualChildren(a: *Node, b: *Node) bool {
+    var a_count: usize = 0;
+    var a_iter = a.childrenIterator();
+
+    var b_count: usize = 0;
+    var b_iter = b.childrenIterator();
+
+    while (a_iter.next()) |a_node| : (a_count += 1) {
+        const b_node = b_iter.next() orelse return false;
+        b_count += 1;
+        if (a_node.isEqualNode(b_node)) {
+            continue;
+        }
+
+        return false;
+    }
+
+    // Make sure both have equal number of children.
+    return a_count == b_count;
 }
 
 pub fn isInShadowTree(self: *Node) bool {


### PR DESCRIPTION
I thought this was complicated, but it turns out it's easy, and we already have the code.