### PR TITLE
webapi: HTMLCollection & named-collection property semantics

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -388,11 +388,7 @@ fn _getIndexQuery(comptime T: type, local: *const Local, func: anytype, idx: u32
     if (@typeInfo(F).@"fn".params.len == 3) {
         @field(args, "2") = getGlobalArg(@TypeOf(args.@"2"), local.ctx);
     }
-    if (@call(.auto, func, args) == false) {
-        return js.Intercepted.no;
-    }
-    info.getReturnValue().set(try local.zigValueToJs(@as(u32, v8.None), .{}));
-    return js.Intercepted.yes;
+    return queryReturn(local, @call(.auto, func, args), info);
 }
 
 pub fn getNamedQuery(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, handle: *const v8.PropertyCallbackInfo) u32 {
@@ -417,12 +413,33 @@ fn _getNamedQuery(comptime T: type, local: *const Local, func: anytype, name: *c
     if (@typeInfo(F).@"fn".params.len == 3) {
         @field(args, "2") = getGlobalArg(@TypeOf(args.@"2"), local.ctx);
     }
-    if (@call(.auto, func, args) == false) {
-        return js.Intercepted.no;
+    return queryReturn(local, @call(.auto, func, args), info);
+}
+
+// A query callback either returns a bool (true -> the property exists as an
+// enumerable, writable, configurable data property, PropertyAttribute.None)
+// or the v8.PropertyAttribute bits directly (e.g. v8.ReadOnly).
+// error.NotHandled falls through to the ordinary property lookup.
+fn queryReturn(local: *const Local, ret: anytype, info: PropertyCallbackInfo) !u32 {
+    const val = switch (@typeInfo(@TypeOf(ret))) {
+        .error_union => |eu| ret catch |err| {
+            if (comptime isInErrorSet(error.NotHandled, eu.error_set)) {
+                if (err == error.NotHandled) {
+                    return js.Intercepted.no;
+                }
+            }
+            return err;
+        },
+        else => ret,
+    };
+    if (@TypeOf(val) == bool) {
+        if (val == false) {
+            return js.Intercepted.no;
+        }
+        info.getReturnValue().set(try local.zigValueToJs(@as(u32, v8.None), .{}));
+    } else {
+        info.getReturnValue().set(try local.zigValueToJs(@as(u32, val), .{}));
     }
-    // The property exists as a supported property name; report it as an
-    // enumerable, writable, configurable data property (PropertyAttribute.None).
-    info.getReturnValue().set(try local.zigValueToJs(@as(u32, v8.None), .{}));
     return js.Intercepted.yes;
 }
 

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -209,59 +209,6 @@ fn _getIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, inf
     return handleIndexedReturn(T, F, true, local, ret, info, opts);
 }
 
-pub fn setIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, js_value: *const v8.Value, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
-    const local = &self.local;
-
-    var hs: js.HandleScope = undefined;
-    hs.init(local.isolate);
-    defer hs.deinit();
-
-    const info = PropertyCallbackInfo{ .handle = handle };
-    return _setIndex(T, local, func, idx, .{ .local = &self.local, .handle = js_value }, info, opts) catch |err| {
-        handleError(T, @TypeOf(func), local, err, info);
-        return js.Intercepted.no;
-    };
-}
-
-fn _setIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, js_value: js.Value, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
-    const F = @TypeOf(func);
-    var args: ParameterTypes(F) = undefined;
-    @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());
-    @field(args, "1") = idx;
-    @field(args, "2") = try local.jsValueToZig(@TypeOf(@field(args, "2")), js_value);
-    if (@typeInfo(F).@"fn".params.len == 4) {
-        @field(args, "3") = getGlobalArg(@TypeOf(args.@"3"), local.ctx);
-    }
-    const ret = @call(.auto, func, args);
-    return handleIndexedReturn(T, F, false, local, ret, info, opts);
-}
-
-pub fn deleteIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
-    const local = &self.local;
-
-    var hs: js.HandleScope = undefined;
-    hs.init(local.isolate);
-    defer hs.deinit();
-
-    const info = PropertyCallbackInfo{ .handle = handle };
-    return _deleteIndex(T, local, func, idx, info, opts) catch |err| {
-        handleError(T, @TypeOf(func), local, err, info);
-        return js.Intercepted.no;
-    };
-}
-
-fn _deleteIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
-    const F = @TypeOf(func);
-    var args: ParameterTypes(F) = undefined;
-    @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());
-    @field(args, "1") = idx;
-    if (@typeInfo(F).@"fn".params.len == 3) {
-        @field(args, "2") = getGlobalArg(@TypeOf(args.@"2"), local.ctx);
-    }
-    const ret = @call(.auto, func, args);
-    return handleIndexedReturn(T, F, false, local, ret, info, opts);
-}
-
 pub fn getNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
     const local = &self.local;
 
@@ -288,6 +235,59 @@ fn _getNamedIndex(comptime T: type, local: *const Local, func: anytype, name: *c
     return handleIndexedReturn(T, F, true, local, ret, info, opts);
 }
 
+pub fn setIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, js_value: *const v8.Value, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
+    const local = &self.local;
+
+    var hs: js.HandleScope = undefined;
+    hs.init(local.isolate);
+    defer hs.deinit();
+
+    const info = PropertyCallbackInfo{ .handle = handle };
+    return _setIndex(T, local, func, idx, .{ .local = &self.local, .handle = js_value }, info, opts) catch |err| {
+        handleError(T, @TypeOf(func), local, err, info);
+        return js.Intercepted.no;
+    };
+}
+
+fn _setIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, js_value: js.Value, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
+    const F = @TypeOf(func);
+    var args: ParameterTypes(F) = undefined;
+    @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());
+    @field(args, "1") = idx;
+    @field(args, "2") = try local.jsValueToZig(@TypeOf(@field(args, "2")), js_value);
+    if (@typeInfo(F).@"fn".params.len == 4) {
+        @field(args, "3") = getGlobalArg(@TypeOf(args.@"3"), local.ctx);
+    }
+    const ret = @call(.auto, func, args);
+    return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
+}
+
+pub fn deleteIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
+    const local = &self.local;
+
+    var hs: js.HandleScope = undefined;
+    hs.init(local.isolate);
+    defer hs.deinit();
+
+    const info = PropertyCallbackInfo{ .handle = handle };
+    return _deleteIndex(T, local, func, idx, info, opts) catch |err| {
+        handleError(T, @TypeOf(func), local, err, info);
+        return js.Intercepted.no;
+    };
+}
+
+fn _deleteIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
+    const F = @TypeOf(func);
+    var args: ParameterTypes(F) = undefined;
+    @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());
+    @field(args, "1") = idx;
+    if (@typeInfo(F).@"fn".params.len == 3) {
+        @field(args, "2") = getGlobalArg(@TypeOf(args.@"2"), local.ctx);
+    }
+    const ret = @call(.auto, func, args);
+    return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
+}
+
 pub fn setNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, js_value: *const v8.Value, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
     const local = &self.local;
 
@@ -312,7 +312,7 @@ fn _setNamedIndex(comptime T: type, local: *const Local, func: anytype, name: *c
         @field(args, "3") = getGlobalArg(@TypeOf(args.@"3"), local.ctx);
     }
     const ret = @call(.auto, func, args);
-    return handleIndexedReturn(T, F, false, local, ret, info, opts);
+    return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
 }
 
 pub fn deleteNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
@@ -338,7 +338,7 @@ fn _deleteNamedIndex(comptime T: type, local: *const Local, func: anytype, name:
         @field(args, "2") = getGlobalArg(@TypeOf(args.@"2"), local.ctx);
     }
     const ret = @call(.auto, func, args);
-    return handleIndexedReturn(T, F, false, local, ret, info, opts);
+    return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
 }
 
 pub fn getEnumerator(self: *Caller, comptime T: type, func: anytype, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
@@ -451,6 +451,18 @@ fn handleIndexedReturn(comptime T: type, comptime F: type, comptime with_value: 
         info.getReturnValue().set(try local.zigValueToJs(non_error_ret, opts));
     }
     return js.Intercepted.yes;
+}
+
+// Setter/deleter interceptors normally return void: intercepting is enough
+// to mark the operation successful. When they return a bool instead, it is
+// forwarded as the v8 return value; false marks the operation as failed,
+// which makes v8 throw a TypeError in strict mode.
+fn returnsBool(comptime F: type) bool {
+    const RT = @typeInfo(F).@"fn".return_type.?;
+    return switch (@typeInfo(RT)) {
+        .error_union => |eu| eu.payload == bool,
+        else => RT == bool,
+    };
 }
 
 fn isInErrorSet(err: anyerror, comptime T: type) bool {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -262,7 +262,7 @@ fn _setIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, js_
     return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
 }
 
-pub fn deleteIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
+pub fn deleteOrDefineIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
     const local = &self.local;
 
     var hs: js.HandleScope = undefined;
@@ -270,13 +270,13 @@ pub fn deleteIndex(self: *Caller, comptime T: type, func: anytype, idx: u32, han
     defer hs.deinit();
 
     const info = PropertyCallbackInfo{ .handle = handle };
-    return _deleteIndex(T, local, func, idx, info, opts) catch |err| {
+    return _deleteOrDefineIndex(T, local, func, idx, info, opts) catch |err| {
         handleError(T, @TypeOf(func), local, err, info);
         return js.Intercepted.no;
     };
 }
 
-fn _deleteIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
+fn _deleteOrDefineIndex(comptime T: type, local: *const Local, func: anytype, idx: u32, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
     const F = @TypeOf(func);
     var args: ParameterTypes(F) = undefined;
     @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());
@@ -315,7 +315,7 @@ fn _setNamedIndex(comptime T: type, local: *const Local, func: anytype, name: *c
     return handleIndexedReturn(T, F, comptime returnsBool(F), local, ret, info, opts);
 }
 
-pub fn deleteNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
+pub fn deleteOrDefineNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *const v8.Name, handle: *const v8.PropertyCallbackInfo, comptime opts: CallOpts) u32 {
     const local = &self.local;
 
     var hs: js.HandleScope = undefined;
@@ -323,13 +323,13 @@ pub fn deleteNamedIndex(self: *Caller, comptime T: type, func: anytype, name: *c
     defer hs.deinit();
 
     const info = PropertyCallbackInfo{ .handle = handle };
-    return _deleteNamedIndex(T, local, func, name, info, opts) catch |err| {
+    return _deleteOrDefineNamedIndex(T, local, func, name, info, opts) catch |err| {
         handleError(T, @TypeOf(func), local, err, info);
         return js.Intercepted.no;
     };
 }
 
-fn _deleteNamedIndex(comptime T: type, local: *const Local, func: anytype, name: *const v8.Name, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
+fn _deleteOrDefineNamedIndex(comptime T: type, local: *const Local, func: anytype, name: *const v8.Name, info: PropertyCallbackInfo, comptime opts: CallOpts) !u32 {
     const F = @TypeOf(func);
     var args: ParameterTypes(F) = undefined;
     @field(args, "0") = try TaggedOpaque.fromJS(*T, info.getThis());

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -454,12 +454,15 @@ fn countExternalReferences() comptime_int {
                 if (value.setter != null) count += 1;
                 if (value.deleter != null) count += 1;
                 if (value.query != null) count += 1;
+                if (value.definer != null) count += 1;
             } else if (T == bridge.NamedIndexed) {
                 count += 1;
                 if (value.setter != null) count += 1;
                 if (value.deleter != null) count += 1;
-                if (value.enumerator != null) count += 1;
                 if (value.query != null) count += 1;
+                if (value.definer != null) count += 1;
+                if (value.descriptor != null) count += 1;
+                if (value.enumerator != null) count += 1;
             }
         }
     }
@@ -547,6 +550,10 @@ fn collectExternalReferences() [countExternalReferences()]isize {
                     references[idx] = @bitCast(@intFromPtr(query));
                     idx += 1;
                 }
+                if (value.definer) |definer| {
+                    references[idx] = @bitCast(@intFromPtr(definer));
+                    idx += 1;
+                }
             } else if (T == bridge.NamedIndexed) {
                 references[idx] = @bitCast(@intFromPtr(value.getter));
                 idx += 1;
@@ -558,12 +565,20 @@ fn collectExternalReferences() [countExternalReferences()]isize {
                     references[idx] = @bitCast(@intFromPtr(deleter));
                     idx += 1;
                 }
-                if (value.enumerator) |enumerator| {
-                    references[idx] = @bitCast(@intFromPtr(enumerator));
-                    idx += 1;
-                }
                 if (value.query) |query| {
                     references[idx] = @bitCast(@intFromPtr(query));
+                    idx += 1;
+                }
+                if (value.definer) |definer| {
+                    references[idx] = @bitCast(@intFromPtr(definer));
+                    idx += 1;
+                }
+                if (value.descriptor) |descriptor| {
+                    references[idx] = @bitCast(@intFromPtr(descriptor));
+                    idx += 1;
+                }
+                if (value.enumerator) |enumerator| {
+                    references[idx] = @bitCast(@intFromPtr(enumerator));
                     idx += 1;
                 }
             }
@@ -852,7 +867,7 @@ fn attachClass(comptime JsApi: type, comptime flatten: bool, isolate: *v8.Isolat
                     .setter = value.setter,
                     .query = value.query,
                     .deleter = value.deleter,
-                    .definer = null,
+                    .definer = if (value.definer) |definer| @ptrCast(definer) else null,
                     .descriptor = null,
                     .index_of = null,
                     .data = null,
@@ -867,8 +882,8 @@ fn attachClass(comptime JsApi: type, comptime flatten: bool, isolate: *v8.Isolat
                     .query = value.query,
                     .deleter = value.deleter,
                     .enumerator = value.enumerator,
-                    .definer = null,
-                    .descriptor = null,
+                    .definer = if (value.definer) |definer| @ptrCast(definer) else null,
+                    .descriptor = if (value.descriptor) |descriptor| @ptrCast(descriptor) else null,
                     .data = null,
                     .flags = v8.kOnlyInterceptStrings | v8.kNonMasking,
                 };

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -347,7 +347,7 @@ pub const Indexed = struct {
                     }
                     defer caller.deinit();
 
-                    return caller.deleteIndex(T, deleter, idx, handle.?, .{
+                    return caller.deleteOrDefineIndex(T, deleter, idx, handle.?, .{
                         .as_typed_array = opts.as_typed_array,
                         .null_as_undefined = opts.null_as_undefined,
                     });
@@ -381,7 +381,7 @@ pub const Indexed = struct {
                     defer caller.deinit();
 
                     // same (self, index) -> bool shape as a deleter
-                    return caller.deleteIndex(T, definer, idx, handle.?, .{});
+                    return caller.deleteOrDefineIndex(T, definer, idx, handle.?, .{});
                 }
             }.wrap;
         }
@@ -476,7 +476,7 @@ pub const NamedIndexed = struct {
                     if (ce_frame) |frame| frame._ce_reactions.popAndInvoke(ce_checkpoint, frame);
                 };
 
-                return caller.deleteNamedIndex(T, deleter, c_name.?, handle.?, .{
+                return caller.deleteOrDefineNamedIndex(T, deleter, c_name.?, handle.?, .{
                     .as_typed_array = opts.as_typed_array,
                     .null_as_undefined = opts.null_as_undefined,
                 });
@@ -493,7 +493,7 @@ pub const NamedIndexed = struct {
                 defer caller.deinit();
 
                 // same (self, name) -> bool shape as a deleter
-                return caller.deleteNamedIndex(T, definer, c_name.?, handle.?, .{});
+                return caller.deleteOrDefineNamedIndex(T, definer, c_name.?, handle.?, .{});
             }
         }.wrap;
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -46,15 +46,23 @@ pub fn Builder(comptime T: type) type {
         }
 
         pub fn indexed(comptime getter_func: anytype, comptime enumerator_func: anytype, comptime opts: Indexed.Opts) Indexed {
-            return Indexed.init(T, getter_func, null, null, null, enumerator_func, opts);
+            return Indexed.init(T, getter_func, null, null, null, null, enumerator_func, opts);
         }
 
         pub fn indexedReadWrite(comptime getter_func: anytype, setter_func: anytype, deleter_func: anytype, query_func: anytype, comptime enumerator_func: anytype, comptime opts: Indexed.Opts) Indexed {
-            return Indexed.init(T, getter_func, setter_func, deleter_func, query_func, enumerator_func, opts);
+            return Indexed.init(T, getter_func, setter_func, deleter_func, query_func, null, enumerator_func, opts);
+        }
+
+        pub fn indexedFull(comptime getter_func: anytype, setter_func: anytype, deleter_func: anytype, query_func: anytype, definer_func: anytype, comptime enumerator_func: anytype, comptime opts: Indexed.Opts) Indexed {
+            return Indexed.init(T, getter_func, setter_func, deleter_func, query_func, definer_func, enumerator_func, opts);
         }
 
         pub fn namedIndexed(comptime getter_func: anytype, setter_func: anytype, deleter_func: anytype, enumerator_func: anytype, query_func: anytype, comptime opts: NamedIndexed.Opts) NamedIndexed {
-            return NamedIndexed.init(T, getter_func, setter_func, deleter_func, enumerator_func, query_func, opts);
+            return NamedIndexed.init(T, getter_func, setter_func, deleter_func, enumerator_func, query_func, null, null, opts);
+        }
+
+        pub fn namedIndexedFull(comptime getter_func: anytype, setter_func: anytype, deleter_func: anytype, enumerator_func: anytype, query_func: anytype, definer_func: anytype, descriptor_func: anytype, comptime opts: NamedIndexed.Opts) NamedIndexed {
+            return NamedIndexed.init(T, getter_func, setter_func, deleter_func, enumerator_func, query_func, definer_func, descriptor_func, opts);
         }
 
         pub fn iterator(comptime func: anytype, comptime opts: Iterator.Opts) Iterator {
@@ -268,13 +276,16 @@ pub const Indexed = struct {
     setter: ?*const fn (idx: u32, c_value: ?*const v8.Value, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
     deleter: ?*const fn (idx: u32, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
     query: ?*const fn (idx: u32, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
+    // v8 expects an Intercepted (u32) return; the stale void-returning
+    // typedef in binding.h is papered over with a @ptrCast at install time.
+    definer: ?*const fn (idx: u32, desc: ?*v8.PropertyDescriptor, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
 
     const Opts = struct {
         as_typed_array: bool = false,
         null_as_undefined: bool = false,
     };
 
-    fn init(comptime T: type, comptime getter: anytype, setter: anytype, deleter: anytype, query: anytype, comptime enumerator: anytype, comptime opts: Opts) Indexed {
+    fn init(comptime T: type, comptime getter: anytype, setter: anytype, deleter: anytype, query: anytype, definer: anytype, comptime enumerator: anytype, comptime opts: Opts) Indexed {
         var indexed = Indexed{
             .enumerator = null,
             .getter = struct {
@@ -359,6 +370,22 @@ pub const Indexed = struct {
             }.wrap;
         }
 
+        if (@typeInfo(@TypeOf(definer)) != .null) {
+            indexed.definer = struct {
+                fn wrap(idx: u32, _: ?*v8.PropertyDescriptor, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 {
+                    const v8_isolate = v8.v8__PropertyCallbackInfo__GetIsolate(handle).?;
+                    var caller: Caller = undefined;
+                    if (!caller.init(v8_isolate)) {
+                        return js.Intercepted.no;
+                    }
+                    defer caller.deinit();
+
+                    // same (self, index) -> bool shape as a deleter
+                    return caller.deleteIndex(T, definer, idx, handle.?, .{});
+                }
+            }.wrap;
+        }
+
         return indexed;
     }
 };
@@ -367,8 +394,12 @@ pub const NamedIndexed = struct {
     getter: *const fn (c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32,
     setter: ?*const fn (c_name: ?*const v8.Name, c_value: ?*const v8.Value, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
     deleter: ?*const fn (c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
-    enumerator: ?*const fn (handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
     query: ?*const fn (c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
+    // v8 expects an Intercepted (u32) return; the stale void-returning
+    // typedefs in binding.h are papered over with a @ptrCast at install time.
+    definer: ?*const fn (c_name: ?*const v8.Name, desc: ?*v8.PropertyDescriptor, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
+    descriptor: ?*const fn (c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
+    enumerator: ?*const fn (handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 = null,
 
     const Opts = struct {
         as_typed_array: bool = false,
@@ -379,7 +410,7 @@ pub const NamedIndexed = struct {
         ce_reactions: bool = false,
     };
 
-    fn init(comptime T: type, comptime getter: anytype, setter: anytype, deleter: anytype, enumerator: anytype, query: anytype, comptime opts: Opts) NamedIndexed {
+    fn init(comptime T: type, comptime getter: anytype, setter: anytype, deleter: anytype, enumerator: anytype, query: anytype, definer: anytype, descriptor: anytype, comptime opts: Opts) NamedIndexed {
         const getter_fn = struct {
             fn wrap(c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 {
                 const v8_isolate = v8.v8__PropertyCallbackInfo__GetIsolate(handle).?;
@@ -452,6 +483,35 @@ pub const NamedIndexed = struct {
             }
         }.wrap;
 
+        const definer_fn = if (@typeInfo(@TypeOf(definer)) == .null) null else struct {
+            fn wrap(c_name: ?*const v8.Name, _: ?*v8.PropertyDescriptor, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 {
+                const v8_isolate = v8.v8__PropertyCallbackInfo__GetIsolate(handle).?;
+                var caller: Caller = undefined;
+                if (!caller.init(v8_isolate)) {
+                    return js.Intercepted.no;
+                }
+                defer caller.deinit();
+
+                // same (self, name) -> bool shape as a deleter
+                return caller.deleteNamedIndex(T, definer, c_name.?, handle.?, .{});
+            }
+        }.wrap;
+
+        const descriptor_fn = if (@typeInfo(@TypeOf(descriptor)) == .null) null else struct {
+            fn wrap(c_name: ?*const v8.Name, handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 {
+                const v8_isolate = v8.v8__PropertyCallbackInfo__GetIsolate(handle).?;
+                var caller: Caller = undefined;
+                if (!caller.init(v8_isolate)) {
+                    return js.Intercepted.no;
+                }
+                defer caller.deinit();
+
+                // same (self, name) -> value shape as a getter; the returned
+                // struct is converted to a JS property descriptor object
+                return caller.getNamedIndex(T, descriptor, c_name.?, handle.?, .{});
+            }
+        }.wrap;
+
         const enumerator_fn = if (@typeInfo(@TypeOf(enumerator)) == .null) null else struct {
             fn wrap(handle: ?*const v8.PropertyCallbackInfo) callconv(.c) u32 {
                 const v8_isolate = v8.v8__PropertyCallbackInfo__GetIsolate(handle).?;
@@ -482,8 +542,10 @@ pub const NamedIndexed = struct {
             .getter = getter_fn,
             .setter = setter_fn,
             .deleter = deleter_fn,
-            .enumerator = enumerator_fn,
             .query = query_fn,
+            .definer = definer_fn,
+            .descriptor = descriptor_fn,
+            .enumerator = enumerator_fn,
         };
     }
 };

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -235,7 +235,7 @@ pub const JsApi = struct {
         };
 
         var names: std.ArrayList([]const u8) = .{};
-        const arena = exec.call_arena;
+        const arena = exec.local_arena;
 
         const len = self.length(frame);
         for (0..len) |i| {

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+const std = @import("std");
 const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
 const Element = @import("../Element.zig");
@@ -146,7 +147,7 @@ pub const JsApi = struct {
     };
 
     pub const length = bridge.accessor(HTMLCollection.length, null, .{});
-    pub const @"[int]" = bridge.indexedReadWrite(HTMLCollection.getAtIndex, null, deleteAtIndex, null, null, .{ .null_as_undefined = true });
+    pub const @"[int]" = bridge.indexedReadWrite(HTMLCollection.getAtIndex, null, deleteAtIndex, null, getIndexes, .{ .null_as_undefined = true });
     pub const @"[str]" = bridge.namedIndexed(struct {
         pub fn wrap(self: *HTMLCollection, name: []const u8, frame: *Frame) !?*Element {
             if (name.len == 0) {
@@ -155,7 +156,63 @@ pub const JsApi = struct {
 
             return self.getByName(name, frame) orelse error.NotHandled;
         }
-    }.wrap, null, deleteByName, null, null, .{ .null_as_undefined = true });
+    }.wrap, null, deleteByName, getNames, null, .{ .null_as_undefined = true });
+
+    fn getIndexes(self: *HTMLCollection, exec: *const Execution) !js.Array {
+        const frame = switch (exec.js.global) {
+            .frame => |f| f,
+            .worker => unreachable,
+        };
+        const len = self.length(frame);
+        var arr = exec.js.local.?.newArray(len);
+        for (0..len) |i| {
+            _ = try arr.set(@intCast(i), i, .{});
+        }
+        return arr;
+    }
+
+    // The supported property names: for each element represented by the
+    // collection, in tree order, its id and (for HTML elements) its name
+    // attribute, skipping empty values and duplicates.
+    fn getNames(self: *HTMLCollection, exec: *const Execution) !js.Array {
+        const frame = switch (exec.js.global) {
+            .frame => |f| f,
+            .worker => unreachable,
+        };
+
+        var names: std.ArrayList([]const u8) = .{};
+        const arena = exec.call_arena;
+
+        const len = self.length(frame);
+        for (0..len) |i| {
+            const element = self.getAtIndex(i, frame) orelse break;
+            if (element.getAttributeSafe(comptime .wrap("id"))) |id| {
+                if (id.len > 0 and !contains(names.items, id)) {
+                    try names.append(arena, id);
+                }
+            }
+            if (element._namespace == .html) {
+                if (element.getAttributeSafe(comptime .wrap("name"))) |name| {
+                    if (name.len > 0 and !contains(names.items, name)) {
+                        try names.append(arena, name);
+                    }
+                }
+            }
+        }
+
+        var arr = exec.js.local.?.newArray(@intCast(names.items.len));
+        for (names.items, 0..) |name, i| {
+            _ = try arr.set(@intCast(i), name, .{});
+        }
+        return arr;
+    }
+
+    fn contains(names: []const []const u8, name: []const u8) bool {
+        for (names) |n| {
+            if (std.mem.eql(u8, n, name)) return true;
+        }
+        return false;
+    }
 
     // Supported indexed and named properties can't be deleted (delete returns
     // false, which throws a TypeError in strict mode); unsupported ones follow

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -146,7 +146,7 @@ pub const JsApi = struct {
     };
 
     pub const length = bridge.accessor(HTMLCollection.length, null, .{});
-    pub const @"[int]" = bridge.indexed(HTMLCollection.getAtIndex, null, .{ .null_as_undefined = true });
+    pub const @"[int]" = bridge.indexedReadWrite(HTMLCollection.getAtIndex, null, deleteAtIndex, null, null, .{ .null_as_undefined = true });
     pub const @"[str]" = bridge.namedIndexed(struct {
         pub fn wrap(self: *HTMLCollection, name: []const u8, frame: *Frame) !?*Element {
             if (name.len == 0) {
@@ -155,7 +155,24 @@ pub const JsApi = struct {
 
             return self.getByName(name, frame) orelse error.NotHandled;
         }
-    }.wrap, null, null, null, null, .{ .null_as_undefined = true });
+    }.wrap, null, deleteByName, null, null, .{ .null_as_undefined = true });
+
+    // Supported indexed and named properties can't be deleted (delete returns
+    // false, which throws a TypeError in strict mode); unsupported ones follow
+    // the ordinary [[Delete]] path.
+    fn deleteAtIndex(self: *HTMLCollection, idx: u32, frame: *Frame) !bool {
+        if (idx < self.length(frame)) {
+            return false;
+        }
+        return error.NotHandled;
+    }
+
+    fn deleteByName(self: *HTMLCollection, name: []const u8, frame: *Frame) !bool {
+        if (self.getByName(name, frame) != null) {
+            return false;
+        }
+        return error.NotHandled;
+    }
 
     pub const item = bridge.function(_item, .{});
     fn _item(self: *HTMLCollection, index: i32, frame: *Frame) ?*Element {

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -229,13 +229,8 @@ pub const JsApi = struct {
     // collection, in tree order, its id and (for HTML elements) its name
     // attribute, skipping empty values and duplicates.
     fn getNames(self: *HTMLCollection, frame: *Frame) !js.Array {
-        const frame = switch (exec.js.global) {
-            .frame => |f| f,
-            .worker => unreachable,
-        };
-
         var names: std.ArrayList([]const u8) = .{};
-        const arena = exec.local_arena;
+        const arena = frame.local_arena;
 
         const len = self.length(frame);
         for (0..len) |i| {
@@ -254,7 +249,7 @@ pub const JsApi = struct {
             }
         }
 
-        var arr = exec.js.local.?.newArray(@intCast(names.items.len));
+        var arr = frame.js.local.?.newArray(@intCast(names.items.len));
         for (names.items, 0..) |name, i| {
             _ = try arr.set(@intCast(i), name, .{});
         }

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -228,7 +228,7 @@ pub const JsApi = struct {
     // The supported property names: for each element represented by the
     // collection, in tree order, its id and (for HTML elements) its name
     // attribute, skipping empty values and duplicates.
-    fn getNames(self: *HTMLCollection, exec: *const Execution) !js.Array {
+    fn getNames(self: *HTMLCollection, frame: *Frame) !js.Array {
         const frame = switch (exec.js.global) {
             .frame => |f| f,
             .worker => unreachable,

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -147,8 +147,8 @@ pub const JsApi = struct {
     };
 
     pub const length = bridge.accessor(HTMLCollection.length, null, .{});
-    pub const @"[int]" = bridge.indexedReadWrite(HTMLCollection.getAtIndex, null, deleteAtIndex, null, getIndexes, .{ .null_as_undefined = true });
-    pub const @"[str]" = bridge.namedIndexed(struct {
+    pub const @"[int]" = bridge.indexedFull(HTMLCollection.getAtIndex, setAtIndex, deleteAtIndex, queryAtIndex, defineAtIndex, getIndexes, .{ .null_as_undefined = true });
+    pub const @"[str]" = bridge.namedIndexedFull(struct {
         pub fn wrap(self: *HTMLCollection, name: []const u8, frame: *Frame) !?*Element {
             if (name.len == 0) {
                 return error.NotHandled;
@@ -156,7 +156,61 @@ pub const JsApi = struct {
 
             return self.getByName(name, frame) orelse error.NotHandled;
         }
-    }.wrap, null, deleteByName, getNames, null, .{ .null_as_undefined = true });
+    }.wrap, null, deleteByName, getNames, null, defineByName, describeByName, .{ .null_as_undefined = true });
+
+    // HTMLCollection has no indexed setter: per Web IDL, assigning to or
+    // defining any array index property fails (TypeError in strict mode).
+    fn setAtIndex(_: *HTMLCollection, _: u32, _: js.Value) bool {
+        return false;
+    }
+
+    fn defineAtIndex(_: *HTMLCollection, _: u32) bool {
+        return false;
+    }
+
+    // Supported indexed properties are enumerable, configurable, read-only.
+    fn queryAtIndex(self: *HTMLCollection, idx: u32, frame: *Frame) !u32 {
+        if (idx < self.length(frame)) {
+            return js.v8.ReadOnly;
+        }
+        return error.NotHandled;
+    }
+
+    // Redefining a supported named property fails; unsupported names follow
+    // the ordinary path, so expandos remain allowed. Note there is no named
+    // setter and no named query: a direct assignment falls through to the
+    // ordinary [[Set]] which ends up in defineByName, while an assignment
+    // through a derived object (the collection as prototype) must ignore the
+    // named property entirely and create an expando on the receiver.
+    fn defineByName(self: *HTMLCollection, name: []const u8, frame: *Frame) !bool {
+        if (name.len > 0 and self.getByName(name, frame) != null) {
+            return false;
+        }
+        return error.NotHandled;
+    }
+
+    // Named properties are [LegacyUnenumerableNamedProperties]: not
+    // enumerable, configurable, read-only.
+    fn describeByName(self: *HTMLCollection, name: []const u8, frame: *Frame) !Descriptor {
+        if (name.len > 0) {
+            if (self.getByName(name, frame)) |element| {
+                return .{
+                    .value = element,
+                    .writable = false,
+                    .enumerable = false,
+                    .configurable = true,
+                };
+            }
+        }
+        return error.NotHandled;
+    }
+
+    const Descriptor = struct {
+        value: *Element,
+        writable: bool,
+        enumerable: bool,
+        configurable: bool,
+    };
 
     fn getIndexes(self: *HTMLCollection, exec: *const Execution) !js.Array {
         const frame = switch (exec.js.global) {

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -625,7 +625,7 @@ pub const NamedNodeMap = struct {
 
         fn getIndexes(self: *const NamedNodeMap, frame: *Frame) !js.Array {
             const len = self.length();
-            var arr = exec.js.local.?.newArray(len);
+            var arr = frame.js.local.?.newArray(len);
             for (0..len) |i| {
                 _ = try arr.set(@intCast(i), i, .{});
             }

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -623,7 +623,7 @@ pub const NamedNodeMap = struct {
         pub const @"[int]" = bridge.indexed(NamedNodeMap.getAtIndex, getIndexes, .{ .null_as_undefined = true });
         pub const @"[str]" = bridge.namedIndexed(NamedNodeMap.getByName, null, null, getNames, null, .{ .null_as_undefined = true });
 
-        fn getIndexes(self: *const NamedNodeMap, exec: *const js.Execution) !js.Array {
+        fn getIndexes(self: *const NamedNodeMap, frame: *Frame) !js.Array {
             const len = self.length();
             var arr = exec.js.local.?.newArray(len);
             for (0..len) |i| {

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -633,8 +633,8 @@ pub const NamedNodeMap = struct {
         }
 
         fn getNames(self: *const NamedNodeMap, frame: *Frame) !js.Array {
-            const names = try self.list().getNames(exec.local_arena);
-            var arr = exec.js.local.?.newArray(@intCast(names.len));
+            const names = try self.list().getNames(frame.local_arena);
+            var arr = frame.js.local.?.newArray(@intCast(names.len));
             for (names, 0..) |name, i| {
                 _ = try arr.set(@intCast(i), name, .{});
             }

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -620,8 +620,26 @@ pub const NamedNodeMap = struct {
         };
 
         pub const length = bridge.accessor(NamedNodeMap.length, null, .{});
-        pub const @"[int]" = bridge.indexed(NamedNodeMap.getAtIndex, null, .{ .null_as_undefined = true });
-        pub const @"[str]" = bridge.namedIndexed(NamedNodeMap.getByName, null, null, null, null, .{ .null_as_undefined = true });
+        pub const @"[int]" = bridge.indexed(NamedNodeMap.getAtIndex, getIndexes, .{ .null_as_undefined = true });
+        pub const @"[str]" = bridge.namedIndexed(NamedNodeMap.getByName, null, null, getNames, null, .{ .null_as_undefined = true });
+
+        fn getIndexes(self: *const NamedNodeMap, exec: *const js.Execution) !js.Array {
+            const len = self.length();
+            var arr = exec.js.local.?.newArray(len);
+            for (0..len) |i| {
+                _ = try arr.set(@intCast(i), i, .{});
+            }
+            return arr;
+        }
+
+        fn getNames(self: *const NamedNodeMap, exec: *const js.Execution) !js.Array {
+            const names = try self.list().getNames(exec.call_arena);
+            var arr = exec.js.local.?.newArray(@intCast(names.len));
+            for (names, 0..) |name, i| {
+                _ = try arr.set(@intCast(i), name, .{});
+            }
+            return arr;
+        }
         pub const getNamedItem = bridge.function(NamedNodeMap.getByName, .{});
         pub const setNamedItem = bridge.function(NamedNodeMap.set, .{ .ce_reactions = true });
         pub const removeNamedItem = bridge.function(NamedNodeMap.removeByName, .{ .ce_reactions = true });

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -633,7 +633,7 @@ pub const NamedNodeMap = struct {
         }
 
         fn getNames(self: *const NamedNodeMap, exec: *const js.Execution) !js.Array {
-            const names = try self.list().getNames(exec.call_arena);
+            const names = try self.list().getNames(exec.local_arena);
             var arr = exec.js.local.?.newArray(@intCast(names.len));
             for (names, 0..) |name, i| {
                 _ = try arr.set(@intCast(i), name, .{});

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -632,7 +632,7 @@ pub const NamedNodeMap = struct {
             return arr;
         }
 
-        fn getNames(self: *const NamedNodeMap, exec: *const js.Execution) !js.Array {
+        fn getNames(self: *const NamedNodeMap, frame: *Frame) !js.Array {
             const names = try self.list().getNames(exec.local_arena);
             var arr = exec.js.local.?.newArray(@intCast(names.len));
             for (names, 0..) |name, i| {

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -141,7 +141,7 @@ pub const JsApi = struct {
     // element's data-* attributes, in attribute order.
     fn getNames(self: *DOMStringMap, exec: *const js.Execution) !js.Array {
         var names: std.ArrayList([]const u8) = .empty;
-        for (try self._element._attributes.getNames(exec.call_arena)) |attr_name| {
+        for (try self._element._attributes.getNames(exec.local_arena)) |attr_name| {
             const camel = (try kebabToCamel(exec.local_arena, attr_name)) orelse continue;
             try names.append(exec.local_arena, camel);
         }

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -142,7 +142,7 @@ pub const JsApi = struct {
     fn getNames(self: *DOMStringMap, exec: *const js.Execution) !js.Array {
         var names: std.ArrayList([]const u8) = .empty;
         for (try self._element._attributes.getNames(exec.call_arena)) |attr_name| {
-            const camel = (try kebabToCamel(exec.call_arena, attr_name)) orelse continue;
+            const camel = (try kebabToCamel(exec.local_arena, attr_name)) orelse continue;
             try names.append(exec.call_arena, camel);
         }
 

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -146,7 +146,7 @@ pub const JsApi = struct {
             try names.append(exec.local_arena, camel);
         }
 
-        var arr = exec.js.local.?.newArray(@intCast(names.items.len));
+        var arr = frame.js.local.?.newArray(@intCast(names.items.len));
         for (names.items, 0..) |name, i| {
             _ = try arr.set(@intCast(i), name, .{});
         }

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -143,7 +143,7 @@ pub const JsApi = struct {
         var names: std.ArrayList([]const u8) = .empty;
         for (try self._element._attributes.getNames(exec.call_arena)) |attr_name| {
             const camel = (try kebabToCamel(exec.local_arena, attr_name)) orelse continue;
-            try names.append(exec.call_arena, camel);
+            try names.append(exec.local_arena, camel);
         }
 
         var arr = exec.js.local.?.newArray(@intCast(names.items.len));

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -139,11 +139,11 @@ pub const JsApi = struct {
 
     // The supported property names are the camel-cased names of the
     // element's data-* attributes, in attribute order.
-    fn getNames(self: *DOMStringMap, exec: *const js.Execution) !js.Array {
+    fn getNames(self: *DOMStringMap, frame: *Frame) !js.Array {
         var names: std.ArrayList([]const u8) = .empty;
-        for (try self._element._attributes.getNames(exec.local_arena)) |attr_name| {
-            const camel = (try kebabToCamel(exec.local_arena, attr_name)) orelse continue;
-            try names.append(exec.local_arena, camel);
+        for (try self._element._attributes.getNames(frame.local_arena)) |attr_name| {
+            const camel = (try kebabToCamel(frame.local_arena, attr_name)) orelse continue;
+            try names.append(frame.local_arena, camel);
         }
 
         var arr = frame.js.local.?.newArray(@intCast(names.items.len));

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -98,27 +98,26 @@ fn camelToKebab(arena: Allocator, camel: String) !String {
     return try String.init(arena, result.items, .{});
 }
 
-// data-foo-bar -> fooBar
+// data-foo-bar -> fooBar. Returns null for non data-* attributes. Per spec,
+// only a '-' followed by an ASCII lowercase letter is folded into an
+// uppercase letter; any other '-' (e.g. trailing) is kept as-is, and the
+// bare "data-" attribute maps to the empty name.
 fn kebabToCamel(arena: Allocator, kebab: []const u8) !?[]const u8 {
     if (!std.mem.startsWith(u8, kebab, "data-")) {
         return null;
     }
 
     const data_part = kebab[5..]; // Skip "data-"
-    if (data_part.len == 0) {
-        return null;
-    }
 
     var result: std.ArrayList(u8) = .empty;
     try result.ensureTotalCapacity(arena, data_part.len);
 
-    var capitalize_next = false;
-    for (data_part) |c| {
-        if (c == '-') {
-            capitalize_next = true;
-        } else if (capitalize_next) {
-            result.appendAssumeCapacity(std.ascii.toUpper(c));
-            capitalize_next = false;
+    var i: usize = 0;
+    while (i < data_part.len) : (i += 1) {
+        const c = data_part[i];
+        if (c == '-' and i + 1 < data_part.len and std.ascii.isLower(data_part[i + 1])) {
+            result.appendAssumeCapacity(std.ascii.toUpper(data_part[i + 1]));
+            i += 1;
         } else {
             result.appendAssumeCapacity(c);
         }
@@ -136,5 +135,21 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const @"[]" = bridge.namedIndexed(getProperty, setProperty, deleteProperty, null, null, .{ .null_as_undefined = true, .ce_reactions = true });
+    pub const @"[]" = bridge.namedIndexed(getProperty, setProperty, deleteProperty, getNames, null, .{ .null_as_undefined = true, .ce_reactions = true });
+
+    // The supported property names are the camel-cased names of the
+    // element's data-* attributes, in attribute order.
+    fn getNames(self: *DOMStringMap, exec: *const js.Execution) !js.Array {
+        var names: std.ArrayList([]const u8) = .empty;
+        for (try self._element._attributes.getNames(exec.call_arena)) |attr_name| {
+            const camel = (try kebabToCamel(exec.call_arena, attr_name)) orelse continue;
+            try names.append(exec.call_arena, camel);
+        }
+
+        var arr = exec.js.local.?.newArray(@intCast(names.items.len));
+        for (names.items, 0..) |name, i| {
+            _ = try arr.set(@intCast(i), name, .{});
+        }
+        return arr;
+    }
 };


### PR DESCRIPTION
Stacked PR 2/22 (based on #2942). Makes `/dom/collections` fully green (53/53) by implementing the Web IDL legacy platform object semantics for HTMLCollection, NamedNodeMap and DOMStringMap.

## Commits

**webapi: supported HTMLCollection properties can't be deleted**
- `delete collection[0]` / `delete collection.name` succeeded; supported properties are backed by the live collection, so deletion must fail (TypeError in strict mode). HTMLCollection now registers indexed/named deleter interceptors.

**webapi: enumerate collection supported properties for ownPropertyNames**
- `Object.getOwnPropertyNames` returned no interceptor-backed properties. HTMLCollection, NamedNodeMap and DOMStringMap now register indexed/named enumerators implementing the spec's supported property names (including the spec's kebab→camel conversion for `data-*`).

**js: support definer/descriptor interceptors; fix HTMLCollection expandos**
- Adds definer and descriptor interceptor callbacks to the JS bridge (new `indexedFull`/`namedIndexedFull` builders; existing call sites untouched). HTMLCollection uses them so assignments and `Object.defineProperty` on supported properties fail, descriptors report the spec attributes (`[LegacyUnenumerableNamedProperties]`), and expandos on derived objects keep working.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/collections/HTMLCollection-delete.html | 2/4 | 4/4 |
| /dom/collections/HTMLCollection-live-mutations.window.html | 4/5 | 5/5 |
| /dom/collections/HTMLCollection-supported-property-names.html | 2/6 | 6/6 |
| /dom/collections/namednodemap-supported-property-names.html | 0/3 | 3/3 |
| /dom/collections/domstringmap-supported-property-names.html | 0/5 | 5/5 |
| /dom/collections/HTMLCollection-own-props.html | 4/8 | 8/8 |
| /dom/collections/HTMLCollection-supported-property-indices.html | 4/7 | 7/7 |

`/dom/collections` ends fully green: 53/53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
