### PR TITLE
Cookie store

### DIFF
--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -625,6 +625,10 @@ pub fn unescape(arena: Allocator, input: []const u8) ![]const u8 {
     return result.items;
 }
 
+pub fn stripFragment(url: []const u8) []const u8 {
+    return url[0 .. std.mem.indexOfScalar(u8, url, '#') orelse url.len];
+}
+
 const AuthorityInfo = struct {
     host_start: usize,
     host_end: usize,
@@ -1691,4 +1695,14 @@ test "URL: resolveNavigation defaults a schemeless host to http (curl-like)" {
         const result = try resolveNavigation(testing.arena_allocator, case.url, .{});
         try testing.expectString(case.expected, result);
     }
+}
+
+test "URL: stripFragment" {
+    try testing.expectEqual("https://www.example.com/", stripFragment("https://www.example.com/"));
+    try testing.expectEqual("https://www.example.com/about", stripFragment("https://www.example.com/about"));
+    try testing.expectEqual("https://www.example.com/?id=3", stripFragment("https://www.example.com/?id=3"));
+
+    try testing.expectEqual("https://www.example.com/", stripFragment("https://www.example.com/#pandapower"));
+    try testing.expectEqual("https://www.example.com/about", stripFragment("https://www.example.com/about#pandapower"));
+    try testing.expectEqual("https://www.example.com/?id=3", stripFragment("https://www.example.com/?id=3#pandapower"));
 }

--- a/src/browser/tests/cookie_store.html
+++ b/src/browser/tests/cookie_store.html
@@ -73,6 +73,71 @@
   });
 </script>
 
+<script id=change-event-binds-listeners-at-mutation type=module>
+  const state = await testing.async();
+  // A change enqueued while nobody is subscribed must not be delivered to a
+  // listener that registers afterwards but before the task drains.
+  await cookieStore.set('pre-listener', 'v');
+
+  const events = [];
+  const handler = (e) => events.push(...e.changed.map(c => c.name));
+  cookieStore.addEventListener('change', handler);
+
+  await cookieStore.set('post-listener', 'v');
+  await new Promise(r => setTimeout(r, 0));
+
+  cookieStore.removeEventListener('change', handler);
+  await cookieStore.delete('pre-listener');
+  await cookieStore.delete('post-listener');
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(false, events.includes('pre-listener'));
+    testing.expectEqual(true, events.includes('post-listener'));
+  });
+</script>
+
+<script id=set-max-age type=module>
+  const state = await testing.async();
+  const events = [];
+  const handler = (e) => events.push(e);
+  cookieStore.addEventListener('change', handler);
+
+  // A positive maxAge stores the cookie.
+  await cookieStore.set({ name: 'ma-pos', value: 'v', maxAge: 60 });
+  const posItem = await cookieStore.get('ma-pos');
+
+  // maxAge <= 0 expires immediately: nothing is stored and no change event
+  // fires for it.
+  await cookieStore.set({ name: 'ma-zero', value: 'v', maxAge: 0 });
+  await cookieStore.set({ name: 'ma-neg', value: 'v', maxAge: -60 });
+  await new Promise(r => setTimeout(r, 0));
+  const zeroItem = await cookieStore.get('ma-zero');
+  const negItem = await cookieStore.get('ma-neg');
+
+  // maxAge and expires are mutually exclusive.
+  let bothRejected = false;
+  try {
+    await cookieStore.set({ name: 'ma-both', value: 'v', maxAge: 60, expires: Date.now() + 60000 });
+  } catch (err) {
+    bothRejected = true;
+  }
+
+  cookieStore.removeEventListener('change', handler);
+  await cookieStore.delete('ma-pos');
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual('v', posItem.value);
+    testing.expectEqual(null, zeroItem);
+    testing.expectEqual(null, negItem);
+    testing.expectEqual(true, bothRejected);
+
+    // Only the stored (positive) cookie should have produced an event.
+    const names = events.flatMap(e => e.changed.map(c => c.name));
+    testing.expectEqual(1, names.length);
+    testing.expectEqual('ma-pos', names[0]);
+  });
+</script>
+
 <script id=delete-options type=module>
   const state = await testing.async();
   await cookieStore.set('tmp', 'x');

--- a/src/browser/tests/cookie_store.html
+++ b/src/browser/tests/cookie_store.html
@@ -21,6 +21,7 @@
   await state.done(() => {
     testing.expectEqual('user', item.name);
     testing.expectEqual('lp', item.value);
+    // We follow Chrome and expose the full attribute set, not just name/value.
     testing.expectEqual('/', item.path);
     testing.expectEqual('strict', item.sameSite);
     testing.expectEqual(null, item.expires);
@@ -162,6 +163,18 @@
   testing.expectEqual('change', ev.type);
   testing.expectEqual(0, ev.changed.length);
   testing.expectEqual(0, ev.deleted.length);
+
+  // The changed/deleted lists must be copied off the transient call arena;
+  // reading them after construction must stay valid.
+  const ev2 = new CookieChangeEvent('change', {
+    changed: [{ name: 'c1', value: 'v1' }, { name: 'c2', value: 'v2' }],
+    deleted: [{ name: 'd1', value: 'w1' }],
+  });
+  testing.expectEqual(2, ev2.changed.length);
+  testing.expectEqual('c1', ev2.changed[0].name);
+  testing.expectEqual('v2', ev2.changed[1].value);
+  testing.expectEqual(1, ev2.deleted.length);
+  testing.expectEqual('d1', ev2.deleted[0].name);
 </script>
 
 <script id=change-event-from-cookieStore-set type=module>

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -23,6 +23,7 @@ const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const Frame = @import("../Frame.zig");
 
+const Cookie = @import("storage/Cookie.zig");
 const Element = @import("Element.zig");
 const Event = @import("Event.zig");
 const EventTarget = @import("EventTarget.zig");
@@ -74,6 +75,51 @@ pub fn click(_: *const WebDriver, element: *Element, frame: *Frame) !void {
     dispatchPointer(element, "pointerup", 0, 0, frame);
     dispatchMouse(element, "mouseup", 0, 0, frame);
     dispatchMouse(element, "click", 0, 0, frame);
+}
+
+const WebDriverCookie = struct {
+    name: []const u8,
+    value: []const u8,
+    path: []const u8,
+    domain: []const u8,
+    secure: bool,
+    httpOnly: bool,
+    sameSite: []const u8,
+    expiry: ?f64,
+};
+
+// Unlike the script-facing CookieStore, WebDriver can see HttpOnly cookies.
+pub fn getNamedCookie(_: *const WebDriver, name: []const u8, frame: *Frame) ?WebDriverCookie {
+    const jar = &frame._session.cookie_jar;
+    const target = Cookie.PreparedUri.init(frame.url);
+    if (target.host.len == 0) {
+        return null;
+    }
+
+    jar.removeExpired(null);
+    for (jar.cookies.items) |*cookie| {
+        if (cookie.appliesTo(&target, true, true, true) == false) {
+            continue;
+        }
+        if (std.mem.eql(u8, cookie.name, name) == false) {
+            continue;
+        }
+        return .{
+            .name = cookie.name,
+            .value = cookie.value,
+            .path = cookie.path,
+            .domain = if (cookie.domain.len > 0 and cookie.domain[0] == '.') cookie.domain[1..] else cookie.domain,
+            .secure = cookie.secure,
+            .httpOnly = cookie.http_only,
+            .sameSite = switch (cookie.same_site) {
+                .strict => "Strict",
+                .lax => "Lax",
+                .none => "None",
+            },
+            .expiry = cookie.expires,
+        };
+    }
+    return null;
 }
 
 // Implements testdriver's `action_sequence` (the WebDriver "Perform Actions"
@@ -469,6 +515,7 @@ pub const JsApi = struct {
     };
     pub const deleteAllCookies = bridge.function(WebDriver.deleteAllCookies, .{});
     pub const getComputedLabel = bridge.function(WebDriver.getComputedLabel, .{});
+    pub const getNamedCookie = bridge.function(WebDriver.getNamedCookie, .{});
     pub const actionSequence = bridge.function(WebDriver.actionSequence, .{});
     pub const click = bridge.function(WebDriver.click, .{});
 };

--- a/src/browser/webapi/event/CookieChangeEvent.zig
+++ b/src/browser/webapi/event/CookieChangeEvent.zig
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
@@ -26,6 +27,7 @@ const CookieStore = @import("../storage/CookieStore.zig");
 
 const String = lp.String;
 const Execution = js.Execution;
+const Allocator = std.mem.Allocator;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/CookieChangeEvent
 const CookieChangeEvent = @This();
@@ -53,8 +55,8 @@ pub fn init(typ: []const u8, _opts: ?Options, exec: *const Execution) !*CookieCh
         type_string,
         CookieChangeEvent{
             ._proto = undefined,
-            ._changed = opts.changed orelse &.{},
-            ._deleted = opts.deleted orelse &.{},
+            ._changed = try cloneListItems(arena, opts.changed),
+            ._deleted = try cloneListItems(arena, opts.deleted),
         },
     );
 
@@ -107,6 +109,25 @@ pub fn initSingle(
 
     Event.populatePrototypes(event, Options{}, true);
     return event;
+}
+
+// Passed in from V8, everything is call_arena allocated, need to dupe it into our arena.
+fn cloneListItems(arena: Allocator, items_: ?[]CookieStore.CookieListItem) ![]CookieStore.CookieListItem {
+    const items = items_ orelse return &.{};
+    const out = try arena.alloc(CookieStore.CookieListItem, items.len);
+    for (items, out) |src, *dst| {
+        dst.* = .{
+            .name = try String.init(arena, src.name.str(), .{}),
+            .value = if (src.value) |v| try String.init(arena, v.str(), .{}) else null,
+            .domain = if (src.domain) |d| try String.init(arena, d.str(), .{}) else null,
+            .path = try String.init(arena, src.path.str(), .{}),
+            .expires = src.expires,
+            .secure = src.secure,
+            .sameSite = try arena.dupe(u8, src.sameSite),
+            .partitioned = src.partitioned,
+        };
+    }
+    return out;
 }
 
 pub fn asEvent(self: *CookieChangeEvent) *Event {

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -68,7 +68,9 @@ fn onCookieChanged(ctx: *anyopaque, data: *const Notification.CookieChanged) !vo
     // same-site treated as first-party against the document URL).
     const doc_url = exec.url.*;
     const target = Cookie.PreparedUri.init(doc_url);
-    if (target.host.len == 0) return;
+    if (target.host.len == 0) {
+        return;
+    }
 
     const probe = Cookie{
         .arena = undefined,
@@ -81,7 +83,16 @@ fn onCookieChanged(ctx: *anyopaque, data: *const Notification.CookieChanged) !vo
         .http_only = data.http_only,
         .same_site = data.same_site,
     };
-    if (!probe.appliesTo(&target, true, true, false)) return;
+    if (!probe.appliesTo(&target, true, true, false)) {
+        return;
+    }
+
+    // Rechecked in ChangeCallback.run, but between now and then, a listener
+    // could be added which should NOT get this event (because it wasn't addded
+    // at this point).
+    if (!exec.hasDirectListeners(self.asEventTarget(), "change", self._on_change)) {
+        return;
+    }
 
     // Per spec, `change` is dispatched as a queued task — never synchronously
     // from the mutation site. We snapshot the notification fields onto a
@@ -205,6 +216,7 @@ const CookieInit = struct {
     name: []const u8,
     value: []const u8,
     expires: ?f64 = null,
+    maxAge: ?f64 = null,
     domain: ?[]const u8 = null,
     path: []const u8 = "/",
     sameSite: SameSite = .strict,
@@ -236,13 +248,18 @@ const SameSite = enum {
     pub const js_enum_from_string = true;
 };
 
-pub fn get(_: *CookieStore, input: GetInput, exec: *const Execution) !js.Promise {
+pub fn get(_: *CookieStore, input: ?GetInput, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
 
-    const name: ?[]const u8, const url: ?[]const u8 = switch (input) {
+    const name: ?[]const u8, const url: ?[]const u8 = if (input) |inp| switch (inp) {
         .name => |n| .{ n, null },
         .options => |o| .{ o.name, o.url },
-    };
+    } else .{ null, null };
+
+    if (name == null and url == null) {
+        // Unlike getAll(), get() requires a name or url
+        return local.rejectPromise(.{ .type_error = "get requires a name or url" });
+    }
 
     const items = matchCookies(exec, name, url, true) catch |err| {
         return local.rejectPromise(.{ .type_error = @errorName(err) });
@@ -319,16 +336,25 @@ fn resolveQueryUrl(exec: *const Execution, _override: ?[]const u8) ![:0]const u8
     const current = exec.url.*;
     const override = _override orelse return current;
 
-    const resolved = try URL.resolve(exec.call_arena, exec.base(), override, .{});
-    if (!exec.isSameOrigin(resolved)) return error.SecurityError;
+    const resolved = try URL.resolve(exec.local_arena, exec.base(), override, .{});
+    if (!exec.isSameOrigin(resolved)) {
+        return error.SecurityError;
+    }
 
     switch (exec.js.global) {
         .frame => {
-            if (!std.mem.eql(u8, resolved, current)) return error.InvalidUrl;
+            // URL that differs from document only by #hash is the same document URL
+            if (!std.mem.eql(u8, stripFragment(resolved), stripFragment(current))) {
+                return error.InvalidUrl;
+            }
         },
         .worker => {},
     }
     return resolved;
+}
+
+fn stripFragment(url: []const u8) []const u8 {
+    return url[0 .. std.mem.indexOfScalar(u8, url, '#') orelse url.len];
 }
 
 fn matchCookies(
@@ -345,20 +371,30 @@ fn matchCookies(
         .path = URL.getPathname(url_resolved),
         .secure = URL.isSecure(url_resolved),
     };
-    if (target.host.len == 0) return error.SecurityError;
+    if (target.host.len == 0) {
+        return error.SecurityError;
+    }
 
     session.cookie_jar.removeExpired(null);
+
+    // Cookie names are normalized. Apply the same normalization to the input
+    // we're matching
+    const normalized_name: ?[]const u8 = if (name) |n| std.mem.trim(u8, n, " \t") else null;
 
     var items: std.ArrayList(CookieListItem) = .empty;
     for (session.cookie_jar.cookies.items) |*cookie| {
         // CookieStore exposes only cookies that script would see for the
         // current document. HttpOnly cookies stay hidden.
-        if (!cookie.appliesTo(&target, true, true, false)) continue;
-        if (name) |n| {
-            if (!std.mem.eql(u8, cookie.name, n)) continue;
+        if (cookie.appliesTo(&target, true, true, false) == false) {
+            continue;
+        }
+        if (normalized_name) |n| {
+            if (std.mem.eql(u8, cookie.name, n) == false) {
+                continue;
+            }
         }
 
-        try items.append(exec.call_arena, .{
+        try items.append(exec.local_arena, .{
             .name = String.wrap(cookie.name),
             .value = String.wrap(cookie.value),
             .domain = if (cookie.domain.len > 0 and cookie.domain[0] == '.')
@@ -389,6 +425,16 @@ fn storeCookie(exec: *const Execution, init_: CookieInit, is_delete: bool) !void
 
     init.name = std.mem.trim(u8, init.name, " \t");
     init.value = std.mem.trim(u8, init.value, " \t");
+
+    if (init.maxAge) |max_age| {
+        if (init.expires != null) {
+            // maxAge and expires are mutually exclusive
+            return error.InvalidArgument;
+        }
+        // convert to absolute time, so the rest of the code is shared for
+        // maxAge and expires.
+        init.expires = (@as(f64, @floatFromInt(std.time.timestamp())) + max_age) * 1000.0;
+    }
 
     // delete() may legitimately target a nameless cookie — its value is always empty.
     if (!is_delete and init.name.len == 0) {

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -344,17 +344,13 @@ fn resolveQueryUrl(exec: *const Execution, _override: ?[]const u8) ![:0]const u8
     switch (exec.js.global) {
         .frame => {
             // URL that differs from document only by #hash is the same document URL
-            if (!std.mem.eql(u8, stripFragment(resolved), stripFragment(current))) {
+            if (!std.mem.eql(u8, URL.stripFragment(resolved), URL.stripFragment(current))) {
                 return error.InvalidUrl;
             }
         },
         .worker => {},
     }
     return resolved;
-}
-
-fn stripFragment(url: []const u8) []const u8 {
-    return url[0 .. std.mem.indexOfScalar(u8, url, '#') orelse url.len];
 }
 
 fn matchCookies(

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -411,7 +411,9 @@ fn matchCookies(
             },
             .partitioned = false,
         });
-        if (first_only) break;
+        if (first_only) {
+            break;
+        }
     }
 
     return items.items;
@@ -434,6 +436,12 @@ fn storeCookie(exec: *const Execution, init_: CookieInit, is_delete: bool) !void
         // convert to absolute time, so the rest of the code is shared for
         // maxAge and expires.
         init.expires = (@as(f64, @floatFromInt(std.time.timestamp())) + max_age) * 1000.0;
+    }
+
+    if (init.expires) |ms| {
+        // 400 day expiry limit, per spec.
+        const cap_ms = (@as(f64, @floatFromInt(std.time.timestamp())) + 400 * std.time.s_per_day) * 1000.0;
+        init.expires = @min(ms, cap_ms);
     }
 
     // delete() may legitimately target a nameless cookie — its value is always empty.
@@ -507,8 +515,9 @@ fn storeCookie(exec: *const Execution, init_: CookieInit, is_delete: bool) !void
                 return error.InvalidPrefixedCookie;
             }
         }
-        const effective_path = if (init.path.len > 0) init.path else "/";
-        if (!std.mem.eql(u8, effective_path, "/")) {
+
+        const resolved_path = try Cookie.parsePath(exec.local_arena, url, init.path);
+        if (std.mem.eql(u8, resolved_path, "/") == false) {
             return error.InvalidPrefixedCookie;
         }
     } else if (std.ascii.startsWithIgnoreCase(init.name, "__Secure-")) {
@@ -586,18 +595,21 @@ pub const JsApi = struct {
 // CookieListItem is an plain JavaScript object, not an interface. The bridge
 // automatically translate a Zig struct -> JS Object This should _not_ have a
 // JsApi.
+//
+// NOTE: Per spec, name and value are the only valid fields. All other fields
+// are experimental. Chrome exposes them all, so we do too.
 pub const CookieListItem = struct {
     name: String,
     // Optional because a deletion change-event reports the removed cookie with
     // `value` omitted (serialized as undefined via the `deleted` accessor's
     // null_as_undefined). For get/getAll and `changed` items it is always set.
-    value: ?String,
-    domain: ?String,
-    path: String,
-    expires: ?f64,
-    secure: bool,
-    sameSite: []const u8,
-    partitioned: bool,
+    value: ?String = null,
+    domain: ?String = null,
+    path: String = String.wrap("/"),
+    expires: ?f64 = null,
+    secure: bool = false,
+    sameSite: []const u8 = "strict",
+    partitioned: bool = false,
 };
 
 const testing = @import("../../../testing.zig");


### PR DESCRIPTION
WPT driven fixes

1 - Fix UAF from JS-created CookieChangeEvent
2 - Add WebDriver.getNamedCookie to give WPT access to http-only cookie.
3 - Support maxAge in cookie store
4 - Prevent CookieStore listener attached AFTER event from getting the event
5 - CookieStore.get now normalizes name to properly match cookies.