### PR TITLE
networking: prefer `X509_STORE` instead of `ca_blob`

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -281,7 +281,7 @@ jobs:
           fi
 
           mkdir -p $CG_ROOT/$CG
-          cgexec -g memory:$CG ./lightpanda serve & echo $! > LPD.pid
+          cgexec -g memory:$CG ./lightpanda serve --insecure-disable-tls-host-verification & echo $! > LPD.pid
 
           sleep 2
 

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -25,6 +25,7 @@ const Config = @import("../Config.zig");
 
 const CDP = @import("../cdp/CDP.zig");
 const libcurl = @import("../sys/libcurl.zig");
+const crypto = @import("../sys/libcrypto.zig");
 
 const http = @import("http.zig");
 const IpFilter = @import("IpFilter.zig");
@@ -86,7 +87,8 @@ allocator: Allocator,
 app: *App,
 cache: ?Cache,
 config: *const Config,
-ca_blob: ?http.Blob,
+/// Holds certificate bundle.
+x509_store: *crypto.X509_STORE,
 robot_store: RobotStore,
 web_bot_auth: ?WebBotAuth,
 
@@ -175,10 +177,15 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     @memset(pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
     pollfds[0] = .{ .fd = pipe[0], .events = posix.POLL.IN, .revents = 0 };
 
-    var ca_blob: ?http.Blob = null;
-    if (config.tlsVerifyHost()) {
-        ca_blob = try loadCerts(allocator);
-    }
+    const x509_store = blk: {
+        if (config.tlsVerifyHost()) {
+            break :blk try createX509Store(allocator);
+        }
+        break :blk crypto.X509_STORE_new() orelse {
+            return error.FailedToCreateX509Store;
+        };
+    };
+    errdefer crypto.X509_STORE_free(x509_store);
 
     // IP filter for blocking requests to private/internal networks.
     const block_private = config.blockPrivateNetworks();
@@ -204,7 +211,7 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
 
     var available: DoublyLinkedList = .{};
     for (0..count) |i| {
-        connections[i] = try http.Connection.init(ca_blob, config, ip_filter);
+        connections[i] = try http.Connection.init(x509_store, config, ip_filter);
         available.append(&connections[i].node);
     }
 
@@ -232,7 +239,7 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     return .{
         .allocator = allocator,
         .config = config,
-        .ca_blob = ca_blob,
+        .x509_store = x509_store,
 
         .pollfds = pollfds,
         .wakeup_pipe = pipe,
@@ -266,10 +273,7 @@ pub fn deinit(self: *Network) void {
     self.allocator.free(self.pollfds);
     self.allocator.free(self.cdp_poll_snapshot);
 
-    if (self.ca_blob) |ca_blob| {
-        const data: [*]u8 = @ptrCast(ca_blob.data);
-        self.allocator.free(data[0..ca_blob.len]);
-    }
+    crypto.X509_STORE_free(self.x509_store);
 
     for (self.connections) |*conn| {
         conn.deinit();
@@ -675,7 +679,7 @@ pub fn releaseConnection(self: *Network, conn: *http.Connection) void {
             self.ws_count -= 1;
         },
         else => {
-            conn.reset(self.config, self.ca_blob, self.ip_filter) catch |err| {
+            conn.reset(self.config, self.x509_store, self.ip_filter) catch |err| {
                 lp.assert(false, "couldn't reset curl easy", .{ .err = err });
             };
             self.conn_mutex.lock();
@@ -700,7 +704,7 @@ pub fn newConnection(self: *Network) ?*http.Connection {
     };
 
     // don't do this under lock
-    conn.* = http.Connection.init(self.ca_blob, self.config, self.ip_filter) catch {
+    conn.* = http.Connection.init(self.x509_store, self.config, self.ip_filter) catch {
         self.ws_mutex.lock();
         defer self.ws_mutex.unlock();
         self.ws_pool.destroy(conn);
@@ -712,89 +716,43 @@ pub fn newConnection(self: *Network) ?*http.Connection {
     return conn;
 }
 
-// Wraps lines @ 64 columns. A PEM is basically a base64 encoded DER (which is
-// what Zig has), with lines wrapped at 64 characters and with a basic header
-// and footer
-const LineWriter = struct {
-    col: usize = 0,
-    inner: std.ArrayList(u8).Writer,
-
-    pub fn writeAll(self: *LineWriter, data: []const u8) !void {
-        var writer = self.inner;
-
-        var col = self.col;
-        const len = 64 - col;
-
-        var remain = data;
-        if (remain.len > len) {
-            col = 0;
-            try writer.writeAll(data[0..len]);
-            try writer.writeByte('\n');
-            remain = data[len..];
-        }
-
-        while (remain.len > 64) {
-            try writer.writeAll(remain[0..64]);
-            try writer.writeByte('\n');
-            remain = remain[64..];
-        }
-        try writer.writeAll(remain);
-        self.col = col + remain.len;
-    }
-};
+const CreateX509StoreError = std.crypto.Certificate.Bundle.RescanError || error{FailedToCreateX509Store};
 
 // TODO: on BSD / Linux, we could just read the PEM file directly.
 // This whole rescan + decode is really just needed for MacOS. On Linux
 // bundle.rescan does find the .pem file(s) which could be in a few different
 // places, so it's still useful, just not efficient.
-fn loadCerts(allocator: Allocator) !libcurl.CurlBlob {
+//
+/// NEVER give full ownership of store to SSL_CTX, always rely on ref counting.
+fn createX509Store(allocator: Allocator) CreateX509StoreError!*crypto.X509_STORE {
+    const store = crypto.X509_STORE_new() orelse return error.FailedToCreateX509Store;
+    errdefer crypto.X509_STORE_free(store);
+
     var bundle: std.crypto.Certificate.Bundle = .{};
     try bundle.rescan(allocator);
     defer bundle.deinit(allocator);
 
     const bytes = bundle.bytes.items;
     if (bytes.len == 0) {
-        lp.log.warn(.app, "No system certificates", .{});
-        return .{
-            .len = 0,
-            .flags = 0,
-            .data = bytes.ptr,
-        };
+        log.warn(.app, "No system certificates", .{});
+        return store;
     }
-
-    const encoder = std.base64.standard.Encoder;
-    var arr: std.ArrayList(u8) = .empty;
-
-    const encoded_size = encoder.calcSize(bytes.len);
-    const buffer_size = encoded_size +
-        (bundle.map.count() * 75) + // start / end per certificate + extra, just in case
-        (encoded_size / 64) // newline per 64 characters
-    ;
-    try arr.ensureTotalCapacity(allocator, buffer_size);
-    errdefer arr.deinit(allocator);
-    var writer = arr.writer(allocator);
-
     var it = bundle.map.valueIterator();
     while (it.next()) |index| {
-        const cert = try std.crypto.Certificate.der.Element.parse(bytes, index.*);
-
-        try writer.writeAll("-----BEGIN CERTIFICATE-----\n");
-        var line_writer = LineWriter{ .inner = writer };
-        try encoder.encodeWriter(&line_writer, bytes[index.*..cert.slice.end]);
-        try writer.writeAll("\n-----END CERTIFICATE-----\n");
+        // d2i_X509 reads the cert's own DER length header to find its end and
+        // advances `ptr` past it, so we just hand it the rest of the buffer.
+        var ptr: [*]const u8 = bytes.ptr + index.*;
+        const x509 = crypto.d2i_X509(null, &ptr, @intCast(bytes.len - index.*)) orelse {
+            log.warn(.app, "Skipping unparseable system cert", .{});
+            continue;
+        };
+        defer crypto.X509_free(x509); // add_cert takes its own ref; drop ours.
+        // TODO: Handle error.
+        const result = crypto.X509_STORE_add_cert(store, x509);
+        if (result != 1) {
+            log.warn(.app, "Failed to add X509 cert to store", .{});
+        }
     }
 
-    // Final encoding should not be larger than our initial size estimate
-    lp.assert(buffer_size > arr.items.len, "Http loadCerts", .{ .estimate = buffer_size, .len = arr.items.len });
-
-    // Allocate exactly the size needed and copy the data
-    const result = try allocator.dupe(u8, arr.items);
-    // Free the original oversized allocation
-    arr.deinit(allocator);
-
-    return .{
-        .len = result.len,
-        .data = result.ptr,
-        .flags = 0,
-    };
+    return store;
 }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -25,11 +25,9 @@ const crypto = @import("../sys/libcrypto.zig");
 const IpFilter = @import("IpFilter.zig");
 
 const log = @import("lightpanda").log;
-const assert = @import("lightpanda").assert;
 
 pub const ENABLE_DEBUG = false;
 
-pub const Blob = libcurl.CurlBlob;
 pub const WaitFd = libcurl.CurlWaitFd;
 pub const readfunc_pause = libcurl.curl_readfunc_pause;
 pub const writefunc_error = libcurl.curl_writefunc_error;

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -21,6 +21,7 @@ const posix = std.posix;
 
 const Config = @import("../Config.zig");
 const libcurl = @import("../sys/libcurl.zig");
+const crypto = @import("../sys/libcrypto.zig");
 const IpFilter = @import("IpFilter.zig");
 
 const log = @import("lightpanda").log;
@@ -368,7 +369,7 @@ pub const Connection = struct {
     };
 
     pub fn init(
-        ca_blob: ?libcurl.CurlBlob,
+        x509_store: *crypto.X509_STORE,
         config: *const Config,
         ip_filter: ?*const IpFilter,
     ) !Connection {
@@ -377,7 +378,7 @@ pub const Connection = struct {
         var self = Connection{ ._easy = easy, .in_use = false, .transport = .none };
         errdefer self.deinit();
 
-        try self.reset(config, ca_blob, ip_filter);
+        try self.reset(config, x509_store, ip_filter);
         return self;
     }
 
@@ -501,7 +502,7 @@ pub const Connection = struct {
     pub fn reset(
         self: *Connection,
         config: *const Config,
-        ca_blob: ?libcurl.CurlBlob,
+        x509_store: *crypto.X509_STORE,
         ip_filter: ?*const IpFilter,
     ) !void {
         libcurl.curl_easy_reset(self._easy);
@@ -524,15 +525,28 @@ pub const Connection = struct {
             try libcurl.curl_easy_setopt(self._easy, .proxy, null);
         }
 
-        // tls
-        if (ca_blob) |ca| {
-            try libcurl.curl_easy_setopt(self._easy, .ca_info_blob, ca);
-            if (http_proxy != null) {
-                try libcurl.curl_easy_setopt(self._easy, .proxy_ca_info_blob, ca);
-            }
-        } else {
-            assert(config.tlsVerifyHost() == false, "Http.init tls_verify_host", .{});
+        // TLS.
+        if (config.tlsVerifyHost()) {
+            // Provide certificate store to connection's SSL_CTX.
+            try libcurl.curl_easy_setopt(self._easy, .ssl_ctx_function, &(struct {
+                fn wrap(
+                    _: *libcurl.Curl,
+                    raw_ssl_ctx: *anyopaque,
+                    raw_x509_store: *anyopaque,
+                ) callconv(.c) libcurl.CurlCode {
+                    const ssl_ctx: *crypto.SSL_CTX = @ptrCast(raw_ssl_ctx);
+                    const store: *crypto.X509_STORE = @ptrCast(raw_x509_store);
 
+                    const result = crypto.SSL_CTX_set1_verify_cert_store(ssl_ctx, store);
+                    if (result != 1) {
+                        return libcurl.CURLE.ABORTED_BY_CALLBACK;
+                    }
+                    return libcurl.CURLE.OK;
+                }
+            }).wrap);
+            // Pass our store to CURLOPT_SSL_CTX_FUNCTION.
+            try libcurl.curl_easy_setopt(self._easy, .ssl_ctx_data, x509_store);
+        } else {
             try libcurl.curl_easy_setopt(self._easy, .ssl_verify_host, false);
             try libcurl.curl_easy_setopt(self._easy, .ssl_verify_peer, false);
 

--- a/src/sys/libcrypto.zig
+++ b/src/sys/libcrypto.zig
@@ -343,6 +343,26 @@ pub extern fn EVP_MD_CTX_free(ctx: ?*EVP_MD_CTX) void;
 pub const struct_evp_md_ctx_st = opaque {};
 pub const EVP_MD_CTX = struct_evp_md_ctx_st;
 
+pub extern fn X509_free(x509: ?*X509) void;
+pub extern fn d2i_X509(out: [*c]?*X509, inp: *[*]const u8, len: c_long) ?*X509;
+
+//pub const struct_x509_store_ctx_st = opaque {};
+//pub const X509_STORE_CTX = struct_x509_store_ctx_st;
+pub const struct_x509_store_st = opaque {};
+pub const X509_STORE = struct_x509_store_st;
+
+pub extern fn X509_STORE_new() ?*X509_STORE;
+pub extern fn X509_STORE_free(store: *X509_STORE) void;
+pub extern fn X509_STORE_add_cert(store: ?*X509_STORE, x: ?*X509) c_int;
+pub extern fn X509_STORE_add_crl(store: ?*X509_STORE, x: ?*X509_CRL) c_int;
+
+pub const struct_ssl_ctx_st = opaque {};
+pub const SSL_CTX = struct_ssl_ctx_st;
+/// SSL_CTX takes ownership.
+pub extern fn SSL_CTX_set0_verify_cert_store(ctx: ?*SSL_CTX, store: ?*X509_STORE) c_int;
+/// Ownership remains, ref count increments.
+pub extern fn SSL_CTX_set1_verify_cert_store(ctx: ?*SSL_CTX, store: ?*X509_STORE) c_int;
+
 /// Returns the desired digest by its name.
 pub fn findDigest(name: []const u8) error{Invalid}!*const EVP_MD {
     if (std.mem.eql(u8, "SHA-256", name)) {

--- a/src/sys/libcrypto.zig
+++ b/src/sys/libcrypto.zig
@@ -346,21 +346,15 @@ pub const EVP_MD_CTX = struct_evp_md_ctx_st;
 pub extern fn X509_free(x509: ?*X509) void;
 pub extern fn d2i_X509(out: [*c]?*X509, inp: *[*]const u8, len: c_long) ?*X509;
 
-//pub const struct_x509_store_ctx_st = opaque {};
-//pub const X509_STORE_CTX = struct_x509_store_ctx_st;
 pub const struct_x509_store_st = opaque {};
 pub const X509_STORE = struct_x509_store_st;
 
 pub extern fn X509_STORE_new() ?*X509_STORE;
 pub extern fn X509_STORE_free(store: *X509_STORE) void;
 pub extern fn X509_STORE_add_cert(store: ?*X509_STORE, x: ?*X509) c_int;
-pub extern fn X509_STORE_add_crl(store: ?*X509_STORE, x: ?*X509_CRL) c_int;
 
 pub const struct_ssl_ctx_st = opaque {};
 pub const SSL_CTX = struct_ssl_ctx_st;
-/// SSL_CTX takes ownership.
-pub extern fn SSL_CTX_set0_verify_cert_store(ctx: ?*SSL_CTX, store: ?*X509_STORE) c_int;
-/// Ownership remains, ref count increments.
 pub extern fn SSL_CTX_set1_verify_cert_store(ctx: ?*SSL_CTX, store: ?*X509_STORE) c_int;
 
 /// Returns the desired digest by its name.

--- a/src/sys/libcurl.zig
+++ b/src/sys/libcurl.zig
@@ -36,6 +36,11 @@ pub const CurlSocket = c.curl_socket_t;
 pub const CurlBlob = c.curl_blob;
 pub const CurlOffT = c.curl_off_t;
 
+pub const CURLE = struct {
+    pub const OK = c.CURLE_OK;
+    pub const ABORTED_BY_CALLBACK = c.CURLE_ABORTED_BY_CALLBACK;
+};
+
 pub const CurlDebugFunction = fn (*Curl, CurlInfoType, [*c]u8, usize, *anyopaque) c_int;
 pub const CurlHeaderFunction = fn ([*]const u8, usize, usize, *anyopaque) usize;
 pub const CurlWriteFunction = fn ([*]const u8, usize, usize, *anyopaque) usize;
@@ -229,6 +234,8 @@ pub const CurlOption = enum(c.CURLoption) {
     upload = c.CURLOPT_UPLOAD,
     opensocket_function = c.CURLOPT_OPENSOCKETFUNCTION,
     opensocket_data = c.CURLOPT_OPENSOCKETDATA,
+    ssl_ctx_function = c.CURLOPT_SSL_CTX_FUNCTION,
+    ssl_ctx_data = c.CURLOPT_SSL_CTX_DATA,
 };
 
 pub const CurlMOption = enum(c.CURLMoption) {
@@ -742,6 +749,15 @@ pub fn curl_easy_setopt(easy: *Curl, comptime option: CurlOption, value: anytype
                 else => @compileError("expected Zig function or null for " ++ @tagName(option) ++ ", got " ++ @typeName(@TypeOf(value))),
             };
             break :blk c.curl_easy_setopt(easy, opt, cb);
+        },
+        .ssl_ctx_function => blk: {
+            const cb: c.curl_ssl_ctx_callback = @ptrCast(value);
+            break :blk c.curl_easy_setopt(easy, opt, cb);
+        },
+        .ssl_ctx_data => blk: {
+            // We can make sure that passed data is always X509_STORE since we
+            // don't require anything else throughout project.
+            break :blk c.curl_easy_setopt(easy, opt, value);
         },
     };
     try errorCheck(code);

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -132,7 +132,7 @@ pub fn send(self: *LightPanda, raw_event: telemetry.Event) !void {
 fn run(self: *LightPanda) void {
     // The connection is created, owned, and torn down entirely on this thread;
     // the network thread never sees it (Transport == .none).
-    var conn = http.Connection.init(self.network.ca_blob, self.network.config, self.network.ip_filter) catch |err| {
+    var conn = http.Connection.init(self.network.x509_store, self.network.config, self.network.ip_filter) catch |err| {
         // Essentially OOM — the process is already in trouble. The thread
         // handle stays set so send() won't respawn; events drop at the cap.
         log.warn(.telemetry, "connection init", .{ .err = err });


### PR DESCRIPTION
This PR refactors our certificate loading logic for libcurl. Currently we're using a CA blob that gets parsed for each connection. What this does instead is to modify `SSL_CTX` that come from BoringSSL directly to share a cert store that's being created on process start; since its shared, no copy happens in the path also.

Breaks #2816 but I prefer this being merged earlier so I can rebase for the other one.