### PR TITLE
Telemetry smaller payload

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -652,13 +652,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
             .timestamp = timestamp(.monotonic),
         });
 
-        // Record telemetry for navigation
-        session.browser.app.telemetry.record(.{
-            .navigate = .{
-                .tls = false, // about:blank and blob: are not TLS
-                .proxy = session.browser.app.config.httpProxy() != null,
-            },
-        });
+        self.recordNavigateTelemetry(false);
 
         session.notification.dispatch(.frame_navigated, &.{
             .req_id = req_id,
@@ -738,10 +732,7 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     });
 
     // Record telemetry for navigation
-    session.browser.app.telemetry.record(.{ .navigate = .{
-        .tls = std.ascii.startsWithIgnoreCase(self.url, "https://"),
-        .proxy = session.browser.app.config.httpProxy() != null,
-    } });
+    self.recordNavigateTelemetry(std.ascii.startsWithIgnoreCase(self.url, "https://"));
 
     session.navigation._current_navigation_kind = opts.kind;
 
@@ -765,6 +756,18 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         log.err(.frame, "navigate request", .{ .url = self.url, .err = err, .type = self._type });
         return err;
     };
+}
+
+fn recordNavigateTelemetry(self: *Frame, tls: bool) void {
+    self._session.browser.app.telemetry.record(.{ .navigate = .{
+        .tls = tls,
+        .context = if (self.parent != null)
+            .iframe
+        else if (self.window._opener != null)
+            .popup
+        else
+            .page,
+    } });
 }
 
 // Navigation can happen in many places, such as executing a <script> tag or

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -36,9 +36,6 @@ writer: std.Io.Writer.Allocating,
 iid: ?[36]u8 = null,
 run_mode: Config.RunMode = .serve,
 interactive: bool = false,
-
-// Per run id
-sid: [16]u8,
 proxy: bool,
 
 // Header is sent before the first message, once sent, it isn't sent again
@@ -67,14 +64,10 @@ pending: std.ArrayList(telemetry.Event) = .empty,
 dropped: u32 = 0,
 
 pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode, interactive: bool) !void {
-    var raw_sid: [8]u8 = undefined;
-    std.crypto.random.bytes(&raw_sid);
-
     self.* = .{
         .iid = iid,
         .run_mode = run_mode,
         .interactive = interactive,
-        .sid = std.fmt.bytesToHex(raw_sid, .lower),
         .proxy = app.config.httpProxy() != null,
         .allocator = app.allocator,
         .network = &app.network,
@@ -256,14 +249,15 @@ fn _flush(self: *LightPanda, conn: *http.Connection) !void {
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
-    return self.writeLine(&EventRow{ .sid = &self.sid, .event = event });
+    return self.writeLine(&EventRow{
+        .iid = if (self.iid) |*iid| iid else "00000000-0000-0000-0000-000000000000",
+        .event = event,
+    });
 }
 
 fn writeHeader(self: *LightPanda) !bool {
-    const iid: ?[]const u8 = if (self.iid) |*id| id else null;
     return self.writeLine(&Header{
-        .sid = &self.sid,
-        .iid = iid,
+        .iid = if (self.iid) |*iid| iid else "00000000-0000-0000-0000-000000000000",
         .mode = self.run_mode,
         .interactive = self.interactive,
         .proxy = self.proxy,
@@ -283,69 +277,30 @@ fn writeLine(self: *LightPanda, value: anytype) !bool {
     return true;
 }
 
-const Header = struct {
-    sid: []const u8,
-    iid: ?[]const u8,
-    mode: Config.RunMode,
-    interactive: bool,
-    proxy: bool,
-
-    pub fn jsonStringify(self: *const Header, writer: anytype) !void {
-        try writer.beginObject();
-
-        try writer.objectField("sid");
-        try writer.write(self.sid);
-
-        if (self.iid) |iid| {
-            try writer.objectField("iid");
-            try writer.write(iid);
-        }
-
-        try writer.objectField("mode");
-        // Special case: when running agent mode in non-interactive, we send a
-        // special running mode.
-        if (self.mode == .agent and self.interactive == false) {
-            try writer.write("agent_replay");
-        } else {
-            try writer.write(self.mode);
-        }
-
-        try writer.objectField("os");
-        try writer.write(builtin.os.tag);
-
-        try writer.objectField("arch");
-        try writer.write(builtin.cpu.arch);
-
-        try writer.objectField("version");
-        try writer.write(build_config.version);
-
-        try writer.objectField("proxy");
-        try writer.write(self.proxy);
-
-        try writer.endObject();
-    }
-};
-
 const EventRow = struct {
-    sid: []const u8,
+    iid: []const u8,
     event: telemetry.Event,
 
     pub fn jsonStringify(self: *const EventRow, writer: anytype) !void {
         try writer.beginArray();
-        try writer.write(self.sid);
+        try writer.write(self.iid);
         switch (self.event) {
-            .run => try writer.write("run"),
+            .run => try writer.write("R"),
             .navigate => |n| {
-                try writer.write("nav");
-                try writer.write(n.tls);
-                try writer.write(n.context);
+                try writer.write("N");
+                try writer.write(@as(u8, if (n.tls) 1 else 0));
+                try writer.write(switch (n.context) {
+                    .iframe => "I",
+                    .popup => "O",
+                    .page => "P",
+                });
             },
             .buffer_overflow => |b| {
-                try writer.write("bof");
+                try writer.write("B");
                 try writer.write(b.dropped);
             },
             .llm => |l| {
-                try writer.write("llm");
+                try writer.write("L");
                 try writer.write(l.provider);
                 try writer.write(l.model);
             },
@@ -354,42 +309,64 @@ const EventRow = struct {
     }
 };
 
-const testing = @import("../testing.zig");
+const Header = struct {
+    iid: []const u8,
+    mode: Config.RunMode,
+    interactive: bool,
+    proxy: bool,
 
+    pub fn jsonStringify(self: *const Header, writer: anytype) !void {
+        try writer.beginArray();
+        try writer.write(self.iid);
+        try writer.write("H");
+        if (self.mode == .agent and self.interactive == false) {
+            try writer.write("agent_replay");
+        } else {
+            try writer.write(self.mode);
+        }
+        try writer.write(@as(u8, if (self.proxy) 1 else 0));
+        try writer.write(builtin.os.tag);
+        try writer.write(builtin.cpu.arch);
+        try writer.write(build_config.version);
+        try writer.endArray();
+    }
+};
+
+const testing = @import("../testing.zig");
 test "Telemetry: event row wire format" {
     const Case = struct { event: telemetry.Event, expected: []const u8 };
     const cases = [_]Case{
-        .{ .event = .{ .run = {} }, .expected = "[\"sid0\",\"run\"]" },
+        .{ .event = .{ .run = {} }, .expected = "[\"sid0\",\"R\"]" },
         .{
             .event = .{ .navigate = .{ .tls = true, .context = .page } },
-            .expected = "[\"sid0\",\"nav\",true,\"page\"]",
+            .expected = "[\"sid0\",\"N\",1,\"P\"]",
         },
         .{
             .event = .{ .navigate = .{ .tls = false, .context = .popup } },
-            .expected = "[\"sid0\",\"nav\",false,\"popup\"]",
+            .expected = "[\"sid0\",\"N\",0,\"O\"]",
         },
         .{
             .event = .{ .navigate = .{ .tls = true, .context = .iframe } },
-            .expected = "[\"sid0\",\"nav\",true,\"iframe\"]",
+            .expected = "[\"sid0\",\"N\",1,\"I\"]",
         },
         .{
             .event = .{ .buffer_overflow = .{ .dropped = 42 } },
-            .expected = "[\"sid0\",\"bof\",42]",
+            .expected = "[\"sid0\",\"B\",42]",
         },
         .{
             .event = .{ .llm = .{ .provider = "anthropic", .model = .wrap("claude") } },
-            .expected = "[\"sid0\",\"llm\",\"anthropic\",\"claude\"]",
+            .expected = "[\"sid0\",\"L\",\"anthropic\",\"claude\"]",
         },
         .{
             .event = .{ .llm = .{ .provider = "nollm", .model = null } },
-            .expected = "[\"sid0\",\"llm\",\"nollm\",null]",
+            .expected = "[\"sid0\",\"L\",\"nollm\",null]",
         },
     };
 
     for (cases) |case| {
         var w = std.Io.Writer.Allocating.init(testing.allocator);
         defer w.deinit();
-        try std.json.Stringify.value(&EventRow{ .sid = "sid0", .event = case.event }, .{}, &w.writer);
+        try std.json.Stringify.value(&EventRow{ .iid = "sid0", .event = case.event }, .{}, &w.writer);
         try testing.expectEqual(case.expected, w.written());
     }
 }
@@ -399,7 +376,6 @@ test "Telemetry: header wire format" {
     defer w.deinit();
 
     const header = Header{
-        .sid = "sid0",
         .iid = "the-iid",
         .mode = .serve,
         .interactive = false,
@@ -407,7 +383,8 @@ test "Telemetry: header wire format" {
     };
     try std.json.Stringify.value(&header, .{}, &w.writer);
 
-    const out = w.written();
-    try testing.expectEqual(true, std.mem.startsWith(u8, out, "{\"sid\":\"sid0\",\"iid\":\"the-iid\",\"mode\":\"serve\","));
-    try testing.expectEqual(true, std.mem.endsWith(u8, out, ",\"proxy\":true}"));
+    const expected = try std.fmt.allocPrint(testing.allocator, "[\"the-iid\",\"H\",\"serve\",1,\"{s}\",\"{s}\",\"{s}\"]", .{ @tagName(builtin.os.tag), @tagName(builtin.cpu.arch), build_config.version });
+    defer testing.allocator.free(expected);
+
+    try testing.expectEqual(expected, w.written());
 }

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -266,7 +266,7 @@ fn _flush(self: *LightPanda, conn: *http.Connection) !void {
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
-    return self.writeLine(&EventRow{.event = event});
+    return self.writeLine(&EventRow{ .event = event });
 }
 
 fn writeHeader(self: *LightPanda) !bool {

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -49,9 +49,6 @@ iid: ?[36]u8 = null,
 mode: []const u8,
 proxy: u8,
 
-// Header is sent before the first message, once sent, it isn't sent again
-header_sent: bool = false,
-
 // `mutex` guards the ring buffer (head/tail/dropped), `running`, and the lazy
 // `thread` creation. The sender thread blocks on `cond` while idle.
 mutex: std.Thread.Mutex = .{},
@@ -207,9 +204,7 @@ fn run(self: *LightPanda) void {
 }
 
 fn postEvents(self: *LightPanda, conn: *http.Connection, events: []const telemetry.Event, dropped: u32, sent: *usize) !void {
-    if (self.header_sent == false) {
-        _ = try self.writeHeader();
-    }
+    _ = try self.writeHeader();
 
     // The overflow report rides ahead of the first body; the rest of that body
     // and any subsequent ones are filled from `events` below.
@@ -244,8 +239,6 @@ fn postEvents(self: *LightPanda, conn: *http.Connection, events: []const telemet
         try self.flush(conn);
         sent.* += queued;
     }
-
-    self.header_sent = true;
 }
 
 fn flush(self: *LightPanda, conn: *http.Connection) !void {

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -25,6 +25,18 @@ const LINGER_MS = 5000;
 const LINGER_BATCH = 16;
 const URL = "https://telemetry.lightpanda.io/v2";
 
+const OS_CODE = switch (builtin.os.tag) {
+    .linux => "L",
+    .macos => "M",
+    .ios => "I",
+    else => "O",
+};
+const ARCH_CODE = switch (builtin.cpu.arch) {
+    .x86_64 => "X",
+    .aarch64 => "A",
+    else => "O",
+};
+
 const LightPanda = @This();
 
 allocator: Allocator,
@@ -34,9 +46,8 @@ network: *Network,
 writer: std.Io.Writer.Allocating,
 
 iid: ?[36]u8 = null,
-run_mode: Config.RunMode = .serve,
-interactive: bool = false,
-proxy: bool,
+mode: []const u8,
+proxy: u8,
 
 // Header is sent before the first message, once sent, it isn't sent again
 header_sent: bool = false,
@@ -66,12 +77,18 @@ dropped: u32 = 0,
 pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode, interactive: bool) !void {
     self.* = .{
         .iid = iid,
-        .run_mode = run_mode,
-        .interactive = interactive,
-        .proxy = app.config.httpProxy() != null,
         .allocator = app.allocator,
         .network = &app.network,
+        .proxy = if (app.config.httpProxy() != null) 1 else 0,
         .writer = std.Io.Writer.Allocating.init(app.allocator),
+        .mode = switch (run_mode) {
+            .fetch => "F",
+            .serve => "S",
+            .agent => if (interactive == false) "AR" else "A",
+            .mcp => "M",
+            .version => "V",
+            .help => "H",
+        },
     };
 }
 
@@ -249,17 +266,13 @@ fn _flush(self: *LightPanda, conn: *http.Connection) !void {
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
-    return self.writeLine(&EventRow{
-        .iid = if (self.iid) |*iid| iid else "00000000-0000-0000-0000-000000000000",
-        .event = event,
-    });
+    return self.writeLine(&EventRow{.event = event});
 }
 
 fn writeHeader(self: *LightPanda) !bool {
     return self.writeLine(&Header{
         .iid = if (self.iid) |*iid| iid else "00000000-0000-0000-0000-000000000000",
-        .mode = self.run_mode,
-        .interactive = self.interactive,
+        .mode = self.mode,
         .proxy = self.proxy,
     });
 }
@@ -278,12 +291,10 @@ fn writeLine(self: *LightPanda, value: anytype) !bool {
 }
 
 const EventRow = struct {
-    iid: []const u8,
     event: telemetry.Event,
 
     pub fn jsonStringify(self: *const EventRow, writer: anytype) !void {
         try writer.beginArray();
-        try writer.write(self.iid);
         switch (self.event) {
             .run => try writer.write("R"),
             .navigate => |n| {
@@ -311,22 +322,17 @@ const EventRow = struct {
 
 const Header = struct {
     iid: []const u8,
-    mode: Config.RunMode,
-    interactive: bool,
-    proxy: bool,
+    mode: []const u8,
+    proxy: u8,
 
     pub fn jsonStringify(self: *const Header, writer: anytype) !void {
         try writer.beginArray();
         try writer.write(self.iid);
         try writer.write("H");
-        if (self.mode == .agent and self.interactive == false) {
-            try writer.write("agent_replay");
-        } else {
-            try writer.write(self.mode);
-        }
-        try writer.write(@as(u8, if (self.proxy) 1 else 0));
-        try writer.write(builtin.os.tag);
-        try writer.write(builtin.cpu.arch);
+        try writer.write(self.mode);
+        try writer.write(self.proxy);
+        try writer.write(OS_CODE);
+        try writer.write(ARCH_CODE);
         try writer.write(build_config.version);
         try writer.endArray();
     }
@@ -336,37 +342,37 @@ const testing = @import("../testing.zig");
 test "Telemetry: event row wire format" {
     const Case = struct { event: telemetry.Event, expected: []const u8 };
     const cases = [_]Case{
-        .{ .event = .{ .run = {} }, .expected = "[\"sid0\",\"R\"]" },
+        .{ .event = .{ .run = {} }, .expected = "[\"R\"]" },
         .{
             .event = .{ .navigate = .{ .tls = true, .context = .page } },
-            .expected = "[\"sid0\",\"N\",1,\"P\"]",
+            .expected = "[\"N\",1,\"P\"]",
         },
         .{
             .event = .{ .navigate = .{ .tls = false, .context = .popup } },
-            .expected = "[\"sid0\",\"N\",0,\"O\"]",
+            .expected = "[\"N\",0,\"O\"]",
         },
         .{
             .event = .{ .navigate = .{ .tls = true, .context = .iframe } },
-            .expected = "[\"sid0\",\"N\",1,\"I\"]",
+            .expected = "[\"N\",1,\"I\"]",
         },
         .{
             .event = .{ .buffer_overflow = .{ .dropped = 42 } },
-            .expected = "[\"sid0\",\"B\",42]",
+            .expected = "[\"B\",42]",
         },
         .{
             .event = .{ .llm = .{ .provider = "anthropic", .model = .wrap("claude") } },
-            .expected = "[\"sid0\",\"L\",\"anthropic\",\"claude\"]",
+            .expected = "[\"L\",\"anthropic\",\"claude\"]",
         },
         .{
             .event = .{ .llm = .{ .provider = "nollm", .model = null } },
-            .expected = "[\"sid0\",\"L\",\"nollm\",null]",
+            .expected = "[\"L\",\"nollm\",null]",
         },
     };
 
     for (cases) |case| {
         var w = std.Io.Writer.Allocating.init(testing.allocator);
         defer w.deinit();
-        try std.json.Stringify.value(&EventRow{ .iid = "sid0", .event = case.event }, .{}, &w.writer);
+        try std.json.Stringify.value(&EventRow{ .event = case.event }, .{}, &w.writer);
         try testing.expectEqual(case.expected, w.written());
     }
 }
@@ -377,13 +383,12 @@ test "Telemetry: header wire format" {
 
     const header = Header{
         .iid = "the-iid",
-        .mode = .serve,
-        .interactive = false,
-        .proxy = true,
+        .mode = "S",
+        .proxy = 1,
     };
     try std.json.Stringify.value(&header, .{}, &w.writer);
 
-    const expected = try std.fmt.allocPrint(testing.allocator, "[\"the-iid\",\"H\",\"serve\",1,\"{s}\",\"{s}\",\"{s}\"]", .{ @tagName(builtin.os.tag), @tagName(builtin.cpu.arch), build_config.version });
+    const expected = try std.fmt.allocPrint(testing.allocator, "[\"the-iid\",\"H\",\"S\",1,\"{s}\",\"{s}\",\"{s}\"]", .{ OS_CODE, ARCH_CODE, build_config.version });
     defer testing.allocator.free(expected);
 
     try testing.expectEqual(expected, w.written());

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -19,6 +19,10 @@ const MAX_PENDING = 4096; // hard cap: drop + count beyond this (reported via bu
 const RECLAIM_CAPACITY = 64; // reclaim the drain buffer once a burst grows it past this
 const MAX_BODY_SIZE = 500 * 1024; // 500KB
 const REQUEST_TIMEOUT_MS = 5000;
+
+// Coalescing window to batch events together
+const LINGER_MS = 5000;
+const LINGER_BATCH = 16;
 const URL = "https://telemetry.lightpanda.io/v2";
 
 const LightPanda = @This();
@@ -147,6 +151,17 @@ fn run(self: *LightPanda) void {
                 return;
             }
             self.cond.wait(&self.mutex);
+        }
+        linger: {
+            var timer = std.time.Timer.start() catch break :linger;
+            const linger_ns = LINGER_MS * std.time.ns_per_ms;
+            while (self.running and self.pending.items.len < LINGER_BATCH) {
+                const elapsed = timer.read();
+                if (elapsed >= linger_ns) {
+                    break;
+                }
+                self.cond.timedWait(&self.mutex, linger_ns - elapsed) catch break;
+            }
         }
 
         // Swap the batch out and release the lock for the (blocking) serialize +
@@ -341,25 +356,25 @@ const EventRow = struct {
 
 const testing = @import("../testing.zig");
 
-test "telemetry: event row wire format" {
+test "Telemetry: event row wire format" {
     const Case = struct { event: telemetry.Event, expected: []const u8 };
     const cases = [_]Case{
         .{ .event = .{ .run = {} }, .expected = "[\"sid0\",\"run\"]" },
         .{
-            .event = .{ .navigate = .{ .tls = true, .context = .page, .reason = .address_bar } },
-            .expected = "[\"sid0\",\"navigate\",true,\"page\",\"address_bar\"]",
+            .event = .{ .navigate = .{ .tls = true, .context = .page } },
+            .expected = "[\"sid0\",\"nav\",true,\"page\"]",
         },
         .{
-            .event = .{ .navigate = .{ .tls = false, .context = .popup, .reason = .anchor } },
-            .expected = "[\"sid0\",\"navigate\",false,\"popup\",\"anchor\"]",
+            .event = .{ .navigate = .{ .tls = false, .context = .popup } },
+            .expected = "[\"sid0\",\"nav\",false,\"popup\"]",
         },
         .{
-            .event = .{ .navigate = .{ .tls = true, .context = .iframe, .reason = .script } },
-            .expected = "[\"sid0\",\"navigate\",true,\"iframe\",\"script\"]",
+            .event = .{ .navigate = .{ .tls = true, .context = .iframe } },
+            .expected = "[\"sid0\",\"nav\",true,\"iframe\"]",
         },
         .{
             .event = .{ .buffer_overflow = .{ .dropped = 42 } },
-            .expected = "[\"sid0\",\"buffer_overflow\",42]",
+            .expected = "[\"sid0\",\"bof\",42]",
         },
         .{
             .event = .{ .llm = .{ .provider = "anthropic", .model = .wrap("claude") } },
@@ -379,7 +394,7 @@ test "telemetry: event row wire format" {
     }
 }
 
-test "telemetry: header wire format" {
+test "Telemetry: header wire format" {
     var w = std.Io.Writer.Allocating.init(testing.allocator);
     defer w.deinit();
 
@@ -394,5 +409,5 @@ test "telemetry: header wire format" {
 
     const out = w.written();
     try testing.expectEqual(true, std.mem.startsWith(u8, out, "{\"sid\":\"sid0\",\"iid\":\"the-iid\",\"mode\":\"serve\","));
-    try testing.expectEqual(true, std.mem.endsWith(u8, out, ",\"proxy\":true,\"driver\":\"cdp\"}"));
+    try testing.expectEqual(true, std.mem.endsWith(u8, out, ",\"proxy\":true}"));
 }

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -19,7 +19,7 @@ const MAX_PENDING = 4096; // hard cap: drop + count beyond this (reported via bu
 const RECLAIM_CAPACITY = 64; // reclaim the drain buffer once a burst grows it past this
 const MAX_BODY_SIZE = 500 * 1024; // 500KB
 const REQUEST_TIMEOUT_MS = 5000;
-const URL = "https://telemetry.lightpanda.io";
+const URL = "https://telemetry.lightpanda.io/v2";
 
 const LightPanda = @This();
 
@@ -32,6 +32,13 @@ writer: std.Io.Writer.Allocating,
 iid: ?[36]u8 = null,
 run_mode: Config.RunMode = .serve,
 interactive: bool = false,
+
+// Per run id
+sid: [16]u8,
+proxy: bool,
+
+// Header is sent before the first message, once sent, it isn't sent again
+header_sent: bool = false,
 
 // `mutex` guards the ring buffer (head/tail/dropped), `running`, and the lazy
 // `thread` creation. The sender thread blocks on `cond` while idle.
@@ -56,10 +63,15 @@ pending: std.ArrayList(telemetry.Event) = .empty,
 dropped: u32 = 0,
 
 pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode, interactive: bool) !void {
+    var raw_sid: [8]u8 = undefined;
+    std.crypto.random.bytes(&raw_sid);
+
     self.* = .{
         .iid = iid,
         .run_mode = run_mode,
         .interactive = interactive,
+        .sid = std.fmt.bytesToHex(raw_sid, .lower),
+        .proxy = app.config.httpProxy() != null,
         .allocator = app.allocator,
         .network = &app.network,
         .writer = std.Io.Writer.Allocating.init(app.allocator),
@@ -170,6 +182,10 @@ fn run(self: *LightPanda) void {
 }
 
 fn postEvents(self: *LightPanda, conn: *http.Connection, events: []const telemetry.Event, dropped: u32, sent: *usize) !void {
+    if (self.header_sent == false) {
+        _ = try self.writeHeader();
+    }
+
     // The overflow report rides ahead of the first body; the rest of that body
     // and any subsequent ones are filled from `events` below.
     const has_overflow = dropped > 0;
@@ -203,6 +219,8 @@ fn postEvents(self: *LightPanda, conn: *http.Connection, events: []const telemet
         try self.flush(conn);
         sent.* += queued;
     }
+
+    self.header_sent = true;
 }
 
 fn flush(self: *LightPanda, conn: *http.Connection) !void {
@@ -223,17 +241,24 @@ fn _flush(self: *LightPanda, conn: *http.Connection) !void {
 }
 
 fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
+    return self.writeLine(&EventRow{ .sid = &self.sid, .event = event });
+}
+
+fn writeHeader(self: *LightPanda) !bool {
     const iid: ?[]const u8 = if (self.iid) |*id| id else null;
-    const wrapped = LightPandaEvent{
+    return self.writeLine(&Header{
+        .sid = &self.sid,
         .iid = iid,
         .mode = self.run_mode,
-        .event = event,
         .interactive = self.interactive,
-    };
+        .proxy = self.proxy,
+    });
+}
 
+fn writeLine(self: *LightPanda, value: anytype) !bool {
     const checkpoint = self.writer.written().len;
 
-    try std.json.Stringify.value(&wrapped, .{ .emit_null_optional_fields = false }, &self.writer.writer);
+    try std.json.Stringify.value(value, .{}, &self.writer.writer);
     try self.writer.writer.writeByte('\n');
 
     if (self.writer.written().len > MAX_BODY_SIZE) {
@@ -243,17 +268,23 @@ fn writeEvent(self: *LightPanda, event: telemetry.Event) !bool {
     return true;
 }
 
-const LightPandaEvent = struct {
+const Header = struct {
+    sid: []const u8,
     iid: ?[]const u8,
     mode: Config.RunMode,
     interactive: bool,
-    event: telemetry.Event,
+    proxy: bool,
 
-    pub fn jsonStringify(self: *const LightPandaEvent, writer: anytype) !void {
+    pub fn jsonStringify(self: *const Header, writer: anytype) !void {
         try writer.beginObject();
 
-        try writer.objectField("iid");
-        try writer.write(self.iid);
+        try writer.objectField("sid");
+        try writer.write(self.sid);
+
+        if (self.iid) |iid| {
+            try writer.objectField("iid");
+            try writer.write(iid);
+        }
 
         try writer.objectField("mode");
         // Special case: when running agent mode in non-interactive, we send a
@@ -273,22 +304,95 @@ const LightPandaEvent = struct {
         try writer.objectField("version");
         try writer.write(build_config.version);
 
-        try writer.objectField("event");
-        try writer.write(@tagName(std.meta.activeTag(self.event)));
-
-        inline for (@typeInfo(telemetry.Event).@"union".fields) |union_field| {
-            if (self.event == @field(telemetry.Event, union_field.name)) {
-                const inner = @field(self.event, union_field.name);
-                const TI = @typeInfo(@TypeOf(inner));
-                if (TI == .@"struct") {
-                    inline for (TI.@"struct".fields) |field| {
-                        try writer.objectField(field.name);
-                        try writer.write(@field(inner, field.name));
-                    }
-                }
-            }
-        }
+        try writer.objectField("proxy");
+        try writer.write(self.proxy);
 
         try writer.endObject();
     }
 };
+
+const EventRow = struct {
+    sid: []const u8,
+    event: telemetry.Event,
+
+    pub fn jsonStringify(self: *const EventRow, writer: anytype) !void {
+        try writer.beginArray();
+        try writer.write(self.sid);
+        switch (self.event) {
+            .run => try writer.write("run"),
+            .navigate => |n| {
+                try writer.write("nav");
+                try writer.write(n.tls);
+                try writer.write(n.context);
+            },
+            .buffer_overflow => |b| {
+                try writer.write("bof");
+                try writer.write(b.dropped);
+            },
+            .llm => |l| {
+                try writer.write("llm");
+                try writer.write(l.provider);
+                try writer.write(l.model);
+            },
+        }
+        try writer.endArray();
+    }
+};
+
+const testing = @import("../testing.zig");
+
+test "telemetry: event row wire format" {
+    const Case = struct { event: telemetry.Event, expected: []const u8 };
+    const cases = [_]Case{
+        .{ .event = .{ .run = {} }, .expected = "[\"sid0\",\"run\"]" },
+        .{
+            .event = .{ .navigate = .{ .tls = true, .context = .page, .reason = .address_bar } },
+            .expected = "[\"sid0\",\"navigate\",true,\"page\",\"address_bar\"]",
+        },
+        .{
+            .event = .{ .navigate = .{ .tls = false, .context = .popup, .reason = .anchor } },
+            .expected = "[\"sid0\",\"navigate\",false,\"popup\",\"anchor\"]",
+        },
+        .{
+            .event = .{ .navigate = .{ .tls = true, .context = .iframe, .reason = .script } },
+            .expected = "[\"sid0\",\"navigate\",true,\"iframe\",\"script\"]",
+        },
+        .{
+            .event = .{ .buffer_overflow = .{ .dropped = 42 } },
+            .expected = "[\"sid0\",\"buffer_overflow\",42]",
+        },
+        .{
+            .event = .{ .llm = .{ .provider = "anthropic", .model = .wrap("claude") } },
+            .expected = "[\"sid0\",\"llm\",\"anthropic\",\"claude\"]",
+        },
+        .{
+            .event = .{ .llm = .{ .provider = "nollm", .model = null } },
+            .expected = "[\"sid0\",\"llm\",\"nollm\",null]",
+        },
+    };
+
+    for (cases) |case| {
+        var w = std.Io.Writer.Allocating.init(testing.allocator);
+        defer w.deinit();
+        try std.json.Stringify.value(&EventRow{ .sid = "sid0", .event = case.event }, .{}, &w.writer);
+        try testing.expectEqual(case.expected, w.written());
+    }
+}
+
+test "telemetry: header wire format" {
+    var w = std.Io.Writer.Allocating.init(testing.allocator);
+    defer w.deinit();
+
+    const header = Header{
+        .sid = "sid0",
+        .iid = "the-iid",
+        .mode = .serve,
+        .interactive = false,
+        .proxy = true,
+    };
+    try std.json.Stringify.value(&header, .{}, &w.writer);
+
+    const out = w.written();
+    try testing.expectEqual(true, std.mem.startsWith(u8, out, "{\"sid\":\"sid0\",\"iid\":\"the-iid\",\"mode\":\"serve\","));
+    try testing.expectEqual(true, std.mem.endsWith(u8, out, ",\"proxy\":true,\"driver\":\"cdp\"}"));
+}

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -111,8 +111,9 @@ pub const Event = union(enum) {
 
     const Navigate = struct {
         tls: bool,
-        proxy: bool,
-        driver: enum { cdp } = .cdp,
+        context: Context,
+
+        const Context = enum { page, iframe, popup };
     };
 
     const BufferOverflow = struct {


### PR DESCRIPTION
First, this adds 1 small piece of data to the navigate event: whether the navigate was a page, frame or popup.

It also adds a session id, but as far as I'm concerned, this isn't "new" information, or any new tracking/insight into users. Between the iid and the "run" event, a "session" was always trackable. By giving it an explicit value, we can shrink the size of all other messages.

This change reduces the telemetry payload by ~70% (despite the extra nav field). I'm hoping this might remove a reason some people would consider turning it off.

It hits a /v2/ endpoint. The changes:

1 - A header is the first message in a session and contains all of the static data, as well as a session id
2 - Every event is encoded as an array, [$SID, "event-type, params...]

```
{"sid":"92e98210a141f497","iid":"$UUID","mode":"fetch","os":"macos","arch":"aarch64","version":"$VERSION","proxy":false}
["92e98210a141f497","run"]
["92e98210a141f497","nav",false,"page"]
```

(the driver=cdp field was removed from nav, because it was always cdp).

Some notes for the server:

1 - The server can tell a header from an event based on the first character, '{' vs '['
2 - The SID is 8 bytes, enough to be unique, but not globally unique. The iid + sid + time window is how a events for the same SID can be grouped.
3 - A valid event is always an array of 2+ items, index 0 = SID, index 1 = type

Although positional data isn't expressive, it's still extendable.

The 4 events:

run, no parameters (mostly just used to flush the header now)
["sid", "run"]

// nav, tls, page/popup/iframe
["sid","nav",true,"page"]

// bof, # of lost telemetry events
["sid","bof",42]

// llm, provider, model (nullable)
["sid","llm","anthropic","claude"]

This also adds more aggressive batching.