### PR TITLE
perf: Increase default max connections

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -353,14 +353,14 @@ pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
 
 pub fn httpMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse 10,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
         else => unreachable,
     };
 }
 
 pub fn httpMaxHostOpen(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse 4,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
         else => unreachable,
     };
 }

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -162,7 +162,7 @@ const script_skill =
     \\   await Promise.all(pages.map((p, i) => p.goto(items[i].url)));   // all in flight at once
     \\   return pages.map((p, i) => ({ ...items[i], ...p.extract({ /* schema */ }) }));
     \\   ```
-    \\   - Concurrency is bounded by the HTTP connection pool (10 by default, `--http-max-concurrent`); extra navigations queue rather than fail. For long lists, fan out in batches and `page.close()` each page once read so its memory is reclaimed.
+    \\   - Concurrency is bounded by the HTTP connection pool (40 by default, `--http-max-concurrent`); extra navigations queue rather than fail. For long lists, fan out in batches and `page.close()` each page once read so its memory is reclaimed.
     \\   - `Promise.all` rejects the whole batch if any `goto` *fails* (a timeout does not reject); use `Promise.allSettled` when partial results are fine.
     \\   - Walk **serially** on one page (`for (const it of items) { await page.goto(it.url); … }`) only when the steps depend on each other — each page decides the next URL, or they share login/session state.
     \\3. **`evaluate` is a last resort, not a reading tool.** A `querySelectorAll`-and-parse `page.evaluate` block is always wrong: lift the raw strings with `page.extract`, then trim/split/parse them in top-level JS. Reserve `page.evaluate` for behavior that must run inside the page and no builtin covers — and remember its state dies on every navigation/reload, while script variables persist.

--- a/src/help.zon
+++ b/src/help.zon
@@ -307,10 +307,10 @@
     \\          Proxy-Authorization: Bearer <token>.
     \\  --http-max-concurrent <INT>
     \\          Maximum number of concurrent HTTP requests.
-    \\          Defaults to 10.
+    \\          Defaults to 40.
     \\  --http-max-host-open <INT>
     \\          Maximum open connections to a given host:port.
-    \\          Defaults to 4.
+    \\          Defaults to 6.
     \\  --http-connect-timeout <INT>
     \\          Time in ms to establish an HTTP connection before timing out. 0 means
     \\          never.


### PR DESCRIPTION
max http connections 10 -> 40
max http connetions per host 4 -> 6

These are just the defaults and can still be adjusted by the command line arguments. 6 appears to be both Chrome and FireFox's default per host (which is probably the more important of the two settings).

The limits are really use-case specific. A use case that it multi-threading different domains can benefit from a conservative max-host with a very large max conn. A use case that is multi-threading the same host will need to decide if it's safe to raise max-host.