### PR TITLE
ops: Don't log TryCatchRethrow errors

### DIFF
--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -95,7 +95,11 @@ pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
 pub fn callRethrow(self: *const Function, comptime T: type, args: anytype) !T {
     var caught: js.TryCatch.Caught = undefined;
     return self._tryCallWithThis(T, self.getThis(), args, &caught, .{ .rethrow = true }) catch |err| {
-        log.warn(.js, "call caught", .{ .err = err, .caught = caught });
+        if (err != error.TryCatchRethrow) {
+            // error.TryCatchRethrow is a control flow (sorry!), not an actual
+            // error we want to log
+            log.warn(.js, "call caught", .{ .err = err, .caught = caught });
+        }
         return err;
     };
 }


### PR DESCRIPTION
error.TryCatchRethrow is used as a control flow (sorry). It signals that an error has already been throw in v8 and that the method should exit (ultimately, it ends up being the return value passed to our v8 bridge, which knows to ignore it). We shouldn't log this as a WARN, it's completely normal that it happens AND it really contains no meaningful information as-is.