### PR TITLE
perf: improve ResizeObserver performance

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1956,7 +1956,7 @@ pub fn domChanged(self: *Frame) void {
     // A DOM change is our "rendering opportunity": re-evaluate the layout
     // observers. Both are no-ops unless something they track actually changed.
     observers.scheduleIntersectionChecks(self);
-    observers.scheduleResizeDelivery(self);
+    observers.scheduleResizeChecks(self);
 }
 
 const ElementIdMaps = struct { lookup: *std.StringHashMapUnmanaged(*Element), removed_ids: *std.StringHashMapUnmanaged(void) };

--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -511,10 +511,12 @@ fn addRawRule(self: *StyleManager, build_arena: Allocator, selector_text: []cons
 
 pub fn sheetRemoved(self: *StyleManager) void {
     self.dirty = true;
+    Frame.observers.scheduleResizeDelivery(self.frame);
 }
 
 pub fn sheetModified(self: *StyleManager) void {
     self.dirty = true;
+    Frame.observers.scheduleResizeDelivery(self.frame);
 }
 
 /// Rebuilds the rule list from all document stylesheets.

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -16,10 +16,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// Per-frame MutationObserver and IntersectionObserver bookkeeping: registration,
-// the scheduling of the microtask deliveries, and broadcasting DOM mutations to
-// the registered observers. The state lives on the Frame (frame._mutation /
-// frame._intersection); these functions operate on it.
+// Per-frame MutationObserver, IntersectionObserver and ResizeObserver
+// bookkeeping: registration, the scheduling of the microtask deliveries, and
+// broadcasting DOM mutations to the registered observers. The state lives on
+// the Frame (frame._mutation / frame._intersection / frame._resize); these
+// functions operate on it.
 
 const std = @import("std");
 const lp = @import("lightpanda");
@@ -57,6 +58,7 @@ pub const Intersection = struct {
 pub const Resize = struct {
     // List of active ResizeObservers (i.e. those with >= 1 observation)
     observers: std.ArrayList(*ResizeObserver) = .empty,
+    check_scheduled: bool = false,
     delivery_scheduled: bool = false,
     delivery_depth: u32 = 0,
 };
@@ -171,6 +173,81 @@ pub fn scheduleResizeDelivery(frame: *Frame) void {
     };
 }
 
+// Called on every DOM change, a full delivery is too expensive to call here.
+// What we can do is schedule a check.
+pub fn scheduleResizeChecks(frame: *Frame) void {
+    if (frame._resize.observers.items.len == 0) {
+        return;
+    }
+    if (frame._resize.check_scheduled or frame._resize.delivery_scheduled) {
+        // check is already scheduled OR delivery is already scheduled
+        return;
+    }
+    frame._resize.check_scheduled = true;
+    frame.js.queueResizeChecks() catch |err| {
+        frame._resize.check_scheduled = false;
+        log.err(.frame, "frame.scheduleResizeChecks", .{ .err = err, .type = frame._type, .url = frame.url });
+    };
+}
+
+pub fn performScheduledResizeChecks(frame: *Frame) void {
+    if (!frame._resize.check_scheduled) {
+        return;
+    }
+
+    frame._resize.check_scheduled = false;
+    if (frame._resize.delivery_scheduled) {
+        return;
+    }
+
+    // Check if we should schedule a delivery. If you're wondering why we're
+    // scheduling within a schedule, it's because this can be expensive and we
+    // want to coalesce as many of these into a single call as possible.
+    for (frame._resize.observers.items) |observer| {
+        if (observer.connectivityChanged()) {
+            scheduleResizeDelivery(frame);
+            return;
+        }
+    }
+}
+
+// Only these attributes can change an element's size or visibility in our
+// styling model (StyleManager.isHidden + Element.getElementDimensions), and
+// only for the element itself and its descendants — so a delivery is only
+// scheduled when an observed element is in the changed element's subtree.
+fn resizeAttributeChanged(frame: *Frame, element: *Element, name: String) void {
+    if (frame._resize.observers.items.len == 0) {
+        return;
+    }
+    if (frame._resize.delivery_scheduled) {
+        return;
+    }
+
+    // This has proven to be on the hot path
+    switch (name.len) {
+        2 => if (!name.eqlWithSameLen(comptime .wrap("id"))) {
+            return;
+        },
+        4 => if (!name.eqlWithSameLen(comptime .wrap("type")) and !name.eqlWithSameLen(comptime .wrap("open"))) {
+            return;
+        },
+        5 => if (!name.eqlWithSameLen(comptime .wrap("style")) and !name.eqlWithSameLen(comptime .wrap("class")) and !name.eqlWithSameLen(comptime .wrap("width"))) {
+            return;
+        },
+        6 => if (!name.eqlWithSameLen(comptime .wrap("hidden")) and !name.eqlWithSameLen(comptime .wrap("height"))) {
+            return;
+        },
+        else => return,
+    }
+
+    for (frame._resize.observers.items) |observer| {
+        if (observer.observesWithin(element)) {
+            scheduleResizeDelivery(frame);
+            return;
+        }
+    }
+}
+
 pub fn deliverResizes(frame: *Frame) void {
     if (!frame._resize.delivery_scheduled) {
         return;
@@ -183,7 +260,7 @@ pub fn deliverResizes(frame: *Frame) void {
     defer if (!frame._resize.delivery_scheduled) {
         frame._resize.delivery_depth = 0;
     };
-    if (frame._resize.delivery_depth > 50) {
+    if (frame._resize.delivery_depth > 16) {
         log.warn(.frame, "frame.ResizeLimit", .{ .type = frame._type, .url = frame.url });
         frame._resize.delivery_depth = 0;
         return;
@@ -242,7 +319,7 @@ pub fn deliverMutations(frame: *Frame) void {
         frame._mutation.delivery_depth = 0;
     };
 
-    if (frame._mutation.delivery_depth > 50) {
+    if (frame._mutation.delivery_depth > 16) {
         log.err(.frame, "frame.MutationLimit", .{ .type = frame._type, .url = frame.url });
         frame._mutation.delivery_depth = 0;
         return;
@@ -292,9 +369,10 @@ pub fn deliverMutations(frame: *Frame) void {
     }
 }
 
-// Broadcast an attribute change to every registered MutationObserver. The
-// caller (Frame.attributeChange / attributeRemove) handles the non-observer
-// side effects (build hooks, custom-element callbacks, slot/popover updates).
+// Broadcast an attribute change to every registered MutationObserver and to
+// the resize bookkeeping. The caller (Frame.attributeChange / attributeRemove)
+// handles the non-observer side effects (build hooks, custom-element
+// callbacks, slot/popover updates).
 pub fn notifyAttributeChange(frame: *Frame, element: *Element, name: String, old_value: ?String) void {
     var it: ?*std.DoublyLinkedList.Node = frame._mutation.observers.first;
     while (it) |node| : (it = node.next) {
@@ -303,6 +381,7 @@ pub fn notifyAttributeChange(frame: *Frame, element: *Element, name: String, old
             log.err(.frame, "attributeChange.notifyObserver", .{ .err = err, .type = frame._type, .url = frame.url });
         };
     }
+    resizeAttributeChanged(frame, element, name);
 }
 
 pub fn notifyCharacterDataChange(frame: *Frame, target: *Node, old_value: String) void {

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -1093,6 +1093,17 @@ pub fn queueIntersectionDelivery(self: *Context) !void {
     }.run);
 }
 
+pub fn queueResizeChecks(self: *Context) !void {
+    self.enqueueMicrotask(struct {
+        fn run(ctx: *Context) void {
+            switch (ctx.global) {
+                .frame => |frame| Frame.observers.performScheduledResizeChecks(frame),
+                .worker => unreachable,
+            }
+        }
+    }.run);
+}
+
 pub fn queueResizeDelivery(self: *Context) !void {
     self.enqueueMicrotask(struct {
         fn run(ctx: *Context) void {

--- a/src/browser/webapi/ResizeObserver.zig
+++ b/src/browser/webapi/ResizeObserver.zig
@@ -52,6 +52,7 @@ _observations: std.ArrayList(Observation) = .empty,
 
 const Observation = struct {
     target: *Element,
+    connected: bool = false,
     last_width: f64 = 0,
     last_height: f64 = 0,
 };
@@ -123,18 +124,50 @@ pub fn disconnect(self: *ResizeObserver, frame: *Frame) void {
     Frame.observers.unregisterResizeObserver(frame, self);
 }
 
+// True if any observed element's connectedness changed since the last
+// delivery. Runs on every DOM change (via Frame.observers), so it must stay
+// pointer walks only — no style lookups.
+pub fn connectivityChanged(self: *const ResizeObserver) bool {
+    for (self._observations.items) |obs| {
+        if (obs.target.asNode().isConnected() != obs.connected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// True if any observed element is `ancestor` or one of its descendants. Walks
+// the same parentElement chain StyleManager.isHidden resolves visibility
+// through.
+pub fn observesWithin(self: *const ResizeObserver, ancestor: *Element) bool {
+    for (self._observations.items) |obs| {
+        var current: ?*Element = obs.target;
+        while (current) |el| : (current = el.parentElement()) {
+            if (el == ancestor) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 // Gather the observations whose size changed since the last delivery and, if
 // any, invoke the callback.
 pub fn deliverEntries(self: *ResizeObserver, frame: *Frame) !void {
     var entries: std.ArrayList(*ResizeObserverEntry) = .empty;
+    // Observed elements share ancestors, so one cache serves the whole pass.
+    var visibility_cache: Element.VisibilityCache = .empty;
     for (self._observations.items) |*obs| {
         const target = obs.target;
+        const connected = target.asNode().isConnected();
+        obs.connected = connected;
 
         const width, const height = blk: {
-            if (obs.target.asNode().isConnected() == false) {
+            if (!connected or !target.checkVisibilityCached(&visibility_cache, frame)) {
                 break :blk .{ 0, 0 };
             }
-            break :blk .{ target.getClientWidth(frame), target.getClientHeight(frame) };
+            const dims = target.getElementDimensions(frame);
+            break :blk .{ dims.width, dims.height };
         };
 
         if (width == obs.last_width and height == obs.last_height) {

--- a/src/string.zig
+++ b/src/string.zig
@@ -179,16 +179,24 @@ pub const String = packed struct {
             return false;
         }
 
-        const len = a.len;
-        if (len < 0 or b.len < 0) {
+        if (a.len < 0 or b.len < 0) {
             return false;
         }
+        return eqlWithSameLen(a, b);
+    }
 
+    // Dangerous. Use this only when you have to (and, obviously, when you know
+    // a.len == b.len)
+    pub fn eqlWithSameLen(a: String, b: String) bool {
+        if (comptime IS_DEBUG) {
+            std.debug.assert(a.len == b.len);
+        }
+
+        const len = a.len;
         if (len <= 12) {
             return a.payload.content == b.payload.content;
         }
 
-        // a.len == b.len at this point
         const al: usize = @intCast(len);
         const bl: usize = @intCast(len);
         const ap: [*]const u8 = @ptrFromInt(a.payload.heap.ptr);


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/3000 improved the correctness of ResizeObserver. The main changes were (a) making sure an observe results in an initial callback and (b) invoking the callback for cases that we can identity (e.g. visibility change).

Like the other observers, we triggered a check on domChanged. But, unlike the other observers, the check is relatively expensive, namely because it involves style lookups.

This commit introduces a number of performance improvements to reduce the check and dispatch frequency.

1 - Only trigger on an allow list of attribute changed (id, class, hidden, width
 ...)
2 - Pre-filter only on observed elements
3 - Leverage the visibility cache for more efficient delivery