### PR TITLE
cdp: make Network.enable idempotent

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -573,6 +573,10 @@ pub const BrowserContext = struct {
     // Browser.setDownloadBehavior calls don't add duplicate listeners.
     download_events_registered: bool = false,
 
+    // True once we've registered for the network notifications, so repeated
+    // Network.enable calls don't add duplicate listeners.
+    network_events_registered: bool = false,
+
     // Extra headers to add to all requests.
     extra_headers: std.ArrayList([*c]const u8) = .empty,
 
@@ -808,12 +812,16 @@ pub const BrowserContext = struct {
     }
 
     pub fn networkEnable(self: *BrowserContext) !void {
+        if (self.network_events_registered) return;
+        errdefer self.networkDisable();
+
         try self.notification.register(.http_request_fail, self, onHttpRequestFail);
         try self.notification.register(.http_request_start, self, onHttpRequestStart);
         try self.notification.register(.http_request_done, self, onHttpRequestDone);
         try self.notification.register(.http_response_data, self, onHttpResponseData);
         try self.notification.register(.http_response_header_done, self, onHttpResponseHeadersDone);
         try self.notification.register(.http_request_served_from_cache, self, onHttpRequestServedFromCache);
+        self.network_events_registered = true;
     }
 
     pub fn networkDisable(self: *BrowserContext) void {
@@ -823,6 +831,7 @@ pub const BrowserContext = struct {
         self.notification.unregister(.http_response_data, self);
         self.notification.unregister(.http_response_header_done, self);
         self.notification.unregister(.http_request_served_from_cache, self);
+        self.network_events_registered = false;
     }
 
     pub fn fetchEnable(self: *BrowserContext, authRequests: bool) !void {

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -981,3 +981,35 @@ test "cdp.Network: configured CDP ignores setCacheDisabled" {
     try ctx.expectSentResult(null, .{ .id = 2 });
     try testing.expect(client.cache == &cache);
 }
+
+test "cdp.Network: repeated enable does not duplicate captured response bodies" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const cdp = ctx.cdp();
+    _ = try cdp.createBrowserContext();
+    var bc = &cdp.browser_context.?;
+    bc.id = "BID-NE";
+    bc.session_id = "SID-NE";
+    bc.target_id = "TID-NE-0000000".*;
+
+    try ctx.processMessage(.{ .id = 1, .method = "Network.enable" });
+    try ctx.processMessage(.{ .id = 2, .method = "Network.enable" });
+
+    const fixture_root = "http://127.0.0.1:9582/src/browser/tests/cdp/";
+    const page = try bc.session.createPage();
+    try page.navigate(fixture_root ++ "dom1.html", .{});
+    try testing.waitForPage(bc);
+
+    const expected = @embedFile("../../browser/tests/cdp/dom1.html");
+    var matches: usize = 0;
+    var responses = bc.captured_responses.valueIterator();
+    while (responses.next()) |response| {
+        if (std.mem.indexOf(u8, response.data.items, "<p>1</p>") == null) {
+            continue;
+        }
+        matches += 1;
+        try std.testing.expectEqualStrings(expected, response.data.items);
+    }
+    try testing.expectEqual(1, matches);
+}


### PR DESCRIPTION
## Summary

- make `Network.enable` idempotent per browser context
- clean up partially registered network listeners if enabling fails
- reset the registration state when `Network.disable` runs
- add a regression test that verifies a response body is captured exactly once after two enable calls

## Root cause

`Notification.register` appends a listener on every call. Calling `Network.enable` twice therefore registers the same `http_response_data` callback twice, and `onHttpResponseData` appends every chunk twice to `captured_responses`.

This is independent of #3037, which covers Network event payload completeness and worker request propagation.

## Reproduction

Without this fix, the new test receives:

```text
<p>1</p> <p>2</p>
<p>1</p> <p>2</p>
```

instead of the fixture body once.

## Testing

- regression test: 1/1 passed after failing on unpatched `main`
- `TEST_FILTER='cdp.Network' ... zig build ... test`: 9/9 passed
- full test suite: 1062/1062 passed
- tracked Zig files: `zig fmt --check`
- `git diff --check`
