### PR TITLE
Fix Seg Fault on `window.reportError`

### DIFF
--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -624,6 +624,9 @@ pub fn reportError(self: *Window, err: js.Value, frame: *Frame) !void {
     }
 
     const event = error_event.asEvent();
+    event.acquireRef();
+    defer event.releaseRef(frame._page);
+
     event._prevent_default = prevent_default;
     // Pass null as handler: onerror was already called above with 5 args.
     // We still dispatch so that addEventListener('error', ...) listeners fire.


### PR DESCRIPTION
If you run the integration tests with the Cache enabled (either FS or Sqlite), the old-reddit test when served from the cache will sometimes segfault within the `window.reportError`. My guess is that the event is somehow being cleaned up before we check the `_prevent_default` later. This seems to fix it in both cases.