### PR TITLE
webapi: foreign-element attribute matching, document.head/getElementsByName, lastModified

### DIFF
--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -202,7 +202,7 @@ pub fn getLastModified(self: *const Document, frame: *Frame) ![]const u8 {
     if (localtime_r(&timestamp, &tm) == null) {
         return error.InvalidArgument;
     }
-    return std.fmt.allocPrint(frame.call_arena, "{d:0>2}/{d:0>2}/{d} {d:0>2}:{d:0>2}:{d:0>2}", .{
+    return std.fmt.allocPrint(frame.local_arena, "{d:0>2}/{d:0>2}/{d} {d:0>2}:{d:0>2}:{d:0>2}", .{
         @as(u32, @intCast(tm.tm_mon + 1)),
         @as(u32, @intCast(tm.tm_mday)),
         tm.tm_year + 1900,

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -180,6 +180,53 @@ pub fn getCompatMode(self: *const Document) []const u8 {
     return if (self.isQuirksMode()) "BackCompat" else "CSS1Compat";
 }
 
+// document.lastModified: the response's Last-Modified header in local time,
+// "MM/DD/YYYY hh:mm:ss", defaulting to the current time.
+pub fn getLastModified(self: *const Document, frame: *Frame) ![]const u8 {
+    var timestamp: i64 = std.time.timestamp();
+    if (self._frame) |doc_frame| {
+        if (doc_frame.document == self) {
+            for (doc_frame._http_headers.items) |header| {
+                if (std.ascii.eqlIgnoreCase(header.name, "last-modified")) {
+                    const DateTime = @import("../../datetime.zig").DateTime;
+                    if (DateTime.parse(header.value, .rfc822)) |dt| {
+                        timestamp = dt.unix(.seconds);
+                    } else |_| {}
+                    break;
+                }
+            }
+        }
+    }
+
+    var tm: LibcTm = undefined;
+    if (localtime_r(&timestamp, &tm) == null) {
+        return error.InvalidArgument;
+    }
+    return std.fmt.allocPrint(frame.call_arena, "{d:0>2}/{d:0>2}/{d} {d:0>2}:{d:0>2}:{d:0>2}", .{
+        @as(u32, @intCast(tm.tm_mon + 1)),
+        @as(u32, @intCast(tm.tm_mday)),
+        tm.tm_year + 1900,
+        @as(u32, @intCast(tm.tm_hour)),
+        @as(u32, @intCast(tm.tm_min)),
+        @as(u32, @intCast(tm.tm_sec)),
+    });
+}
+
+const LibcTm = extern struct {
+    tm_sec: c_int,
+    tm_min: c_int,
+    tm_hour: c_int,
+    tm_mday: c_int,
+    tm_mon: c_int,
+    tm_year: c_int,
+    tm_wday: c_int,
+    tm_yday: c_int,
+    tm_isdst: c_int,
+    tm_gmtoff: c_long,
+    tm_zone: ?[*:0]const u8,
+};
+extern "c" fn localtime_r(timep: *const i64, result: *LibcTm) ?*LibcTm;
+
 pub fn getCharset(self: *const Document) []const u8 {
     if (self._charset) |charset| {
         return charset;
@@ -1549,6 +1596,7 @@ pub const JsApi = struct {
     pub const charset = bridge.accessor(getCharacterSet, null, .{});
     pub const inputEncoding = bridge.accessor(getCharacterSet, null, .{});
     pub const compatMode = bridge.accessor(Document.getCompatMode, null, .{});
+    pub const lastModified = bridge.accessor(Document.getLastModified, null, .{});
     fn getCharacterSet(self: *const Document) []const u8 {
         return self.getCharset();
     }

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -183,25 +183,23 @@ pub fn getCompatMode(self: *const Document) []const u8 {
 // document.lastModified: the response's Last-Modified header in local time,
 // "MM/DD/YYYY hh:mm:ss", defaulting to the current time.
 pub fn getLastModified(self: *const Document, frame: *Frame) ![]const u8 {
-    var timestamp: i64 = std.time.timestamp();
-    if (self._frame) |doc_frame| {
-        if (doc_frame.document == self) {
-            for (doc_frame._http_headers.items) |header| {
+    const dt = @import("../../datetime.zig");
+
+    const timestamp = blk: {
+        if (self._frame) |owner| {
+            for (owner._http_headers.items) |header| {
                 if (std.ascii.eqlIgnoreCase(header.name, "last-modified")) {
-                    const DateTime = @import("../../datetime.zig").DateTime;
-                    if (DateTime.parse(header.value, .rfc822)) |dt| {
-                        timestamp = dt.unix(.seconds);
+                    if (dt.DateTime.parse(header.value, .rfc822)) |parsed| {
+                        break :blk parsed.unix(.seconds);
                     } else |_| {}
                     break;
                 }
             }
         }
-    }
+        break :blk std.time.timestamp();
+    };
 
-    var tm: LibcTm = undefined;
-    if (localtime_r(&timestamp, &tm) == null) {
-        return error.InvalidArgument;
-    }
+    const tm = try dt.localTime(timestamp);
     return std.fmt.allocPrint(frame.local_arena, "{d:0>2}/{d:0>2}/{d} {d:0>2}:{d:0>2}:{d:0>2}", .{
         @as(u32, @intCast(tm.tm_mon + 1)),
         @as(u32, @intCast(tm.tm_mday)),
@@ -211,21 +209,6 @@ pub fn getLastModified(self: *const Document, frame: *Frame) ![]const u8 {
         @as(u32, @intCast(tm.tm_sec)),
     });
 }
-
-const LibcTm = extern struct {
-    tm_sec: c_int,
-    tm_min: c_int,
-    tm_hour: c_int,
-    tm_mday: c_int,
-    tm_mon: c_int,
-    tm_year: c_int,
-    tm_wday: c_int,
-    tm_yday: c_int,
-    tm_isdst: c_int,
-    tm_gmtoff: c_long,
-    tm_zone: ?[*:0]const u8,
-};
-extern "c" fn localtime_r(timep: *const i64, result: *LibcTm) ?*LibcTm;
 
 pub fn getCharset(self: *const Document) []const u8 {
     if (self._charset) |charset| {

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -49,8 +49,8 @@ pub fn asEventTarget(self: *HTMLDocument) *@import("EventTarget.zig") {
 // "blah:head" is an HTMLUnknownElement but still qualifies).
 pub fn getHead(self: *HTMLDocument) ?*Element {
     const doc_el = self._proto.getDocumentElement() orelse return null;
-    var child = doc_el.asNode().firstChild();
-    while (child) |node| : (child = node.nextSibling()) {
+    var it = doc_el.asNode().childrenIterator();
+    while (it.next()) |node| {
         const el = node.is(Element) orelse continue;
         if (el._namespace == .html and std.mem.eql(u8, el.getLocalName(), "head")) {
             return el;

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -44,14 +44,17 @@ pub fn asEventTarget(self: *HTMLDocument) *@import("EventTarget.zig") {
 }
 
 // HTML-specific accessors
-pub fn getHead(self: *HTMLDocument) ?*Element.Html.Head {
+// The head is the first html-namespace child of the document element whose
+// local name is head, whatever its Zig element type (e.g. a createElementNS
+// "blah:head" is an HTMLUnknownElement but still qualifies).
+pub fn getHead(self: *HTMLDocument) ?*Element {
     const doc_el = self._proto.getDocumentElement() orelse return null;
     var child = doc_el.asNode().firstChild();
-    while (child) |node| {
-        if (node.is(Element.Html.Head)) |head| {
-            return head;
+    while (child) |node| : (child = node.nextSibling()) {
+        const el = node.is(Element) orelse continue;
+        if (el._namespace == .html and std.mem.eql(u8, el.getLocalName(), "head")) {
+            return el;
         }
-        child = node.nextSibling();
     }
     return null;
 }

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -283,6 +283,8 @@ pub fn NodeLive(comptime mode: Mode) type {
                 },
                 .name => {
                     const el = node.is(Element) orelse return false;
+                    // getElementsByName only considers HTML elements.
+                    if (el._namespace != .html) return false;
                     const name_attr = el.getAttributeSafe(comptime .wrap("name")) orelse return false;
                     return std.mem.eql(u8, name_attr, self._filter);
                 },

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -529,15 +529,7 @@ fn normalizeNameForLookup(name: String, frame: *Frame) !String {
     return .wrap(normalized);
 }
 
-pub fn normalizeNameForLookupAlloc(allocator: Allocator, name: String) !String {
-    if (!needsLowerCasing(name.str())) {
-        return name.dupe(allocator);
-    }
-    const normalized = try std.ascii.allocLowerString(allocator, name.str());
-    return .wrap(normalized);
-}
-
-fn needsLowerCasing(name: []const u8) bool {
+pub fn needsLowerCasing(name: []const u8) bool {
     var remaining = name;
     if (comptime std.simd.suggestVectorLength(u8)) |vector_len| {
         while (remaining.len > vector_len) {
@@ -555,6 +547,11 @@ fn needsLowerCasing(name: []const u8) bool {
         }
     }
     return false;
+}
+
+pub fn normalizeNameForLookupAlloc(allocator: Allocator, name: String) !String {
+    const normalized = try std.ascii.allocLowerString(allocator, name.str());
+    return .wrap(normalized);
 }
 
 pub const NamedNodeMap = struct {

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -445,7 +445,11 @@ fn matchesPart(el: *Node.Element, part: Part, scope: *Node, frame: *Frame) bool 
 }
 
 fn matchesAttribute(el: *Node.Element, attr: Selector.Attribute) bool {
-    const value = el.getAttributeSafe(attr.name) orelse {
+    // Attribute names match ASCII case-insensitively on HTML elements (both
+    // sides lowercased) and case-sensitively on foreign elements, whose
+    // attributes are stored as written.
+    const name = if (el._namespace == .html) attr.name else attr.original_name;
+    const value = el.getAttributeSafe(name) orelse {
         return false;
     };
 

--- a/src/browser/webapi/selector/Parser.zig
+++ b/src/browser/webapi/selector/Parser.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const Node = @import("../Node.zig");
 const Attribute = @import("../element/Attribute.zig");
@@ -159,7 +160,7 @@ pub fn parseList(arena: Allocator, input: []const u8) ParseError![]const Selecto
     return selectors.items;
 }
 
-pub fn parse(arena: Allocator, input: []const u8) ParseError!Selector.Selector {
+fn parse(arena: Allocator, input: []const u8) ParseError!Selector.Selector {
     var parser = Parser{ .input = input };
     var segments: std.ArrayList(Segment) = .empty;
     var current_compound: std.ArrayList(Part) = .empty;
@@ -961,12 +962,16 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
         self.input = self.input[1..];
     }
 
+    // Kept as-written in original_name for the case-sensitive match on
+    // foreign elements; like the rest of the AST, it borrows the input.
     const attr_name = try self.attributeName(arena);
-    // As written, for the case-sensitive match on foreign elements.
-    const original_name = try arena.dupe(u8, attr_name);
 
     // Normalize the name to lowercase for fast matching (consistent with Attribute.normalizeNameForLookup)
-    const name = try Attribute.normalizeNameForLookupAlloc(arena, .wrap(attr_name));
+    const name = if (Attribute.needsLowerCasing(attr_name))
+        try Attribute.normalizeNameForLookupAlloc(arena, .wrap(attr_name))
+    else
+        lp.String.wrap(attr_name);
+
     var case_insensitive = false;
     _ = self.skipSpaces();
 
@@ -976,7 +981,12 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
         if (self.peek() == ']') {
             self.input = self.input[1..];
         }
-        return .{ .name = name, .original_name = .wrap(original_name), .matcher = .presence, .case_insensitive = case_insensitive };
+        return .{
+            .name = name,
+            .matcher = .presence,
+            .original_name = .wrap(attr_name),
+            .case_insensitive = case_insensitive,
+        };
     }
 
     const matcher_type = try self.attributeMatcher();
@@ -1014,7 +1024,12 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
         .presence => unreachable,
     };
 
-    return .{ .name = name, .original_name = .wrap(original_name), .matcher = matcher, .case_insensitive = case_insensitive };
+    return .{
+        .name = name,
+        .matcher = matcher,
+        .original_name = .wrap(attr_name),
+        .case_insensitive = case_insensitive,
+    };
 }
 
 fn attributeName(self: *Parser, arena: Allocator) ![]const u8 {

--- a/src/browser/webapi/selector/Parser.zig
+++ b/src/browser/webapi/selector/Parser.zig
@@ -962,6 +962,8 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
     }
 
     const attr_name = try self.attributeName(arena);
+    // As written, for the case-sensitive match on foreign elements.
+    const original_name = try arena.dupe(u8, attr_name);
 
     // Normalize the name to lowercase for fast matching (consistent with Attribute.normalizeNameForLookup)
     const name = try Attribute.normalizeNameForLookupAlloc(arena, .wrap(attr_name));
@@ -974,7 +976,7 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
         if (self.peek() == ']') {
             self.input = self.input[1..];
         }
-        return .{ .name = name, .matcher = .presence, .case_insensitive = case_insensitive };
+        return .{ .name = name, .original_name = .wrap(original_name), .matcher = .presence, .case_insensitive = case_insensitive };
     }
 
     const matcher_type = try self.attributeMatcher();
@@ -1012,7 +1014,7 @@ fn attribute(self: *Parser, arena: Allocator) !Selector.Attribute {
         .presence => unreachable,
     };
 
-    return .{ .name = name, .matcher = matcher, .case_insensitive = case_insensitive };
+    return .{ .name = name, .original_name = .wrap(original_name), .matcher = matcher, .case_insensitive = case_insensitive };
 }
 
 fn attributeName(self: *Parser, arena: Allocator) ![]const u8 {

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -229,7 +229,11 @@ pub const Part = union(enum) {
 };
 
 pub const Attribute = struct {
+    // Lowercased for the HTML-element case-insensitive match.
     name: String,
+    // As written in the selector: attribute names match case-sensitively on
+    // foreign (SVG/MathML) elements, whose attributes are stored unnormalized.
+    original_name: String,
     matcher: AttributeMatcher,
     case_insensitive: bool,
 };

--- a/src/datetime.zig
+++ b/src/datetime.zig
@@ -621,6 +621,29 @@ fn paddingTwoDigits(value: usize) [2]u8 {
     return digits[value * 2 ..][0..2].*;
 }
 
+pub fn localTime(ts: i64) !LibcTm {
+    var tm: LibcTm = undefined;
+    if (localtime_r(&ts, &tm) == null) {
+        return error.InvalidArgument;
+    }
+    return tm;
+}
+
+const LibcTm = extern struct {
+    tm_sec: c_int,
+    tm_min: c_int,
+    tm_hour: c_int,
+    tm_mday: c_int,
+    tm_mon: c_int,
+    tm_year: c_int,
+    tm_wday: c_int,
+    tm_yday: c_int,
+    tm_isdst: c_int,
+    tm_gmtoff: c_long,
+    tm_zone: ?[*:0]const u8,
+};
+extern "c" fn localtime_r(timep: *const i64, result: *LibcTm) ?*LibcTm;
+
 const Parser = struct {
     input: []const u8,
     pos: usize,


### PR DESCRIPTION
Stacked PR 19/22 (based on #2959). Document-level lookups and metadata: foreign-element attribute matching, document.head/getElementsByName, lastModified.

## Commits

**selector: attribute names match case-sensitively on foreign elements**
- Attribute names in selectors match ASCII case-insensitively against HTML elements but case-sensitively against SVG/MathML elements; the parsed selector keeps the name as written and matching picks the right form per element.

**webapi: document.head matches by local name; getElementsByName is HTML-only**
- `document.head` is the first html-namespace child of the document element whose *local* name is head (a `blah:head` HTMLUnknownElement counts); `getElementsByName` only considers HTML-namespace elements.

**webapi: implement document.lastModified**
- Reports the navigation response's Last-Modified header formatted as "MM/DD/YYYY hh:mm:ss" in local time; documents without the header report the current time per spec.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/nodes/querySelector-mixed-case.html | 0/1 | 1/1 |
| /html/dom/documents/dom-tree-accessors/document.head-02.html | 0/1 | 1/1 |
| .../document.getElementsByName/document.getElementsByName-namespace.html | 0/1 | 1/1 |
| .../resource-metadata-management/document-lastModified.html | 0/1 | 1/1 |
| .../resource-metadata-management/document-lastModified-01.html | 0/3 | 3/3 |

## Review follow-ups

- `beeeb886c` — the formatted `lastModified` string uses the **local arena** (converted by the bridge before the arena resets, like other local_arena-backed return values).

Re-verified: build clean, document-lastModified.html 1/1, document-lastModified-01.html 3/3; unit suite 1039/1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

