### PR TITLE
fetch: honor redirect option (manual and error modes)

### DIFF
--- a/src/browser/HttpClient.zig
+++ b/src/browser/HttpClient.zig
@@ -1121,28 +1121,39 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     if (effective_err == null) {
         const status = try msg.conn.getResponseCode();
         if (isRedirectStatus(status)) {
-            if (msg.conn.getResponseHeader("location", 0)) |location| {
-                try transfer.handleRedirect(location.value);
+            if (msg.conn.getResponseHeader("location", 0)) |location| switch (transfer.req.redirect) {
+                .follow => {
+                    try transfer.handleRedirect(location.value);
 
-                const conn = transfer._conn.?;
+                    const conn = transfer._conn.?;
 
-                try self.handles.remove(conn);
-                conn.debug_removed = 3;
-                // Conn temporarily out of multi during reconfigure.
-                // _detached_conn lets processMessages release it if any of
-                // the steps below throw. State stays .inflight; _conn stays set
-                transfer._detached_conn = conn;
+                    try self.handles.remove(conn);
+                    conn.debug_removed = 3;
+                    // Conn temporarily out of multi during reconfigure.
+                    // _detached_conn lets processMessages release it if any of
+                    // the steps below throw. State stays .inflight; _conn stays set
+                    transfer._detached_conn = conn;
 
-                transfer.reset();
-                try transfer.configureConn(conn);
-                try self.handles.add(conn);
-                conn.debug_added = 2;
-                transfer._detached_conn = null;
+                    transfer.reset();
+                    try transfer.configureConn(conn);
+                    try self.handles.add(conn);
+                    conn.debug_added = 2;
+                    transfer._detached_conn = null;
 
-                _ = try self.perform(0);
+                    _ = try self.perform(0);
 
-                return false;
-            }
+                    return false;
+                },
+                // error_callback surfaces this as a TypeError.
+                .@"error" => {
+                    transfer.state = .completing;
+                    transfer.requestFailed(error.RedirectNotAllowed, true);
+                    return true;
+                },
+                // Don't follow; fall through to deliver the 3xx as the final
+                // response, which the fetch layer turns into an opaque redirect.
+                .manual => {},
+            };
         }
     }
 
@@ -1356,6 +1367,10 @@ pub const Request = struct {
         }
     };
 
+    // Fetch request redirect mode. `.follow` keeps navigations, XHR and
+    // internal requests transparently following redirects.
+    pub const RedirectMode = enum { follow, manual, @"error" };
+
     frame_id: u32,
     loader_id: u32,
     method: Method,
@@ -1365,6 +1380,7 @@ pub const Request = struct {
     cookie_jar: ?*CookieJar,
     cookie_origin: [:0]const u8,
     resource_type: ResourceType,
+    redirect: RedirectMode = .follow,
     credentials: ?[:0]const u8 = null,
     notification: *Notification,
     timeout_ms: u32 = 0,

--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -85,6 +85,40 @@
   }
 </script>
 
+<script id=fetch_redirect_manual type=module>
+  {
+    const state = await testing.async();
+    const response = await fetch('http://127.0.0.1:9582/xhr/redirect', { redirect: 'manual' });
+    const text = await response.text();
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(0, response.status);
+      testing.expectEqual('opaqueredirect', response.type);
+      testing.expectEqual(false, response.redirected);
+      testing.expectEqual('', response.url);
+      testing.expectEqual('', text);
+    });
+  }
+</script>
+
+<script id=fetch_redirect_error type=module>
+  {
+    const state = await testing.async();
+    let rejected = false;
+    try {
+      await fetch('http://127.0.0.1:9582/xhr/redirect', { redirect: 'error' });
+    } catch (e) {
+      rejected = e instanceof TypeError;
+    }
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(true, rejected);
+    });
+  }
+</script>
+
 <script id=fetch_404 type=module>
   {
     const state = await testing.async();

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -41,6 +41,7 @@ _response: *Response,
 _resolver: js.PromiseResolver.Global,
 _owns_response: bool,
 _signal: ?*AbortSignal,
+_manual_redirect: bool,
 
 pub const Input = Request.Input;
 pub const InitOpts = Request.InitOpts;
@@ -74,6 +75,7 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         ._response = response,
         ._owns_response = true,
         ._signal = request._signal,
+        ._manual_redirect = request._redirect == .manual,
     };
 
     const session = exec.session;
@@ -110,6 +112,11 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         .resource_type = .fetch,
         .cookie_jar = cookie_jar,
         .cookie_origin = exec.url.*,
+        .redirect = switch (request._redirect) {
+            .follow => .follow,
+            .manual => .manual,
+            .@"error" => .@"error",
+        },
         .notification = session.notification,
         .start_callback = httpStartCallback,
         .header_callback = httpHeaderDoneCallback,
@@ -157,6 +164,17 @@ fn httpHeaderDoneCallback(response: HttpClient.Response) !HttpClient.HeaderResul
     res._status_text = std.http.Status.phrase(@enumFromInt(response.status().?)) orelse "";
     res._url = try arena.dupeZ(u8, response.url());
     res._is_redirected = response.redirectCount().? > 0;
+
+    // redirect: "manual" surfaces the unfollowed 3xx as an opaque-redirect
+    // filtered response: status 0, no headers, no body.
+    if (self._manual_redirect and HttpClient.isRedirectStatus(res._status)) {
+        res._status = 0;
+        res._status_text = "";
+        res._url = "";
+        res._type = .opaqueredirect;
+        res._is_redirected = false;
+        return .proceed;
+    }
 
     // Determine response type based on origin comparison
     const exec = self._exec;

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -41,6 +41,7 @@ _body: ?[]const u8,
 _arena: Allocator,
 _cache: Cache,
 _credentials: Credentials,
+_redirect: Redirect,
 _signal: ?*AbortSignal,
 _body_used: bool = false,
 
@@ -55,11 +56,19 @@ pub const InitOpts = struct {
     body: ?BodyInit = null,
     cache: Cache = .default,
     credentials: Credentials = .@"same-origin",
+    redirect: Redirect = .follow,
     signal: ?*AbortSignal = null,
     priority: ?[]const u8 = null,
 };
 
 const Priority = enum { high, low, auto };
+
+const Redirect = enum {
+    follow,
+    manual,
+    @"error",
+    pub const js_enum_from_string = true;
+};
 
 const Credentials = enum {
     omit,
@@ -138,6 +147,7 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         ._headers = headers,
         ._cache = opts.cache,
         ._credentials = opts.credentials,
+        ._redirect = opts.redirect,
         ._body = body,
         ._signal = signal,
     });
@@ -177,6 +187,10 @@ pub fn getCache(self: *const Request) []const u8 {
 
 pub fn getCredentials(self: *const Request) []const u8 {
     return @tagName(self._credentials);
+}
+
+pub fn getRedirect(self: *const Request) []const u8 {
+    return @tagName(self._redirect);
 }
 
 pub fn getSignal(self: *const Request) ?*AbortSignal {
@@ -271,6 +285,7 @@ pub fn clone(self: *const Request, exec: *const Execution) !*Request {
         ._headers = self._headers,
         ._cache = self._cache,
         ._credentials = self._credentials,
+        ._redirect = self._redirect,
         ._body = self._body,
         ._signal = self._signal,
     });
@@ -291,6 +306,7 @@ pub const JsApi = struct {
     pub const headers = bridge.accessor(Request.getHeaders, null, .{});
     pub const cache = bridge.accessor(Request.getCache, null, .{});
     pub const credentials = bridge.accessor(Request.getCredentials, null, .{});
+    pub const redirect = bridge.accessor(Request.getRedirect, null, .{});
     pub const signal = bridge.accessor(Request.getSignal, null, .{});
     pub const bodyUsed = bridge.accessor(Request.getBodyUsed, null, .{});
     pub const blob = bridge.function(Request.blob, .{});


### PR DESCRIPTION
## Summary

Fixes #2908. `fetch()` ignored `RequestInit.redirect`: both `redirect: "manual"` and `redirect: "error"` behaved like the default `"follow"` — the redirect was transparently followed and a normal `200`/`basic` response returned.

Root cause: `redirect` was never parsed. It wasn't a field on `Request.InitOpts`, wasn't stored on `Request`, and the HTTP layer unconditionally followed any 3xx with a `Location` header.

## Changes

- **`HttpClient.zig`** — new `Request.RedirectMode { follow, manual, @"error" }` (default `.follow`); `processOneMessage` branches on it in the redirect path:
  - `follow` → existing behavior
  - `error` → `requestFailed` → `error_callback`, which the fetch layer surfaces as a `TypeError`
  - `manual` → don't follow; fall through so the 3xx is delivered as the final response
- **`webapi/net/Request.zig`** — adds the `redirect` init option, `_redirect` field, `Request.prototype.redirect` accessor, and propagates it through `clone()`.
- **`webapi/net/Fetch.zig`** — threads the mode into `makeRequest`; for `manual`, synthesizes the opaque-redirect filtered response (`status: 0`, `type: "opaqueredirect"`, `redirected: false`, empty url/headers/body).
- **`tests/net/fetch.html`** — two tests against the existing `/xhr/redirect` (302) endpoint: opaque-redirect response for `manual`, `TypeError` rejection for `error`.

Default stays `.follow`, so navigations, XHR, scripts and internal requests are unaffected.

## Behavior

Matches the [Fetch standard](https://fetch.spec.whatwg.org/#concept-request-redirect-mode) and the issue's expected output:

```
follow {"status":200,"type":"basic","redirected":true,"url":".../done"}
manual {"status":0,"type":"opaqueredirect","redirected":false,"url":""}
error  rejected with TypeError
```