### PR TITLE
webapi: Allow CustomElements to extend any HTMLElement interfaces.

### DIFF
--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -22,6 +22,11 @@ const lp = @import("lightpanda");
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
 
+// Not ideal, but its children have special constructor rules (can be extended
+// can't be instantiated). And rather than coming up with a generic definition
+// for this one case, we just hardcode it.
+const HtmlElement = @import("../webapi/element/Html.zig");
+
 const v8 = js.v8;
 const log = lp.log;
 const JsApis = bridge.JsApis;
@@ -402,6 +407,9 @@ fn countExternalReferences() comptime_int {
     // +1 for the illegal constructor callback shared by various types
     count += 1;
 
+    // +1 for the upgrade constructor shared by built-in element interfaces
+    count += 1;
+
     // +1 for the noop function shared by various types
     count += 1;
 
@@ -472,6 +480,9 @@ fn collectExternalReferences() [countExternalReferences()]isize {
     var references = std.mem.zeroes([countExternalReferences()]isize);
 
     references[idx] = @bitCast(@intFromPtr(&illegalConstructorCallback));
+    idx += 1;
+
+    references[idx] = @bitCast(@intFromPtr(HtmlElement.JsApi.upgrade_constructor.func));
     idx += 1;
 
     references[idx] = @bitCast(@intFromPtr(&bridge.Function.noopFunction));
@@ -676,14 +687,15 @@ fn protoIndexLookup(comptime JsApi: type) ?u16 {
 
 // Generate a constructor template for a JsApi type (public for reuse)
 pub fn generateConstructor(comptime JsApi: type, isolate: *v8.Isolate) *const v8.FunctionTemplate {
-    const callback = blk: {
+    const callback, const arity = comptime blk: {
         if (@hasDecl(JsApi, "constructor")) {
-            break :blk JsApi.constructor.func;
+            break :blk .{ JsApi.constructor.func, JsApi.constructor.arity };
         }
-        break :blk illegalConstructorCallback;
+        if (inheritsFromHtmlElement(JsApi)) {
+            break :blk .{ HtmlElement.JsApi.upgrade_constructor.func, @as(c_int, HtmlElement.JsApi.upgrade_constructor.arity) };
+        }
+        break :blk .{ &illegalConstructorCallback, @as(c_int, 0) };
     };
-
-    const arity: c_int = if (@hasDecl(JsApi, "constructor")) JsApi.constructor.arity else 0;
     const template = v8.v8__FunctionTemplate__New__Config(isolate, &.{
         .length = arity,
         .callback = callback,
@@ -702,6 +714,26 @@ pub fn generateConstructor(comptime JsApi: type, isolate: *v8.Isolate) *const v8
     // Web IDL: interface object's `prototype` property is non-writable/non-configurable.
     v8.v8__FunctionTemplate__ReadOnlyPrototype(template);
     return template;
+}
+
+// hard-coded special case for HtmlElement which can be extended but not
+// instantiated.
+fn inheritsFromHtmlElement(comptime JsApi: type) bool {
+    comptime {
+        var T = JsApi.bridge.type;
+        if (T == HtmlElement) {
+            return false;
+        }
+
+        while (@hasField(T, "_proto")) {
+            const Parent = @typeInfo(std.meta.fieldInfo(T, ._proto).type).pointer.child;
+            if (Parent == HtmlElement) {
+                return true;
+            }
+            T = Parent;
+        }
+        return false;
+    }
 }
 
 // Attach JsApi members to a template (public for reuse). This is called on all

--- a/src/browser/tests/custom_elements/built_in.html
+++ b/src/browser/tests/custom_elements/built_in.html
@@ -68,6 +68,39 @@
 }
 
 {
+    let constructorCalled = 0;
+
+    class TypedButton extends HTMLButtonElement {
+        constructor() {
+            super();
+            constructorCalled++;
+            this.custom = true;
+        }
+    }
+
+    customElements.define('typed-button', TypedButton, { extends: 'button' });
+
+    const btn = document.createElement('button', { is: 'typed-button' });
+    testing.expectEqual(1, constructorCalled);
+    testing.expectEqual(true, btn instanceof TypedButton);
+    testing.expectEqual(true, btn instanceof HTMLButtonElement);
+    testing.expectEqual('BUTTON', btn.tagName);
+    testing.expectEqual(true, btn.custom);
+}
+
+// Directly constructing a built-in interface is unsupported and must throw a
+// TypeError (not silently succeed).
+{
+    let threw = false;
+    try {
+        new HTMLDivElement();
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    testing.expectEqual(true, threw);
+}
+
+{
     let connectedCount = 0;
     let disconnectedCount = 0;
     let attributeChanges = [];

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -106,7 +106,7 @@ const HtmlElement = @This();
 _type: Type,
 _proto: *Element,
 
-// Special constructor for custom elements.
+// Special constructor for custom elements (autonomous, `extends HTMLElement`).
 // Two paths:
 //  - Upgrade path: customElements.define / createElement / upgrade set
 //    `_upgrading_element` before calling newInstance, and we just return it.
@@ -117,6 +117,15 @@ pub fn construct(new_target: js.Function, frame: *Frame) !*Element {
         return node.is(Element) orelse return error.IllegalConstructor;
     }
     return Frame.node_factory.constructCustomElement(frame, new_target);
+}
+
+// Shared constructor callback for builtin html element interfaces. These types
+// cannot be instantinated (e.g. new HTMLDivElement), but a custom element can
+// be extended, so super() has to create them. All of these types have their
+// constructors routed here.
+pub fn upgradeConstruct(frame: *Frame) !*Element {
+    const node = frame._upgrading_element orelse return error.TypeError;
+    return node.is(Element) orelse return error.TypeError;
 }
 
 pub const Type = union(enum) {
@@ -1643,6 +1652,7 @@ pub const JsApi = struct {
     };
 
     pub const constructor = bridge.constructor(HtmlElement.construct, .{ .new_target = true });
+    pub const upgrade_constructor = bridge.constructor(HtmlElement.upgradeConstruct, .{});
 
     pub const innerText = bridge.accessor(_innerText, _setInnerText, .{ .ce_reactions = true });
     fn _innerText(self: *HtmlElement, frame: *Frame) ![]const u8 {


### PR DESCRIPTION
Pervious, extension was limited to HtmlElement. CustomElements can now extend any html element interface.

The implementation isn't great. This is a special case, and rather than coming up with some abstract way to define this in bridge, we make the Snapshot aware of this specific case directly.