### PR TITLE
page: flush deferred transfers after a synchronous stylesheet fetch

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2048,6 +2048,20 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []co
     };
 
     const http_client = &session.browser.http_client;
+
+    // `syncRequest` below registers a blocking request for this frame, which
+    // makes the DeferringLayer hold back the completion callbacks of every
+    // OTHER in-flight transfer for the frame (e.g. a `<script defer>` still
+    // loading) so they don't run JS while we're on the parser stack. Those
+    // deferred completions must be flushed once the sync fetch returns —
+    // otherwise a `<script defer>` whose fetch finishes during this window is
+    // left at `complete == false` forever, the deferred-script queue never
+    // drains, and `documentIsLoaded` (readyState -> "interactive",
+    // DOMContentLoaded, the load event) never fires. The blocking-`<script>`
+    // path (ScriptManager.addFromElement) and the worker path already flush;
+    // the external-stylesheet path must too.
+    defer http_client.deferring_layer.flushFrame(self._frame_id);
+
     var headers = try http_client.newHeaders();
     try headers.add("Accept: text/css,*/*;q=0.1");
     try self.headersForRequest(&headers);

--- a/src/browser/tests/css/deferred_script_then_stylesheet.html
+++ b/src/browser/tests/css/deferred_script_then_stylesheet.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<head>
+  <script src="../testing.js"></script>
+  <script id=deferred_script_drains_after_sync_stylesheet>
+    // Runs during parsing, before the body's deferred script + stylesheet.
+    // Crucially this is the LAST blocking <script> in the document: nothing
+    // blocking follows the <link rel=stylesheet> below, so the only thing
+    // that can flush the deferred script's completion is the stylesheet
+    // fetch itself (the regression). A blocking <script> after the <link>
+    // would call flushFrame on its own and hide the bug.
+    testing.expectEqual('loading', document.readyState);
+    testing.expectEqual(undefined, window.__deferRan);
+
+    testing.onload(() => {
+      // Reaching load means the deferred-script queue drained: the deferred
+      // script ran and the document advanced out of "loading".
+      testing.expectEqual(true, window.__deferRan);
+      testing.expectEqual('complete', document.readyState);
+    });
+  </script>
+</head>
+<body>
+  <!--
+    Regression: a `<script defer>` followed by an external
+    `<link rel=stylesheet>` (external-stylesheet loading enabled).
+
+    Frame.loadExternalStylesheet fetches the sheet SYNCHRONOUSLY, registering
+    a blocking request for the frame. While that blocking request is active,
+    the DeferringLayer holds back the completion callbacks of every OTHER
+    in-flight transfer for the frame — including the deferred script that
+    started loading just above. Those deferred completions must be flushed
+    once the sync fetch returns; otherwise the script stays at
+    `complete == false`, the deferred-script queue never drains, and
+    DOMContentLoaded / the load event / readyState -> "complete" never fire.
+  -->
+  <script defer src="/defer-marker.js"></script>
+  <link rel="stylesheet" href="/styles/visibility.css">
+</body>

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -288,3 +288,14 @@ test "WebApi: HTML.Link external stylesheet" {
     defer filter.deinit();
     try testing.htmlRunner("css/external_stylesheet.html", .{ .load_external_stylesheets = true });
 }
+
+// Regression: a synchronous external-stylesheet fetch must not strand the
+// completion of an in-flight <script defer> (deferred by the blocking-request
+// window). Otherwise the deferred-script queue never drains and the document
+// is stuck at readyState "loading". See Frame.loadExternalStylesheet's
+// flushFrame call.
+test "WebApi: HTML.Link deferred script then external stylesheet" {
+    const filter: testing.LogFilter = .init(&.{.http});
+    defer filter.deinit();
+    try testing.htmlRunner("css/deferred_script_then_stylesheet.html", .{ .load_external_stylesheets = true });
+}

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -715,6 +715,17 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/defer-marker.js")) {
+        // A deferred script body. Used by the regression test for a
+        // <script defer> whose completion is deferred by a later
+        // <link rel=stylesheet>'s synchronous fetch — it must still execute.
+        return req.respond("window.__deferRan = true;", .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "application/javascript" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/xhr/500")) {
         return req.respond("Internal Server Error", .{
             .status = .internal_server_error,


### PR DESCRIPTION
## What

When external stylesheet loading is enabled (`--enable-external-stylesheets` / `LP.configureLoading {externalStylesheets: true}`), an external `<link rel=stylesheet>` placed after a `<script defer>` permanently stalls page load: the deferred script never executes, `Page.domContentEventFired` / `Page.loadEventFired` never fire, and `document.readyState` stays `"loading"` — even though the document, the script, and the stylesheet all complete with HTTP 200. A downstream CDP client that navigates and waits for the load event (or polls `readyState`) never sees the page finish.

Closes #2842.

## Root cause

`Frame.loadExternalStylesheet` fetches the stylesheet **synchronously**, which registers a blocking request for the frame. While that blocking request is active, the `DeferringLayer` holds back the completion callbacks of every *other* in-flight transfer for the frame (so they don't run JS on the parser stack) and buffers them until the frame is flushed. The blocking-`<script>` path (`ScriptManager.addFromElement`) and the worker path (`WorkerGlobalScope`) both call `deferring_layer.flushFrame(frame_id)` after their synchronous fetch — but the external-stylesheet path never did. So a `<script defer>` that finished loading during the stylesheet's blocking window stayed at `complete == false`, the deferred-script queue never drained, and the load lifecycle never advanced.

```mermaid
flowchart LR
    A[sync stylesheet fetch] --> B[deferring layer holds completions]
    B --> C[deferred script left incomplete]
    C --> D[deferred queue never drains]
    D --> E[readyState stuck loading]
    style B fill:#fdd
    style C fill:#fdd
    style E fill:#fdd
```

## Fix

- `src/browser/Frame.zig` — `loadExternalStylesheet`: after the synchronous fetch, flush the frame's deferring layer (`http_client.deferring_layer.flushFrame(self._frame_id)`) via a `defer`, so any transfer completion that was held back during the blocking window is delivered. Mirrors the two existing synchronous-request call sites.

```mermaid
flowchart LR
    A[sync stylesheet fetch] --> B[flush deferring layer]
    B --> C[deferred script completes]
    C --> D[deferred queue drains]
    D --> E[readyState reaches complete]
    style B fill:#dfd
    style C fill:#dfd
    style E fill:#dfd
```

## Test

- **Unit test**: `WebApi: HTML.Link deferred script then external stylesheet` (`src/browser/webapi/element/html/Link.zig`), fixture `src/browser/tests/css/deferred_script_then_stylesheet.html`. A `<script defer>` is followed by an external `<link rel=stylesheet>` with the assertion script placed in `<head>` (so nothing blocking follows the `<link>` to mask the bug). It asserts the deferred script runs and the document reaches `readyState "complete"`. Fails on `main`, passes with this commit. New HTTP route `/defer-marker.js` added to the test server.
- **Reproducer**: the `repro.sh` from #2842 exits 1 on `main` (`FAIL: stuck at readyState="loading", deferred script ran=false.`) and exits 0 with this commit (`PASS: document reached "complete" and the deferred script ran.`).

Full suite: `zig build test` — no new failures attributable to this change.

## Notes

- The stall only occurs on the synchronous-stylesheet path; without external stylesheet loading the document reaches `complete` normally.
- The fix is purely additive (one `defer` flush) and does not change behavior when no other transfer is in flight during the stylesheet fetch.
