### PR TITLE
perf(css): skip inline-style allocation for elements without inline styles

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -864,9 +864,13 @@ const CheckVisibilityOptions = struct {
 const INLINE_PRIORITY: u64 = std.math.maxInt(u64);
 
 fn getInlineStyleProperty(el: *Element, property_name: String, frame: *Frame) ?*CSSStyleProperty {
-    const style = el.getOrCreateStyle(frame) catch |err| {
-        log.err(.browser, "StyleManager getOrCreateStyle", .{ .err = err });
-        return null;
+    const style = frame._element_styles.get(el) orelse blk: {
+        // No JS-set style object and no style attribute -> nothing inline to read.
+        if (el.getAttributeSafe(comptime .wrap("style")) == null) return null;
+        break :blk el.getOrCreateStyle(frame) catch |err| {
+            log.err(.browser, "StyleManager getOrCreateStyle", .{ .err = err });
+            return null;
+        };
     };
     return style.asCSSStyleDeclaration().findProperty(property_name);
 }


### PR DESCRIPTION
## What

The visibility predicate (`getInlineStyleProperty` → `getOrCreateStyle`) allocated
a `CSSStyleProperties` + `CSSStyleDeclaration` and inserted into
`frame._element_styles` for **every** element it checked — even the majority with
no inline `style=`. Every semantic-tree / interactiveElements walk visits every
element, so this materialized a style object per element and kept it for the
page's lifetime.

Now we only materialize the inline-style object when one already exists (JS-set
styles) or the element actually carries a `style=` attribute; otherwise we return
`null` without allocating. Behavior is unchanged.

## Impact

Headless, text-only — this is a **memory** win, not a CPU one. On a generated
~14k-element page, live CSS style objects held for the page lifetime:

| | Live style objects / page |
|---|---:|
| before | 11,264 |
| after | **40** |
| | **−99.6%** |

Wall-clock for the tree dump is unchanged (these allocations are cheap next to
selector matching / xpath / name computation). The point is footprint: ~11k fewer
live objects + hashmap entries per page.

## Tests

`make test` green (986/986, no leaks). Numbers from a debug build; the object
count is build-independent.
