### PR TITLE
refactor(cdp): store viewport override at the browser level

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -25,6 +25,7 @@ const Notification = @import("../Notification.zig");
 const js = @import("js/js.zig");
 const Page = @import("Page.zig");
 const Session = @import("Session.zig");
+const Viewport = @import("Viewport.zig");
 const HttpClient = @import("HttpClient.zig");
 const PermissionState = @import("webapi/Permissions.zig").State;
 
@@ -49,6 +50,14 @@ http_client: HttpClient,
 // across page navigations, mirroring how Chrome scopes permissions to the
 // browser context. Keys are owned by `allocator`; values are enum tags.
 permissions: std.StringHashMapUnmanaged(PermissionState) = .empty,
+
+// Runtime viewport override set via Emulation.setDeviceMetricsOverride and
+// cleared via clearDeviceMetricsOverride. Null means use the compile-time
+// Viewport.default. Scoped to the Browser so it persists across page
+// navigations (matching how Chrome scopes the override to the connection).
+// Every viewport consumer reads it through Page.getViewport so they all
+// observe the same (possibly overridden) value.
+viewport_override: ?Viewport = null,
 
 // used by sessions to allocate pages.
 page_pool: std.heap.MemoryPool(Page),
@@ -138,6 +147,12 @@ pub fn clearPermissions(self: *Browser) void {
         self.allocator.free(key.*);
     }
     self.permissions.clearRetainingCapacity();
+}
+
+// The viewport every consumer should read: the runtime override if set,
+// otherwise the compile-time default.
+pub fn getViewport(self: *const Browser) Viewport {
+    return self.viewport_override orelse Viewport.default;
 }
 
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -124,16 +124,12 @@ closed_frames: std.ArrayList(*Frame) = .empty,
 // notification (so CDP doesn't reset its node registry yet) and
 _state: enum { active, pending } = .active,
 
-// Runtime viewport override set via Emulation.setDeviceMetricsOverride and
-// cleared via Emulation.clearDeviceMetricsOverride. Null means use the
-// compile-time Viewport.default. Read every viewport consumer through
-// getViewport so they all observe the same (possibly overridden) value.
-viewport_override: ?Viewport = null,
-
-// The viewport every consumer should read: the runtime override if set,
-// otherwise the compile-time default.
+// The viewport every consumer should read. The runtime override (set via
+// Emulation.setDeviceMetricsOverride) is stored on the Browser so it persists
+// across page navigations; delegate to it here, keeping a single read path for
+// every viewport consumer.
 pub fn getViewport(self: *const Page) Viewport {
-    return self.viewport_override orelse Viewport.default;
+    return self.session.browser.getViewport();
 }
 
 // Initialize a Page and its root Frame.

--- a/src/cdp/domains/emulation.zig
+++ b/src/cdp/domains/emulation.zig
@@ -94,13 +94,14 @@ fn setDeviceMetricsOverride(cmd: *CDP.Command) !void {
         if (v != 0) log.warn(.not_implemented, "Emulation.setDeviceMetricsOverride", .{ .param = "screenHeight", .value = v });
     }
 
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const page = bc.session.currentPage() orelse return error.FrameNotLoaded;
+    // The override is stored on the Browser so it persists across page
+    // navigations for the whole CDP connection.
+    const browser = &cmd.cdp.browser;
 
     // CDP convention: a 0 width/height means "don't override that dimension",
     // so keep the current value for any dimension passed as 0.
-    const current = page.getViewport();
-    page.viewport_override = .{
+    const current = browser.getViewport();
+    browser.viewport_override = .{
         .width = if (params.width > 0) params.width else current.width,
         .height = if (params.height > 0) params.height else current.height,
     };
@@ -109,9 +110,7 @@ fn setDeviceMetricsOverride(cmd: *CDP.Command) !void {
 }
 
 fn clearDeviceMetricsOverride(cmd: *CDP.Command) !void {
-    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
-    const page = bc.session.currentPage() orelse return error.FrameNotLoaded;
-    page.viewport_override = null;
+    cmd.cdp.browser.viewport_override = null;
     return cmd.sendResult(null, .{});
 }
 
@@ -285,6 +284,11 @@ test "cdp.Emulation: setDeviceMetricsOverride and clear" {
     try ctx.expectSentResult(null, .{ .id = 8 });
     try testing.expectEqual(375, page.getViewport().width);
     try testing.expectEqual(812, page.getViewport().height);
+
+    // The override lives on the Browser, so it persists across page
+    // navigations rather than being lost with the page.
+    try testing.expectEqual(375, bc.session.browser.getViewport().width);
+    try testing.expectEqual(812, bc.session.browser.getViewport().height);
 
     try ctx.processMessage(.{
         .id = 9,


### PR DESCRIPTION
Follow-up to #2664, addressing @krichprollsch's review note that the viewport override should live at the browser level so it survives navigation rather than being lost with the page.

## Change

- `Browser` gains the `viewport_override` field and a `getViewport()` helper (mirroring how the permission state already lives on `Browser`).
- `Page.getViewport()` now delegates to `Browser.getViewport()`, so all the viewport consumers (window.innerWidth/innerHeight, screen.*, visualViewport.*, getLayoutMetrics, IntersectionObserver, matchMedia / the StyleManager media cascade) keep reading through the same single path with no change.
- `Emulation.setDeviceMetricsOverride` / `clearDeviceMetricsOverride` now write the override on the `Browser`.

The override now persists across page navigations for the lifetime of the CDP connection.

## Test

Extended the existing `cdp.Emulation: setDeviceMetricsOverride and clear` test to assert the override is visible at the browser level (so it outlives the current page).

`make test` passes (the only failing test, `WebApi: Frames`, fails identically on a clean `main` for me — environment-dependent, unrelated to this change). `zig fmt --check` clean, `make build` OK.