### PR TITLE
webapi, fix: don't strip leading BOM for non-document parsing

### DIFF
--- a/src/browser/tests/element/inner.html
+++ b/src/browser/tests/element/inner.html
@@ -240,3 +240,20 @@
   testing.expectEqual('a<b>bold</b>', d1.innerHTML);
   testing.expectEqual('B', d1.lastChild.tagName);
 </script>
+
+<script id=leadingBOM>
+  // A leading U+FEFF (BOM / ZWNBSP) is only stripped from a document's input
+  // stream, never from a parsed fragment. innerHTML must preserve it, otherwise
+  // round-tripped markup (e.g. React hydrating BOM-prefixed CMS strings) breaks.
+  // Uses the \uFEFF escape rather than a raw BOM byte so the assertion does not
+  // depend on this file's charset.
+  const el = document.createElement('div');
+  el.innerHTML = '\uFEFFabc';
+  testing.expectEqual(4, el.textContent.length);
+  testing.expectEqual(0xFEFF, el.textContent.charCodeAt(0));
+  testing.expectEqual('\uFEFFabc', el.textContent);
+
+  // An interior BOM is likewise preserved.
+  el.innerHTML = 'x\uFEFFy';
+  testing.expectEqual('x\uFEFFy', el.textContent);
+</script>

--- a/src/html5ever/lib.rs
+++ b/src/html5ever/lib.rs
@@ -526,9 +526,20 @@ pub extern "C" fn html5ever_parse_fragment(
         }
     };
 
+    // Only a document's input stream may have a single leading U+FEFF BOM
+    // stripped; fragment parsing (innerHTML, setHTMLUnsafe, etc.) must preserve
+    // a leading U+FEFF as a ZWNBSP.
+    let opts = ParseOpts {
+        tokenizer: html5ever::tokenizer::TokenizerOpts {
+            discard_bom: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
     parse_fragment(
         sink,
-        Default::default(),
+        opts,
         QualName::new(None, ns!(html), context_local),
         vec![], // attributes
         false,  // context_element_allows_scripting


### PR DESCRIPTION
On for the main document parsing should a leading BOM be stripped. When setting innerHTML, it should be preserved (and becomes a text node).

Fixes react hydration issue with theverge.com