### PR TITLE
webapi: cookie-averse docs, script insertion steps, moveBefore reactions, outerText

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2538,9 +2538,7 @@ pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*N
 
     var it = source.childrenIterator();
     while (it.next()) |child| {
-        if (notify) {
-            try moved.append(self.call_arena, child);
-        }
+        try moved.append(self.call_arena, child);
         const child_was_connected = child.isConnected();
         self.removeNode(source, child, .{ .will_be_reconnected = dest_connected, .notify_observers = false });
         if (ref_node) |ref| {
@@ -2548,10 +2546,10 @@ pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*N
                 parent,
                 child,
                 .{ .before = ref },
-                .{ .child_already_connected = child_was_connected, .notify_observers = false },
+                .{ .child_already_connected = child_was_connected, .notify_observers = false, .run_ready = false },
             );
         } else {
-            try self.appendNode(parent, child, .{ .child_already_connected = child_was_connected, .notify_observers = false });
+            try self.appendNode(parent, child, .{ .child_already_connected = child_was_connected, .notify_observers = false, .run_ready = false });
         }
     }
 
@@ -2560,6 +2558,21 @@ pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*N
         if (notify_mode == .records) {
             observers.notifyChildListChange(self, parent, moved.items, &.{}, previous_sibling, ref_node);
         }
+    }
+
+    // Nodes moved into a not-yet-started script run the script's
+    // children-changed steps first (whatwg/html#10188), then each inserted
+    // node's own ready work runs, in tree order, with everything in place.
+    if (parent.isConnected()) {
+        if (parent.is(Element.Html.Script)) |script| {
+            if (!script._executed) {
+                try self.nodeIsReady(false, parent);
+            }
+        }
+    }
+
+    for (moved.items) |child| {
+        try self.nodeIsReadySubtree(child);
     }
 }
 
@@ -2573,6 +2586,10 @@ const InsertNodeOpts = struct {
     adopting_to_new_document: bool = false,
     // Set to false when the caller queues its own combined mutation record
     notify_observers: bool = true,
+    // Set to false for multi-node insertions (fragments): the caller runs
+    // the ready work itself once every node is in place, so an earlier
+    // script observes its later siblings already inserted.
+    run_ready: bool = true,
 };
 pub fn insertNodeRelative(self: *Frame, parent: *Node, child: *Node, relative: InsertNodeRelative, opts: InsertNodeOpts) !void {
     return self._insertNodeRelative(false, parent, child, relative, opts);
@@ -2655,12 +2672,16 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
 
     const parent_is_connected = parent.isConnected();
 
-    // nodeIsReady resolves the node's owning frame itself (only for the few node
-    // types that have ready work), so pass the incumbent `self`.
-    try self.nodeIsReady(false, child);
+    // Mutation records queue synchronously at insertion, before any script
+    // runs: an inserted script can observe its own record via takeRecords.
+    if (opts.notify_observers) {
+        self.notifyChildInserted(parent, child);
+    }
 
-    // Check if text was added to a script that hasn't started yet.
-    if (child._type == .cdata and parent_is_connected) {
+    // Inserting into a not-yet-started script runs the script's
+    // children-changed steps first, then the inserted nodes' own ready work
+    // (whatwg/html#10188: the outer script executes before an inner one).
+    if (opts.run_ready and parent_is_connected) {
         if (parent.is(Element.Html.Script)) |script| {
             if (!script._executed) {
                 try self.nodeIsReady(false, parent);
@@ -2668,8 +2689,10 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
         }
     }
 
-    if (opts.notify_observers) {
-        self.notifyChildInserted(parent, child);
+    // nodeIsReady resolves the node's owning frame itself (only for the few node
+    // types that have ready work), so pass the incumbent `self`.
+    if (opts.run_ready) {
+        try self.nodeIsReadySubtree(child);
     }
 
     if (opts.child_already_connected and !opts.adopting_to_new_document) {
@@ -2901,6 +2924,19 @@ fn parseHtmlAsChildrenInner(self: *Frame, node: *Node, html: []const u8, opts: F
     }
 }
 
+// Runs the "ready" work for an inserted node and, when it's an element with
+// children, for its descendants in tree order: appending a subtree
+// containing scripts must execute them all, after the whole insertion.
+fn nodeIsReadySubtree(self: *Frame, node: *Node) !void {
+    if (node._type != .element or node.firstChild() == null) {
+        return self.nodeIsReady(false, node);
+    }
+    var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(node, .{});
+    while (tw.next()) |el| {
+        try self.nodeIsReady(false, el.asNode());
+    }
+}
+
 fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {
     if ((comptime from_parser) and self._parse_mode == .fragment) {
         if (self._fragment_scripts_runnable == false) {
@@ -2922,6 +2958,16 @@ fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {
     // walk, so we only do it once we've matched a node type that has ready work
     // (the common text/element insertion does nothing here). The parser inserts
     // into its own document, so from_parser always uses `self`.
+    // Scripts, iframes, links and styles activate on becoming connected;
+    // appending them to a detached parent does nothing (they run/load later
+    // if the subtree gets inserted into the document).
+    if (comptime from_parser == false) {
+        switch (node._type) {
+            .element => if (!node.isConnected()) return,
+            else => {},
+        }
+    }
+
     if (node.is(Element.Html.Script)) |script| {
         if ((comptime from_parser == false) and script._src.len == 0) {
             // Script was added via JavaScript without a src attribute.

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2563,16 +2563,17 @@ pub fn moveAllChildren(self: *Frame, source: *Node, parent: *Node, ref_node: ?*N
     // Nodes moved into a not-yet-started script run the script's
     // children-changed steps first (whatwg/html#10188), then each inserted
     // node's own ready work runs, in tree order, with everything in place.
+    // Ready work only happens on becoming connected, so a detached
+    // destination has none.
     if (parent.isConnected()) {
         if (parent.is(Element.Html.Script)) |script| {
             if (!script._executed) {
                 try self.nodeIsReady(false, parent);
             }
         }
-    }
-
-    for (moved.items) |child| {
-        try self.nodeIsReadySubtree(child);
+        for (moved.items) |child| {
+            try self.nodeIsReadySubtree(child);
+        }
     }
 }
 
@@ -2681,17 +2682,17 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
     // Inserting into a not-yet-started script runs the script's
     // children-changed steps first, then the inserted nodes' own ready work
     // (whatwg/html#10188: the outer script executes before an inner one).
+    // Ready work only happens on becoming connected, so a detached parent
+    // has none.
     if (opts.run_ready and parent_is_connected) {
         if (parent.is(Element.Html.Script)) |script| {
             if (!script._executed) {
                 try self.nodeIsReady(false, parent);
             }
         }
-    }
 
-    // nodeIsReady resolves the node's owning frame itself (only for the few node
-    // types that have ready work), so pass the incumbent `self`.
-    if (opts.run_ready) {
+        // nodeIsReady resolves the node's owning frame itself (only for the few node
+        // types that have ready work), so pass the incumbent `self`.
         try self.nodeIsReadySubtree(child);
     }
 
@@ -2931,9 +2932,16 @@ fn nodeIsReadySubtree(self: *Frame, node: *Node) !void {
     if (node._type != .element or node.firstChild() == null) {
         return self.nodeIsReady(false, node);
     }
+
+    // Scripts can mutate the tree. Safe to do this since nodeIsReady re-checks
+    // connectivity.
+    var elements: std.ArrayList(*Node) = .empty;
     var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(node, .{});
     while (tw.next()) |el| {
-        try self.nodeIsReady(false, el.asNode());
+        try elements.append(self.call_arena, el.asNode());
+    }
+    for (elements.items) |el| {
+        try self.nodeIsReady(false, el);
     }
 }
 

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -872,8 +872,13 @@ pub const Script = struct {
         const local = &ls.local;
 
         // Per spec, trigger any microtasks BEFORE execution in case the parser
-        // (e.g. via event callbacks) queued anything.
-        local.runMicrotasks();
+        // (e.g. via event callbacks) queued anything. Only at a microtask
+        // checkpoint though (empty JS stack): a script executing because a
+        // running script inserted it must not drain the queue mid-task -
+        // e.g. its own insertion record must survive for takeRecords().
+        if (frame.js.call_depth == 0) {
+            local.runMicrotasks();
+        }
 
         // Handle importmap special case here: the content is a JSON containing imports.
         // Multiple <script type="importmap"> elements merge with first-wins semantics.

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -272,7 +272,18 @@ pub fn setDomain(self: *Document, value: []const u8) !void {
     try doc_frame.js.setOrigin(key);
 }
 
-pub fn getCookie(_: *Document, frame: *Frame) ![]const u8 {
+// A cookie-averse document (no browsing context: createHTMLDocument,
+// DOMParser, XHR documents) reads cookies as the empty string and ignores
+// writes.
+fn isCookieAverse(self: *const Document, frame: *const Frame) bool {
+    const doc_frame = self._frame orelse return true;
+    return doc_frame.document != self and frame.document != self;
+}
+
+pub fn getCookie(self: *Document, frame: *Frame) ![]const u8 {
+    if (self.isCookieAverse(frame)) {
+        return "";
+    }
     var buf: std.ArrayList(u8) = .empty;
     try frame._session.cookie_jar.forRequest(frame.url, buf.writer(frame.local_arena), .{
         .is_http = false,
@@ -281,7 +292,10 @@ pub fn getCookie(_: *Document, frame: *Frame) ![]const u8 {
     return buf.items;
 }
 
-pub fn setCookie(_: *Document, cookie_str: []const u8, frame: *Frame) ![]const u8 {
+pub fn setCookie(self: *Document, cookie_str: []const u8, frame: *Frame) ![]const u8 {
+    if (self.isCookieAverse(frame)) {
+        return cookie_str;
+    }
     // we use the cookie jar's allocator to parse the cookie because it
     // outlives the frame's arena.
     const Cookie = @import("storage/Cookie.zig");

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1084,21 +1084,11 @@ pub fn getChildren(self: *Element, frame: *Frame) !collections.NodeLive(.child_e
 }
 
 pub fn append(self: *Element, nodes: []const Node.NodeOrText, frame: *Frame) !void {
-    const parent = self.asNode();
-    for (nodes) |node_or_text| {
-        const child = try node_or_text.toNode(frame);
-        _ = try parent.appendChild(child, frame);
-    }
+    return self.asNode().appendNodes(nodes, frame);
 }
 
 pub fn prepend(self: *Element, nodes: []const Node.NodeOrText, frame: *Frame) !void {
-    const parent = self.asNode();
-    var i = nodes.len;
-    while (i > 0) {
-        i -= 1;
-        const child = try nodes[i].toNode(frame);
-        _ = try parent.insertBefore(child, parent.firstChild(), frame);
-    }
+    return self.asNode().prependNodes(nodes, frame);
 }
 
 pub fn moveBefore(self: *Element, node: js.Value, child: js.Value, frame: *Frame) !void {

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1431,6 +1431,38 @@ pub fn getElementsByClassName(self: *Node, class_name: []const u8, frame: *Frame
 
 /// Shared implementation of replaceChildren for Element, Document, and DocumentFragment.
 /// Validates all nodes, removes existing children, then appends new children.
+// ParentNode.append/prepend with several nodes convert them into a fragment
+// first, so the insertion happens as one operation: an earlier script must
+// observe its later siblings inserted (and can remove them before they run).
+pub fn appendNodes(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void {
+    if (nodes.len == 1) {
+        const child = try nodes[0].toNode(frame);
+        _ = try self.appendChild(child, frame);
+        return;
+    }
+    const fragment = (try DocumentFragment.init(frame)).asNode();
+    for (nodes) |node_or_text| {
+        const child = try node_or_text.toNode(frame);
+        _ = try fragment.appendChild(child, frame);
+    }
+    _ = try self.appendChild(fragment, frame);
+}
+
+pub fn prependNodes(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void {
+    const reference = self.firstChild();
+    if (nodes.len == 1) {
+        const child = try nodes[0].toNode(frame);
+        _ = try self.insertBefore(child, reference, frame);
+        return;
+    }
+    const fragment = (try DocumentFragment.init(frame)).asNode();
+    for (nodes) |node_or_text| {
+        const child = try node_or_text.toNode(frame);
+        _ = try fragment.appendChild(child, frame);
+    }
+    _ = try self.insertBefore(fragment, reference, frame);
+}
+
 pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void {
     // First pass: validate all nodes and collect them
     // We need to collect because DocumentFragments contribute their children, not themselves

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1429,8 +1429,6 @@ pub fn getElementsByClassName(self: *Node, class_name: []const u8, frame: *Frame
     }, frame);
 }
 
-/// Shared implementation of replaceChildren for Element, Document, and DocumentFragment.
-/// Validates all nodes, removes existing children, then appends new children.
 // ParentNode.append/prepend with several nodes convert them into a fragment
 // first, so the insertion happens as one operation: an earlier script must
 // observe its later siblings inserted (and can remove them before they run).
@@ -1440,29 +1438,40 @@ pub fn appendNodes(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void 
         _ = try self.appendChild(child, frame);
         return;
     }
-    const fragment = (try DocumentFragment.init(frame)).asNode();
+    const fragment = try DocumentFragment.init(frame);
+    const fragment_node = fragment.asNode();
+    // The fragment is internal — JS never sees it, and no mutation record
+    // targets it — so it can be reclaimed once its children have moved out.
+    // If conversion or insertion failed, nodes left inside stay parented to
+    // it (per spec), so it must live on.
+    defer if (fragment_node.firstChild() == null) frame._factory.destroy(fragment);
     for (nodes) |node_or_text| {
         const child = try node_or_text.toNode(frame);
-        _ = try fragment.appendChild(child, frame);
+        _ = try fragment_node.appendChild(child, frame);
     }
-    _ = try self.appendChild(fragment, frame);
+    _ = try self.appendChild(fragment_node, frame);
 }
 
 pub fn prependNodes(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void {
-    const reference = self.firstChild();
     if (nodes.len == 1) {
         const child = try nodes[0].toNode(frame);
-        _ = try self.insertBefore(child, reference, frame);
+        _ = try self.insertBefore(child, self.firstChild(), frame);
         return;
     }
-    const fragment = (try DocumentFragment.init(frame)).asNode();
+    const fragment = try DocumentFragment.init(frame);
+    const fragment_node = fragment.asNode();
+    defer if (fragment_node.firstChild() == null) frame._factory.destroy(fragment);
     for (nodes) |node_or_text| {
         const child = try node_or_text.toNode(frame);
-        _ = try fragment.appendChild(child, frame);
+        _ = try fragment_node.appendChild(child, frame);
     }
-    _ = try self.insertBefore(fragment, reference, frame);
+    // The reference child is evaluated after converting nodes into the
+    // fragment: one of the arguments may be the current first child.
+    _ = try self.insertBefore(fragment_node, self.firstChild(), frame);
 }
 
+/// Shared implementation of replaceChildren for Element, Document, and DocumentFragment.
+/// Validates all nodes, removes existing children, then appends new children.
 pub fn replaceChildren(self: *Node, nodes: []const NodeOrText, frame: *Frame) !void {
     // First pass: validate all nodes and collect them
     // We need to collect because DocumentFragments contribute their children, not themselves

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -372,6 +372,17 @@ pub fn setTranslate(self: *HtmlElement, translate: bool, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("translate"), .wrap(if (translate) "yes" else "no"), frame);
 }
 
+// accessKeyLabel: the UA-assigned shortcut for a valid (single character)
+// accesskey, or the empty string. We report an Alt+ chord like Chromium.
+pub fn getAccessKeyLabel(self: *HtmlElement, frame: *Frame) ![]const u8 {
+    const value = self.asElement().getAttributeSafe(comptime .wrap("accesskey")) orelse return "";
+    const codepoints = std.unicode.utf8CountCodepoints(value) catch return "";
+    if (codepoints != 1) {
+        return "";
+    }
+    return std.fmt.allocPrint(frame.call_arena, "Alt+{s}", .{value});
+}
+
 pub fn getPopover(self: *HtmlElement) ?[]const u8 {
     const s = popover.getState(self.asElement()) orelse return null;
     return @tagName(s);
@@ -1735,6 +1746,7 @@ pub const JsApi = struct {
     pub const dir = bridge.accessor(HtmlElement.getDir, HtmlElement.setDir, .{ .ce_reactions = true });
     pub const hidden = bridge.accessor(HtmlElement.getHidden, HtmlElement.setHidden, .{ .ce_reactions = true });
     pub const translate = bridge.accessor(HtmlElement.getTranslate, HtmlElement.setTranslate, .{ .ce_reactions = true });
+    pub const accessKeyLabel = bridge.accessor(HtmlElement.getAccessKeyLabel, null, .{});
     pub const popover = bridge.accessor(HtmlElement.getPopover, HtmlElement.setPopover, .{ .ce_reactions = true });
     pub const showPopover = bridge.function(HtmlElement.showPopover, .{});
     pub const hidePopover = bridge.function(HtmlElement.hidePopover, .{});

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -243,6 +243,11 @@ pub fn setInnerText(self: *HtmlElement, text: []const u8, frame: *Frame) !void {
 
 pub fn setOuterText(self: *HtmlElement, text: []const u8, frame: *Frame) !void {
     const el = self.asElement();
+    // outerText is an HTMLElement property. MathML elements currently share
+    // the HTML wrapper types, so keep the assignment inert for them.
+    if (el._namespace != .html) {
+        return;
+    }
     const node = el.asNode();
     const parent = node.parentNode() orelse return error.NoModificationAllowed;
 

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -225,10 +225,11 @@ fn invokeCallbackOnElement(element: *Element, comptime callback_name: [:0]const 
     // for "move", we call "connectedMoveCallback" if it exists, else we fallback
     // to  "disconnectedCallback" + "connectedCallback"
     if (js_element.has("connectedMoveCallback")) {
-        js_element.callMethod(void, "connectedMoveCallback", .{}) catch return;
+        js_element.callMethod(void, "connectedMoveCallback", .{}) catch {};
     } else {
-        js_element.callMethod(void, "disconnectedCallback", .{}) catch return;
-        js_element.callMethod(void, "connectedCallback", .{}) catch return;
+        // Either callback may be undefined; the other still runs.
+        js_element.callMethod(void, "disconnectedCallback", .{}) catch {};
+        js_element.callMethod(void, "connectedCallback", .{}) catch {};
     }
 }
 


### PR DESCRIPTION
Stacked PR 20/22 (based on #2960). HTML element behaviors: outerText on MathML, cookie-averse documents, script insertion steps, moveBefore reactions.

## Commits

**webapi: assigning outerText to a MathML element leaves the tree alone**
- outerText is an HTMLElement property; assigning it on a MathML element (which currently shares the HTML wrapper types) stays inert.

**webapi: cookie-averse documents; HTMLElement.accessKeyLabel**
- A document without a browsing context reads `document.cookie` as "" and ignores writes; `accessKeyLabel` reports an Alt+ chord for a valid single-character accesskey, like Chromium.

**webapi: spec-conformant script insertion/execution steps**
- Scripts appended to a detached parent don't activate until connected; subtree insertion runs ready work in tree order after all nodes are in place (an earlier script can remove a later sibling to prevent it running); append/prepend with several arguments convert to a fragment per spec; inserting into a not-yet-started connected script runs its children-changed steps first (whatwg/html#10188); mutation records queue before any script runs, and the pre-execution microtask drain only happens at a real checkpoint.

**webapi: moveBefore fires connectedCallback without a disconnectedCallback**
- The fallback for a missing connectedMoveCallback tolerates either of disconnectedCallback/connectedCallback being undefined.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| .../the-innertext-and-outertext-properties/outertext-setter.html | 42/43 | 43/43 |
| .../resource-metadata-management/document-cookie.html | 4/5 | 5/5 |
| /html/dom/access-key-label.html | 1/2 | 2/2 |
| /dom/nodes/insertion-removing-steps/ | 5/20 files | 15/20 files |
| /dom/nodes/moveBefore/custom-element-move-reactions.html | 5/6 | 6/6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

