### PR TITLE
Scope `help <command>` to command-specific options, add `--all`

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -696,36 +696,29 @@ pub const HttpHeaders = struct {
     }
 };
 
-pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) void {
+pub fn printUsageAndExit(self: *const Config, help_for: RunMode, all: bool, success: bool) void {
     const exec_name = self.exec_name;
     const Help = @import("help.zon");
     const is_debug = builtin.mode == .Debug;
     const info_or_warn = if (comptime is_debug) "info" else "warn";
     const pretty_or_logfmt = if (comptime is_debug) "pretty" else "logfmt";
-    const comptimePrint = std.fmt.comptimePrint;
 
     switch (help_for) {
-        // Requested help for everything.
-        .help => {
-            const template = comptimePrint(
-                \\{s}
-                \\
-            , .{Help.general});
-            std.debug.print(template, .{exec_name});
+        // `.help` renders the general overview; the command tags render their
+        // own section. `--all` appends the common options to any of them.
+        inline .help, .fetch, .serve, .mcp, .agent => |tag| {
+            const section = comptime if (tag == .help) Help.general else @field(Help, @tagName(tag));
+            if (all) {
+                std.debug.print(section ++ "\n\n" ++ Help.common_options ++ "\n", .{ exec_name, info_or_warn, pretty_or_logfmt });
+            } else {
+                const footer = comptime if (tag == .help)
+                    ""
+                else
+                    "\nRun \"{0s} help " ++ @tagName(tag) ++ " --all\" to also show common options.\n";
+                std.debug.print(section ++ "\n" ++ footer, .{exec_name});
+            }
         },
-        inline .fetch, .serve, .mcp, .agent => |tag| {
-            const template = comptimePrint(
-                \\{s}
-                \\
-                \\{s}
-                \\
-            , .{ @field(Help, @tagName(tag)), Help.common_options });
-            std.debug.print(template, .{ exec_name, info_or_warn, pretty_or_logfmt });
-        },
-        .version => {
-            const template = Help.version ++ "\n";
-            std.debug.print(template, .{exec_name});
-        },
+        .version => std.debug.print(Help.version ++ "\n", .{exec_name}),
     }
 
     if (success) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -33,10 +33,12 @@ const log = lp.log;
 ///
 ///   - When no command is given, the parser defaults to `serve`.
 ///   - `help`, `help <command>`, `<command> help`, and `<command> --help` all
-///     yield the `help` union variant. When a command is named (in either
-///     position), the variant carries that command's enum tag so callers can
-///     print command-specific help; bare `help` and `help help` carry the
-///     `.help` tag. An unknown name after `help` returns
+///     yield the `help` union variant, whose payload is `.{ tag, all }`. When a
+///     command is named (in either position), `tag` is that command's enum so
+///     callers can print command-specific help; bare `help` and `help help`
+///     carry the `.help` tag. A trailing `--all` (accepted in any of these
+///     forms) sets `all = true`, which asks the renderer to also print the
+///     common options. An unknown name after `help` returns
 ///     `error.UnknownCommand`.
 ///   - Legacy fallback: if the first argument starts with `--` and matches a
 ///     known fetch/serve flag, the parser sniffs the command from it and
@@ -287,8 +289,8 @@ pub fn Builder(comptime commands: anytype) type {
                 union_fields[i] = .{ .name = command.name, .type = T, .alignment = @alignOf(T) };
             }
 
-            // Entry for help; just takes `Enum` itself.
-            const Help = Enum;
+            // Entry for help; carries the target command tag and an `all` flag.
+            const Help = struct { tag: Enum, all: bool = false };
             union_fields[i] = .{ .name = "help", .type = Help, .alignment = @alignOf(Help) };
 
             break :blk @Type(.{
@@ -339,28 +341,19 @@ pub fn Builder(comptime commands: anytype) type {
 
             // Help is not in `commands`; so, we have to special case it.
             if (std.mem.eql(u8, cmd_str, "help")) {
-                // Check if we're followed by a command name.
-                const command_name: []const u8 = args.next() orelse {
-                    // "lightpanda help"; short-circuit.
-                    return .{ exec_name, @unionInit(Union, "help", .help) };
-                };
-
-                inline for (commands) |command| {
-                    if (std.mem.eql(u8, command_name, command.name)) {
-                        return .{
-                            exec_name,
-                            @unionInit(Union, "help", std.meta.stringToEnum(Enum, command.name).?),
-                        };
+                var tag: Enum = .help;
+                var all = false;
+                while (args.next()) |arg| {
+                    if (std.mem.eql(u8, arg, "--all")) {
+                        all = true;
+                        continue;
                     }
+                    tag = std.meta.stringToEnum(Enum, arg) orelse {
+                        log.fatal(.app, "unknown command", .{ .arg = arg });
+                        return error.UnknownCommand;
+                    };
                 }
-
-                // Treat `help help` as the full help.
-                if (std.mem.eql(u8, command_name, "help")) {
-                    return .{ exec_name, @unionInit(Union, "help", .help) };
-                }
-
-                log.fatal(.app, "unknown command", .{ .arg = command_name });
-                return error.UnknownCommand;
+                return .{ exec_name, @unionInit(Union, "help", .{ .tag = tag, .all = all }) };
             }
 
             // Last resort, try sniffing.
@@ -368,7 +361,7 @@ pub fn Builder(comptime commands: anytype) type {
 
             // Legacy `--help` situation.
             if (command_enum == .help) {
-                return .{ exec_name, @unionInit(Union, "help", .help) };
+                return .{ exec_name, @unionInit(Union, "help", .{ .tag = .help }) };
             }
 
             // "cmd_str" wasn't a command but an option. We can't reset args, but
@@ -682,7 +675,11 @@ pub fn Builder(comptime commands: anytype) type {
 
                 // Subcommand help: `lightpanda fetch help` or `lightpanda fetch --help`.
                 if (std.mem.eql(u8, option_name, "help") or std.mem.eql(u8, option_name, "--help")) {
-                    return @unionInit(Union, "help", std.meta.stringToEnum(Enum, command.name).?);
+                    const all = if (args.next()) |next| std.mem.eql(u8, next, "--all") else false;
+                    return @unionInit(Union, "help", .{
+                        .tag = std.meta.stringToEnum(Enum, command.name).?,
+                        .all = all,
+                    });
                 }
 
                 // Encountered an option we don't know of.

--- a/src/help.zon
+++ b/src/help.zon
@@ -12,6 +12,7 @@
     \\  version     displays the version of {0s}
     \\
     \\Use "{0s} help <command>" for more information about a command.
+    \\Add --all (e.g. "{0s} help <command> --all") to also show the common options.
     ,
     .serve =
     \\usage: {0s} serve [OPTIONS] [COMMON_OPTIONS]

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,7 +70,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     defer args.deinit(main_arena);
 
     switch (args.mode) {
-        .help => |tag| return args.printUsageAndExit(tag, true),
+        .help => |h| return args.printUsageAndExit(h.tag, h.all, true),
         .version => |opts| {
             if (opts.check) {
                 try lp.checkVersion(allocator, &args);
@@ -115,7 +115,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             log.debug(.app, "startup", .{ .mode = "serve", .snapshot = app.snapshot.fromEmbedded() });
             const address = std.net.Address.parseIp(opts.host, opts.port) catch |err| {
                 log.fatal(.app, "invalid server address", .{ .err = err, .host = opts.host, .port = opts.port });
-                return args.printUsageAndExit(.serve, false);
+                return args.printUsageAndExit(.serve, false, false);
             };
 
             var server = lp.Server.init(app, address) catch |err| {


### PR DESCRIPTION
## What

`lightpanda help <command>` used to print the command-specific options **and** the entire common/browser options block. For a command like `agent` that has a lot of its own flags, the useful per-command help scrolled off the top under a wall of shared `--http-*` / `--log-*` / `--cookie` options.

Now:

- `help <command>` shows **only** that command's options, ending with a one-line footer pointing at `--all`.
- `--all` opts into the full listing (command options + common options), and is accepted on every help form:
  - `lightpanda help agent --all`
  - `lightpanda agent --help --all`
  - `lightpanda agent help --all`
  - `lightpanda help --all` (general command list + common options)

`help agent --all` reproduces exactly the old `help agent` output, so anything scripting the previous behavior can just append `--all`.

## How

- The `help` union variant now carries `.{ tag, all }` instead of a bare enum tag (`src/cli.zig`).
- `Config.printUsageAndExit` takes an `all` flag and renders the requested section, appending `common_options` only when `all` is set (`src/Config.zig`).
- The general-help footer in `src/help.zon` mentions `--all`.

| Command | common opts? | footer? |
|---|---|---|
| `help agent` | no | yes |
| `help agent --all` / `agent --help --all` / `agent help --all` | yes | no |
| `help` | no | no |
| `help --all` / `help --all agent` | yes | — |
| `help version` | no (version has none) | no |
| `help bogus` | `unknown command`, exit 1 | |
| `serve --host <bad>` | terse serve usage, exit 1 | |