### PR TITLE
Fix charset=unicode HTML prescan fallback

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1340,6 +1340,10 @@ fn urlBasename(arena: Allocator, url: []const u8) !?[]const u8 {
     return try arena.dupe(u8, name);
 }
 
+fn isUtf16Encoding(charset: []const u8) bool {
+    return std.mem.eql(u8, charset, "UTF-16LE") or std.mem.eql(u8, charset, "UTF-16BE");
+}
+
 fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
     var self: *Frame = @ptrCast(@alignCast(response.ctx));
 
@@ -1355,8 +1359,10 @@ fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
 
         // If the HTTP Content-Type header didn't specify a charset and this is HTML,
         // prescan the first 1024 bytes for a <meta charset> declaration.
+        var html_prescan_found_charset = false;
         if (mime.content_type == .text_html and mime.is_default_charset) {
             if (Mime.prescanCharset(data)) |charset| {
+                html_prescan_found_charset = true;
                 if (charset.len <= 40) {
                     @memcpy(mime.charset[0..charset.len], charset);
                     mime.charset[charset.len] = 0;
@@ -1380,7 +1386,8 @@ fn frameDataCallback(response: HttpClient.Response, data: []const u8) !void {
                 const charset_str = mime.charsetString();
                 const info = h5e.encoding_for_label(charset_str.ptr, charset_str.len);
                 if (info.isValid()) {
-                    self.charset = info.name();
+                    const name = info.name();
+                    self.charset = if (html_prescan_found_charset and isUtf16Encoding(name)) "UTF-8" else name;
                 }
                 self._parse_state = .{ .html = .{
                     .buffer = .empty,

--- a/src/browser/tests/page/encoding.html
+++ b/src/browser/tests/page/encoding.html
@@ -69,6 +69,30 @@
   }
 </script>
 
+<script id="unicode_label_falls_back_to_utf8" type=module>
+  {
+    const state = await testing.async();
+
+    // The legacy "unicode" label maps to UTF-16LE, but HTML prescan maps
+    // UTF-16 labels back to UTF-8 so ASCII pages stay readable.
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.src = 'encoding/unicode_label.html';
+    iframe.onload = () => { state.resolve(); }
+
+    await state.done(() => {
+      testing.expectEqual('Hello world', iframe.contentDocument.getElementById('title').textContent);
+      testing.expectEqual(
+        'This page is plain ASCII but declares charset=unicode.',
+        iframe.contentDocument.getElementById('body').textContent,
+      );
+      testing.expectEqual('UTF-8', iframe.contentDocument.characterSet);
+      testing.expectEqual('UTF-8', iframe.contentDocument.charset);
+      testing.expectEqual('UTF-8', iframe.contentDocument.inputEncoding);
+    });
+  }
+</script>
+
 <script id="no_charset_fallback" type=module>
   {
     const state = await testing.async();

--- a/src/browser/tests/page/encoding/unicode_label.html
+++ b/src/browser/tests/page/encoding/unicode_label.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<META http-equiv=Content-Type content="text/html; charset=unicode">
+<title>Hello</title>
+<h1 id="title">Hello world</h1>
+<p id="body">This page is plain ASCII but declares charset=unicode.</p>


### PR DESCRIPTION
## Summary
- Treat UTF-16 canonical labels discovered by HTML meta prescan as UTF-8.
- Add a regression fixture for an ASCII page that declares legacy `charset=unicode`.

## Why
Fixes #2856.

Before this change, a document-level `charset=unicode` declaration could canonicalize to UTF-16LE and make plain ASCII HTML parse as mojibake. This keeps the fallback scoped to charset labels discovered in the document prescan path; HTTP `Content-Type` charset handling is unchanged.

## Tests
- `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk DEVELOPER_DIR=/Library/Developer/CommandLineTools MACOSX_DEPLOYMENT_TARGET=15.0 mise x zig@0.15.2 -- make test F="WebApi: Frame#encoding.html"` - pass, `2 of 2 tests passed`
- `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk DEVELOPER_DIR=/Library/Developer/CommandLineTools MACOSX_DEPLOYMENT_TARGET=15.0 mise x zig@0.15.2 -- zig fmt --check ./*.zig ./**/*.zig` - pass
- `git diff --check` - pass

## Scope
- Narrowly changes HTML meta charset prescan handling.
- Adds focused page encoding regression coverage.
- Non-goals: broad encoding detector/rewrite, changed HTTP header charset behavior, unrelated parser/network changes.

## Caveats
- Full `make test` was not run.
- Local Zig 0.15.2 failed to link the build runner against the default macOS 26 SDK; the focused proof used the installed macOS 15.4 Command Line Tools SDK.
