### PR TITLE
feat(webapi): reflect HTMLAreaElement attributes

### DIFF
--- a/src/browser/tests/element/html/area.html
+++ b/src/browser/tests/element/html/area.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<map name="m">
+  <area id="a1" alt="logo" coords="0,0,82,126" shape="rect" target="_blank" download="pic" rel="noopener noreferrer" referrerpolicy="no-referrer" href="/page">
+  <area id="a2">
+</map>
+
+<script id="area-from-html">
+  {
+    const a1 = document.getElementById('a1');
+    testing.expectEqual('HTMLAreaElement', a1.constructor.name);
+    testing.expectEqual('logo', a1.alt);
+    testing.expectEqual('0,0,82,126', a1.coords);
+    testing.expectEqual('rect', a1.shape);
+    testing.expectEqual('_blank', a1.target);
+    testing.expectEqual('pic', a1.download);
+    testing.expectEqual('noopener noreferrer', a1.rel);
+    testing.expectEqual('no-referrer', a1.referrerPolicy);
+    testing.expectEqual(2, a1.relList.length);
+    testing.expectEqual('noopener', a1.relList.item(0));
+    testing.expectEqual('noreferrer', a1.relList.item(1));
+    testing.expectEqual(true, a1.relList.contains('noopener'));
+
+    const a2 = document.getElementById('a2');
+    testing.expectEqual('', a2.alt);
+    testing.expectEqual('', a2.coords);
+    testing.expectEqual('', a2.shape);
+    testing.expectEqual('', a2.target);
+    testing.expectEqual('', a2.download);
+    testing.expectEqual('', a2.rel);
+    testing.expectEqual('', a2.referrerPolicy);
+    testing.expectEqual(0, a2.relList.length);
+  }
+</script>
+
+<script id="area-reflection">
+  {
+    const a = document.createElement('area');
+
+    a.alt = 'hero';
+    testing.expectEqual('hero', a.getAttribute('alt'));
+    a.setAttribute('alt', 'banner');
+    testing.expectEqual('banner', a.alt);
+
+    a.coords = '1,2,3,4';
+    testing.expectEqual('1,2,3,4', a.getAttribute('coords'));
+
+    a.shape = 'circle';
+    testing.expectEqual('circle', a.getAttribute('shape'));
+
+    a.target = '_self';
+    testing.expectEqual('_self', a.getAttribute('target'));
+
+    a.download = 'file.png';
+    testing.expectEqual('file.png', a.getAttribute('download'));
+
+    a.rel = 'nofollow';
+    testing.expectEqual('nofollow', a.getAttribute('rel'));
+    testing.expectEqual('nofollow', a.relList.item(0));
+
+    // referrerPolicy reflects an enumerated attribute: unknown values map to ''
+    a.referrerPolicy = 'origin';
+    testing.expectEqual('origin', a.referrerPolicy);
+    a.setAttribute('referrerpolicy', 'bogus');
+    testing.expectEqual('', a.referrerPolicy);
+  }
+</script>

--- a/src/browser/webapi/element/html/Area.zig
+++ b/src/browser/webapi/element/html/Area.zig
@@ -29,8 +29,78 @@ _proto: *HtmlElement,
 pub fn asElement(self: *Area) *Element {
     return self._proto._proto;
 }
+pub fn asConstElement(self: *const Area) *const Element {
+    return self._proto._proto;
+}
 pub fn asNode(self: *Area) *Node {
     return self.asElement().asNode();
+}
+
+pub fn getAlt(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("alt")) orelse "";
+}
+
+pub fn setAlt(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("alt"), .wrap(value), frame);
+}
+
+pub fn getCoords(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("coords")) orelse "";
+}
+
+pub fn setCoords(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("coords"), .wrap(value), frame);
+}
+
+pub fn getShape(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("shape")) orelse "";
+}
+
+pub fn setShape(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("shape"), .wrap(value), frame);
+}
+
+pub fn getTarget(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("target")) orelse "";
+}
+
+pub fn setTarget(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
+}
+
+pub fn getDownload(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("download")) orelse "";
+}
+
+pub fn setDownload(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("download"), .wrap(value), frame);
+}
+
+pub fn getRel(self: *const Area) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("rel")) orelse "";
+}
+
+pub fn setRel(self: *Area, value: []const u8, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("rel"), .wrap(value), frame);
+}
+
+pub fn getReferrerPolicy(self: *const Area) []const u8 {
+    const valid_referrer_policy = [_][]const u8{
+        "",
+        "no-referrer",
+        "no-referrer-when-downgrade",
+        "same-origin",
+        "origin",
+        "strict-origin",
+        "origin-when-cross-origin",
+        "strict-origin-when-cross-origin",
+        "unsafe-url",
+    };
+    return HtmlElement.reflectEnumerated(self.asConstElement().getAttributeSafe(.wrap("referrerpolicy")), &valid_referrer_policy, "", "").?;
+}
+
+pub fn setReferrerPolicy(self: *Area, value: []const u8, frame: *Frame) !void {
+    return self.asElement().setAttributeSafe(.wrap("referrerpolicy"), .wrap(value), frame);
 }
 
 pub fn getHref(self: *Area, frame: *Frame) ![]const u8 {
@@ -211,5 +281,28 @@ pub const JsApi = struct {
     pub const pathname = bridge.accessor(Area.getPathname, Area.setPathname, .{ .ce_reactions = true });
     pub const search = bridge.accessor(Area.getSearch, Area.setSearch, .{ .ce_reactions = true });
     pub const hash = bridge.accessor(Area.getHash, Area.setHash, .{ .ce_reactions = true });
+    pub const alt = bridge.accessor(Area.getAlt, Area.setAlt, .{ .ce_reactions = true });
+    pub const coords = bridge.accessor(Area.getCoords, Area.setCoords, .{ .ce_reactions = true });
+    pub const shape = bridge.accessor(Area.getShape, Area.setShape, .{ .ce_reactions = true });
+    pub const target = bridge.accessor(Area.getTarget, Area.setTarget, .{ .ce_reactions = true });
+    pub const download = bridge.accessor(Area.getDownload, Area.setDownload, .{ .ce_reactions = true });
+    pub const rel = bridge.accessor(Area.getRel, Area.setRel, .{ .ce_reactions = true });
+    pub const referrerPolicy = bridge.accessor(Area.getReferrerPolicy, Area.setReferrerPolicy, .{ .ce_reactions = true });
+    pub const relList = bridge.accessor(_getRelList, null, .{ .null_as_undefined = true });
     pub const toString = bridge.function(Area.getHref, .{});
+
+    fn _getRelList(self: *Area, frame: *Frame) !?*@import("../../collections.zig").DOMTokenList {
+        const element = self.asElement();
+        // relList is only valid for HTML and SVG <area> elements
+        const namespace = element._namespace;
+        if (namespace != .html and namespace != .svg) {
+            return null;
+        }
+        return element.getRelList(frame);
+    }
 };
+
+const testing = @import("../../../../testing.zig");
+test "WebApi: HTML.Area" {
+    try testing.htmlRunner("element/html/area.html", .{});
+}


### PR DESCRIPTION
## What

`HTMLAreaElement` previously implemented only the URL / `HTMLHyperlinkElementUtils` mixin (`href`, `origin`, `protocol`, `host`, `pathname`, ...). Its area-specific reflected IDL attributes were missing, so `alt`, `coords`, `shape`, `target`, `download`, `rel`, `referrerPolicy` and `relList` all read back as `undefined`.

## Change

Reflect the missing attributes, following the existing `HTMLAnchorElement` / `HTMLLinkElement` implementations in the same directory:

- `alt`, `coords`, `shape`, `target`, `download`, `rel` — plain string reflection via `getAttributeSafe` / `setAttributeSafe`.
- `referrerPolicy` — enumerated reflection via `reflectEnumerated` against the referrer-policy token set (same list as `HTMLLinkElement`).
- `relList` — the shared `DOMTokenList` helper (`element.getRelList`), guarded to the html/svg namespaces, matching `HTMLAnchorElement`.

`ping` is intentionally left out to match the current `HTMLAnchorElement` precedent (which also does not implement it).

## Test

Adds `src/browser/tests/element/html/area.html`: a parse-from-HTML block asserting each reflected attribute (including `relList` via `.length` / `.item()` / `.contains()`), a defaults block for a bare `<area>`, and a `createElement('area')` round-trip block. Wired via a `test "WebApi: HTML.Area"` block in `Area.zig`.

## Verification

- `make test F="Area"` → `2 of 2 tests passed` (`WebApi: HTML.Area` green).
- `zig fmt --check` clean on the changed file.
- Custom test runner reports no leaked allocations.