### PR TITLE
support +/-/all syntax in --log-filter-scopes

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -38,17 +38,37 @@ pub const CDP_KEEPALIVE_CNT: c_int = 3;
 
 const Config = @This();
 
-fn logFilterScopesValidator(allocator: Allocator, args: *std.process.ArgIterator, list: *std.ArrayList(log.Scope)) !void {
+fn logFilterScopesValidator(allocator: Allocator, args: *std.process.ArgIterator, list: *std.ArrayList(log.FilterRule)) !void {
     const str = args.next() orelse return error.InvalidOption;
 
     var it = std.mem.splitScalar(u8, str, ',');
     while (it.next()) |part| {
-        const v = std.meta.stringToEnum(log.Scope, part) orelse {
+        if (part.len == 0) continue;
+
+        // `+X` filters in, `-X` filters out, bare `X` is an alias for `-X`
+        // (backward compatible). `all` targets every scope.
+        var name = part;
+        var enable = false;
+        switch (part[0]) {
+            '+' => {
+                enable = true;
+                name = part[1..];
+            },
+            '-' => name = part[1..],
+            else => {},
+        }
+
+        if (std.mem.eql(u8, name, "all")) {
+            try list.append(allocator, .{ .scope = null, .enable = enable });
+            continue;
+        }
+
+        const v = std.meta.stringToEnum(log.Scope, name) orelse {
             log.fatal(.app, "invalid option choice", .{ .arg = "--log-filter-scopes", .value = part });
             return error.InvalidOption;
         };
 
-        try list.append(allocator, v);
+        try list.append(allocator, .{ .scope = v, .enable = enable });
     }
 }
 
@@ -78,7 +98,7 @@ const CommonOptions = .{
     .{ .name = "insecure_disable_tls_host_verification", .type = bool },
     .{ .name = "log_level", .type = ?log.Level, .validator = logLevelValidator },
     .{ .name = "log_format", .type = ?log.Format },
-    .{ .name = "log_filter_scopes", .type = log.Scope, .multiple = true, .validator = logFilterScopesValidator },
+    .{ .name = "log_filter_scopes", .type = log.FilterRule, .multiple = true, .validator = logFilterScopesValidator },
     .{ .name = "user_agent_suffix", .type = ?[]const u8 },
     .{ .name = "http_cache_dir", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
@@ -418,7 +438,7 @@ pub fn logFormat(self: *const Config) ?log.Format {
     };
 }
 
-pub fn logFilterScopes(self: *const Config) std.ArrayList(log.Scope) {
+pub fn logFilterScopes(self: *const Config) std.ArrayList(log.FilterRule) {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.log_filter_scopes,
         else => unreachable,

--- a/src/help.zon
+++ b/src/help.zon
@@ -316,8 +316,10 @@
     \\          Defaults to {2s}.
     \\          Allowed values: "pretty", "logfmt".
     \\  --log-filter-scopes <SCOPES>
-    \\          Filter out too-verbose logs per scope, comma-separated.
-    \\          e.g. http, unknown_prop, event.
+    \\          Filter logs per scope, comma-separated, applied left-to-right.
+    \\          "-X" (or bare "X") filters out a scope, "+X" filters it in, and
+    \\          "all" targets every scope. e.g. "http,unknown_prop" hides those
+    \\          two; "-all,+cdp" hides everything except cdp.
     \\  --user-agent <STRING>
     \\          Override the User-Agent header entirely. Must not impersonate other
     \\          browsers; any value containing "Mozilla" is forbidden. The browser

--- a/src/log.zig
+++ b/src/log.zig
@@ -44,10 +44,38 @@ pub const Scope = enum {
     storage,
 };
 
+pub const num_scopes = @typeInfo(Scope).@"enum".fields.len;
+
+/// A single `--log-filter-scopes` directive. `scope == null` targets every
+/// scope (the `all` keyword). `enable` is true for `+X` (filter in), false
+/// for `-X` / bare `X` (filter out).
+pub const FilterRule = struct {
+    scope: ?Scope,
+    enable: bool,
+};
+
+/// Resolve an ordered list of filter directives into a per-scope enabled
+/// array. Directives apply left-to-right, so `-all,+cdp` disables every
+/// scope then re-enables `cdp`. Scopes untouched by any directive stay
+/// enabled.
+pub fn resolveFilterScopes(rules: []const FilterRule) [num_scopes]bool {
+    var scope_enabled = [_]bool{true} ** num_scopes;
+    for (rules) |rule| {
+        if (rule.scope) |scope| {
+            scope_enabled[@intFromEnum(scope)] = rule.enable;
+        } else {
+            for (&scope_enabled) |*e| e.* = rule.enable;
+        }
+    }
+    return scope_enabled;
+}
+
 const Opts = struct {
     format: Format = if (is_debug) .pretty else .logfmt,
     level: Level = if (is_debug) .info else .warn,
-    filter_scopes: []const Scope = &.{},
+    // Per-scope enabled flags; a `false` entry suppresses that scope's logs.
+    // Only consulted in Debug builds. Default: everything enabled.
+    scope_enabled: [num_scopes]bool = [_]bool{true} ** num_scopes,
 };
 
 pub var opts = Opts{};
@@ -66,10 +94,8 @@ pub fn enabled(scope: Scope, level: Level) bool {
     }
 
     if (comptime builtin.mode == .Debug) {
-        for (opts.filter_scopes) |fs| {
-            if (fs == scope) {
-                return false;
-            }
+        if (opts.scope_enabled[@intFromEnum(scope)] == false) {
+            return false;
         }
     }
 
@@ -546,5 +572,46 @@ test "log: string escape" {
         aw.clearRetainingCapacity();
         try logTo(.app, .err, "test", .{ .string = "\n \thi  \" \" " }, &aw.writer);
         try testing.expectEqual(prefix ++ "string=\"\\n \thi  \\\" \\\" \"\n", aw.written());
+    }
+}
+
+test "log: resolveFilterScopes" {
+    // No directives: everything enabled.
+    {
+        const se = resolveFilterScopes(&.{});
+        try testing.expectEqual(true, se[@intFromEnum(Scope.cdp)]);
+        try testing.expectEqual(true, se[@intFromEnum(Scope.http)]);
+    }
+
+    // Backward compatible: bare/`-` scope filters that scope out, rest stay in.
+    {
+        const se = resolveFilterScopes(&.{
+            .{ .scope = .cdp, .enable = false },
+            .{ .scope = .http, .enable = false },
+        });
+        try testing.expectEqual(false, se[@intFromEnum(Scope.cdp)]);
+        try testing.expectEqual(false, se[@intFromEnum(Scope.http)]);
+        try testing.expectEqual(true, se[@intFromEnum(Scope.js)]);
+    }
+
+    // `-all,+cdp`: disable everything, then re-enable cdp.
+    {
+        const se = resolveFilterScopes(&.{
+            .{ .scope = null, .enable = false },
+            .{ .scope = .cdp, .enable = true },
+        });
+        try testing.expectEqual(true, se[@intFromEnum(Scope.cdp)]);
+        try testing.expectEqual(false, se[@intFromEnum(Scope.http)]);
+        try testing.expectEqual(false, se[@intFromEnum(Scope.js)]);
+    }
+
+    // `+all,-cdp`: enable everything, then disable cdp. Order matters.
+    {
+        const se = resolveFilterScopes(&.{
+            .{ .scope = null, .enable = true },
+            .{ .scope = .cdp, .enable = false },
+        });
+        try testing.expectEqual(false, se[@intFromEnum(Scope.cdp)]);
+        try testing.expectEqual(true, se[@intFromEnum(Scope.http)]);
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,7 +79,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     }
 
     // Set log filter scopes.
-    log.opts.filter_scopes = args.logFilterScopes().items;
+    log.opts.scope_enabled = log.resolveFilterScopes(args.logFilterScopes().items);
 
     // must be installed before any other threads
     const sighandler = try main_arena.create(SigHandler);

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -834,19 +834,21 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
 /// LogFilter provides a scoped way to suppress specific log categories during tests.
 /// This is useful for tests that trigger expected errors or warnings.
 pub const LogFilter = struct {
-    old_filter: []const log.Scope,
+    old_filter: [log.num_scopes]bool,
 
     /// Sets the log filter to suppress the specified scope(s).
     /// Returns a LogFilter that should be deinitialized to restore previous filters.
     pub fn init(comptime scopes: []const log.Scope) LogFilter {
         comptime std.debug.assert(@TypeOf(scopes) == []const log.Scope);
-        const old_filter = log.opts.filter_scopes;
-        log.opts.filter_scopes = scopes;
+        const old_filter = log.opts.scope_enabled;
+        inline for (scopes) |scope| {
+            log.opts.scope_enabled[@intFromEnum(scope)] = false;
+        }
         return .{ .old_filter = old_filter };
     }
 
     /// Restores the log filters to their previous state.
     pub fn deinit(self: LogFilter) void {
-        log.opts.filter_scopes = self.old_filter;
+        log.opts.scope_enabled = self.old_filter;
     }
 };


### PR DESCRIPTION
`--log-filter-scopes` previously took a comma-separated list of scopes to suppress. Extend it with explicit include/exclude directives applied left-to-right:

  -X     filter out scope X
  X      alias for -X (backward compatible)
  +X     filter in scope X
  all    target every scope

This makes "filter everything except one scope" expressible, e.g. `-all,+cdp` suppresses all logs except `cdp`. Bare scope names keep their old meaning, so existing invocations like `http,unknown_prop` are unaffected.

Internally, the suppressed-scope list is replaced by a resolved per-scope `scope_enabled` boolean array built via `log.resolveFilterScopes()`, so the hot-path `enabled()` check is a single array index. Filtering remains Debug-only, as before. `testing.LogFilter` is adapted to the new representation; all existing call sites are unchanged.

Adds a unit test for resolveFilterScopes (default, backward-compat, -all,+cdp, ordering) and updates the help text.