### PR TITLE
agent: emit intent comments in saved scripts

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -171,6 +171,19 @@ const script_skill =
     \\6. **Let failures fail.** Primitives throw on error and stop the script — only `try/catch` where you have a real fallback (e.g. optional cookie banner: `try { page.click("#accept") } catch {}`).
     \\7. **End with `return <result>`.** `console.log` is for debug output only and doesn't JSON-format objects.
     \\8. Modern, readable JS: `const`/`let`, `for (const x of xs)`, template literals, destructuring, 2-space indent.
+    \\9. **Comment the intent of each block.** Put a one-line `//` comment above each logical step describing what it accomplishes toward the goal (not restating the call). One comment per block, not per line — skip self-evident lines:
+    \\   ```js
+    \\   // Load the Hacker News front page
+    \\   const page = new Page();
+    \\   await page.goto("https://news.ycombinator.com");
+    \\
+    \\   // Pull the top 5 stories (title + link)
+    \\   const { stories } = page.extract({ stories: [{ selector: "tr.athing", limit: 5, fields: { title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
+    \\
+    \\   // Open each story page in parallel and read its text
+    \\   const pages = stories.map(() => new Page());
+    \\   await Promise.all(pages.map((p, i) => p.goto(stories[i].url)));
+    \\   ```
     \\
     \\## Common errors
     \\

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -169,7 +169,14 @@ pub const save_synthesis_prompt =
     \\didn't use. Never round-trip a result through `lp.*`, and never append
     \\no-op page.extract(...) probes or `page.evaluate("return lp....")` tails to
     \\surface output.
-    \\Output ONLY JavaScript source — no markdown fences, no commentary.
+    \\Annotate the script with short `//` intent comments so a later reader grasps
+    \\it at a glance: one comment above each logical block (navigate, extract a
+    \\list, fan out to detail pages, aggregate, return) stating what that block
+    \\accomplishes toward the goal — NOT restating the API call. One comment per
+    \\step, not per line; skip self-evident lines.
+    \\Output ONLY JavaScript source — no markdown fences and no prose outside the
+    \\code, but DO annotate the script with the `//` intent comments described
+    \\above.
 ;
 
 /// Script-language rules for consumers that never see the full


### PR DESCRIPTION
## What

Make `/save` annotate the generated Lightpanda agent script with concise **per-block `//` intent comments**, so a later reader — human or agent — can grasp what the script does at a glance instead of reverse-engineering intent from selectors and control flow.

Before:
```js
const page = new Page();
await page.goto("https://news.ycombinator.com");
const { stories } = page.extract({ stories: [{ selector: "tr.athing", limit: 5, fields: { title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });
const pages = stories.map(() => new Page());
await Promise.all(pages.map((p, i) => p.goto(stories[i].url)));
```

After:
```js
// Load the Hacker News front page
const page = new Page();
await page.goto("https://news.ycombinator.com");

// Pull the top 5 stories (title + link)
const { stories } = page.extract({ stories: [{ selector: "tr.athing", limit: 5, fields: { title: ".titleline > a", url: { selector: ".titleline > a", attr: "href" } } }] });

// Open each story page in parallel and read its text
const pages = stories.map(() => new Page());
await Promise.all(pages.map((p, i) => p.goto(stories[i].url)));
```

## How

Prompt-only change — no struct or plumbing changes. `/save` with a model attached runs an LLM synthesis turn that writes the script; steering that prompt is where real intent lives (the model has the full conversation context).

- **`src/browser/tools.zig` — `save_synthesis_prompt`**: add a directive to annotate each logical block (navigate, extract, fan out, aggregate, return) with a one-line `//` comment stating intent — one per step, not per line, skipping self-evident lines. Reword the closing line from *"no markdown fences, no commentary"* → forbid only prose/markdown fences **outside** the code while explicitly asking for the intent comments (the old wording read as "no code comments"). This prompt also backs the MCP `save` tool, so both surfaces benefit.
- **`src/agent/Agent.zig` — `script_skill`**: add best-practice item 9 codifying the convention with a commented example.

The no-LLM raw-buffer save path is unchanged (no model there to synthesize intent; it already emits the user's per-turn instruction as a comment). No changes to the recorder.