### PR TITLE
webapi: handler return-false cancels events; same-fragment navigations don't reload

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -432,11 +432,6 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
     }
 }
 
-// Per the HTML "event handler processing algorithm", an event handler (on*
-// property or attribute) returning false cancels the event — unlike
-// addEventListener listeners, whose return value is ignored. The inverted
-// special case for onerror only applies to the global's onerror, which is
-// invoked via Window.reportError, not through this node dispatch path.
 fn processHandlerReturnValue(event: *Event, handler_return: ?js.Value) void {
     const ret = handler_return orelse return;
     if (ret.isFalse() and !event._type_string.eql(comptime .wrap("error"))) {

--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -351,9 +351,11 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
             // Inline handlers (e.g. onclick property) follow the same "report,
             // don't propagate" rule as addEventListener listeners — see Listener.run.
             var caught: js.TryCatch.Caught = undefined;
-            ls.toLocal(inline_handler).tryCallWithThis(void, target_et, .{event}, &caught) catch |err| {
+            const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, target_et, .{event}, &caught) catch |err| ret: {
                 log.warn(.event, "inline handler", .{ .err = err, .caught = caught });
+                break :ret null;
             };
+            processHandlerReturnValue(event, handler_return);
 
             if (event._stop_propagation) {
                 return;
@@ -405,9 +407,11 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
                 }
 
                 var caught: js.TryCatch.Caught = undefined;
-                ls.toLocal(inline_handler).tryCallWithThis(void, current_target, .{event}, &caught) catch |err| {
+                const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, current_target, .{event}, &caught) catch |err| ret: {
                     log.warn(.event, "inline handler", .{ .err = err, .caught = caught });
+                    break :ret null;
                 };
+                processHandlerReturnValue(event, handler_return);
 
                 if (event._needs_retargeting) {
                     event._target = original_target;
@@ -428,6 +432,20 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event, comptime opts
     }
 }
 
+// Per the HTML "event handler processing algorithm", an event handler (on*
+// property or attribute) returning false cancels the event — unlike
+// addEventListener listeners, whose return value is ignored. The inverted
+// special case for onerror only applies to the global's onerror, which is
+// invoked via Window.reportError, not through this node dispatch path.
+fn processHandlerReturnValue(event: *Event, handler_return: ?js.Value) void {
+    const ret = handler_return orelse return;
+    if (ret.isFalse() and !event._type_string.eql(comptime .wrap("error"))) {
+        event.preventDefault();
+    }
+}
+
+// Per spec ("invocation target in shadow tree"), window.event is left
+// undefined while invoking listeners whose target lives in a shadow tree.
 fn currentEventForTarget(target: *EventTarget, event: *Event) ?*Event {
     return if (rootIsShadowRoot(target)) null else event;
 }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -894,6 +894,20 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     };
 
     const session = target._session;
+
+    // Re-navigating to the exact current URL is only a reload when the URL
+    // has no fragment. With a fragment it's a fragment navigation per the
+    // HTML "navigate" steps (url equals the document's URL excluding
+    // fragments and url's fragment is non-null): no reload, and since the
+    // fragment didn't change, no hashchange and no new history entry either.
+    if (!opts.force and
+        std.mem.eql(u8, target.url, resolved_url) and
+        std.mem.indexOfScalar(u8, resolved_url, '#') != null)
+    {
+        session.releaseArena(arena);
+        return;
+    }
+
     // Short-circuit only true fragment-only navigations (same path/query, different
     // fragment). Identical URLs fall through and trigger a real reload.
     const is_fragment_navigation = !std.mem.eql(u8, target.url, resolved_url) and URL.eqlDocument(target.url, resolved_url);

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -901,6 +901,7 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: Allocator, request_url
     // fragments and url's fragment is non-null): no reload, and since the
     // fragment didn't change, no hashchange and no new history entry either.
     if (!opts.force and
+        opts.kind != .reload and
         std.mem.eql(u8, target.url, resolved_url) and
         std.mem.indexOfScalar(u8, resolved_url, '#') != null)
     {

--- a/src/browser/tests/events.html
+++ b/src/browser/tests/events.html
@@ -900,3 +900,43 @@
     window.removeEventListener('win_throw', c);
   }
 </script>
+
+<div id=return_false_parent><span id=return_false_child></span></div>
+<script id=inlineHandlerReturnFalseCancels>
+  // Per the HTML event handler processing algorithm, an event handler (on*
+  // property/attribute) returning false cancels the event; the return value
+  // of addEventListener listeners is ignored.
+  {
+    const parent = $('#return_false_parent');
+    const child = $('#return_false_child');
+
+    // At-target inline handler.
+    child.onclick = () => false;
+    const ev1 = new MouseEvent('click', {bubbles: true, cancelable: true});
+    testing.expectEqual(false, child.dispatchEvent(ev1));
+    testing.expectEqual(true, ev1.defaultPrevented);
+    child.onclick = null;
+
+    // Inline handler on an ancestor (bubble phase).
+    parent.onclick = () => false;
+    const ev2 = new MouseEvent('click', {bubbles: true, cancelable: true});
+    testing.expectEqual(false, child.dispatchEvent(ev2));
+    testing.expectEqual(true, ev2.defaultPrevented);
+    parent.onclick = null;
+
+    // Only false cancels; other falsy values don't.
+    child.onclick = () => undefined;
+    const ev3 = new MouseEvent('click', {bubbles: true, cancelable: true});
+    testing.expectEqual(true, child.dispatchEvent(ev3));
+    testing.expectEqual(false, ev3.defaultPrevented);
+    child.onclick = null;
+
+    // addEventListener listeners returning false don't cancel.
+    const listener = () => false;
+    child.addEventListener('click', listener);
+    const ev4 = new MouseEvent('click', {bubbles: true, cancelable: true});
+    testing.expectEqual(true, child.dispatchEvent(ev4));
+    testing.expectEqual(false, ev4.defaultPrevented);
+    child.removeEventListener('click', listener);
+  }
+</script>

--- a/src/browser/tests/window/location.html
+++ b/src/browser/tests/window/location.html
@@ -68,3 +68,24 @@
   location.hash = "";
   testing.expectEqual("", location.hash);
 </script>
+
+<script id=location_hash_no_change>
+  // Per the Location hash setter, assigning a value that doesn't change the
+  // fragment must not navigate at all: re-assigning "" on a fragment-less URL
+  // must not schedule a same-URL reload, and re-assigning the current
+  // fragment must be a no-op too.
+  const stable_href = location.href;
+  location.hash = "";
+  location.hash = "";
+  testing.expectEqual(stable_href, location.href);
+
+  location.hash = "#same";
+  const with_fragment = location.href;
+  location.hash = "#same";
+  location.hash = "same";
+  testing.expectEqual(with_fragment, location.href);
+  testing.expectEqual("#same", location.hash);
+
+  location.hash = "";
+  testing.expectEqual(stable_href, location.href);
+</script>

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -112,7 +112,9 @@ pub fn setHash(_: *const Location, hash: []const u8, frame: *Frame) !void {
         } else if (hash[0] == '#') {
             break :blk hash;
         }
-        break :blk try std.fmt.allocPrint(frame.call_arena, "#{s}", .{hash});
+        // Scratch only: scheduleNavigation dupes the URL into its own arena
+        // synchronously, so the local arena suffices.
+        break :blk try std.fmt.allocPrint(frame.local_arena, "#{s}", .{hash});
     };
 
     // Per the Location hash setter, when the fragment doesn't change no

--- a/src/browser/webapi/Location.zig
+++ b/src/browser/webapi/Location.zig
@@ -101,21 +101,30 @@ pub fn setSearch(_: *const Location, search: []const u8, frame: *Frame) !void {
 }
 
 pub fn setHash(_: *const Location, hash: []const u8, frame: *Frame) !void {
-    const normalized_hash = blk: {
-        if (hash.len == 0) {
-            const old_url = frame.url;
+    const old_url = frame.url;
+    const base_end = std.mem.indexOfScalar(u8, old_url, '#') orelse old_url.len;
+    // Includes the leading '#'; empty when the URL has no fragment.
+    const old_fragment = old_url[base_end..];
 
-            break :blk if (std.mem.indexOfScalar(u8, old_url, '#')) |index|
-                old_url[0..index]
-            else
-                old_url;
-        } else if (hash[0] == '#')
-            break :blk hash
-        else
-            break :blk try std.fmt.allocPrint(frame.call_arena, "#{s}", .{hash});
+    const normalized_hash: []const u8 = blk: {
+        if (hash.len == 0) {
+            break :blk "";
+        } else if (hash[0] == '#') {
+            break :blk hash;
+        }
+        break :blk try std.fmt.allocPrint(frame.call_arena, "#{s}", .{hash});
     };
 
-    return frame.scheduleNavigation(normalized_hash, .{
+    // Per the Location hash setter, when the fragment doesn't change no
+    // navigation happens at all — in particular `location.hash = ""` on a
+    // fragment-less URL must not turn into a same-URL reload.
+    if (std.mem.eql(u8, old_fragment, normalized_hash)) {
+        return;
+    }
+
+    const target_url = if (normalized_hash.len == 0) old_url[0..base_end] else normalized_hash;
+
+    return frame.scheduleNavigation(target_url, .{
         .reason = .script,
         .kind = .{ .replace = null },
     }, .{ .script = frame });


### PR DESCRIPTION
Stacked PR 21/22 (based on #2961). Two fixes for latent navigation bugs surfaced by the HttpClient refactor (queued navigations now reliably execute).

## Commits

**webapi: event handlers returning false cancel the event**
- Per the HTML "event handler processing algorithm", an `on*` property/attribute handler returning exactly `false` cancels the event (preventDefault) — unlike addEventListener listeners, whose return value is ignored. Without this, `form.onsubmit = () => false` really submitted and the scheduled form navigation reloaded the page in a loop. Unit tests added in tests/events.html.

**webapi: same-fragment navigations must not reload the page**
- Re-navigating to the exact current URL is only a reload when the URL has no fragment; with a fragment (re-clicking the same `#link` anchor) it's a no-op fragment navigation. `location.hash` skips the navigation entirely when the fragment doesn't change. Upstream's "identical URL reloads" behavior (`iframe.src = "about:blank"` twice) is untouched. Unit tests added in tests/window/location.html.

## WPT coverage

| Test file | Before | After |
|---|---|---|
| /dom/events/Event-dispatch-click.html | 0/0 (reload loop) | 33/33 |
| /dom/events/Event-dispatch-single-activation-behavior.html | 0/0 (reload loop; 3/132 pre-rebase) | 83/132 |
| /html/webappapis/scripting/events/event-handler-processing-algorithm.html | — | 7/7 |

## Review follow-ups

- `130199ef9` — the normalized hash in `Location.setHash` uses the **local arena** (scheduleNavigation dupes the URL into its own arena synchronously at entry), per the arena pattern from #2943.

WPT re-verified: Event-dispatch-click.html 33/33, Event-dispatch-single-activation-behavior.html 83/132 (the claimed coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

