### PR TITLE
cdp: Fix Page.frameAttached params double-wrapping that broke sub-frame interception

### DIFF
--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -585,10 +585,10 @@ pub fn frameChildFrameCreated(bc: *CDP.BrowserContext, event: *const Notificatio
     const cdp = bc.cdp;
     const frame_id = &id.toFrameId(event.frame_id);
 
-    try cdp.sendEvent("Page.frameAttached", .{ .params = .{
+    try cdp.sendEvent("Page.frameAttached", .{
         .frameId = frame_id,
         .parentFrameId = &id.toFrameId(event.parent_id),
-    } }, .{ .session_id = session_id });
+    }, .{ .session_id = session_id });
 
     if (bc.page_life_cycle_events) {
         try cdp.sendEvent("Page.lifecycleEvent", LifecycleEvent{
@@ -1053,6 +1053,25 @@ test "cdp.frame: getFrameTree" {
             },
         }, .{ .id = 12 });
     }
+}
+
+test "cdp.frame: frameAttached" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .session_id = "SID-X" });
+
+    bc.notification.dispatch(.frame_child_frame_created, &.{
+        .frame_id = 2,
+        .parent_id = 1,
+        .loader_id = 7,
+        .timestamp = 0,
+    });
+
+    try ctx.expectSentEvent("Page.frameAttached", .{
+        .frameId = "FID-0000000002",
+        .parentFrameId = "FID-0000000001",
+    }, .{ .session_id = "SID-X" });
 }
 
 test "cdp.frame: captureScreenshot" {


### PR DESCRIPTION
# cdp: Fix `Page.frameAttached` params double-wrapping that broke sub-frame request interception

**TL;PL**: The format of the CDP message Page.frameAttached sends an invalid extra param struct.

**Disclaimer**: Analysis, code and PR message written by claude. Tested by me and it fixes my issue. 

## Summary
`Fetch`/`page.route` request interception silently did **not** apply to iframe
(sub-frame) document navigations: the child frame loaded from the real network
instead of being paused for the CDP client. This breaks any automation that
mocks or blocks resources loaded inside iframes (e.g. the cross-origin
3rd-party-cookie-check iframe loaded by `keycloak-js` during OIDC init).

The interception layer was **not** at fault — it does emit `Fetch.requestPaused`
for sub-frames. The bug is a malformed `Page.frameAttached` CDP event.

## Root cause
In `src/cdp/domains/page.zig`, `frameChildFrameCreated()` emitted the event with
its payload wrapped in an extra `.{ .params = ... }`:

```zig
cdp.sendEvent("Page.frameAttached", .{ .params = .{
    .frameId = frame_id,
    .parentFrameId = &id.toFrameId(event.parent_id),
} }, .{ .session_id = session_id });
```

`CDP.sendEvent(method, payload, opts)` already places `payload` into the event's
`params` field, so this produced a double-nested event on the wire:

```jsonc
// before (wrong):
{"method":"Page.frameAttached","params":{"params":{"frameId":"…","parentFrameId":"…"}}}
// expected (CDP spec / Chrome):
{"method":"Page.frameAttached","params":{"frameId":"…","parentFrameId":"…"}}
```

Every sibling frame event in the same function (`frameStartedNavigating`,
`frameRequestedNavigation`, `frameStartedLoading`, …) already passes its fields
flat; `frameAttached` was the only call site that double-wrapped.

## Why it breaks interception
A CDP client (Playwright via `connectOverCDP` + `page.route`) parses
`frameId`/`parentFrameId` at the top level of `params`. With the fields one
level too deep the client never registers the child frame, so when that frame's
`Fetch.requestPaused` arrives it is **bare-`continueRequest`’d** instead of being
matched against a route — the request proceeds to the real network.

### Evidence (Playwright, `DEBUG=pw:protocol`)
```jsonc
◀ {"method":"Page.frameAttached","params":{"params":{"frameId":"FID-…2","parentFrameId":"FID-…1"}}}
◀ {"method":"Fetch.requestPaused","params":{"requestId":"INT-…2","frameId":"FID-…2",
     "request":{"url":"http://route.test/child"},"resourceType":"Document"}}
► {"method":"Fetch.continueRequest","params":{"requestId":"INT-…2"}}   // bare continue — route not applied
```
Before the fix, `page.frames()` reported only the main frame; the iframe loaded
the real response. A raw CDP client (single session, manual `Fetch.enable`)
already received the sub-frame `requestPaused` correctly, confirming the engine
side was fine and isolating the bug to the event payload shape.

## Fix
Drop the extra wrapper so the payload is flat, matching every sibling event.

## Test
Adds a regression test (`cdp.frame: frameAttached params are flat …`) that
dispatches `frame_child_frame_created` and asserts `Page.frameAttached` carries
`frameId`/`parentFrameId` directly under `params`. Verified it **fails** on the
old double-nested shape and **passes** after the fix.

## Verification
- End-to-end (Playwright + `lightpanda serve`): iframe route now fulfills
  (`CHILD_ROUTED`), the child frame appears in `page.frames()`, and
  `Fetch.requestPaused` fires once for the iframe document with
  `resourceType:"Document"` and the correct `frameId`.
- `make test` → all tests pass (incl. the new one); `zig fmt --check` clean.

## Note for reviewers reproducing this
Playwright evaluates `page.route(...)` patterns in **reverse registration
order**, so a catch-all `**/*` must be registered *before* the specific routes
or it shadows them. Register specifics last when writing the repro.
