### PR TITLE
webapi: pre-insert validity, Attr adoption, fragment/replaceChild mutation records

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2494,17 +2494,19 @@ pub fn insertAllChildrenBefore(self: *Frame, fragment: *Node, parent: *Node, ref
     return self.moveAllChildren(fragment, parent, ref_node, .records);
 }
 
-pub const MoveChildrenNotify = enum { records, silent };
+pub const MoveChildrenNotify = enum { records, silent_parent };
 
 // Moves every child of `source` into `parent` (before `ref_node`, or
 // appended). Per the DOM insert algorithm for fragments, observers get one
 // removal record on the source and one addition record on the parent, not
-// one record per child. `.silent` suppresses even those (replaceChild queues
-// its own combined record).
+// one record per child. `.silent_parent` suppresses only the parent record
+// (replaceChild queues its own combined record); the source record is queued
+// regardless — the spec's insert algorithm notes it "intentionally does not
+// pay attention to suppressObservers".
 pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*Node, notify_mode: MoveChildrenNotify) !void {
     self.domChanged();
     const dest_connected = parent.isConnected();
-    const notify = notify_mode == .records and observers.hasMutationObservers(self);
+    const notify = observers.hasMutationObservers(self);
 
     var moved: std.ArrayList(*Node) = .empty;
     const previous_sibling = if (ref_node) |ref| ref.previousSibling() else parent.lastChild();
@@ -2530,7 +2532,9 @@ pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*N
 
     if (notify and moved.items.len > 0) {
         observers.notifyChildListChange(self, source, &.{}, moved.items, null, null);
-        observers.notifyChildListChange(self, parent, moved.items, &.{}, previous_sibling, ref_node);
+        if (notify_mode == .records) {
+            observers.notifyChildListChange(self, parent, moved.items, &.{}, previous_sibling, ref_node);
+        }
     }
 }
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2487,31 +2487,50 @@ pub fn appendNode(self: *Frame, parent: *Node, child: *Node, opts: InsertNodeOpt
 }
 
 pub fn appendAllChildren(self: *Frame, parent: *Node, target: *Node) !void {
-    self.domChanged();
-    const dest_connected = target.isConnected();
-
-    var it = parent.childrenIterator();
-    while (it.next()) |child| {
-        const child_was_connected = child.isConnected();
-        self.removeNode(parent, child, .{ .will_be_reconnected = dest_connected });
-        try self.appendNode(target, child, .{ .child_already_connected = child_was_connected });
-    }
+    return self.moveAllChildren(parent, target, null, .records);
 }
 
 pub fn insertAllChildrenBefore(self: *Frame, fragment: *Node, parent: *Node, ref_node: *Node) !void {
+    return self.moveAllChildren(fragment, parent, ref_node, .records);
+}
+
+pub const MoveChildrenNotify = enum { records, silent };
+
+// Moves every child of `source` into `parent` (before `ref_node`, or
+// appended). Per the DOM insert algorithm for fragments, observers get one
+// removal record on the source and one addition record on the parent, not
+// one record per child. `.silent` suppresses even those (replaceChild queues
+// its own combined record).
+pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*Node, notify_mode: MoveChildrenNotify) !void {
     self.domChanged();
     const dest_connected = parent.isConnected();
+    const notify = notify_mode == .records and observers.hasMutationObservers(self);
 
-    var it = fragment.childrenIterator();
+    var moved: std.ArrayList(*Node) = .empty;
+    const previous_sibling = if (ref_node) |ref| ref.previousSibling() else parent.lastChild();
+
+    var it = source.childrenIterator();
     while (it.next()) |child| {
+        if (notify) {
+            try moved.append(self.call_arena, child);
+        }
         const child_was_connected = child.isConnected();
-        self.removeNode(fragment, child, .{ .will_be_reconnected = dest_connected });
-        try self.insertNodeRelative(
-            parent,
-            child,
-            .{ .before = ref_node },
-            .{ .child_already_connected = child_was_connected },
-        );
+        self.removeNode(source, child, .{ .will_be_reconnected = dest_connected, .notify_observers = false });
+        if (ref_node) |ref| {
+            try self.insertNodeRelative(
+                parent,
+                child,
+                .{ .before = ref },
+                .{ .child_already_connected = child_was_connected, .notify_observers = false },
+            );
+        } else {
+            try self.appendNode(parent, child, .{ .child_already_connected = child_was_connected, .notify_observers = false });
+        }
+    }
+
+    if (notify and moved.items.len > 0) {
+        observers.notifyChildListChange(self, source, &.{}, moved.items, null, null);
+        observers.notifyChildListChange(self, parent, moved.items, &.{}, previous_sibling, ref_node);
     }
 }
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2599,13 +2599,16 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
         }
     }
 
-    // The parser path does its own (limited) connected-callback work, then
-    // returns.
+    // The parser path does its own (limited) notification and
+    // connected-callback work, then returns.
     if (comptime from_parser) {
-        // No mutation records from parser insertions: the initial document
-        // parse never notifies, and fragment parses (innerHTML et al.) queue
-        // one combined "replace all" record at the call site (Node.setHTML)
-        // instead of one per inserted child.
+        // Main-document parser insertions notify per node: scripts running
+        // during parsing can observe the document. Fragment parses
+        // (innerHTML et al.) stay silent; Node.setHTML queues one combined
+        // "replace all" record instead.
+        if (self._parse_mode != .fragment) {
+            self.notifyChildInserted(parent, child);
+        }
 
         if (child.is(Element)) |el| {
             // Invoke connectedCallback for custom elements during parsing.

--- a/src/browser/tests/mutation_observer/childlist.html
+++ b/src/browser/tests/mutation_observer/childlist.html
@@ -183,28 +183,18 @@
   replaceParent.replaceChild(replaceNew, replaceOld);
 
   await state.done((mutations) => {
-    // replaceChild generates two separate mutation records in modern spec:
-    // 1. First record for insertBefore (new node added)
-    // 2. Second record for removeChild (old node removed)
-    testing.expectEqual(2, mutations.length);
+    // Per the DOM "replace" algorithm, replaceChild queues one combined
+    // mutation record with both the added and the removed node.
+    testing.expectEqual(1, mutations.length);
 
-    // First mutation: insertion of new node
     testing.expectEqual('childList', mutations[0].type);
     testing.expectEqual(replaceParent, mutations[0].target);
     testing.expectEqual(1, mutations[0].addedNodes.length);
     testing.expectEqual(replaceNew, mutations[0].addedNodes[0]);
-    testing.expectEqual(0, mutations[0].removedNodes.length);
+    testing.expectEqual(1, mutations[0].removedNodes.length);
+    testing.expectEqual(replaceOld, mutations[0].removedNodes[0]);
     testing.expectEqual(null, mutations[0].previousSibling);
-    testing.expectEqual(replaceOld, mutations[0].nextSibling);
-
-    // Second mutation: removal of old node
-    testing.expectEqual('childList', mutations[1].type);
-    testing.expectEqual(replaceParent, mutations[1].target);
-    testing.expectEqual(0, mutations[1].addedNodes.length);
-    testing.expectEqual(1, mutations[1].removedNodes.length);
-    testing.expectEqual(replaceOld, mutations[1].removedNodes[0]);
-    testing.expectEqual(replaceNew, mutations[1].previousSibling);
-    testing.expectEqual(null, mutations[1].nextSibling);
+    testing.expectEqual(null, mutations[0].nextSibling);
   });
 </script>
 

--- a/src/browser/tests/mutation_observer/childlist.html
+++ b/src/browser/tests/mutation_observer/childlist.html
@@ -198,6 +198,98 @@
   });
 </script>
 
+<div id="replace-frag-parent"><div id="replace-frag-old">Old</div></div>
+
+<script id="childlist_replace_child_fragment" type=module>
+  const state = await testing.async();
+  const parent = document.getElementById('replace-frag-parent');
+  const oldChild = document.getElementById('replace-frag-old');
+
+  const fragment = document.createDocumentFragment();
+  const frag1 = document.createElement('div');
+  const frag2 = document.createElement('div');
+  fragment.append(frag1, frag2);
+
+  const observer = new MutationObserver((records) => {
+    observer.disconnect();
+    state.resolve(records);
+  });
+  observer.observe(parent, { childList: true });
+  observer.observe(fragment, { childList: true });
+
+  parent.replaceChild(fragment, oldChild);
+
+  await state.done((mutations) => {
+    // The fragment's removal record is queued even though the replacement
+    // itself suppresses observers (the spec's insert algorithm notes the
+    // fragment record "intentionally does not pay attention to
+    // suppressObservers"), followed by the parent's combined record.
+    testing.expectEqual(2, mutations.length);
+
+    testing.expectEqual('childList', mutations[0].type);
+    testing.expectEqual(fragment, mutations[0].target);
+    testing.expectEqual(0, mutations[0].addedNodes.length);
+    testing.expectEqual(2, mutations[0].removedNodes.length);
+    testing.expectEqual(frag1, mutations[0].removedNodes[0]);
+    testing.expectEqual(frag2, mutations[0].removedNodes[1]);
+    testing.expectEqual(null, mutations[0].previousSibling);
+    testing.expectEqual(null, mutations[0].nextSibling);
+
+    testing.expectEqual('childList', mutations[1].type);
+    testing.expectEqual(parent, mutations[1].target);
+    testing.expectEqual(2, mutations[1].addedNodes.length);
+    testing.expectEqual(frag1, mutations[1].addedNodes[0]);
+    testing.expectEqual(frag2, mutations[1].addedNodes[1]);
+    testing.expectEqual(1, mutations[1].removedNodes.length);
+    testing.expectEqual(oldChild, mutations[1].removedNodes[0]);
+    testing.expectEqual(null, mutations[1].previousSibling);
+    testing.expectEqual(null, mutations[1].nextSibling);
+  });
+</script>
+
+<div id="replace-adjacent-parent"><div id="replace-adjacent-a">A</div><div id="replace-adjacent-new">New</div><div id="replace-adjacent-old">Old</div><div id="replace-adjacent-b">B</div></div>
+
+<script id="childlist_replace_child_adjacent" type=module>
+  const state = await testing.async();
+  const parent = document.getElementById('replace-adjacent-parent');
+  const a = document.getElementById('replace-adjacent-a');
+  const newChild = document.getElementById('replace-adjacent-new');
+  const oldChild = document.getElementById('replace-adjacent-old');
+  const b = document.getElementById('replace-adjacent-b');
+
+  const observer = new MutationObserver((records) => {
+    observer.disconnect();
+    state.resolve(records);
+  });
+  observer.observe(parent, { childList: true });
+
+  // Replacing a child with its immediate previous sibling: the combined
+  // record's previousSibling is captured before newChild is removed from
+  // its old position, so it is newChild itself.
+  parent.replaceChild(newChild, oldChild);
+
+  await state.done((mutations) => {
+    testing.expectEqual(2, mutations.length);
+
+    testing.expectEqual('childList', mutations[0].type);
+    testing.expectEqual(parent, mutations[0].target);
+    testing.expectEqual(0, mutations[0].addedNodes.length);
+    testing.expectEqual(1, mutations[0].removedNodes.length);
+    testing.expectEqual(newChild, mutations[0].removedNodes[0]);
+    testing.expectEqual(a, mutations[0].previousSibling);
+    testing.expectEqual(oldChild, mutations[0].nextSibling);
+
+    testing.expectEqual('childList', mutations[1].type);
+    testing.expectEqual(parent, mutations[1].target);
+    testing.expectEqual(1, mutations[1].addedNodes.length);
+    testing.expectEqual(newChild, mutations[1].addedNodes[0]);
+    testing.expectEqual(1, mutations[1].removedNodes.length);
+    testing.expectEqual(oldChild, mutations[1].removedNodes[0]);
+    testing.expectEqual(newChild, mutations[1].previousSibling);
+    testing.expectEqual(b, mutations[1].nextSibling);
+  });
+</script>
+
 <div id="multiple-parent"></div>
 
 <script id="childlist_multiple_mutations" type=module>

--- a/src/browser/tests/node/replace_child.html
+++ b/src/browser/tests/node/replace_child.html
@@ -22,9 +22,10 @@
   let c4 = document.createElement('div');
   c4.id = 'c4';
 
+  // Per spec, a child with the wrong parent is a NotFoundError.
   testing.withError((err) => {
-    testing.expectEqual(3, err.code);
-    testing.expectEqual("HierarchyRequestError", err.name);
+    testing.expectEqual(8, err.code);
+    testing.expectEqual("NotFoundError", err.name);
   }, () => d1.replaceChild(c4, c3));
 
   testing.expectEqual(c2, d1.replaceChild(c4, c2));

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -226,39 +226,93 @@ fn validateNodeInsertion(parent: *Node, node: *Node) !void {
     }
 }
 
-// DOM "ensure pre-insert validity" rules specific to document parents: a
-// document can't contain text nodes and has at most one element child.
-// `replaced_child` is the node about to be replaced (replaceChild), which
-// doesn't count against the single-element rule. Not part of
-// validateNodeInsertion because replaceChildren replaces every existing
-// child and must skip the single-element rule entirely.
-fn validateDocumentInsertion(parent: *Node, node: *const Node, replaced_child: ?*const Node) !void {
-    if (parent._type != .document) {
-        return;
+// DOM "ensure pre-insert validity" (and its replaceChild variant), with the
+// checks in spec order: parent type, cycle, child-parent (NotFoundError),
+// node type, then the document-parent structure rules.
+const PreInsertMode = enum { insert, replace };
+
+fn ensurePreInsertValidity(parent: *Node, node: *Node, child: ?*Node, comptime mode: PreInsertMode) !void {
+    switch (parent._type) {
+        .document, .document_fragment, .element => {},
+        else => return error.HierarchyError,
     }
+
+    if (node.contains(parent)) {
+        return error.HierarchyError;
+    }
+
+    if (child) |c| {
+        if (c._parent == null or c._parent.? != parent) {
+            return error.NotFound;
+        }
+    }
+
     switch (node._type) {
+        .document, .attribute => return error.HierarchyError,
         .cdata => |cd| {
-            if (cd._type == .text or cd._type == .cdata_section) {
+            if ((cd._type == .text or cd._type == .cdata_section) and parent._type == .document) {
                 // A Text node (CDATASection included) cannot be a child of a
                 // document.
                 return error.HierarchyError;
             }
         },
-        .element => {
-            var it = parent.childrenIterator();
-            while (it.next()) |existing| {
-                if (existing._type == .element and existing != node and existing != replaced_child) {
-                    // A document can have at most one element child.
-                    return error.HierarchyError;
-                }
+        .document_type => {
+            if (parent._type != .document) {
+                return error.HierarchyError;
             }
         },
+        else => {},
+    }
+
+    if (parent._type != .document) {
+        return;
+    }
+
+    switch (node._type) {
+        .document_fragment => {
+            var element_count: u32 = 0;
+            var it = node.childrenIterator();
+            while (it.next()) |frag_child| {
+                switch (frag_child._type) {
+                    .element => element_count += 1,
+                    .cdata => |cd| {
+                        if (cd._type == .text) {
+                            return error.HierarchyError;
+                        }
+                    },
+                    else => {},
+                }
+            }
+            if (element_count > 1) {
+                return error.HierarchyError;
+            }
+            if (element_count == 1) {
+                try checkDocumentElementRules(parent, node, child, mode);
+            }
+        },
+        .element => try checkDocumentElementRules(parent, node, child, mode),
         .document_type => {
             var it = parent.childrenIterator();
             while (it.next()) |existing| {
-                if (existing._type == .document_type and existing != node and existing != replaced_child) {
-                    // A document can have at most one doctype child.
+                if (existing._type == .document_type and existing != node) {
+                    if (mode == .replace and existing == child) continue;
                     return error.HierarchyError;
+                }
+            }
+            if (child) |c| {
+                // An element preceding child?
+                var prev = c.previousSibling();
+                while (prev) |p| : (prev = p.previousSibling()) {
+                    if (p._type == .element) {
+                        return error.HierarchyError;
+                    }
+                }
+            } else if (mode == .insert) {
+                var it2 = parent.childrenIterator();
+                while (it2.next()) |existing| {
+                    if (existing._type == .element) {
+                        return error.HierarchyError;
+                    }
                 }
             }
         },
@@ -266,14 +320,36 @@ fn validateDocumentInsertion(parent: *Node, node: *const Node, replaced_child: ?
     }
 }
 
+fn checkDocumentElementRules(parent: *Node, node: *Node, child: ?*Node, comptime mode: PreInsertMode) !void {
+    // A document can have at most one element child.
+    var it = parent.childrenIterator();
+    while (it.next()) |existing| {
+        if (existing._type == .element and existing != node) {
+            if (mode == .replace and existing == child) continue;
+            return error.HierarchyError;
+        }
+    }
+    if (child) |c| {
+        if (mode == .insert and c._type == .document_type) {
+            return error.HierarchyError;
+        }
+        // A doctype following child?
+        var next = c.nextSibling();
+        while (next) |n| : (next = n.nextSibling()) {
+            if (n._type == .document_type) {
+                return error.HierarchyError;
+            }
+        }
+    }
+}
+
 pub fn appendChild(self: *Node, child: *Node, frame: *Frame) !*Node {
+    try ensurePreInsertValidity(self, child, null, .insert);
+
     if (child.is(DocumentFragment)) |_| {
         try frame.appendAllChildren(child, self);
         return child;
     }
-
-    try validateNodeInsertion(self, child);
-    try validateDocumentInsertion(self, child, null);
 
     frame.domChanged();
 
@@ -675,12 +751,13 @@ pub fn removeChild(self: *Node, child: *Node, frame: *Frame) !*Node {
 }
 
 pub fn insertBefore(self: *Node, new_node: *Node, ref_node_: ?*Node, frame: *Frame) !*Node {
-    return self.insertBeforeReplacing(new_node, ref_node_, null, frame);
+    try ensurePreInsertValidity(self, new_node, ref_node_, .insert);
+    return self.insertBeforeInner(new_node, ref_node_, frame);
 }
 
-// `replacing` is the child replaceChild is about to remove; it doesn't count
-// against the document single-element rule.
-fn insertBeforeReplacing(self: *Node, new_node: *Node, ref_node_: ?*Node, replacing: ?*const Node, frame: *Frame) !*Node {
+// The insertion work, after pre-insert (or replace) validity was ensured by
+// the caller.
+fn insertBeforeInner(self: *Node, new_node: *Node, ref_node_: ?*Node, frame: *Frame) !*Node {
     const ref_node = ref_node_ orelse {
         return self.appendChild(new_node, frame);
     };
@@ -700,17 +777,10 @@ fn insertBeforeReplacing(self: *Node, new_node: *Node, ref_node_: ?*Node, replac
         return new_node;
     }
 
-    if (ref_node._parent == null or ref_node._parent.? != self) {
-        return error.NotFound;
-    }
-
     if (new_node.is(DocumentFragment)) |_| {
         try frame.insertAllChildrenBefore(new_node, self, ref_node);
         return new_node;
     }
-
-    try validateNodeInsertion(self, new_node);
-    try validateDocumentInsertion(self, new_node, replacing);
 
     const child_already_connected = new_node.isConnected();
 
@@ -744,14 +814,9 @@ fn insertBeforeReplacing(self: *Node, new_node: *Node, ref_node_: ?*Node, replac
 }
 
 pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Frame) !*Node {
-    if (old_child._parent == null or old_child._parent.? != self) {
-        return error.HierarchyError;
-    }
+    try ensurePreInsertValidity(self, new_child, old_child, .replace);
 
-    try validateNodeInsertion(self, new_child);
-    try validateDocumentInsertion(self, new_child, old_child);
-
-    _ = try self.insertBeforeReplacing(new_child, old_child, old_child, frame);
+    _ = try self.insertBeforeInner(new_child, old_child, frame);
 
     // Special case: if we replace a node by itself, insertBefore was a noop.
     if (new_child != old_child) {
@@ -1447,7 +1512,10 @@ pub const JsApi = struct {
     pub const contains = bridge.function(Node.contains, .{});
     pub const removeChild = bridge.function(Node.removeChild, .{ .ce_reactions = true });
     pub const nodeValue = bridge.accessor(Node.getNodeValue, Node.setNodeValue, .{ .ce_reactions = true });
-    pub const insertBefore = bridge.function(Node.insertBefore, .{ .ce_reactions = true });
+    pub const insertBefore = bridge.function(_insertBefore, .{ .ce_reactions = true });
+    fn _insertBefore(self: *Node, new_node: *Node, ref_node: js.Nullable(*Node), frame: *Frame) !*Node {
+        return self.insertBefore(new_node, ref_node.value, frame);
+    }
     pub const replaceChild = bridge.function(Node.replaceChild, .{ .ce_reactions = true });
     pub const normalize = bridge.function(Node.normalize, .{ .ce_reactions = true });
     pub const cloneNode = bridge.function(Node.cloneNode, .{ .ce_reactions = true });

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -824,11 +824,73 @@ fn insertBeforeInner(self: *Node, new_node: *Node, ref_node_: ?*Node, frame: *Fr
 pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Frame) !*Node {
     try ensurePreInsertValidity(self, new_child, old_child, .replace);
 
-    _ = try self.insertBeforeInner(new_child, old_child, frame);
+    frame.domChanged();
+    const notify = Frame.observers.hasMutationObservers(frame);
 
-    // Special case: if we replace a node by itself, insertBefore was a noop.
-    if (new_child != old_child) {
-        frame.removeNode(self, old_child, .{ .will_be_reconnected = false });
+    if (new_child == old_child) {
+        // Replacing a node with itself doesn't change the tree; observers
+        // still get a removal record followed by an addition record.
+        if (notify) {
+            const prev = old_child.previousSibling();
+            const next = old_child.nextSibling();
+            const nodes = [_]*Node{old_child};
+            Frame.observers.notifyChildListChange(frame, self, &.{}, &nodes, prev, next);
+            Frame.observers.notifyChildListChange(frame, self, &nodes, &.{}, prev, next);
+        }
+        return old_child;
+    }
+
+    // Removing new_child from its current position (internal replacement)
+    // notifies normally; the replacement itself queues one combined record
+    // with both the added and the removed node.
+    const child_already_connected = new_child.isConnected();
+    const child_owner = new_child.ownerDocument(frame);
+    const parent_owner = self.ownerDocument(frame) orelse self.as(Document);
+    const adopting = child_owner != null and child_owner.? != parent_owner;
+    const will_be_reconnected = self.isConnected() and !adopting;
+
+    if (new_child.is(DocumentFragment) == null) {
+        if (new_child._parent) |previous_parent| {
+            frame.removeNode(previous_parent, new_child, .{ .will_be_reconnected = will_be_reconnected });
+        }
+        if (adopting) {
+            try frame.adoptNodeTree(new_child, child_owner.?, parent_owner);
+        }
+    }
+
+    const prev = old_child.previousSibling();
+    const next = old_child.nextSibling();
+
+    var added: std.ArrayList(*Node) = .empty;
+    if (new_child.is(DocumentFragment)) |_| {
+        if (notify) {
+            var it = new_child.childrenIterator();
+            while (it.next()) |fragment_child| {
+                try added.append(frame.call_arena, fragment_child);
+            }
+        }
+        try frame.moveAllChildren(new_child, self, old_child, .silent);
+    } else {
+        if (notify) {
+            try added.append(frame.call_arena, new_child);
+        }
+        try frame.insertNodeRelative(
+            self,
+            new_child,
+            .{ .before = old_child },
+            .{
+                .child_already_connected = child_already_connected,
+                .adopting_to_new_document = adopting,
+                .notify_observers = false,
+            },
+        );
+    }
+
+    frame.removeNode(self, old_child, .{ .will_be_reconnected = false, .notify_observers = false });
+
+    if (notify) {
+        const removed = [_]*Node{old_child};
+        Frame.observers.notifyChildListChange(frame, self, added.items, &removed, prev, next);
     }
 
     return old_child;

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -276,7 +276,9 @@ fn ensurePreInsertValidity(parent: *Node, node: *Node, child: ?*Node, comptime m
                 switch (frag_child._type) {
                     .element => element_count += 1,
                     .cdata => |cd| {
-                        if (cd._type == .text) {
+                        // A Text node (CDATASection included) cannot be a
+                        // child of a document.
+                        if (cd._type == .text or cd._type == .cdata_section) {
                             return error.HierarchyError;
                         }
                     },
@@ -840,6 +842,17 @@ pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Fra
         return old_child;
     }
 
+    // The combined record's siblings are captured before new_child is
+    // removed from its old position (spec: referenceChild and
+    // previousSibling are set before the adopt step), so new_child itself
+    // can be the record's previousSibling. A referenceChild that is
+    // new_child becomes new_child's next sibling.
+    const prev = old_child.previousSibling();
+    var next = old_child.nextSibling();
+    if (next == new_child) {
+        next = new_child.nextSibling();
+    }
+
     // Removing new_child from its current position (internal replacement)
     // notifies normally; the replacement itself queues one combined record
     // with both the added and the removed node.
@@ -858,9 +871,6 @@ pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Fra
         }
     }
 
-    const prev = old_child.previousSibling();
-    const next = old_child.nextSibling();
-
     var added: std.ArrayList(*Node) = .empty;
     if (new_child.is(DocumentFragment)) |_| {
         if (notify) {
@@ -869,7 +879,7 @@ pub fn replaceChild(self: *Node, new_child: *Node, old_child: *Node, frame: *Fra
                 try added.append(frame.call_arena, fragment_child);
             }
         }
-        try frame.moveAllChildren(new_child, self, old_child, .silent);
+        try frame.moveAllChildren(new_child, self, old_child, .silent_parent);
     } else {
         if (notify) {
             try added.append(frame.call_arena, new_child);

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -650,6 +650,14 @@ pub fn ownerDocument(self: *const Node, frame: *const Frame) ?*Document {
         return null;
     }
 
+    // An attribute node has no parent; its owner follows its element's
+    // (including across adoption into another document).
+    if (self._type == .attribute) {
+        if (self._type.attribute._element) |element| {
+            return element.asNode().ownerDocument(frame);
+        }
+    }
+
     // The root of the tree that a node belongs to is its owner.
     var current = self;
     while (current._parent) |parent| {

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -347,19 +347,16 @@ pub fn insertNode(self: *Range, node: *Node, frame: *Frame) !void {
         } else {
             const text_data = container.getData().str();
             const byte_off = byteOffset(text_data, offset);
-            if (byte_off >= text_data.len) {
-                _ = try parent.insertBefore(node, container.nextSibling(), frame);
+            const text = if (byte_off < text_data.len) container.is(Node.CData.Text) else null;
+            if (text) |t| {
+                // Split the text node in place and insert before the second
+                // half. splitText keeps live ranges updated and produces the
+                // records browsers do (one for the split-off node, one for
+                // the inserted node).
+                const second = try t.splitText(offset, frame);
+                _ = try parent.insertBefore(node, second._proto.asNode(), frame);
             } else {
-                // Split the text node into before and after parts
-                const before_text = text_data[0..byte_off];
-                const after_text = text_data[byte_off..];
-
-                const before = try Frame.node_factory.createTextNode(frame, before_text);
-                const after = try Frame.node_factory.createTextNode(frame, after_text);
-
-                _ = try parent.replaceChild(before, container, frame);
-                _ = try parent.insertBefore(node, before.nextSibling(), frame);
-                _ = try parent.insertBefore(after, node.nextSibling(), frame);
+                _ = try parent.insertBefore(node, container.nextSibling(), frame);
             }
         }
     } else {


### PR DESCRIPTION
Stacked PR 14/22 (based on #2954). Pre-insert validity, Attr adoption, and the remaining combined mutation records.

## Commits

**webapi: spec-ordered, complete pre-insert validity for node insertion**
- "Ensure pre-insert validity" now runs its checks in spec order and completely: parent-kind and cycle checks before the reference-child NotFoundError, Document nodes rejected, DocumentFragment-into-document rules, doctype ordering rules, replaceChild's NotFoundError for a wrong-parent child, and insertBefore's required-but-nullable reference argument.

**webapi: Attr.ownerDocument follows the owning element**
- After adopting an element, its attribute nodes' ownerDocument reports the new document: an Attr with an owning element delegates to that element's ownerDocument.

**webapi: spec mutation records for fragment insertion and replaceChild**
- Inserting a DocumentFragment queues exactly two records (all removals on the fragment, all additions on the parent); replaceChild queues one combined {addedNodes, removedNodes} record; Range.insertNode into a Text container uses splitText (two records, live ranges updated).

**webapi: parser insertions into the document notify mutation observers**
- A script observing the document with {subtree, childList} during the initial parse receives records for subsequently parsed nodes. No overhead when no observer exists.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/nodes/Node-insertBefore.html | 16/40 | 40/40 |
| /dom/nodes/Node-replaceChild.html | 15/29 | 29/29 |
| /dom/nodes/Node-appendChild.html | 9/11 | 11/11 |
| /dom/nodes/Node-mutation-adoptNode.html | 1/2 | 2/2 |
| /dom/nodes/attributes-namednodemap-cross-document.window.html | 0/2 | 1/2 |
| /dom/nodes/MutationObserver-childList.html | 30/38 | 38/38 |
| /dom/ranges/Range-mutations-replaceChild.html | 37/60 | 39/60 |
| /dom/nodes/MutationObserver-document.html | 1/4 | 2/4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
