### PR TITLE
tests: remove external connection from unit tests

### DIFF
--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -1287,10 +1287,10 @@ test "MCP - press Enter on form input triggers submit (lowercase alias)" {
 test "MCP - getCookies: defaults to current page, url filter, all flag" {
     defer testing.reset();
     var out: std.io.Writer.Allocating = .init(testing.arena_allocator);
-    const server = try testLoadPage("http://example.com/", &out.writer);
+    const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_press_form.htm", &out.writer);
     defer server.deinit();
 
-    try server.session.cookie_jar.populateFromResponse("http://example.com/", "session=abc; Path=/");
+    try server.session.cookie_jar.populateFromResponse("http://localhost:9582", "session=abc; Path=/");
     try server.session.cookie_jar.populateFromResponse("http://other.test/", "tracking=xyz; Path=/");
 
     const default_msg =


### PR DESCRIPTION
A unit test was hitting http://example.com/. As far as I can tell, there was no good reason for this. Replaced it with hitting the local test server and the test continues to pass.

Three reasons to avoid hitting an external resource in a unit test: 

1 - it can be slow
2 - if it's flaky, it's outside our control
3 - since every zig build test generates a new binary, my firewall warns me
    about a new outgoing connection every test