### PR TITLE
agent: simplify local provider detection

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,8 +35,8 @@
             .hash = "sqlite3-3.51.0-DMxLWssOAABZ8cAvU_LfBIbp0kZjm824PU8sSLXpEDdr",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#d678998f9a1357187102c83946db113385940a7b",
-            .hash = "zenai-0.0.0-iOY_VGC1BACPKloQXVNob3hbdsaIJ_Poe0nB0Zqps3jN",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#043a7580c6b0074f3e297edf6c3c7c6abb017a34",
+            .hash = "zenai-0.0.0-iOY_VLuwBAAjLp9IPa2LjSK8nbwuP5qVRZPLCBbcuCKF",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline?ref=lightpanda#832a9fe25f5f4458fcc47b5acc7c21db669c2f47",

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -683,17 +683,12 @@ fn runRepl(self: *Agent) void {
             },
         };
 
-        if (cmd == .llm) {
-            var name_buf: [32]u8 = undefined;
-            const name = std.fmt.bufPrint(&name_buf, "/{s}", .{@tagName(cmd.llm)}) catch "/?";
-            if (!self.requireLlm(name)) continue :repl;
-        }
-
         switch (cmd) {
             .comment => continue :repl,
             .llm => |lc| {
                 var label_buf: [32]u8 = undefined;
                 const label = std.fmt.bufPrint(&label_buf, "/{s}", .{@tagName(lc)}) catch "/?";
+                if (!self.requireLlm(label)) continue :repl;
                 _ = self.runTurn(.{ .prompt = lc.prompt(), .record_comment = line, .capture_for_save = true, .label = label });
             },
             .tool_call => |tc| {
@@ -902,11 +897,11 @@ fn handleProvider(self: *Agent, _: std.mem.Allocator, rest: []const u8) void {
         return;
     };
     // Ollama's key is a placeholder, so probe the server instead of trusting it.
-    if (provider == .ollama and settings.detectOllama(self.allocator, self.model_base_url) == null) {
+    if (provider == .ollama and settings.detectLocalProvider(self.allocator, .ollama, self.model_base_url) == null) {
         self.terminal.printError("no Ollama server with a pulled model at {s}", .{self.model_base_url orelse zenai.provider.ollama_default_base_url});
         return;
     }
-    if (provider == .llama_cpp and settings.detectLlamaCpp(self.allocator, self.model_base_url) == null) {
+    if (provider == .llama_cpp and settings.detectLocalProvider(self.allocator, .llama_cpp, self.model_base_url) == null) {
         self.terminal.printError("no llama.cpp server with a loaded model at {s}", .{self.model_base_url orelse zenai.provider.llama_cpp_default_base_url});
         return;
     }
@@ -1568,14 +1563,15 @@ fn processUserMessage(self: *Agent, input: TurnInput) !?[]const u8 {
             if (last_extract_idx) |idx| {
                 if (tool == .extract and idx != i) continue;
             }
-            const args = browser_tools.normalizeArgKeys(self.conversation.arena.allocator(), tool, tc.arguments) catch tc.arguments;
+            const ca = self.conversation.arena.allocator();
+            const args = browser_tools.normalizeArgKeys(ca, tool, tc.arguments) catch tc.arguments;
             // Fall back to the navigation a read tool performed, so a
             // markdown/tree-driven turn isn't lost from `/save`.
             const cmd = Command.fromToolCall(tool, args);
             const to_record = if (cmd.isRecorded())
                 cmd
             else
-                navigationGoto(self.conversation.arena.allocator(), tool, args) orelse continue;
+                navigationGoto(ca, tool, args) orelse continue;
             if (!recorded_any) {
                 if (input.record_comment) |c| self.recordSaveComment(c);
                 recorded_any = true;

--- a/src/agent/settings.zig
+++ b/src/agent/settings.zig
@@ -52,14 +52,6 @@ pub fn detectLocalProvider(allocator: std.mem.Allocator, tag: Config.AiProvider,
     return .{ .provider = tag, .key = key };
 }
 
-pub fn detectOllama(allocator: std.mem.Allocator, base_url: ?[:0]const u8) ?Credentials {
-    return detectLocalProvider(allocator, .ollama, base_url);
-}
-
-pub fn detectLlamaCpp(allocator: std.mem.Allocator, base_url: ?[:0]const u8) ?Credentials {
-    return detectLocalProvider(allocator, .llama_cpp, base_url);
-}
-
 /// True when a non-Ollama provider key is available (flag, remembered, or
 /// env-detected). Skips the Ollama probe so it isn't run twice at startup; the
 /// interactive picker only fires on detected keys, which this still catches.
@@ -91,10 +83,10 @@ pub fn resolveCredentials(allocator: std.mem.Allocator, opts: Config.Agent, reme
     var buf: [zenai.provider.default_candidates.len]Credentials = undefined;
     const found = zenai.provider.detectKeys(&buf, zenai.provider.default_candidates);
     if (found.len == 0) {
-        if (detectOllama(allocator, opts.base_url)) |creds| {
+        if (detectLocalProvider(allocator, .ollama, opts.base_url)) |creds| {
             return .{ .credentials = creds, .source = .detected };
         }
-        if (detectLlamaCpp(allocator, opts.base_url)) |creds| {
+        if (detectLocalProvider(allocator, .llama_cpp, opts.base_url)) |creds| {
             return .{ .credentials = creds, .source = .detected };
         }
         std.debug.print(
@@ -164,7 +156,7 @@ pub fn saveRemembered(remembered: Remembered) !void {
 }
 
 /// Cloud providers with a key set. Ollama is excluded — its availability needs
-/// a live probe (`detectOllama`), too costly for an unconditional startup scan.
+/// a live probe (`detectLocalProvider`), too costly for an unconditional startup scan.
 pub fn availableProviders(buf: []Credentials) []Credentials {
     return zenai.provider.detectKeys(buf, zenai.provider.default_candidates);
 }


### PR DESCRIPTION
Remove redundant `detectOllama` and `detectLlamaCpp` wrappers in settings, calling `detectLocalProvider` directly instead. Also clean up some logic in Agent.zig.