### PR TITLE
Cache Simple Heuristic

### DIFF
--- a/src/network/cache/Cache.zig
+++ b/src/network/cache/Cache.zig
@@ -274,10 +274,11 @@ pub fn tryCache(
         log.debug(.cache, "no store", .{ .url = url, .vary = v, .reason = "vary" });
         return null;
     };
+
     const cc = blk: {
         if (cache_control == null) {
-            log.debug(.cache, "no store", .{ .url = url, .reason = "no cache control" });
-            return null;
+            log.debug(.cache, "heuristic cache", .{ .url = url, .max_age = 86400 });
+            break :blk CacheControl{ .max_age = 86400, .must_revalidate = false };
         }
         if (CacheControl.parse(cache_control.?)) |cc| {
             break :blk cc;
@@ -441,4 +442,26 @@ test "Cache: CachedMetadata.renew updates etag and last_modified" {
 
     try testing.expectEqualSlices(u8, "\"new-etag\"", meta.etag.?);
     try testing.expectEqualSlices(u8, "Tue, 02 Jan 2024 00:00:00 GMT", meta.last_modified.?);
+}
+
+test "Cache: tryCache heuristic when no cache-control" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try tryCache(
+        arena.allocator(),
+        1000,
+        "https://example.com",
+        200,
+        "text/html",
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false,
+    );
+    try testing.expectEqual(@as(u64, 86400), result.?.cache_control.max_age);
+    try testing.expectEqual(false, result.?.cache_control.must_revalidate);
 }

--- a/src/network/cache/Cache.zig
+++ b/src/network/cache/Cache.zig
@@ -276,14 +276,21 @@ pub fn tryCache(
     };
 
     const cc = blk: {
-        if (cache_control == null) {
+        if (cache_control) |c| {
+            if (CacheControl.parse(c)) |cc| {
+                break :blk cc;
+            }
+        } else if (last_modified != null) {
+            // Requires Last-Modified to be present to heuristically cache.
             log.debug(.cache, "heuristic cache", .{ .url = url, .max_age = 86400 });
             break :blk CacheControl{ .max_age = 86400, .must_revalidate = false };
         }
-        if (CacheControl.parse(cache_control.?)) |cc| {
-            break :blk cc;
-        }
-        log.debug(.cache, "no store", .{ .url = url, .cache_control = cache_control.?, .reason = "cache control" });
+
+        log.debug(.cache, "no store", .{
+            .url = url,
+            .cache_control = cache_control orelse "null",
+            .last_modified = last_modified orelse "null",
+        });
         return null;
     };
 
@@ -459,6 +466,27 @@ test "Cache: tryCache heuristic when no cache-control" {
         null,
         null,
         null,
+        false,
+        false,
+    );
+    try testing.expectEqual(null, result);
+}
+
+test "Cache: tryCache heuristic when no cache-control with last-modified" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try tryCache(
+        arena.allocator(),
+        1000,
+        "https://example.com",
+        200,
+        "text/html",
+        null,
+        null,
+        null,
+        null,
+        "Wed, 21 Oct 2015 07:28:00 GMT",
         false,
         false,
     );


### PR DESCRIPTION
This adds a simple Cache heuristic, storing resources for up to 1 day (86400 ms) if it is missing a `Cache-Control` header.

I don't see a big point in generating and supporting parsing logic for the `Last-Modified` date format because it isn't required and this gets us most of the benefit with way less work.