### PR TITLE
perf: Skip CSSStyleProperty creation if there is no style attribute

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -864,6 +864,10 @@ const CheckVisibilityOptions = struct {
 const INLINE_PRIORITY: u64 = std.math.maxInt(u64);
 
 fn getInlineStyleProperty(el: *Element, property_name: String, frame: *Frame) ?*CSSStyleProperty {
+    if (!el.hasAttributeSafe(comptime .wrap("style"))) {
+        // cheap guard to avoid creating the CSSStyleProperty if there is no style attribute
+        return null;
+    }
     const style = el.getOrCreateStyle(frame) catch |err| {
         log.err(.browser, "StyleManager getOrCreateStyle", .{ .err = err });
         return null;


### PR DESCRIPTION
Was reviewing https://github.com/lightpanda-io/browser/pull/2836 and realized the StyleManager's getInlineStyleProperty could be optimized  to avoid creating the CSSStyleProperties in the case where there's no style attribute.