### PR TITLE
webapi: Fix cross-origin MessageEvent.source WindowProxy identity

### DIFF
--- a/src/browser/tests/frames/cross_origin_message_source.html
+++ b/src/browser/tests/frames/cross_origin_message_source.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<!--
+MessageEvent.source is the WindowProxy of the frame the message came from, so it
+is reference-equal to that frame's iframe.contentWindow — for a cross-origin
+sender as well as a same-origin one. The two children below differ only by origin:
+localhost is cross-origin to the 127.0.0.1 test page, 127.0.0.1 is same-origin;
+both must satisfy event.source === iframe.contentWindow.
+-->
+
+<script id="message_source_identity" type=module>
+{
+  const state = await testing.async();
+  const ALT_BASE = testing.BASE_URL.replace('127.0.0.1', 'localhost');
+  const ALT_ORIGIN = testing.ORIGIN.replace('127.0.0.1', 'localhost');
+
+  function loadAndAwait(src, expectedOrigin) {
+    return new Promise((resolve) => {
+      const iframe = document.createElement('iframe');
+      const onmsg = (e) => {
+        if (e.origin !== expectedOrigin) return;
+        window.removeEventListener('message', onmsg);
+        resolve({ iframe, event: e });
+      };
+      window.addEventListener('message', onmsg);
+      iframe.src = src;
+      document.documentElement.appendChild(iframe);
+    });
+  }
+
+  // localhost is a different origin than the 127.0.0.1 test page: cross-origin sender.
+  const cross = await loadAndAwait(ALT_BASE + 'frames/support/post_to_parent.html', ALT_ORIGIN);
+  // 127.0.0.1 is the test page's own origin: same-origin control.
+  const same = await loadAndAwait(testing.BASE_URL + 'frames/support/post_to_parent.html', testing.ORIGIN);
+  state.resolve();
+
+  await state.done(() => {
+    testing.expectEqual('hello', cross.event.data);
+    testing.expectEqual(ALT_ORIGIN, cross.event.origin);
+    testing.expectFalse(cross.event.source === null);
+    testing.expectTrue(cross.event.source === cross.iframe.contentWindow);
+
+    testing.expectEqual('hello', same.event.data);
+    testing.expectEqual(testing.ORIGIN, same.event.origin);
+    testing.expectTrue(same.event.source === same.iframe.contentWindow);
+  });
+}
+</script>

--- a/src/browser/tests/frames/support/post_to_parent.html
+++ b/src/browser/tests/frames/support/post_to_parent.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+  parent.postMessage('hello', '*');
+</script>

--- a/src/browser/webapi/event/MessageEvent.zig
+++ b/src/browser/webapi/event/MessageEvent.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Frame = @import("../../Frame.zig");
 
 const Event = @import("../Event.zig");
 const MessagePort = @import("../MessagePort.zig");
@@ -116,8 +117,9 @@ pub fn getOrigin(self: *const MessageEvent) []const u8 {
     return self._origin;
 }
 
-pub fn getSource(self: *const MessageEvent) ?*Window {
-    return self._source;
+pub fn getSource(self: *const MessageEvent, frame: *Frame) ?Window.Access {
+    const source = self._source orelse return null;
+    return Window.Access.init(frame.window, source);
 }
 
 pub fn getPorts(self: *const MessageEvent) []const *MessagePort {


### PR DESCRIPTION
# webapi: Fix cross-origin `MessageEvent.source` identity

*Human*

Still trying to get lightpanda through our login system, this second one gets me one step closer  :)

TL:PL; Wrong source on event.source from a postMessage in a iframe; My understanding is that it should return a ref to the WindowProxy. Seems to align with Chrome behaviour.

Disclaimer: Investigation & code with claude. Tested by me.

**LLM** 

## Summary
For a **cross-origin** child iframe, `event.source !== iframe.contentWindow`, even though both
refer to the same frame (same-origin was already correct). Per the WHATWG HTML spec there is
exactly one `WindowProxy` per browsing context and `MessageEvent.source` *is* that `WindowProxy`,
so the two must be reference-equal **regardless of origin** — confirmed empirically in Chrome 149.

The mismatch breaks `postMessage` handshakes that authenticate the sender by reference identity —
notably `keycloak-js`'s 3rd-party-cookie check (`if (iframe.contentWindow !== event.source) return;`),
which never passes cross-origin, times out, and fails OIDC `init()`.

## Root cause
`MessageEvent.getSource` returned the bare `*Window` — the only window accessor that did **not**
route through `Window.Access.init`. Every other accessor (`iframe.contentWindow`, `window.parent`,
`window.top`) wraps a cross-origin target as `*CrossOriginWindow`. JS object identity is keyed by
Zig pointer (`identity_map`), so the two paths produced different JS objects cross-origin:

| path (parent reads, child is the source) | pointer returned | JS object |
|---|---|---|
| `iframe.contentWindow` | `&child._cross_origin_wrapper` (`*CrossOriginWindow`) | A |
| `event.source` | `child` (`*Window`) | B |

Same-origin, `Access.init` returns the bare `*Window` on *both* paths → same pointer → same cached
object → `===` held. That asymmetry is exactly why only the cross-origin case was affected.

## Fix
Route `getSource` through `Window.Access.init(frame.window, source)`, exactly like
`IFrame.getContentWindow`. Both paths now resolve to the same per-frame proxy
(`&child._cross_origin_wrapper` cross-origin, the bare `*Window` same-origin). No internal caller
depended on the old `?*Window` return type.

```zig
pub fn getSource(self: *const MessageEvent, frame: *Frame) ?Window.Access {
    const source = self._source orelse return null;
    return Window.Access.init(frame.window, source);
}
```

## Test
`src/browser/tests/frames/cross_origin_message_source.html` loads a cross-origin and a same-origin
child (`support/post_to_parent.html`) that each `parent.postMessage('unsupported', '*')`, and
asserts `event.source === iframe.contentWindow` (plus `data`/`origin` and non-null `source`) for
both. Auto-discovered by `test "WebApi: Frames"`. It **fails** on the old bare-`*Window` getter
(`expected: true, got: false`) and **passes** after the fix.

## Verification
- `make test` → all pass; `zig fmt --check ./*.zig ./**/*.zig` → clean.
- Cross-checked against real Google Chrome 149: `event.source === iframe.contentWindow` is `true`
  for both cross- and same-origin (and `source` is non-null) — Lightpanda now matches.

## Spec references
- `MessageEvent.source`: https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageevent-source
- window post message steps: https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps
- `iframe.contentWindow`: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-iframe-contentwindow
- one `WindowProxy` per browsing context: https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-windowproxy-exotic-object

🤖 Generated with [Claude Code](https://claude.com/claude-code)
