### PR TITLE
Add `make wpt` to run Web Platform Tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ZIG := zig
 BC := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # option test filter make test F="server"
 F=
+# single-test filter for `make wpt` (e.g. make wpt T=Node-childNodes.html)
+T=
 
 # Extra flags forwarded to every `$(ZIG) build` invocation. Most commonly used
 # to point at a prebuilt V8 archive and skip the multi-minute source rebuild:
@@ -72,7 +74,7 @@ help:
 
 # $(ZIG) commands
 # ------------
-.PHONY: build build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
+.PHONY: build build-v8-snapshot build-dev download-v8 run run-release test bench data end2end wpt clean
 
 ## Download the prebuilt V8 archive (skips the 10+ min source build)
 download-v8:
@@ -127,6 +129,27 @@ endif
 end2end:
 	@test -d ../demo
 	cd ../demo && go run runner/main.go
+
+# Web Platform Tests, run locally. Needs the WPT fork in ../wpt and the demo
+# runner in ../demo (same convention as `end2end`). See the README for setup.
+WPT_BIN  := $(BC)zig-out/bin/lightpanda
+WPT_DIR  := $(abspath $(BC)../wpt)
+DEMO_DIR := $(abspath $(BC)../demo)
+
+## Run the Web Platform Tests locally (whole suite, or one test with T=Foo.html)
+wpt:
+	@test -d $(WPT_DIR) || { printf "\033[33mMissing $(WPT_DIR). Clone the fork:\n  git clone -b fork --depth=1 git@github.com:lightpanda-io/wpt.git $(WPT_DIR)\033[0m\n"; exit 1; }
+	@test -d $(DEMO_DIR)/wptrunner || { printf "\033[33mMissing $(DEMO_DIR). Clone the runner:\n  git clone --depth=1 git@github.com:lightpanda-io/demo.git $(DEMO_DIR)\033[0m\n"; exit 1; }
+	@grep -q web-platform.test /etc/hosts || { printf "\033[33mWPT custom hosts not installed (one-time, needs sudo):\n  cd $(WPT_DIR) && ./wpt make-hosts-file | sudo tee -a /etc/hosts\033[0m\n"; exit 1; }
+	@test -f $(WPT_DIR)/MANIFEST.json || ( printf "\033[36mGenerating MANIFEST.json...\033[0m\n"; cd $(WPT_DIR) && ./wpt manifest )
+	@printf "\033[36mBuilding lightpanda (-Dwpt_extensions, release fast)...\033[0m\n"
+	@$(ZIG) build $(ZIGFLAGS) -Dwpt_extensions -Doptimize=ReleaseFast || (printf "\033[33mBuild ERROR\033[0m\n"; exit 1;)
+	@printf "\033[36mServing WPT and running the suite (Ctrl-C to stop)...\033[0m\n"
+	@cd $(WPT_DIR) && ./wpt serve 2>/dev/null & \
+		WPT_PID=$$!; \
+		trap 'kill $$WPT_PID 2>/dev/null' EXIT INT TERM; \
+		sleep 20; \
+		cd $(DEMO_DIR)/wptrunner && go run . -lpd-path $(WPT_BIN) $(if $(T),$(T),-summary)
 
 ## Remove build artifacts (keeps .lp-cache/ and zig-pkg/ — slow to re-fetch)
 clean:

--- a/README.md
+++ b/README.md
@@ -356,6 +356,26 @@ details.
 
 #### Run WPT test suite
 
+##### Quick local run
+
+If the WPT fork is cloned in `../wpt` and the [demo
+repository](https://github.com/lightpanda-io/demo) (which holds the runner) in
+`../demo` — both siblings of this repo, the same convention as `make end2end` —
+a single target builds Lightpanda with `-Dwpt_extensions`, starts `./wpt serve`,
+runs the suite and tears the server down:
+
+```
+make wpt                          # whole suite (summary output)
+make wpt T=Node-childNodes.html   # one test
+```
+
+It checks the prerequisites first (the two clones, the custom hosts entry, the
+`MANIFEST.json`) and prints the exact command to fix whichever is missing. The
+custom hosts still need a one-time `sudo` (see below); `make wpt` won't do that
+for you. The manual flow below is the same thing, step by step.
+
+##### Manual run
+
 An external [Go](https://go.dev) runner is provided by
 [github.com/lightpanda-io/demo/](https://github.com/lightpanda-io/demo/)
 repository, located into `wptrunner/` dir.


### PR DESCRIPTION
Running the Web Platform Tests locally currently means following the README by hand: build with `-Dwpt_extensions`, start `./wpt serve`, run the demo repo's `wptrunner`, then kill the server. This adds a `make wpt` target that does all of it, mirroring the `make end2end` convention (both expect the sibling clones in `../wpt` and `../demo`).

```
make wpt                          # whole suite (summary output)
make wpt T=Node-childNodes.html   # one test
```

It checks the prerequisites first (the two clones, the `web-platform.test` hosts entry, the `MANIFEST.json`) and prints the exact command to fix whichever is missing. Then it builds Lightpanda, serves WPT, runs the suite via `-lpd-path` so the runner spawns the binary the same way CI does, and kills the server on exit with a `trap`. The one-time `sudo` for the custom hosts is left to you; the target detects the missing entry rather than running sudo on your behalf.

The runner invocation reuses the two documented forms: `-lpd-path` from the CI job in `.github/workflows/wpt.yml`, and the positional single-test name from the README. I couldn't run it end to end here (neither sibling repo is cloned on this machine, and the hosts file needs sudo), so passing `-lpd-path` together with a positional test name is the one thing worth confirming on a first real run.

The README's WPT section gains a short "Quick local run" note pointing at the target, with the existing manual steps kept below as the detailed reference.
