### PR TITLE
cli: page help output through $PAGER when stdout is a tty

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -714,7 +714,7 @@ pub const HttpHeaders = struct {
     }
 };
 
-pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) void {
+pub fn printUsageAndExit(self: *const Config, allocator: Allocator, help_for: RunMode, success: bool) !void {
     const exec_name = self.exec_name;
     const Help = @import("help.zon");
     const is_debug = builtin.mode == .Debug;
@@ -722,34 +722,93 @@ pub fn printUsageAndExit(self: *const Config, help_for: RunMode, success: bool) 
     const pretty_or_logfmt = if (comptime is_debug) "pretty" else "logfmt";
     const comptimePrint = std.fmt.comptimePrint;
 
-    switch (help_for) {
+    const text = switch (help_for) {
         // Requested help for everything.
-        .help => {
+        .help => text: {
             const template = comptimePrint(
                 \\{s}
                 \\
             , .{Help.general});
-            std.debug.print(template, .{exec_name});
+            break :text try std.fmt.allocPrint(allocator, template, .{exec_name});
         },
-        inline .fetch, .serve, .mcp, .agent => |tag| {
+        inline .fetch, .serve, .mcp, .agent => |tag| text: {
             const template = comptimePrint(
                 \\{s}
                 \\
                 \\{s}
                 \\
             , .{ @field(Help, @tagName(tag)), Help.common_options });
-            std.debug.print(template, .{ exec_name, info_or_warn, pretty_or_logfmt });
+            break :text try std.fmt.allocPrint(allocator, template, .{ exec_name, info_or_warn, pretty_or_logfmt });
         },
-        .version => {
+        .version => text: {
             const template = Help.version ++ "\n";
-            std.debug.print(template, .{exec_name});
+            break :text try std.fmt.allocPrint(allocator, template, .{exec_name});
         },
-    }
+    };
+    defer allocator.free(text);
 
     if (success) {
+        printPaged(allocator, text);
         return std.process.cleanExit();
     }
+    var stderr = std.fs.File.stderr().writer(&.{});
+    stderr.interface.writeAll(text) catch {};
     std.process.exit(1);
+}
+
+fn printPlain(text: []const u8) void {
+    var stdout = std.fs.File.stdout().writer(&.{});
+    stdout.interface.writeAll(text) catch {};
+}
+
+/// Pages explicitly requested help through $PAGER (fallback: less) when
+/// stdout is an interactive terminal; prints plainly otherwise.
+fn printPaged(allocator: Allocator, text: []const u8) void {
+    if (!std.posix.isatty(std.posix.STDOUT_FILENO)) {
+        return printPlain(text);
+    }
+    const term = std.posix.getenv("TERM") orelse "";
+    if (term.len == 0 or std.mem.eql(u8, term, "dumb")) {
+        return printPlain(text);
+    }
+
+    const pager = std.posix.getenv("PAGER") orelse "";
+    const argv: []const []const u8 = if (pager.len > 0)
+        &.{ "/bin/sh", "-c", pager }
+    else
+        &.{ "less", "-FIRX" };
+
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Pipe;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.spawn() catch return printPlain(text);
+
+    // The pager can exit before we finish writing (e.g. `q` in less, or
+    // `sh -c` failing to find $PAGER); without this the resulting SIGPIPE
+    // would kill us. The process exits right after, so no need to restore.
+    std.posix.sigaction(std.posix.SIG.PIPE, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+
+    if (child.stdin) |stdin| {
+        var writer = stdin.writer(&.{});
+        // A write error here is the pager exiting early (user quit, or the
+        // command failed) — wait() below decides which.
+        writer.interface.writeAll(text) catch {};
+        stdin.close();
+        child.stdin = null;
+    }
+
+    const term_result = child.wait() catch return printPlain(text);
+    const clean_exit = term_result == .Exited and term_result.Exited == 0;
+    // Quitting the pager early is still exit 0; a non-zero exit means the
+    // pager failed (e.g. $PAGER not found) and the help was never shown.
+    if (!clean_exit) {
+        printPlain(text);
+    }
 }
 
 pub fn parseArgs(allocator: Allocator) !Config {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -784,15 +784,6 @@ fn printPaged(allocator: Allocator, text: []const u8) void {
     child.stderr_behavior = .Inherit;
     child.spawn() catch return printPlain(text);
 
-    // The pager can exit before we finish writing (e.g. `q` in less, or
-    // `sh -c` failing to find $PAGER); without this the resulting SIGPIPE
-    // would kill us. The process exits right after, so no need to restore.
-    std.posix.sigaction(std.posix.SIG.PIPE, &.{
-        .handler = .{ .handler = std.posix.SIG.IGN },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    }, null);
-
     if (child.stdin) |stdin| {
         var writer = stdin.writer(&.{});
         // A write error here is the pager exiting early (user quit, or the

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,7 +70,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
     defer args.deinit(main_arena);
 
     switch (args.mode) {
-        .help => |tag| return args.printUsageAndExit(tag, true),
+        .help => |tag| return args.printUsageAndExit(main_arena, tag, true),
         .version => |opts| {
             if (opts.check) {
                 try lp.checkVersion(allocator, &args);
@@ -121,7 +121,7 @@ fn run(allocator: Allocator, main_arena: Allocator) !void {
             log.debug(.app, "startup", .{ .mode = "serve", .snapshot = app.snapshot.fromEmbedded() });
             const address = std.net.Address.parseIp(opts.host, opts.port) catch |err| {
                 log.fatal(.app, "invalid server address", .{ .err = err, .host = opts.host, .port = opts.port });
-                return args.printUsageAndExit(.serve, false);
+                return args.printUsageAndExit(main_arena, .serve, false);
             };
 
             var server = lp.Server.init(app, address) catch |err| {


### PR DESCRIPTION
## Why

`lightpanda help agent` prints ~225 lines (the agent section plus all common options) straight to the terminal, clobbering the screen. Help also went to **stderr** (via `std.debug.print`), so `lightpanda help | grep proxy` captured nothing at all.

## What

- Explicitly requested help (`help`, `help <cmd>`, `--help`) now goes to **stdout**, following the usual CLI convention.
- When stdout is an interactive terminal (and `TERM` isn't dumb/empty), the help text is piped through `$PAGER` (run via `/bin/sh -c`, like git) or `less -FIRX` as fallback. `-F` makes less exit immediately when the text fits one screen, so short help like the general `lightpanda help` looks exactly as before.
- Piped or redirected output stays plain — no pager involved, scripting against stdout works normally.
- Error-path usage (bad args) remains on **stderr**, unpaged, exit code 1 — unchanged.
- A pager that exits early or fails to start can't lose the help: writes to a dead pager surface as `error.BrokenPipe` (std already installs a noop SIGPIPE handler at startup), and a non-zero pager exit (e.g. `$PAGER` points at a missing command, sh exits 127) falls back to printing the help plainly.

## Behavior change note

Anything that captured help via `2>&1` or expected it on stderr will now find it on stdout. Error usage output is untouched.