### PR TITLE
perf, v8: reduce gc hint frequency

### DIFF
--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -121,7 +121,7 @@ fn _wait(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
     // alive for seconds while running heavy JS accumulates wrappers and
     // external-ref'd Zig allocations V8 has no reason to drop. `.moderate`
     // speeds up incremental GC without stalling the tick.
-    const gc_hint_period_ns: u64 = std.time.ns_per_s;
+    const gc_hint_period_ns: u64 = std.time.ns_per_s * 5;
     var gc_hint_timer = std.time.Timer.start() catch unreachable;
 
     while (true) {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -190,7 +190,7 @@ pub fn deinit(self: *Session) void {
 
     self.cookie_jar.deinit();
 
-    self.browser.env.memoryPressureNotification(.critical);
+    self.browser.env.memoryPressureNotification(.moderate);
 
     self.storage_shed.deinit(self.browser.app.allocator);
     self.idb.deinit();

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -190,7 +190,7 @@ pub fn deinit(self: *Session) void {
 
     self.cookie_jar.deinit();
 
-    self.browser.env.memoryPressureNotification(.moderate);
+    self.browser.env.memoryPressureNotification(.critical);
 
     self.storage_shed.deinit(self.browser.app.allocator);
     self.idb.deinit();

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -503,25 +503,11 @@ pub fn runIdleTasks(self: *const Env) void {
 
 // V8 doesn't immediately free memory associated with
 // a Context, it's managed by the garbage collector. We use the
-// `lowMemoryNotification` call on the isolate to encourage v8 to free
-// any contexts which have been freed.
-// This GC is very aggressive. Use memoryPressureNotification for less
-// aggressive GC passes.
-pub fn lowMemoryNotification(self: *Env) void {
-    var handle_scope: js.HandleScope = undefined;
-    handle_scope.init(self.isolate);
-    defer handle_scope.deinit();
-    self.isolate.lowMemoryNotification();
-}
-
-// V8 doesn't immediately free memory associated with
-// a Context, it's managed by the garbage collector. We use the
 // `memoryPressureNotification` call on the isolate to encourage v8 to free
 // any contexts which have been freed.
 // The level indicates the aggressivity of the GC required:
 // moderate speeds up incremental GC
 // critical runs one full GC
-// For a more aggressive GC, use lowMemoryNotification.
 pub fn memoryPressureNotification(self: *Env, level: Isolate.MemoryPressureLevel) void {
     var handle_scope: js.HandleScope = undefined;
     handle_scope.init(self.isolate);

--- a/src/browser/js/Isolate.zig
+++ b/src/browser/js/Isolate.zig
@@ -41,10 +41,6 @@ pub fn exit(self: Isolate) void {
     v8.v8__Isolate__Exit(self.handle);
 }
 
-pub fn lowMemoryNotification(self: Isolate) void {
-    v8.v8__Isolate__LowMemoryNotification(self.handle);
-}
-
 pub const MemoryPressureLevel = enum(u32) {
     none = v8.kNone,
     moderate = v8.kModerate,


### PR DESCRIPTION
Reduce v8 GC hint frequency from every 1s to every 5s.

I also experimented with changing the .critical -> .moderate on Session.deinit, but that caused our e2e memory regression to trip (+ ~1.2MB). So staying with this safe change for now.

V8 does have callbacks for when a GC starts/stops, and we could probe memory usage to do this more surgically. Users can also tweak thisvia the dangerous/unsupported `--v8-flags-unsafe` flag.