### PR TITLE
ci: summarize WPT results by area in the job summary

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -116,6 +116,47 @@ jobs:
           ./wptrunner -lpd-path ./lightpanda -json -concurrency 5 -pool 5 --mem-limit 400 > wpt.json
           kill `cat WPT.pid`
 
+      - name: summarize results by area
+        if: always()
+        run: |
+          test -s wpt.json || { echo "No wpt.json produced; nothing to summarize." >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+          python3 - wpt.json >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import collections, json, sys
+          try:
+              with open(sys.argv[1]) as fh:
+                  results = json.load(fh)
+          except Exception as e:
+              print(f"Could not parse {sys.argv[1]}: {e}")
+              sys.exit(0)
+          total = len(results)
+          passed = sum(1 for t in results if t.get("pass"))
+          # area = first path segment of the test name, e.g. /FileAPI/x.html -> FileAPI
+          stats = collections.defaultdict(lambda: [0, 0, 0, 0])  # [tests, passed, subtests, sub_passed]
+          for t in results:
+              seg = (t.get("name") or "").lstrip("/").split("/", 1)
+              s = stats[seg[0] if seg and seg[0] else "(root)"]
+              s[0] += 1
+              s[1] += 1 if t.get("pass") else 0
+              for c in t.get("cases") or []:
+                  s[2] += 1
+                  s[3] += 1 if c.get("pass") else 0
+          pct = lambda p, n: f"{(100.0 * p / n):.1f}%" if n else "-"
+          rows = [(a, n, p, n - p, cp, ct) for a, (n, p, ct, cp) in stats.items()]
+          rows.sort(key=lambda r: (-r[3], r[0]))  # most failing tests first
+          row = lambda a, n, p, f, cp, ct: f"| `/{a}/` | {n:,} | {p:,} | {f:,} | {pct(p, n)} | {cp:,}/{ct:,} |"
+          head = ["| Area | Tests | Passed | Failed | Pass rate | Subtests |",
+                  "|------|------:|-------:|-------:|----------:|---------:|"]
+          out = ["## WPT results by area", "",
+                 f"**{passed:,} / {total:,} tests passing ({pct(passed, total)})**, "
+                 f"{total - passed:,} failing across {len(rows)} areas.", "",
+                 "Sorted by failing tests, so the areas with the most to gain sit on top:", ""]
+          out += head + [row(*r) for r in rows[:25]]
+          if len(rows) > 25:
+              out += ["", f"<details><summary>{len(rows) - 25} more areas</summary>", ""] + head
+              out += [row(*r) for r in rows[25:]] + ["", "</details>"]
+          print("\n".join(out))
+          PY
+
       - name: write commit
         run: |
           echo "${{github.sha}}" > commit.txt


### PR DESCRIPTION
The nightly WPT run produces `wpt.json`, but it only lands as a raw artifact plus the Slack diff. There's no at-a-glance view of *which areas* are failing most, which is exactly what you need to decide where to spend effort to pass more tests.

This adds one step to the `run-wpt` job: after `wpt.json` is written, it parses the results and appends a per-area table to the GitHub job summary (`$GITHUB_STEP_SUMMARY`), sorted by failing tests. What runs is unchanged: the same full nightly suite.

Sample from the 2026-06-23 run:

> ## WPT results by area
>
> **6,231 / 37,266 tests passing (16.7%)**, 31,035 failing across 263 areas.
>
> | Area | Tests | Passed | Failed | Pass rate | Subtests |
> |------|------:|-------:|-------:|----------:|---------:|
> | `/html/` | 8,379 | 1,444 | 6,935 | 17.2% | 65,251/100,862 |
> | `/css/` | 7,198 | 920 | 6,278 | 12.8% | 80,624/169,807 |
> | `/referrer-policy/` | 1,390 | 193 | 1,197 | 13.9% | 902/8,469 |
> | `/fetch/` | 906 | 89 | 817 | 9.8% | 2,612/8,363 |
> | `/IndexedDB/` | 813 | 2 | 811 | 0.2% | 32/2,682 |

Top 25 areas show inline; the rest collapse into a `<details>`. The subtests column separates deeply-broken areas (`/IndexedDB/` at 0.2%, almost no subtests passing) from near-misses worth a push (areas where most subtests already pass but the test file doesn't flip green yet).

Notes:

- Inline `python3` rather than a committed script, because `run-wpt` checks out the wpt fork repo, not this one. `python3` is already on that runner for `./wpt serve`.
- `if: always()` plus a `test -s wpt.json` guard and a `try/except` around the parse, so a missing or partial `wpt.json` writes a short note instead of failing the job.
