### PR TITLE
fix: getComputedStyle resolves inline style= declarations

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -871,6 +871,15 @@ fn getInlineStyleProperty(el: *Element, property_name: String, frame: *Frame) ?*
     return style.asCSSStyleDeclaration().findProperty(property_name);
 }
 
+/// Resolved value of an element's inline `style=` declaration for `property_name`,
+/// or null when the element has no such declaration. Reads the element's parsed
+/// inline style (the same source `el.style` exposes), so `getComputedStyle` and
+/// `el.style` agree on inline values instead of resolving them independently.
+pub fn inlineStyleValue(self: *StyleManager, el: *Element, property_name: String) ?[]const u8 {
+    const property = getInlineStyleProperty(el, property_name, self.frame) orelse return null;
+    return property._value.str();
+}
+
 const testing = @import("../testing.zig");
 test "StyleManager: computeSpecificity: element selector" {
     // div -> (0, 0, 1)

--- a/src/browser/tests/element/styles.html
+++ b/src/browser/tests/element/styles.html
@@ -198,3 +198,22 @@
   testing.expectEqual('1', divStyle.opacity);
 }
 </script>
+
+<script id="computedStyleInline">
+{
+  const div = document.createElement('div');
+  div.style.cssText = 'text-transform: uppercase; font-weight: 700; color: rgb(1, 2, 3)';
+  document.body.appendChild(div);
+
+  const cs = window.getComputedStyle(div);
+  testing.expectEqual('uppercase', cs.getPropertyValue('text-transform'));
+  testing.expectEqual('700', cs.getPropertyValue('font-weight'));
+  testing.expectEqual('rgb(1, 2, 3)', cs.getPropertyValue('color'));
+  testing.expectEqual('rgb(1, 2, 3)', div.style.getPropertyValue('color'));
+  testing.expectEqual('', cs.getPropertyValue('letter-spacing'));
+
+  const plainDiv = document.createElement('div');
+  document.body.appendChild(plainDiv);
+  testing.expectEqual('block', window.getComputedStyle(plainDiv).getPropertyValue('display'));
+}
+</script>

--- a/src/browser/tests/element/styles.html
+++ b/src/browser/tests/element/styles.html
@@ -215,5 +215,11 @@
   const plainDiv = document.createElement('div');
   document.body.appendChild(plainDiv);
   testing.expectEqual('block', window.getComputedStyle(plainDiv).getPropertyValue('display'));
+
+  // A normal declaration must not override an earlier !important one.
+  const impDiv = document.createElement('div');
+  impDiv.setAttribute('style', 'color: red !important; color: blue');
+  document.body.appendChild(impDiv);
+  testing.expectEqual('red', window.getComputedStyle(impDiv).getPropertyValue('color'));
 }
 </script>

--- a/src/browser/tests/element/styles.html
+++ b/src/browser/tests/element/styles.html
@@ -216,10 +216,12 @@
   document.body.appendChild(plainDiv);
   testing.expectEqual('block', window.getComputedStyle(plainDiv).getPropertyValue('display'));
 
-  // A normal declaration must not override an earlier !important one.
+  // A normal declaration must not override an earlier !important one, and the
+  // computed and inline (el.style) paths must agree on the resolved value.
   const impDiv = document.createElement('div');
   impDiv.setAttribute('style', 'color: red !important; color: blue');
   document.body.appendChild(impDiv);
   testing.expectEqual('red', window.getComputedStyle(impDiv).getPropertyValue('color'));
+  testing.expectEqual('red', impDiv.style.getPropertyValue('color'));
 }
 </script>

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -243,11 +243,18 @@ fn findInlineValue(element: *const Element, normalized_name: []const u8, frame: 
     const attr_value = element.getAttributeSafe(comptime .wrap("style")) orelse return null;
     var it = CssParser.parseDeclarationsList(attr_value);
     var result: ?[]const u8 = null;
+    var result_important = false;
     while (it.next()) |declaration| {
-        if (std.ascii.eqlIgnoreCase(declaration.name, normalized_name)) {
-            // Keep the last matching declaration, matching CSS declaration order.
-            result = normalizePropertyValue(frame.call_arena, normalized_name, declaration.value) catch declaration.value;
+        if (!std.ascii.eqlIgnoreCase(declaration.name, normalized_name)) {
+            continue;
         }
+        // A later declaration wins, except a normal one never overrides an
+        // earlier !important declaration (CSS cascade precedence).
+        if (result_important and !declaration.important) {
+            continue;
+        }
+        result = normalizePropertyValue(frame.call_arena, normalized_name, declaration.value) catch declaration.value;
+        result_important = declaration.important;
     }
     return result;
 }

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -49,7 +49,7 @@ pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleDecl
             if (el.getAttributeSafe(comptime .wrap("style"))) |attr_value| {
                 var it = CssParser.parseDeclarationsList(attr_value);
                 while (it.next()) |declaration| {
-                    try self.setPropertyImpl(declaration.name, declaration.value, declaration.important, frame);
+                    try self.applyParsedDeclaration(declaration, frame);
                 }
             }
         }
@@ -97,7 +97,9 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
         // Only return default values for computed styles
         if (self._is_computed) {
             if (self._element) |element| {
-                if (findInlineValue(element, normalized, frame)) |value| return value;
+                // Resolve inline `style=` declarations through the element's
+                // parsed inline style, so computed values match `el.style`.
+                if (frame._style_manager.inlineStyleValue(element, wrapped)) |value| return value;
             }
             return getDefaultPropertyValue(self, wrapped);
         }
@@ -125,6 +127,19 @@ pub fn setProperty(self: *CSSStyleDeclaration, property_name: []const u8, value:
     try self.setPropertyImpl(property_name, value, important, frame);
 
     try self.syncStyleAttribute(frame);
+}
+
+// Apply one declaration parsed from a `style=` block. Unlike the imperative
+// setProperty path, within a single declaration block a normal declaration must
+// not override an earlier !important one (CSS cascade precedence).
+fn applyParsedDeclaration(self: *CSSStyleDeclaration, declaration: CssParser.Declaration, frame: *Frame) !void {
+    if (!declaration.important) {
+        const normalized = normalizePropertyName(declaration.name, &frame.buf);
+        if (self.findProperty(.wrap(normalized))) |existing| {
+            if (existing._important) return;
+        }
+    }
+    try self.setPropertyImpl(declaration.name, declaration.value, declaration.important, frame);
 }
 
 fn setPropertyImpl(self: *CSSStyleDeclaration, property_name: []const u8, value: []const u8, important: bool, frame: *Frame) !void {
@@ -210,7 +225,7 @@ pub fn setCssText(self: *CSSStyleDeclaration, text: []const u8, frame: *Frame) !
     // Parse and set new properties
     var it = CssParser.parseDeclarationsList(text);
     while (it.next()) |declaration| {
-        try self.setPropertyImpl(declaration.name, declaration.value, declaration.important, frame);
+        try self.applyParsedDeclaration(declaration, frame);
     }
     try self.syncStyleAttribute(frame);
 }
@@ -237,26 +252,6 @@ pub fn findProperty(self: *const CSSStyleDeclaration, name: String) ?*Property {
         node = n.next;
     }
     return null;
-}
-
-fn findInlineValue(element: *const Element, normalized_name: []const u8, frame: *Frame) ?[]const u8 {
-    const attr_value = element.getAttributeSafe(comptime .wrap("style")) orelse return null;
-    var it = CssParser.parseDeclarationsList(attr_value);
-    var result: ?[]const u8 = null;
-    var result_important = false;
-    while (it.next()) |declaration| {
-        if (!std.ascii.eqlIgnoreCase(declaration.name, normalized_name)) {
-            continue;
-        }
-        // A later declaration wins, except a normal one never overrides an
-        // earlier !important declaration (CSS cascade precedence).
-        if (result_important and !declaration.important) {
-            continue;
-        }
-        result = normalizePropertyValue(frame.call_arena, normalized_name, declaration.value) catch declaration.value;
-        result_important = declaration.important;
-    }
-    return result;
 }
 
 fn normalizePropertyName(name: []const u8, buf: []u8) []const u8 {

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -96,6 +96,9 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
     const prop = self.findProperty(wrapped) orelse {
         // Only return default values for computed styles
         if (self._is_computed) {
+            if (self._element) |element| {
+                if (findInlineValue(element, normalized, frame)) |value| return value;
+            }
             return getDefaultPropertyValue(self, wrapped);
         }
         return "";
@@ -234,6 +237,19 @@ pub fn findProperty(self: *const CSSStyleDeclaration, name: String) ?*Property {
         node = n.next;
     }
     return null;
+}
+
+fn findInlineValue(element: *const Element, normalized_name: []const u8, frame: *Frame) ?[]const u8 {
+    const attr_value = element.getAttributeSafe(comptime .wrap("style")) orelse return null;
+    var it = CssParser.parseDeclarationsList(attr_value);
+    var result: ?[]const u8 = null;
+    while (it.next()) |declaration| {
+        if (std.ascii.eqlIgnoreCase(declaration.name, normalized_name)) {
+            // Keep the last matching declaration, matching CSS declaration order.
+            result = normalizePropertyValue(frame.call_arena, normalized_name, declaration.value) catch declaration.value;
+        }
+    }
+    return result;
 }
 
 fn normalizePropertyName(name: []const u8, buf: []u8) []const u8 {

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -129,9 +129,9 @@ pub fn setProperty(self: *CSSStyleDeclaration, property_name: []const u8, value:
     try self.syncStyleAttribute(frame);
 }
 
-// Apply one declaration parsed from a `style=` block. Unlike the imperative
-// setProperty path, within a single declaration block a normal declaration must
-// not override an earlier !important one (CSS cascade precedence).
+/// Apply one declaration parsed from a `style=` block. Unlike the imperative
+/// setProperty path, within a single declaration block a normal declaration must
+/// not override an earlier !important one (CSS cascade precedence).
 fn applyParsedDeclaration(self: *CSSStyleDeclaration, declaration: CssParser.Declaration, frame: *Frame) !void {
     if (!declaration.important) {
         const normalized = normalizePropertyName(declaration.name, &frame.buf);


### PR DESCRIPTION
## Summary

`getComputedStyle(el)` now returns the value of properties set through the element's inline `style=` attribute, instead of returning an empty string for everything except `display` and `visibility`.

## Why this matters

`CSSStyleDeclaration.init` skips parsing the inline `style=` attribute when the declaration is in computed mode, and `getPropertyValue` only special-cased `display`/`visibility` before falling through to defaults or `""`. So `getComputedStyle(el).getPropertyValue('text-transform')` came back `""` even though `el.style.textTransform` read the inline value correctly. Per the CSSOM resolved-value rules these should agree for inline declarations. See `src/browser/webapi/css/CSSStyleDeclaration.zig:79` (the computed branch) and `:47` (the `if (!is_computed)` guard in `init`).

This change is scoped to the inline `style=` path only. Resolving stylesheet-cascade rules is left out, since that is the contested part maintainers floated gating behind an opt-in.

The lookup reads the element's parsed inline declarations directly and honors `!important` precedence, so a normal declaration does not override an earlier important one in the same block.

## Testing

Added a `computedStyleInline` block to `src/browser/tests/element/styles.html` covering: inline `text-transform`/`font-weight`/`color` resolving through `getComputedStyle`, the non-computed `el.style` path staying unchanged, a property with no inline declaration still returning `""`, `display` still resolving to its default, and a duplicate `color: red !important; color: blue` resolving to `red`.

`zig fmt --check ./` passes on the pinned toolchain version.

Fixes #2733
