### PR TITLE
design: multi-page session

### DIFF
--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -731,12 +731,14 @@ pub fn getNodeDetails(
 const testing = @import("testing.zig");
 
 test "SemanticTree backendDOMNodeId" {
+    defer testing.reset();
+
     var registry: CDPNode.Registry = .init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/registry1.html", .{});
-    defer testing.reset();
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/registry1.html", .{});
+    defer page.close();
+    const frame = page.frame().?;
 
     const st: Self = .{
         .dom_node = frame.window._document.asNode(),
@@ -755,12 +757,13 @@ test "SemanticTree backendDOMNodeId" {
 }
 
 test "SemanticTree max_depth" {
+    defer testing.reset();
     var registry: CDPNode.Registry = .init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/registry1.html", .{});
-    defer testing.reset();
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/registry1.html", .{});
+    defer page.close();
+    const frame = page.frame().?;
 
     const st: Self = .{
         .dom_node = frame.window._document.asNode(),

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -725,7 +725,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     // and the in-flight transfer survives the OLD page's frame.deinit which
     // calls http_client.abortList() on the shared frame_id during
     // commitPendingPage.
-    const is_pending_root = self._page._state == .pending;
+    const is_pending_root = self._page.replaces != null;
 
     // We dispatch frame_navigate event before sending the request.
     // It ensures the event frame_navigated is not dispatched before this one.
@@ -1120,8 +1120,8 @@ fn frameHeaderDoneCallback(response: HttpClient.Response) !HttpClient.HeaderResu
     // frame_remove (clears OLD V8 context group + CDP node_registry),
     // tears down the OLD page, flips the pointer, and dispatches
     // frame_created against the new (now active) frame.
-    if (self._page._state == .pending) {
-        try self._session.commitPendingPage();
+    if (self._page.replaces != null) {
+        try self._session.commitPendingPage(self._page);
     }
 
     const response_url = response.url();
@@ -1566,8 +1566,8 @@ fn frameErrorCallback(ctx: *anyopaque, err: anyerror) void {
     // pending Page; the OLD active Page (and its V8 context) is untouched.
     // We do NOT run frameDoneCallback against the pending frame — the frame
     // is about to be freed.
-    if (self._page._state == .pending) {
-        self._session.discardPendingPage();
+    if (self._page.replaces != null) {
+        self._session.discardPendingPage(self._page);
         return;
     }
 
@@ -3274,9 +3274,10 @@ test "Page: isSameOrigin" {
 }
 
 test "Frame: httpMetadata after navigation" {
-    const frame = try testing.pageTest("page/meta.html", .{});
-    defer testing.test_session.removePage();
-    const meta = frame.httpMetadata();
+    const page = try testing.pageTest("page/meta.html", .{});
+    defer page.close();
+
+    const meta = page.frame().?.httpMetadata();
     try testing.expect(meta.status != null);
     try std.testing.expectEqual(@as(u16, 200), meta.status.?);
     try testing.expect(meta.headers.len > 0);
@@ -3284,17 +3285,21 @@ test "Frame: httpMetadata after navigation" {
 }
 
 test "Frame: httpMetadata 404" {
-    const frame = try testing.pageTest("nonexistent_page_xyz.html", .{});
-    defer testing.test_session.removePage();
-    const meta = frame.httpMetadata();
+    const page = try testing.pageTest("nonexistent_page_xyz.html", .{});
+    defer page.close();
+
+    const meta = page.frame().?.httpMetadata();
     try testing.expect(meta.status != null);
     try testing.expectEqual(404, meta.status.?);
 }
 
 test "Frame: 401" {
-    var frame = try testing.pageTest("401", .{});
     defer testing.reset();
-    defer frame._session.removePage();
+
+    var page = try testing.pageTest("401", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
 
     var buf = std.Io.Writer.Allocating.init(testing.allocator);
     defer buf.deinit();

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -116,13 +116,15 @@ popups: std.ArrayList(*Frame) = .empty,
 // ideal from a memory point of view).
 closed_frames: std.ArrayList(*Frame) = .empty,
 
-// Lifecycle state. A Page is `.pending` while we hold it as the in-flight
-// destination of a root navigation — its V8 context exists but is not yet the
-// session's active context. Flipped to `.active` by Session.commitPendingPage
-// when response headers arrive. Frame.navigate / frameHeaderDoneCallback
-// branch on this to stamp `is_pending_root` on the frame_navigate
-// notification (so CDP doesn't reset its node registry yet) and
-_state: enum { active, pending } = .active,
+// In-flight navigation for a root page. When not null, this page will "replace"
+// the referenced page once the response header arrives. This is necessary
+// because, during navigation, both the "old" and "new" pages remain addressable
+// in CDP
+replaces: ?*Page = null,
+
+// Inverse of `replaces`. While we don't strictly need both, it does streamline
+// code. The two are kept in sync.
+replacement: ?*Page = null,
 
 // The viewport every consumer should read. The runtime override (set via
 // Emulation.setDeviceMetricsOverride) is stored on the Browser so it persists

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -33,20 +33,34 @@ const IS_DEBUG = builtin.mode == .Debug;
 
 const Runner = @This();
 
+// The "main" or "primary" frame which is used against our `until` checks. This
+// is, hopefully, temporary during our transition to multi-page sessions. It
+// helps preserve existing behavior for single-page sessions (which CDP and
+// fetch use exclusively). But once we start adding multi-page to Agent, and
+// maybe CDP and fetch, then "completeness" should gain a clearer meaning.
 frame: *Frame,
+
 session: *Session,
 http_client: *HttpClient,
 
 pub const Opts = struct {};
 
 pub fn init(session: *Session, _: Opts) !Runner {
-    const frame = session.currentFrame() orelse return error.NoPage;
+    const frame = firstFrame(session) orelse return error.NoPage;
 
     return .{
         .frame = frame,
         .session = session,
         .http_client = &session.browser.http_client,
     };
+}
+
+// See the `frame` field. Hopefully this goes away and we make Runner truly
+// multi-page aware.
+fn firstFrame(session: *Session) ?*Frame {
+    const page = (session.primaryPage() orelse return null).page().?;
+    const target = session.replacementOf(page) orelse page;
+    return &target.frame;
 }
 
 pub const WaitOpts = struct {
@@ -156,12 +170,22 @@ pub fn tick(self: *Runner, opts: TickOpts) !TickResult {
 }
 
 fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
+    const session = self.session;
+    const http_client = self.http_client;
+
+    // Drain queued navigations across every live page (one page per call)
+    // A navigation can swap a frame pointer or the page set,
+    // so restart the tick to re-resolve cleanly.
+    if (try session.processQueuedNavigation()) {
+        self.frame = firstFrame(session) orelse return .done;
+        return .{ .ok = 0 };
+    }
+
     // Refresh self.frame from session. In case of pending page, we want to
     // take its state while loading. If we use only the current frame, we will
     // return a .done result immediately.
-    self.frame = self.session.pendingOrCurrentFrame() orelse return .done;
-    const frame = self.frame;
-    const http_client = self.http_client;
+    const frame = firstFrame(session) orelse return .done;
+    self.frame = frame;
 
     switch (frame._parse_state) {
         .pre, .raw, .text, .image, .download => {
@@ -177,14 +201,6 @@ fn _tick(self: *Runner, comptime is_cdp: bool, opts: TickOpts) !TickResult {
             return .{ .ok = 0 };
         },
         .html, .complete => {
-            const session = self.session;
-            if (session.currentPage()) |page| {
-                if (page.queued_navigation.items.len != 0) {
-                    try session.processQueuedNavigation();
-                    self.frame = session.currentFrame().?; // might have changed
-                    return .{ .ok = 0 };
-                }
-            }
             const browser = session.browser;
 
             // The HTML page was parsed. We now either have JS scripts to
@@ -381,35 +397,34 @@ test "Runner: no page" {
 }
 
 test "Runner: waitForSelector timeout" {
-    const frame = try testing.pageTest("runner/runner1.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("runner/runner1.html", .{});
+    defer page.close();
 
-    var runner = try frame._session.runner(.{});
+    var runner = try page.session.runner(.{});
     try testing.expectError(error.Timeout, runner.waitForSelector("#nope", 10));
 }
 
 test "Runner: waitForSelector" {
     defer testing.reset();
-    const frame = try testing.pageTest("runner/runner1.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("runner/runner1.html", .{});
 
-    var runner = try frame._session.runner(.{});
+    var runner = try page.session.runner(.{});
     const el = try runner.waitForSelector("#sel1", 10);
     try testing.expectEqual("selector-1-content", try el.asNode().getTextContentAlloc(testing.arena_allocator));
 }
 
 test "Runner: waitForScript timeout" {
-    const frame = try testing.pageTest("runner/runner1.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("runner/runner1.html", .{});
+    defer page.close();
 
-    var runner = try frame._session.runner(.{});
+    var runner = try page.session.runner(.{});
     try testing.expectError(error.Timeout, runner.waitForScript("document.querySelector('#nope')", 10));
 }
 
 test "Runner: waitForScript" {
-    const frame = try testing.pageTest("runner/runner1.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("runner/runner1.html", .{});
+    defer page.close();
 
-    var runner = try frame._session.runner(.{});
+    var runner = try page.session.runner(.{});
     try runner.waitForScript("document.querySelector('#sel1')", 10);
 }

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -478,9 +478,10 @@ const testing = @import("../testing.zig");
 
 test "ScriptManager: PreloadedScript.shutdownCallback drops a .loading preload" {
     defer testing.reset();
-    const frame = try testing.pageTest("mcp_nav.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("mcp_nav.html", .{});
+    defer page.close();
 
+    const frame = page.frame().?;
     const sm = &frame._script_manager;
     const url: [:0]const u8 = "http://127.0.0.1:9582/killed-preload.js";
 

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -1030,8 +1030,9 @@ const testing = @import("../testing.zig");
 
 test "ScriptManagerBase: shutdownCallback fails a .loading module" {
     defer testing.reset();
-    const frame = try testing.pageTest("mcp_nav.html", .{});
-    defer frame._session.removePage();
+    const page = try testing.pageTest("mcp_nav.html", .{});
+    defer page.close();
+    const frame = page.frame().?;
 
     const sm = &frame._script_manager.base;
     const url: [:0]const u8 = "http://127.0.0.1:9582/killed-module.js";

--- a/src/browser/SelectorPath.zig
+++ b/src/browser/SelectorPath.zig
@@ -213,9 +213,11 @@ fn isFirstMatch(self: SelectorPath, target: *Element, candidate: []const u8) boo
 const testing = @import("../testing.zig");
 
 fn expectSelector(comptime selector: []const u8, comptime expected: []const u8) !void {
-    var frame = try testing.pageTest("selector_path.html", .{});
     defer testing.reset();
-    defer frame._session.removePage();
+
+    var page = try testing.pageTest("selector_path.html", .{});
+    defer page.close();
+    const frame = page.frame().?;
 
     const root = frame.window._document.asNode();
     const target = (try Selector.querySelector(root, selector, frame)) orelse return error.TargetNotFound;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -334,8 +334,6 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     return frame;
 }
 
-// NOTE: the caller is not the owner of the returned value,
-// the pointer on Frame is just returned as a convenience
 pub fn createPage(self: *Session) !PageHandle {
     // Drain any pending Page deinits now, while we're at a known-safe point
     self.processDestroyQueues();

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -27,10 +27,10 @@ const storage = @import("webapi/storage/storage.zig");
 const Navigation = @import("webapi/navigation/Navigation.zig");
 const History = @import("webapi/History.zig");
 
-const Frame = @import("Frame.zig");
 const Page = @import("Page.zig");
-pub const Runner = @import("Runner.zig");
+const Frame = @import("Frame.zig");
 const Browser = @import("Browser.zig");
+pub const Runner = @import("Runner.zig");
 const Notification = @import("../Notification.zig");
 const QueuedNavigation = Frame.QueuedNavigation;
 
@@ -40,13 +40,10 @@ const Allocator = std.mem.Allocator;
 const IS_DEBUG = builtin.mode == .Debug;
 
 // A Session represents a browsing context group (cookie jar, session storage,
-// navigation history) within a Browser. It hosts one Page at a time — the
+// navigation history) within a Browser. It owns a set of live Pages — each a
 // root Frame and all of its descendants — and is responsible for Page
 // lifecycle (create, remove, replace on root navigation).
-//
-// Multiple concurrent Pages (e.g. an old Page retiring while a new provisional
-// Page is loading) are not yet supported; see Page.zig for the intended
-// direction.
+
 const Session = @This();
 
 browser: *Browser,
@@ -65,14 +62,14 @@ inject_scripts: []const []const u8 = &.{},
 // Shared allocator. Used by Session itself and borrowed by Pages.
 arena_pool: *ArenaPool,
 
-// The currently-active Page
-// flips this pointer.
-_active: ?*Page = null,
-
-// In-flight root navigation
-_pending: ?*Page = null,
+// All live top-level Pages. During a root navigation this transiently holds
+// both the live page and its in-flight replacement.
+pages: std.ArrayList(*Page) = .{},
 
 _page_destruction_queue: std.ArrayList(*Page) = .{},
+
+// Round-robin cursor for fair page iteration (processQueuedNavigation)
+_nav_cursor: usize = 0,
 
 // Loader IDs are scoped to the Session: each new BrowserContext gets a
 // fresh counter. Frame IDs (`frame_id_gen`) live on `Browser` instead so
@@ -168,25 +165,12 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     errdefer self._console_messages.deinit();
 }
 
-/// Register the console listener so `drainConsoleMessages` returns output. Idempotent.
-pub fn enableConsoleCapture(self: *Session) !void {
-    if (self._console_capture) return;
-    try self.notification.register(.console_message, self, onConsoleMessage);
-    self._console_capture = true;
-}
-
 pub fn deinit(self: *Session) void {
     if (self._console_capture) {
         self.notification.unregister(.console_message, self);
     }
 
-    if (self._pending != null) {
-        self.discardPendingPage();
-    }
-    if (self._active != null) {
-        self.removePage();
-    }
-    self.processDestroyQueues();
+    self.closeAllPages();
 
     self.cookie_jar.deinit();
 
@@ -204,6 +188,13 @@ pub fn deinit(self: *Session) void {
     }
     self._console_messages.deinit();
     self.arena_pool.release(self.arena);
+}
+
+/// Register the console listener so `drainConsoleMessages` returns output. Idempotent.
+pub fn enableConsoleCapture(self: *Session) !void {
+    if (self._console_capture) return;
+    try self.notification.register(.console_message, self, onConsoleMessage);
+    self._console_capture = true;
 }
 
 fn onConsoleMessage(ctx: *anyopaque, msg: *const Notification.ConsoleMessage) !void {
@@ -254,10 +245,8 @@ pub fn processDestroyQueues(self: *Session) void {
     }
 }
 
-// True iff there is an active Page. CDP / external callers should use this
-// (or `currentPage()`) rather than poking at the underlying field.
 pub fn hasPage(self: *const Session) bool {
-    return self._active != null;
+    return self.pages.items.len != 0;
 }
 
 // Allocate and initialize a Page.
@@ -272,6 +261,23 @@ fn allocatePage(self: *Session, frame_id: u32) !*Page {
 // Tear down and free a Page allocated via allocatePage.
 fn queuePageDestruction(self: *Session, page: *Page) void {
     self._page_destruction_queue.append(self.arena, page) catch @panic("OOM");
+}
+
+fn retire(self: *Session, page: *Page) void {
+    if (page.replaces) |live| {
+        // page is being destroyed, if it was replacing a page, then update that
+        // page's replacement to keep replaces<->replacement consistent.
+        live.replacement = null;
+    }
+
+    page.frame.abortTransfers();
+    for (self.pages.items, 0..) |p, i| {
+        if (p == page) {
+            _ = self.pages.swapRemove(i);
+            break;
+        }
+    }
+    self.queuePageDestruction(page);
 }
 
 // Tear down the currently-active Page. Dispatches `frame_remove` first
@@ -292,18 +298,9 @@ fn queuePageDestruction(self: *Session, page: *Page) void {
 // NOT a substitute for the careful 5-step sequence in commitPendingPage,
 // which interleaves the OLD-page teardown with the pending-page promotion
 // in a specific order.
-fn tearDownActivePage(self: *Session) void {
+fn tearDownPage(self: *Session, page: *Page) void {
     self.notification.dispatch(.frame_remove, .{});
-    const page = self._active orelse {
-        if (comptime IS_DEBUG) {
-            lp.assert(false, "Session.tearDownActivePage - no active page", .{});
-        }
-        return;
-    };
-
-    page.frame.abortTransfers();
-    self.queuePageDestruction(page);
-    self._active = null;
+    self.retire(page);
     self.navigation.onRemoveFrame();
 }
 
@@ -319,8 +316,9 @@ fn tearDownActivePage(self: *Session) void {
 fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     const page = try self.allocatePage(frame_id);
     errdefer self.queuePageDestruction(page);
-    self._active = page;
-    errdefer self._active = null;
+
+    try self.pages.append(self.arena, page);
+    errdefer _ = self.pages.pop();
 
     const frame = &page.frame;
     try self.navigation.onNewFrame(frame);
@@ -332,34 +330,45 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
 
 // NOTE: the caller is not the owner of the returned value,
 // the pointer on Frame is just returned as a convenience
-pub fn createPage(self: *Session) !*Frame {
-    lp.assert(self._active == null, "Session.createPage - page not null", .{});
-
+pub fn createPage(self: *Session) !PageHandle {
     // Drain any pending Page deinits now, while we're at a known-safe point
     self.processDestroyQueues();
 
     if (comptime IS_DEBUG) {
         log.debug(.browser, "create page", .{});
     }
-    return self.installNewActivePage(self.nextFrameId());
+
+    const frame_id = self.nextFrameId();
+    _ = try self.installNewActivePage(frame_id);
+
+    return .{ .session = self, .frame_id = frame_id };
 }
 
-pub fn removePage(self: *Session) void {
-    if (self._active == null) {
-        lp.assert(false, "Session.removePage - page is null", .{});
-    }
+// Tear down the live page for `frame_id` and any in-flight replacement.
+pub fn closePage(self: *Session, frame_id: u32) void {
+    const live = self.livePage(frame_id) orelse return;
 
     // If a navigation is in flight, drop the pending Page first. Its
     // transfer was protected from abort to survive commitPendingPage's
     // teardown of the old page, but we are now permanently removing the
-    // session's page state — the pending transfer should die with it.
-    if (self._pending != null) {
-        self.discardPendingPage();
+    // page state — the pending transfer should die with it.
+    if (self.replacementOf(live)) |pending| {
+        self.discardPendingPage(pending);
     }
-    self.tearDownActivePage();
-    if (comptime IS_DEBUG) {
-        log.debug(.browser, "remove page", .{});
+    self.tearDownPage(live);
+}
+
+// Does not dispatch notifications. Used in session.deinit() and used in tests.
+// We queue then process so that there is a single place (processDestroyQueues)
+// where pages get destroyed.
+pub fn closeAllPages(self: *Session) void {
+    self._page_destruction_queue.ensureUnusedCapacity(self.arena, self.pages.items.len) catch @panic("OOM");
+    for (self.pages.items) |page| {
+        page.frame.abortTransfers();
+        self._page_destruction_queue.appendAssumeCapacity(page);
     }
+    self.pages.clearRetainingCapacity();
+    self.processDestroyQueues();
 }
 
 pub fn getArena(self: *Session, size_or_bucket: anytype, debug: []const u8) !Allocator {
@@ -370,35 +379,76 @@ pub fn releaseArena(self: *Session, allocator: Allocator) void {
     self.arena_pool.release(allocator);
 }
 
-pub fn getOrCreateOrigin(self: *Session, key_: ?[]const u8) !*js.Origin {
-    return self.currentPage().?.getOrCreateOrigin(key_);
+// The live page for a top-level browsing context, by its root frame id.
+pub fn livePage(self: *Session, frame_id: u32) ?*Page {
+    for (self.pages.items) |page| {
+        if (page.frame._frame_id == frame_id) {
+            // If this page is replacing another page, then other page is
+            // considered the "live" on. Only once this page is committed will
+            // that swap.
+            return page.replaces orelse page;
+        }
+    }
+    return null;
 }
 
-pub fn releaseOrigin(self: *Session, origin: *js.Origin) void {
-    self.currentPage().?.releaseOrigin(origin);
+// The in-flight replacement for `page`
+pub fn replacementOf(self: *Session, page: *Page) ?*Page {
+    const replacement = page.replacement;
+
+    if (comptime IS_DEBUG) {
+        // quick check to make sure our replacement <=> replaces link is in sync
+        var found: ?*Page = null;
+        for (self.pages.items) |p| {
+            if (p.replaces == page) {
+                found = p;
+                break;
+            }
+        }
+        std.debug.assert(found == replacement);
+    }
+    return replacement;
 }
 
-pub fn currentPage(self: *Session) ?*Page {
-    return self._active;
+// DEPRECATED.
+// Needed by Runner so long as Runner is largel single-page driven.
+// Ultimately the goal is that runner is full multi-page, but during this
+// transition to multi-page sessions, we maintain the idea that one page is
+// the "main" page.
+pub fn primaryPage(self: *Session) ?PageHandle {
+    if (self.pages.items.len == 0) {
+        return null;
+    }
+    const page = self.pages.items[0];
+    if (comptime IS_DEBUG) {
+        std.debug.assert(page.replaces == null);
+    }
+    return .{ .session = self, .frame_id = page.frame._frame_id };
 }
 
-pub fn pendingPage(self: *Session) ?*Page {
-    return self._pending;
-}
-
-pub fn pendingOrCurrentFrame(self: *Session) ?*Frame {
-    const page = self.pendingPage() orelse self.currentPage() orelse return null;
-    return &page.frame;
-}
-
+// DEPRECATED. Exists during our transition to multi-page sessions.
 pub fn currentFrame(self: *Session) ?*Frame {
-    const page = self.currentPage() orelse return null;
+    if (self.pages.items.len == 0) {
+        return null;
+    }
+    const page = self.pages.items[0];
+    if (comptime IS_DEBUG) {
+        std.debug.assert(page.replaces == null);
+    }
     return &page.frame;
 }
 
+// Multi-page aware: frame ids are globally unique (monotonic on `Browser`), so
+// search every live page's frame tree. During a root navigation the old and
+// replacement pages share the root frame_id; the old page sits at index 0 and
+// is matched first — the addressable page until commit.
 pub fn findFrameByFrameId(self: *Session, frame_id: u32) ?*Frame {
-    const page = self.currentPage() orelse return null;
-    return page.findFrameByFrameId(frame_id);
+    for (self.pages.items) |page| {
+        if (page.findFrameByFrameId(frame_id)) |frame| {
+            return frame;
+        }
+    }
+    return null;
 }
 
 pub fn runner(self: *Session, opts: Runner.Opts) !Runner {
@@ -411,7 +461,7 @@ pub fn runner(self: *Session, opts: Runner.Opts) !Runner {
 pub fn idleSlice(self: *Session) u31 {
     const quiet_ms = 250;
     self.processDestroyQueues();
-    var r = self.runner(.{}) catch return quiet_ms;
+    var r = self.runner(.{}) catch return quiet_ms; // error.NoPage when pageless
     const result = r.tick(.{ .ms = 25 }) catch return quiet_ms;
     return switch (result) {
         .done => quiet_ms,
@@ -419,12 +469,44 @@ pub fn idleSlice(self: *Session) u31 {
     };
 }
 
-pub fn scheduleNavigation(self: *Session, frame: *Frame) !void {
-    return self.currentPage().?.scheduleNavigation(frame);
+pub fn scheduleNavigation(_: *Session, frame: *Frame) !void {
+    return frame._page.scheduleNavigation(frame);
 }
 
-pub fn processQueuedNavigation(self: *Session) !void {
-    const page = self.currentPage() orelse return;
+// Drain one page's queued navigations and return whether any page had work.
+// Processing a root navigation mutates self.pages, so it's safer to do this
+// just once, signal the caller, and have them call again. We use a cursor
+// to prevent one page from starving the rest.
+pub fn processQueuedNavigation(self: *Session) !bool {
+    const pages = self.pages.items;
+    if (pages.len == 0) {
+        return false;
+    }
+
+    var i = self._nav_cursor;
+    if (i >= pages.len) {
+        i = 0;
+    }
+
+    for (0..pages.len) |_| {
+        const page = pages[i];
+
+        i += 1;
+        if (i == pages.len) {
+            i = 0;
+        }
+
+        if (page.queued_navigation.items.len != 0) {
+            // i was already incremented (and wrapped) to the "next" page
+            self._nav_cursor = i;
+            try self.processPageQueuedNavigation(page);
+            return true;
+        }
+    }
+    return false;
+}
+
+fn processPageQueuedNavigation(self: *Session, page: *Page) !void {
     const navigations = page.queued_navigation;
     if (page.queued_navigation == &page.queued_navigation_1) {
         page.queued_navigation = &page.queued_navigation_2;
@@ -439,7 +521,7 @@ pub fn processQueuedNavigation(self: *Session) !void {
         // is different enough that have two distinct code blocks is, imo,
         // better. Yes, there will be duplication.
         navigations.clearRetainingCapacity();
-        return self.processRootQueuedNavigation();
+        return self.processRootQueuedNavigation(page);
     }
 
     const about_blank_queue = &page.queued_queued_navigation;
@@ -545,7 +627,7 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
 
     const frame_id = frame._frame_id;
     const reuse_window = frame.window;
-    const page = self.currentPage().?;
+    const page = frame._page;
     frame.deinit();
     frame.* = undefined;
 
@@ -581,7 +663,7 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
 // Re-navigates a popup Frame in place. Both the Frame pointer and its Window
 // stay stable across the re-init, so a cached `window.open()` return value keeps
 // a valid `.location` instead of dangling against the freed one.
-fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) !void {
+fn processPopupNavigation(_: *Session, frame: *Frame, qn: *QueuedNavigation) !void {
     // Preserve popup identity fields. _name lives in the Page arena and
     // survives Frame.deinit; _opener is just a pointer.
 
@@ -589,7 +671,7 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
     const saved_name = reuse_window._name;
     const saved_opener = reuse_window._opener;
     const frame_id = frame._frame_id;
-    const page = self.currentPage().?;
+    const page = frame._page;
 
     frame.deinit();
     frame.* = undefined;
@@ -616,11 +698,8 @@ fn processPopupNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation) 
     };
 }
 
-fn processRootQueuedNavigation(self: *Session) !void {
-    const active = self._active orelse {
-        lp.assert(false, "Session.processRootQueuedNavigation - no active page", .{});
-    };
-    const current_frame = &active.frame;
+fn processRootQueuedNavigation(self: *Session, page: *Page) !void {
+    const current_frame = &page.frame;
 
     // Detach the QueuedNavigation. Whether we keep it on the active frame
     // (synthetic path) or transfer it to the pending frame (HTTP path), the
@@ -651,7 +730,11 @@ fn processRootQueuedNavigation(self: *Session) !void {
 // queued-navigation path (processRootQueuedNavigation) and the CDP entry point
 // (initiateRootNavigation); each caller owns any arena tied to `url`/`opts`.
 fn replaceRootImmediate(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
-    self.tearDownActivePage();
+    if (self.livePage(frame_id)) |page| {
+        self.tearDownPage(page);
+    } else if (comptime IS_DEBUG) {
+        lp.assert(false, "Session.replaceRootImmediate - no live page", .{});
+    }
     const new_frame = try self.installNewActivePage(frame_id);
 
     new_frame.navigate(url, opts) catch |err| {
@@ -666,7 +749,15 @@ fn replaceRootImmediate(self: *Session, frame_id: u32, url: [:0]const u8, opts: 
 // trip — Runtime.evaluate, DOM.*, etc. continue to operate on the OLD page
 // until commitPendingPage swaps the pointer when response headers arrive.
 pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, opts: Frame.NavigateOpts) !void {
-    self.discardPendingPage();
+    const live = self.livePage(frame_id) orelse {
+        lp.assert(false, "Session.initiateRootNavigation - no live page", .{});
+    };
+
+    // Re-navigation before a previous root nav committed: drop the outstanding
+    // replacement so `replaces` stays a single link, never a chain.
+    if (self.replacementOf(live)) |old_replacement| {
+        self.discardPendingPage(old_replacement);
+    }
 
     // Synthetic navigations (about:blank, blob:) have no HTTP round-trip and
     // therefore no frameHeaderDoneCallback to commit a pending Page. Swap the
@@ -679,9 +770,15 @@ pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, 
     const page = try self.allocatePage(frame_id);
     errdefer self.queuePageDestruction(page);
 
-    page._state = .pending;
-    self._pending = page;
-    errdefer self._pending = null;
+    // Reuses `live`'s frame_id: the replacement IS the same browsing context.
+    // `replaces` keeps `live` addressable until commit; the `replacement`
+    // back-pointer is its inverse
+    page.replaces = live;
+    live.replacement = page;
+
+    errdefer live.replacement = null;
+    try self.pages.append(self.arena, page);
+    errdefer _ = self.pages.pop();
 
     if (comptime IS_DEBUG) {
         log.debug(.browser, "initiate root navigation", .{ .url = url });
@@ -698,86 +795,85 @@ pub fn initiateRootNavigation(self: *Session, frame_id: u32, url: [:0]const u8, 
     };
 }
 
-// Promote the pending Page to be the active Page. Called from
-// frameHeaderDoneCallback when the in-flight pending root navigation's
-// response headers arrive.
+// Promote a pending replacement Page to be the live Page.
+// Called from frameHeaderDoneCallback, aka when we get the headers, of the
+// replacement page.
 //
 // Order matters here:
 //   1. frame_remove dispatch — CDP's frameRemove resets the V8 inspector
 //      context group (emits Runtime.executionContextsCleared) and clears
-//      isolated world contexts plus the node_registry. The OLD page's
-//      memory is still alive at this point (intentional: CDP teardown can
-//      walk old-page state without UAF).
-//   2. Pointer flip and _state = .active. session.page now points at the
-//      pending page.
-//   3. frame_created dispatch — CDP creates fresh isolated world contexts
-//      against the new (now active) frame. While pending_page is still
-//      non-null at this point, CDP's frameCreated handler skips its
-//      frame_arena reset and captured_responses zeroing (the captured_
+//      isolated world contexts plus the node_registry. OLD is still the live
+//      page and its memory is alive (intentional: CDP teardown can walk
+//      old-page state without UAF).
+//   2. frame_created dispatch — CDP creates fresh isolated world contexts
+//      against the new frame. `replacement.replaces` is still set, so the
+//      session still reports an in-flight nav and CDP's frameCreated skips
+//      its frame_arena reset and captured_responses zeroing (the captured
 //      response for the request we are committing was just inserted by
 //      onHttpResponseHeadersDone moments earlier and must survive).
-//   4. pending_page = null. Order matters: step 3 reads it.
-pub fn commitPendingPage(self: *Session) !void {
-    const pending = self._pending orelse {
-        lp.assert(false, "Session.commitPendingPage - no pending page", .{});
-    };
-    const old_active = self._active orelse {
-        lp.assert(false, "Session.commitPendingPage - no active page", .{});
+//   3. Promote: clear `replaces` and unlink OLD from `pages`, so
+//      `currentFrame()` / `livePage()` now resolve to `replacement`. Done AFTER
+//      step 2 so the in-commit signal (replaces != null) survives the dispatch
+//      — this is why no separate "committing" flag is needed.
+//   4. Tear down OLD last.
+pub fn commitPendingPage(self: *Session, replacement: *Page) !void {
+    const old = replacement.replaces orelse {
+        lp.assert(false, "Session.commitPendingPage - page has no replaces", .{});
     };
 
     if (comptime IS_DEBUG) {
         log.debug(.browser, "commit pending page", .{});
     }
 
-    // Step 1: clear the OLD page's CDP / V8 inspector state.
+    // Step 1: clear the OLD page's CDP / V8 inspector state while it is still
+    // walkable (node_registry, inspector context group, isolated worlds). OLD
+    // is still the live page (index 0); its memory stays alive until step 4.
     self.notification.dispatch(.frame_remove, .{});
     self.navigation.onRemoveFrame();
 
-    // Step 2: pointer flip. Page addresses are stable (heap-allocated),
-    // so every self-pointer inside `pending` (window._frame,
-    // document._frame, EventManager.frame, etc.) remains valid.
-    self._active = pending;
-    pending._state = .active;
-
-    // Step 3: register the new page with CDP. `pending` is still set at
-    // this point — CDP's frameCreated handler reads `pendingPage() != null`
-    // to skip the captured_responses / frame_arena resets that would wipe
-    // the in-flight response we just received.
-    self.navigation.onNewFrame(&pending.frame) catch |err| {
+    // Step 2: register the new page with CDP. `replacement.replaces` is still
+    // set, so the session still reports an in-flight nav and CDP's frameCreated
+    // skips the captured_responses / frame_arena reset that would wipe the
+    // response we just received.
+    self.navigation.onNewFrame(&replacement.frame) catch |err| {
         log.err(.browser, "commitPendingPage onNewFrame", .{ .err = err });
     };
-    self.notification.dispatch(.frame_created, &pending.frame);
+    self.notification.dispatch(.frame_created, &replacement.frame);
 
-    // Step 4: `pending` = null AFTER frame_created so step 3 saw it.
-    self._pending = null;
+    // Step 3: promote — clear `replaces` and unlink OLD so  `livePage()`
+    // resolve to `replacement` (both share OLD's frame_id). OLD stays allocated
+    // (torn down next) but is no longer the addressable live page.
 
-    // Step 5: tear down the OLD page LAST. Anything in steps 1-4 that
-    // needed to walk the OLD page's state (CDP node_registry, inspector
-    // context group, isolated worlds) has already done so. Kill any
-    // remaining transfers/websockets synchronously before queuing for
-    // deferred destroy — otherwise a still-inflight transfer firing its
-    // done_callback after this point would re-enter against the new
-    // _active and trip the half-torn-down session.
-    old_active.frame.abortTransfers();
-    self.queuePageDestruction(old_active);
+    old.replacement = null;
+    replacement.replaces = null;
+    for (self.pages.items, 0..) |p, i| {
+        if (p == old) {
+            _ = self.pages.swapRemove(i);
+            break;
+        }
+    }
+
+    // Step 4: tear down the OLD page LAST. Anything in steps 1-3 that needed to
+    // walk the OLD page's state has already done so. Kill any remaining
+    // transfers/websockets synchronously before queuing for deferred destroy —
+    // otherwise a still-inflight transfer firing its done_callback after this
+    // point would re-enter against the now-live `replacement` and trip a
+    // half-torn-down session.
+    old.frame.abortTransfers();
+    self.queuePageDestruction(old);
 }
 
 // Discard a pending Page without committing. Used for failure paths
 // (HTTP error before commit, session deinit during pending, etc.). The
 // active page is untouched.
-pub fn discardPendingPage(self: *Session) void {
-    const page = self._pending orelse return;
-
+pub fn discardPendingPage(self: *Session, replacement: *Page) void {
     if (comptime IS_DEBUG) {
         log.debug(.browser, "discard pending page", .{});
     }
 
-    // Force abort all inflight queries (HTTP + WS) before queuing for
-    // deferred destroy.
-    page.frame.abortTransfers();
-
-    self._pending = null;
-    self.queuePageDestruction(page);
+    // Force abort all inflight queries (HTTP + WS) and queue for deferred
+    // destroy. The live page it was replacing is untouched.
+    self.retire(replacement);
 }
 
 // Frame IDs come from `Browser` (per-CDP-connection scope), not
@@ -792,3 +888,27 @@ pub fn nextLoaderId(self: *Session) u32 {
     self.loader_id_gen = id;
     return id;
 }
+
+// A stable, navigation-safe reference to a top-level browsing context (what
+// `openPage` opens).
+pub const PageHandle = struct {
+    frame_id: u32,
+    session: *Session,
+
+    pub fn frame(self: PageHandle) ?*Frame {
+        return &(self.page() orelse return null).frame;
+    }
+
+    pub fn page(self: PageHandle) ?*Page {
+        return self.session.livePage(self.frame_id);
+    }
+
+    pub fn close(self: PageHandle) void {
+        self.session.closePage(self.frame_id);
+    }
+
+    pub fn navigate(self: PageHandle, request_url: [:0]const u8, opts: Frame.NavigateOpts) !void {
+        const f = self.frame() orelse return error.FrameNotLoaded;
+        return f.navigate(request_url, opts);
+    }
+};

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -270,14 +270,20 @@ fn retire(self: *Session, page: *Page) void {
         live.replacement = null;
     }
 
-    page.frame.abortTransfers();
-    for (self.pages.items, 0..) |p, i| {
-        if (p == page) {
-            _ = self.pages.swapRemove(i);
-            break;
-        }
+    if (page.replacement) |replacement| {
+        // page is being destroyed, also detroy its replacement
+        self.discardPendingPage(replacement);
     }
+
+    page.frame.abortTransfers();
+    self.removePageFromList(page);
     self.queuePageDestruction(page);
+}
+
+fn removePageFromList(self: *Session, page: *Page) void {
+    if (std.mem.indexOfScalar(*Page, self.pages.items, page)) |i| {
+        _ = self.pages.swapRemove(i);
+    }
 }
 
 // Tear down the currently-active Page. Dispatches `frame_remove` first
@@ -438,11 +444,13 @@ pub fn currentFrame(self: *Session) ?*Frame {
     return &page.frame;
 }
 
-// Multi-page aware: frame ids are globally unique (monotonic on `Browser`), so
-// search every live page's frame tree. During a root navigation the old and
-// replacement pages share the root frame_id; the old page sits at index 0 and
-// is matched first — the addressable page until commit.
+// Multi-page aware: frame ids are globally unique (monotonic on `Browser`).
+// First we find the "live" page for a frame, then we search every nested
+// frame within that page.
 pub fn findFrameByFrameId(self: *Session, frame_id: u32) ?*Frame {
+    if (self.livePage(frame_id)) |page| {
+        return &page.frame;
+    }
     for (self.pages.items) |page| {
         if (page.findFrameByFrameId(frame_id)) |frame| {
             return frame;
@@ -846,12 +854,7 @@ pub fn commitPendingPage(self: *Session, replacement: *Page) !void {
 
     old.replacement = null;
     replacement.replaces = null;
-    for (self.pages.items, 0..) |p, i| {
-        if (p == old) {
-            _ = self.pages.swapRemove(i);
-            break;
-        }
-    }
+    self.removePageFromList(old);
 
     // Step 4: tear down the OLD page LAST. Anything in steps 1-3 that needed to
     // walk the OLD page's state has already done so. Kill any remaining
@@ -901,6 +904,11 @@ pub const PageHandle = struct {
 
     pub fn page(self: PageHandle) ?*Page {
         return self.session.livePage(self.frame_id);
+    }
+
+    pub fn inCommit(self: PageHandle) bool {
+        const live = self.page() orelse return false;
+        return self.session.replacementOf(live) != null;
     }
 
     pub fn close(self: PageHandle) void {

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -375,9 +375,11 @@ const testing = @import("../testing.zig");
 // <base> element), so reusing one frame across opts would leak that mutation
 // into later dumps.
 fn expectDump(opts: Opts, expected: []const u8) !void {
-    var frame = try testing.pageTest("dump.html", .{});
     defer testing.reset();
-    defer frame._session.removePage();
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
 
     var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
     try root(frame.window._document, opts, &aw.writer, frame);

--- a/src/browser/forms.zig
+++ b/src/browser/forms.zig
@@ -278,6 +278,7 @@ fn collectSelectOptions(
 const testing = @import("../testing.zig");
 fn testForms(html: []const u8) ![]FormInfo {
     const frame = try testing.createFrame();
+    errdefer testing.test_session.closeAllPages();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);

--- a/src/browser/forms.zig
+++ b/src/browser/forms.zig
@@ -276,9 +276,8 @@ fn collectSelectOptions(
 }
 
 const testing = @import("../testing.zig");
-
 fn testForms(html: []const u8) ![]FormInfo {
-    const frame = try testing.test_session.createPage();
+    const frame = try testing.createFrame();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
@@ -289,7 +288,6 @@ fn testForms(html: []const u8) ![]FormInfo {
 
 test "browser.forms: login form" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form action="/login" method="POST">
         \\  <input type="email" name="email" required placeholder="Email">
@@ -297,6 +295,8 @@ test "browser.forms: login form" {
         \\  <input type="submit" value="Log In">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual("/login", forms[0].action.?);
     try testing.expectEqual("post", forms[0].method.?);
@@ -310,7 +310,6 @@ test "browser.forms: login form" {
 
 test "browser.forms: form with select" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <select name="color">
@@ -319,6 +318,8 @@ test "browser.forms: form with select" {
         \\  </select>
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(1, forms[0].fields.len);
     try testing.expectEqual("select", forms[0].fields[0].tag_name);
@@ -329,12 +330,13 @@ test "browser.forms: form with select" {
 
 test "browser.forms: form with textarea" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form method="POST">
         \\  <textarea name="message" placeholder="Your message"></textarea>
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(1, forms[0].fields.len);
     try testing.expectEqual("textarea", forms[0].fields[0].tag_name);
@@ -343,24 +345,26 @@ test "browser.forms: form with textarea" {
 
 test "browser.forms: empty form skipped" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form action="/empty">
         \\  <p>No fields here</p>
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(0, forms.len);
 }
 
 test "browser.forms: hidden inputs excluded" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <input type="hidden" name="csrf" value="token123">
         \\  <input type="text" name="username">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(1, forms[0].fields.len);
     try testing.expectEqual("username", forms[0].fields[0].name.?);
@@ -368,7 +372,6 @@ test "browser.forms: hidden inputs excluded" {
 
 test "browser.forms: multiple forms" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form action="/search" method="GET">
         \\  <input type="text" name="q" placeholder="Search">
@@ -378,6 +381,8 @@ test "browser.forms: multiple forms" {
         \\  <input type="password" name="pass">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(2, forms.len);
     try testing.expectEqual(1, forms[0].fields.len);
     try testing.expectEqual(2, forms[1].fields.len);
@@ -385,13 +390,14 @@ test "browser.forms: multiple forms" {
 
 test "browser.forms: disabled fields flagged" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <input type="text" name="enabled_field">
         \\  <input type="text" name="disabled_field" disabled>
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(2, forms[0].fields.len);
     try testing.expect(!forms[0].fields[0].disabled);
@@ -400,7 +406,6 @@ test "browser.forms: disabled fields flagged" {
 
 test "browser.forms: disabled fieldset" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <fieldset disabled>
@@ -409,6 +414,8 @@ test "browser.forms: disabled fieldset" {
         \\  <input type="text" name="outside_fieldset">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(2, forms[0].fields.len);
     try testing.expect(forms[0].fields[0].disabled);
@@ -417,26 +424,28 @@ test "browser.forms: disabled fieldset" {
 
 test "browser.forms: external field via form attribute" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<input type="text" name="external" form="myform">
         \\<form id="myform" action="/submit">
         \\  <input type="text" name="internal">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(2, forms[0].fields.len);
 }
 
 test "browser.forms: checkbox and radio return value attribute" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <input type="checkbox" name="agree" value="yes" checked>
         \\  <input type="radio" name="color" value="red">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(2, forms[0].fields.len);
     try testing.expectEqual("checkbox", forms[0].fields[0].input_type.?);
@@ -447,12 +456,13 @@ test "browser.forms: checkbox and radio return value attribute" {
 
 test "browser.forms: form without action or method" {
     defer testing.reset();
-    defer testing.test_session.removePage();
     const forms = try testForms(
         \\<form>
         \\  <input type="text" name="q">
         \\</form>
     );
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, forms.len);
     try testing.expectEqual(null, forms[0].action);
     try testing.expectEqual("get", forms[0].method.?);

--- a/src/browser/interactive.zig
+++ b/src/browser/interactive.zig
@@ -497,7 +497,7 @@ const testing = @import("../testing.zig");
 
 fn testInteractive(html: []const u8) ![]InteractiveElement {
     const frame = try testing.createFrame();
-    defer testing.test_session.closeAllPages();
+    errdefer testing.test_session.closeAllPages();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
@@ -508,6 +508,7 @@ fn testInteractive(html: []const u8) ![]InteractiveElement {
 
 test "browser.interactive: button" {
     const elements = try testInteractive("<button>Click me</button>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual("button", elements[0].tag_name);
     try testing.expectEqual("button", elements[0].role.?);
@@ -517,6 +518,7 @@ test "browser.interactive: button" {
 
 test "browser.interactive: anchor with href" {
     const elements = try testInteractive("<a href=\"/page\">Link</a>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual("a", elements[0].tag_name);
     try testing.expectEqual("link", elements[0].role.?);
@@ -525,6 +527,7 @@ test "browser.interactive: anchor with href" {
 
 test "browser.interactive: anchor without href" {
     const elements = try testInteractive("<a>Not a link</a>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(0, elements.len);
 }
 
@@ -533,6 +536,7 @@ test "browser.interactive: input types" {
         \\<input type="text" placeholder="Search">
         \\<input type="hidden" name="csrf">
     );
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual("input", elements[0].tag_name);
     try testing.expectEqual("text", elements[0].input_type.?);
@@ -544,6 +548,7 @@ test "browser.interactive: select and textarea" {
         \\<select name="color"><option>Red</option></select>
         \\<textarea name="msg"></textarea>
     );
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(2, elements.len);
     try testing.expectEqual("select", elements[0].tag_name);
     try testing.expectEqual("textarea", elements[1].tag_name);
@@ -551,6 +556,7 @@ test "browser.interactive: select and textarea" {
 
 test "browser.interactive: aria role" {
     const elements = try testInteractive("<div role=\"button\">Custom</div>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual("div", elements[0].tag_name);
     try testing.expectEqual("button", elements[0].role.?);
@@ -559,12 +565,14 @@ test "browser.interactive: aria role" {
 
 test "browser.interactive: contenteditable" {
     const elements = try testInteractive("<div contenteditable=\"true\">Edit me</div>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual(InteractivityType.contenteditable, elements[0].interactivity_type);
 }
 
 test "browser.interactive: tabindex" {
     const elements = try testInteractive("<div tabindex=\"0\">Focusable</div>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expectEqual(InteractivityType.focusable, elements[0].interactivity_type);
     try testing.expectEqual(@as(i32, 0), elements[0].tab_index);
@@ -572,6 +580,7 @@ test "browser.interactive: tabindex" {
 
 test "browser.interactive: disabled" {
     const elements = try testInteractive("<button disabled>Off</button>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(1, elements.len);
     try testing.expect(elements[0].disabled);
 }
@@ -583,6 +592,7 @@ test "browser.interactive: disabled by fieldset" {
         \\  <legend><button>In legend</button></legend>
         \\</fieldset>
     );
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(2, elements.len);
     // Button outside legend is disabled by fieldset
     try testing.expect(elements[0].disabled);
@@ -592,16 +602,19 @@ test "browser.interactive: disabled by fieldset" {
 
 test "browser.interactive: pointer-events none" {
     const elements = try testInteractive("<button style=\"pointer-events: none;\">Click me</button>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(0, elements.len);
 }
 
 test "browser.interactive: non-interactive div" {
     const elements = try testInteractive("<div>Just text</div>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(0, elements.len);
 }
 
 test "browser.interactive: details and summary" {
     const elements = try testInteractive("<details><summary>More</summary><p>Content</p></details>");
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(2, elements.len);
     try testing.expectEqual("details", elements[0].tag_name);
     try testing.expectEqual("summary", elements[1].tag_name);
@@ -618,5 +631,6 @@ test "browser.interactive: mixed elements" {
         \\  <div role="tab">Tab</div>
         \\</div>
     );
+    defer testing.test_session.closeAllPages();
     try testing.expectEqual(4, elements.len);
 }

--- a/src/browser/interactive.zig
+++ b/src/browser/interactive.zig
@@ -496,8 +496,8 @@ fn getListenerTypes(target: *EventTarget, listener_targets: ListenerTargetMap) [
 const testing = @import("../testing.zig");
 
 fn testInteractive(html: []const u8) ![]InteractiveElement {
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -644,9 +644,8 @@ const PrivateSymbols = struct {
 
 const testing = @import("../../testing.zig");
 test "Env: Worker context " {
-    const session = testing.test_session;
-    const frame = try session.createPage();
-    defer session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const worker = try @import("../webapi/Worker.zig").init("http://localhost:9582/src/browser/tests/testing.js", null, frame);
 
@@ -659,9 +658,8 @@ test "Env: Worker context " {
 }
 
 test "Env: Frame context" {
-    const session = testing.test_session;
-    const frame = try session.createPage();
-    defer session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     // Frame already has a context created, use it directly
     const ctx = frame.js;

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -80,9 +80,8 @@ pub const Unbound = struct {
 
 const testing = @import("../../testing.zig");
 test "Script: persisted unbound script re-binds and re-runs" {
-    const session = testing.test_session;
-    const frame = try session.createPage();
-    defer session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
@@ -99,9 +98,8 @@ test "Script: persisted unbound script re-binds and re-runs" {
 }
 
 test "Script: code cache round-trips and rejects a source mismatch" {
-    const session = testing.test_session;
-    const frame = try session.createPage();
-    defer session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -509,9 +509,8 @@ fn G(comptime global_type: GlobalType) type {
 
 const testing = @import("../../testing.zig");
 test "Value: jsonStringify maps unserializable JS values to null" {
-    const session = testing.test_session;
-    const frame = try session.createPage();
-    defer session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/links.zig
+++ b/src/browser/links.zig
@@ -90,6 +90,8 @@ const testing = @import("../testing.zig");
 
 fn testLinks(html: []const u8) ![]Link {
     const frame = try testing.createFrame();
+    errdefer testing.test_session.closeAllPages();
+
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
     try frame.parseHtmlAsChildren(div.asNode(), html);

--- a/src/browser/links.zig
+++ b/src/browser/links.zig
@@ -88,12 +88,8 @@ pub fn collectLinks(arena: Allocator, root: *Node, frame: *Frame) ![]Link {
 
 const testing = @import("../testing.zig");
 
-// Caller must `defer testing.test_session.removePage()` after a successful
-// call — the returned slices live in the page's call_arena.
 fn testLinks(html: []const u8) ![]Link {
-    const frame = try testing.test_session.createPage();
-    errdefer testing.test_session.removePage();
-
+    const frame = try testing.createFrame();
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
     try frame.parseHtmlAsChildren(div.asNode(), html);
@@ -102,12 +98,12 @@ fn testLinks(html: []const u8) ![]Link {
 }
 
 test "links: text and href" {
+    defer testing.test_session.closeAllPages();
     const links = try testLinks(
         \\<a href="https://example.com/login">Sign in</a>
         \\<a href="/page/2">  Next page </a>
         \\<a>no href, skipped</a>
     );
-    defer testing.test_session.removePage();
 
     try testing.expectEqual(2, links.len);
     try testing.expectEqual("Sign in", links[0].text.?);
@@ -116,10 +112,10 @@ test "links: text and href" {
 }
 
 test "links: empty text" {
+    defer testing.test_session.closeAllPages();
     const links = try testLinks(
         \\<a href="/icon"><img src="i.png"></a>
     );
-    defer testing.test_session.removePage();
 
     try testing.expectEqual(1, links.len);
     try testing.expectEqual(null, links[0].text);

--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -589,10 +589,11 @@ pub fn dump(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !voi
     }
 }
 
+const testing = @import("../testing.zig");
+
 fn testMarkdownHTML(html: []const u8, expected: []const u8) !void {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;
@@ -793,9 +794,8 @@ test "browser.markdown: skip empty links" {
 }
 
 test "browser.markdown: resolve links" {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "https://example.com/a/index.html";
 
     const doc = frame.window._document;
@@ -833,9 +833,8 @@ test "browser.markdown: anchor fallback label" {
 }
 
 test "browser.markdown: max_bytes leaves output untouched when under cap" {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;
@@ -850,9 +849,8 @@ test "browser.markdown: max_bytes leaves output untouched when under cap" {
 }
 
 test "browser.markdown: max_bytes truncates with marker" {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;
@@ -872,9 +870,8 @@ test "browser.markdown: max_bytes truncates with marker" {
 // (open) shadow tree with `shadow`, then dumps the host. Declarative shadow DOM
 // parsing isn't implemented, so the shadow tree is attached imperatively.
 fn testMarkdownShadow(light: []const u8, shadow: []const u8, expected: []const u8) !void {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;
@@ -927,9 +924,8 @@ test "browser.markdown: slot fallback content when nothing assigned" {
 // End-to-end: a declarative shadow root (parsed via setHTMLUnsafe) is attached
 // as a real shadow tree, and markdown's composed-tree piercing then renders it.
 test "browser.markdown: declarative shadow DOM renders through piercing" {
-    const testing = @import("../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;

--- a/src/browser/structured_data.zig
+++ b/src/browser/structured_data.zig
@@ -488,12 +488,8 @@ fn collectLink(
 
 const testing = @import("../testing.zig");
 
-// Caller is responsible for `defer testing.test_session.removePage()` after a
-// successful call — the returned StructuredData's slices live in the page's
-// call_arena, which is released when the page is removed.
 fn testStructuredData(html: []const u8) !StructuredData {
-    const frame = try testing.test_session.createPage();
-    errdefer testing.test_session.removePage();
+    const frame = try testing.createFrame();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
@@ -515,7 +511,8 @@ test "structured_data: json-ld" {
         \\{"@context":"https://schema.org","@type":"Article","headline":"Test"}
         \\</script>
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, data.json_ld.len);
     try testing.expect(std.mem.indexOf(u8, data.json_ld[0], "Article") != null);
 }
@@ -526,7 +523,8 @@ test "structured_data: multiple json-ld" {
         \\<script type="application/ld+json">{"@type":"BreadcrumbList"}</script>
         \\<script type="text/javascript">var x = 1;</script>
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(2, data.json_ld.len);
 }
 
@@ -539,7 +537,8 @@ test "structured_data: open graph" {
         \\<meta property="og:type" content="article">
         \\<meta property="article:published_time" content="2026-03-10">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(6, data.open_graph.len);
     try testing.expectEqual("My Page", findProperty(data.open_graph, "title").?);
     try testing.expectEqual("article", findProperty(data.open_graph, "type").?);
@@ -553,7 +552,8 @@ test "structured_data: open graph duplicate keys" {
         \\<meta property="og:image" content="https://example.com/img2.jpg">
         \\<meta property="og:image" content="https://example.com/img3.jpg">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     // Duplicate keys are preserved as separate Property entries.
     try testing.expectEqual(4, data.open_graph.len);
 
@@ -582,7 +582,8 @@ test "structured_data: twitter card" {
         \\<meta name="twitter:site" content="@example">
         \\<meta name="twitter:title" content="My Page">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(3, data.twitter_card.len);
     try testing.expectEqual("summary_large_image", findProperty(data.twitter_card, "card").?);
     try testing.expectEqual("@example", findProperty(data.twitter_card, "site").?);
@@ -596,7 +597,8 @@ test "structured_data: meta tags" {
         \\<meta name="keywords" content="test, example">
         \\<meta name="robots" content="index, follow">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual("Page Title", findProperty(data.meta, "title").?);
     try testing.expectEqual("A test page", findProperty(data.meta, "description").?);
     try testing.expectEqual("Test Author", findProperty(data.meta, "author").?);
@@ -611,7 +613,8 @@ test "structured_data: link elements" {
         \\<link rel="manifest" href="/manifest.json">
         \\<link rel="stylesheet" href="/style.css">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(3, data.links.len);
     try testing.expectEqual("https://example.com/page", findProperty(data.links, "canonical").?);
     // stylesheet should be filtered out
@@ -623,7 +626,8 @@ test "structured_data: alternate links" {
         \\<link rel="alternate" href="https://example.com/fr" hreflang="fr" title="French">
         \\<link rel="alternate" href="https://example.com/de" hreflang="de">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(2, data.alternate.len);
     try testing.expectEqual("fr", data.alternate[0].hreflang.?);
     try testing.expectEqual("French", data.alternate[0].title.?);
@@ -637,7 +641,8 @@ test "structured_data: non-metadata elements ignored" {
         \\<p>More text</p>
         \\<a href="/link">Link</a>
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(0, data.json_ld.len);
     try testing.expectEqual(0, data.open_graph.len);
     try testing.expectEqual(0, data.twitter_card.len);
@@ -650,7 +655,8 @@ test "structured_data: charset and http-equiv" {
         \\<meta charset="utf-8">
         \\<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual("utf-8", findProperty(data.meta, "charset").?);
     try testing.expectEqual("text/html; charset=utf-8", findProperty(data.meta, "Content-Type").?);
 }
@@ -694,8 +700,8 @@ test "structured_data: parseLinkHeader - escaped quote in param does not split l
 }
 
 test "structured_data: link headers from response" {
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     // Stand in for what frameHeaderDoneCallback records from the navigation.
     try frame._http_headers.append(frame.arena, .{ .name = "Link", .value = 
@@ -723,7 +729,8 @@ test "structured_data: no link header yields empty list" {
     const data = try testStructuredData(
         \\<link rel="canonical" href="https://example.com">
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(0, data.link_headers.len);
 }
 
@@ -736,7 +743,8 @@ test "structured_data: mixed content" {
         \\<link rel="canonical" href="https://example.com">
         \\<script type="application/ld+json">{"@type":"WebSite"}</script>
     );
-    defer testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
+
     try testing.expectEqual(1, data.json_ld.len);
     try testing.expectEqual(1, data.open_graph.len);
     try testing.expectEqual(1, data.twitter_card.len);

--- a/src/browser/structured_data.zig
+++ b/src/browser/structured_data.zig
@@ -490,6 +490,7 @@ const testing = @import("../testing.zig");
 
 fn testStructuredData(html: []const u8) !StructuredData {
     const frame = try testing.createFrame();
+    errdefer testing.test_session.closeAllPages();
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1423,8 +1423,10 @@ fn mapActionError(err: anytype) ToolError {
 /// If the previous action queued a navigation (form submit, link click,
 /// Enter on an input), drive the runner until it completes or times out.
 fn awaitQueuedNavigation(session: *lp.Session) ToolError!void {
-    const page = session.currentPage() orelse return;
-    if (page.queued_navigation.items.len == 0) return;
+    const navigated = session.processQueuedNavigation() catch return ToolError.InternalError;
+    if (navigated == false) {
+        return;
+    }
     var runner = session.runner(.{}) catch return ToolError.InternalError;
     runner.wait(.{ .ms = 10000, .until = .done }) catch |err|
         return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
@@ -1826,12 +1828,14 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
 const default_nav_wait: lp.Config.WaitUntil = .load;
 
 fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32) ToolError!lp.Session.Runner.WaitResult {
-    if (session.hasPage()) {
+    if (session.primaryPage()) |old_page| {
         registry.reset();
-        session.removePage();
+        old_page.close();
     }
     const page = session.createPage() catch return ToolError.NavigationFailed;
-    _ = page.navigate(url, .{
+    // frame cannot be null immediately after createPage, but don't cache it
+    // since navigate can change/null it.
+    _ = page.frame().?.navigate(url, .{
         .reason = .address_bar,
         .kind = .{ .push = null },
     }) catch return ToolError.NavigationFailed;
@@ -1842,7 +1846,8 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
         .until = default_nav_wait,
     }) catch |err| return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
 
-    const frame = session.currentFrame() orelse return ToolError.NavigationFailed;
+    // re-fetch frame, navigate might have changed it.
+    const frame = page.frame() orelse return ToolError.NavigationFailed;
     if (frame._last_navigate_error != null) return ToolError.NavigationFailed;
     return result;
 }

--- a/src/browser/webapi/TreeWalker.zig
+++ b/src/browser/webapi/TreeWalker.zig
@@ -160,8 +160,8 @@ pub fn TreeWalker(comptime mode: Mode) type {
 
 test "TreeWalker: skipChildren" {
     const testing = @import("../../testing.zig");
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
     const doc = frame.window._document;
 
     // <div>

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -494,8 +494,8 @@ pub const JsApi = struct {
 const testing = @import("../../../testing.zig");
 
 test "Navigation: about:blank commits entry" {
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     // The test_session is shared; prior tests leak entries into it via
     // session.navigation. Reset it so we exercise a fresh session-style state.
@@ -523,8 +523,8 @@ test "Navigation: about:blank commits entry" {
 }
 
 test "Navigation: reload on empty stack seeds an entry" {
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     testing.test_session.navigation._entries.clearRetainingCapacity();
     testing.test_session.navigation._index = 0;

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -610,8 +610,8 @@ fn buildTestFile(arena: Allocator, page: *@import("../../Page.zig"), name: []con
 
 test "FormData: multipart with file" {
     const allocator = testing.arena_allocator;
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const file = try buildTestFile(allocator, frame._page, "hello.txt", "text/plain", "hello");
     defer file._proto.releaseRef(frame._page);
@@ -648,8 +648,8 @@ test "FormData: multipart with file" {
 
 test "FormData: multipart with empty file defaults to octet-stream" {
     const allocator = testing.arena_allocator;
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const file = try buildTestFile(allocator, frame._page, "", "", "");
     defer file._proto.releaseRef(frame._page);
@@ -682,8 +682,8 @@ test "FormData: multipart with empty file defaults to octet-stream" {
 
 test "FormData: multipart escapes file name and filename" {
     const allocator = testing.arena_allocator;
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const file = try buildTestFile(allocator, frame._page, "a\"b\r\nc.txt", "text/plain", "x");
     defer file._proto.releaseRef(frame._page);
@@ -716,8 +716,8 @@ test "FormData: multipart escapes file name and filename" {
 
 test "FormData: file entry collapses to filename in urlencode" {
     const allocator = testing.arena_allocator;
-    const frame = try testing.test_session.createPage();
-    defer testing.test_session.removePage();
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
 
     const file = try buildTestFile(allocator, frame._page, "hello.txt", "text/plain", "hello");
     defer file._proto.releaseRef(frame._page);

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -1514,8 +1514,10 @@ test "AXNode: writer" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/dom3.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/dom3.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1604,8 +1606,10 @@ test "AXNode: writer prunes hidden and resolves labels" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1737,8 +1741,10 @@ test "AXNode: Writer query filters by role" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1776,8 +1782,10 @@ test "AXNode: writer maps password input to textbox" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const body = (try doc.querySelector(comptime .wrap("body"), frame)).?;
@@ -1851,8 +1859,10 @@ test "AXNode: Writer query filters by accessible name" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1890,8 +1900,10 @@ test "AXNode: Writer query combined role+name filter promotes hidden-input label
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1941,8 +1953,10 @@ test "AXNode: Writer query no match returns empty array" {
     var registry = Node.Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/ax_tree.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/ax_tree.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
@@ -1977,8 +1991,10 @@ test "AXNode: nameFromContentRole" {
 }
 
 test "AXNode: getName name-from-content honors explicit role" {
-    var frame = try testing.pageTest("cdp/accname.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/accname.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     const Case = struct { selector: []const u8, expected: ?[]const u8 };

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -28,6 +28,7 @@ const js = @import("../browser/js/js.zig");
 const Browser = @import("../browser/Browser.zig");
 const Session = @import("../browser/Session.zig");
 const Frame = @import("../browser/Frame.zig");
+const Page = @import("../browser/Page.zig");
 const Mime = @import("../browser/Mime.zig");
 const Element = @import("../browser/webapi/Element.zig");
 const Label = @import("../browser/webapi/element/html/Label.zig");
@@ -262,8 +263,8 @@ pub fn tick(self: *CDP) !bool {
 }
 
 fn pageWait(self: *CDP, ms: u32) !void {
-    const session = &(self.browser.session orelse return error.NoPage);
-    var runner = try session.runner(.{});
+    const bc = &(self.browser_context orelse return error.NoPage);
+    var runner = try bc.session.runner(.{});
     return runner.waitCDP(.{ .ms = ms });
 }
 
@@ -499,6 +500,12 @@ pub const BrowserContext = struct {
     // time, we only have 1 target_id.
     target_id: ?[14]u8,
 
+    // Root frame_id of this context's page, captured when `frameCreated`
+    // fires. A BrowserContext is single-target by protocol, so it can resolve
+    // its (live) page/frame from the Session by this id — see `mainFrame` /
+    // `mainPage`. Stable across navigations (the replacement reuses it).
+    frame_id: ?u32 = null,
+
     // The CDP session_id. After the target/page is created, the client
     // "attaches" to it (either explicitly or automatically). We return a
     // "sessionId" which identifies this link. `sessionId` is the how
@@ -707,12 +714,11 @@ pub const BrowserContext = struct {
     }
 
     pub fn axnodeWriter(self: *BrowserContext, temp_arena: Allocator, root: *const Node, opts: AXNode.Writer.Opts) !AXNode.Writer {
-        // Bind the writer to the frame that owns the root node, not whatever
-        // happens to be `currentFrame`. Name resolution (`Label.findLabelByFor`
-        // against `ownerDocument`) and visibility checks (`frame._style_manager`)
-        // are per-frame; getting this wrong on cross-frame queries produces
-        // names/visibility from the wrong document.
-        const fallback = self.session.currentFrame() orelse return error.FrameNotLoaded;
+        // Bind the writer to the frame that owns the root node. Name resolution
+        // (`Label.findLabelByFor` against `ownerDocument`) and visibility
+        // checks (`frame._style_manager`) are per-frame; getting this wrong on
+        // cross-frame queries produces names/visibility from the wrong document.
+        const fallback = self.mainFrame() orelse return error.FrameNotLoaded;
         const frame = root.dom.ownerFrame(fallback);
         const cache = try frame.call_arena.create(Element.VisibilityCache);
         cache.* = .empty;
@@ -729,14 +735,32 @@ pub const BrowserContext = struct {
         };
     }
 
+    // The root frame of this context's live Page.
+    pub fn mainFrame(self: *const BrowserContext) ?*Frame {
+        return &(self.mainPage() orelse return null).frame;
+    }
+
+    // True while this context's page is mid-commit (a root navigation's
+    // replacement is being promoted).
+    pub fn inCommit(self: *const BrowserContext) bool {
+        const page = self.mainPage() orelse return false;
+        return self.session.replacementOf(page) != null;
+    }
+
+    // The live Page for this single-target context (resolved by frame_id),
+    // or null if no page is loaded.
+    pub fn mainPage(self: *const BrowserContext) ?*Page {
+        return self.session.livePage(self.frame_id orelse return null);
+    }
+
     pub fn getURL(self: *const BrowserContext) ?[:0]const u8 {
-        const frame = self.session.currentFrame() orelse return null;
+        const frame = self.mainFrame() orelse return null;
         const url = frame.url;
         return if (url.len == 0) null else url;
     }
 
     pub fn getTitle(self: *const BrowserContext) ?[]const u8 {
-        const frame = self.session.currentFrame() orelse return null;
+        const frame = self.mainFrame() orelse return null;
         return frame.getTitle() catch |err| {
             log.err(.cdp, "page title", .{ .err = err });
             return null;

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -500,11 +500,12 @@ pub const BrowserContext = struct {
     // time, we only have 1 target_id.
     target_id: ?[14]u8,
 
-    // Root frame_id of this context's page, captured when `frameCreated`
-    // fires. A BrowserContext is single-target by protocol, so it can resolve
-    // its (live) page/frame from the Session by this id — see `mainFrame` /
-    // `mainPage`. Stable across navigations (the replacement reuses it).
-    frame_id: ?u32 = null,
+    // Navigation-safe handle to this context's page, set when `frameCreated`
+    // fires. A BrowserContext is single-target by protocol, so it resolves its
+    // (live) page/frame through this handle — see `mainFrame` / `mainPage`. The
+    // handle's frame_id is stable across navigations (the replacement reuses
+    // it). null until the first page is created.
+    page_handle: ?Session.PageHandle = null,
 
     // The CDP session_id. After the target/page is created, the client
     // "attaches" to it (either explicitly or automatically). We return a
@@ -743,14 +744,13 @@ pub const BrowserContext = struct {
     // True while this context's page is mid-commit (a root navigation's
     // replacement is being promoted).
     pub fn inCommit(self: *const BrowserContext) bool {
-        const page = self.mainPage() orelse return false;
-        return self.session.replacementOf(page) != null;
+        return (self.page_handle orelse return false).inCommit();
     }
 
-    // The live Page for this single-target context (resolved by frame_id),
-    // or null if no page is loaded.
+    // The live Page for this single-target context, or null if no page is
+    // loaded.
     pub fn mainPage(self: *const BrowserContext) ?*Page {
-        return self.session.livePage(self.frame_id orelse return null);
+        return (self.page_handle orelse return null).page();
     }
 
     pub fn getURL(self: *const BrowserContext) ?[:0]const u8 {

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -345,8 +345,10 @@ test "cdp Node: Registry register" {
     try testing.expectEqual(0, registry.lookup_by_id.count());
     try testing.expectEqual(0, registry.lookup_by_node.count());
 
-    var frame = try testing.pageTest("cdp/registry1.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/registry1.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     {
@@ -402,8 +404,10 @@ test "cdp Node: search list" {
     }
 
     {
-        var frame = try testing.pageTest("cdp/registry2.html", .{});
-        defer frame._session.removePage();
+        var page = try testing.pageTest("cdp/registry2.html", .{});
+        defer page.close();
+
+        const frame = page.frame().?;
         var doc = frame.window._document;
 
         {
@@ -442,8 +446,10 @@ test "cdp Node: Writer" {
     var registry = Registry.init(testing.allocator);
     defer registry.deinit();
 
-    var frame = try testing.pageTest("cdp/registry3.html", .{});
-    defer frame._session.removePage();
+    var page = try testing.pageTest("cdp/registry3.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
     var doc = frame.window._document;
 
     {

--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -55,7 +55,7 @@ fn getFullAXTree(cmd: *CDP.Command) !void {
 
     const frame = blk: {
         const frame_id = params.frameId orelse {
-            break :blk session.currentFrame() orelse return error.FrameNotLoaded;
+            break :blk bc.mainFrame() orelse return error.FrameNotLoaded;
         };
         break :blk session.findFrameByFrameId(try id.parseFrameId(frame_id)) orelse {
             return cmd.sendError(-32000, "Frame with the given id does not belong to the target.", .{});
@@ -84,7 +84,7 @@ fn queryAXTree(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const node = try dom.getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer frame.releaseArena(temp_arena);
 

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -388,7 +388,7 @@ test "cdp.browser: setDownloadBehavior writes an attachment to disk and emits ev
     });
     try ctx.expectSentResult(null, .{ .id = 37, .session_id = null });
 
-    const frame = try bc.session.createPage();
+    const frame = (try bc.session.createPage()).frame().?;
     try frame.navigate("http://127.0.0.1:9582/download/report.csv", .{});
     var runner = try bc.session.runner(.{});
     try runner.wait(.{ .ms = 2000 });

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -92,7 +92,7 @@ fn getDocument(cmd: *CDP.Command) !void {
     }
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = try bc.node_registry.register(frame.window._document.asNode());
     return cmd.sendResult(.{ .root = bc.nodeWriter(node, .{ .depth = params.depth }) }, .{});
@@ -156,7 +156,7 @@ fn performSearch(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
     const root = frame.window._document.asNode();
 
     if (isXPathQuery(params.query)) {
@@ -284,7 +284,7 @@ fn querySelector(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = bc.node_registry.lookup_by_id.get(params.nodeId) orelse {
         return cmd.sendError(-32000, "Could not find node with given id", .{});
@@ -310,7 +310,7 @@ fn querySelectorAll(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = bc.node_registry.lookup_by_id.get(params.nodeId) orelse {
         return cmd.sendError(-32000, "Could not find node with given id", .{});
@@ -343,7 +343,7 @@ fn resolveNode(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     var ls: ?js.Local.Scope = null;
     defer if (ls) |*_ls| {
@@ -471,7 +471,7 @@ pub fn getNode(arena: Allocator, bc: *CDP.BrowserContext, node_id: ?Node.Id, bac
         return bc.node_registry.lookup_by_id.get(input_node_id_) orelse return error.NodeNotFound;
     }
     if (object_id) |object_id_| {
-        const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+        const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
         var ls: js.Local.Scope = undefined;
         frame.js.localScope(&ls);
         defer ls.deinit();
@@ -493,7 +493,7 @@ fn getContentQuads(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
@@ -519,7 +519,7 @@ fn getBoxModel(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
@@ -592,7 +592,7 @@ fn getOuterHTML(cmd: *CDP.Command) !void {
         log.warn(.not_implemented, "DOM.getOuterHTML", .{ .param = "includeShadowDOM" });
     }
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
 
@@ -627,7 +627,7 @@ fn setFileInputFiles(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = try getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
     const element = node.dom.is(DOMNode.Element) orelse return error.NodeIsNotAnElement;
@@ -885,7 +885,7 @@ test "cdp.dom: setFileInputFiles exposes files to JS" {
         try b.writeAll("bbbb");
     }
 
-    const frame = bc.session.currentFrame().?;
+    const frame = bc.mainFrame().?;
     var ls: lp.js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -289,7 +289,7 @@ test "cdp.Emulation: setDeviceMetricsOverride and clear" {
 
     const bc = try ctx.loadBrowserContext(.{ .id = "BID-DM1" });
     _ = try bc.session.createPage();
-    const page = bc.session.currentPage().?;
+    const page = bc.mainPage().?;
 
     // Defaults to the compile-time viewport before any override.
     try testing.expectEqual(1920, page.getViewport().width);

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -59,7 +59,7 @@ fn dispatchKeyEvent(cmd: *CDP.Command) !void {
     if (params.type == .rawKeyDown) return;
 
     const bc = cmd.browser_context orelse return;
-    const frame = bc.session.currentFrame() orelse return;
+    const frame = bc.mainFrame() orelse return;
 
     const KeyboardEvent = @import("../../browser/webapi/event/KeyboardEvent.zig");
     const keyboard_event = try KeyboardEvent.initTrusted(switch (params.type) {
@@ -112,7 +112,7 @@ fn dispatchMouseEvent(cmd: *CDP.Command) !void {
     try cmd.sendResult(null, .{});
 
     const bc = cmd.browser_context orelse return;
-    const frame = bc.session.currentFrame() orelse return;
+    const frame = bc.mainFrame() orelse return;
 
     // Map the CDP button name to the DOM MouseEvent.button value.
     // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
@@ -140,7 +140,7 @@ fn insertText(cmd: *CDP.Command) !void {
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return;
-    const frame = bc.session.currentFrame() orelse return;
+    const frame = bc.mainFrame() orelse return;
 
     try Frame.user_input.insertText(frame, params.text);
 
@@ -155,7 +155,9 @@ test "cdp.input: dispatchMouseEvent mouseMoved fires hover events" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -195,7 +197,9 @@ test "cdp.input: dispatchMouseEvent mouseReleased fires mouseup" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -232,7 +236,9 @@ test "cdp.input: dispatchMouseEvent mouseWheel fires wheel event" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -269,7 +275,9 @@ test "cdp.input: dispatchMouseEvent right button fires contextmenu, double-click
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -321,7 +329,9 @@ test "cdp.input: dispatchKeyEvent Tab runs sequential focus navigation" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -92,7 +92,7 @@ fn getSemanticTree(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse Params{};
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const dom_node = if (params.backendNodeId) |nodeId|
         (bc.node_registry.lookup_by_id.get(nodeId) orelse return error.InvalidNodeId).dom
@@ -133,7 +133,7 @@ fn getMarkdown(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse Params{};
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const dom_node = if (params.nodeId) |nodeId|
         (bc.node_registry.lookup_by_id.get(nodeId) orelse return error.InvalidNodeId).dom
@@ -156,7 +156,7 @@ fn getInteractiveElements(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse Params{};
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const root = if (params.nodeId) |nodeId|
         (bc.node_registry.lookup_by_id.get(nodeId) orelse return error.InvalidNodeId).dom
@@ -178,7 +178,7 @@ fn getNodeDetails(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse return error.InvalidParam;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node = (bc.node_registry.lookup_by_id.get(params.backendNodeId) orelse return error.InvalidNodeId).dom;
 
@@ -191,7 +191,7 @@ fn getNodeDetails(cmd: anytype) !void {
 
 fn getStructuredData(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const data = try structured_data.collectStructuredData(
         frame.document.asNode(),
@@ -210,7 +210,7 @@ fn getStructuredData(cmd: anytype) !void {
 // is enabled, since the robots layer is what populates the store.
 fn getContentSignal(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
     const network = bc.cdp.browser.http_client.network;
 
     const empty: []const Robots.ContentSignal = &.{};
@@ -227,7 +227,7 @@ fn getContentSignal(cmd: anytype) !void {
 
 fn detectForms(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const forms_data = try lp.forms.collectForms(
         cmd.arena,
@@ -250,7 +250,7 @@ fn clickNode(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse return error.InvalidParam;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node_id = params.nodeId orelse params.backendNodeId orelse return error.InvalidParam;
     const node = bc.node_registry.lookup_by_id.get(node_id) orelse return error.InvalidNodeId;
@@ -272,7 +272,7 @@ fn fillNode(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse return error.InvalidParam;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const node_id = params.nodeId orelse params.backendNodeId orelse return error.InvalidParam;
     const node = bc.node_registry.lookup_by_id.get(node_id) orelse return error.InvalidNodeId;
@@ -295,7 +295,7 @@ fn scrollNode(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse return error.InvalidParam;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const maybe_node_id = params.nodeId orelse params.backendNodeId;
 
@@ -321,7 +321,7 @@ fn waitForSelector(cmd: anytype) !void {
     const params = (try cmd.params(Params)) orelse return error.InvalidParam;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
-    _ = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    _ = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const timeout_ms = params.timeout orelse 5000;
     const selector_z = try cmd.arena.dupeZ(u8, params.selector);
@@ -458,7 +458,9 @@ test "cdp.lp: action tools" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -519,7 +521,9 @@ test "cdp.lp: waitForSelector" {
     defer ctx.deinit();
 
     const bc = try ctx.loadBrowserContext(.{});
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
     const url = "http://localhost:9582/src/browser/tests/mcp_wait_for_selector.html";
     try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
     var runner = try bc.session.runner(.{});
@@ -594,7 +598,7 @@ test "cdp.lp: handleJavaScriptDialog controls confirm/prompt/alert return values
 
     var bc = try ctx.loadBrowserContext(.{ .id = "BID-D2", .url = "cdp/dialog.html", .target_id = "FID-000000000X".* });
 
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     var ls: lp.js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -244,7 +244,7 @@ fn getCookies(cmd: *CDP.Command) !void {
     const params = (try cmd.params(GetCookiesParam)) orelse GetCookiesParam{};
 
     // If not specified, use the URLs of the page and all of its subframes. TODO subframes
-    const frame_url = if (bc.session.currentFrame()) |frame| frame.url else null;
+    const frame_url = if (bc.mainFrame()) |frame| frame.url else null;
     const param_urls = params.urls orelse &[_][:0]const u8{frame_url orelse return error.InvalidParams};
 
     var urls = try std.ArrayList(CdpStorage.PreparedUri).initCapacity(cmd.arena, param_urls.len);

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -137,7 +137,7 @@ fn setLifecycleEventsEnabled(cmd: *CDP.Command) !void {
 
     // When we enable lifecycle events, we must dispatch events for all
     // attached targets.
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     if (frame._load_state == .complete) {
         const frame_id = &id.toFrameId(frame._frame_id);
@@ -240,7 +240,8 @@ fn close(cmd: *CDP.Command) !void {
         bc.session_id = null;
     }
 
-    bc.session.removePage();
+    if (bc.frame_id) |frame_id| bc.session.closePage(frame_id);
+    bc.frame_id = null;
     for (bc.isolated_worlds.items) |world| {
         world.deinit();
     }
@@ -262,7 +263,7 @@ fn createIsolatedWorld(cmd: *CDP.Command) !void {
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
 
     const world = try bc.createIsolatedWorld(params.worldName, params.grantUniveralAccess);
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const js_context = try world.createContext(frame);
     const aux_data = try std.fmt.allocPrint(cmd.arena, "{{\"isDefault\":false,\"type\":\"isolated\",\"frameId\":\"{s}\"}}", .{params.frameId});
@@ -303,7 +304,7 @@ fn navigate(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    const frame = session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const encoded_url = try URL.ensureEncoded(frame.call_arena, params.url, "UTF-8");
 
@@ -340,7 +341,7 @@ fn doReload(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    const frame = session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     // Capture URL plus the prior navigation's method/body/header before
     // we free the old frame's arena. Replaying the same HTTP
@@ -432,7 +433,7 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
     const idx = target_index orelse return error.InvalidParams;
     const url = target_url orelse return error.InvalidParams;
 
-    const frame = session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     const opts = Frame.NavigateOpts{
         .reason = .history,
@@ -527,12 +528,17 @@ pub fn frameRemove(bc: *CDP.BrowserContext) void {
 }
 
 pub fn frameCreated(bc: *CDP.BrowserContext, frame: *Frame) !void {
+    // Record the root frame_id so the context can resolve its live page/frame
+    // (mainFrame / mainPage) without a session-wide "current" shim.
+    bc.frame_id = frame._frame_id;
+
     // Detect "in commit" mode: Session.commitPendingPage dispatches frame_
-    // created BEFORE clearing pending_page (deliberate ordering — see
-    // Session.commitPendingPage). The captured_response for the request we
-    // just committed was inserted by onHttpResponseHeadersDone moments ago
-    // and lives in cdp.frame_arena; resetting either would lose it.
-    const in_commit = bc.session.pendingPage() != null;
+    // created BEFORE clearing `replaces` (deliberate ordering — see
+    // Session.commitPendingPage), so the replacement still reports as in-flight.
+    // The captured_response for the request we just committed was inserted by
+    // onHttpResponseHeadersDone moments ago and lives in cdp.frame_arena;
+    // resetting either would lose it.
+    const in_commit = bc.inCommit();
 
     if (!in_commit) {
         bc.cdp.browser.arena_pool.reset(bc.frame_arena, 1024 * 512);
@@ -645,7 +651,7 @@ pub fn frameNavigated(arena: Allocator, bc: *CDP.BrowserContext, event: *const N
         }, .{ .session_id = session_id });
     }
 
-    const root_frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const root_frame = bc.mainFrame() orelse return error.FrameNotLoaded;
     const is_root_frame = event.frame_id == root_frame._frame_id;
 
     // When we actually recreated the context we should have the inspector send
@@ -1183,8 +1189,8 @@ test "cdp.frame: reload replays POST navigation" {
 
     // First navigation: POST a form-style payload to /echo_method.
     {
-        const f = try bc.session.createPage();
-        try f.navigate("http://127.0.0.1:9582/echo_method", .{
+        const page = try bc.session.createPage();
+        try page.navigate("http://127.0.0.1:9582/echo_method", .{
             .method = .POST,
             .body = "key=value",
             .header = "Content-Type: application/x-www-form-urlencoded",
@@ -1195,7 +1201,7 @@ test "cdp.frame: reload replays POST navigation" {
 
     // Sanity: the body confirms a POST round-tripped.
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1214,7 +1220,7 @@ test "cdp.frame: reload replays POST navigation" {
     }
 
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1240,8 +1246,8 @@ test "cdp.frame: reload after POST→redirect drops the POST" {
 
     // First navigation: POST /redirect_to_echo → 302 → GET /echo_method.
     {
-        const f = try bc.session.createPage();
-        try f.navigate("http://127.0.0.1:9582/redirect_to_echo", .{
+        const page = try bc.session.createPage();
+        try page.navigate("http://127.0.0.1:9582/redirect_to_echo", .{
             .method = .POST,
             .body = "key=value",
             .header = "Content-Type: application/x-www-form-urlencoded",
@@ -1252,7 +1258,7 @@ test "cdp.frame: reload after POST→redirect drops the POST" {
 
     // Sanity: after the redirect, the loaded page is /echo_method via GET.
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1270,7 +1276,7 @@ test "cdp.frame: reload after POST→redirect drops the POST" {
     }
 
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1298,7 +1304,7 @@ test "cdp.frame: navigate inherits original fragment across redirect" {
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
 
-        const frame = bc.session.currentFrame() orelse unreachable;
+        const frame = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target#myfrag", frame.url);
     }
 
@@ -1313,7 +1319,7 @@ test "cdp.frame: navigate inherits original fragment across redirect" {
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
 
-        const frame = bc.session.currentFrame() orelse unreachable;
+        const frame = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target#target_fragment", frame.url);
     }
 
@@ -1328,7 +1334,7 @@ test "cdp.frame: navigate inherits original fragment across redirect" {
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
 
-        const frame = bc.session.currentFrame() orelse unreachable;
+        const frame = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/redirect-target", frame.url);
     }
 }
@@ -1351,7 +1357,7 @@ test "cdp.frame: navigate renders body of 3xx response without Location" {
     var runner = try bc.session.runner(.{});
     try runner.wait(.{ .ms = 2000 });
 
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/303-no-location", frame.url);
 
     var ls: js.Local.Scope = undefined;
@@ -1380,7 +1386,7 @@ test "cdp.frame: navigate does not follow Location on a non-redirect 3xx" {
     var runner = try bc.session.runner(.{});
     try runner.wait(.{ .ms = 2000 });
 
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/300-with-location", frame.url);
 
     var ls: js.Local.Scope = undefined;
@@ -1411,7 +1417,7 @@ test "cdp.frame: navigate answers with errorText when the navigation fails" {
     try runner.wait(.{ .ms = 2000 });
 
     // The pending page was discarded; the active document is untouched.
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html", frame.url);
 
     try ctx.expectSentResult(.{
@@ -1434,7 +1440,7 @@ test "cdp.frame: navigate to about:blank replaces a non-blank document" {
 
     // Precondition: the tab is on a non-blank document.
     {
-        const frame = bc.session.currentFrame() orelse unreachable;
+        const frame = bc.mainFrame() orelse unreachable;
         try testing.expect(std.mem.endsWith(u8, frame.url, "/hi.html"));
     }
 
@@ -1445,7 +1451,7 @@ test "cdp.frame: navigate to about:blank replaces a non-blank document" {
     }
 
     // The active frame must now point at the replaced about:blank document.
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     try testing.expectEqualSlices(u8, "about:blank", frame.url);
 
     // ...and the active page's JS context must agree — the exact symptom in the
@@ -1475,8 +1481,8 @@ test "cdp.frame: anchor click sends Referer matching the originating page" {
     // Initial navigation to the page hosting the anchor — driven directly via
     // Frame.navigate(.address_bar), so this request itself has no Referer.
     {
-        const f = try bc.session.createPage();
-        try f.navigate("http://127.0.0.1:9582/referer_link.html", .{});
+        const page = try bc.session.createPage();
+        try page.navigate("http://127.0.0.1:9582/referer_link.html", .{});
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
     }
@@ -1485,7 +1491,7 @@ test "cdp.frame: anchor click sends Referer matching the originating page" {
     // (.reason = .script), which must capture the originating frame's URL as
     // the Referer for the queued navigation.
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1497,7 +1503,7 @@ test "cdp.frame: anchor click sends Referer matching the originating page" {
     // After the click navigation completes, the loaded page is /echo_referer
     // and its body echoes the Referer header the server actually saw.
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1524,14 +1530,14 @@ test "cdp.frame: address-bar Page.navigate sends no Referer" {
     bc.target_id = "TID-A18B-00000".*;
 
     {
-        const f = try bc.session.createPage();
-        try f.navigate("http://127.0.0.1:9582/echo_referer", .{});
+        const page = try bc.session.createPage();
+        try page.navigate("http://127.0.0.1:9582/echo_referer", .{});
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
     }
 
     {
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         f.js.localScope(&ls);
         defer ls.deinit();
@@ -1581,7 +1587,7 @@ test "cdp.frame: addScriptToEvaluateOnNewDocument" {
             .frame = .{ .loaderId = "LID-0000000002" },
         }, .{});
 
-        const frame = bc.session.currentFrame() orelse unreachable;
+        const frame = bc.mainFrame() orelse unreachable;
 
         var ls: js.Local.Scope = undefined;
         frame.js.localScope(&ls);
@@ -1669,7 +1675,7 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
 
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html", f.url);
     }
 
@@ -1683,7 +1689,7 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         var runner = try bc.session.runner(.{});
         try runner.wait(.{ .ms = 2000 });
 
-        const f = bc.session.currentFrame() orelse unreachable;
+        const f = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/cdp/dom2.html", f.url);
     }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -240,8 +240,10 @@ fn close(cmd: *CDP.Command) !void {
         bc.session_id = null;
     }
 
-    if (bc.frame_id) |frame_id| bc.session.closePage(frame_id);
-    bc.frame_id = null;
+    if (bc.page_handle) |handle| {
+        handle.close();
+    }
+    bc.page_handle = null;
     for (bc.isolated_worlds.items) |world| {
         world.deinit();
     }
@@ -528,9 +530,9 @@ pub fn frameRemove(bc: *CDP.BrowserContext) void {
 }
 
 pub fn frameCreated(bc: *CDP.BrowserContext, frame: *Frame) !void {
-    // Record the root frame_id so the context can resolve its live page/frame
-    // (mainFrame / mainPage) without a session-wide "current" shim.
-    bc.frame_id = frame._frame_id;
+    // Record a handle to the new page so the context can resolve its live
+    // page/frame (mainFrame / mainPage) without a session-wide "current" shim.
+    bc.page_handle = .{ .session = bc.session, .frame_id = frame._frame_id };
 
     // Detect "in commit" mode: Session.commitPendingPage dispatches frame_
     // created BEFORE clearing `replaces` (deliberate ordering — see

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -129,7 +129,7 @@ const ConsoleMessage = struct {
 
 pub fn consoleMessage(arena: Allocator, bc: *CDP.BrowserContext, event: *const Notification.ConsoleMessage) !void {
     const session_id = bc.session_id orelse return;
-    const frame = bc.session.currentFrame() orelse return error.FrameNotLoaded;
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
@@ -179,7 +179,7 @@ test "cdp.runtime: consoleAPICalled type matches the console method" {
     var bc = try ctx.loadBrowserContext(.{ .id = "BID-CONS", .url = "hi.html", .target_id = "FID-0000000CON".* });
     try ctx.processMessage(.{ .id = 60, .method = "Runtime.enable" });
 
-    const frame = bc.session.currentFrame() orelse unreachable;
+    const frame = bc.mainFrame() orelse unreachable;
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -306,9 +306,9 @@ fn closeTarget(cmd: *CDP.Command) !void {
         bc.session_id = null;
     }
 
-    if (bc.frame_id) |frame_id| {
-        bc.session.closePage(frame_id);
-        bc.frame_id = null;
+    if (bc.page_handle) |handle| {
+        handle.close();
+        bc.page_handle = null;
     }
     for (bc.isolated_worlds.items) |world| {
         world.deinit();

--- a/src/cdp/domains/target.zig
+++ b/src/cdp/domains/target.zig
@@ -176,10 +176,11 @@ fn createTarget(cmd: *CDP.Command) !void {
     // if target_id is null, we should never have a session_id
     lp.assert(bc.session_id == null, "CDP.target.createTarget not null session_id", .{});
 
-    const frame = try bc.session.createPage();
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
 
     // the target_id == the frame_id of the "root" frame
-    const frame_id = id.toFrameId(frame._frame_id);
+    const frame_id = id.toFrameId(page.frame_id);
     bc.target_id = frame_id;
     const target_id = &bc.target_id.?;
     {
@@ -305,7 +306,10 @@ fn closeTarget(cmd: *CDP.Command) !void {
         bc.session_id = null;
     }
 
-    bc.session.removePage();
+    if (bc.frame_id) |frame_id| {
+        bc.session.closePage(frame_id);
+        bc.frame_id = null;
+    }
     for (bc.isolated_worlds.items) |world| {
         world.deinit();
     }
@@ -426,7 +430,7 @@ fn setAutoAttach(cmd: *CDP.Command) !void {
     // autoAttach is set to true, we must attach to all existing targets.
     if (cmd.browser_context) |bc| {
         if (bc.target_id == null) {
-            if (bc.session.currentFrame()) |frame| {
+            if (bc.mainFrame()) |frame| {
                 // the target_id == the frame_id of the "root" frame
                 bc.target_id = id.toFrameId(frame._frame_id);
                 try doAttachtoTarget(cmd, &bc.target_id.?);

--- a/src/cdp/domains/webmcp.zig
+++ b/src/cdp/domains/webmcp.zig
@@ -61,7 +61,7 @@ fn enable(cmd: *CDP.Command) !void {
 
     // Replay any tools registered before enable. We walk the current
     // frame only; subframes will be added when they register.
-    if (bc.session.currentFrame()) |frame| {
+    if (bc.mainFrame()) |frame| {
         const mc = frame.window.getModelContext();
         const tools = mc.tools();
         if (tools.len > 0) {
@@ -346,7 +346,7 @@ test "cdp.WebMCP: register fires toolsAdded after enable" {
 
     // Register a fresh tool from JS, expect a new toolsAdded event.
     var ls: @import("../../browser/js/js.zig").Local.Scope = undefined;
-    bc.session.currentFrame().?.js.localScope(&ls);
+    bc.mainFrame().?.js.localScope(&ls);
     defer ls.deinit();
     _ = try ls.local.exec(
         \\navigator.modelContext.registerTool({
@@ -371,7 +371,7 @@ test "cdp.WebMCP: invokeTool fires toolInvoked + toolResponded" {
         .target_id = "TID-000000000M".*,
         .url = "cdp/webmcp_fixture.html",
     });
-    const frame_id = id.toFrameId(bc.session.currentFrame().?._frame_id);
+    const frame_id = id.toFrameId(bc.mainFrame().?._frame_id);
 
     try ctx.processMessage(.{ .id = 1, .method = "WebMCP.enable", .session_id = "SID-M" });
     try ctx.expectSentResult(null, .{ .id = 1 });
@@ -411,7 +411,7 @@ test "cdp.WebMCP: invokeTool unknown name" {
         .target_id = "TID-000000000M".*,
         .url = "cdp/webmcp_fixture.html",
     });
-    const frame_id = id.toFrameId(bc.session.currentFrame().?._frame_id);
+    const frame_id = id.toFrameId(bc.mainFrame().?._frame_id);
 
     try ctx.processMessage(.{ .id = 1, .method = "WebMCP.enable", .session_id = "SID-M" });
     try ctx.expectSentResult(null, .{ .id = 1 });
@@ -447,7 +447,7 @@ test "cdp.WebMCP: cancelInvocation" {
 
     // Register a never-settling tool so we have an invocation to cancel.
     var ls: @import("../../browser/js/js.zig").Local.Scope = undefined;
-    bc.session.currentFrame().?.js.localScope(&ls);
+    bc.mainFrame().?.js.localScope(&ls);
     defer ls.deinit();
     _ = try ls.local.exec(
         \\navigator.modelContext.registerTool({
@@ -460,7 +460,7 @@ test "cdp.WebMCP: cancelInvocation" {
         .tools = &.{.{ .name = "hang" }},
     }, .{ .session_id = "SID-M" });
 
-    const frame_id = id.toFrameId(bc.session.currentFrame().?._frame_id);
+    const frame_id = id.toFrameId(bc.mainFrame().?._frame_id);
     try ctx.processMessage(.{
         .id = 2,
         .method = "WebMCP.invokeTool",

--- a/src/cdp/testing.zig
+++ b/src/cdp/testing.zig
@@ -94,14 +94,14 @@ const TestContext = struct {
             if (bc.target_id == null) {
                 bc.target_id = "TID-000000000Z".*;
             }
-            const frame = try bc.session.createPage();
+            const page = try bc.session.createPage();
             const full_url = try std.fmt.allocPrintSentinel(
                 base.arena_allocator,
                 "http://127.0.0.1:9582/src/browser/tests/{s}",
                 .{url},
                 0,
             );
-            try frame.navigate(full_url, .{});
+            try page.navigate(full_url, .{});
             var runner = try bc.session.runner(.{});
             try runner.wait(.{ .ms = 2000 });
         }

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -98,49 +98,12 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
     // Stash scripts user want to inject.
     session.inject_scripts = opts.inject_script.items;
 
+    // A navigation-safe handle: `page.frame()` always re-resolves the live
+    // frame, so there's no stale-*Frame footgun across navigate / wait.
+    const page = try session.createPage();
     {
-        const frame = try session.createPage();
-        // frame isn't safe to use after navigate, it can be swapped out
-
-        // // Comment this out to get a profile of the JS code in v8/profile.json.
-        // // You can open this in Chrome's profiler.
-        // // I've seen it generate invalid JSON, but I'm not sure why. It
-        // // happens rarely, and I manually fix the file.
-        // frame.js.startCpuProfiler();
-        // defer {
-        //     if (frame.js.stopCpuProfiler()) |profile| {
-        //         std.fs.cwd().writeFile(.{
-        //             .sub_path = ".lp-cache/cpu_profile.json",
-        //             .data = profile,
-        //         }) catch |err| {
-        //             log.err(.app, "profile write error", .{ .err = err });
-        //         };
-        //     } else |err| {
-        //         log.err(.app, "profile error", .{ .err = err });
-        //     }
-        // }
-
-        // // Comment this out to get a heap V8 heap profil
-        // frame.js.startHeapProfiler();
-        // defer {
-        //     if (frame.js.stopHeapProfiler()) |profile| {
-        //         std.fs.cwd().writeFile(.{
-        //             .sub_path = ".lp-cache/allocating.heapprofile",
-        //             .data = profile.@"0",
-        //         }) catch |err| {
-        //             log.err(.app, "allocating write error", .{ .err = err });
-        //         };
-        //         std.fs.cwd().writeFile(.{
-        //             .sub_path = ".lp-cache/snapshot.heapsnapshot",
-        //             .data = profile.@"1",
-        //         }) catch |err| {
-        //             log.err(.app, "heapsnapshot write error", .{ .err = err });
-        //         };
-        //     } else |err| {
-        //         log.err(.app, "profile error", .{ .err = err });
-        //     }
-        // }
-
+        const frame = page.frame().?;
+        // not guaranteed to be valid after navigate
         const encoded_url = try URL.ensureEncoded(frame.call_arena, url, "UTF-8");
         _ = try frame.navigate(encoded_url, .{
             .reason = .address_bar,
@@ -181,15 +144,14 @@ pub fn fetch(app: *App, browser: *Browser, url: [:0]const u8, opts: FetchOpts) !
         defer aw.deinit();
 
         if (opts.dump_mode) |mode| blk: {
-            const frame = session.currentFrame() orelse break :blk;
+            const frame = page.frame() orelse break :blk;
             try dumpContent(app, mode, opts.dump, frame, &aw.writer);
         }
 
-        const frame = session.currentFrame();
-        try writeJsonEnvelope(writer, frame, opts.dump_mode, aw.written());
+        try writeJsonEnvelope(writer, page.frame(), opts.dump_mode, aw.written());
     } else {
         if (opts.dump_mode) |mode| blk: {
-            const frame = session.currentFrame() orelse {
+            const frame = page.frame() orelse {
                 try writer.writeAll("Frame closed. Please open a bug report including the URL\n");
                 break :blk;
             };

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -1025,7 +1025,8 @@ test "MCP - Actions by selector: hover, selectOption, setChecked" {
     const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_actions.html", &out.writer);
     defer server.deinit();
 
-    const page = server.session.currentPage().?;
+    // Single-page test: reach straight into the live page.
+    const page = server.session.pages.items[0];
 
     {
         const msg =
@@ -1361,8 +1362,8 @@ fn testLoadPage(url: [:0]const u8, writer: *std.Io.Writer) !*Server {
     var server = try Server.init(testing.allocator, testing.test_app, writer);
     errdefer server.deinit();
 
-    const frame = try server.session.createPage();
-    try frame.navigate(url, .{});
+    const page = try server.session.createPage();
+    try page.navigate(url, .{});
 
     var runner = try server.session.runner(.{});
     try runner.wait(.{ .ms = 2000 });

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -846,7 +846,7 @@ fn terminateRuntimeSoon(runtime: *Runtime) void {
 
 test "agent script runtime: goto and evaluate dispatch through browser tools" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -897,7 +897,7 @@ test "agent script runtime: a method on an un-navigated page errors" {
 
 test "agent script runtime: page.close stales the handle" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -918,7 +918,7 @@ test "agent script runtime: page.close stales the handle" {
 
 test "agent script runtime: a stale page handle is a hard error" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -940,7 +940,7 @@ test "agent script runtime: a stale page handle is a hard error" {
 
 test "agent script runtime: extract returns a JavaScript object" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -995,7 +995,7 @@ test "agent script runtime: extract returns a JavaScript object" {
 
 test "agent script runtime: extract tolerates list selectors that match nothing" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1024,7 +1024,7 @@ test "agent script runtime: extract tolerates list selectors that match nothing"
 
 test "agent script runtime: strict-mode scripts can call primitives" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1063,7 +1063,7 @@ test "agent script runtime: promise microtasks run to completion" {
 
 test "agent script runtime: primitives re-entered from argument callbacks stay isolated" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1086,7 +1086,7 @@ test "agent script runtime: primitives re-entered from argument callbacks stay i
 
 test "agent script runtime: terminate interrupts local JavaScript" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1104,7 +1104,7 @@ test "agent script runtime: terminate interrupts local JavaScript" {
 
 test "agent script runtime: agent variables persist and page globals are isolated" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1129,7 +1129,7 @@ test "agent script runtime: agent variables persist and page globals are isolate
 
 test "agent script runtime: page evaluate cannot see agent primitives or bindings" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1165,7 +1165,7 @@ test "agent script runtime: console is available in agent context" {
 
 test "agent script runtime: tool errors throw and stop execution" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();
@@ -1192,7 +1192,7 @@ test "agent script runtime: tool errors throw and stop execution" {
 
 test "agent script runtime: builtin argument marshalling (positional + options)" {
     defer testing.reset();
-    defer if (testing.test_session.hasPage()) testing.test_session.removePage();
+    defer testing.test_session.closeAllPages();
 
     var registry = CDPNode.Registry.init(testing.allocator);
     defer registry.deinit();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -336,6 +336,13 @@ pub var test_browser: Browser = undefined;
 pub var test_notification: *Notification = undefined;
 pub var test_session: *Session = undefined;
 
+// Create a fresh page on `test_session` and return its root frame — for tests
+// that just need a frame to build a DOM in. The page lives on the session;
+// release it with `defer testing.test_session.closeAllPages()`.
+pub fn createFrame() !*Frame {
+    return (try test_session.createPage()).frame().?;
+}
+
 const WEB_API_TEST_ROOT = "src/browser/tests/";
 const HtmlRunnerOpts = struct {
     timeout_ms: u32 = 2000,
@@ -405,8 +412,8 @@ pub fn htmlRunner(comptime path: []const u8, opts: HtmlRunnerOpts) !void {
 }
 
 fn runWebApiTest(test_file: [:0]const u8, timeout_ms: u32) !void {
-    const frame = try test_session.createPage();
-    defer test_session.removePage();
+    const page = try test_session.createPage();
+    defer page.close();
 
     const url = try std.fmt.allocPrintSentinel(
         arena_allocator,
@@ -414,6 +421,8 @@ fn runWebApiTest(test_file: [:0]const u8, timeout_ms: u32) !void {
         .{test_file},
         0,
     );
+
+    const frame = page.frame().?;
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
@@ -463,9 +472,9 @@ fn runWebApiTest(test_file: [:0]const u8, timeout_ms: u32) !void {
 const PageTestOpts = struct {
     wait_until_done: bool = true,
 };
-pub fn pageTest(comptime test_file: []const u8, opts: PageTestOpts) !*Frame {
-    const frame = try test_session.createPage();
-    errdefer test_session.removePage();
+pub fn pageTest(comptime test_file: []const u8, opts: PageTestOpts) !Session.PageHandle {
+    const page = try test_session.createPage();
+    errdefer page.close();
 
     const url = try std.fmt.allocPrintSentinel(
         arena_allocator,
@@ -474,12 +483,12 @@ pub fn pageTest(comptime test_file: []const u8, opts: PageTestOpts) !*Frame {
         0,
     );
 
-    try frame.navigate(url, .{});
+    try page.navigate(url, .{});
     var runner = try test_session.runner(.{});
     if (opts.wait_until_done) {
         try runner.wait(.{ .ms = 2000 });
     }
-    return frame;
+    return page;
 }
 
 const TestHTTPServer = @import("TestHTTPServer.zig");


### PR DESCRIPTION
Replaces the 1 (+1 inflight) page design of session for an unlimited number of pages. The main goal is to support a more efficient async goto (1). Without this commit, async goto has two implementation: multiple browser, which is resource intensive (thread + isolate per page), bolting it onto sub-frames (like iframe or popups). The issue with the 2nd version (which I originally suggested) is that most resources are tied to the Page. So even if an async goto "page" (which would map to a Frame) is released, most things stay in memory, including the DOM (page.factory) and the V8::Context.

This new approach adds multiple page support to sessions. The advantage is pretty clear: the existing memory model (page-tied resources) becomes a strength of the design, rather than a weakness.

This change is not tirivla, but the diff is inflated by 2 large mechanial changes, so it isn't _that_ big either. That said, I'd divide this into four parts.

1 - The old concept of _active/_pending is now baked into the Page itself. A Page has a `replaces: ?*Page = null` and `replacement: ?*Page = null` field.

2 - Because of #1 above, the Session now just has an `pages: ArrayList(*Page)`. As much as possible, single-page APIs, like `removePage` no longer exists. We're trying to present a consistent multi-page API. See #3.

3 - References to *Page and *Frame have always been dangerous. For example, `lightpanda.fetch` has a block to scope `frame`:

```zig
{
    const frame = try session.createPage();
    // frame isn't safe to use after navigate, it can be swapped out
    _ = try frame.navigate(...)
}
```

While we still hand out *Page and *Frame (user-beware), some of the more important APIs now take a frame_id which Session can resolve. Furthermore, createPage now returns a PageHandle which is a safe wrapper around a page/frame.

4 - Two large mechanical changes were made:
  a - Many tests were superficially changed to account for new naming or use
      a new test-helper to preserve the single-page illusion (because 99% of
      tests _are_ single-page)
  b - Many CDP changes where `bc.session.currentFrame()` -> `bc.mainFrame()`).
      This isn't to say CDP changes are meaningless, but it's mostly 1 change
      about how the "main" target/frame_id is tracked (by CDP itself, rather
      than the Session) that required a number of superficial changes to
      accomodate

`Runner` remains largely single-page focused. Runner and some MCP/Agent tools continue to be tied to the "currentFrame" or "primaryPage". The Runner is something I want to address in a follow-up PR, but we need to figure out what it means to "wait" for multiple pages.
As much as possible, Session becomes multi-page native and has no concept of a special/first/primary/main page. Users of session become responsible for tracking pages of interest.

This change is not trivial, but the diff is inflated by 2 large mechanical changes:
1 - Many tests

(1) https://github.com/lightpanda-io/browser/pull/2759