### PR TITLE
uaf: Extend closed popup's lifetime from Frame to Page

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -110,6 +110,11 @@ frame: Frame,
 // to the original page like this.
 popups: std.ArrayList(*Frame) = .empty,
 
+// Popup Frames that have been closed. The window can still be referenced / used
+// from JS, so we defer shutting them down until page tear down (which isn't
+// ideal from a memory point of view).
+closed_frames: std.ArrayList(*Frame) = .empty,
+
 // Lifecycle state. A Page is `.pending` while we hold it as the in-flight
 // destination of a root navigation — its V8 context exists but is not yet the
 // session's active context. Flipped to `.active` by Session.commitPendingPage
@@ -141,6 +146,11 @@ pub fn deinit(self: *Page) void {
         popup.deinit();
     }
     self.popups = .empty;
+
+    for (self.closed_frames.items) |frame| {
+        frame.deinit();
+    }
+    self.closed_frames = .empty;
 
     self.frame.deinit();
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -487,6 +487,16 @@ pub fn processQueuedNavigation(self: *Session) !void {
 fn processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) !void {
     frame._queued_navigation = null;
     defer self.releaseArena(qn.arena);
+
+    // A popup whose window was close()'d is parked in page.closed_frames and
+    // torn down at Page.deinit. It must never be navigated. This navigation
+    // can happen _after_ window.close() has been called (because JS can do
+    // anything with that window), so the safest place to prevent navigation
+    // from happening is here.
+    if (frame.window._closed) {
+        return;
+    }
+
     self._processFrameNavigation(frame, qn) catch |err| {
         log.warn(.frame, "frame navigation", .{ .url = qn.url, .err = err });
         return err;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -73,7 +73,6 @@ _active: ?*Page = null,
 _pending: ?*Page = null,
 
 _page_destruction_queue: std.ArrayList(*Page) = .{},
-_frame_destruction_queue: std.ArrayList(*Frame) = .{},
 
 // Loader IDs are scoped to the Session: each new BrowserContext gets a
 // fresh counter. Frame IDs (`frame_id_gen`) live on `Browser` instead so
@@ -225,16 +224,6 @@ pub fn drainConsoleMessages(self: *Session) []const u8 {
 
 pub fn processDestroyQueues(self: *Session) void {
     {
-        const queue = self._frame_destruction_queue.items;
-        if (queue.len > 0) {
-            for (queue) |frame| {
-                frame.deinit();
-            }
-            self._frame_destruction_queue.clearRetainingCapacity();
-        }
-    }
-
-    {
         const queue = self._page_destruction_queue.items;
         if (queue.len > 0) {
             for (queue) |page| {
@@ -264,10 +253,6 @@ fn allocatePage(self: *Session, frame_id: u32) !*Page {
 // Tear down and free a Page allocated via allocatePage.
 fn queuePageDestruction(self: *Session, page: *Page) void {
     self._page_destruction_queue.append(self.arena, page) catch @panic("OOM");
-}
-
-pub fn queueFrameDestruction(self: *Session, frame: *Frame) void {
-    self._frame_destruction_queue.append(self.arena, frame) catch @panic("OOM");
 }
 
 // Tear down the currently-active Page. Dispatches `frame_remove` first

--- a/src/browser/tests/window/open.html
+++ b/src/browser/tests/window/open.html
@@ -108,6 +108,32 @@
 }
 </script>
 
+<script id=stale_window_after_close>
+{
+  // A closed popup's Window is often still referenced by JS. We must NOT tear
+  // the Frame down (free its V8 context / arena / refcounted Location URL)
+  // while that reference is live, or a later access is a use-after-free. The
+  // Frame is kept alive (neutered) until Page.deinit instead.
+  //
+  // Crash condition: do NOT read .location before close(), so the popup's URL
+  // holds only the single internal ref. Pre-fix, the deferred Frame.deinit
+  // released it (refcount -> 0, URL freed) and reading .location afterwards
+  // re-wrapped the dangling Location into a double-free (release overflow).
+  const w = window.open('about:blank');
+  const doc = w.document;
+  const node = doc.createElement('section');
+
+  w.close();
+  testing.expectEqual(true, w.closed);
+
+  // Everything reachable through the stale Window stays valid and inert.
+  testing.expectEqual('about:blank', w.location.href);
+  testing.expectEqual('BODY', doc.body.tagName);
+  testing.expectEqual('SECTION', node.tagName);
+  testing.expectEqual('P', doc.createElement('p').tagName);
+}
+</script>
+
 <script id=popup_self_close type=module>
 {
   // Popup navigates to a real URL (not about:blank, which takes a synchronous

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -603,8 +603,7 @@ pub fn close(self: *Window) void {
 
     _ = page.popups.swapRemove(popup_index);
 
-    // Drop any pending queued navigation for this frame, otherwise
-    // processQueuedNavigation would try to re-navigate the closed popup.
+    // Drop any pending queued navigation for this frame.
     if (frame._queued_navigation != null) {
         for (page.queued_navigation.items, 0..) |f, i| {
             if (f == frame) {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -108,8 +108,10 @@ _cross_origin_wrapper: CrossOriginWindow,
 // we're still alive. Only valid if `!_opener.?._closed`.
 _opener: ?*Window = null,
 
-// True after our Frame has been deinit'd by window.close. Many things on the
-// window become invalid once this is true.
+// True after window.close. The Frame itself stays alive (parked in
+// page.closed_frames until Page.deinit) so cached references to this Window
+// don't dangle, but the popup is neutered: dropped from page.popups, its
+// transfers aborted, scheduler reset, and unreachable for events / name lookup.
 _closed: bool = false,
 
 // Popup name (owned by page.arena)
@@ -601,9 +603,8 @@ pub fn close(self: *Window) void {
 
     _ = page.popups.swapRemove(popup_index);
 
-    // Drop any pending queued navigation for this frame. Frame.deinit will
-    // release the QueuedNavigation arena, but the entry in page.queued_navigation
-    // would otherwise have processQueuedNavigation re-deinit the popup.
+    // Drop any pending queued navigation for this frame, otherwise
+    // processQueuedNavigation would try to re-navigate the closed popup.
     if (frame._queued_navigation != null) {
         for (page.queued_navigation.items, 0..) |f, i| {
             if (f == frame) {
@@ -614,13 +615,15 @@ pub fn close(self: *Window) void {
     }
 
     frame.js.scheduler.reset();
+    frame.abortTransfers();
 
-    // We can't tear the Frame down here — close() is invoked from JS still
-    // running on top of this Frame's V8 context, often deep inside a script
-    // eval whose parser is still holding the Frame. Destroying the context
-    // now leaves dangling pointers in the unwinding script eval (load event
-    // dispatch, runMacrotasks, etc.). Defer to Page.deinit instead.
-    page.session.queueFrameDestruction(frame);
+    // Do not teardown the frame. The Window can still be referenced in JS
+    // (window.open(...) returns the window). It would be nice to be able to
+    // free this now (just like it would be nice to be more pro-active about
+    // freeing workers and iframes), but, for now, we don't have the
+    // infrastructure to do this safely so doing it on page tear down is our
+    // only option.
+    page.closed_frames.append(page.frame_arena, frame) catch @panic("OOM");
 }
 
 pub fn postMessage(self: *Window, message: js.Value, target_origin: ?[]const u8, transfer: ?[]const *MessagePort, frame: *Frame) !void {


### PR DESCRIPTION
Follow up to https://github.com/lightpanda-io/browser/pull/2742

Where 2742 dealt with window-reuse across navigation, this commit addresses window lifetime after a .close() (so, specifically for popups). I was hoping for a fancier solution which would let us maintain eager release with safety, but instead opted for the much simpler "window lifetime is tied to the page".

There's a couple reasons for this. It _is_ more consistent with how everything else works (Workers, and iframes), but the real reason is that we lack the infrastructure to do this safely/cleanly.