### PR TITLE
webapi: listener option validation, window-reflecting handlers, exception propagation

### DIFF
--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -515,6 +515,10 @@ fn handleError(comptime T: type, comptime F: type, local: *const Local, err: any
 
     const js_err: *const v8.Value = switch (err) {
         error.TryCatchRethrow => return,
+        // A JS exception is already pending in the isolate (e.g. a value's
+        // toString threw during argument conversion); throwing anything here
+        // would replace the original exception the script expects to see.
+        error.JsException => return,
         error.InvalidArgument => isolate.createTypeError("invalid argument"),
         error.TypeError => isolate.createTypeError(""),
         error.RangeError => isolate.createRangeError(""),
@@ -1016,6 +1020,11 @@ fn getArgs(comptime F: type, comptime offset: usize, local: *const Local, info: 
             // type instantiation of jsValueToZig may not include such errors
             // in its inferred error set.
             @field(args, tupleFieldName(field_index)) = local.jsValueToZig(param.type.?, js_val) catch |err| {
+                if (err == error.JsException) {
+                    // an exception thrown by user code (e.g. a toString
+                    // getter) is pending; propagate it untouched
+                    return err;
+                }
                 const DOMException = @import("../webapi/DOMException.zig");
                 if (DOMException.fromError(err) != null) {
                     return err;

--- a/src/browser/tests/frames/support/window_reflecting.html
+++ b/src/browser/tests/frames/support/window_reflecting.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<!-- The onresize attribute exercises the parse-time path: it must land on
+     THIS frame's window, not the top frame's. -->
+<body onresize="window.__attr_resize = true">
+  <p>x</p>
+</body>

--- a/src/browser/tests/frames/window_reflecting_handlers.html
+++ b/src/browser/tests/frames/window_reflecting_handlers.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<head></head>
+<body>
+<script src="../testing.js"></script>
+
+<!--
+The window-reflecting body element event handlers (onblur, onerror, onfocus,
+onload, onresize, onscroll) alias the Window of the body's node document. A
+same-origin script reaching into another frame (parent setting a handler on
+an iframe's body) must target the iframe's window, not the window of the
+realm running the assignment.
+-->
+<iframe id="wrh" src="support/window_reflecting.html"></iframe>
+
+<script id="cross_realm_property_handlers">
+  testing.onload(() => {
+    const idf = document.getElementById('wrh');
+    const ibody = idf.contentDocument.body;
+    const iwin = idf.contentWindow;
+
+    const cb = () => {};
+    ibody.onblur = cb;
+    testing.expectEqual(cb, ibody.onblur);
+    testing.expectEqual(cb, iwin.onblur);
+    // the parent's window (the caller's realm) must be untouched
+    testing.expectTrue(window.onblur == null);
+    testing.expectTrue(document.body.onblur == null);
+
+    ibody.onblur = null;
+    testing.expectTrue(iwin.onblur == null);
+  });
+</script>
+
+<script id="cross_realm_attribute_handlers">
+  testing.onload(() => {
+    const idf = document.getElementById('wrh');
+    const ibody = idf.contentDocument.body;
+    const iwin = idf.contentWindow;
+
+    // Parse-time: the onresize attribute in the iframe's markup was compiled
+    // onto the iframe's window while the parent frame was the active one.
+    testing.expectEqual('function', typeof iwin.onresize);
+    testing.expectTrue(window.onresize == null);
+
+    // Runtime: setting the content attribute from the parent realm.
+    ibody.setAttribute('onscroll', 'window.__parent_set = true');
+    testing.expectEqual('function', typeof iwin.onscroll);
+    testing.expectTrue(window.onscroll == null);
+
+    ibody.removeAttribute('onscroll');
+    testing.expectTrue(iwin.onscroll == null);
+  });
+</script>

--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -23,6 +23,7 @@ const Page = @import("../Page.zig");
 const EventManager = @import("../EventManager.zig");
 
 const Event = @import("Event.zig");
+const AbortSignal = @import("AbortSignal.zig");
 
 const RegisterOptions = EventManager.RegisterOptions;
 
@@ -83,7 +84,17 @@ pub fn dispatchEvent(self: *EventTarget, event: *Event, exec: *js.Execution) !bo
 
 const AddEventListenerOptions = union(enum) {
     capture: bool,
-    options: RegisterOptions,
+    options: Options,
+
+    // The signal is kept as a raw js.Value so that an explicit null (or any
+    // non-AbortSignal value) can be told apart from an absent or undefined
+    // member, and rejected with a TypeError per the dictionary conversion.
+    const Options = struct {
+        once: bool = false,
+        capture: bool = false,
+        passive: bool = false,
+        signal: ?js.Value = null,
+    };
 };
 
 pub const EventListenerCallback = union(enum) {
@@ -91,19 +102,32 @@ pub const EventListenerCallback = union(enum) {
     object: js.Object,
 };
 pub fn addEventListener(self: *EventTarget, typ: []const u8, callback_: ?EventListenerCallback, opts_: ?AddEventListenerOptions, exec: *js.Execution) !void {
+    // Convert the options before the null-callback early return: per spec,
+    // the dictionary conversion throws even when the callback is null.
+    const options = blk: {
+        const o = opts_ orelse break :blk RegisterOptions{};
+        break :blk switch (o) {
+            .options => |opts| RegisterOptions{
+                .once = opts.once,
+                .capture = opts.capture,
+                .passive = opts.passive,
+                .signal = signal: {
+                    const signal = opts.signal orelse break :signal null;
+                    if (signal.isUndefined()) {
+                        break :signal null;
+                    }
+                    break :signal try signal.toZig(*AbortSignal);
+                },
+            },
+            .capture => |capture| RegisterOptions{ .capture = capture },
+        };
+    };
+
     const callback = callback_ orelse return;
 
     const em_callback: EventManager.Callback = switch (callback) {
         .object => |obj| .{ .object = obj },
         .function => |func| .{ .function = func },
-    };
-
-    const options = blk: {
-        const o = opts_ orelse break :blk RegisterOptions{};
-        break :blk switch (o) {
-            .options => |opts| opts,
-            .capture => |capture| RegisterOptions{ .capture = capture },
-        };
     };
 
     switch (exec.js.global) {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -428,7 +428,7 @@ pub fn setOnScroll(self: *Window, setter: ?FunctionSetter) void {
 // event handlers of body and frameset elements are aliases for the Window's.
 // Returns the Window storage slot for the given content attribute name, or
 // null if the attribute isn't part of the set.
-pub fn windowReflectingHandler(self: *Window, name: lp.String) ?*?js.Function.Global {
+fn windowReflectingHandler(self: *Window, name: lp.String) ?*?js.Function.Global {
     if (name.eql(comptime .wrap("onblur"))) return &self._on_blur;
     if (name.eql(comptime .wrap("onerror"))) return &self._on_error;
     if (name.eql(comptime .wrap("onfocus"))) return &self._on_focus;

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -82,6 +82,10 @@ _on_pageshow: ?js.Function.Global = null,
 _on_popstate: ?js.Function.Global = null,
 _on_hashchange: ?js.Function.Global = null,
 _on_error: ?js.Function.Global = null,
+_on_blur: ?js.Function.Global = null,
+_on_focus: ?js.Function.Global = null,
+_on_resize: ?js.Function.Global = null,
+_on_scroll: ?js.Function.Global = null,
 _on_message: ?js.Function.Global = null,
 _on_rejection_handled: ?js.Function.Global = null,
 _on_unhandled_rejection: ?js.Function.Global = null,
@@ -386,6 +390,68 @@ pub fn getOnError(self: *const Window) ?js.Function.Global {
 
 pub fn setOnError(self: *Window, setter: ?FunctionSetter) void {
     self._on_error = getFunctionFromSetter(setter);
+}
+
+pub fn getOnBlur(self: *const Window) ?js.Function.Global {
+    return self._on_blur;
+}
+
+pub fn setOnBlur(self: *Window, setter: ?FunctionSetter) void {
+    self._on_blur = getFunctionFromSetter(setter);
+}
+
+pub fn getOnFocus(self: *const Window) ?js.Function.Global {
+    return self._on_focus;
+}
+
+pub fn setOnFocus(self: *Window, setter: ?FunctionSetter) void {
+    self._on_focus = getFunctionFromSetter(setter);
+}
+
+pub fn getOnResize(self: *const Window) ?js.Function.Global {
+    return self._on_resize;
+}
+
+pub fn setOnResize(self: *Window, setter: ?FunctionSetter) void {
+    self._on_resize = getFunctionFromSetter(setter);
+}
+
+pub fn getOnScroll(self: *const Window) ?js.Function.Global {
+    return self._on_scroll;
+}
+
+pub fn setOnScroll(self: *Window, setter: ?FunctionSetter) void {
+    self._on_scroll = getFunctionFromSetter(setter);
+}
+
+// The "window-reflecting body element event handler set" (HTML spec): these
+// event handlers of body and frameset elements are aliases for the Window's.
+// Returns the Window storage slot for the given content attribute name, or
+// null if the attribute isn't part of the set.
+pub fn windowReflectingHandler(self: *Window, name: lp.String) ?*?js.Function.Global {
+    if (name.eql(comptime .wrap("onblur"))) return &self._on_blur;
+    if (name.eql(comptime .wrap("onerror"))) return &self._on_error;
+    if (name.eql(comptime .wrap("onfocus"))) return &self._on_focus;
+    if (name.eql(comptime .wrap("onload"))) return &self._on_load;
+    if (name.eql(comptime .wrap("onresize"))) return &self._on_resize;
+    if (name.eql(comptime .wrap("onscroll"))) return &self._on_scroll;
+    return null;
+}
+
+// Applies a window-reflecting content attribute (set on a body or frameset
+// element) to the Window's event handler. A null value clears the handler.
+pub fn setWindowReflectingHandlerFromAttribute(self: *Window, name: lp.String, value: ?[]const u8, frame: *Frame) void {
+    const slot = self.windowReflectingHandler(name) orelse return;
+    const expr = value orelse {
+        slot.* = null;
+        return;
+    };
+    if (frame.js.stringToPersistedFunction(expr, &.{"event"}, &.{})) |func| {
+        slot.* = func;
+    } else |err| {
+        log.err(.js, "window reflecting handler", .{ .err = err, .str = expr });
+        slot.* = null;
+    }
 }
 
 pub fn getOnMessage(self: *const Window) ?js.Function.Global {
@@ -1010,7 +1076,7 @@ const PostMessageCallback = struct {
     }
 };
 
-const FunctionSetter = union(enum) {
+pub const FunctionSetter = union(enum) {
     func: js.Function.Global,
     anything: js.Value,
 };
@@ -1018,7 +1084,7 @@ const FunctionSetter = union(enum) {
 // window.onload = {}; doesn't fail, but it doesn't do anything.
 // seems like setting to null is ok (though, at least on Firefix, it preserves
 // the original value, which we could do, but why?)
-fn getFunctionFromSetter(setter_: ?FunctionSetter) ?js.Function.Global {
+pub fn getFunctionFromSetter(setter_: ?FunctionSetter) ?js.Function.Global {
     const setter = setter_ orelse return null;
     return switch (setter) {
         .func => |func| func, // Already a Global from bridge auto-conversion
@@ -1076,6 +1142,10 @@ pub const JsApi = struct {
     pub const onpopstate = bridge.accessor(Window.getOnPopState, Window.setOnPopState, .{});
     pub const onhashchange = bridge.accessor(Window.getOnHashChange, Window.setOnHashChange, .{});
     pub const onerror = bridge.accessor(Window.getOnError, Window.setOnError, .{});
+    pub const onblur = bridge.accessor(Window.getOnBlur, Window.setOnBlur, .{});
+    pub const onfocus = bridge.accessor(Window.getOnFocus, Window.setOnFocus, .{});
+    pub const onresize = bridge.accessor(Window.getOnResize, Window.setOnResize, .{});
+    pub const onscroll = bridge.accessor(Window.getOnScroll, Window.setOnScroll, .{});
     pub const onmessage = bridge.accessor(Window.getOnMessage, Window.setOnMessage, .{});
     pub const onrejectionhandled = bridge.accessor(Window.getOnRejectionHandled, Window.setOnRejectionHandled, .{});
     pub const onunhandledrejection = bridge.accessor(Window.getOnUnhandledRejection, Window.setOnUnhandledRejection, .{});

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -212,13 +212,9 @@ pub const JsApi = struct {
         configurable: bool,
     };
 
-    fn getIndexes(self: *HTMLCollection, exec: *const Execution) !js.Array {
-        const frame = switch (exec.js.global) {
-            .frame => |f| f,
-            .worker => unreachable,
-        };
+    fn getIndexes(self: *HTMLCollection, frame: *Frame) !js.Array {
         const len = self.length(frame);
-        var arr = exec.js.local.?.newArray(len);
+        var arr = frame.js.local.?.newArray(len);
         for (0..len) |i| {
             _ = try arr.set(@intCast(i), i, .{});
         }

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -22,9 +22,10 @@ const Frame = @import("../../../Frame.zig");
 
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
+const Window = @import("../../Window.zig");
 const HtmlElement = @import("../Html.zig");
 
-const log = lp.log;
+const String = lp.String;
 
 const Body = @This();
 
@@ -37,14 +38,49 @@ pub fn asNode(self: *Body) *Node {
     return self.asElement().asNode();
 }
 
-/// Special-case: `body.onload` is actually an alias for `window.onload`.
-pub fn setOnLoad(_: *Body, callback: ?js.Function.Global, frame: *Frame) !void {
-    frame.window._on_load = callback;
+// Special-case: the "window-reflecting body element event handler set"
+// (blur, error, focus, load, resize, scroll) are aliases for the Window's
+// event handlers.
+pub fn getOnBlur(_: *Body, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_blur;
+}
+pub fn setOnBlur(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_blur = Window.getFunctionFromSetter(setter);
 }
 
-/// Special-case: `body.onload` is actually an alias for `window.onload`.
+pub fn getOnError(_: *Body, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_error;
+}
+pub fn setOnError(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_error = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnFocus(_: *Body, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_focus;
+}
+pub fn setOnFocus(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_focus = Window.getFunctionFromSetter(setter);
+}
+
 pub fn getOnLoad(_: *Body, frame: *Frame) ?js.Function.Global {
     return frame.window._on_load;
+}
+pub fn setOnLoad(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_load = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnResize(_: *Body, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_resize;
+}
+pub fn setOnResize(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_resize = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnScroll(_: *Body, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_scroll;
+}
+pub fn setOnScroll(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub const JsApi = struct {
@@ -56,17 +92,33 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    pub const onblur = bridge.accessor(getOnBlur, setOnBlur, .{ .null_as_undefined = false });
+    pub const onerror = bridge.accessor(getOnError, setOnError, .{ .null_as_undefined = false });
+    pub const onfocus = bridge.accessor(getOnFocus, setOnFocus, .{ .null_as_undefined = false });
     pub const onload = bridge.accessor(getOnLoad, setOnLoad, .{ .null_as_undefined = false });
+    pub const onresize = bridge.accessor(getOnResize, setOnResize, .{ .null_as_undefined = false });
+    pub const onscroll = bridge.accessor(getOnScroll, setOnScroll, .{ .null_as_undefined = false });
 };
 
 pub const Build = struct {
+    const window_reflecting_attributes = [_][]const u8{
+        "onblur", "onerror", "onfocus", "onload", "onresize", "onscroll",
+    };
+
     pub fn complete(node: *Node, frame: *Frame) !void {
         const el = node.as(Element);
-        const on_load = el.getAttributeSafe(comptime .wrap("onload")) orelse return;
-        if (frame.js.stringToPersistedFunction(on_load, &.{"event"}, &.{})) |func| {
-            frame.window._on_load = func;
-        } else |err| {
-            log.err(.js, "body.onload", .{ .err = err, .str = on_load });
+        inline for (window_reflecting_attributes) |attr| {
+            if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
+                frame.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, frame);
+            }
         }
+    }
+
+    pub fn attributeChange(_: *Element, name: String, value: String, frame: *Frame) !void {
+        frame.window.setWindowReflectingHandlerFromAttribute(name, value.str(), frame);
+    }
+
+    pub fn attributeRemove(_: *Element, name: String, frame: *Frame) !void {
+        frame.window.setWindowReflectingHandlerFromAttribute(name, null, frame);
     }
 };

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -41,46 +41,54 @@ pub fn asNode(self: *Body) *Node {
 // Special-case: the "window-reflecting body element event handler set"
 // (blur, error, focus, load, resize, scroll) are aliases for the Window's
 // event handlers.
-pub fn getOnBlur(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_blur;
-}
-pub fn setOnBlur(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_blur = Window.getFunctionFromSetter(setter);
+
+// The aliased Window is the one of the element's node document's frame — not
+// the caller's frame, which differs when a same-origin script reaches into
+// another frame (e.g. the parent setting iframeDoc.body.onblur).
+fn reflectedWindow(self: *Body, frame: *Frame) *Window {
+    return self.asElement().ownerFrame(frame).window;
 }
 
-pub fn getOnError(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_error;
+pub fn getOnBlur(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_blur;
 }
-pub fn setOnError(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_error = Window.getFunctionFromSetter(setter);
-}
-
-pub fn getOnFocus(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_focus;
-}
-pub fn setOnFocus(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_focus = Window.getFunctionFromSetter(setter);
+pub fn setOnBlur(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_blur = Window.getFunctionFromSetter(setter);
 }
 
-pub fn getOnLoad(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_load;
+pub fn getOnError(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_error;
 }
-pub fn setOnLoad(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_load = Window.getFunctionFromSetter(setter);
-}
-
-pub fn getOnResize(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_resize;
-}
-pub fn setOnResize(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_resize = Window.getFunctionFromSetter(setter);
+pub fn setOnError(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_error = Window.getFunctionFromSetter(setter);
 }
 
-pub fn getOnScroll(_: *Body, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_scroll;
+pub fn getOnFocus(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_focus;
 }
-pub fn setOnScroll(_: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_scroll = Window.getFunctionFromSetter(setter);
+pub fn setOnFocus(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_focus = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnLoad(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_load;
+}
+pub fn setOnLoad(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_load = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnResize(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_resize;
+}
+pub fn setOnResize(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_resize = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnScroll(self: *Body, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_scroll;
+}
+pub fn setOnScroll(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub const JsApi = struct {
@@ -107,18 +115,21 @@ pub const Build = struct {
 
     pub fn complete(node: *Node, frame: *Frame) !void {
         const el = node.as(Element);
+        const owner = node.ownerFrame(frame);
         inline for (window_reflecting_attributes) |attr| {
             if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
-                frame.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, frame);
+                owner.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, owner);
             }
         }
     }
 
-    pub fn attributeChange(_: *Element, name: String, value: String, frame: *Frame) !void {
-        frame.window.setWindowReflectingHandlerFromAttribute(name, value.str(), frame);
+    pub fn attributeChange(el: *Element, name: String, value: String, frame: *Frame) !void {
+        const owner = el.ownerFrame(frame);
+        owner.window.setWindowReflectingHandlerFromAttribute(name, value.str(), owner);
     }
 
-    pub fn attributeRemove(_: *Element, name: String, frame: *Frame) !void {
-        frame.window.setWindowReflectingHandlerFromAttribute(name, null, frame);
+    pub fn attributeRemove(el: *Element, name: String, frame: *Frame) !void {
+        const owner = el.ownerFrame(frame);
+        owner.window.setWindowReflectingHandlerFromAttribute(name, null, owner);
     }
 };

--- a/src/browser/webapi/element/html/FrameSet.zig
+++ b/src/browser/webapi/element/html/FrameSet.zig
@@ -23,46 +23,54 @@ pub fn asNode(self: *FrameSet) *Node {
 // Special-case: the "window-reflecting body element event handler set"
 // (blur, error, focus, load, resize, scroll) are aliases for the Window's
 // event handlers, on frameset elements just like on body elements.
-pub fn getOnBlur(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_blur;
-}
-pub fn setOnBlur(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_blur = Window.getFunctionFromSetter(setter);
+
+// The aliased Window is the one of the element's node document's frame — not
+// the caller's frame, which differs when a same-origin script reaches into
+// another frame (e.g. the parent setting a handler on a child frameset).
+fn reflectedWindow(self: *FrameSet, frame: *Frame) *Window {
+    return self.asElement().ownerFrame(frame).window;
 }
 
-pub fn getOnError(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_error;
+pub fn getOnBlur(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_blur;
 }
-pub fn setOnError(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_error = Window.getFunctionFromSetter(setter);
-}
-
-pub fn getOnFocus(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_focus;
-}
-pub fn setOnFocus(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_focus = Window.getFunctionFromSetter(setter);
+pub fn setOnBlur(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_blur = Window.getFunctionFromSetter(setter);
 }
 
-pub fn getOnLoad(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_load;
+pub fn getOnError(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_error;
 }
-pub fn setOnLoad(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_load = Window.getFunctionFromSetter(setter);
-}
-
-pub fn getOnResize(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_resize;
-}
-pub fn setOnResize(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_resize = Window.getFunctionFromSetter(setter);
+pub fn setOnError(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_error = Window.getFunctionFromSetter(setter);
 }
 
-pub fn getOnScroll(_: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return frame.window._on_scroll;
+pub fn getOnFocus(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_focus;
 }
-pub fn setOnScroll(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    frame.window._on_scroll = Window.getFunctionFromSetter(setter);
+pub fn setOnFocus(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_focus = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnLoad(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_load;
+}
+pub fn setOnLoad(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_load = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnResize(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_resize;
+}
+pub fn setOnResize(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_resize = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnScroll(self: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return self.reflectedWindow(frame)._on_scroll;
+}
+pub fn setOnScroll(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    self.reflectedWindow(frame)._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub fn getCols(self: *FrameSet) []const u8 {
@@ -108,19 +116,22 @@ pub const Build = struct {
 
     pub fn complete(node: *Node, frame: *Frame) !void {
         const el = node.as(Element);
+        const owner = node.ownerFrame(frame);
         inline for (window_reflecting_attributes) |attr| {
             if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
-                frame.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, frame);
+                owner.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, owner);
             }
         }
     }
 
-    pub fn attributeChange(_: *Element, name: String, value: String, frame: *Frame) !void {
-        frame.window.setWindowReflectingHandlerFromAttribute(name, value.str(), frame);
+    pub fn attributeChange(el: *Element, name: String, value: String, frame: *Frame) !void {
+        const owner = el.ownerFrame(frame);
+        owner.window.setWindowReflectingHandlerFromAttribute(name, value.str(), owner);
     }
 
-    pub fn attributeRemove(_: *Element, name: String, frame: *Frame) !void {
-        frame.window.setWindowReflectingHandlerFromAttribute(name, null, frame);
+    pub fn attributeRemove(el: *Element, name: String, frame: *Frame) !void {
+        const owner = el.ownerFrame(frame);
+        owner.window.setWindowReflectingHandlerFromAttribute(name, null, owner);
     }
 };
 

--- a/src/browser/webapi/element/html/FrameSet.zig
+++ b/src/browser/webapi/element/html/FrameSet.zig
@@ -1,8 +1,13 @@
+const lp = @import("lightpanda");
+
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
+const Window = @import("../../Window.zig");
 const HtmlElement = @import("../Html.zig");
+
+const String = lp.String;
 
 const FrameSet = @This();
 
@@ -13,6 +18,51 @@ pub fn asElement(self: *FrameSet) *Element {
 }
 pub fn asNode(self: *FrameSet) *Node {
     return self.asElement().asNode();
+}
+
+// Special-case: the "window-reflecting body element event handler set"
+// (blur, error, focus, load, resize, scroll) are aliases for the Window's
+// event handlers, on frameset elements just like on body elements.
+pub fn getOnBlur(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_blur;
+}
+pub fn setOnBlur(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_blur = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnError(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_error;
+}
+pub fn setOnError(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_error = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnFocus(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_focus;
+}
+pub fn setOnFocus(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_focus = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnLoad(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_load;
+}
+pub fn setOnLoad(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_load = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnResize(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_resize;
+}
+pub fn setOnResize(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_resize = Window.getFunctionFromSetter(setter);
+}
+
+pub fn getOnScroll(_: *FrameSet, frame: *Frame) ?js.Function.Global {
+    return frame.window._on_scroll;
+}
+pub fn setOnScroll(_: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
+    frame.window._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub fn getCols(self: *FrameSet) []const u8 {
@@ -42,6 +92,36 @@ pub const JsApi = struct {
 
     pub const cols = bridge.accessor(FrameSet.getCols, FrameSet.setCols, .{ .ce_reactions = true });
     pub const rows = bridge.accessor(FrameSet.getRows, FrameSet.setRows, .{ .ce_reactions = true });
+
+    pub const onblur = bridge.accessor(getOnBlur, setOnBlur, .{ .null_as_undefined = false });
+    pub const onerror = bridge.accessor(getOnError, setOnError, .{ .null_as_undefined = false });
+    pub const onfocus = bridge.accessor(getOnFocus, setOnFocus, .{ .null_as_undefined = false });
+    pub const onload = bridge.accessor(getOnLoad, setOnLoad, .{ .null_as_undefined = false });
+    pub const onresize = bridge.accessor(getOnResize, setOnResize, .{ .null_as_undefined = false });
+    pub const onscroll = bridge.accessor(getOnScroll, setOnScroll, .{ .null_as_undefined = false });
+};
+
+pub const Build = struct {
+    const window_reflecting_attributes = [_][]const u8{
+        "onblur", "onerror", "onfocus", "onload", "onresize", "onscroll",
+    };
+
+    pub fn complete(node: *Node, frame: *Frame) !void {
+        const el = node.as(Element);
+        inline for (window_reflecting_attributes) |attr| {
+            if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
+                frame.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, frame);
+            }
+        }
+    }
+
+    pub fn attributeChange(_: *Element, name: String, value: String, frame: *Frame) !void {
+        frame.window.setWindowReflectingHandlerFromAttribute(name, value.str(), frame);
+    }
+
+    pub fn attributeRemove(_: *Element, name: String, frame: *Frame) !void {
+        frame.window.setWindowReflectingHandlerFromAttribute(name, null, frame);
+    }
 };
 
 const testing = @import("../../../../testing.zig");


### PR DESCRIPTION
Stacked PR 3/22 (based on #2943). Event listener/handler plumbing fixes from the `/dom/events` suite.

## Commits

**webapi: throw TypeError for addEventListener({ signal: null })**
- The options dictionary declares `signal` as non-nullable, so an explicit `null` (or any non-AbortSignal) must throw a TypeError during dictionary conversion — even when the listener is null. The bridge collapsed missing and explicit-null into the same Zig `null`; the signal member is now received as a raw `js.Value` and validated before the null-callback early return.

**webapi: window-reflecting body/frameset event handlers**
- Per HTML, `onblur/onerror/onfocus/onload/onresize/onscroll` on body and frameset are aliases for the Window's handlers. Setting the IDL attribute or the content attribute (at parse time or runtime) now stores the handler on the Window, and non-callable assignments store null per `[LegacyTreatNonObjectAsNull]`.

**js: propagate pending JS exceptions from argument conversion**
- When argument conversion runs user code that throws (e.g. a throwing `toString`), the pending exception was replaced by a generic "TypeError: invalid argument". `error.JsException` now passes through the conversion catch so the original exception surfaces.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/events/AddEventListenerOptions-signal.any.html (+ .worker) | 9/11 | 11/11 |
| /dom/events/Body-FrameSet-Event-Handlers.html | 24/48 | 48/48 |
| /dom/events/Event-constructors.any.html (+ .worker) | 13/14 | 14/14 |

## Review follow-ups

- `dba25389c` — window-reflecting body/frameset handlers now resolve the **element's owner frame** instead of the caller's (review discussion): `iframeDoc.body.onblur = cb` set from the parent realm lands on the iframe's window. Applies to all six getter/setter pairs and the content-attribute Build hooks; cross-realm unit test added (`tests/frames/window_reflecting_handlers.html`), which fails without the fix.
- `0c0e3626f` — `HTMLCollection.getIndexes` takes the injected `*Frame` (same pattern as the getNames suggestions on #2943).

WPT re-verified after the follow-ups: Body-FrameSet-Event-Handlers.html 48/48, /dom/collections 53/53, AddEventListenerOptions-signal 11/11 (both variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

