### PR TITLE
cache: Never cache the top-level root page

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -763,6 +763,9 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
         .loader_id = self._loader_id,
         .method = opts.method,
         .body = opts.body,
+        // don't cache top-level pages, most cases won't revisit this, and, if they
+        // do, they probably don't want the cached version.
+        .skip_cache = self.parent == null,
         .cookie_jar = &session.cookie_jar,
         .cookie_origin = opts.initiator_url orelse self.url,
         .resource_type = .document,

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -818,7 +818,7 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
     const cache = self.cache orelse return false;
 
     const req = &transfer.req;
-    if (req.method != .GET or req.streaming) {
+    if (req.method != .GET or req.streaming or req.skip_cache) {
         return false;
     }
 
@@ -1536,6 +1536,7 @@ pub const Request = struct {
     credentials: ?[:0]const u8 = null,
     notification: *Notification,
     timeout_ms: u32 = 0,
+    skip_cache: bool = false,
 
     // Requests that are internal to the browser and skip various layers,
     // these do not need to be deferred and do not obey robots.txt.


### PR DESCRIPTION
The idea is that, for most cases, the top level page isn't revisited, so caching is just overhead + wasted space. Plus, if someone does revisit it, chances are they want a fresh copy.

Imagine someone scraping a typical ecommerce site. Sure, they want to cache the .js files which get re-used from product to product. But do they want to cache each individual product page?