### PR TITLE
Always clear buffered events on `firePartial`

### DIFF
--- a/src/network/layer/DeferringLayer.zig
+++ b/src/network/layer/DeferringLayer.zig
@@ -324,6 +324,7 @@ const DeferredContext = struct {
     fn firePartial(self: *DeferredContext) void {
         const stable_response = self.stable_resp orelse @panic("stable_resp must be set for any of the partial fire events");
         const response = Response.fromStable(&stable_response);
+        defer self.buffered.clearRetainingCapacity();
 
         for (self.buffered.items) |event| {
             switch (event) {
@@ -355,7 +356,5 @@ const DeferredContext = struct {
                 .done, .err => @panic("firePartial cant fire terminal events"),
             }
         }
-
-        self.buffered.clearRetainingCapacity();
     }
 };


### PR DESCRIPTION
This makes it so that the buffered events in the `DeferredLayer` will be cleared even on a `firePartial` that ends up forwarding an error. Previously, these events would remain buffered if the loop did not properly succeed.