### PR TITLE
webapi: response content type, element scroll events, translate, SVGAElement.relList

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -236,6 +236,10 @@ _factory: *Factory,
 
 _load_state: LoadState = .waiting,
 
+// The navigation response's MIME essence, recorded when the first chunk
+// arrives and applied to the new document (document.contentType) once the
+// navigation commits. null means the text/html default.
+_pending_content_type: ?[]const u8 = null,
 _parse_state: ParseState = .pre,
 
 /// `frameErrorCallback` swallows the failure into a placeholder page;
@@ -1427,6 +1431,19 @@ fn frameDataCallback(transfer: *HttpClient.Transfer, data: []const u8) !void {
             });
         }
 
+        // Record the response's MIME essence so the resulting document
+        // reports it (document.contentType); text/html stays the default.
+        self._pending_content_type = null;
+        if (transfer.contentType()) |ct| {
+            const end = std.mem.indexOfScalar(u8, ct, ';') orelse ct.len;
+            const essence = std.mem.trim(u8, ct[0..end], " \t");
+            if (essence.len > 0 and !std.ascii.eqlIgnoreCase(essence, "text/html")) {
+                const lower = try self.arena.dupe(u8, essence);
+                _ = std.ascii.lowerString(lower, essence);
+                self._pending_content_type = lower;
+            }
+        }
+
         switch (mime.content_type) {
             .text_html => {
                 // Normalize and store the charset using encoding_rs canonical names
@@ -1500,6 +1517,11 @@ fn frameDoneCallback(ctx: *anyopaque) !void {
 
     //We need to handle different navigation types differently.
     try self._session.navigation.commitNavigation(self);
+
+    if (self._pending_content_type) |content_type| {
+        self.document._content_type = content_type;
+        self._pending_content_type = null;
+    }
 
     defer if (comptime IS_DEBUG) {
         log.debug(.frame, "frame load complete", .{

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1432,15 +1432,18 @@ fn frameDataCallback(transfer: *HttpClient.Transfer, data: []const u8) !void {
         }
 
         // Record the response's MIME essence so the resulting document
-        // reports it (document.contentType); text/html stays the default.
+        // reports it (document.contentType). text/html keeps the default, so an
+        // HTML response (parsed from the header, or sniffed when there's no
+        // header) never needs an override; inside this branch the essence can
+        // no longer be text/html.
         self._pending_content_type = null;
-        if (transfer.contentType()) |ct| {
-            const end = std.mem.indexOfScalar(u8, ct, ';') orelse ct.len;
-            const essence = std.mem.trim(u8, ct[0..end], " \t");
-            if (essence.len > 0 and !std.ascii.eqlIgnoreCase(essence, "text/html")) {
-                const lower = try self.arena.dupe(u8, essence);
-                _ = std.ascii.lowerString(lower, essence);
-                self._pending_content_type = lower;
+        if (mime.content_type != .text_html) {
+            if (transfer.contentType()) |ct| {
+                const end = std.mem.indexOfScalarPos(u8, ct, 0, ';') orelse ct.len;
+                const essence = std.mem.trim(u8, ct[0..end], " \t");
+                if (essence.len > 0) {
+                    self._pending_content_type = try std.ascii.allocLowerString(self.arena, essence);
+                }
             }
         }
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1715,17 +1715,79 @@ fn scheduleScrollEvents(self: *Element, frame: *Frame) !void {
     }
     gop.value_ptr.state = .scroll;
 
-    const task = try frame.arena.create(ScrollEventTask);
-    task.* = .{ .frame = frame, .element = self };
+    const task = try frame._factory.create(ScrollEventTask{ .frame = frame, .element = self });
     try frame.js.scheduler.add(task, ScrollEventTask.dispatchScroll, 10, .{ .low_priority = true });
-    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScrollEnd, 20, .{ .low_priority = true });
+    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScrollEnd, 20, .{ .low_priority = true, .finalizer = ScrollEventTask.cancelled });
 }
 
 const ScrollEventTask = struct {
     frame: *Frame,
     element: *Element,
 
-    fn eventTarget(self: *ScrollEventTask) *@import("EventTarget.zig") {
+    fn cancelled(ctx: *anyopaque) void {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
+        self.deinit();
+    }
+
+    fn deinit(self: *ScrollEventTask) void {
+        self.frame._factory.destroy(self);
+    }
+
+    fn dispatchScroll(ctx: *anyopaque) anyerror!?u32 {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
+        const f = self.frame;
+        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
+        if (pos.state != .scroll) {
+            return null;
+        }
+
+        const Event = @import("Event.zig");
+        const event = try Event.initTrusted(comptime .wrap("scroll"), .{ .bubbles = self.bubbles() }, f._page);
+        try f._event_manager.dispatch(self.eventTarget(), event);
+
+        // can't use gop on _element_scroll_positions above, since the JS callback
+        // can mutate _element_scroll_positions and invalidate any pointers
+        if (f._element_scroll_positions.getPtr(self.element)) |p| {
+            p.state = .end;
+        }
+        return null;
+    }
+
+    fn dispatchScrollEnd(ctx: *anyopaque) anyerror!?u32 {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
+
+        const f = self.frame;
+        const pos = f._element_scroll_positions.getPtr(self.element) orelse {
+            self.deinit();
+            return null;
+        };
+
+        switch (pos.state) {
+            // The scroll event is still pending; retry in 10ms. Must not destroy
+            // the task here — the entry is re-scheduled and runs again.
+            .scroll => return 10,
+            .end => {},
+            .done => {
+                self.deinit();
+                return null;
+            },
+        }
+
+        defer self.deinit();
+        const Event = @import("Event.zig");
+        const event = try Event.initTrusted(comptime .wrap("scrollend"), .{ .bubbles = self.bubbles() }, f._page);
+        try f._event_manager.dispatch(self.eventTarget(), event);
+
+        // can't use gop on _element_scroll_positions above, since the JS callback
+        // can mutate _element_scroll_positions and invalidate any pointers
+        if (f._element_scroll_positions.getPtr(self.element)) |p| {
+            p.state = .done;
+        }
+
+        return null;
+    }
+
+    fn eventTarget(self: *ScrollEventTask) *EventTarget {
         if (self.frame.document.getDocumentElement() == self.element) {
             return self.frame.document.asEventTarget();
         }
@@ -1736,36 +1798,6 @@ const ScrollEventTask = struct {
     // scrolls (the scrolling element, dispatched at the document) do.
     fn bubbles(self: *ScrollEventTask) bool {
         return self.frame.document.getDocumentElement() == self.element;
-    }
-
-    fn dispatchScroll(ptr: *anyopaque) anyerror!?u32 {
-        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
-        const f = self.frame;
-        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
-        if (pos.state != .scroll) {
-            return null;
-        }
-        const Event = @import("Event.zig");
-        const event = try Event.initTrusted(comptime .wrap("scroll"), .{ .bubbles = self.bubbles() }, f._page);
-        try f._event_manager.dispatch(self.eventTarget(), event);
-        pos.state = .end;
-        return null;
-    }
-
-    fn dispatchScrollEnd(ptr: *anyopaque) anyerror!?u32 {
-        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
-        const f = self.frame;
-        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
-        switch (pos.state) {
-            .scroll => return 10,
-            .end => {},
-            .done => return null,
-        }
-        const Event = @import("Event.zig");
-        const event = try Event.initTrusted(comptime .wrap("scrollend"), .{ .bubbles = self.bubbles() }, f._page);
-        try f._event_manager.dispatch(self.eventTarget(), event);
-        pos.state = .done;
-        return null;
     }
 };
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -56,6 +56,9 @@ pub const NamespaceUriLookup = std.AutoHashMapUnmanaged(*Element, []const u8);
 pub const ScrollPosition = struct {
     x: u32 = 0,
     y: u32 = 0,
+    // Throttle state for the async scroll/scrollend dispatch (mirrors
+    // Window._scroll_pos.state).
+    state: enum { scroll, end, done } = .done,
 };
 pub const ScrollPositionLookup = std.AutoHashMapUnmanaged(*Element, ScrollPosition);
 
@@ -1344,7 +1347,11 @@ pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
-    gop.value_ptr.y = @intCast(@max(0, value));
+    const new_y: u32 = @intCast(@max(0, value));
+    if (gop.value_ptr.y != new_y) {
+        gop.value_ptr.y = new_y;
+        try self.scheduleScrollEvents(frame);
+    }
 }
 
 pub fn getScrollLeft(self: *Element, frame: *Frame) u32 {
@@ -1357,7 +1364,11 @@ pub fn setScrollLeft(self: *Element, value: i32, frame: *Frame) !void {
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
-    gop.value_ptr.x = @intCast(@max(0, value));
+    const new_x: u32 = @intCast(@max(0, value));
+    if (gop.value_ptr.x != new_x) {
+        gop.value_ptr.x = new_x;
+        try self.scheduleScrollEvents(frame);
+    }
 }
 
 pub fn getScrollHeight(self: *Element, frame: *Frame) f64 {
@@ -1647,6 +1658,8 @@ pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
+    const old_x = gop.value_ptr.x;
+    const old_y = gop.value_ptr.y;
     switch (o) {
         .x => |x| {
             gop.value_ptr.x = @intCast(@max(0, x));
@@ -1656,6 +1669,9 @@ pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
             if (dict.left) |left| gop.value_ptr.x = @intCast(@max(0, left));
             if (dict.top) |top| gop.value_ptr.y = @intCast(@max(0, top));
         },
+    }
+    if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
+        try self.scheduleScrollEvents(frame);
     }
 }
 
@@ -1672,7 +1688,74 @@ pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
     };
     gop.value_ptr.x = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.x)) + dx));
     gop.value_ptr.y = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.y)) + dy));
+    if (dx != 0 or dy != 0) {
+        try self.scheduleScrollEvents(frame);
+    }
 }
+
+// Scrolling an element fires a scroll event and then a scrollend event,
+// asynchronously and throttled, mirroring Window.scrollTo. Scrolls of the
+// scrolling element (the root) are fired at the document instead.
+fn scheduleScrollEvents(self: *Element, frame: *Frame) !void {
+    const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = .{};
+    }
+    gop.value_ptr.state = .scroll;
+
+    const task = try frame.arena.create(ScrollEventTask);
+    task.* = .{ .frame = frame, .element = self };
+    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScroll, 10, .{ .low_priority = true });
+    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScrollEnd, 20, .{ .low_priority = true });
+}
+
+const ScrollEventTask = struct {
+    frame: *Frame,
+    element: *Element,
+
+    fn eventTarget(self: *ScrollEventTask) *@import("EventTarget.zig") {
+        if (self.frame.document.getDocumentElement() == self.element) {
+            return self.frame.document.asEventTarget();
+        }
+        return self.element.asEventTarget();
+    }
+
+    // Scroll events fired at an element don't bubble; only document-level
+    // scrolls (the scrolling element, dispatched at the document) do.
+    fn bubbles(self: *ScrollEventTask) bool {
+        return self.frame.document.getDocumentElement() == self.element;
+    }
+
+    fn dispatchScroll(ptr: *anyopaque) anyerror!?u32 {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
+        const f = self.frame;
+        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
+        if (pos.state != .scroll) {
+            return null;
+        }
+        const Event = @import("Event.zig");
+        const event = try Event.initTrusted(comptime .wrap("scroll"), .{ .bubbles = self.bubbles() }, f._page);
+        try f._event_manager.dispatch(self.eventTarget(), event);
+        pos.state = .end;
+        return null;
+    }
+
+    fn dispatchScrollEnd(ptr: *anyopaque) anyerror!?u32 {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
+        const f = self.frame;
+        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
+        switch (pos.state) {
+            .scroll => return 10,
+            .end => {},
+            .done => return null,
+        }
+        const Event = @import("Event.zig");
+        const event = try Event.initTrusted(comptime .wrap("scrollend"), .{ .bubbles = self.bubbles() }, f._page);
+        try f._event_manager.dispatch(self.eventTarget(), event);
+        pos.state = .done;
+        return null;
+    }
+};
 
 pub fn format(self: *Element, writer: *std.Io.Writer) !void {
     try writer.writeByte('<');

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1337,37 +1337,46 @@ pub fn getClientRects(self: *Element, frame: *Frame) ![]*DOMRect {
     return rects;
 }
 
+// Scroll positions live in the map of the element's own frame — not the
+// caller's, which differs when a same-origin script scrolls an element in
+// another frame (e.g. inside an iframe). All scroll accessors resolve the
+// owner frame first so the state, the fired events and the document
+// comparison stay in the element's frame.
 pub fn getScrollTop(self: *Element, frame: *Frame) u32 {
-    const pos = frame._element_scroll_positions.get(self) orelse return 0;
+    const owner = self.ownerFrame(frame);
+    const pos = owner._element_scroll_positions.get(self) orelse return 0;
     return pos.y;
 }
 
 pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
-    const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
+    const owner = self.ownerFrame(frame);
+    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
     const new_y: u32 = @intCast(@max(0, value));
     if (gop.value_ptr.y != new_y) {
         gop.value_ptr.y = new_y;
-        try self.scheduleScrollEvents(frame);
+        try self.scheduleScrollEvents(owner);
     }
 }
 
 pub fn getScrollLeft(self: *Element, frame: *Frame) u32 {
-    const pos = frame._element_scroll_positions.get(self) orelse return 0;
+    const owner = self.ownerFrame(frame);
+    const pos = owner._element_scroll_positions.get(self) orelse return 0;
     return pos.x;
 }
 
 pub fn setScrollLeft(self: *Element, value: i32, frame: *Frame) !void {
-    const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
+    const owner = self.ownerFrame(frame);
+    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
     const new_x: u32 = @intCast(@max(0, value));
     if (gop.value_ptr.x != new_x) {
         gop.value_ptr.x = new_x;
-        try self.scheduleScrollEvents(frame);
+        try self.scheduleScrollEvents(owner);
     }
 }
 
@@ -1654,7 +1663,8 @@ const ScrollToOpts = union(enum) {
 
 pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
-    const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
+    const owner = self.ownerFrame(frame);
+    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
@@ -1671,14 +1681,15 @@ pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
         },
     }
     if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
-        try self.scheduleScrollEvents(frame);
+        try self.scheduleScrollEvents(owner);
     }
 }
 
 // scrollBy(): like scrollTo() but relative to the current position.
 pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
-    const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
+    const owner = self.ownerFrame(frame);
+    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
@@ -1689,13 +1700,14 @@ pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
     gop.value_ptr.x = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.x)) + dx));
     gop.value_ptr.y = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.y)) + dy));
     if (dx != 0 or dy != 0) {
-        try self.scheduleScrollEvents(frame);
+        try self.scheduleScrollEvents(owner);
     }
 }
 
 // Scrolling an element fires a scroll event and then a scrollend event,
 // asynchronously and throttled, mirroring Window.scrollTo. Scrolls of the
 // scrolling element (the root) are fired at the document instead.
+// `frame` is the element's owner frame (resolved by the public accessors).
 fn scheduleScrollEvents(self: *Element, frame: *Frame) !void {
     const gop = try frame._element_scroll_positions.getOrPut(frame.arena, self);
     if (!gop.found_existing) {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -345,6 +345,28 @@ pub fn setHidden(self: *HtmlElement, hidden: bool, frame: *Frame) !void {
     }
 }
 
+// The translate IDL attribute reflects the element's translation mode:
+// translate="yes"/"" enables it, "no" disables it, anything else (or no
+// attribute) inherits from the parent, defaulting to enabled.
+pub fn getTranslate(self: *HtmlElement) bool {
+    var node: ?*Node = self.asElement().asNode();
+    while (node) |n| : (node = n.parentNode()) {
+        const el = n.is(Element) orelse continue;
+        const value = el.getAttributeSafe(comptime .wrap("translate")) orelse continue;
+        if (value.len == 0 or std.ascii.eqlIgnoreCase(value, "yes")) {
+            return true;
+        }
+        if (std.ascii.eqlIgnoreCase(value, "no")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+pub fn setTranslate(self: *HtmlElement, translate: bool, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("translate"), .wrap(if (translate) "yes" else "no"), frame);
+}
+
 pub fn getPopover(self: *HtmlElement) ?[]const u8 {
     const s = popover.getState(self.asElement()) orelse return null;
     return @tagName(s);
@@ -1707,6 +1729,7 @@ pub const JsApi = struct {
     pub const autofocus = bridge.accessor(HtmlElement.getAutofocus, HtmlElement.setAutofocus, .{ .ce_reactions = true });
     pub const dir = bridge.accessor(HtmlElement.getDir, HtmlElement.setDir, .{ .ce_reactions = true });
     pub const hidden = bridge.accessor(HtmlElement.getHidden, HtmlElement.setHidden, .{ .ce_reactions = true });
+    pub const translate = bridge.accessor(HtmlElement.getTranslate, HtmlElement.setTranslate, .{ .ce_reactions = true });
     pub const popover = bridge.accessor(HtmlElement.getPopover, HtmlElement.setPopover, .{ .ce_reactions = true });
     pub const showPopover = bridge.function(HtmlElement.showPopover, .{});
     pub const hidePopover = bridge.function(HtmlElement.hidePopover, .{});

--- a/src/browser/webapi/element/svg/A.zig
+++ b/src/browser/webapi/element/svg/A.zig
@@ -22,6 +22,7 @@ const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const AnimatedString = @import("../../svg/AnimatedString.zig");
+const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 
 const Graphics = @import("Graphics.zig");
 
@@ -33,6 +34,10 @@ pub fn asElement(self: *A) *Element {
 }
 pub fn asNode(self: *A) *Node {
     return self.asElement().asNode();
+}
+
+pub fn getRelList(self: *A, frame: *Frame) !*DOMTokenList {
+    return self.asElement().getRelList(frame);
 }
 
 pub const JsApi = struct {
@@ -49,8 +54,5 @@ pub const JsApi = struct {
         return AnimatedString.getOrCreate(self.asElement(), .href, frame);
     }
 
-    pub const relList = bridge.accessor(_getRelList, null, .{});
-    fn _getRelList(self: *A, frame: *Frame) !*@import("../../collections.zig").DOMTokenList {
-        return self.asElement().getRelList(frame);
-    }
+    pub const relList = bridge.accessor(A.getRelList, null, .{});
 };

--- a/src/browser/webapi/element/svg/A.zig
+++ b/src/browser/webapi/element/svg/A.zig
@@ -48,4 +48,9 @@ pub const JsApi = struct {
     fn _href(self: *A, frame: *Frame) !*AnimatedString {
         return AnimatedString.getOrCreate(self.asElement(), .href, frame);
     }
+
+    pub const relList = bridge.accessor(_getRelList, null, .{});
+    fn _getRelList(self: *A, frame: *Frame) !*@import("../../collections.zig").DOMTokenList {
+        return self.asElement().getRelList(frame);
+    }
 };


### PR DESCRIPTION
Stacked PR 18/22 (based on #2958). Document content type, element scroll events, the translate attribute, and SVGAElement.relList.

## Commits

**webapi: documents report the navigation response's content type**
- Documents created from non-HTML responses report the response's MIME essence from `document.contentType` instead of the text/html default.

**webapi: element scrolls fire scroll and scrollend events**
- `Element.scrollTo/scrollBy` and the scrollTop/scrollLeft setters now schedule the throttled scroll + scrollend pair when the position changes; element-targeted events don't bubble, and scrolling the scrolling element dispatches at the document.

**webapi: implement the translate IDL attribute**
- `HTMLElement.translate` computes the translation mode per HTML (yes/""/no, ancestor inheritance, default enabled); the setter reflects "yes"/"no".

**webapi: SVGAElement exposes relList**
- An SVG-namespace `<a>` exposes relList as a DOMTokenList (SVG area/link have none), reflecting rel through the shared Element.getRelList.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/nodes/Document-contentType/contentType/ | 5/15 files | 14/15 files |
| /dom/events/scrolling/ | 4 files passing | 20 files passing |
| /html/dom/elements/global-attributes/ translate tests (7 files) | 0/1 each | 1/1 each |
| /dom/lists/DOMTokenList-coverage-for-attributes.html | 174/175 | 175/175 |

## Review follow-ups

- `80f5a1474` — element scroll state lives in the **element's own frame**: the positions map, the scheduled scroll/scrollend events and the scrolling-element (root) comparison used the caller's frame; all six scroll accessors now resolve `Element.ownerFrame` first (pattern from #2944's review).

WPT re-verified: /dom/events/scrolling/ 20 files passing (the claimed coverage), including all 16 subframe/iframe variants.

## Review follow-ups (2)

- `3ce7cc295` — `SVGAElement.getRelList` moves out of the JsApi bridge block (plain delegation, no v8 adaptation).

Re-verified: build clean, DOMTokenList-coverage-for-attributes.html 175/175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



