### PR TITLE
v8: When re-using window, detach from original context first

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.4.9'
+    default: 'v0.5.0'
   v8:
     description: 'v8 version to install'
     required: false

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig-v8 release tag the prebuilt lib came from'
     required: false
-    default: 'v0.4.9'
+    default: 'v0.5.0'
 
 runs:
   using: "composite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.9.207.35
-ARG ZIG_V8=v0.4.9
+ARG ZIG_V8=v0.5.0
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.4.9.tar.gz",
-            .hash = "v8-0.0.0-xddH63jnAgB8guO5jPzJD4pnX-CI5od-g4v-fIIjmQXr",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/refs/tags/v0.5.0.tar.gz",
+            .hash = "v8-0.0.0-xddH613pAgDFIxC9Xq1zCPVj2n-8Dxsm-TVMfSRVzq6Z",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -660,6 +660,7 @@ fn _processFrameNavigation(self: *Session, frame: *Frame, qn: *QueuedNavigation)
     const frame_id = frame._frame_id;
     const reuse_window = frame.window;
     const page = frame._page;
+    frame.js.detachGlobal();
     frame.deinit();
     frame.* = undefined;
 
@@ -705,6 +706,7 @@ fn processPopupNavigation(_: *Session, frame: *Frame, qn: *QueuedNavigation) !vo
     const frame_id = frame._frame_id;
     const page = frame._page;
 
+    frame.js.detachGlobal();
     frame.deinit();
     frame.* = undefined;
 

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -229,6 +229,24 @@ pub fn deinit(self: *Context) void {
     v8.v8__MicrotaskQueue__DELETE(self.microtask_queue);
 }
 
+// The global (e.g. Window) can be reused across contexts. If you do:
+//
+// var w = iframe.contentWindow;
+// iframe.src = 'two.html';
+// w === iframe.contentWindow  (must be true)
+//
+// so when we navigate, the Window/Global is re-used. That's fine with v8, but
+// we need to explicitly detach it from the original before we can safely attach
+// it to the new
+pub fn detachGlobal(self: *Context) void {
+    var hs: js.HandleScope = undefined;
+    hs.init(self.isolate);
+    defer hs.deinit();
+
+    const local_v8_context: *const v8.Context = @ptrCast(v8.v8__Global__Get(&self.handle, self.isolate.handle));
+    v8.v8__Context__DetachGlobal(local_v8_context);
+}
+
 // setOrigin is called at navigation (opaque -> real origin) and again when a
 // script sets document.domain (real origin -> '!'-marked effective domain).
 pub fn setOrigin(self: *Context, key: ?[]const u8) !void {


### PR DESCRIPTION
Depends on: https://github.com/lightpanda-io/zig-v8-fork/pull/185

Fixes a WPT DCHECK crash in /html/browsers/the-window-object/named-access-on-the-window-object/navigated-named-objects.window.html

https://github.com/lightpanda-io/browser/pull/2742 added the re-use of the global (window) when an iframe or popup is re-navigated. This is fine with v8, but we need to detach it from the origin first.