### PR TITLE
network: fix build, std.posix.shutdown is gone in Zig 0.16

### DIFF
--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -395,7 +395,7 @@ fn dropCdp(self: *Network, link: *CdpLink, err: ?anyerror, opts: DropCdpOpts) vo
     self.cdp_dirty = true;
 
     if (opts.shutdown_socket) {
-        posix.shutdown(link.socket, .both) catch {};
+        sys_net.shutdown(link.socket, .both) catch {};
     }
 
     if (opts.notify) {


### PR DESCRIPTION
#3018 (improve-dead-peer-detection) merged without a rebase onto the Zig 0.16 upgrade, so `main` currently fails to compile:

```
src/network/Network.zig:398:14: error: root source file struct 'posix' has no member named 'shutdown'
        posix.shutdown(link.socket, .both) catch {};
        ~~~~~^~~~~~~~~
```

`std.posix.shutdown` was removed in 0.16; this switches the call to the `src/sys/net.zig` wrapper introduced by the 0.16 port (same `.both` semantics, `posix.socket_t` unchanged).

Verified `zig build` succeeds on this branch with Zig 0.16.0.