### PR TITLE
crash: Fix handlescope corruption on iframe load

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1011,11 +1011,8 @@ pub fn iframeCompletedLoading(self: *Frame, iframe: *IFrame) void {
         return;
     }
 
-    var ls: JS.Local.Scope = undefined;
-    self.js.localScope(&ls);
-    defer ls.deinit();
-
-    const entered = self.js.enter(&ls.handle_scope);
+    var hs: JS.HandleScope = undefined;
+    const entered = self.js.enter(&hs);
     defer entered.exit();
 
     blk: {


### PR DESCRIPTION
In trying to fuzz test a different issue, I ran into a reproducible case where we end up with a broken handlescope stack. The issue requires a large number of handlescopes created with aggressive GC, so hopefully it isn't something that too many users have run into.

The issue is that a single HandleScope address is used to initialize two HandleScopes. The fix could just be to create a 2nd HS variable (to get a 2nd address), but the first initialization is unnecessary and can just be removed.

(Note that EventManager dispatch creates its own HandleScope, so the one removed in frameCompletedLoading really did nothing)