### PR TITLE
webapi: ResizeObserver.observer box option default

### DIFF
--- a/src/browser/webapi/ResizeObserver.zig
+++ b/src/browser/webapi/ResizeObserver.zig
@@ -30,7 +30,7 @@ fn init(cbk: js.Function) ResizeObserver {
 }
 
 const Options = struct {
-    box: []const u8,
+    box: []const u8 = "content-box",
 };
 pub fn observe(self: *const ResizeObserver, element: *Element, options_: ?Options) void {
     _ = self;


### PR DESCRIPTION
This should default to "content-box". Not that the value is important, but without the default, we fail if an empty object is passed.