### PR TITLE
cdp: expose lightpanda version

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -283,6 +283,7 @@ fn buildJSONVersionResponse(app: *const App, port: u16) ![]const u8 {
         "\"Browser\": \"Lightpanda/1.0\", " ++
         "\"Protocol-Version\": \"1.3\", " ++
         "\"User-Agent\": \"Lightpanda/1.0\", " ++
+        "\"Lightpanda-Version\": \"" ++ lp.build_config.version ++ "\", " ++
         "\"webSocketDebuggerUrl\": \"ws://{s}:{d}/\"" ++
         "}}";
     const body_len = std.fmt.count(body_format, .{ host, port });
@@ -316,6 +317,7 @@ test "server: buildJSONVersionResponse" {
     try testing.expect(std.mem.indexOf(u8, res, "\"Browser\": \"Lightpanda/") != null);
     try testing.expect(std.mem.indexOf(u8, res, "\"Protocol-Version\": \"1.3\"") != null);
     try testing.expect(std.mem.indexOf(u8, res, "\"User-Agent\": \"Lightpanda/") != null);
+    try testing.expect(std.mem.indexOf(u8, res, "\"Lightpanda-Version\": \"" ++ lp.build_config.version ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, res, "\"webSocketDebuggerUrl\": \"ws://127.0.0.1:9222/\"") != null);
 }
 

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -45,6 +45,7 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         waitForSelector,
         handleJavaScriptDialog,
         configureLoading,
+        version,
     }, cmd.input.action) orelse return error.UnknownMethod;
 
     switch (action) {
@@ -61,7 +62,14 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .waitForSelector => return waitForSelector(cmd),
         .handleJavaScriptDialog => return handleJavaScriptDialog(cmd),
         .configureLoading => return configureLoading(cmd),
+        .version => return version(cmd),
     }
+}
+
+fn version(cmd: *CDP.Command) !void {
+    return cmd.sendResult(.{
+        .version = lp.build_config.version,
+    }, .{});
 }
 
 fn configureLoading(cmd: *CDP.Command) !void {
@@ -386,6 +394,19 @@ fn handleJavaScriptDialog(cmd: anytype) !void {
 }
 
 const testing = @import("../testing.zig");
+test "cdp.lp: version" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "LP.version",
+    });
+
+    const result = (try ctx.getSentMessage(0)).?.object.get("result").?.object;
+    try testing.expectEqualSlices(u8, lp.build_config.version, result.get("version").?.string);
+}
+
 test "cdp.lp: getMarkdown" {
     var ctx = try testing.context();
     defer ctx.deinit();


### PR DESCRIPTION
This PR exposes the real Lightpanda's version for CDP in 2 ways:

1. on `/json/version` response

```
$ curl http://127.0.0.1:9222/json/version |jq .
{
  "Browser": "Lightpanda/1.0",
  "Protocol-Version": "1.3",
  "User-Agent": "Lightpanda/1.0",
  "Lightpanda-Version": "1.0.0-dev.8052+447a34036",
  "webSocketDebuggerUrl": "ws://127.0.0.1:9222/"
}
```

2.  on custom CDP command `LP.version`
```
{"id": 1, "result": {"version": "1.0.0-dev.8052+447a34036"}}
```