### PR TITLE
webapi: dispatch passes, trusted clicks, listener exceptions to onerror

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -300,8 +300,18 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
             }
         }
 
+        // Per spec, the target is invoked once during the capturing iteration
+        // and once during the bubbling iteration, each with its own snapshot
+        // of the listener list: a bubble listener added while running the
+        // target's capture listeners must run.
         if (self.base.getListeners(target_et, event._type_string)) |list| {
-            try self.dispatchPhase(list, target_et, event, &was_handled, &ls.local, comptime .init(null, opts));
+            try self.dispatchPhase(list, target_et, event, &was_handled, &ls.local, comptime .init(true, opts));
+            if (event._stop_propagation) {
+                return;
+            }
+        }
+        if (self.base.getListeners(target_et, event._type_string)) |list| {
+            try self.dispatchPhase(list, target_et, event, &was_handled, &ls.local, comptime .init(false, opts));
             if (event._stop_propagation) {
                 return;
             }

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -434,14 +434,20 @@ pub const Listener = struct {
         event: *Event,
         comptime context: []const u8,
     ) error{OutOfMemory}!void {
-        var caught: js.TryCatch.Caught = undefined;
         switch (self.function) {
-            .value => |value| local.toLocal(value).tryCallWithThis(void, event._current_target.?, .{event}, &caught) catch |err| {
-                if (err == error.JsException) {
-                    event._listeners_did_throw = true;
-                } else {
-                    log.warn(.event, context, .{ .err = err, .caught = caught });
-                }
+            .value => |value| {
+                var try_catch: js.TryCatch = undefined;
+                try_catch.init(local);
+                defer try_catch.deinit();
+                local.toLocal(value).callWithThisRethrow(void, event._current_target.?, .{event}) catch |err| switch (err) {
+                    // The rethrow variant surfaces a thrown JS exception as
+                    // TryCatchRethrow so our enclosing TryCatch holds it.
+                    error.JsException, error.TryCatchRethrow => {
+                        event._listeners_did_throw = true;
+                        reportException(&try_catch, local);
+                    },
+                    else => log.warn(.event, context, .{ .err = err }),
+                };
             },
             .string => |string| {
                 const str = try arena.dupeZ(u8, string.str());
@@ -449,7 +455,7 @@ pub const Listener = struct {
                     if (err == error.JsException) {
                         event._listeners_did_throw = true;
                     } else {
-                        log.warn(.event, context, .{ .err = err, .caught = caught });
+                        log.warn(.event, context, .{ .err = err });
                     }
                 };
             },
@@ -465,12 +471,15 @@ pub const Listener = struct {
                     break :blk null;
                 };
                 if (handle_event) |handleEvent| {
-                    handleEvent.tryCallWithThis(void, obj, .{event}, &caught) catch |err| {
-                        if (err == error.JsException) {
+                    var try_catch: js.TryCatch = undefined;
+                    try_catch.init(local);
+                    defer try_catch.deinit();
+                    handleEvent.callWithThisRethrow(void, obj, .{event}) catch |err| switch (err) {
+                        error.JsException, error.TryCatchRethrow => {
                             event._listeners_did_throw = true;
-                        } else {
-                            log.warn(.event, context, .{ .err = err, .caught = caught });
-                        }
+                            reportException(&try_catch, local);
+                        },
+                        else => log.warn(.event, context, .{ .err = err }),
                     };
                 } else {
                     // The listener was an object without the handleEvent function
@@ -478,6 +487,18 @@ pub const Listener = struct {
                     event._listeners_did_throw = true;
                 }
             },
+        }
+    }
+
+    // Reports a listener exception to the relevant global (firing
+    // window.onerror / an "error" event) without stopping the dispatch.
+    fn reportException(try_catch: *js.TryCatch, local: *const js.Local) void {
+        const exc = try_catch.exceptionValue() orelse return;
+        switch (local.ctx.global) {
+            .frame => |frame| frame.window.reportError(exc, frame) catch |err| {
+                log.warn(.event, "listener report error", .{ .err = err });
+            },
+            .worker => {},
         }
     }
 };

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -112,6 +112,14 @@ pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args
     };
 }
 
+// Like callWithThis, but a thrown JS exception is rethrown past the internal
+// TryCatch, so an enclosing TryCatch of the caller can observe the exception
+// value itself (e.g. to report it to window.onerror).
+pub fn callWithThisRethrow(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
+    var caught: js.TryCatch.Caught = undefined;
+    return self._tryCallWithThis(T, this, args, &caught, .{ .rethrow = true });
+}
+
 pub fn tryCall(self: *const Function, comptime T: type, args: anytype, caught: *js.TryCatch.Caught) !T {
     return self._tryCallWithThis(T, self.getThis(), args, caught, .{});
 }

--- a/src/browser/js/TryCatch.zig
+++ b/src/browser/js/TryCatch.zig
@@ -46,6 +46,12 @@ pub fn rethrow(self: *TryCatch) void {
     _ = v8.v8__TryCatch__ReThrow(&self.handle);
 }
 
+// The raw caught exception value, e.g. to report it to a global's onerror.
+pub fn exceptionValue(self: TryCatch) ?js.Value {
+    const handle = v8.v8__TryCatch__Exception(&self.handle) orelse return null;
+    return .{ .local = self.local, .handle = handle };
+}
+
 pub fn caught(self: TryCatch, allocator: Allocator) ?Caught {
     if (self.hasCaught() == false) {
         return null;

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -949,9 +949,9 @@ pub fn cloneNode(self: *Node, deep_: ?bool, frame: *Frame) CloneError!*Node {
             cloned._ready_state = .complete;
 
             if (deep) {
-                var child = self.firstChild();
-                while (child) |c| : (child = c.nextSibling()) {
-                    if (try c.cloneNodeForAppending(true, frame)) |cloned_child| {
+                var child_it = self.childrenIterator();
+                while (child_it.next()) |child| {
+                    if (try child.cloneNodeForAppending(true, frame)) |cloned_child| {
                         _ = cloned.asNode().appendChild(cloned_child, frame) catch return error.CloneError;
                     }
                 }

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -940,7 +940,24 @@ pub fn cloneNode(self: *Node, deep_: ?bool, frame: *Frame) CloneError!*Node {
             };
         },
         .element => |el| return el.clone(deep, frame),
-        .document => return error.NotSupported,
+        .document => |doc| {
+            const cloned = switch (doc._type) {
+                .xml => (frame._factory.document(Document.XMLDocument{ ._proto = undefined }) catch return error.CloneError).asDocument(),
+                else => (frame._factory.document(Document.HTMLDocument{ ._proto = undefined }) catch return error.CloneError).asDocument(),
+            };
+            cloned._url = doc._url;
+            cloned._ready_state = .complete;
+
+            if (deep) {
+                var child = self.firstChild();
+                while (child) |c| : (child = c.nextSibling()) {
+                    if (try c.cloneNodeForAppending(true, frame)) |cloned_child| {
+                        _ = cloned.asNode().appendChild(cloned_child, frame) catch return error.CloneError;
+                    }
+                }
+            }
+            return cloned.asNode();
+        },
         .document_type => |dt| {
             const cloned = dt.clone(frame) catch return error.CloneError;
             return cloned.asNode();

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -49,6 +49,20 @@ pub fn getComputedLabel(_: *const WebDriver, element: *Element, frame: *Frame) !
     return (try axnode.getName(frame, frame.call_arena)) orelse "";
 }
 
+// Implements testdriver's `click`: a full trusted primary-button click
+// sequence on the element, as a real user click would produce. Unlike
+// HTMLElement.click() (a lone untrusted click event), the events are trusted
+// and preceded by the pointer/mouse press and release. Dispatched
+// synchronously so the events are observable when the testdriver promise
+// resolves.
+pub fn click(_: *const WebDriver, element: *Element, frame: *Frame) !void {
+    dispatchPointer(element, "pointerdown", 0, 1, frame);
+    dispatchMouse(element, "mousedown", 0, 1, frame);
+    dispatchPointer(element, "pointerup", 0, 0, frame);
+    dispatchMouse(element, "mouseup", 0, 0, frame);
+    dispatchMouse(element, "click", 0, 0, frame);
+}
+
 // Implements testdriver's `action_sequence` (the WebDriver "Perform Actions"
 // command) for the renderless browser. We can't do real hit-testing, so we only
 // support the subset that targets a concrete element via `origin`. Each input
@@ -333,4 +347,5 @@ pub const JsApi = struct {
     pub const deleteAllCookies = bridge.function(WebDriver.deleteAllCookies, .{});
     pub const getComputedLabel = bridge.function(WebDriver.getComputedLabel, .{});
     pub const actionSequence = bridge.function(WebDriver.actionSequence, .{});
+    pub const click = bridge.function(WebDriver.click, .{});
 };

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -89,6 +89,7 @@ _on_scroll: ?js.Function.Global = null,
 _on_message: ?js.Function.Global = null,
 _on_rejection_handled: ?js.Function.Global = null,
 _on_unhandled_rejection: ?js.Function.Global = null,
+_reporting_error: bool = false,
 _current_event: ?*Event = null,
 _location: *Location,
 _timers: Timers = .{},
@@ -556,6 +557,15 @@ pub fn cancelIdleCallback(self: *Window, id: u32) void {
 }
 
 pub fn reportError(self: *Window, err: js.Value, frame: *Frame) !void {
+    // Per spec's "in error reporting mode": an exception thrown while an
+    // error is being reported (e.g. by an "error" listener) is not reported
+    // again, which would otherwise recurse without bound.
+    if (self._reporting_error) {
+        return;
+    }
+    self._reporting_error = true;
+    defer self._reporting_error = false;
+
     const error_event = try ErrorEvent.initTrusted(comptime .wrap("error"), .{
         .@"error" = try err.persist(),
         .message = err.toStringSlice() catch "Unknown error",


### PR DESCRIPTION
Stacked PR 4/22 (based on #2944). Event dispatch fixes: Document cloning, the at-target dual pass, trusted testdriver clicks, and reporting listener exceptions to `window.onerror`.

## Commits

**webapi: implement cloneNode for Document nodes**
- `document.cloneNode()` threw NotSupportedError. Per the DOM cloning steps, a new document of the same type/URL is created and a deep clone copies its children.

**webapi: invoke event target separately for capture and bubble passes**
- The target participates in both the capturing and bubbling iterations, each with its own snapshot of the listener list: a bubble listener added by one of the target's capture listeners must run. The at-target step now dispatches capture listeners first, then non-capture, re-fetching the list in between.

**webapi: add WebDriver.click for trusted testdriver clicks**
- `test_driver.click()` was shimmed with `HTMLElement.click()` (one untrusted click, no press/release). `window.webdriver` (the `-Dwpt_extensions` API) now exposes `click(element)`: a trusted pointerdown/mousedown/pointerup/mouseup/click sequence.

**webapi: report listener exceptions to window.onerror**
- Exceptions thrown by listeners were only logged internally; they are now routed to `Window.reportError` (firing `window.onerror` and the "error" event) while dispatch continues, with the spec's "in error reporting mode" guard against unbounded recursion.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/events/Event-dispatch-bubbles-false.html | 4/5 | 5/5 |
| /dom/events/Event-dispatch-bubbles-true.html | 4/5 | 5/5 |
| /dom/events/Event-dispatch-handlers-changed.html | 0/1 | 1/1 |
| /dom/events/Event-dispatch-redispatch.html | 3/4 | 4/4 |
| /dom/events/Event-dispatch-throwing.html | 0/2 | 2/2 |
| /dom/events/EventTarget-dispatchEvent.html | 4/25 | 5/25 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
