### PR TITLE
frame: emit networkIdle lifecycle events for child frames

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2188,6 +2188,27 @@ pub fn scheduleCustomElementBackupDrain(self: *Frame) !void {
     try self.js.queueCustomElementBackupDrain();
 }
 
+// Run the network-idle notification checks for this frame and, recursively,
+// its child frames. CDP clients (e.g. puppeteer's networkidle0) expect the
+// networkIdle/networkAlmostIdle lifecycle events on every frame, like Chrome
+// emits them, not just on the root frame.
+pub fn checkIdleNotifications(self: *Frame, total_http_activity: usize) void {
+    switch (self._parse_state) {
+        .html, .complete => {
+            if (self._notified_network_almost_idle.check(total_http_activity <= 2)) {
+                self.notifyNetworkAlmostIdle();
+            }
+            if (self._notified_network_idle.check(total_http_activity == 0)) {
+                self.notifyNetworkIdle();
+            }
+        },
+        else => {},
+    }
+    for (self.child_frames.items) |child| {
+        child.checkIdleNotifications(total_http_activity);
+    }
+}
+
 pub fn notifyNetworkIdle(self: *Frame) void {
     lp.assert(self._notified_network_idle == .done, "Frame.notifyNetworkIdle", .{});
     self._session.notification.dispatch(.frame_network_idle, &.{

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -263,12 +263,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
                 }
             },
             .html, .complete => {
-                if (frame._notified_network_almost_idle.check(total_http_activity <= 2)) {
-                    frame.notifyNetworkAlmostIdle();
-                }
-                if (frame._notified_network_idle.check(total_http_activity == 0)) {
-                    frame.notifyNetworkIdle();
-                }
+                frame.checkIdleNotifications(total_http_activity);
 
                 const met = switch (condition.until) {
                     .done => is_done,
@@ -472,4 +467,28 @@ test "Runner: waitForScript" {
 
     var runner = page.session.runner(.{});
     try runner.waitForScript(page.frame_id, "document.querySelector('#sel1')", 10);
+}
+
+test "Runner: networkidle notifies child frames" {
+    const page = try testing.pageTest("runner/iframe_idle.html", .{});
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    const frame = page.frame().?;
+    try testing.expectEqual(2, frame.child_frames.items.len);
+
+    // A `.networkidle` wait resolves via `is_done` once the page is fully
+    // idle, which can happen before the 500ms idle-notification hold. Keep
+    // ticking (like the CDP serve loop does) until the notifications fire.
+    var attempts: usize = 0;
+    while (frame._notified_network_idle != .done and attempts < 50) : (attempts += 1) {
+        _ = try runner.tickForFrame(page.frame_id, 20, .{ .until = .networkidle });
+        std.Thread.sleep(25 * std.time.ns_per_ms);
+    }
+
+    try testing.expectEqual(true, frame._notified_network_idle == .done);
+    for (frame.child_frames.items) |child| {
+        try testing.expectEqual(true, child._notified_network_almost_idle == .done);
+        try testing.expectEqual(true, child._notified_network_idle == .done);
+    }
 }

--- a/src/browser/tests/runner/iframe_idle.html
+++ b/src/browser/tests/runner/iframe_idle.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<iframe src="about:blank"></iframe>
+<iframe src="runner1.html"></iframe>


### PR DESCRIPTION
Puppeteer's networkidle0 requires the networkIdle/networkAlmostIdle lifecycle events on every frame that started loading, like Chrome emits them — not just the root frame. Run the idle-notification checks recursively over the frame tree in Runner._tick.

Fixes goto({waitUntil: 'networkidle0'}) timing out on pages with iframes (e.g. reddit.com post pages).