### PR TITLE
initial implementation for `update` command

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const Updater = lp.Updater;
 const log = lp.log;
 const builtin = @import("builtin");
 const zenai = @import("zenai");
@@ -188,6 +189,10 @@ fn injectScriptFileValidator(
     return list.append(allocator, bytes);
 }
 
+fn nightlyChannelValidator(_: Allocator, _: *std.process.ArgIterator) !Updater.Channel {
+    return .nightly;
+}
+
 /// Definition for all the commands and its arguments. See @cli.zig for further.
 const Commands = cli.Builder(.{
     .{
@@ -259,6 +264,20 @@ const Commands = cli.Builder(.{
             .{ .name = "effort", .type = ?Effort },
             .{ .name = "list_models", .type = bool },
             .{ .name = "no_llm", .type = bool },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{
+        .name = "update",
+        .options = .{
+            .{
+                .name = "channel",
+                .type = Updater.Channel,
+                .default = .stable,
+                .variants = .{
+                    .{ .name = "nightly", .validator = nightlyChannelValidator },
+                },
+            },
         },
         .shared_options = CommonOptions,
     },
@@ -355,7 +374,7 @@ pub fn v8MaxHeapMb(self: *const Config) ?u32 {
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
+        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_proxy,
         else => unreachable,
     };
 }
@@ -363,7 +382,7 @@ pub fn httpProxy(self: *const Config) ?[:0]const u8 {
 pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.proxy_bearer_token,
-        .help, .version => null,
+        else => null,
     };
 }
 
@@ -383,14 +402,14 @@ pub fn httpMaxHostOpen(self: *const Config) u8 {
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_connect_timeout orelse 0,
         else => unreachable,
     };
 }
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
+        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_timeout orelse 5000,
         else => unreachable,
     };
 }
@@ -401,7 +420,7 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size,
+        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_max_response_size,
         else => unreachable,
     };
 }
@@ -465,14 +484,14 @@ pub fn logFilterScopes(self: *const Config) std.ArrayList(log.FilterRule) {
 pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent_suffix,
-        .help, .version => null,
+        else => null,
     };
 }
 
 pub fn userAgent(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent,
-        .help, .version => null,
+        else => null,
     };
 }
 
@@ -520,7 +539,7 @@ pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
             .keyid = opts.web_bot_auth_keyid orelse return null,
             .domain = opts.web_bot_auth_domain orelse return null,
         },
-        .help, .version => null,
+        else => null,
     };
 }
 
@@ -700,6 +719,7 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
             , .{ @field(Help, @tagName(tag)), Help.common_options });
             std.debug.print(template, .{ exec_name, info_or_warn, pretty_or_logfmt });
         },
+        .update => @panic("TODO"),
         .version => {
             const template = Help.version ++ "\n";
             std.debug.print(template, .{exec_name});

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -18,7 +18,6 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const Updater = lp.Updater;
 const log = lp.log;
 const builtin = @import("builtin");
 const zenai = @import("zenai");
@@ -189,10 +188,6 @@ fn injectScriptFileValidator(
     return list.append(allocator, bytes);
 }
 
-fn nightlyChannelValidator(_: Allocator, _: *std.process.ArgIterator) !Updater.Channel {
-    return .nightly;
-}
-
 /// Definition for all the commands and its arguments. See @cli.zig for further.
 const Commands = cli.Builder(.{
     .{
@@ -267,20 +262,7 @@ const Commands = cli.Builder(.{
         },
         .shared_options = CommonOptions,
     },
-    .{
-        .name = "update",
-        .options = .{
-            .{
-                .name = "channel",
-                .type = Updater.Channel,
-                .default = .stable,
-                .variants = .{
-                    .{ .name = "nightly", .validator = nightlyChannelValidator },
-                },
-            },
-        },
-        .shared_options = CommonOptions,
-    },
+    .{ .name = "update", .options = .{}, .shared_options = CommonOptions },
     .{ .name = "version", .options = .{} },
 });
 

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -692,7 +692,7 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
             , .{Help.general});
             std.debug.print(template, .{exec_name});
         },
-        inline .fetch, .serve, .mcp, .agent => |tag| {
+        inline .fetch, .serve, .mcp, .agent, .update => |tag| {
             const template = comptimePrint(
                 \\{s}
                 \\
@@ -701,7 +701,6 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
             , .{ @field(Help, @tagName(tag)), Help.common_options });
             std.debug.print(template, .{ exec_name, info_or_warn, pretty_or_logfmt });
         },
-        .update => @panic("TODO"),
         .version => {
             const template = Help.version ++ "\n";
             std.debug.print(template, .{exec_name});

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -262,8 +262,9 @@ const Commands = cli.Builder(.{
         },
         .shared_options = CommonOptions,
     },
-    .{ .name = "update", .options = .{}, .shared_options = CommonOptions },
-    .{ .name = "version", .options = .{} },
+    .{ .name = "version", .options = .{
+        .{ .name = "check", .type = bool },
+    } },
 });
 
 pub const RunMode = Commands.Enum;
@@ -275,7 +276,11 @@ exec_name: []const u8,
 http_headers: HttpHeaders,
 
 fn modeNeedsHttp(mode: Mode) bool {
-    return mode != .help and mode != .version;
+    return switch (mode) {
+        .help => false,
+        .version => |opts| opts.check,
+        else => true,
+    };
 }
 
 pub fn init(allocator: Allocator, exec_name: []const u8, mode: Mode) !Config {
@@ -308,6 +313,8 @@ pub fn interactive(self: *const Config) bool {
 pub fn tlsVerifyHost(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,
+        // `version --check` talks to the release endpoint; always verify.
+        .version => true,
         else => unreachable,
     };
 }
@@ -356,7 +363,8 @@ pub fn v8MaxHeapMb(self: *const Config) ?u32 {
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_proxy,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
+        .version => null,
         else => unreachable,
     };
 }
@@ -384,14 +392,16 @@ pub fn httpMaxHostOpen(self: *const Config) u8 {
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
+        .version => 0,
         else => unreachable,
     };
 }
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_timeout orelse 5000,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
+        .version => 5000,
         else => unreachable,
     };
 }
@@ -402,7 +412,7 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent, .update => |opts| opts.http_max_response_size,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size,
         else => unreachable,
     };
 }
@@ -692,7 +702,7 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
             , .{Help.general});
             std.debug.print(template, .{exec_name});
         },
-        inline .fetch, .serve, .mcp, .agent, .update => |tag| {
+        inline .fetch, .serve, .mcp, .agent => |tag| {
             const template = comptimePrint(
                 \\{s}
                 \\

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -111,9 +111,43 @@ fn resetConnection(self: *Updater) !void {
     self.conn_err = .none;
 }
 
+const SortContext = struct {
+    object: std.json.ObjectMap,
+
+    pub fn lessThan(ctx: SortContext, a_index: usize, b_index: usize) bool {
+        const keys = ctx.object.keys();
+        const a_version = std.SemanticVersion.parse(keys[a_index]) catch unreachable;
+        const b_version = std.SemanticVersion.parse(keys[b_index]) catch unreachable;
+        return a_version.order(b_version).compare(.gt);
+    }
+};
+
 /// Informs about running version to given `Writer` by desired `Channel`.
-pub fn inform(self: *Updater, channel: Channel, writer: std.Io.Writer) void {
+pub fn inform(self: *Updater, channel: Channel, writer: *std.Io.Writer) !void {
     const versions = try self.getVersions();
+    defer self.resetConnection() catch {};
+
+    switch (channel) {
+        .stable => {
+            var stable = versions.object;
+            // Get rid of `nightly`.
+            lp.assert(stable.swapRemove("nightly"), "Updater.inform: incorrect JSON", .{});
+
+            // Sort and retrieve the newest.
+            stable.sort(SortContext{ .object = stable });
+            // Newest is at the beginning.
+            const newest = stable.values()[0].object;
+            const version = (newest.get("version") orelse return error.IncorrectJson).string;
+            try writer.print("Latest stable Lightpanda version is {s}.\n", .{version});
+            return writer.flush();
+        },
+        .nightly => {
+            const nightly = (versions.object.get("nightly") orelse return error.IncorrectJson).object;
+            const version = (nightly.get("version") orelse return error.IncorrectJson).string;
+            try writer.print("Latest nightly Lightpanda version is {s}.\n", .{version});
+            return writer.flush();
+        },
+    }
 }
 
 /// Invoked by `Connection` when there are body bytes.

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -74,25 +74,9 @@ pub fn deinit(self: *Updater) void {
     self.arena.deinit();
 }
 
-// TODO: Update this with actual versions.json when ready.
-const Versions = struct {
-    master: Entry,
-    @"0.16.0": Entry, // Consider this as stable.
-
-    /// Single version record.
-    const Entry = struct {
-        version: []const u8,
-        src: struct {
-            tarball: []const u8,
-            shasum: []const u8,
-            size: u64,
-        },
-    };
-};
-
 /// Returns Lightpanda versions; call `resetConnection` after you're done with
 /// `Versions` to do further requests.
-fn getVersions(self: *Updater) !Versions {
+fn getVersions(self: *Updater) !std.json.Value {
     try self.conn.setURL(VersionsUrl);
     try self.conn.setGetMode();
     try self.conn.setFollowLocation(true);
@@ -109,7 +93,7 @@ fn getVersions(self: *Updater) !Versions {
     }
 
     return std.json.parseFromSliceLeaky(
-        Versions,
+        std.json.Value,
         self.arena.allocator(),
         self.conn_read_buffer.items,
         .{

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -119,15 +119,22 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
     try libcurl.curl_easy_setopt(conn._easy, .write_data, &ctx);
 
     // Make a request.
-    const status_int = conn.request(&self.config.http_headers) catch |err| {
+    const status_int = conn.perform() catch |err| {
         ctx.err catch |ctx_err| return ctx_err;
         return err;
     };
     const status: std.http.Status = @enumFromInt(status_int);
-    if (status != .ok) {
-        return error.UnexpectedStatus;
+    switch (status) {
+        // Write what's received.
+        .ok => try writer.writeAll(ctx.buffer.items),
+        // Client failed.
+        .bad_request => try writer.writeAll("Versions format is invalid.\n"),
+        // Server failed.
+        .internal_server_error,
+        .service_unavailable,
+        => try writer.writeAll("Couldn't get the versions list from remote.\n"),
+        else => return error.UnexpectedStatus,
     }
 
-    try writer.writeAll(ctx.buffer.items);
     return writer.flush();
 }

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -17,6 +17,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const json = std.json;
+const SemanticVersion = std.SemanticVersion;
 const lp = @import("lightpanda");
 
 const Network = @import("network/Network.zig");
@@ -74,26 +76,54 @@ pub fn deinit(self: *Updater) void {
     self.arena.deinit();
 }
 
-/// Returns Lightpanda versions; call `resetConnection` after you're done with
-/// `Versions` to do further requests.
-fn getVersions(self: *Updater) !std.json.Value {
+const Version = struct {
+    @"aarch64-linux": Entry,
+    @"aarch64-macos": Entry,
+    date: []const u8,
+    version: []const u8,
+    @"x86_64-linux": Entry,
+    @"x86_64-macos": Entry,
+
+    const Entry = struct {
+        download_url: []const u8,
+        shasum: []const u8,
+        size: u64,
+    };
+};
+
+const Nightly = struct { nightly: Version };
+
+/// Returns Lightpanda versions for a channel; call `resetConnection` after
+/// you're done with `Versions` to do further requests.
+fn getVersions(
+    self: *Updater,
+    comptime channel: Channel,
+) !switch (channel) {
+    .stable => json.ArrayHashMap(Version),
+    .nightly => Nightly, // Only care about nightly record.
+} {
     try self.conn.setURL(VersionsUrl);
     try self.conn.setGetMode();
     try self.conn.setFollowLocation(true);
     try self.conn.setWriteCallback(onBytes);
 
-    const status = self.conn.request(&self.config.http_headers) catch |err| {
+    const status_int = self.conn.request(&self.config.http_headers) catch |err| {
         switch (self.conn_err) {
             .none => return err,
             .out_of_memory => return error.OutOfMemory,
         }
     };
-    if (status != 200) {
+    const status: std.http.Status = @enumFromInt(status_int);
+    if (status != .ok) {
         return error.UnexpectedStatus;
     }
 
-    return std.json.parseFromSliceLeaky(
-        std.json.Value,
+    const Json = switch (channel) {
+        .stable => json.ArrayHashMap(Version),
+        .nightly => Nightly,
+    };
+    return json.parseFromSliceLeaky(
+        Json,
         self.arena.allocator(),
         self.conn_read_buffer.items,
         .{
@@ -111,40 +141,59 @@ fn resetConnection(self: *Updater) !void {
     self.conn_err = .none;
 }
 
-const SortContext = struct {
-    object: std.json.ObjectMap,
+const SortCtx = struct {
+    keys: []const []const u8,
+    /// Carries the error that might happen while sorting.
+    err: anyerror!void = {},
 
-    pub fn lessThan(ctx: SortContext, a_index: usize, b_index: usize) bool {
-        const keys = ctx.object.keys();
-        const a_version = std.SemanticVersion.parse(keys[a_index]) catch unreachable;
-        const b_version = std.SemanticVersion.parse(keys[b_index]) catch unreachable;
-        return a_version.order(b_version).compare(.gt);
+    pub fn lessThan(ctx: *SortCtx, a_index: usize, b_index: usize) bool {
+        const keys = ctx.keys;
+        const a_version = SemanticVersion.parse(keys[a_index]) catch |err| {
+            ctx.err = err;
+            return false;
+        };
+        const b_version = SemanticVersion.parse(keys[b_index]) catch |err| {
+            ctx.err = err;
+            return false;
+        };
+
+        return a_version.order(b_version).compare(.lt);
     }
 };
 
 /// Informs about running version to given `Writer` by desired `Channel`.
 pub fn inform(self: *Updater, channel: Channel, writer: *std.Io.Writer) !void {
-    const versions = try self.getVersions();
-    defer self.resetConnection() catch {};
-
     switch (channel) {
         .stable => {
-            var stable = versions.object;
-            // Get rid of `nightly`.
-            lp.assert(stable.swapRemove("nightly"), "Updater.inform: incorrect JSON", .{});
+            var versions = (try self.getVersions(.stable)).map;
+            defer self.resetConnection() catch {};
 
-            // Sort and retrieve the newest.
-            stable.sort(SortContext{ .object = stable });
-            // Newest is at the beginning.
-            const newest = stable.values()[0].object;
-            const version = (newest.get("version") orelse return error.IncorrectJson).string;
-            try writer.print("Latest stable Lightpanda version is {s}.\n", .{version});
-            return writer.flush();
+            // Remove "nightly" entry.
+            lp.assert(versions.swapRemove("nightly"), "Updater.inform: \"nightly\" entry not found", .{});
+            // Sorting is necessary.
+            var sort_ctx = SortCtx{ .keys = versions.keys() };
+            versions.sort(&sort_ctx);
+            sort_ctx.err catch |err| return err;
+
+            // Get the latest.
+            const values = versions.values();
+            const top = values[values.len - 1];
+
+            std.debug.print("{s}\n", .{top.version});
         },
         .nightly => {
-            const nightly = (versions.object.get("nightly") orelse return error.IncorrectJson).object;
-            const version = (nightly.get("version") orelse return error.IncorrectJson).string;
-            try writer.print("Latest nightly Lightpanda version is {s}.\n", .{version});
+            const versions = try self.getVersions(.nightly);
+            defer self.resetConnection() catch {};
+            const nightly = versions.nightly;
+            // Parse to SemVer for comparison.
+            const semver_nightly = try SemanticVersion.parse(nightly.version);
+            const semver_current = try SemanticVersion.parse(lp.build_config.version);
+
+            switch (semver_current.order(semver_nightly)) {
+                .lt => try writer.print("A new version of Lightpanda nightly ({s}) is available.\n", .{nightly.version}),
+                .eq => try writer.writeAll("You're up-to-date."),
+                .gt => unreachable,
+            }
             return writer.flush();
         },
     }

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -53,6 +53,7 @@ pub fn init(allocator: Allocator, config: *const Config) !Updater {
 
 pub fn deinit(self: *Updater) void {
     Network.globalDeinit();
+    crypto.X509_STORE_free(self.x509_store);
     self.arena.deinit();
 }
 

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -29,7 +29,7 @@ const log = @import("log.zig");
 const MockVersion: [:0]const u8 = "0.16.0";
 
 /// Where to find versions JSON.
-const VersionsUrl: [:0]const u8 = "https://ziglang.org/download/index.json";
+const VersionsUrl: [:0]const u8 = "https://get.lightpanda.io/versions.json";
 
 pub const Channel = enum(u1) { stable, nightly };
 

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -31,21 +31,16 @@ const log = @import("log.zig");
 
 /// Sole purpose of this client is to do updates; hence, its very minimal.
 const Updater = @This();
-arena: std.heap.ArenaAllocator,
 x509_store: *crypto.X509_STORE,
 config: *const Config,
 
 /// Initializes the update client; meant to be used as singleton.
 pub fn init(allocator: Allocator, config: *const Config) !Updater {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    errdefer arena.deinit();
-
     Network.globalInit(allocator);
     errdefer Network.globalDeinit();
-    const x509_store = try Network.createX509Store(arena.allocator());
+    const x509_store = try Network.createX509Store(allocator);
 
     return .{
-        .arena = arena,
         .x509_store = x509_store,
         .config = config,
     };
@@ -54,7 +49,6 @@ pub fn init(allocator: Allocator, config: *const Config) !Updater {
 pub fn deinit(self: *Updater) void {
     Network.globalDeinit();
     crypto.X509_STORE_free(self.x509_store);
-    self.arena.deinit();
 }
 
 fn versioning() []const u8 {
@@ -67,6 +61,7 @@ fn versioning() []const u8 {
 }
 
 /// Sends running Lightpanda version to remote to get update information.
+/// Outputs directly to given `Writer`.
 pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
     const kind = comptime versioning();
     if (comptime std.mem.eql(u8, "dev", kind)) {
@@ -81,15 +76,7 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
     const conn = try http.Connection.init(self.x509_store, self.config, null);
     defer conn.deinit();
 
-    const allocator = self.arena.allocator();
-    const url = try std.fmt.allocPrintSentinel(
-        allocator,
-        "https://telemetry.lightpanda.io/v/{s}",
-        .{lp.build_config.version},
-        0,
-    );
-    defer allocator.free(url);
-
+    const url = std.fmt.comptimePrint("https://telemetry.lightpanda.io/v/{s}", .{lp.build_config.version});
     // Prepare the request.
     try conn.setURL(url);
     try conn.setGetMode();
@@ -97,26 +84,26 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
 
     // Wraps everything needed to receive bytes.
     const ReceiverContext = struct {
-        allocator: std.mem.Allocator,
-        buffer: std.ArrayList(u8) = .empty,
-        err: Allocator.Error!void = {},
+        writer: *std.Io.Writer,
+        err: std.Io.Writer.Error!void = {},
 
-        fn onBytes(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_ctx: ?*anyopaque) usize {
+        /// curl -> writer.
+        fn drain(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_ctx: ?*anyopaque) usize {
             const ctx: *@This() = @ptrCast(@alignCast(raw_ctx));
             const chunk = buffer[0 .. buf_count * buf_len];
-            ctx.buffer.appendSlice(ctx.allocator, chunk) catch |err| {
+            ctx.writer.writeAll(chunk) catch |err| {
                 ctx.err = err;
                 return 0;
             };
+
             return chunk.len;
         }
     };
 
-    try libcurl.curl_easy_setopt(conn._easy, .write_function, ReceiverContext.onBytes);
     // Set receiver context.
-    var ctx = ReceiverContext{ .allocator = allocator };
-    defer ctx.buffer.deinit(allocator);
+    var ctx = ReceiverContext{ .writer = writer };
     try libcurl.curl_easy_setopt(conn._easy, .write_data, &ctx);
+    try libcurl.curl_easy_setopt(conn._easy, .write_function, ReceiverContext.drain);
 
     // Make a request.
     const status_int = conn.perform() catch |err| {
@@ -124,17 +111,13 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
         return err;
     };
     const status: std.http.Status = @enumFromInt(status_int);
-    switch (status) {
-        // Write what's received.
-        .ok => try writer.writeAll(ctx.buffer.items),
-        // Client failed.
-        .bad_request => try writer.writeAll("Versions format is invalid.\n"),
-        // Server failed.
+    return switch (status) {
+        // We expect any of those.
+        .ok,
+        .bad_request,
         .internal_server_error,
         .service_unavailable,
-        => try writer.writeAll("Couldn't get the versions list from remote.\n"),
-        else => return error.UnexpectedStatus,
-    }
-
-    return writer.flush();
+        => writer.flush(),
+        else => error.UnexpectedStatus,
+    };
 }

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -25,116 +25,35 @@ const lp = @import("lightpanda");
 const Network = @import("network/Network.zig");
 const http = @import("network/http.zig");
 const libcurl = @import("sys/libcurl.zig");
+const crypto = @import("sys/libcrypto.zig");
 const Config = @import("Config.zig");
 const log = @import("log.zig");
-
-/// Where to find versions JSON.
-const VersionsUrl: [:0]const u8 = "https://get.lightpanda.io/versions.json";
-
-pub const Channel = enum(u1) { stable, nightly };
 
 /// Sole purpose of this client is to do updates; hence, its very minimal.
 const Updater = @This();
 arena: std.heap.ArenaAllocator,
-ca_blob: libcurl.CurlBlob,
-/// Connection where client does all of its network I/O.
-conn: http.Connection,
-/// Read buffer for `conn`.
-conn_read_buffer: std.ArrayList(u8) = .empty,
-/// Needed to report OutOfMemory.
-conn_err: Allocator.Error!void = {},
-/// TODO: Come up with a solution where we don't have to embed this here?
+x509_store: *crypto.X509_STORE,
 config: *const Config,
 
 /// Initializes the update client; meant to be used as singleton.
 pub fn init(allocator: Allocator, config: *const Config) !Updater {
     var arena = std.heap.ArenaAllocator.init(allocator);
     errdefer arena.deinit();
-    const arena_allocator = arena.allocator();
 
     Network.globalInit(allocator);
     errdefer Network.globalDeinit();
-    // On error, will be deinitialized by arena.
-    const ca_blob = try Network.loadCerts(arena_allocator);
-    // Init connection.
-    const connection = try http.Connection.init(ca_blob, config, null);
-    errdefer connection.deinit();
+    const x509_store = try Network.createX509Store(arena.allocator());
 
     return .{
         .arena = arena,
-        .ca_blob = ca_blob,
-        .conn = connection,
+        .x509_store = x509_store,
         .config = config,
     };
 }
 
 pub fn deinit(self: *Updater) void {
-    self.conn.deinit();
     Network.globalDeinit();
     self.arena.deinit();
-}
-
-const Version = struct {
-    @"aarch64-linux": Entry,
-    @"aarch64-macos": Entry,
-    date: []const u8,
-    version: []const u8,
-    @"x86_64-linux": Entry,
-    @"x86_64-macos": Entry,
-
-    const Entry = struct {
-        download_url: []const u8,
-        shasum: []const u8,
-        size: u64,
-    };
-};
-
-const Nightly = struct { nightly: Version };
-
-/// Returns Lightpanda versions for a channel; call `resetConnection` after
-/// you're done with `Versions` to do further requests.
-fn getVersions(
-    self: *Updater,
-    comptime channel: Channel,
-) !switch (channel) {
-    .stable => json.ArrayHashMap(Version),
-    .nightly => Nightly, // Only care about nightly record.
-} {
-    try self.conn.setURL(VersionsUrl);
-    try self.conn.setGetMode();
-    try self.conn.setFollowLocation(true);
-    try self.conn.setWriteCallback(onBytes);
-
-    const status_int = self.conn.request(&self.config.http_headers) catch |err| {
-        self.conn_err catch |conn_err| return conn_err;
-        return err;
-    };
-    const status: std.http.Status = @enumFromInt(status_int);
-    if (status != .ok) {
-        return error.UnexpectedStatus;
-    }
-
-    const Json = switch (channel) {
-        .stable => json.ArrayHashMap(Version),
-        .nightly => Nightly,
-    };
-    return json.parseFromSliceLeaky(
-        Json,
-        self.arena.allocator(),
-        self.conn_read_buffer.items,
-        .{
-            .ignore_unknown_fields = true,
-            .allocate = .alloc_if_needed,
-            .parse_numbers = true,
-        },
-    );
-}
-
-/// Resets everything related to `conn`.
-fn resetConnection(self: *Updater) void {
-    self.conn.reset(self.config, self.ca_blob, null) catch {};
-    self.conn_read_buffer.clearRetainingCapacity();
-    self.conn_err = {};
 }
 
 fn versioning() []const u8 {
@@ -146,27 +65,7 @@ fn versioning() []const u8 {
     }
 }
 
-const SortCtx = struct {
-    keys: []const []const u8,
-    /// Carries the error that might happen while sorting.
-    err: anyerror!void = {},
-
-    pub fn lessThan(ctx: *SortCtx, a_index: usize, b_index: usize) bool {
-        const keys = ctx.keys;
-        const a_version = SemanticVersion.parse(keys[a_index]) catch |err| {
-            ctx.err = err;
-            return false;
-        };
-        const b_version = SemanticVersion.parse(keys[b_index]) catch |err| {
-            ctx.err = err;
-            return false;
-        };
-
-        return a_version.order(b_version).compare(.lt);
-    }
-};
-
-/// Informs about running version to given `Writer`.
+/// Sends running Lightpanda version to remote to get update information.
 pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
     const kind = comptime versioning();
     if (comptime std.mem.eql(u8, "dev", kind)) {
@@ -178,46 +77,56 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
         return writer.flush();
     }
 
-    var versions = (try self.getVersions(.stable)).map;
-    defer self.resetConnection();
+    const conn = try http.Connection.init(self.x509_store, self.config, null);
+    defer conn.deinit();
 
-    // Remove "nightly" entry.
-    lp.assert(versions.swapRemove("nightly"), "Updater.inform: \"nightly\" entry not found", .{});
-    // Sorting is necessary.
-    var sort_ctx = SortCtx{ .keys = versions.keys() };
-    versions.sort(&sort_ctx);
-    sort_ctx.err catch |err| return err;
+    const allocator = self.arena.allocator();
+    const url = try std.fmt.allocPrintSentinel(
+        allocator,
+        "https://telemetry.lightpanda.io/v/{s}",
+        .{lp.build_config.version},
+        0,
+    );
+    defer allocator.free(url);
 
-    // Get the latest.
-    const values = versions.values();
-    const top = values[values.len - 1];
+    // Prepare the request.
+    try conn.setURL(url);
+    try conn.setGetMode();
+    try conn.setFollowLocation(true);
 
-    const latest = try std.SemanticVersion.parse(top.version);
-    const current = try std.SemanticVersion.parse(lp.build_config.version);
+    // Wraps everything needed to receive bytes.
+    const ReceiverContext = struct {
+        allocator: std.mem.Allocator,
+        buffer: std.ArrayList(u8) = .empty,
+        err: Allocator.Error!void = {},
 
-    switch (current.order(latest)) {
-        .lt => try writer.print(
-            \\Running an older version of Lightpanda ({s}), latest release is {s}.
-            \\
-            \\Update via one-liner:
-            \\curl -fsSL https://pkg.lightpanda.io/install.sh | bash
-            \\
-        , .{ lp.build_config.version, top.version }),
-        .gt, .eq => try writer.writeAll("Lightpanda is up-to-date.\n"),
+        fn onBytes(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_ctx: ?*anyopaque) usize {
+            const ctx: *@This() = @ptrCast(@alignCast(raw_ctx));
+            const chunk = buffer[0 .. buf_count * buf_len];
+            ctx.buffer.appendSlice(ctx.allocator, chunk) catch |err| {
+                ctx.err = err;
+                return 0;
+            };
+            return chunk.len;
+        }
+    };
+
+    try libcurl.curl_easy_setopt(conn._easy, .write_function, ReceiverContext.onBytes);
+    // Set receiver context.
+    var ctx = ReceiverContext{ .allocator = allocator };
+    defer ctx.buffer.deinit(allocator);
+    try libcurl.curl_easy_setopt(conn._easy, .write_data, &ctx);
+
+    // Make a request.
+    const status_int = conn.request(&self.config.http_headers) catch |err| {
+        ctx.err catch |ctx_err| return ctx_err;
+        return err;
+    };
+    const status: std.http.Status = @enumFromInt(status_int);
+    if (status != .ok) {
+        return error.UnexpectedStatus;
     }
 
+    try writer.writeAll(ctx.buffer.items);
     return writer.flush();
-}
-
-/// Invoked by `Connection` when there are body bytes.
-fn onBytes(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_conn: ?*anyopaque) usize {
-    const conn: *http.Connection = @ptrCast(@alignCast(raw_conn));
-    const self: *Updater = @fieldParentPtr("conn", conn);
-
-    const chunk = buffer[0 .. buf_count * buf_len];
-    self.conn_read_buffer.appendSlice(self.arena.allocator(), chunk) catch |err| {
-        self.conn_err = err;
-        return 0;
-    };
-    return chunk.len;
 }

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -69,7 +69,12 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
         err: std.Io.Writer.Error!void = {},
 
         /// curl -> writer.
-        fn drain(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_ctx: ?*anyopaque) usize {
+        fn drain(
+            buffer: [*]const u8,
+            buf_count: usize,
+            buf_len: usize,
+            raw_ctx: *anyopaque,
+        ) callconv(.c) usize {
             const ctx: *@This() = @ptrCast(@alignCast(raw_ctx));
             const chunk = buffer[0 .. buf_count * buf_len];
             ctx.writer.writeAll(chunk) catch |err| {

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const json = std.json;
 const SemanticVersion = std.SemanticVersion;
+const Allocator = std.mem.Allocator;
 const lp = @import("lightpanda");
 
 const Network = @import("network/Network.zig");
@@ -26,9 +27,6 @@ const http = @import("network/http.zig");
 const libcurl = @import("sys/libcurl.zig");
 const Config = @import("Config.zig");
 const log = @import("log.zig");
-
-// TODO: Remove this.
-const MockVersion: [:0]const u8 = "0.16.0";
 
 /// Where to find versions JSON.
 const VersionsUrl: [:0]const u8 = "https://get.lightpanda.io/versions.json";
@@ -44,12 +42,12 @@ conn: http.Connection,
 /// Read buffer for `conn`.
 conn_read_buffer: std.ArrayList(u8) = .empty,
 /// Needed to report OutOfMemory.
-conn_err: enum(u1) { none, out_of_memory } = .none,
+conn_err: Allocator.Error!void = {},
 /// TODO: Come up with a solution where we don't have to embed this here?
 config: *const Config,
 
 /// Initializes the update client; meant to be used as singleton.
-pub fn init(allocator: std.mem.Allocator, config: *const Config) !Updater {
+pub fn init(allocator: Allocator, config: *const Config) !Updater {
     var arena = std.heap.ArenaAllocator.init(allocator);
     errdefer arena.deinit();
     const arena_allocator = arena.allocator();
@@ -108,10 +106,8 @@ fn getVersions(
     try self.conn.setWriteCallback(onBytes);
 
     const status_int = self.conn.request(&self.config.http_headers) catch |err| {
-        switch (self.conn_err) {
-            .none => return err,
-            .out_of_memory => return error.OutOfMemory,
-        }
+        self.conn_err catch |conn_err| return conn_err;
+        return err;
     };
     const status: std.http.Status = @enumFromInt(status_int);
     if (status != .ok) {
@@ -135,10 +131,19 @@ fn getVersions(
 }
 
 /// Resets everything related to `conn`.
-fn resetConnection(self: *Updater) !void {
-    try self.conn.reset(self.config, self.ca_blob, null);
+fn resetConnection(self: *Updater) void {
+    self.conn.reset(self.config, self.ca_blob, null) catch {};
     self.conn_read_buffer.clearRetainingCapacity();
-    self.conn_err = .none;
+    self.conn_err = {};
+}
+
+fn versioning() []const u8 {
+    comptime {
+        const version = SemanticVersion.parse(lp.build_config.version) catch unreachable;
+        const pre = version.pre orelse return "";
+        const index = std.mem.indexOfScalar(u8, pre, '.') orelse pre.len;
+        return pre[0..index];
+    }
 }
 
 const SortCtx = struct {
@@ -161,42 +166,47 @@ const SortCtx = struct {
     }
 };
 
-/// Informs about running version to given `Writer` by desired `Channel`.
-pub fn inform(self: *Updater, channel: Channel, writer: *std.Io.Writer) !void {
-    switch (channel) {
-        .stable => {
-            var versions = (try self.getVersions(.stable)).map;
-            defer self.resetConnection() catch {};
-
-            // Remove "nightly" entry.
-            lp.assert(versions.swapRemove("nightly"), "Updater.inform: \"nightly\" entry not found", .{});
-            // Sorting is necessary.
-            var sort_ctx = SortCtx{ .keys = versions.keys() };
-            versions.sort(&sort_ctx);
-            sort_ctx.err catch |err| return err;
-
-            // Get the latest.
-            const values = versions.values();
-            const top = values[values.len - 1];
-
-            std.debug.print("{s}\n", .{top.version});
-        },
-        .nightly => {
-            const versions = try self.getVersions(.nightly);
-            defer self.resetConnection() catch {};
-            const nightly = versions.nightly;
-            // Parse to SemVer for comparison.
-            const semver_nightly = try SemanticVersion.parse(nightly.version);
-            const semver_current = try SemanticVersion.parse(lp.build_config.version);
-
-            switch (semver_current.order(semver_nightly)) {
-                .lt => try writer.print("A new version of Lightpanda nightly ({s}) is available.\n", .{nightly.version}),
-                .eq => try writer.writeAll("You're up-to-date."),
-                .gt => unreachable,
-            }
-            return writer.flush();
-        },
+/// Informs about running version to given `Writer`.
+pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
+    const kind = comptime versioning();
+    if (comptime std.mem.eql(u8, "dev", kind)) {
+        try writer.print("Running a development version of Lightpanda ({s}).\n", .{lp.build_config.version});
+        return writer.flush();
     }
+    if (comptime std.mem.eql(u8, "nightly", kind)) {
+        try writer.print("Running a nightly version of Lightpanda ({s}).\n", .{lp.build_config.version});
+        return writer.flush();
+    }
+
+    var versions = (try self.getVersions(.stable)).map;
+    defer self.resetConnection();
+
+    // Remove "nightly" entry.
+    lp.assert(versions.swapRemove("nightly"), "Updater.inform: \"nightly\" entry not found", .{});
+    // Sorting is necessary.
+    var sort_ctx = SortCtx{ .keys = versions.keys() };
+    versions.sort(&sort_ctx);
+    sort_ctx.err catch |err| return err;
+
+    // Get the latest.
+    const values = versions.values();
+    const top = values[values.len - 1];
+
+    const latest = try std.SemanticVersion.parse(top.version);
+    const current = try std.SemanticVersion.parse(lp.build_config.version);
+
+    switch (current.order(latest)) {
+        .lt => try writer.print(
+            \\Running an older version of Lightpanda ({s}), latest release is {s}.
+            \\
+            \\Update via one-liner:
+            \\curl -fsSL https://pkg.lightpanda.io/install.sh | bash
+            \\
+        , .{ lp.build_config.version, top.version }),
+        .gt, .eq => try writer.writeAll("Lightpanda is up-to-date.\n"),
+    }
+
+    return writer.flush();
 }
 
 /// Invoked by `Connection` when there are body bytes.
@@ -206,9 +216,7 @@ fn onBytes(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_conn: ?*an
 
     const chunk = buffer[0 .. buf_count * buf_len];
     self.conn_read_buffer.appendSlice(self.arena.allocator(), chunk) catch |err| {
-        if (err != error.OutOfMemory) unreachable;
-        // We have to do this in order to report errors from here.
-        self.conn_err = .out_of_memory;
+        self.conn_err = err;
         return 0;
     };
     return chunk.len;

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -1,0 +1,148 @@
+// Copyright (C) 2023-2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const Network = @import("network/Network.zig");
+const http = @import("network/http.zig");
+const libcurl = @import("sys/libcurl.zig");
+const Config = @import("Config.zig");
+const log = @import("log.zig");
+
+// TODO: Remove this.
+const MockVersion: [:0]const u8 = "0.16.0";
+
+/// Where to find versions JSON.
+const VersionsUrl: [:0]const u8 = "https://ziglang.org/download/index.json";
+
+pub const Channel = enum(u1) { stable, nightly };
+
+/// Sole purpose of this client is to do updates; hence, its very minimal.
+const Updater = @This();
+arena: std.heap.ArenaAllocator,
+ca_blob: libcurl.CurlBlob,
+/// Connection where client does all of its network I/O.
+conn: http.Connection,
+/// Read buffer for `conn`.
+conn_read_buffer: std.ArrayList(u8) = .empty,
+/// Needed to report OutOfMemory.
+conn_err: enum(u1) { none, out_of_memory } = .none,
+/// TODO: Come up with a solution where we don't have to embed this here?
+config: *const Config,
+
+/// Initializes the update client; meant to be used as singleton.
+pub fn init(allocator: std.mem.Allocator, config: *const Config) !Updater {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    Network.globalInit(allocator);
+    errdefer Network.globalDeinit();
+    // On error, will be deinitialized by arena.
+    const ca_blob = try Network.loadCerts(arena_allocator);
+    // Init connection.
+    const connection = try http.Connection.init(ca_blob, config, null);
+    errdefer connection.deinit();
+
+    return .{
+        .arena = arena,
+        .ca_blob = ca_blob,
+        .conn = connection,
+        .config = config,
+    };
+}
+
+pub fn deinit(self: *Updater) void {
+    self.conn.deinit();
+    Network.globalDeinit();
+    self.arena.deinit();
+}
+
+// TODO: Update this with actual versions.json when ready.
+const Versions = struct {
+    master: Entry,
+    @"0.16.0": Entry, // Consider this as stable.
+
+    /// Single version record.
+    const Entry = struct {
+        version: []const u8,
+        src: struct {
+            tarball: []const u8,
+            shasum: []const u8,
+            size: u64,
+        },
+    };
+};
+
+/// Returns Lightpanda versions; call `resetConnection` after you're done with
+/// `Versions` to do further requests.
+fn getVersions(self: *Updater) !Versions {
+    try self.conn.setURL(VersionsUrl);
+    try self.conn.setGetMode();
+    try self.conn.setFollowLocation(true);
+    try self.conn.setWriteCallback(onBytes);
+
+    const status = self.conn.request(&self.config.http_headers) catch |err| {
+        switch (self.conn_err) {
+            .none => return err,
+            .out_of_memory => return error.OutOfMemory,
+        }
+    };
+    if (status != 200) {
+        return error.UnexpectedStatus;
+    }
+
+    return std.json.parseFromSliceLeaky(
+        Versions,
+        self.arena.allocator(),
+        self.conn_read_buffer.items,
+        .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_if_needed,
+            .parse_numbers = true,
+        },
+    );
+}
+
+/// Resets everything related to `conn`.
+fn resetConnection(self: *Updater) !void {
+    try self.conn.reset(self.config, self.ca_blob, null);
+    self.conn_read_buffer.clearRetainingCapacity();
+    self.conn_err = .none;
+}
+
+/// Informs about running version to given `Writer` by desired `Channel`.
+pub fn inform(self: *Updater, channel: Channel, writer: std.Io.Writer) void {
+    const versions = try self.getVersions();
+}
+
+/// Invoked by `Connection` when there are body bytes.
+fn onBytes(buffer: [*]const u8, buf_count: usize, buf_len: usize, raw_conn: ?*anyopaque) usize {
+    const conn: *http.Connection = @ptrCast(@alignCast(raw_conn));
+    const self: *Updater = @fieldParentPtr("conn", conn);
+
+    const chunk = buffer[0 .. buf_count * buf_len];
+    self.conn_read_buffer.appendSlice(self.arena.allocator(), chunk) catch |err| {
+        if (err != error.OutOfMemory) unreachable;
+        // We have to do this in order to report errors from here.
+        self.conn_err = .out_of_memory;
+        return 0;
+    };
+    return chunk.len;
+}

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -51,28 +51,9 @@ pub fn deinit(self: *Updater) void {
     crypto.X509_STORE_free(self.x509_store);
 }
 
-fn versioning() []const u8 {
-    comptime {
-        const version = SemanticVersion.parse(lp.build_config.version) catch unreachable;
-        const pre = version.pre orelse return "";
-        const index = std.mem.indexOfScalar(u8, pre, '.') orelse pre.len;
-        return pre[0..index];
-    }
-}
-
 /// Sends running Lightpanda version to remote to get update information.
 /// Outputs directly to given `Writer`.
 pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
-    const kind = comptime versioning();
-    if (comptime std.mem.eql(u8, "dev", kind)) {
-        try writer.print("Running a development version of Lightpanda ({s}).\n", .{lp.build_config.version});
-        return writer.flush();
-    }
-    if (comptime std.mem.eql(u8, "nightly", kind)) {
-        try writer.print("Running a nightly version of Lightpanda ({s}).\n", .{lp.build_config.version});
-        return writer.flush();
-    }
-
     const conn = try http.Connection.init(self.x509_store, self.config, null);
     defer conn.deinit();
 

--- a/src/Updater.zig
+++ b/src/Updater.zig
@@ -110,14 +110,6 @@ pub fn inform(self: *Updater, writer: *std.Io.Writer) !void {
         ctx.err catch |ctx_err| return ctx_err;
         return err;
     };
-    const status: std.http.Status = @enumFromInt(status_int);
-    return switch (status) {
-        // We expect any of those.
-        .ok,
-        .bad_request,
-        .internal_server_error,
-        .service_unavailable,
-        => writer.flush(),
-        else => error.UnexpectedStatus,
-    };
+    _ = status_int;
+    return writer.flush();
 }

--- a/src/help.zon
+++ b/src/help.zon
@@ -237,16 +237,16 @@
     \\MISTRAL_API_KEY. The local servers (Ollama, llama.cpp) do not require an
     \\API key.
     ,
-    .update =
-    \\usage: {0s} update [COMMON_OPTIONS]
-    \\
-    \\Checks whether a newer release of {0s} is available. When one is found,
-    \\prints the running version, the latest release, and how to update.
-    ,
     .version =
-    \\usage:  {0s} version
+    \\usage:  {0s} version [OPTIONS]
     \\
     \\Displays the version of {0s}.
+    \\
+    \\options:
+    \\  --check
+    \\          Checks whether a newer release of {0s} is available. When one is
+    \\          found, prints the running version, the latest release, and how to
+    \\          update.
     ,
     .help =
     \\usage: {0s} help

--- a/src/help.zon
+++ b/src/help.zon
@@ -237,6 +237,12 @@
     \\MISTRAL_API_KEY. The local servers (Ollama, llama.cpp) do not require an
     \\API key.
     ,
+    .update =
+    \\usage: {0s} update [COMMON_OPTIONS]
+    \\
+    \\Checks whether a newer release of {0s} is available. When one is found,
+    \\prints the running version, the latest release, and how to update.
+    ,
     .version =
     \\usage:  {0s} version
     \\

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -56,6 +56,8 @@ pub const build_config = @import("build_config");
 pub const crash_handler = @import("crash_handler.zig");
 pub const core_dump = @import("core_dump.zig");
 
+pub const Updater = @import("Updater.zig");
+
 pub const FetchOpts = struct {
     wait_ms: u32 = 5000,
     wait_until: ?Config.WaitUntil = null,
@@ -221,6 +223,16 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: 
         },
         .wpt => try dumpWPT(frame, writer),
     }
+}
+
+/// Check `Config.zig` for `options`.
+pub fn update(allocator: std.mem.Allocator, config: *const Config, options: anytype) !void {
+    if (options.channel == .nightly) @panic("TODO");
+
+    var client = try Updater.init(allocator, config);
+    defer client.deinit();
+
+    try client.getVersions();
 }
 
 // Writes a single page's result object. Framing (the enclosing array and any

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -225,8 +225,7 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: 
     }
 }
 
-/// Check `Config.zig` for `options`.
-pub fn update(allocator: std.mem.Allocator, config: *const Config) !void {
+pub fn checkVersion(allocator: std.mem.Allocator, config: *const Config) !void {
     var client = try Updater.init(allocator, config);
     defer client.deinit();
 
@@ -234,7 +233,6 @@ pub fn update(allocator: std.mem.Allocator, config: *const Config) !void {
     var buf: [4096]u8 = undefined;
     var writer = stdout.writer(&buf);
     const w = &writer.interface;
-    // Inform to stdout about version.
     try client.inform(w);
 }
 

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -227,12 +227,15 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: 
 
 /// Check `Config.zig` for `options`.
 pub fn update(allocator: std.mem.Allocator, config: *const Config, options: anytype) !void {
-    if (options.channel == .nightly) @panic("TODO");
-
     var client = try Updater.init(allocator, config);
     defer client.deinit();
 
-    try client.getVersions();
+    var stdout = std.fs.File.stdout();
+    var buf: [4096]u8 = undefined;
+    var writer = stdout.writer(&buf);
+    const w = &writer.interface;
+    // Inform to stdout about version.
+    try client.inform(options.channel, w);
 }
 
 // Writes a single page's result object. Framing (the enclosing array and any

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -226,7 +226,7 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: 
 }
 
 /// Check `Config.zig` for `options`.
-pub fn update(allocator: std.mem.Allocator, config: *const Config, options: anytype) !void {
+pub fn update(allocator: std.mem.Allocator, config: *const Config) !void {
     var client = try Updater.init(allocator, config);
     defer client.deinit();
 
@@ -235,7 +235,7 @@ pub fn update(allocator: std.mem.Allocator, config: *const Config, options: anyt
     var writer = stdout.writer(&buf);
     const w = &writer.interface;
     // Inform to stdout about version.
-    try client.inform(options.channel, w);
+    try client.inform(w);
 }
 
 // Writes a single page's result object. Framing (the enclosing array and any

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,9 +71,13 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
 
     switch (args.mode) {
         .help => |tag| return args.printUsageAndExit(tag, true),
-        .version => {
-            var stdout = std.fs.File.stdout().writer(&.{});
-            try stdout.interface.print("{s}\n", .{lp.build_config.version});
+        .version => |opts| {
+            if (opts.check) {
+                try lp.checkVersion(allocator, &args);
+            } else {
+                var stdout = std.fs.File.stdout().writer(&.{});
+                try stdout.interface.print("{s}\n", .{lp.build_config.version});
+            }
             return std.process.cleanExit();
         },
         .agent => |opts| if (opts.list_models) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,10 +80,6 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             try lp.Agent.listModels(allocator, opts);
             return std.process.cleanExit();
         },
-        .update => {
-            try lp.update(allocator, &args);
-            return std.process.cleanExit();
-        },
         else => {},
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,6 +80,10 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             try lp.Agent.listModels(allocator, opts);
             return std.process.cleanExit();
         },
+        .update => |options| {
+            try lp.update(allocator, &args, options);
+            return std.process.cleanExit();
+        },
         else => {},
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,8 +80,8 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             try lp.Agent.listModels(allocator, opts);
             return std.process.cleanExit();
         },
-        .update => |options| {
-            try lp.update(allocator, &args, options);
+        .update => {
+            try lp.update(allocator, &args);
             return std.process.cleanExit();
         },
         else => {},

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -724,7 +724,7 @@ const CreateX509StoreError = std.crypto.Certificate.Bundle.RescanError || error{
 
 /// NEVER give full ownership of store to `SSL_CTX`, always rely on ref counting.
 /// Allocations made through passed `allocator` are freed before this function returns.
-fn createX509Store(allocator: Allocator) CreateX509StoreError!*crypto.X509_STORE {
+pub fn createX509Store(allocator: Allocator) CreateX509StoreError!*crypto.X509_STORE {
     const store = crypto.X509_STORE_new() orelse return error.FailedToCreateX509Store;
     errdefer crypto.X509_STORE_free(store);
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -138,7 +138,9 @@ cdp_start: usize,
 /// Optional IP filter for blocking requests to private/internal networks (--block-private-networks).
 ip_filter: ?*IpFilter = null,
 
-fn globalInit(allocator: Allocator) void {
+/// Calling `init` also calls this function; only marked public for situations
+/// networking is needed without `App`.
+pub fn globalInit(allocator: Allocator) void {
     // Only route curl's own allocations through our allocator in Debug, so the
     // leak detector sees them. In Release it'd just wrap c_allocator (curl's
     // default malloc anyway) at the cost of a per-allocation header.
@@ -152,7 +154,9 @@ fn globalInit(allocator: Allocator) void {
     };
 }
 
-fn globalDeinit() void {
+/// Calling `deinit` also calls this function; only marked public for situations
+/// networking is needed without `App`.
+pub fn globalDeinit() void {
     libcurl.curl_global_cleanup();
 }
 


### PR DESCRIPTION
This PR adds `update` command which allows checking if newer version of Lightpanda is out. Self-updating is still open for discussion, hence not implemented in this one.