### PR TITLE
webapi: implement HTMLScriptElement.supports and DOMTokenList.supports

### DIFF
--- a/src/browser/tests/element/html/script/supports.html
+++ b/src/browser/tests/element/html/script/supports.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../../../testing.js"></script>
+
+<script id=supports>
+{
+  testing.expectEqual(true, HTMLScriptElement.supports('classic'));
+  testing.expectEqual(true, HTMLScriptElement.supports('module'));
+  testing.expectEqual(true, HTMLScriptElement.supports('importmap'));
+  testing.expectEqual(false, HTMLScriptElement.supports('speculationrules'));
+  testing.expectEqual(false, HTMLScriptElement.supports('Module'));
+}
+</script>

--- a/src/browser/tests/element/rel_list.html
+++ b/src/browser/tests/element/rel_list.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<link id=l1 rel="stylesheet" href="data:text/css,">
+<div id=d1 class="foo"></div>
+
+<script id=supports>
+{
+  const rl = $('#l1').relList;
+  testing.expectEqual(true, rl.supports('modulepreload'));
+  testing.expectEqual(true, rl.supports('MODULEPRELOAD'));
+  testing.expectEqual(true, rl.supports('preload'));
+  testing.expectEqual(true, rl.supports('stylesheet'));
+  testing.expectEqual(false, rl.supports('prefetch'));
+}
+</script>
+
+<script id=supports_undefined_tokens>
+{
+  // classList's backing attribute defines no supported tokens.
+  testing.expectError('TypeError', () => $('#d1').classList.supports('foo'));
+}
+</script>

--- a/src/browser/webapi/collections/DOMTokenList.zig
+++ b/src/browser/webapi/collections/DOMTokenList.zig
@@ -69,6 +69,22 @@ pub fn item(self: *const DOMTokenList, index: usize, frame: *Frame) !?[]const u8
     return null;
 }
 
+/// https://dom.spec.whatwg.org/#dom-domtokenlist-supports
+/// Only `rel` defines supported tokens here; per spec every other backing
+/// attribute throws. Loaders probe `relList.supports("modulepreload")` and
+/// fall back to fetch()-based legacy loading when it fails.
+pub fn supports(self: *const DOMTokenList, token: []const u8, frame: *Frame) !bool {
+    if (!std.ascii.eqlIgnoreCase(self._attribute_name.str(), "rel")) {
+        return error.TypeError;
+    }
+    const supported = [_][]const u8{ "stylesheet", "preload", "modulepreload" };
+    const lower = try std.ascii.allocLowerString(frame.call_arena, token);
+    for (supported) |s| {
+        if (std.mem.eql(u8, lower, s)) return true;
+    }
+    return false;
+}
+
 pub fn contains(self: *const DOMTokenList, search: []const u8) !bool {
     var it = std.mem.tokenizeAny(u8, self.getValue(), WHITESPACE);
     while (it.next()) |token| {
@@ -310,6 +326,7 @@ pub const JsApi = struct {
     }
 
     pub const contains = bridge.function(DOMTokenList.contains, .{ .dom_exception = true });
+    pub const supports = bridge.function(DOMTokenList.supports, .{ .dom_exception = true });
     pub const add = bridge.function(DOMTokenList.add, .{ .dom_exception = true, .ce_reactions = true });
     pub const remove = bridge.function(DOMTokenList.remove, .{ .dom_exception = true, .ce_reactions = true });
     pub const toggle = bridge.function(DOMTokenList.toggle, .{ .dom_exception = true, .ce_reactions = true });

--- a/src/browser/webapi/collections/DOMTokenList.zig
+++ b/src/browser/webapi/collections/DOMTokenList.zig
@@ -78,7 +78,7 @@ pub fn supports(self: *const DOMTokenList, token: []const u8, frame: *Frame) !bo
         return error.TypeError;
     }
     const supported = [_][]const u8{ "stylesheet", "preload", "modulepreload" };
-    const lower = try std.ascii.allocLowerString(frame.call_arena, token);
+    const lower = try std.ascii.allocLowerString(frame.local_arena, token);
     for (supported) |s| {
         if (std.mem.eql(u8, lower, s)) return true;
     }

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -115,6 +115,17 @@ pub fn setInnerText(self: *Script, text: []const u8, frame: *Frame) !void {
     try self.asNode().setTextContent(text, frame);
 }
 
+/// https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports
+/// Only the types this engine actually loads; loaders feature-detect module
+/// support here and fall back to fetch()-based legacy loading when it fails.
+pub fn supports(value: []const u8) bool {
+    const supported = [_][]const u8{ "classic", "module", "importmap" };
+    for (supported) |s| {
+        if (std.mem.eql(u8, value, s)) return true;
+    }
+    return false;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Script);
 
@@ -131,6 +142,7 @@ pub const JsApi = struct {
     pub const nonce = bridge.accessor(Script.getNonce, Script.setNonce, .{ .ce_reactions = true });
     pub const charset = bridge.accessor(Script.getCharset, Script.setCharset, .{ .ce_reactions = true });
     pub const noModule = bridge.accessor(Script.getNoModule, null, .{});
+    pub const supports = bridge.function(Script.supports, .{ .static = true });
     pub const innerText = bridge.accessor(_innerText, Script.setInnerText, .{ .ce_reactions = true });
     fn _innerText(self: *Script, frame: *const Frame) ![]const u8 {
         var buf = std.Io.Writer.Allocating.init(frame.call_arena);


### PR DESCRIPTION
Found while investigating why lightpanda lost a retail-scraping benchmark to headless Chrome by ~40% on allbirds.com (Shopify, Vue theme) — full evidence chain in the benchmarks repo (`pandascript-vs-cdp/RETAIL-INVESTIGATION.md`).

## What's missing and why it matters

Module loaders feature-detect `HTMLScriptElement.supports("module")` and `link.relList.supports("modulepreload")` (Vite legacy-plugin pattern; Shopify themes). Both throw in lightpanda today, so themes take their **legacy `fetch()`-based chunk loader** path:

- **676 requests instead of 305** for two page loads (HAR-verified) — the same module (`vue.esm-bundler.js`) fetched **9× per page** by page JS. lightpanda's own module map dedupes correctly; the waste is entirely the theme's fallback loader.
- Measured wall-clock: closes ~40% of the Chrome gap on its own (Chrome-anchored A/B, 8 round-robin rotations against the live site). Combined with `--http-cache-dir`, lightpanda reaches Chrome parity (1.03×).
- **Eliminated a ~4% CDP driver flake**: the legacy path replaces the document mid-flight, invalidating driver node handles (`DOM.resolveNode` → `UnknownNode`; Playwright: "Unable to adopt element handle from a different document"). Without this change the flake reproduces within ~3 loop iterations; with it, 0 failures in 50 runs.

## Implementation

- `HTMLScriptElement.supports` (static): true for the types this engine loads — `classic`, `module`, `importmap`; false otherwise (incl. `speculationrules`, which we don't implement). https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports
- `DOMTokenList.supports`: the `rel` supported-tokens set (`stylesheet`, `preload`, `modulepreload`, ASCII case-insensitive); throws `TypeError` for backing attributes that define no supported tokens (e.g. `classList`). https://dom.spec.whatwg.org/#dom-domtokenlist-supports

Tests: `element/rel_list.html`, `element/html/script/supports.html`. Full suite 999/999.