### PR TITLE
iframe: load about:blank on un-parsable URL

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1751,6 +1751,11 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
         src = "about:blank";
     }
 
+    if (URL.isCompleteHTTPUrl(src) and !URL.canParse(src, null)) {
+        // per spec, if we can't parse the URL, we should load about:blank
+        src = "about:blank";
+    }
+
     if (iframe._window != null) {
         // This frame is being re-navigated. We need to do this through a
         // scheduleNavigation phase. We can't navigate immediately here, for

--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -62,6 +62,13 @@ pub fn resolveNavigation(allocator: Allocator, url: []const u8, options: Resolve
     };
 }
 
+pub fn canParse(url: []const u8, maybe_base: ?[]const u8) bool {
+    if (maybe_base) |base| {
+        return U.url_can_parse_with_base(base.ptr, base.len, url.ptr, url.len);
+    }
+    return U.url_can_parse(url.ptr, url.len);
+}
+
 const EncodeSet = enum { path, query, query_legacy, userinfo, fragment, component };
 
 pub fn percentEncodeSegment(allocator: Allocator, segment: []const u8, comptime encode_set: EncodeSet) ![]const u8 {

--- a/src/browser/tests/frames/unparseable_src.html
+++ b/src/browser/tests/frames/unparseable_src.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id="unparseable_src" type=module>
+  // An absolute-but-unparseable src (the bare "https://" bot-detection
+  // scripts probe with) loads about:blank instead of failing the frame.
+  {
+    const state = await testing.async();
+    const ifr = document.createElement('iframe');
+    ifr.src = 'https://';
+    document.documentElement.appendChild(ifr);
+    testing.expectEqual('about:blank', ifr.contentWindow.location.href);
+
+    // re-navigating an existing frame takes the scheduled path
+    ifr.onload = () => state.resolve();
+    ifr.src = 'https://';
+    await state.done(() => {
+      testing.expectEqual('about:blank', ifr.contentWindow.location.href);
+    });
+  }
+</script>

--- a/src/browser/webapi/URL.zig
+++ b/src/browser/webapi/URL.zig
@@ -309,12 +309,7 @@ pub fn toString(self: *const URL, exec: *const Execution) ![]const u8 {
     return out[0..len];
 }
 
-pub fn canParse(url: []const u8, maybe_base: ?[]const u8) bool {
-    if (maybe_base) |base| {
-        return U.url_can_parse_with_base(base.ptr, base.len, url.ptr, url.len);
-    }
-    return U.url_can_parse(url.ptr, url.len);
-}
+pub const canParse = @import("../URL.zig").canParse;
 
 pub fn createObjectURL(blob: *Blob, exec: *const Execution) ![]const u8 {
     var uuid_buf: [36]u8 = undefined;


### PR DESCRIPTION
Spec says this is what we should do and it's apparently used a part of bot detections (because bots don't load about:blank and thus the iframe's state can easily be checked to be invalid, I guess).