### PR TITLE
feat(cdp): emit Page.navigatedWithinDocument for same-document navigations

### DIFF
--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -75,6 +75,7 @@ const EventListeners = struct {
     frame_created: List = .{},
     frame_navigate: List = .{},
     frame_navigated: List = .{},
+    frame_navigated_within_document: List = .{},
     frame_navigate_failed: List = .{},
     frame_network_idle: List = .{},
     frame_network_almost_idle: List = .{},
@@ -104,6 +105,7 @@ const Events = union(enum) {
     frame_created: *Frame,
     frame_navigate: *const FrameNavigate,
     frame_navigated: *const FrameNavigated,
+    frame_navigated_within_document: *const FrameNavigatedWithinDocument,
     frame_navigate_failed: *const FrameNavigateFailed,
     frame_network_idle: *const FrameNetworkIdle,
     frame_network_almost_idle: *const FrameNetworkAlmostIdle,
@@ -152,6 +154,24 @@ pub const FrameNavigated = struct {
     timestamp: u64,
     url: [:0]const u8,
     opts: Frame.NavigatedOpts,
+};
+
+// A same-document navigation (History pushState/replaceState, fragment
+// changes, or history traversal). The document and its execution context
+// stay alive — only the URL changes — so CDP must emit
+// Page.navigatedWithinDocument WITHOUT clearing the execution context or
+// sending DOM.documentUpdated.
+pub const FrameNavigatedWithinDocument = struct {
+    frame_id: u32,
+    timestamp: u64,
+    url: [:0]const u8,
+    navigation_type: NavigationType = .other,
+
+    pub const NavigationType = enum {
+        fragment,
+        historyApi,
+        other,
+    };
 };
 
 // A root navigation that failed before commit (DNS failure, connection

--- a/src/Notification.zig
+++ b/src/Notification.zig
@@ -163,7 +163,6 @@ pub const FrameNavigated = struct {
 // sending DOM.documentUpdated.
 pub const FrameNavigatedWithinDocument = struct {
     frame_id: u32,
-    timestamp: u64,
     url: [:0]const u8,
     navigation_type: NavigationType = .other,
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -33,7 +33,6 @@ const Parser = @import("parser/Parser.zig");
 const h5e = @import("parser/html5ever.zig");
 
 const CustomElementReactions = @import("CustomElementReactions.zig");
-const Notification = @import("../Notification.zig");
 
 const URL = @import("URL.zig");
 const Blob = @import("webapi/Blob.zig");
@@ -598,22 +597,6 @@ pub fn isSameOrigin(self: *const Frame, url: [:0]const u8) bool {
     // Starting here, at least protocols are equals.
     // Compare hosts (domain:port) strictly
     return std.mem.eql(u8, URL.getHost(url), URL.getHost(current_origin));
-}
-
-// Notify observers of a same-document navigation (History pushState /
-// replaceState, fragment change, or history traversal). Unlike navigate(),
-// the document and its execution context are unchanged — only the URL moves.
-pub fn notifyNavigatedWithinDocument(
-    self: *Frame,
-    url: [:0]const u8,
-    navigation_type: Notification.FrameNavigatedWithinDocument.NavigationType,
-) void {
-    self._session.notification.dispatch(.frame_navigated_within_document, &.{
-        .frame_id = self._frame_id,
-        .url = url,
-        .timestamp = timestamp(.monotonic),
-        .navigation_type = navigation_type,
-    });
 }
 
 pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !void {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -33,6 +33,7 @@ const Parser = @import("parser/Parser.zig");
 const h5e = @import("parser/html5ever.zig");
 
 const CustomElementReactions = @import("CustomElementReactions.zig");
+const Notification = @import("../Notification.zig");
 
 const URL = @import("URL.zig");
 const Blob = @import("webapi/Blob.zig");
@@ -597,6 +598,22 @@ pub fn isSameOrigin(self: *const Frame, url: [:0]const u8) bool {
     // Starting here, at least protocols are equals.
     // Compare hosts (domain:port) strictly
     return std.mem.eql(u8, URL.getHost(url), URL.getHost(current_origin));
+}
+
+// Notify observers of a same-document navigation (History pushState /
+// replaceState, fragment change, or history traversal). Unlike navigate(),
+// the document and its execution context are unchanged — only the URL moves.
+pub fn notifyNavigatedWithinDocument(
+    self: *Frame,
+    url: [:0]const u8,
+    navigation_type: Notification.FrameNavigatedWithinDocument.NavigationType,
+) void {
+    self._session.notification.dispatch(.frame_navigated_within_document, &.{
+        .frame_id = self._frame_id,
+        .url = url,
+        .timestamp = timestamp(.monotonic),
+        .navigation_type = navigation_type,
+    });
 }
 
 pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !void {

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -62,6 +62,8 @@ pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8
     frame.url = url;
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
+
+    frame.notifyNavigatedWithinDocument(url, .historyApi);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, frame: *Frame) !void {
@@ -77,6 +79,8 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
     frame.url = url;
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
+
+    frame.notifyNavigatedWithinDocument(url, .historyApi);
 }
 
 fn goInner(delta: i32, frame: *Frame) !void {

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -17,9 +17,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const js = @import("../js/js.zig");
 
+const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+
 const PopStateEvent = @import("event/PopStateEvent.zig");
 
 const History = @This();
@@ -50,37 +51,47 @@ pub fn setScrollRestoration(self: *History, str: []const u8) void {
 }
 
 pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, frame: *Frame) !void {
-    const arena = frame._session.arena;
+    const session = frame._session;
+    const arena = session.arena;
     const url = if (_url) |u|
         try @import("../URL.zig").resolve(arena, frame.url, u, .{})
     else
         try arena.dupeZ(u8, frame.url);
 
     const json = state.toJson(arena) catch return error.DataClone;
-    _ = try frame._session.navigation.pushEntry(url, .{ .source = .history, .value = json }, frame, true);
+    _ = try session.navigation.pushEntry(url, .{ .source = .history, .value = json }, frame, true);
 
     frame.url = url;
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
 
-    frame.notifyNavigatedWithinDocument(url, .historyApi);
+    session.notification.dispatch(.frame_navigated_within_document, &.{
+        .url = url,
+        .frame_id = frame._frame_id,
+        .navigation_type = .historyApi,
+    });
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, frame: *Frame) !void {
-    const arena = frame._session.arena;
+    const session = frame._session;
+    const arena = session.arena;
     const url = if (_url) |u|
         try @import("../URL.zig").resolve(arena, frame.url, u, .{})
     else
         try arena.dupeZ(u8, frame.url);
 
     const json = state.toJson(arena) catch return error.DataClone;
-    _ = try frame._session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, frame, true);
+    _ = try session.navigation.replaceEntry(url, .{ .source = .history, .value = json }, frame, true);
 
     frame.url = url;
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
 
-    frame.notifyNavigatedWithinDocument(url, .historyApi);
+    session.notification.dispatch(.frame_navigated_within_document, &.{
+        .url = url,
+        .frame_id = frame._frame_id,
+        .navigation_type = .historyApi,
+    });
 }
 
 fn goInner(delta: i32, frame: *Frame) !void {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -629,6 +629,7 @@ pub const BrowserContext = struct {
         try notification.register(.frame_created, self, onFrameCreated);
         try notification.register(.frame_navigate, self, onFrameNavigate);
         try notification.register(.frame_navigated, self, onFrameNavigated);
+        try notification.register(.frame_navigated_within_document, self, onFrameNavigatedWithinDocument);
         try notification.register(.frame_navigate_failed, self, onFrameNavigateFailed);
         try notification.register(.frame_child_frame_created, self, onFrameChildFrameCreated);
         try notification.register(.frame_dom_content_loaded, self, onFrameDOMContentLoaded);
@@ -920,6 +921,11 @@ pub const BrowserContext = struct {
     pub fn onFrameNavigateFailed(ctx: *anyopaque, msg: *const Notification.FrameNavigateFailed) !void {
         const self: *BrowserContext = @ptrCast(@alignCast(ctx));
         return @import("domains/page.zig").frameNavigateFailed(self, msg);
+    }
+
+    pub fn onFrameNavigatedWithinDocument(ctx: *anyopaque, msg: *const Notification.FrameNavigatedWithinDocument) !void {
+        const self: *BrowserContext = @ptrCast(@alignCast(ctx));
+        return @import("domains/page.zig").frameNavigatedWithinDocument(self, msg);
     }
 
     pub fn onFrameChildFrameCreated(ctx: *anyopaque, msg: *const Notification.FrameChildFrameCreated) !void {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -755,6 +755,22 @@ pub fn frameNavigated(arena: Allocator, bc: *CDP.BrowserContext, event: *const N
     try cdp.sendEvent("DOM.documentUpdated", null, .{ .session_id = session_id });
 }
 
+pub fn frameNavigatedWithinDocument(bc: anytype, event: *const Notification.FrameNavigatedWithinDocument) !void {
+    const session_id = bc.session_id orelse return;
+    const frame_id = &id.toFrameId(event.frame_id);
+
+    // Same-document navigation (pushState / replaceState / fragment). The
+    // document and its execution context are unchanged, so — unlike
+    // frameNavigated — we deliberately do NOT send Runtime.executionContextsCleared
+    // or DOM.documentUpdated; doing so would invalidate the client's live
+    // execution context ids and break Puppeteer's frame.evaluate().
+    try bc.cdp.sendEvent("Page.navigatedWithinDocument", .{
+        .frameId = frame_id,
+        .url = event.url,
+        .navigationType = @tagName(event.navigation_type),
+    }, .{ .session_id = session_id });
+}
+
 pub fn frameDOMContentLoaded(bc: anytype, event: *const Notification.FrameDOMContentLoaded) !void {
     const session_id = bc.session_id orelse return;
     const timestamp = event.timestamp;
@@ -1692,4 +1708,29 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         });
         try ctx.expectSentError(-31998, "InvalidParams", .{ .id = 42 });
     }
+}
+
+test "cdp.frame: history.pushState emits Page.navigatedWithinDocument" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-9", .url = "hi.html", .target_id = "FID-000000000X".* });
+
+    const frame = bc.mainFrame() orelse unreachable;
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("history.pushState({}, '', '/next')", null);
+    }
+
+    // Same-document navigation must surface as Page.navigatedWithinDocument
+    // (not a full Page.frameNavigated), carrying the new URL and the
+    // history-API navigation type. The main frame is assigned the internal
+    // id FID-0000000001.
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+    }, .{});
 }

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -1732,5 +1732,6 @@ test "cdp.frame: history.pushState emits Page.navigatedWithinDocument" {
     try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
         .frameId = "FID-0000000001",
         .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/next",
     }, .{});
 }


### PR DESCRIPTION
Fixes part of #2829.

## Problem

Same-document navigations were invisible to CDP. `history.pushState` / `replaceState` update `frame.url`, but no CDP event was emitted, so a driver's `frame.url()` went stale and `waitForNavigation` never fired on client-side (SPA / react-router) route changes — the dominant modern web-app shape.

## Change

- New `frame_navigated_within_document` notification (`Notification.FrameNavigatedWithinDocument`), carrying `frame_id`, `url`, and a `navigation_type` (`fragment` / `historyApi` / `other`).
- `Frame.notifyNavigatedWithinDocument()` dispatches it, mirroring the existing `.frame_navigated` path.
- `History.pushState` / `replaceState` call it with `navigationType: historyApi`.
- The Page domain handler emits `Page.navigatedWithinDocument` with `frameId`, `url`, `navigationType`.

**Deliberately** does not send `Runtime.executionContextsCleared` or `DOM.documentUpdated` (which `frameNavigated` does): the document and its execution context are unchanged in a same-document navigation, and clearing them would invalidate the client's live execution-context ids and break `frame.evaluate()` / `frame.content()`.

## Scope

This first slice covers the History-API path (`pushState`/`replaceState`), the most common SPA case. The fragment/anchor path and the Navigation-API (`push`/`replace`/`traverse`) branches are natural follow-ups reusing the same event.

## Test

`cdp.frame: history.pushState emits Page.navigatedWithinDocument` — drives `history.pushState` on a loaded page and asserts `Page.navigatedWithinDocument` is emitted with the new url and `navigationType: historyApi`. `make test F="cdp.frame"` → 18/18 pass; `zig fmt --check` clean; no leaked allocations.

## Note

@bebsworthy — you filed this and have a fix on a fork branch that isn't upstream yet. I built the History-API slice with a test to get it moving; happy to defer to your branch, fold in your approach, or have you take the fragment/Navigation-API follow-ups — whichever you and the maintainers prefer. Didn't want the issue to stall.