### PR TITLE
agent: support provider-specific default effort

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -35,8 +35,8 @@
             .hash = "sqlite3-3.51.0-DMxLWssOAABZ8cAvU_LfBIbp0kZjm824PU8sSLXpEDdr",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#e803802c9ce749d655a58aac8ea58ae6061eb018",
-            .hash = "zenai-0.0.0-iOY_VLmwBADsJaEhHm_VxzpRK0aHFKhvyCvaWV06L6Xt",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#a8c031222f7545c363b91197394b50024d370a7e",
+            .hash = "zenai-0.0.0-iOY_VB6zBABxSlIgM38xQQv53QEzy8PuDgHopcQ4mwbV",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline?ref=lightpanda#832a9fe25f5f4458fcc47b5acc7c21db669c2f47",

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -352,7 +352,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App, opts: Config.Agent) !*Agent
         }
     };
 
-    const effort = settings.resolveEffort(opts, remembered, will_repl);
+    const effort = settings.resolveEffort(opts, remembered, will_repl, if (resolved) |r| r.credentials.provider else null);
     const verbosity = settings.resolveVerbosity(opts, remembered);
 
     if (resolved) |r| {
@@ -942,6 +942,10 @@ fn setProvider(self: *Agent, credentials: Credentials) !void {
     self.allocator.free(self.model);
     self.model = new_model;
     self.terminal.printInfo("provider: {s}", .{@tagName(credentials.provider)});
+    if (zenai.provider.defaultEffort(credentials.provider)) |e| if (e != self.effort) {
+        self.effort = e;
+        self.terminal.printInfo("effort: {s} ({s} default)", .{ @tagName(e), @tagName(credentials.provider) });
+    };
     self.reportSaved("model", self.model);
     _ = completionModels(self, self.allocator);
 }

--- a/src/agent/settings.zig
+++ b/src/agent/settings.zig
@@ -175,13 +175,14 @@ pub fn resolveModelName(opts: Config.Agent, resolved: ?ResolvedProvider, remembe
 }
 
 /// Precedence: explicit `--effort` flag > remembered `.lp-agent.zon` value >
-/// mode default. The interactive REPL defaults to `.low` so turns stay snappy;
-/// one-shot `--task` defaults to `.medium`, where answer quality matters more
-/// than per-turn latency. (Script runs never call the LLM, so the resolved
-/// effort is unused there.)
-pub fn resolveEffort(opts: Config.Agent, remembered: ?Remembered, will_repl: bool) Config.Effort {
+/// provider default > mode default. The interactive REPL defaults to `.low` so
+/// turns stay snappy; one-shot `--task` defaults to `.medium`, where answer
+/// quality matters more than per-turn latency. (Script runs never call the LLM,
+/// so the resolved effort is unused there.)
+pub fn resolveEffort(opts: Config.Agent, remembered: ?Remembered, will_repl: bool, provider: ?Config.AiProvider) Config.Effort {
     if (opts.effort) |e| return e;
     if (remembered) |r| if (r.effort) |e| return e;
+    if (provider) |p| if (zenai.provider.defaultEffort(p)) |e| return e;
     return if (will_repl) .low else .medium;
 }
 


### PR DESCRIPTION
Updates the zenai dependency and resolves the agent's effort based on the configured provider's default. Also dynamically updates the active effort when switching providers.