### PR TITLE
v8: Expose Float16Array

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.5.1'
+    default: 'v0.5.2'
   v8:
     description: 'v8 version to install'
     required: false

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig-v8 release tag the prebuilt lib came from'
     required: false
-    default: 'v0.5.1'
+    default: 'v0.5.2'
 
 runs:
   using: "composite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.9.207.35
-ARG ZIG_V8=v0.5.1
+ARG ZIG_V8=v0.5.2
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/d2f997de95dd35174969e38599d98be50c057d85.tar.gz",
-            .hash = "v8-0.0.0-xddH6zTvAgB67DOl86uWsVwNpK8VXaEOYzu8fkl9glNe",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/78b6c77d5f6f040a575539203e6f3fad42453890.tar.gz",
+            .hash = "v8-0.0.0-xddH6xHyAgDVbf39iQaZfmzZCdNi7m3iTqOKbKz74Ggx",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -931,6 +931,12 @@ fn jsValueToTypedArray(comptime T: type, js_val: js.Value) !?[]T {
                 return ptr[0..num_elements];
             }
         },
+        f16 => {
+            if (js_val.isFloat16Array()) {
+                const ptr = @as([*]f16, @ptrCast(@alignCast(base)));
+                return ptr[0..num_elements];
+            }
+        },
         f32 => {
             if (js_val.isFloat32Array()) {
                 const ptr = @as([*]f32, @ptrCast(@alignCast(base)));
@@ -1069,6 +1075,9 @@ fn probeJsValueToZig(self: *const Local, comptime T: type, js_val: js.Value) !Pr
                             return .{ .ok = {} };
                         },
                         i64 => if (js_val.isBigInt64Array()) {
+                            return .{ .ok = {} };
+                        },
+                        f16 => if (js_val.isFloat16Array()) {
                             return .{ .ok = {} };
                         },
                         f32 => if (js_val.isFloat32Array()) {

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -166,6 +166,10 @@ pub fn isBigInt64Array(self: Value) bool {
     return v8.v8__Value__IsBigInt64Array(self.handle);
 }
 
+pub fn isFloat16Array(self: Value) bool {
+    return v8.v8__Value__IsFloat16Array(self.handle);
+}
+
 pub fn isFloat32Array(self: Value) bool {
     return v8.v8__Value__IsFloat32Array(self.handle);
 }


### PR DESCRIPTION
Depends on https://github.com/lightpanda-io/zig-v8-fork/pull/191

If nothing else, it allows more WPT tests to pass, e.g.: /websockets/Send-binary-arraybufferview-float16.any.html?default