### PR TITLE
feat(cdp): implement Accessibility.getPartialAXTree

### DIFF
--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -17,9 +17,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
+
 const id = @import("../id.zig");
 const CDP = @import("../CDP.zig");
+
 const dom = @import("dom.zig");
+
+const log = lp.log;
 
 pub fn processMessage(cmd: *CDP.Command) !void {
     const action = std.meta.stringToEnum(enum {
@@ -106,8 +111,17 @@ fn getPartialAXTree(cmd: *CDP.Command) !void {
         // Accepted for Chrome protocol compatibility. The ancestor chain is
         // not yet emitted; this returns the subtree rooted at the resolved
         // node, matching the scope of queryAXTree.
-        fetchRelatives: ?bool = true,
+        fetchRelatives: ?bool = null,
     })) orelse return error.InvalidParams;
+
+    if (params.fetchRelatives orelse true) {
+        // orelse true, because that's what Chrome defaults too, and if people
+        // aren't setting it, then they're expecting true.
+        log.warn(.not_implemented, "getPartialAXTree", .{
+            .cdp_cmd = "Accessibility.getPartialAXTree",
+            .param = "fetchRelatives",
+        });
+    }
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
     const node = try dom.getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
@@ -162,7 +176,7 @@ test "cdp.accessibility: getPartialAXTree requires nodeId, backendNodeId or obje
     try ctx.processMessage(.{
         .id = 1,
         .method = "Accessibility.getPartialAXTree",
-        .params = .{ .fetchRelatives = true },
+        .params = .{ .fetchRelatives = false },
     });
     try ctx.expectSentError(-31998, "MissingParams", .{ .id = 1 });
 }
@@ -176,7 +190,7 @@ test "cdp.accessibility: getPartialAXTree with unknown nodeId returns error" {
     try ctx.processMessage(.{
         .id = 1,
         .method = "Accessibility.getPartialAXTree",
-        .params = .{ .nodeId = 99999 },
+        .params = .{ .nodeId = 99999, .fetchRelatives = false },
     });
     try ctx.expectSentError(-31998, "NodeNotFound", .{ .id = 1 });
 }

--- a/src/cdp/domains/accessibility.zig
+++ b/src/cdp/domains/accessibility.zig
@@ -26,6 +26,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         enable,
         disable,
         getFullAXTree,
+        getPartialAXTree,
         queryAXTree,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
@@ -33,6 +34,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .enable => return enable(cmd),
         .disable => return disable(cmd),
         .getFullAXTree => return getFullAXTree(cmd),
+        .getPartialAXTree => return getPartialAXTree(cmd),
         .queryAXTree => return queryAXTree(cmd),
     }
 }
@@ -96,6 +98,29 @@ fn queryAXTree(cmd: *CDP.Command) !void {
     }) }, .{});
 }
 
+fn getPartialAXTree(cmd: *CDP.Command) !void {
+    const params = (try cmd.params(struct {
+        nodeId: ?u32 = null,
+        backendNodeId: ?u32 = null,
+        objectId: ?[]const u8 = null,
+        // Accepted for Chrome protocol compatibility. The ancestor chain is
+        // not yet emitted; this returns the subtree rooted at the resolved
+        // node, matching the scope of queryAXTree.
+        fetchRelatives: ?bool = true,
+    })) orelse return error.InvalidParams;
+
+    const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+    const node = try dom.getNode(cmd.arena, bc, params.nodeId, params.backendNodeId, params.objectId);
+
+    const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
+    const temp_arena = try frame.getArena(.medium, "AXNode");
+    defer frame.releaseArena(temp_arena);
+
+    // No filter: emit the full accessibility subtree rooted at the resolved
+    // node, the same shape getFullAXTree produces for the document root.
+    return cmd.sendResult(.{ .nodes = try bc.axnodeWriter(temp_arena, node, .{}) }, .{});
+}
+
 const testing = @import("../testing.zig");
 
 test "cdp.accessibility: queryAXTree requires nodeId, backendNodeId or objectId" {
@@ -122,6 +147,35 @@ test "cdp.accessibility: queryAXTree with unknown nodeId returns error" {
     try ctx.processMessage(.{
         .id = 1,
         .method = "Accessibility.queryAXTree",
+        .params = .{ .nodeId = 99999 },
+    });
+    try ctx.expectSentError(-31998, "NodeNotFound", .{ .id = 1 });
+}
+
+test "cdp.accessibility: getPartialAXTree requires nodeId, backendNodeId or objectId" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
+
+    // Params present but no node identifier — dom.getNode returns MissingParams.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Accessibility.getPartialAXTree",
+        .params = .{ .fetchRelatives = true },
+    });
+    try ctx.expectSentError(-31998, "MissingParams", .{ .id = 1 });
+}
+
+test "cdp.accessibility: getPartialAXTree with unknown nodeId returns error" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{ .id = "BID-A", .url = "cdp/ax_tree.html" });
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Accessibility.getPartialAXTree",
         .params = .{ .nodeId = 99999 },
     });
     try ctx.expectSentError(-31998, "NodeNotFound", .{ .id = 1 });


### PR DESCRIPTION
Toward #1736.

## What

The Accessibility CDP domain implemented `getFullAXTree` and `queryAXTree` but not `getPartialAXTree`, so a client requesting the accessibility subtree rooted at a specific node received `UnknownMethod`. Accessibility tooling (Playwright/Puppeteer, axe-core, Lighthouse) uses `getPartialAXTree` for scoped a11y snapshots.

## Change

One method in `src/cdp/domains/accessibility.zig`, built from the two existing siblings: resolve the target node via `dom.getNode` (the node resolution `queryAXTree` uses — `nodeId` / `backendNodeId` / `objectId`), and emit its accessibility subtree via `bc.axnodeWriter` with no filter (the unfiltered shape `getFullAXTree` produces for the document root).

`fetchRelatives` is accepted for Chrome protocol compatibility; the current scope is the subtree rooted at the resolved node, matching `queryAXTree`. Emitting the ancestor chain is a natural follow-up.

Partial step toward the umbrella issue #1736; does not close it.

## Test

Two tests mirroring the existing `queryAXTree` coverage: `getPartialAXTree` with no node identifier returns `MissingParams`, and with an unknown `nodeId` returns `NodeNotFound`. `make test F="accessibility"` -> 4/4 pass; `zig fmt --check` clean.