### PR TITLE
webapi: quirks-mode class matching; Range createRange/collapse/deleteContents

### DIFF
--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -269,10 +269,17 @@ pub fn blob(_: *const Factory, arena: Allocator, child: anytype) !*@TypeOf(child
     return chain.get(1);
 }
 
-pub fn abstractRange(_: *const Factory, arena: Allocator, child: anytype, frame: *Frame) !*@TypeOf(child) {
+pub fn abstractRange(self: *const Factory, arena: Allocator, child: anytype, frame: *Frame) !*@TypeOf(child) {
+    return self.abstractRangeIn(arena, child, frame.document.asNode(), frame);
+}
+
+// `container` is the initial start/end container: per spec, createRange()
+// initializes both boundary points to (document, 0) of the document it was
+// called on, which is not necessarily the frame's main document.
+pub fn abstractRangeIn(_: *const Factory, arena: Allocator, child: anytype, container: *Node, frame: *Frame) !*@TypeOf(child) {
     const chain = try PrototypeChain(&.{ AbstractRange, @TypeOf(child) }).allocate(arena);
 
-    const doc = frame.document.asNode();
+    const doc = container;
     const abstract_range = chain.get(0);
     abstract_range.* = AbstractRange{
         ._rc = .{},

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -269,17 +269,10 @@ pub fn blob(_: *const Factory, arena: Allocator, child: anytype) !*@TypeOf(child
     return chain.get(1);
 }
 
-pub fn abstractRange(self: *const Factory, arena: Allocator, child: anytype, frame: *Frame) !*@TypeOf(child) {
-    return self.abstractRangeIn(arena, child, frame.document.asNode(), frame);
-}
-
-// `container` is the initial start/end container: per spec, createRange()
-// initializes both boundary points to (document, 0) of the document it was
-// called on, which is not necessarily the frame's main document.
-pub fn abstractRangeIn(_: *const Factory, arena: Allocator, child: anytype, container: *Node, frame: *Frame) !*@TypeOf(child) {
+pub fn abstractRange(_: *const Factory, arena: Allocator, child: anytype, frame: *Frame) !*@TypeOf(child) {
     const chain = try PrototypeChain(&.{ AbstractRange, @TypeOf(child) }).allocate(arena);
 
-    const doc = container;
+    const doc = frame.document.asNode();
     const abstract_range = chain.get(0);
     abstract_range.* = AbstractRange{
         ._rc = .{},

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -162,6 +162,21 @@ pub fn setLocation(self: *Document, url: [:0]const u8) !void {
     return frame.scheduleNavigation(url, .{ .reason = .script, .kind = .{ .push = null } }, .{ .script = frame });
 }
 
+// Approximation of quirks mode: an HTML document without a doctype is in
+// quirks mode. (Legacy doctypes that also trigger quirks are not detected.)
+pub fn isQuirksMode(self: *const Document) bool {
+    if (self._type != .html) {
+        return false;
+    }
+    var child = self._proto.firstChild();
+    while (child) |c| : (child = c.nextSibling()) {
+        if (c._type == .document_type) {
+            return false;
+        }
+    }
+    return true;
+}
+
 pub fn getCharset(self: *const Document) []const u8 {
     if (self._charset) |charset| {
         return charset;
@@ -1428,6 +1443,7 @@ pub const JsApi = struct {
         return frame._factory.node(Document{
             ._proto = undefined,
             ._type = .generic,
+            ._url = "about:blank",
             ._charset = "UTF-8",
         });
     }
@@ -1517,7 +1533,10 @@ pub const JsApi = struct {
     pub const characterSet = bridge.accessor(getCharacterSet, null, .{});
     pub const charset = bridge.accessor(getCharacterSet, null, .{});
     pub const inputEncoding = bridge.accessor(getCharacterSet, null, .{});
-    pub const compatMode = bridge.property("CSS1Compat", .{ .template = false });
+    pub const compatMode = bridge.accessor(getCompatMode, null, .{});
+    fn getCompatMode(self: *const Document) []const u8 {
+        return if (self.isQuirksMode()) "BackCompat" else "CSS1Compat";
+    }
 
     fn getCharacterSet(self: *const Document) []const u8 {
         return self.getCharset();

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -162,15 +162,14 @@ pub fn setLocation(self: *Document, url: [:0]const u8) !void {
     return frame.scheduleNavigation(url, .{ .reason = .script, .kind = .{ .push = null } }, .{ .script = frame });
 }
 
-// Approximation of quirks mode: an HTML document without a doctype is in
-// quirks mode. (Legacy doctypes that also trigger quirks are not detected.)
+// Approximation of quirks mode: an HTML document without a doctype is in quirks mode.
 pub fn isQuirksMode(self: *const Document) bool {
     if (self._type != .html) {
         return false;
     }
-    var child = self._proto.firstChild();
-    while (child) |c| : (child = c.nextSibling()) {
-        if (c._type == .document_type) {
+    var it = self._proto.childrenIterator();
+    while (it.next()) |child| {
+        if (child._type == .document_type) {
             return false;
         }
     }

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -177,6 +177,10 @@ pub fn isQuirksMode(self: *const Document) bool {
     return true;
 }
 
+pub fn getCompatMode(self: *const Document) []const u8 {
+    return if (self.isQuirksMode()) "BackCompat" else "CSS1Compat";
+}
+
 pub fn getCharset(self: *const Document) []const u8 {
     if (self._charset) |charset| {
         return charset;
@@ -1533,11 +1537,7 @@ pub const JsApi = struct {
     pub const characterSet = bridge.accessor(getCharacterSet, null, .{});
     pub const charset = bridge.accessor(getCharacterSet, null, .{});
     pub const inputEncoding = bridge.accessor(getCharacterSet, null, .{});
-    pub const compatMode = bridge.accessor(getCompatMode, null, .{});
-    fn getCompatMode(self: *const Document) []const u8 {
-        return if (self.isQuirksMode()) "BackCompat" else "CSS1Compat";
-    }
-
+    pub const compatMode = bridge.accessor(Document.getCompatMode, null, .{});
     fn getCharacterSet(self: *const Document) []const u8 {
         return self.getCharset();
     }

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -505,8 +505,8 @@ pub fn createProcessingInstruction(self: *Document, target: []const u8, data: []
 }
 
 const Range = @import("Range.zig");
-pub fn createRange(_: *const Document, frame: *Frame) !*Range {
-    return Range.init(frame);
+pub fn createRange(self: *Document, frame: *Frame) !*Range {
+    return Range.initIn(self.asNode(), frame);
 }
 
 pub fn createEvent(_: *const Document, event_type: []const u8, frame: *Frame) !*@import("Event.zig") {

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1402,7 +1402,12 @@ pub fn getElementsByClassName(self: *Node, class_name: []const u8, frame: *Frame
         try class_names.append(arena, try frame.dupeString(name));
     }
 
-    return collections.NodeLive(.class_name).init(self, class_names.items, frame);
+    const doc: ?*Document = if (self._type == .document) self._type.document else self.ownerDocument(frame);
+    const quirks = if (doc) |d| d.isQuirksMode() else false;
+    return collections.NodeLive(.class_name).init(self, .{
+        .names = class_names.items,
+        .case_insensitive = quirks,
+    }, frame);
 }
 
 /// Shared implementation of replaceChildren for Element, Document, and DocumentFragment.

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1402,8 +1402,7 @@ pub fn getElementsByClassName(self: *Node, class_name: []const u8, frame: *Frame
         try class_names.append(arena, try frame.dupeString(name));
     }
 
-    const doc: ?*Document = if (self._type == .document) self._type.document else self.ownerDocument(frame);
-    const quirks = if (doc) |d| d.isQuirksMode() else false;
+    const quirks = if (self.ownerDocumentIncludingSelf(frame)) |doc| doc.isQuirksMode() else false;
     return collections.NodeLive(.class_name).init(self, .{
         .names = class_names.items,
         .case_insensitive = quirks,

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -134,7 +134,8 @@ pub fn selectNodeContents(self: *Range, node: *Node) !void {
 }
 
 pub fn collapse(self: *Range, to_start: ?bool) void {
-    if (to_start orelse true) {
+    // Per spec, toStart defaults to false: collapse to the end point.
+    if (to_start orelse false) {
         self._proto._end_container = self._proto._start_container;
         self._proto._end_offset = self._proto._start_offset;
     } else {

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -38,11 +38,15 @@ pub fn init(frame: *Frame) !*Range {
 }
 
 // Both boundary points start at (container, 0); document.createRange()
-// passes the document it was called on.
+// passes the document it was called on, which is not necessarily the
+// frame's main document.
 pub fn initIn(container: *Node, frame: *Frame) !*Range {
     const arena = try frame.getArena(.medium, "Range");
     errdefer frame.releaseArena(arena);
-    return frame._factory.abstractRangeIn(arena, Range{ ._proto = undefined }, container, frame);
+    const range = try frame._factory.abstractRange(arena, Range{ ._proto = undefined }, frame);
+    range._proto._start_container = container;
+    range._proto._end_container = container;
+    return range;
 }
 
 pub fn asAbstractRange(self: *Range) *AbstractRange {
@@ -452,11 +456,14 @@ pub fn deleteContents(self: *Range, frame: *Frame) !void {
 // range's boundary points. Appends the top-most contained nodes (those whose
 // parent isn't contained) under `node`, without descending into them.
 fn collectContained(self: *const Range, node: *Node, list: *std.ArrayList(*Node), arena: std.mem.Allocator) !void {
-    var child = node.firstChild();
-    while (child) |c| : (child = c.nextSibling()) {
+    var it = node.childrenIterator();
+    while (it.next()) |c| {
         if (self.nodeContained(c)) {
             try list.append(arena, c);
-        } else {
+        } else if (c.contains(self._proto._start_container) or c.contains(self._proto._end_container)) {
+            // A non-contained child either straddles a boundary point or lies
+            // entirely outside the range; only the former can have contained
+            // descendants, so don't descend into the rest.
             try self.collectContained(c, list, arena);
         }
     }

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -395,76 +395,87 @@ pub fn deleteContents(self: *Range, frame: *Frame) !void {
     }
     frame.domChanged();
 
-    // Simple case: same container
-    if (self._proto._start_container == self._proto._end_container) {
-        if (self._proto._start_container.is(Node.CData)) |cdata| {
-            // Delete part of text node
-            const old_value = cdata.getData();
-            const text_data = old_value.str();
-            cdata._data = try String.concat(
-                frame.arena,
-                &.{
-                    text_data[0..byteOffset(text_data, self._proto._start_offset)],
-                    text_data[byteOffset(text_data, self._proto._end_offset)..],
-                },
-            );
-            Frame.observers.notifyCharacterDataChange(frame, self._proto._start_container, old_value);
+    const start_node = self._proto._start_container;
+    const start_offset = self._proto._start_offset;
+    const end_node = self._proto._end_container;
+    const end_offset = self._proto._end_offset;
+
+    // Same CharacterData container: replace the data in place.
+    if (start_node == end_node) {
+        if (start_node.is(Node.CData)) |cdata| {
+            try cdata.replaceData(start_offset, end_offset - start_offset, "", frame);
+            try self.setStart(start_node, start_offset);
+            try self.setEnd(start_node, start_offset);
+            return;
+        }
+    }
+
+    // Contained nodes whose parent isn't also contained, in tree order.
+    var to_remove: std.ArrayList(*Node) = .empty;
+    try self.collectContained(self._proto.getCommonAncestorContainer(), &to_remove, frame.call_arena);
+
+    // Where the collapsed range ends up: the start point if the start node
+    // is an inclusive ancestor of the end node; otherwise just after the
+    // highest partially-contained ancestor of the start node.
+    var new_node = start_node;
+    var new_offset = start_offset;
+    if (start_node != end_node and !start_node.contains(end_node)) {
+        var reference = start_node;
+        while (reference.parentNode()) |parent| {
+            if (parent == end_node or parent.contains(end_node)) break;
+            reference = parent;
+        }
+        new_node = reference.parentNode().?;
+        new_offset = (new_node.getChildIndex(reference) orelse 0) + 1;
+    }
+
+    if (start_node.is(Node.CData)) |cdata| {
+        const length: u32 = @intCast(cdata.getLength());
+        try cdata.replaceData(start_offset, length - start_offset, "", frame);
+    }
+
+    for (to_remove.items) |node| {
+        if (node.parentNode()) |parent| {
+            _ = try parent.removeChild(node, frame);
+        }
+    }
+
+    if (end_node.is(Node.CData)) |cdata| {
+        try cdata.replaceData(0, end_offset, "", frame);
+    }
+
+    try self.setStart(new_node, new_offset);
+    try self.setEnd(new_node, new_offset);
+}
+
+// A node is contained in the range when its whole extent lies between the
+// range's boundary points. Appends the top-most contained nodes (those whose
+// parent isn't contained) under `node`, without descending into them.
+fn collectContained(self: *const Range, node: *Node, list: *std.ArrayList(*Node), arena: std.mem.Allocator) !void {
+    var child = node.firstChild();
+    while (child) |c| : (child = c.nextSibling()) {
+        if (self.nodeContained(c)) {
+            try list.append(arena, c);
         } else {
-            // Delete child nodes in range.
-            // Capture count before the loop: removeChild triggers live range
-            // updates that decrement _end_offset on each removal.
-            const count = self._proto._end_offset - self._proto._start_offset;
-            var i: u32 = 0;
-            while (i < count) : (i += 1) {
-                if (self._proto._start_container.getChildAt(self._proto._start_offset)) |child| {
-                    _ = try self._proto._start_container.removeChild(child, frame);
-                }
-            }
-        }
-        self.collapse(true);
-        return;
-    }
-
-    // Complex case: different containers
-    // Handle start container - if it's a text node, truncate it
-    if (self._proto._start_container.is(Node.CData)) |cdata| {
-        const text_data = cdata._data.str();
-        const byte_start = byteOffset(text_data, self._proto._start_offset);
-        if (byte_start < text_data.len) {
-            // Keep only the part before start_offset
-            const new_text = text_data[0..byte_start];
-            try self._proto._start_container.setData(new_text, frame);
+            try self.collectContained(c, list, arena);
         }
     }
+}
 
-    // Handle end container - if it's a text node, truncate it
-    if (self._proto._end_container.is(Node.CData)) |cdata| {
-        const text_data = cdata._data.str();
-        const byte_end = byteOffset(text_data, self._proto._end_offset);
-        if (byte_end < text_data.len) {
-            // Keep only the part from end_offset onwards
-            const new_text = text_data[byte_end..];
-            try self._proto._end_container.setData(new_text, frame);
-        } else if (byte_end == text_data.len) {
-            // If we're at the end, set to empty (will be removed if needed)
-            try self._proto._end_container.setData("", frame);
-        }
-    }
-
-    // Remove nodes between start and end containers
-    // For now, handle the common case where they're siblings
-    if (self._proto._start_container.parentNode() == self._proto._end_container.parentNode()) {
-        var current = self._proto._start_container.nextSibling();
-        while (current != null and current != self._proto._end_container) {
-            const next = current.?.nextSibling();
-            if (current.?.parentNode()) |parent| {
-                _ = try parent.removeChild(current.?, frame);
-            }
-            current = next;
-        }
-    }
-
-    self.collapse(true);
+fn nodeContained(self: *const Range, node: *Node) bool {
+    const after_start = AbstractRange.compareBoundaryPoints(
+        node,
+        0,
+        self._proto._start_container,
+        self._proto._start_offset,
+    ) == .after;
+    if (!after_start) return false;
+    return AbstractRange.compareBoundaryPoints(
+        node,
+        node.getLength(),
+        self._proto._end_container,
+        self._proto._end_offset,
+    ) == .before;
 }
 
 pub fn cloneContents(self: *const Range, frame: *Frame) !*DocumentFragment {

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -34,9 +34,15 @@ const Range = @This();
 _proto: *AbstractRange,
 
 pub fn init(frame: *Frame) !*Range {
+    return initIn(frame.document.asNode(), frame);
+}
+
+// Both boundary points start at (container, 0); document.createRange()
+// passes the document it was called on.
+pub fn initIn(container: *Node, frame: *Frame) !*Range {
     const arena = try frame.getArena(.medium, "Range");
     errdefer frame.releaseArena(arena);
-    return frame._factory.abstractRange(arena, Range{ ._proto = undefined }, frame);
+    return frame._factory.abstractRangeIn(arena, Range{ ._proto = undefined }, container, frame);
 }
 
 pub fn asAbstractRange(self: *Range) *AbstractRange {

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -46,6 +46,13 @@ const Mode = enum {
     form,
 };
 
+pub const ClassNameFilter = struct {
+    names: [][]const u8,
+    // getElementsByClassName matches class names ASCII case-insensitively
+    // when the document is in quirks mode.
+    case_insensitive: bool = false,
+};
+
 pub const TagNameNsFilter = struct {
     namespace: ?Element.Namespace, // null means wildcard "*"
     local_name: String,
@@ -55,7 +62,7 @@ const Filters = union(Mode) {
     tag: Element.Tag,
     tag_name: String,
     tag_name_ns: TagNameNsFilter,
-    class_name: [][]const u8,
+    class_name: ClassNameFilter,
     name: []const u8,
     all_elements,
     child_elements,
@@ -261,14 +268,14 @@ pub fn NodeLive(comptime mode: Mode) type {
                     return self._filter.local_name.eqlSlice(el.getLocalName());
                 },
                 .class_name => {
-                    if (self._filter.len == 0) {
+                    if (self._filter.names.len == 0) {
                         return false;
                     }
 
                     const el = node.is(Element) orelse return false;
                     const class_attr = el.getAttributeSafe(comptime .wrap("class")) orelse return false;
-                    for (self._filter) |class_name| {
-                        if (!Selector.classAttributeContains(class_attr, class_name)) {
+                    for (self._filter.names) |class_name| {
+                        if (!Selector.classAttributeContainsCase(class_attr, class_name, self._filter.case_insensitive)) {
                             return false;
                         }
                     }

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -183,10 +183,18 @@ pub fn matchesUncached(arena: Allocator, el: *Node.Element, input: []const u8, f
 }
 
 pub fn classAttributeContains(class_attr: []const u8, class_name: []const u8) bool {
+    return classAttributeContainsCase(class_attr, class_name, false);
+}
+
+pub fn classAttributeContainsCase(class_attr: []const u8, class_name: []const u8, case_insensitive: bool) bool {
     if (class_name.len == 0 or class_name.len > class_attr.len) return false;
 
     var search = class_attr;
-    while (std.mem.indexOf(u8, search, class_name)) |pos| {
+    while (if (case_insensitive)
+        std.ascii.indexOfIgnoreCase(search, class_name)
+    else
+        std.mem.indexOf(u8, search, class_name)) |pos|
+    {
         const is_start = pos == 0 or isClassWhitespace(search[pos - 1]);
         const end = pos + class_name.len;
         const is_end = end == search.len or isClassWhitespace(search[end]);

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -187,14 +187,17 @@ pub fn classAttributeContains(class_attr: []const u8, class_name: []const u8) bo
 }
 
 pub fn classAttributeContainsCase(class_attr: []const u8, class_name: []const u8, case_insensitive: bool) bool {
-    if (class_name.len == 0 or class_name.len > class_attr.len) return false;
+    if (class_name.len == 0 or class_name.len > class_attr.len) {
+        return false;
+    }
 
     var search = class_attr;
-    while (if (case_insensitive)
-        std.ascii.indexOfIgnoreCase(search, class_name)
-    else
-        std.mem.indexOf(u8, search, class_name)) |pos|
-    {
+    while (true) {
+        const pos = (if (case_insensitive)
+            std.ascii.indexOfIgnoreCase(search, class_name)
+        else
+            std.mem.indexOf(u8, search, class_name)) orelse break;
+
         const is_start = pos == 0 or isClassWhitespace(search[pos - 1]);
         const end = pos + class_name.len;
         const is_end = end == search.len or isClassWhitespace(search[end]);


### PR DESCRIPTION
Stacked PR 15/22 (based on #2955). Quirks-mode class matching and Range basics (createRange, collapse, deleteContents).

## Commits

**webapi: quirks-mode documents match class names case-insensitively**
- Introduces quirks-mode detection (HTML document without a doctype child); `compatMode` reports BackCompat, and getElementsByClassName matches ASCII case-insensitively in quirks mode.

**webapi: createRange() boundary points start in the document it's called on**
- `foreignDoc.createRange()` produced a range rooted in the main document; the range factory now takes the initial container.

**webapi: Range.collapse() defaults to collapsing to the end**
- `collapse(optional boolean toStart = false)`: with the argument omitted, the range collapses to its end point, not the start.

**webapi: implement the spec algorithm for Range.deleteContents**
- deleteContents now follows the DOM algorithm: same-CharacterData in-place replaceData, top-most contained nodes collected before mutation and removed anywhere in the tree, partial CharacterData boundaries truncated, and the spec's "new node/new offset" collapse rule.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/nodes/getElementsByClassName-14.htm | 1/2 | 2/2 |
| /dom/ranges/Range-cloneRange.html | 40/62 | 62/62 |
| /dom/ranges/Range-collapse.html | 142/186 | 186/186 |
| /dom/ranges/Range-deleteContents.html | 105/125 | 125/125 |
| /dom/ranges/Range-extractContents.html | 141/187 | 153/187 |

## Review follow-ups

- `3b4c0769a` — `getCompatMode` moves out of the JsApi bridge block onto Document (JsApi is for JS/v8 bridging only; the accessor just references it).

Re-verified: build clean, getElementsByClassName-14.htm 2/2, Range-collapse.html 186/186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

