### PR TITLE
Dispose Event for `NavigationHistoryEntry`

### DIFF
--- a/src/browser/webapi/EventTarget.zig
+++ b/src/browser/webapi/EventTarget.zig
@@ -45,6 +45,7 @@ pub const Type = union(enum) {
     broadcast_channel: *@import("BroadcastChannel.zig"),
     text_track_cue: *@import("media/TextTrackCue.zig"),
     navigation: *@import("navigation/Navigation.zig"),
+    navigation_history_entry: *@import("navigation/NavigationHistoryEntry.zig"),
     screen: *@import("Screen.zig"),
     screen_orientation: *@import("Screen.zig").Orientation,
     visual_viewport: *@import("VisualViewport.zig"),
@@ -234,6 +235,7 @@ pub fn format(self: *EventTarget, writer: *std.Io.Writer) !void {
         .idb_database => writer.writeAll("<IDBDatabase>"),
         .idb_transaction => writer.writeAll("<IDBTransaction>"),
         .notification => writer.writeAll("<Notification>"),
+        .navigation_history_entry => writer.writeAll("<NavigationHistoryEntry>"),
     };
 }
 
@@ -263,6 +265,7 @@ pub fn toString(self: *EventTarget) []const u8 {
         .idb_database => return "[object IDBDatabase]",
         .idb_transaction => return "[object IDBTransaction]",
         .notification => return "[object Notification]",
+        .navigation_history_entry => return "[object NavigationHistoryEntry]",
     };
 }
 

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -195,13 +195,13 @@ pub fn pushEntry(
 
     // truncates our history here.
     const retained_index = self._index + 1;
+    var disposed: []*NavigationHistoryEntry = &.{};
     if (self._entries.items.len > retained_index) {
-        const disposed = try frame.call_arena.dupe(
+        disposed = try frame.call_arena.dupe(
             *NavigationHistoryEntry,
             self._entries.items[retained_index..],
         );
         self._entries.shrinkRetainingCapacity(retained_index);
-        for (disposed) |d| try d.fireDispose(frame);
     }
 
     const index = self._entries.items.len;
@@ -225,18 +225,20 @@ pub fn pushEntry(
     try self._entries.append(arena, entry);
     self._index = index;
 
-    if (previous == null or should_dispatch == false) {
-        return entry;
+    if (previous != null and should_dispatch) {
+        if (self._on_currententrychange) |cec| {
+            const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
+                .wrap("currententrychange"),
+                .{ .from = previous.?, .navigationType = @tagName(.push) },
+                frame,
+            )).asEvent();
+            try self.dispatch(cec, event, frame);
+        }
     }
 
-    if (self._on_currententrychange) |cec| {
-        const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
-            .wrap("currententrychange"),
-            .{ .from = previous.?, .navigationType = @tagName(.push) },
-            frame,
-        )).asEvent();
-        try self.dispatch(cec, event, frame);
-    }
+    // Per spec, dispose fires last: after the entry list is updated and
+    // currententrychange has been dispatched.
+    for (disposed) |d| try d.fireDispose(frame);
 
     return entry;
 }
@@ -268,20 +270,20 @@ pub fn replaceEntry(
 
     const old_entry = self._entries.items[self._index];
     self._entries.items[self._index] = entry;
+
+    if (should_dispatch) {
+        if (self._on_currententrychange) |cec| {
+            const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
+                .wrap("currententrychange"),
+                .{ .from = previous, .navigationType = @tagName(.replace) },
+                frame,
+            )).asEvent();
+            try self.dispatch(cec, event, frame);
+        }
+    }
+
+    // Per spec, dispose fires last, after currententrychange.
     try old_entry.fireDispose(frame);
-
-    if (should_dispatch == false) {
-        return entry;
-    }
-
-    if (self._on_currententrychange) |cec| {
-        const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
-            .wrap("currententrychange"),
-            .{ .from = previous, .navigationType = @tagName(.replace) },
-            frame,
-        )).asEvent();
-        try self.dispatch(cec, event, frame);
-    }
 
     return entry;
 }

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -485,6 +485,7 @@ fn getOnCurrentEntryChange(self: *Navigation) ?js.Function.Global {
 }
 
 pub fn setOnCurrentEntryChange(self: *Navigation, listener: ?js.Function) !void {
+    if (self._on_currententrychange) |old| old.release();
     if (listener) |listen| {
         self._on_currententrychange = try listen.persistWithThis(self);
     } else {

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -189,11 +189,14 @@ pub fn pushEntry(
     const url = try arena.dupeZ(u8, _url);
 
     // truncates our history here.
-    if (self._entries.items.len > self._index + 1) {
-        for (self._entries.items[self._index + 1 ..]) |disposed| {
-            try disposed.fireDispose(frame);
-        }
-        self._entries.shrinkRetainingCapacity(self._index + 1);
+    const retained_index = self._index + 1;
+    if (self._entries.items.len > retained_index) {
+        const disposed = try frame.call_arena.dupe(
+            *NavigationHistoryEntry,
+            self._entries.items[retained_index..],
+        );
+        self._entries.shrinkRetainingCapacity(retained_index);
+        for (disposed) |d| try d.fireDispose(frame);
     }
 
     const index = self._entries.items.len;

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -56,10 +56,16 @@ fn asEventTarget(self: *Navigation) *EventTarget {
 
 pub fn onRemoveFrame(self: *Navigation) void {
     self._proto = undefined;
+    for (self._entries.items) |entry| {
+        entry._proto = undefined;
+    }
 }
 
 pub fn onNewFrame(self: *Navigation, frame: *Frame) !void {
     self._proto = try frame._factory.standaloneEventTarget(self);
+    for (self._entries.items) |entry| {
+        entry._proto = try frame._factory.standaloneEventTarget(entry);
+    }
 }
 
 pub fn getActivation(self: *const Navigation) ?NavigationActivation {
@@ -184,6 +190,9 @@ pub fn pushEntry(
 
     // truncates our history here.
     if (self._entries.items.len > self._index + 1) {
+        for (self._entries.items[self._index + 1 ..]) |disposed| {
+            try disposed.fireDispose(frame);
+        }
         self._entries.shrinkRetainingCapacity(self._index + 1);
     }
 
@@ -196,6 +205,7 @@ pub fn pushEntry(
 
     const entry = try arena.create(NavigationHistoryEntry);
     entry.* = NavigationHistoryEntry{
+        ._proto = try frame._factory.standaloneEventTarget(entry),
         ._id = id_str,
         ._key = id_str,
         ._url = url,
@@ -241,13 +251,16 @@ pub fn replaceEntry(
 
     const entry = try arena.create(NavigationHistoryEntry);
     entry.* = NavigationHistoryEntry{
+        ._proto = try frame._factory.standaloneEventTarget(entry),
         ._id = id_str,
         ._key = previous._key,
         ._url = url,
         ._state = state,
     };
 
+    const old_entry = self._entries.items[self._index];
     self._entries.items[self._index] = entry;
+    try old_entry.fireDispose(frame);
 
     if (should_dispatch == false) {
         return entry;

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -204,6 +204,16 @@ pub fn pushEntry(
         self._entries.shrinkRetainingCapacity(retained_index);
     }
 
+    // Per spec, dispose fires last: after the entry list is updated and
+    // currententrychange has been dispatched. These entries are already out
+    // of _entries, so fire even if a later step fails, and don't let one
+    // entry's failure skip the others.
+    defer for (disposed) |d| {
+        d.fireDispose(frame) catch |err| {
+            log.warn(.event, "NavigationHistoryEntry.dispose", .{ .err = err });
+        };
+    };
+
     const index = self._entries.items.len;
 
     const id = self._next_entry_id;
@@ -236,10 +246,6 @@ pub fn pushEntry(
         }
     }
 
-    // Per spec, dispose fires last: after the entry list is updated and
-    // currententrychange has been dispatched.
-    for (disposed) |d| try d.fireDispose(frame);
-
     return entry;
 }
 
@@ -271,6 +277,12 @@ pub fn replaceEntry(
     const old_entry = self._entries.items[self._index];
     self._entries.items[self._index] = entry;
 
+    // Per spec, dispose fires last, after currententrychange. old_entry is
+    // already out of _entries, so fire even if the dispatch below fails.
+    defer old_entry.fireDispose(frame) catch |err| {
+        log.warn(.event, "NavigationHistoryEntry.dispose", .{ .err = err });
+    };
+
     if (should_dispatch) {
         if (self._on_currententrychange) |cec| {
             const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
@@ -281,9 +293,6 @@ pub fn replaceEntry(
             try self.dispatch(cec, event, frame);
         }
     }
-
-    // Per spec, dispose fires last, after currententrychange.
-    try old_entry.fireDispose(frame);
 
     return entry;
 }

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -56,7 +56,12 @@ fn asEventTarget(self: *Navigation) *EventTarget {
 
 pub fn onRemoveFrame(self: *Navigation) void {
     self._proto = undefined;
+    if (self._on_currententrychange) |cb| cb.release();
+    self._on_currententrychange = null;
+
     for (self._entries.items) |entry| {
+        if (entry._on_dispose) |cb| cb.release();
+        entry._on_dispose = null;
         entry._proto = undefined;
     }
 }

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -92,9 +92,10 @@ fn getOnDispose(self: *const NavigationHistoryEntry) ?js.Function.Global {
     return self._on_dispose;
 }
 
-pub fn setOnDispose(self: *NavigationHistoryEntry, listener: ?js.Function) !void {
-    if (listener) |listen| {
-        self._on_dispose = try listen.persistWithThis(self);
+pub fn setOnDispose(self: *NavigationHistoryEntry, cb_: ?js.Function) !void {
+    if (self._on_dispose) |od| od.release();
+    if (cb_) |cb| {
+        self._on_dispose = try cb.persistWithThis(self);
     } else {
         self._on_dispose = null;
     }

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -81,10 +81,11 @@ pub fn getState(self: *const NavigationHistoryEntry, frame: *Frame) !StateReturn
 }
 
 pub fn fireDispose(self: *NavigationHistoryEntry, frame: *Frame) !void {
-    const cec = self._on_dispose orelse return;
+    if (!frame.hasDirectListeners(self.asEventTarget(), "dispose", self._on_dispose)) return;
+    if (self._on_dispose == null) return;
 
     const event = try Event.initTrusted(comptime .wrap("dispose"), .{}, frame._page);
-    try frame.dispatch(self.asEventTarget(), event, cec, .{ .context = "NavigationHistoryEntry" });
+    try frame.dispatch(self.asEventTarget(), event, self._on_dispose.?, .{ .context = "NavigationHistoryEntry" });
 }
 
 fn getOnDispose(self: *const NavigationHistoryEntry) ?js.Function.Global {

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -19,18 +19,25 @@
 const std = @import("std");
 const URL = @import("../URL.zig");
 const NavigationState = @import("root.zig").NavigationState;
+const Event = @import("../Event.zig");
+const EventTarget = @import("../EventTarget.zig");
 const Frame = @import("../../Frame.zig");
 const js = @import("../../js/js.zig");
 
 const NavigationHistoryEntry = @This();
 
 // https://developer.mozilla.org/en-US/docs/Web/API/NavigationHistoryEntry
-// no proto for now
-// _proto: ?*EventTarget,
+_proto: *EventTarget,
 _id: []const u8,
 _key: []const u8,
 _url: ?[:0]const u8,
 _state: NavigationState,
+
+_on_dispose: ?js.Function.Global = null,
+
+fn asEventTarget(self: *NavigationHistoryEntry) *EventTarget {
+    return self._proto;
+}
 
 pub fn id(self: *const NavigationHistoryEntry) []const u8 {
     return self._id;
@@ -73,6 +80,25 @@ pub fn getState(self: *const NavigationHistoryEntry, frame: *Frame) !StateReturn
     return .undefined;
 }
 
+pub fn fireDispose(self: *NavigationHistoryEntry, frame: *Frame) !void {
+    const cec = self._on_dispose orelse return;
+
+    const event = try Event.initTrusted(comptime .wrap("dispose"), .{}, frame._page);
+    try frame.dispatch(self.asEventTarget(), event, cec, .{ .context = "NavigationHistoryEntry" });
+}
+
+fn getOnDispose(self: *const NavigationHistoryEntry) ?js.Function.Global {
+    return self._on_dispose;
+}
+
+pub fn setOnDispose(self: *NavigationHistoryEntry, listener: ?js.Function) !void {
+    if (listener) |listen| {
+        self._on_dispose = try listen.persistWithThis(self);
+    } else {
+        self._on_dispose = null;
+    }
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(NavigationHistoryEntry);
 
@@ -88,4 +114,9 @@ pub const JsApi = struct {
     pub const sameDocument = bridge.accessor(NavigationHistoryEntry.sameDocument, null, .{});
     pub const url = bridge.accessor(NavigationHistoryEntry.url, null, .{});
     pub const getState = bridge.function(NavigationHistoryEntry.getState, .{});
+    pub const ondispose = bridge.accessor(
+        NavigationHistoryEntry.getOnDispose,
+        NavigationHistoryEntry.setOnDispose,
+        .{},
+    );
 };

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -82,10 +82,9 @@ pub fn getState(self: *const NavigationHistoryEntry, frame: *Frame) !StateReturn
 
 pub fn fireDispose(self: *NavigationHistoryEntry, frame: *Frame) !void {
     if (!frame.hasDirectListeners(self.asEventTarget(), "dispose", self._on_dispose)) return;
-    if (self._on_dispose == null) return;
 
     const event = try Event.initTrusted(comptime .wrap("dispose"), .{}, frame._page);
-    try frame.dispatch(self.asEventTarget(), event, self._on_dispose.?, .{ .context = "NavigationHistoryEntry" });
+    try frame.dispatch(self.asEventTarget(), event, self._on_dispose, .{ .context = "NavigationHistoryEntry" });
 }
 
 fn getOnDispose(self: *const NavigationHistoryEntry) ?js.Function.Global {


### PR DESCRIPTION
This adds the `dispose` event for the `NavigationHistoryEntry`
https://developer.mozilla.org/en-US/docs/Web/API/NavigationHistoryEntry/dispose_event