### PR TITLE
webapi: insert-adjacent semantics; combined mutation records

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2373,7 +2373,6 @@ pub fn dupeSSO(self: *Frame, value: []const u8) !String {
 const RemoveNodeOpts = struct {
     will_be_reconnected: bool,
     // Set to false when the caller queues its own combined mutation record
-    // (e.g. replaceChildren's single "replace all" record).
     notify_observers: bool = true,
 };
 pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpts) void {
@@ -2509,7 +2508,6 @@ const InsertNodeOpts = struct {
     child_already_connected: bool = false,
     adopting_to_new_document: bool = false,
     // Set to false when the caller queues its own combined mutation record
-    // (e.g. replaceChildren's single "replace all" record).
     notify_observers: bool = true,
 };
 pub fn insertNodeRelative(self: *Frame, parent: *Node, child: *Node, relative: InsertNodeRelative, opts: InsertNodeOpts) !void {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2566,14 +2566,13 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
         }
     }
 
-    // The parser path does its own (limited) notification and connected-callback
-    // work, then returns.
+    // The parser path does its own (limited) connected-callback work, then
+    // returns.
     if (comptime from_parser) {
-        // Of the parser insertions, only fragment parses (innerHTML) mutate a
-        // live tree; the initial document parse suppresses notifications.
-        if (self._parse_mode == .fragment) {
-            self.notifyChildInserted(parent, child);
-        }
+        // No mutation records from parser insertions: the initial document
+        // parse never notifies, and fragment parses (innerHTML et al.) queue
+        // one combined "replace all" record at the call site (Node.setHTML)
+        // instead of one per inserted child.
 
         if (child.is(Element)) |el| {
             // Invoke connectedCallback for custom elements during parsing.
@@ -2829,21 +2828,11 @@ fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, opts: F
     }
     node._children = first._children;
 
-    if (observers.hasMutationObservers(self)) {
-        var it = node.childrenIterator();
-        while (it.next()) |child| {
-            child._parent = node;
-            // Notify mutation observers for each unwrapped child
-            const previous_sibling = child.previousSibling();
-            const next_sibling = child.nextSibling();
-            const added = [_]*Node{child};
-            observers.notifyChildListChange(self, node, &added, &.{}, previous_sibling, next_sibling);
-        }
-    } else {
-        var it = node.childrenIterator();
-        while (it.next()) |child| {
-            child._parent = node;
-        }
+    // No mutation records for the unwrapped children either; see the comment
+    // about fragment parses in _insertNodeRelative.
+    var it = node.childrenIterator();
+    while (it.next()) |child| {
+        child._parent = node;
     }
 }
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2372,6 +2372,9 @@ pub fn dupeSSO(self: *Frame, value: []const u8) !String {
 
 const RemoveNodeOpts = struct {
     will_be_reconnected: bool,
+    // Set to false when the caller queues its own combined mutation record
+    // (e.g. replaceChildren's single "replace all" record).
+    notify_observers: bool = true,
 };
 pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpts) void {
     // Capture siblings before removing
@@ -2406,7 +2409,7 @@ pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpt
 
     slotting.removalSteps(parent, child, self);
 
-    if (observers.hasMutationObservers(self)) {
+    if (opts.notify_observers and observers.hasMutationObservers(self)) {
         const removed = [_]*Node{child};
         observers.notifyChildListChange(self, parent, &.{}, &removed, previous_sibling, next_sibling);
     }
@@ -2505,6 +2508,9 @@ const InsertNodeRelative = union(enum) {
 const InsertNodeOpts = struct {
     child_already_connected: bool = false,
     adopting_to_new_document: bool = false,
+    // Set to false when the caller queues its own combined mutation record
+    // (e.g. replaceChildren's single "replace all" record).
+    notify_observers: bool = true,
 };
 pub fn insertNodeRelative(self: *Frame, parent: *Node, child: *Node, relative: InsertNodeRelative, opts: InsertNodeOpts) !void {
     return self._insertNodeRelative(false, parent, child, relative, opts);
@@ -2598,7 +2604,9 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
         }
     }
 
-    self.notifyChildInserted(parent, child);
+    if (opts.notify_observers) {
+        self.notifyChildInserted(parent, child);
+    }
 
     if (opts.child_already_connected and !opts.adopting_to_new_document) {
         // The child is already connected in the same document, we don't have to reconnect it.

--- a/src/browser/tests/mutation_observer/childlist.html
+++ b/src/browser/tests/mutation_observer/childlist.html
@@ -269,41 +269,18 @@
   innerHtmlParent.innerHTML = '<span>New 1</span><span>New 2</span><span>New 3</span>';
 
   await state.done((mutations) => {
-    // innerHTML triggers mutations for both removals and additions
-    // With tri-state: from_parser=true + parse_mode=fragment -> mutations fire
-    // HTML wrapper element is filtered out, so: 3 removals + 3 additions = 6
-    testing.expectEqual(6, mutations.length);
+    // Per the "replace all" algorithm, innerHTML queues a single mutation
+    // record combining all removed and added nodes.
+    testing.expectEqual(1, mutations.length);
 
-    // First 3: removals
     testing.expectEqual('childList', mutations[0].type);
-    testing.expectEqual(1, mutations[0].removedNodes.length);
+    testing.expectEqual(3, mutations[0].removedNodes.length);
     testing.expectEqual(oldChildren[0], mutations[0].removedNodes[0]);
-    testing.expectEqual(0, mutations[0].addedNodes.length);
-
-    testing.expectEqual('childList', mutations[1].type);
-    testing.expectEqual(1, mutations[1].removedNodes.length);
-    testing.expectEqual(oldChildren[1], mutations[1].removedNodes[0]);
-    testing.expectEqual(0, mutations[1].addedNodes.length);
-
-    testing.expectEqual('childList', mutations[2].type);
-    testing.expectEqual(1, mutations[2].removedNodes.length);
-    testing.expectEqual(oldChildren[2], mutations[2].removedNodes[0]);
-    testing.expectEqual(0, mutations[2].addedNodes.length);
-
-    // Last 3: additions (unwrapped span elements)
-    testing.expectEqual('childList', mutations[3].type);
-    testing.expectEqual(0, mutations[3].removedNodes.length);
-    testing.expectEqual(1, mutations[3].addedNodes.length);
-    testing.expectEqual('SPAN', mutations[3].addedNodes[0].nodeName);
-
-    testing.expectEqual('childList', mutations[4].type);
-    testing.expectEqual(0, mutations[4].removedNodes.length);
-    testing.expectEqual(1, mutations[4].addedNodes.length);
-    testing.expectEqual('SPAN', mutations[4].addedNodes[0].nodeName);
-
-    testing.expectEqual('childList', mutations[5].type);
-    testing.expectEqual(0, mutations[5].removedNodes.length);
-    testing.expectEqual(1, mutations[5].addedNodes.length);
-    testing.expectEqual('SPAN', mutations[5].addedNodes[0].nodeName);
+    testing.expectEqual(oldChildren[1], mutations[0].removedNodes[1]);
+    testing.expectEqual(oldChildren[2], mutations[0].removedNodes[2]);
+    testing.expectEqual(3, mutations[0].addedNodes.length);
+    testing.expectEqual('SPAN', mutations[0].addedNodes[0].nodeName);
+    testing.expectEqual('SPAN', mutations[0].addedNodes[1].nodeName);
+    testing.expectEqual('SPAN', mutations[0].addedNodes[2].nodeName);
   });
 </script>

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -472,13 +472,34 @@ pub fn setOuterHTML(self: *Element, html: []const u8, frame: *Frame) !void {
     }
 
     frame.domChanged();
+
+    // Observers of the parent must see a single mutation record replacing
+    // this node with the parsed nodes.
+    const notify = Frame.observers.hasMutationObservers(frame);
+    const previous_sibling = node.previousSibling();
+    const next_sibling = node.nextSibling();
+    var added: std.ArrayList(*Node) = .empty;
+
     if (html.len > 0) {
         const fragment = (try Node.DocumentFragment.init(frame)).asNode();
         try frame.parseHtmlAsChildren(fragment, html);
-        try frame.insertAllChildrenBefore(fragment, parent, node);
+        const dest_connected = parent.isConnected();
+        var it = fragment.childrenIterator();
+        while (it.next()) |child| {
+            if (notify) {
+                try added.append(frame.call_arena, child);
+            }
+            frame.removeNode(fragment, child, .{ .will_be_reconnected = dest_connected, .notify_observers = false });
+            try frame.insertNodeRelative(parent, child, .{ .before = node }, .{ .notify_observers = false });
+        }
     }
 
-    frame.removeNode(parent, node, .{ .will_be_reconnected = false });
+    frame.removeNode(parent, node, .{ .will_be_reconnected = false, .notify_observers = false });
+
+    if (notify) {
+        const removed = [_]*Node{node};
+        Frame.observers.notifyChildListChange(frame, parent, added.items, &removed, previous_sibling, next_sibling);
+    }
 }
 
 pub fn getInnerHTML(self: *Element, writer: *std.Io.Writer, frame: *Frame) !void {

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -771,9 +771,14 @@ pub fn insertAdjacentElement(
     position: []const u8,
     element: *Element,
     frame: *Frame,
-) !void {
-    const target_node, const prev_node = try self.asNode().findAdjacentNodes(position);
+) !?*Element {
+    const target_node, const prev_node = self.asNode().findAdjacentNodes(position, .node) catch |err| switch (err) {
+        // beforebegin/afterend with no parent is a no-op returning null.
+        error.AdjacentNoParent => return null,
+        else => return err,
+    };
     _ = try target_node.insertBefore(element.asNode(), prev_node, frame);
+    return element;
 }
 
 pub fn insertAdjacentText(
@@ -782,8 +787,12 @@ pub fn insertAdjacentText(
     data: []const u8,
     frame: *Frame,
 ) !void {
+    const target_node, const prev_node = self.asNode().findAdjacentNodes(where, .node) catch |err| switch (err) {
+        // beforebegin/afterend with no parent is a no-op.
+        error.AdjacentNoParent => return,
+        else => return err,
+    };
     const text_node = try Frame.node_factory.createTextNode(frame, data);
-    const target_node, const prev_node = try self.asNode().findAdjacentNodes(where);
     _ = try target_node.insertBefore(text_node, prev_node, frame);
 }
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -487,7 +487,7 @@ pub fn setOuterHTML(self: *Element, html: []const u8, frame: *Frame) !void {
         var it = fragment.childrenIterator();
         while (it.next()) |child| {
             if (notify) {
-                try added.append(frame.call_arena, child);
+                try added.append(frame.local_arena, child);
             }
             frame.removeNode(fragment, child, .{ .will_be_reconnected = dest_connected, .notify_observers = false });
             try frame.insertNodeRelative(parent, child, .{ .before = node }, .{ .notify_observers = false });

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -350,7 +350,6 @@ pub fn deliverRecords(self: *MutationObserver, frame: *Frame) !void {
     defer ls.deinit();
 
     var caught: js.TryCatch.Caught = undefined;
-    // Per spec, the callback is invoked with the observer as its this value.
     ls.toLocal(self._callback).tryCallWithThis(void, self, .{ records, self }, &caught) catch |err| {
         log.err(.frame, "MutObserver.deliverRecords", .{ .err = err, .caught = caught });
         return err;

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -350,7 +350,8 @@ pub fn deliverRecords(self: *MutationObserver, frame: *Frame) !void {
     defer ls.deinit();
 
     var caught: js.TryCatch.Caught = undefined;
-    ls.toLocal(self._callback).tryCall(void, .{ records, self }, &caught) catch |err| {
+    // Per spec, the callback is invoked with the observer as its this value.
+    ls.toLocal(self._callback).tryCallWithThis(void, self, .{ records, self }, &caught) catch |err| {
         log.err(.frame, "MutObserver.deliverRecords", .{ .err = err, .caught = caught });
         return err;
     };

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1318,19 +1318,38 @@ pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !v
 /// Shared implementation in Element and DocumentFragment
 pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, frame: *Frame) !void {
     frame.domChanged();
+
+    // Observers of this subtree get one combined "replace all" mutation
+    // record; per-node notification is suppressed for the removals here and
+    // for the parser insertions (fragment parsing never notifies).
+    const notify = Frame.observers.hasMutationObservers(frame);
+    var removed: std.ArrayList(*Node) = .empty;
+
     var it = self.childrenIterator();
     while (it.next()) |child| {
-        frame.removeNode(self, child, .{ .will_be_reconnected = false });
+        if (notify) {
+            try removed.append(frame.call_arena, child);
+        }
+        frame.removeNode(self, child, .{ .will_be_reconnected = false, .notify_observers = false });
     }
 
-    if (html.len == 0) {
-        return;
+    if (html.len > 0) {
+        if (allow_declarative_shadow) {
+            try frame.parseHtmlUnsafeAsChildren(self, html);
+        } else {
+            try frame.parseHtmlAsChildren(self, html);
+        }
     }
 
-    if (allow_declarative_shadow) {
-        try frame.parseHtmlUnsafeAsChildren(self, html);
-    } else {
-        try frame.parseHtmlAsChildren(self, html);
+    if (notify) {
+        var added: std.ArrayList(*Node) = .empty;
+        var child_it = self.childrenIterator();
+        while (child_it.next()) |child| {
+            try added.append(frame.call_arena, child);
+        }
+        if (removed.items.len > 0 or added.items.len > 0) {
+            Frame.observers.notifyChildListChange(frame, self, added.items, removed.items, null, null);
+        }
     }
 }
 

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -127,7 +127,7 @@ pub fn is(self: *Node, comptime T: type) ?*T {
 /// NoModificationAllowedError for a null or document parent, while
 /// insertAdjacentElement/Text return null for a null parent and otherwise
 /// rely on the pre-insert validity checks (HierarchyRequestError).
-pub const AdjacentVariant = enum { html, node };
+const AdjacentVariant = enum { html, node };
 
 /// Given a position, returns target and previous nodes required for
 /// insertAdjacentHTML, insertAdjacentElement and insertAdjacentText.
@@ -1274,11 +1274,11 @@ pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !v
             var frag_it = frag.asNode().childrenIterator();
             while (frag_it.next()) |frag_child| {
                 try validateNodeInsertion(self, frag_child);
-                try children_to_add.append(frame.call_arena, frag_child);
+                try children_to_add.append(frame.local_arena, frag_child);
             }
         } else {
             try validateNodeInsertion(self, child);
-            try children_to_add.append(frame.call_arena, child);
+            try children_to_add.append(frame.local_arena, child);
         }
     }
 
@@ -1294,7 +1294,7 @@ pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !v
     var it = self.childrenIterator();
     while (it.next()) |child| {
         if (notify) {
-            try removed.append(frame.call_arena, child);
+            try removed.append(frame.local_arena, child);
         }
         frame.removeNode(self, child, .{ .will_be_reconnected = false, .notify_observers = false });
     }
@@ -1328,7 +1328,7 @@ pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, fr
     var it = self.childrenIterator();
     while (it.next()) |child| {
         if (notify) {
-            try removed.append(frame.call_arena, child);
+            try removed.append(frame.local_arena, child);
         }
         frame.removeNode(self, child, .{ .will_be_reconnected = false, .notify_observers = false });
     }
@@ -1345,7 +1345,7 @@ pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, fr
         var added: std.ArrayList(*Node) = .empty;
         var child_it = self.childrenIterator();
         while (child_it.next()) |child| {
-            try added.append(frame.call_arena, child);
+            try added.append(frame.local_arena, child);
         }
         if (removed.items.len > 0 or added.items.len > 0) {
             Frame.observers.notifyChildListChange(frame, self, added.items, removed.items, null, null);

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1284,10 +1284,19 @@ pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !v
 
     frame.domChanged();
 
+    // Per the "replace all" algorithm, observers get one combined mutation
+    // record with all removed and added nodes, so per-node notification is
+    // suppressed here.
+    const notify = Frame.observers.hasMutationObservers(frame);
+    var removed: std.ArrayList(*Node) = .empty;
+
     // Remove all existing children
     var it = self.childrenIterator();
     while (it.next()) |child| {
-        frame.removeNode(self, child, .{ .will_be_reconnected = false });
+        if (notify) {
+            try removed.append(frame.call_arena, child);
+        }
+        frame.removeNode(self, child, .{ .will_be_reconnected = false, .notify_observers = false });
     }
 
     // Append new children
@@ -1298,7 +1307,11 @@ pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !v
             child_connected = child.isConnected();
             frame.removeNode(previous_parent, child, .{ .will_be_reconnected = parent_is_connected });
         }
-        try frame.appendNode(self, child, .{ .child_already_connected = child_connected });
+        try frame.appendNode(self, child, .{ .child_already_connected = child_connected, .notify_observers = false });
+    }
+
+    if (notify and (removed.items.len > 0 or children_to_add.items.len > 0)) {
+        Frame.observers.notifyChildListChange(frame, self, children_to_add.items, removed.items, null, null);
     }
 }
 

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -123,11 +123,17 @@ pub fn is(self: *Node, comptime T: type) ?*T {
     return null;
 }
 
+/// Which "insert adjacent" flavor is asking. insertAdjacentHTML throws
+/// NoModificationAllowedError for a null or document parent, while
+/// insertAdjacentElement/Text return null for a null parent and otherwise
+/// rely on the pre-insert validity checks (HierarchyRequestError).
+pub const AdjacentVariant = enum { html, node };
+
 /// Given a position, returns target and previous nodes required for
 /// insertAdjacentHTML, insertAdjacentElement and insertAdjacentText.
 /// * `target_node` is `*Node` (where we actually insert),
 /// * `previous_node` is `?*Node`.
-pub fn findAdjacentNodes(self: *Node, position: []const u8) !struct { *Node, ?*Node } {
+pub fn findAdjacentNodes(self: *Node, position: []const u8, variant: AdjacentVariant) !struct { *Node, ?*Node } {
     // Case-insensitive match per HTML spec.
     // "beforeend" was the most common case in my tests; we might adjust the order
     // depending on which ones websites prefer most.
@@ -142,11 +148,16 @@ pub fn findAdjacentNodes(self: *Node, position: []const u8) !struct { *Node, ?*N
 
     if (std.ascii.eqlIgnoreCase(position, "beforebegin")) {
         // The node must have a parent node in order to use this variant.
-        const parent_node = self.parentNode() orelse return error.NoModificationAllowed;
-        // Parent cannot be Document.
-        switch (parent_node._type) {
-            .document, .document_fragment => return error.NoModificationAllowed,
-            else => {},
+        const parent_node = self.parentNode() orelse switch (variant) {
+            .html => return error.NoModificationAllowed,
+            .node => return error.AdjacentNoParent,
+        };
+        if (variant == .html) {
+            // Parent cannot be Document.
+            switch (parent_node._type) {
+                .document, .document_fragment => return error.NoModificationAllowed,
+                else => {},
+            }
         }
 
         return .{ parent_node, self };
@@ -154,11 +165,16 @@ pub fn findAdjacentNodes(self: *Node, position: []const u8) !struct { *Node, ?*N
 
     if (std.ascii.eqlIgnoreCase(position, "afterend")) {
         // The node must have a parent node in order to use this variant.
-        const parent_node = self.parentNode() orelse return error.NoModificationAllowed;
-        // Parent cannot be Document.
-        switch (parent_node._type) {
-            .document, .document_fragment => return error.NoModificationAllowed,
-            else => {},
+        const parent_node = self.parentNode() orelse switch (variant) {
+            .html => return error.NoModificationAllowed,
+            .node => return error.AdjacentNoParent,
+        };
+        if (variant == .html) {
+            // Parent cannot be Document.
+            switch (parent_node._type) {
+                .document, .document_fragment => return error.NoModificationAllowed,
+                else => {},
+            }
         }
 
         // Get the next sibling or null; null indicates our node is the only one.
@@ -220,6 +236,36 @@ fn validateNodeInsertion(parent: *Node, node: *Node) !void {
     }
 }
 
+// DOM "ensure pre-insert validity" rules specific to document parents: a
+// document can't contain text nodes and has at most one element child.
+// `replaced_child` is the node about to be replaced (replaceChild), which
+// doesn't count against the single-element rule. Not part of
+// validateNodeInsertion because replaceChildren replaces every existing
+// child and must skip the single-element rule entirely.
+fn validateDocumentInsertion(parent: *Node, node: *const Node, replaced_child: ?*const Node) !void {
+    if (parent._type != .document) {
+        return;
+    }
+    switch (node._type) {
+        .cdata => |cd| {
+            if (cd._type == .text) {
+                // A Text node cannot be a child of a document.
+                return error.HierarchyError;
+            }
+        },
+        .element => {
+            var it = parent.childrenIterator();
+            while (it.next()) |existing| {
+                if (existing._type == .element and existing != node and existing != replaced_child) {
+                    // A document can have at most one element child.
+                    return error.HierarchyError;
+                }
+            }
+        },
+        else => {},
+    }
+}
+
 pub fn appendChild(self: *Node, child: *Node, frame: *Frame) !*Node {
     if (child.is(DocumentFragment)) |_| {
         try frame.appendAllChildren(child, self);
@@ -227,6 +273,7 @@ pub fn appendChild(self: *Node, child: *Node, frame: *Frame) !*Node {
     }
 
     try validateNodeInsertion(self, child);
+    try validateDocumentInsertion(self, child, null);
 
     frame.domChanged();
 
@@ -628,6 +675,12 @@ pub fn removeChild(self: *Node, child: *Node, frame: *Frame) !*Node {
 }
 
 pub fn insertBefore(self: *Node, new_node: *Node, ref_node_: ?*Node, frame: *Frame) !*Node {
+    return self.insertBeforeReplacing(new_node, ref_node_, null, frame);
+}
+
+// `replacing` is the child replaceChild is about to remove; it doesn't count
+// against the document single-element rule.
+fn insertBeforeReplacing(self: *Node, new_node: *Node, ref_node_: ?*Node, replacing: ?*const Node, frame: *Frame) !*Node {
     const ref_node = ref_node_ orelse {
         return self.appendChild(new_node, frame);
     };
@@ -657,6 +710,7 @@ pub fn insertBefore(self: *Node, new_node: *Node, ref_node_: ?*Node, frame: *Fra
     }
 
     try validateNodeInsertion(self, new_node);
+    try validateDocumentInsertion(self, new_node, replacing);
 
     const child_already_connected = new_node.isConnected();
 
@@ -695,8 +749,9 @@ pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Fra
     }
 
     try validateNodeInsertion(self, new_child);
+    try validateDocumentInsertion(self, new_child, old_child);
 
-    _ = try self.insertBefore(new_child, old_child, frame);
+    _ = try self.insertBeforeReplacing(new_child, old_child, old_child, frame);
 
     // Special case: if we replace a node by itself, insertBefore was a noop.
     if (new_child != old_child) {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -287,7 +287,7 @@ pub fn insertAdjacentHTML(
     const fragment = (try DocumentFragment.init(frame)).asNode();
     try frame.parseHtmlAsChildren(fragment, html);
 
-    const target_node, const prev_node = try self.asElement().asNode().findAdjacentNodes(position);
+    const target_node, const prev_node = try self.asElement().asNode().findAdjacentNodes(position, .html);
 
     var iter = fragment.childrenIterator();
     while (iter.next()) |child_node| {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -287,7 +287,7 @@ pub fn insertAdjacentHTML(
     const fragment = (try DocumentFragment.init(frame)).asNode();
     try frame.parseHtmlAsChildren(fragment, html);
 
-    const target_node, const prev_node = try self.asElement().asNode().findAdjacentNodes(position, .html);
+    const target_node, const prev_node = try self.asNode().findAdjacentNodes(position, .html);
 
     var iter = fragment.childrenIterator();
     while (iter.next()) |child_node| {


### PR DESCRIPTION
Stacked PR 11/22 (based on #2951). Insert-adjacent semantics and combined mutation records.

## Commits

**webapi: insert-adjacent spec semantics; document pre-insert validity**
- insertAdjacentElement/Text return null for a null parent (instead of throwing NoModificationAllowedError) and rely on pre-insert validity otherwise; insertAdjacentElement returns the inserted element. Pre-insert validity gains the document-parent rules (no Text children, at most one element child).

**webapi: invoke MutationObserver callbacks with the observer as this**
- The mutation callback's `this` value must be the MutationObserver itself, not globalThis.

**webapi: replace-all queues one combined mutation record**
- The "replace all" algorithm (textContent setter, replaceChildren) queues a single tree mutation record with all removed and added nodes, instead of one record per child.

**webapi: innerHTML/outerHTML queue one combined mutation record**
- Setting innerHTML queues a single replace-all record; setting outerHTML a single record replacing the element with the parsed nodes. Fragment parsing no longer notifies observers per inserted child.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/nodes/Element-insertAdjacentElement.html | 1/6 | 6/6 |
| /dom/nodes/Element-insertAdjacentText.html | 5/6 | 6/6 |
| /dom/nodes/insert-adjacent.html | 11/14 | 14/14 |
| /dom/nodes/Node-insertBefore.html | 13/40 | 16/40 |
| /dom/nodes/Node-replaceChild.html | 14/29 | 15/29 |
| /dom/nodes/MutationObserver-callback-arguments.html | 0/1 | 1/1 |
| /dom/nodes/MutationObserver-textContent.html | 1/4 | 4/4 |
| /dom/nodes/ParentNode-replaceChildren.html | 25/29 | 29/29 |
| /dom/nodes/MutationObserver-childList.html | 29/38 | 30/38 |
| /dom/nodes/MutationObserver-inner-outer.html | 0/3 | 3/3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
