### PR TITLE
webapi: AbortSignal conformance fixes (dependent signals, null reason, timeout after detach)

### DIFF
--- a/src/browser/webapi/AbortController.zig
+++ b/src/browser/webapi/AbortController.zig
@@ -37,8 +37,8 @@ pub fn getSignal(self: *const AbortController) *AbortSignal {
     return self._signal;
 }
 
-pub fn abort(self: *AbortController, reason_: ?js.Value.Global, exec: *const Execution) !void {
-    try self._signal.abort(if (reason_) |r| .{ .js_val = r } else null, exec);
+pub fn abort(self: *AbortController, reason_: ?js.Value, exec: *const Execution) !void {
+    try self._signal.abort(try AbortSignal.reasonFromJs(reason_), exec);
 }
 
 pub const JsApi = struct {

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -35,14 +35,18 @@ const Dependend = union(enum) {
     signal: *AbortSignal,
     model_context_tool: *ModelContextTool,
 
-    fn markAborted(self: Dependend, reason_: ?Reason, exec: *const Execution) !void {
+    // Returns false if the dependent was already aborted, in which case no
+    // abort event must be dispatched for it.
+    fn markAborted(self: Dependend, reason_: ?Reason, exec: *const Execution) !bool {
         switch (self) {
             .signal => |dep| {
-                if (dep._aborted) return;
+                if (dep._aborted) return false;
                 try dep.markAborted(reason_, exec);
+                return true;
             },
             .model_context_tool => |dep| {
                 try dep.markAborted(exec);
+                return true;
             },
         }
     }
@@ -101,8 +105,9 @@ pub fn abort(self: *AbortSignal, reason_: ?Reason, exec: *const Execution) !void
     // so we never need to recurse here.
     var to_dispatch: std.ArrayList(Dependend) = .{};
     for (self._dependents.items) |dep| {
-        try dep.markAborted(self._reason, exec);
-        try to_dispatch.append(exec.arena, dep);
+        if (try dep.markAborted(self._reason, exec)) {
+            try to_dispatch.append(exec.arena, dep);
+        }
     }
 
     try self.dispatchAbortEvent(exec);
@@ -123,7 +128,11 @@ fn markAborted(self: *AbortSignal, reason_: ?Reason, exec: *const Execution) !vo
             .undefined => self._reason = reason,
         }
     } else {
-        self._reason = .{ .dom = DOMException.fromError(error.AbortError).? };
+        // Allocate the DOMException so the reason keeps a single JS identity:
+        // dependent signals must expose the very same DOMException instance.
+        const dom = try exec.arena.create(DOMException);
+        dom.* = DOMException.fromError(error.AbortError).?;
+        self._reason = .{ .dom = dom };
     }
 }
 
@@ -207,7 +216,7 @@ pub fn throwIfAborted(self: *const AbortSignal, exec: *const Execution) !ThrowIf
 
 const Reason = union(enum) {
     js_val: js.Value.Global,
-    dom: DOMException,
+    dom: *DOMException,
     string: []const u8,
     undefined: void,
 };
@@ -218,10 +227,16 @@ const TimeoutCallback = struct {
 
     fn run(ctx: *anyopaque) !?u32 {
         const self: *TimeoutCallback = @ptrCast(@alignCast(ctx));
-        self.signal.abort(.{ .dom = DOMException.fromError(error.TimeoutError).? }, self.exec) catch |err| {
+        self.timeoutAbort() catch |err| {
             log.warn(.app, "abort signal timeout", .{ .err = err });
         };
         return null;
+    }
+
+    fn timeoutAbort(self: *TimeoutCallback) !void {
+        const dom = try self.exec.arena.create(DOMException);
+        dom.* = DOMException.fromError(error.TimeoutError).?;
+        try self.signal.abort(.{ .dom = dom }, self.exec);
     }
 };
 

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -245,6 +245,22 @@ const TimeoutCallback = struct {
     }
 
     fn timeoutAbort(self: *TimeoutCallback) !void {
+        // Per spec, the abort is queued as a global task on the signal's
+        // global: it must not run when the global's document is no longer
+        // fully active (e.g. the iframe that created the signal was detached).
+        switch (self.exec.js.global) {
+            .frame => |frame| {
+                var current: ?@TypeOf(frame) = frame;
+                while (current) |f| : (current = f.parent) {
+                    const iframe = f.iframe orelse continue;
+                    if (!iframe.asNode().isConnected()) {
+                        return;
+                    }
+                }
+            },
+            .worker => {},
+        }
+
         const dom = try self.exec.arena.create(DOMException);
         dom.* = DOMException.fromError(error.TimeoutError).?;
         try self.signal.abort(.{ .dom = dom }, self.exec);

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -149,10 +149,21 @@ fn dispatchAbortEvent(self: *AbortSignal, exec: *const Execution) !void {
     }
 }
 
+// Converts an abort(reason) JS argument to a Reason. Per spec, only a
+// missing or undefined reason falls back to the default "AbortError"
+// DOMException: an explicit null (or any other value) is kept as-is.
+pub fn reasonFromJs(reason_: ?js.Value) !?Reason {
+    const reason = reason_ orelse return null;
+    if (reason.isUndefined()) {
+        return null;
+    }
+    return .{ .js_val = try reason.persist() };
+}
+
 // Static method to create an already-aborted signal
-pub fn createAborted(reason_: ?js.Value.Global, exec: *const Execution) !*AbortSignal {
+pub fn createAborted(reason_: ?js.Value, exec: *const Execution) !*AbortSignal {
     const signal = try init(exec);
-    try signal.abort(if (reason_) |r| .{ .js_val = r } else null, exec);
+    try signal.abort(try reasonFromJs(reason_), exec);
     return signal;
 }
 


### PR DESCRIPTION
First of a series of stacked PRs splitting the `web_api_robot-dom` WPT work into reviewable chunks. This one fixes three AbortSignal conformance issues found by the WPT `/dom/abort/` suite.

## Commits

**webapi: fix AbortSignal dependent-signal abort semantics**
- Reentrant aborts (a source aborting another source from inside an abort listener) made a shared dependent signal fire its `abort` event twice; per spec only not-yet-aborted dependents are appended to the dispatch list.
- `signal.reason` re-wrapped a fresh `DOMException` on every access, so `source.reason === dependent.reason` failed. The reason is now a single `*DOMException` allocated at abort time and identity-mapped by the JS bridge.

**webapi: keep explicit null as AbortSignal abort reason**
- `controller.abort(null)` fell back to the default `AbortError` because the JS→Zig conversion collapsed explicit `null` into a missing argument. The reason parameter now preserves the missing vs explicit-null distinction; only missing/`undefined` gets the default.

**webapi: don't fire AbortSignal.timeout() after frame detach**
- The scheduler task kept running after the iframe that created the signal was detached, so the signal aborted anyway. The callback now skips the abort when a hosting iframe in the frame's ancestor chain is no longer connected, per the spec's fully-active requirement for queued global tasks.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/abort/abort-signal-any.any.html | 11/14 | 14/14 |
| /dom/abort/abort-signal-any.any.worker.html | 11/14 | 14/14 |
| /dom/abort/event.any.html | 15/16 | 16/16 |
| /dom/abort/event.any.worker.html | 15/16 | 16/16 |
| /dom/abort/abort-signal-timeout.html | 0/1 | 1/1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
