### PR TITLE
build: bump zenai dependency to change Mistral's default model

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,8 +35,8 @@
             .hash = "sqlite3-3.51.0-DMxLWssOAABZ8cAvU_LfBIbp0kZjm824PU8sSLXpEDdr",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#043a7580c6b0074f3e297edf6c3c7c6abb017a34",
-            .hash = "zenai-0.0.0-iOY_VLuwBAAjLp9IPa2LjSK8nbwuP5qVRZPLCBbcuCKF",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#e803802c9ce749d655a58aac8ea58ae6061eb018",
+            .hash = "zenai-0.0.0-iOY_VLmwBADsJaEhHm_VxzpRK0aHFKhvyCvaWV06L6Xt",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline?ref=lightpanda#832a9fe25f5f4458fcc47b5acc7c21db669c2f47",


### PR DESCRIPTION
Let's pin it to `mistral-medium-3.5`.