### PR TITLE
ci: publish agent-regression results to slack, run nightly

### DIFF
--- a/.github/workflows/agent-regression.yml
+++ b/.github/workflows/agent-regression.yml
@@ -1,6 +1,10 @@
 name: agent-regression
 
 on:
+  schedule:
+    # Offset from wpt's 02:21 nightly.
+    - cron: "37 3 * * *"
+
   workflow_dispatch:
     inputs:
       model:
@@ -57,6 +61,8 @@ jobs:
       - run: chmod a+x bin/lightpanda
 
       - name: run agent regression suite (deterministic + live)
+        # Explicit bash gets pipefail, so tee doesn't mask the suite's exit code.
+        shell: bash
         env:
           LPD_PATH: ${{ github.workspace }}/bin/lightpanda
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -64,4 +70,27 @@ jobs:
           # Optional: news.ycombinator.com often blocks datacenter IPs. Reuse
           # the residential proxy secret if present; empty is fine locally.
           LP_HTTP_PROXY: ${{ secrets.MASSIVE_PROXY_RESIDENTIAL_US }}
-        run: ./agent/run.sh all
+        run: ./agent/run.sh all 2>&1 | tee result.log
+
+      # run.sh colors its output unconditionally; strip the ANSI codes for
+      # Slack (the Actions log above keeps them).
+      - name: prepare slack log
+        id: log
+        if: ${{ !cancelled() }}
+        run: |
+          sed 's/\x1b\[[0-9;]*m//g' result.log > slack.log 2>/dev/null \
+            || echo "suite produced no output (earlier step failed)" > slack.log
+          echo "summary=$(grep -o 'SUMMARY: .*' slack.log | tail -1)" >> "$GITHUB_OUTPUT"
+
+      - name: Send result to slack
+        if: ${{ !cancelled() }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          errors: true
+          method: files.uploadV2
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel_id: ${{ vars.AGENT_SLACK_CHANNEL_ID }}
+            initial_comment: "Agent regression — ${{ steps.log.outputs.summary || 'no summary (suite crashed?)' }}"
+            file: "./slack.log"
+            filename: "agent-regression-${{ github.sha }}.txt"


### PR DESCRIPTION
## What

Adds Slack publishing to the `agent-regression` workflow, mirroring the pattern already used by `wpt.yml` and `e2e-integration-test.yml`, and makes the suite actually nightly (the workflow's comments already called it "the nightly suite", but it was dispatch-only).

- **Nightly cron** `37 3 * * *` (offset from wpt's 02:21); `workflow_dispatch` with the `model` input stays for manual runs. On schedule runs the model input is empty, which `agent/run.sh` treats as the suite default.
- The suite step tees its output to `result.log` under an explicit `shell: bash` so pipefail keeps a failing suite failing the job.
- A prep step strips the ANSI colors `run.sh` emits (the Actions log keeps them) and extracts the final `SUMMARY: N passed, M failed` line.
- The Slack step uploads the log to **#ci-agent** (`AGENT_SLACK_CHANNEL_ID`, already set) via `CI_SLACK_BOT_TOKEN` / `files.uploadV2`, with the summary as the comment. Both post-steps run on `!cancelled()` so failures are reported too.

## Setup already done

- `AGENT_SLACK_CHANNEL_ID` repo variable set to the #ci-agent channel.
- The CI bot invited to #ci-agent (`files.uploadV2` fails with `not_in_channel` otherwise).

## Verification

- YAML parses; sed/grep pipeline smoke-tested locally against a captured colored log (strip + summary extraction + missing-log fallback).
- End-to-end needs the file on the default branch: after merge, `gh workflow run agent-regression.yml` and check #ci-agent.
