### PR TITLE
webapi: bound scroll task allocations; tighten DOM allocation lifetimes

### DIFF
--- a/src/browser/tests/events.html
+++ b/src/browser/tests/events.html
@@ -940,3 +940,16 @@
     child.removeEventListener('click', listener);
   }
 </script>
+
+<script id=beforeUnloadEventReturnValue>
+  {
+    const event = document.createEvent('BeforeUnloadEvent');
+    testing.expectEqual('', event.returnValue);
+
+    event.returnValue = 'first';
+    testing.expectEqual('first', event.returnValue);
+
+    event.returnValue = 'replacement';
+    testing.expectEqual('replacement', event.returnValue);
+  }
+</script>

--- a/src/browser/tests/window_scroll.html
+++ b/src/browser/tests/window_scroll.html
@@ -34,3 +34,52 @@
   testing.expectEqual(0, window.scrollX);
   testing.expectEqual(0, window.scrollY);
 </script>
+
+<script id=element_scroll_events_coalesce_and_preserve_reentrancy type=module>
+  const state = await testing.async();
+  const element = document.createElement('div');
+  let scrolls = 0;
+  let scrollends = 0;
+
+  element.addEventListener('scroll', () => {
+    scrolls++;
+    if (scrolls === 1) {
+      element.scrollTop = 101;
+    }
+  });
+  element.addEventListener('scrollend', () => {
+    scrollends++;
+    if (scrollends === 1) {
+      element.scrollTop = 102;
+    }
+  });
+
+  for (let i = 1; i <= 100; i++) {
+    element.scrollTop = i;
+  }
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(3, scrolls);
+    testing.expectEqual(2, scrollends);
+  });
+</script>
+
+<script id=element_scrollBy_noop_does_not_fire_events type=module>
+  const state = await testing.async();
+  const element = document.createElement('div');
+  let scrolls = 0;
+  let scrollends = 0;
+
+  element.addEventListener('scroll', () => scrolls++);
+  element.addEventListener('scrollend', () => scrollends++);
+  element.scrollBy(-1, -1);
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(0, scrolls);
+    testing.expectEqual(0, scrollends);
+  });
+</script>

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -106,7 +106,7 @@ pub fn abort(self: *AbortSignal, reason_: ?Reason, exec: *const Execution) !void
     var to_dispatch: std.ArrayList(Dependend) = .{};
     for (self._dependents.items) |dep| {
         if (try dep.markAborted(self._reason, exec)) {
-            try to_dispatch.append(exec.arena, dep);
+            try to_dispatch.append(exec.call_arena, dep);
         }
     }
 

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1693,9 +1693,11 @@ pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
         .x => |x| .{ x, y orelse 0 },
         .opts => |dict| .{ dict.left orelse 0, dict.top orelse 0 },
     };
+    const old_x = gop.value_ptr.x;
+    const old_y = gop.value_ptr.y;
     gop.value_ptr.x = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.x)) + dx));
     gop.value_ptr.y = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.y)) + dy));
-    if (dx != 0 or dy != 0) {
+    if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
         try self.scheduleScrollEvents(owner);
     }
 }
@@ -1709,81 +1711,29 @@ fn scheduleScrollEvents(self: *Element, frame: *Frame) !void {
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
+    const task_pending = gop.value_ptr.state != .done;
     gop.value_ptr.state = .scroll;
+    if (task_pending) {
+        return;
+    }
 
     const task = try frame._factory.create(ScrollEventTask{ .frame = frame, .element = self });
-    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScroll, 10, .{ .low_priority = true });
-    try frame.js.scheduler.add(task, ScrollEventTask.dispatchScrollEnd, 20, .{ .low_priority = true, .finalizer = ScrollEventTask.cancelled });
+    errdefer {
+        gop.value_ptr.state = .done;
+        frame._factory.destroy(task);
+    }
+    try frame.js.scheduler.add(task, ScrollEventTask.run, 10, .{
+        .name = "element.scrollEvents",
+        .low_priority = true,
+        .finalizer = ScrollEventTask.cancelled,
+    });
 }
 
 const ScrollEventTask = struct {
     frame: *Frame,
     element: *Element,
 
-    fn cancelled(ctx: *anyopaque) void {
-        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
-        self.deinit();
-    }
-
-    fn deinit(self: *ScrollEventTask) void {
-        self.frame._factory.destroy(self);
-    }
-
-    fn dispatchScroll(ctx: *anyopaque) anyerror!?u32 {
-        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
-        const f = self.frame;
-        const pos = f._element_scroll_positions.getPtr(self.element) orelse return null;
-        if (pos.state != .scroll) {
-            return null;
-        }
-
-        const Event = @import("Event.zig");
-        const event = try Event.initTrusted(comptime .wrap("scroll"), .{ .bubbles = self.bubbles() }, f._page);
-        try f._event_manager.dispatch(self.eventTarget(), event);
-
-        // can't use gop on _element_scroll_positions above, since the JS callback
-        // can mutate _element_scroll_positions and invalidate any pointers
-        if (f._element_scroll_positions.getPtr(self.element)) |p| {
-            p.state = .end;
-        }
-        return null;
-    }
-
-    fn dispatchScrollEnd(ctx: *anyopaque) anyerror!?u32 {
-        const self: *ScrollEventTask = @ptrCast(@alignCast(ctx));
-
-        const f = self.frame;
-        const pos = f._element_scroll_positions.getPtr(self.element) orelse {
-            self.deinit();
-            return null;
-        };
-
-        switch (pos.state) {
-            // The scroll event is still pending; retry in 10ms. Must not destroy
-            // the task here — the entry is re-scheduled and runs again.
-            .scroll => return 10,
-            .end => {},
-            .done => {
-                self.deinit();
-                return null;
-            },
-        }
-
-        defer self.deinit();
-        const Event = @import("Event.zig");
-        const event = try Event.initTrusted(comptime .wrap("scrollend"), .{ .bubbles = self.bubbles() }, f._page);
-        try f._event_manager.dispatch(self.eventTarget(), event);
-
-        // can't use gop on _element_scroll_positions above, since the JS callback
-        // can mutate _element_scroll_positions and invalidate any pointers
-        if (f._element_scroll_positions.getPtr(self.element)) |p| {
-            p.state = .done;
-        }
-
-        return null;
-    }
-
-    fn eventTarget(self: *ScrollEventTask) *EventTarget {
+    fn eventTarget(self: *ScrollEventTask) *@import("EventTarget.zig") {
         if (self.frame.document.getDocumentElement() == self.element) {
             return self.frame.document.asEventTarget();
         }
@@ -1794,6 +1744,51 @@ const ScrollEventTask = struct {
     // scrolls (the scrolling element, dispatched at the document) do.
     fn bubbles(self: *ScrollEventTask) bool {
         return self.frame.document.getDocumentElement() == self.element;
+    }
+
+    fn cancelled(ptr: *anyopaque) void {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
+        if (self.frame._element_scroll_positions.getPtr(self.element)) |pos| {
+            pos.state = .done;
+        }
+        self.frame._factory.destroy(self);
+    }
+
+    fn run(ptr: *anyopaque) anyerror!?u32 {
+        const self: *ScrollEventTask = @ptrCast(@alignCast(ptr));
+        const f = self.frame;
+        const pos = f._element_scroll_positions.getPtr(self.element) orelse {
+            f._factory.destroy(self);
+            return null;
+        };
+        switch (pos.state) {
+            .scroll => {
+                pos.state = .end;
+                self.dispatchEvent(comptime .wrap("scroll"));
+                return 10;
+            },
+            .end => {
+                pos.state = .done;
+                defer f._factory.destroy(self);
+                self.dispatchEvent(comptime .wrap("scrollend"));
+                return null;
+            },
+            .done => {
+                f._factory.destroy(self);
+                return null;
+            },
+        }
+    }
+
+    fn dispatchEvent(self: *ScrollEventTask, comptime event_type: String) void {
+        const Event = @import("Event.zig");
+        const event = Event.initTrusted(event_type, .{ .bubbles = self.bubbles() }, self.frame._page) catch |err| {
+            log.warn(.dom, "element.scroll.event", .{ .err = err });
+            return;
+        };
+        self.frame._event_manager.dispatch(self.eventTarget(), event) catch |err| {
+            log.warn(.dom, "element.scroll.dispatch", .{ .err = err });
+        };
     }
 };
 

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -380,7 +380,7 @@ pub fn getAccessKeyLabel(self: *HtmlElement, frame: *Frame) ![]const u8 {
     if (codepoints != 1) {
         return "";
     }
-    return std.fmt.allocPrint(frame.call_arena, "Alt+{s}", .{value});
+    return std.fmt.allocPrint(frame.local_arena, "Alt+{s}", .{value});
 }
 
 pub fn getPopover(self: *HtmlElement) ?[]const u8 {

--- a/src/browser/webapi/event/BeforeUnloadEvent.zig
+++ b/src/browser/webapi/event/BeforeUnloadEvent.zig
@@ -71,8 +71,8 @@ pub fn getReturnValue(self: *const BeforeUnloadEvent) []const u8 {
     return self._return_value;
 }
 
-pub fn setReturnValue(self: *BeforeUnloadEvent, value: []const u8, frame: *Frame) !void {
-    self._return_value = try frame.dupeString(value);
+pub fn setReturnValue(self: *BeforeUnloadEvent, value: []const u8) !void {
+    self._return_value = try self._proto._arena.dupe(u8, value);
 }
 
 pub const JsApi = struct {


### PR DESCRIPTION
Stacked PR 22/22 (based on #2962). Memory-lifetime tightening for the new DOM work.

## Commits

**webapi: bound element scroll task allocations**
- One slab-allocated scheduler task per active element scroll sequence, recycled on completion/cancellation, so repeated programmatic scrolling doesn't grow the frame arena and task queue without bound. Throttle state advances before dispatch so re-entrant callbacks can't be overwritten; clamped no-op scrollBy calls schedule nothing.

**webapi: tighten DOM allocation lifetimes**
- The call arena is used only for the AbortSignal dependent list that must survive re-entrant abort handlers; scratch-only DOM reads move to the local arena; `BeforeUnloadEvent.returnValue` lives in the event-owned arena instead of accumulating in the frame arena.

No WPT coverage change — behavior-preserving allocation fixes, with unit tests for scroll coalescing, re-entrant event paths, no-op scrolling, and returnValue replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

