### PR TITLE
browser: report native arena memory to V8

### DIFF
--- a/src/ArenaPool.zig
+++ b/src/ArenaPool.zig
@@ -23,6 +23,7 @@ const builtin = @import("builtin");
 const log = lp.log;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
+const NativeMemoryAccount = @import("browser/NativeMemoryAccount.zig");
 
 const ArenaPool = @This();
 
@@ -44,7 +45,92 @@ const Entry = struct {
     next: ?*Entry,
     arena: ArenaAllocator,
     bucket: *Bucket,
+    parent_allocator: Allocator,
+    owner: std.atomic.Value(?*NativeMemoryAccount) = .init(null),
+    allocated_bytes: std.atomic.Value(usize) = .init(0),
     debug: if (IS_DEBUG) []const u8 else void = if (IS_DEBUG) "" else {},
+
+    const vtable = Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn allocator(self: *Entry) Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn setOwner(self: *Entry, owner: ?*NativeMemoryAccount) void {
+        std.debug.assert(self.owner.load(.acquire) == null);
+        self.owner.store(owner, .release);
+        if (owner) |account| {
+            const bytes = self.allocated_bytes.load(.acquire);
+            account.add(bytes);
+            lp.metrics.browser_native_memory_bytes.incrBy(bytes);
+        }
+    }
+
+    fn clearOwner(self: *Entry) void {
+        const owner = self.owner.swap(null, .acq_rel) orelse return;
+        const bytes = self.allocated_bytes.load(.acquire);
+        owner.remove(bytes);
+        lp.metrics.browser_native_memory_bytes.decrBy(bytes);
+    }
+
+    fn addBytes(self: *Entry, bytes: usize) void {
+        if (bytes == 0) return;
+        _ = self.allocated_bytes.fetchAdd(bytes, .monotonic);
+        if (self.owner.load(.acquire)) |owner| {
+            owner.add(bytes);
+            lp.metrics.browser_native_memory_bytes.incrBy(bytes);
+        }
+    }
+
+    fn removeBytes(self: *Entry, bytes: usize) void {
+        if (bytes == 0) return;
+        const previous = self.allocated_bytes.fetchSub(bytes, .monotonic);
+        std.debug.assert(previous >= bytes);
+        if (self.owner.load(.acquire)) |owner| {
+            owner.remove(bytes);
+            lp.metrics.browser_native_memory_bytes.decrBy(bytes);
+        }
+    }
+
+    fn adjustBytes(self: *Entry, old_len: usize, new_len: usize) void {
+        if (new_len > old_len) {
+            self.addBytes(new_len - old_len);
+        } else {
+            self.removeBytes(old_len - new_len);
+        }
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, return_address: usize) ?[*]u8 {
+        const self: *Entry = @ptrCast(@alignCast(ctx));
+        const result = self.parent_allocator.rawAlloc(len, alignment, return_address) orelse return null;
+        self.addBytes(len);
+        return result;
+    }
+
+    fn resize(ctx: *anyopaque, old_mem: []u8, alignment: std.mem.Alignment, new_len: usize, return_address: usize) bool {
+        const self: *Entry = @ptrCast(@alignCast(ctx));
+        if (!self.parent_allocator.rawResize(old_mem, alignment, new_len, return_address)) return false;
+        self.adjustBytes(old_mem.len, new_len);
+        return true;
+    }
+
+    fn remap(ctx: *anyopaque, old_mem: []u8, alignment: std.mem.Alignment, new_len: usize, return_address: usize) ?[*]u8 {
+        const self: *Entry = @ptrCast(@alignCast(ctx));
+        const result = self.parent_allocator.rawRemap(old_mem, alignment, new_len, return_address) orelse return null;
+        self.adjustBytes(old_mem.len, new_len);
+        return result;
+    }
+
+    fn free(ctx: *anyopaque, old_mem: []u8, alignment: std.mem.Alignment, return_address: usize) void {
+        const self: *Entry = @ptrCast(@alignCast(ctx));
+        self.parent_allocator.rawFree(old_mem, alignment, return_address);
+        self.removeBytes(old_mem.len);
+    }
 };
 
 pub const Config = struct {
@@ -111,6 +197,10 @@ pub fn deinit(self: *ArenaPool) void {
 // - Pass a BucketSize (.tiny, .small, .medium, .large) for explicit bucket selection
 // - Pass a usize for automatic bucket selection based on expected size
 pub fn acquire(self: *ArenaPool, size_or_bucket: anytype, debug: []const u8) !Allocator {
+    return self.acquireFor(null, size_or_bucket, debug);
+}
+
+pub fn acquireFor(self: *ArenaPool, owner: ?*NativeMemoryAccount, size_or_bucket: anytype, debug: []const u8) !Allocator {
     const bucket_size: BucketSize = blk: {
         const T = @TypeOf(size_or_bucket);
         if (T == BucketSize or T == @TypeOf(.enum_literal)) {
@@ -146,6 +236,7 @@ pub fn acquire(self: *ArenaPool, size_or_bucket: anytype, debug: []const u8) !Al
             }
             gop.value_ptr.* += 1;
         }
+        entry.setOwner(owner);
         lp.metrics.arena_hit.incr(bucket_size);
         return entry.arena.allocator();
     }
@@ -156,9 +247,12 @@ pub fn acquire(self: *ArenaPool, size_or_bucket: anytype, debug: []const u8) !Al
     entry.* = .{
         .next = null,
         .bucket = bucket,
+        .parent_allocator = self.allocator,
         .debug = if (IS_DEBUG) debug else {},
-        .arena = ArenaAllocator.init(self.allocator),
+        .arena = undefined,
     };
+    entry.arena = ArenaAllocator.init(entry.allocator());
+    entry.setOwner(owner);
 
     if (IS_DEBUG) {
         const gop = try self._leak_track.getOrPut(self.allocator, debug);
@@ -192,6 +286,7 @@ pub fn release(self: *ArenaPool, allocator: Allocator) void {
     }
 
     _ = arena.reset(.{ .retain_with_limit = bucket.retain_bytes });
+    entry.clearOwner();
 
     self.mutex.lockUncancelable(lp.io);
     defer self.mutex.unlock(lp.io);
@@ -380,4 +475,48 @@ test "ArenaPool: size-based acquire" {
     try testing.expectEqual(1, pool.small.free_list_len);
     try testing.expectEqual(1, pool.medium.free_list_len);
     try testing.expectEqual(1, pool.large.free_list_len);
+}
+
+test "ArenaPool: browser account follows retained capacity ownership" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+    var first: NativeMemoryAccount = .{};
+    var second: NativeMemoryAccount = .{};
+
+    const first_arena = try pool.acquireFor(&first, .tiny, "first");
+    _ = try first_arena.alloc(u8, 256);
+    const retained_bytes = first.active();
+    try testing.expect(retained_bytes > 0);
+    try testing.expectEqual(@as(i64, @intCast(retained_bytes)), first.takePendingDelta());
+
+    pool.release(first_arena);
+    try testing.expectEqual(0, first.active());
+    try testing.expectEqual(-@as(i64, @intCast(retained_bytes)), first.takePendingDelta());
+
+    const second_arena = try pool.acquireFor(&second, .tiny, "second");
+    try testing.expectEqual(retained_bytes, second.active());
+    try testing.expectEqual(@as(i64, @intCast(retained_bytes)), second.takePendingDelta());
+
+    pool.release(second_arena);
+    try testing.expectEqual(0, second.active());
+    try testing.expectEqual(-@as(i64, @intCast(retained_bytes)), second.takePendingDelta());
+}
+
+test "ArenaPool: reset updates the active browser account" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+    var account: NativeMemoryAccount = .{};
+
+    const arena = try pool.acquireFor(&account, .large, "reset");
+    _ = try arena.alloc(u8, 256 * 1024);
+    try testing.expect(account.active() > 0);
+    _ = account.takePendingDelta();
+
+    pool.reset(arena, 0);
+    try testing.expectEqual(0, account.active());
+    try testing.expect(account.takePendingDelta() < 0);
+
+    pool.release(arena);
+    try testing.expectEqual(0, account.active());
+    try testing.expectEqual(0, account.takePendingDelta());
 }

--- a/src/Metrics.zig
+++ b/src/Metrics.zig
@@ -30,6 +30,7 @@ js_heap_limits: Counter = .{},
 script_errors: Counter = .{},
 arena_hit: CounterEnum("size", @import("ArenaPool.zig").BucketSize) = .{},
 arena_miss: CounterEnum("size", @import("ArenaPool.zig").BucketSize) = .{},
+browser_native_memory_bytes: Gauge = .{},
 navigate: CounterEnum("type", @import("telemetry/telemetry.zig").Event.Navigate.Context) = .{},
 js_heap_size_bytes: Histogram(&.{
     4 * 1024 * 1024,
@@ -84,6 +85,7 @@ const help = .{
     .script_errors = "Scripts that failed to evaluate, e.g. an uncaught top-level exception",
     .arena_hit = "Arena pool acquisitions served from the free list",
     .arena_miss = "Arena pool acquisitions that had to allocate a new arena",
+    .browser_native_memory_bytes = "Arena backing memory attributed to active browser connections",
     .navigate = "Navigations by initiating frame type",
     .js_heap_size_bytes = "V8 heap physical size, sampled when a page is closed",
     .http_requests = "HTTP requests submitted, by dispatch mode (excludes internal requests like robots.txt)",
@@ -139,11 +141,19 @@ const Gauge = struct {
     value: isize = 0,
 
     pub fn incr(self: *Gauge) void {
-        _ = @atomicRmw(isize, &self.value, .Add, 1, .monotonic);
+        self.incrBy(1);
+    }
+
+    pub fn incrBy(self: *Gauge, value: usize) void {
+        _ = @atomicRmw(isize, &self.value, .Add, @intCast(value), .monotonic);
     }
 
     pub fn decr(self: *Gauge) void {
-        _ = @atomicRmw(isize, &self.value, .Sub, 1, .monotonic);
+        self.decrBy(1);
+    }
+
+    pub fn decrBy(self: *Gauge, value: usize) void {
+        _ = @atomicRmw(isize, &self.value, .Sub, @intCast(value), .monotonic);
     }
 
     fn write(self: *const Gauge, comptime name: []const u8, comptime help_text: []const u8, writer: *std.Io.Writer) !void {

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -23,6 +23,7 @@ const CDP = @import("../cdp/CDP.zig");
 const Notification = @import("../Notification.zig");
 
 const js = @import("js/js.zig");
+const NativeMemoryAccount = @import("NativeMemoryAccount.zig");
 const Page = @import("Page.zig");
 const Watchdog = @import("../Watchdog.zig");
 const Session = @import("Session.zig");
@@ -45,6 +46,11 @@ session: ?Session,
 allocator: Allocator,
 arena_pool: *ArenaPool,
 http_client: HttpClient,
+
+// Arena backing allocations owned by this browser. Allocation paths update
+// atomics; only flushNativeMemory calls V8 from the isolate thread.
+native_memory: NativeMemoryAccount = .{},
+reported_native_memory: i64 = 0,
 
 // Shared across pages, survives navigation. See Selector.Cache.
 selector_cache: Selector.Cache,
@@ -133,6 +139,7 @@ pub fn init(self: *Browser, app: *App, opts: InitOpts, cdp: ?*CDP) !void {
 
 pub fn deinit(self: *Browser) void {
     self.closeSession();
+    std.debug.assert(self.native_memory.active() == 0);
     // After this returns, the watchdog thread holds no reference to our env
     // or http_client — required before either is torn down.
     self.app.watchdog.unregister(&self.watchdog_entry);
@@ -191,13 +198,21 @@ pub fn closeSession(self: *Browser) void {
         session.deinit();
         self.session = null;
     }
+    self.flushNativeMemory();
+}
+
+pub fn flushNativeMemory(self: *Browser) void {
+    const delta = self.native_memory.takePendingDelta();
+    if (delta != 0) self.reported_native_memory = self.env.isolate.adjustAmountOfExternalAllocatedMemory(delta);
 }
 
 pub fn runMicrotasks(self: *Browser) void {
+    defer self.flushNativeMemory();
     self.env.runMicrotasks();
 }
 
 pub fn runMacrotasks(self: *Browser) !void {
+    defer self.flushNativeMemory();
     const env = &self.env;
 
     try self.env.runMacrotasks();
@@ -223,6 +238,7 @@ pub fn msToNextTask(self: *Browser) ?u64 {
     return self.env.msToNextTask();
 }
 
-pub fn runIdleTasks(self: *const Browser) void {
+pub fn runIdleTasks(self: *Browser) void {
+    defer self.flushNativeMemory();
     self.env.runIdleTasks();
 }

--- a/src/browser/NativeMemoryAccount.zig
+++ b/src/browser/NativeMemoryAccount.zig
@@ -1,0 +1,65 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const NativeMemoryAccount = @This();
+
+active_bytes: std.atomic.Value(usize) = .init(0),
+pending_delta: std.atomic.Value(i64) = .init(0),
+
+pub fn add(self: *NativeMemoryAccount, bytes: usize) void {
+    if (bytes == 0) return;
+    const delta: i64 = @intCast(bytes);
+    _ = self.active_bytes.fetchAdd(bytes, .monotonic);
+    _ = self.pending_delta.fetchAdd(delta, .release);
+}
+
+pub fn remove(self: *NativeMemoryAccount, bytes: usize) void {
+    if (bytes == 0) return;
+    const delta: i64 = @intCast(bytes);
+    const previous = self.active_bytes.fetchSub(bytes, .monotonic);
+    std.debug.assert(previous >= bytes);
+    _ = self.pending_delta.fetchSub(delta, .release);
+}
+
+pub fn active(self: *const NativeMemoryAccount) usize {
+    return self.active_bytes.load(.acquire);
+}
+
+pub fn takePendingDelta(self: *NativeMemoryAccount) i64 {
+    return self.pending_delta.swap(0, .acq_rel);
+}
+
+const testing = std.testing;
+
+test "NativeMemoryAccount: accumulates signed pending changes" {
+    var account: NativeMemoryAccount = .{};
+
+    account.add(100);
+    account.add(25);
+    account.remove(40);
+
+    try testing.expectEqual(85, account.active());
+    try testing.expectEqual(85, account.takePendingDelta());
+    try testing.expectEqual(0, account.takePendingDelta());
+
+    account.remove(85);
+    try testing.expectEqual(0, account.active());
+    try testing.expectEqual(-85, account.takePendingDelta());
+}

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -146,7 +146,7 @@ pub fn getViewport(self: *const Page) Viewport {
 
 // Initialize a Page and its root Frame.
 pub fn init(self: *Page, session: *Session, frame_id: u32) !void {
-    const frame_arena = try session.arena_pool.acquire(.large, "Page.frame_arena");
+    const frame_arena = try session.getArena(.large, "Page.frame_arena");
     errdefer session.arena_pool.release(frame_arena);
 
     self.* = .{
@@ -217,10 +217,9 @@ pub fn deinit(self: *Page) void {
     }
     // Defensive cleanup in case origins leaked.
     {
-        const app = session.browser.app;
         var it = self.origins.valueIterator();
         while (it.next()) |value| {
-            value.*.deinit(app);
+            value.*.deinit();
         }
         self.origins = .empty;
     }
@@ -244,7 +243,7 @@ pub fn getOrCreateOrigin(self: *Page, key_: ?[]const u8) !*js.Origin {
         // Origin.init will dupe opaque_origin. It's fine that this doesn't
         // get added to self.origins. In fact, it further isolates it. When the
         // context is freed, it'll call Page.releaseOrigin which will free it.
-        return js.Origin.init(session.browser.app, session.browser.env.isolate, &opaque_origin);
+        return js.Origin.init(session.arena_pool, &session.browser.native_memory, session.browser.env.isolate, &opaque_origin);
     };
 
     const gop = try self.origins.getOrPut(session.arena, key);
@@ -256,7 +255,7 @@ pub fn getOrCreateOrigin(self: *Page, key_: ?[]const u8) !*js.Origin {
 
     errdefer _ = self.origins.remove(key);
 
-    const origin = try js.Origin.init(session.browser.app, session.browser.env.isolate, key);
+    const origin = try js.Origin.init(session.arena_pool, &session.browser.native_memory, session.browser.env.isolate, key);
     gop.key_ptr.* = origin.key;
     gop.value_ptr.* = origin;
     return origin;
@@ -295,7 +294,7 @@ pub fn releaseOrigin(self: *Page, origin: *js.Origin) void {
     const rc = origin.rc;
     if (rc == 1) {
         _ = self.origins.remove(origin.key);
-        origin.deinit(self.session.browser.app);
+        origin.deinit();
     } else {
         origin.rc = rc - 1;
     }

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -205,6 +205,7 @@ fn _tick(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
     const session = self.session;
     const browser = self.browser;
     const http_client = self.http_client;
+    defer browser.flushNativeMemory();
 
     // Arms the watchdog (and proves liveness): a stall anywhere in this tick
     // ages this stamp until the watchdog fires.

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -158,7 +158,7 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     const allocator = browser.app.allocator;
     const arena_pool = browser.arena_pool;
 
-    const arena = try arena_pool.acquire(.small, "Session");
+    const arena = try arena_pool.acquireFor(&browser.native_memory, .small, "Session");
     errdefer arena_pool.release(arena);
 
     self.* = .{
@@ -393,7 +393,7 @@ pub fn closeAllPages(self: *Session) void {
 }
 
 pub fn getArena(self: *Session, size_or_bucket: anytype, debug: []const u8) !Allocator {
-    return self.arena_pool.acquire(size_or_bucket, debug);
+    return self.arena_pool.acquireFor(&self.browser.native_memory, size_or_bucket, debug);
 }
 
 pub fn releaseArena(self: *Session, allocator: Allocator) void {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -115,6 +115,7 @@ pub fn deinit(self: *Caller) void {
     ctx.call_depth = call_depth;
     ctx.local = self.prev_local;
     ctx.global.setJs(self.prev_context);
+    if (call_depth == 0) ctx.page.session.browser.flushNativeMemory();
 }
 
 pub const CallOpts = struct {

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -205,7 +205,7 @@ pub fn deinit(self: *Context) void {
     }
 
     const env = self.env;
-    defer env.app.arena_pool.release(self.arena);
+    defer self.page.session.releaseArena(self.arena);
 
     // Unlink any IndexedDB gate participants first: the session-scoped engine
     // must never wake a waiter into this scheduler once it's torn down.

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -254,8 +254,8 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
     const T = @TypeOf(global);
     const is_frame = T == *Frame;
 
-    const context_arena = try self.app.arena_pool.acquire(.medium, params.debug_name);
-    errdefer self.app.arena_pool.release(context_arena);
+    const context_arena = try global._session.getArena(.medium, params.debug_name);
+    errdefer global._session.releaseArena(context_arena);
 
     const isolate = self.isolate;
     var hs: js.HandleScope = undefined;

--- a/src/browser/js/Isolate.zig
+++ b/src/browser/js/Isolate.zig
@@ -51,6 +51,10 @@ pub fn memoryPressureNotification(self: Isolate, level: MemoryPressureLevel) voi
     v8.v8__Isolate__MemoryPressureNotification(self.handle, @intFromEnum(level));
 }
 
+pub fn adjustAmountOfExternalAllocatedMemory(self: Isolate, delta: i64) i64 {
+    return v8.v8__Isolate__AdjustAmountOfExternalAllocatedMemory(self.handle, delta);
+}
+
 pub fn notifyContextDisposed(self: Isolate) void {
     _ = v8.v8__Isolate__ContextDisposedNotification(self.handle);
 }

--- a/src/browser/js/Origin.zig
+++ b/src/browser/js/Origin.zig
@@ -27,7 +27,8 @@
 const std = @import("std");
 const js = @import("js.zig");
 
-const App = @import("../../App.zig");
+const ArenaPool = @import("../../ArenaPool.zig");
+const NativeMemoryAccount = @import("../NativeMemoryAccount.zig");
 
 const v8 = js.v8;
 const Allocator = std.mem.Allocator;
@@ -36,6 +37,7 @@ const Origin = @This();
 
 rc: usize = 1,
 arena: Allocator,
+arena_pool: *ArenaPool,
 
 // The key, e.g. lightpanda.io:443
 key: []const u8,
@@ -44,9 +46,9 @@ key: []const u8,
 // as their security token for V8 to allow cross-context access
 security_token: v8.Global,
 
-pub fn init(app: *App, isolate: js.Isolate, key: []const u8) !*Origin {
-    const arena = try app.arena_pool.acquire(.tiny, "Origin");
-    errdefer app.arena_pool.release(arena);
+pub fn init(arena_pool: *ArenaPool, owner: *NativeMemoryAccount, isolate: js.Isolate, key: []const u8) !*Origin {
+    const arena = try arena_pool.acquireFor(owner, .tiny, "Origin");
+    errdefer arena_pool.release(arena);
 
     var hs: js.HandleScope = undefined;
     hs.init(isolate);
@@ -61,13 +63,14 @@ pub fn init(app: *App, isolate: js.Isolate, key: []const u8) !*Origin {
     self.* = .{
         .rc = 1,
         .arena = arena,
+        .arena_pool = arena_pool,
         .key = owned_key,
         .security_token = token_global,
     };
     return self;
 }
 
-pub fn deinit(self: *Origin, app: *App) void {
+pub fn deinit(self: *Origin) void {
     v8.v8__Global__Reset(&self.security_token);
-    app.arena_pool.release(self.arena);
+    self.arena_pool.release(self.arena);
 }

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -720,13 +720,13 @@ pub const BrowserContext = struct {
 
     pub fn createIsolatedWorld(self: *BrowserContext, world_name: []const u8, grant_universal_access: bool) !*IsolatedWorld {
         const browser = &self.cdp.browser;
-        const arena = try browser.arena_pool.acquire(.small, "IsolatedWorld");
+        const arena = try browser.arena_pool.acquireFor(&browser.native_memory, .small, "IsolatedWorld");
         errdefer browser.arena_pool.release(arena);
 
-        const call_arena = try browser.arena_pool.acquire(.tiny, "IsolatedWorld.call_arena");
+        const call_arena = try browser.arena_pool.acquireFor(&browser.native_memory, .tiny, "IsolatedWorld.call_arena");
         errdefer browser.arena_pool.release(call_arena);
 
-        const local_arena = try browser.arena_pool.acquire(.tiny, "IsolatedWorld.local_arena");
+        const local_arena = try browser.arena_pool.acquireFor(&browser.native_memory, .tiny, "IsolatedWorld.local_arena");
         errdefer browser.arena_pool.release(local_arena);
 
         const world = try arena.create(IsolatedWorld);
@@ -1408,6 +1408,31 @@ test "cdp: invalid sessionId" {
         try ctx.processMessage(.{ .method = "Hi", .sessionId = "SESS-1" });
         try ctx.expectSentError(-32001, "Unknown sessionId", .{});
     }
+}
+
+test "cdp: browser arena memory is reported to V8" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    _ = try ctx.loadBrowserContext(.{});
+    const browser = &ctx.cdp().browser;
+    browser.flushNativeMemory();
+    const native_before = browser.native_memory.active();
+    const reported_before = browser.reported_native_memory;
+
+    {
+        const arena = try browser.arena_pool.acquireFor(&browser.native_memory, .large, "external memory test");
+        defer browser.arena_pool.release(arena);
+        _ = try arena.alloc(u8, 64 * 1024);
+        const native_added = browser.native_memory.active() - native_before;
+        try testing.expect(native_added > 0);
+
+        browser.flushNativeMemory();
+        try testing.expectEqual(reported_before + @as(i64, @intCast(native_added)), browser.reported_native_memory);
+    }
+    browser.flushNativeMemory();
+    try testing.expectEqual(native_before, browser.native_memory.active());
+    try testing.expectEqual(reported_before, browser.reported_native_memory);
 }
 
 test "cdp: STARTUP sessionId" {


### PR DESCRIPTION
## Summary

Track backing allocations for browser-owned `ArenaPool` arenas and report signed changes to the owning V8 isolate with `AdjustAmountOfExternalAllocatedMemory`.

Each `Browser` owns an atomic `NativeMemoryAccount`. Arena allocation, resize, remap, free, reuse, reset, and pool-return paths update only atomics, so network or allocator threads never call V8. Pending deltas are flushed from runner ticks, V8-to-Zig callback returns, and session teardown on the isolate-owning thread.

Retained capacity is transferred to an account when a pooled arena is checked out and removed when it returns to the process-wide pool. Session, page, context, origin, worker, and isolated-world arenas are attributed to their browser. The process-wide `browser_native_memory_bytes` gauge exposes the currently attributed total.

Tests cover signed delta accumulation, backing allocation and reset accounting, retained-capacity transfer between two browser accounts, V8 reporting, and zero active bytes at browser teardown.

Closes #3027.

## Dependencies

This PR is now rebased onto current `main`, so the merged #3026 commit is no longer part of its diff.

`build.zig.zon` now points to merged upstream commit `acde80cb05841e60a8396273adebb49b708c83ac` in `lightpanda-io/zig-v8-fork`, which contains the Zig 0.16 migration from zig-v8-fork#189 and the external-memory binding from zig-v8-fork#190. The temporary dependency on my fork has been removed.

The remaining readiness blocker is a published zig-v8 prebuilt archive containing the new binding. Browser CI and release builds consume those archives, and the latest published archive predates #190. Once that archive is released, this PR can update to its release tag and be marked ready.

## Testing

- Full Zig 0.16 debug suite: 1073/1073 passed
- Zig 0.16 `ReleaseFast` targeted V8-reporting test: 1/1 passed
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`

Until the new upstream archive is published, local validation used the existing macOS V8 archive with a temporary uncommitted C++ shim for `v8__Isolate__AdjustAmountOfExternalAllocatedMemory`. No generated archive, shim, or local SDK-path adjustment is committed.
