### PR TITLE
agent: respect configured reasoning effort

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1066,6 +1066,18 @@ fn abortSave(self: *Agent, baseline: usize, reason: []const u8) void {
     self.failSave(reason);
 }
 
+/// Save synthesis warrants more reasoning than a normal turn. `.none` stays off
+/// so users can opt out on models that reject `reasoning_effort` (e.g. Mistral).
+fn bumpedEffort(effort: Config.Effort) Config.Effort {
+    return switch (effort) {
+        .none => .none,
+        .minimal => .low,
+        .low => .medium,
+        .medium => .high,
+        .high, .xhigh => .xhigh,
+    };
+}
+
 /// LLM-synthesized `/save`: hand the model the builtin catalog, the full
 /// conversation, and the deterministic record of what ran, then write the
 /// idiomatic script it returns.
@@ -1125,7 +1137,7 @@ fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8,
             .max_turns = 1,
             .max_tokens = 8192,
             .tool_choice = .none,
-            .effort = .medium,
+            .effort = bumpedEffort(self.effort),
             .cancel = .{ .context = @ptrCast(self), .checkFn = checkCancel },
         },
     ) catch |err| {
@@ -1610,9 +1622,9 @@ fn processUserMessage(self: *Agent, input: TurnInput) !?[]const u8 {
                 .max_turns = 1,
                 .max_tokens = 4096,
                 .tool_choice = .none,
-                // .low (≈512 tokens) so reasoning models still pick an answer
-                // but can't burn the whole turn on thinking and emit nothing.
-                .effort = .low,
+                // .low caps thinking so reasoning models still emit an answer;
+                // `.none` stays off to opt out on models that reject it.
+                .effort = if (self.effort == .none) .none else .low,
                 .cancel = .{ .context = @ptrCast(self), .checkFn = checkCancel },
             },
         ) catch |err| {


### PR DESCRIPTION
Respect the user's configured reasoning effort during save synthesis and user message processing. This prevents API errors on models that do not support reasoning effort (like Mistral) when `.none` is set.