### PR TITLE
fix: Reject xhr send() when send already active

### DIFF
--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -481,3 +481,30 @@
     testing.expectEqual(false, registered);
   }
 </script>
+
+<script id=xhr_send_flag type=module>
+  {
+    // Per spec, calling send() while a request is already in flight throws
+    // InvalidStateError (the "send() flag"). Without it, two concurrent
+    // transfers race on the XHR's single response slot and one is left dangling
+    // at teardown (the "release overflow" UAF).
+    const state = await testing.async();
+    const req = new XMLHttpRequest();
+    req.onload = () => state.resolve();
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    req.send();
+    testing.expectError('InvalidStateError', () => req.send());
+
+    await state.done(() => {
+      // the first request was unaffected by the rejected second send()
+      testing.expectEqual(200, req.status);
+    });
+
+    // a fresh open() clears the flag, so the object is reusable
+    const state2 = await testing.async();
+    req.onload = () => state2.resolve();
+    req.open('GET', 'http://127.0.0.1:9582/xhr');
+    req.send();
+    await state2.done(() => testing.expectEqual(200, req.status));
+  }
+</script>

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -52,6 +52,7 @@ _http_response: ?HttpClient.Response = null,
 // number of inflight requests, we can have multiple, e.g. xhr calling its own
 // send from the onload callback
 _active_requests: u8 = 0,
+_send_flag: bool = false,
 
 _url: [:0]const u8 = "",
 _method: http.Method = .GET,
@@ -185,6 +186,7 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8) !void
         transfer.abort(error.Abort);
         self._http_response = null;
     }
+    self._send_flag = false;
 
     // Reset internal state. _override_mime intentionally survives open()
     // per https://xhr.spec.whatwg.org/#the-overridemimetype()-method.
@@ -224,7 +226,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     if (comptime IS_DEBUG) {
         log.debug(.http, "XMLHttpRequest.send", .{ .url = self._url });
     }
-    if (self._ready_state != .opened) {
+    if (self._ready_state != .opened or self._send_flag) {
         return error.InvalidStateError;
     }
 
@@ -259,6 +261,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
 
     self.acquireRef();
     self._active_requests += 1;
+    self._send_flag = true;
 
     exec.makeRequest(.{
         .ctx = self,
@@ -282,6 +285,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
         .body_outlives_request = true,
     }) catch |err| {
         self.releaseSelfRef();
+        self._send_flag = false;
         return err;
     };
 }


### PR DESCRIPTION
This builds on top of 995efd57e62730728d4c169ee14e4edd4b3ce4a8. That commit tracked the number of requests being made on a single XHR instance (because a new request can be initiated from a load/error callback of an existing one). However, that was unbound. It wasn't just 1 old + 1 new, it was an unlimited number of new requests, because we didn't prevent sending while sending was already active.

This adds a boolean to track our send state, and prevents a send from happening when a send is already active.