### PR TITLE
ops: Reduce logging of JsException on event dispatch

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -286,8 +286,9 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
 
             // Inline handlers (e.g. onclick property) follow the same "report,
             // don't propagate" rule as addEventListener listeners — see Listener.run.
-            ls.toLocal(inline_handler).callWithThis(void, target_et, .{event}) catch |err| {
-                log.warn(.event, "inline handler", .{ .err = err });
+            var caught: js.TryCatch.Caught = undefined;
+            ls.toLocal(inline_handler).tryCallWithThis(void, target_et, .{event}, &caught) catch |err| {
+                log.warn(.event, "inline handler", .{ .err = err, .caught = caught });
             };
 
             if (event._stop_propagation) {
@@ -325,8 +326,9 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
                     event._target = getAdjustedTarget(original_target, current_target);
                 }
 
-                ls.toLocal(inline_handler).callWithThis(void, current_target, .{event}) catch |err| {
-                    log.warn(.event, "inline handler", .{ .err = err });
+                var caught: js.TryCatch.Caught = undefined;
+                ls.toLocal(inline_handler).tryCallWithThis(void, current_target, .{event}, &caught) catch |err| {
+                    log.warn(.event, "inline handler", .{ .err = err, .caught = caught });
                 };
 
                 if (event._needs_retargeting) {

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -287,11 +287,12 @@ pub fn dispatchDirect(
     // Call the property handler (e.g., onmessage) if present
     if (getFunction(handler, &ls.local)) |func| {
         event._current_target = target;
-        _ = func.callWithThis(void, target, .{event}) catch |err| {
+        var caught: js.TryCatch.Caught = undefined;
+        _ = func.tryCallWithThis(void, target, .{event}, &caught) catch |err| {
             if (err == error.JsException) {
                 event._listeners_did_throw = true;
             } else {
-                log.warn(.event, opts.context, .{ .err = err });
+                log.warn(.event, opts.context, .{ .err = err, .caught = caught });
             }
         };
     }
@@ -433,12 +434,13 @@ pub const Listener = struct {
         event: *Event,
         comptime context: []const u8,
     ) error{OutOfMemory}!void {
+        var caught: js.TryCatch.Caught = undefined;
         switch (self.function) {
-            .value => |value| local.toLocal(value).callWithThis(void, event._current_target.?, .{event}) catch |err| {
+            .value => |value| local.toLocal(value).tryCallWithThis(void, event._current_target.?, .{event}, &caught) catch |err| {
                 if (err == error.JsException) {
                     event._listeners_did_throw = true;
                 } else {
-                    log.warn(.event, context, .{ .err = err });
+                    log.warn(.event, context, .{ .err = err, .caught = caught });
                 }
             },
             .string => |string| {
@@ -447,7 +449,7 @@ pub const Listener = struct {
                     if (err == error.JsException) {
                         event._listeners_did_throw = true;
                     } else {
-                        log.warn(.event, context, .{ .err = err });
+                        log.warn(.event, context, .{ .err = err, .caught = caught });
                     }
                 };
             },
@@ -463,11 +465,11 @@ pub const Listener = struct {
                     break :blk null;
                 };
                 if (handle_event) |handleEvent| {
-                    handleEvent.callWithThis(void, obj, .{event}) catch |err| {
+                    handleEvent.tryCallWithThis(void, obj, .{event}, &caught) catch |err| {
                         if (err == error.JsException) {
                             event._listeners_did_throw = true;
                         } else {
-                            log.warn(.event, context, .{ .err = err });
+                            log.warn(.event, context, .{ .err = err, .caught = caught });
                         }
                     };
                 } else {


### PR DESCRIPTION
Event dispatch using a try/catch (tryCallWithThis) so that the EventManager can decide how to handle the error. Previously, using the `callWithThis` would result in always logging the error. Now, the EventManager can skip logging JsExceptions.