### PR TITLE
make: key the prebuilt-V8 cache on the zig-v8 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,18 @@ endif
 # Building V8 from source takes 10+ minutes. `make download-v8` fetches the
 # matching prebuilt archive from the zig-v8-fork releases instead. The versions
 # are read from the install action so they can't drift from CI.
+#
+# The cache path is keyed on ZIG_V8_TAG as well as the archive name: a
+# zig-v8-fork release keeps the same asset filename across tags (the name
+# encodes only the V8 version), so a tag bump that leaves V8_VERSION alone
+# still ships different bytes. Keying the cache on the filename alone made
+# download-v8's `test -f` guard skip that refresh and leave a stale archive
+# in place, which then fails at link time on undefined v8__* symbols.
 V8_ACTION := .github/actions/install/action.yml
 V8_VERSION := $(shell awk -F\' '/^  v8:/{f=1} f&&/default:/{print $$2; exit}' $(V8_ACTION))
 ZIG_V8_TAG := $(shell awk -F\' '/^  zig-v8:/{f=1} f&&/default:/{print $$2; exit}' $(V8_ACTION))
 V8_ARCHIVE := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).a
-V8_CACHE   := .lp-cache/prebuilt-v8/$(V8_ARCHIVE)
+V8_CACHE   := .lp-cache/prebuilt-v8/$(ZIG_V8_TAG)/$(V8_ARCHIVE)
 
 # If the prebuilt archive is in place and the caller hasn't set ZIGFLAGS, point
 # the build at it rather than building V8 from source.


### PR DESCRIPTION
## Problem

`make download-v8` caches the prebuilt archive at a path keyed on the asset filename:

```make
V8_ARCHIVE := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).a
V8_CACHE   := .lp-cache/prebuilt-v8/$(V8_ARCHIVE)
```

That filename encodes the V8 version but not the zig-v8-fork tag, and the fork reuses the name across releases. Same name, different bytes:

| tag | asset | size |
|---|---|---|
| `v0.5.0` | `libc_v8_14.9.207.35_macos_aarch64.a` | 106944896 |
| `v0.5.1` | `libc_v8_14.9.207.35_macos_aarch64.a` | 106945416 |
| `v0.5.2` | `libc_v8_14.9.207.35_macos_aarch64.a` | 106945984 |

So when `zig-v8` is bumped in `.github/actions/install/action.yml` while `v8` stays put, the cache is never invalidated. The `test -f $(V8_CACHE)` guard finds the old archive and skips the download:

```make
@test -f $(V8_CACHE) || ( ... curl ... )
```

The build then links bindings from whichever tag you happened to fetch first. After the `v0.5.2` bump that surfaces as:

```
error: undefined symbol: _v8__Value__IsFloat16Array
error: undefined symbol: _v8__V8__SetFlagsFromString
error: undefined symbol: _v8__Isolate__AddNearHeapLimitCallback
error: 3 compilation errors
```

I hit this building `main` at `044d5c91`. My cache held the 106944896-byte `v0.5.0` asset, which `download-v8` had kept through both the `v0.5.1` and `v0.5.2` bumps. What made it hard to spot: `make download-v8` prints `V8 ready:` right before the link dies, and the archive it names really is there.

## Fix

Put the tag in the cache path:

```make
V8_CACHE := .lp-cache/prebuilt-v8/$(ZIG_V8_TAG)/$(V8_ARCHIVE)
```

Each tag gets its own entry, so a bump downloads and a repeat run still hits the cache. The download URL is untouched and keeps using the bare asset name, since that is what the release publishes. `mkdir -p $(dir $(V8_CACHE))` already creates the new subdirectory, and the `wildcard` check that auto-populates `ZIGFLAGS` follows the same variable.

## Testing

On macOS aarch64, `main` at `044d5c91`:

```
$ make download-v8                          # fresh
Downloading prebuilt V8 14.9.207.35 (v0.5.2)...
V8 ready: .lp-cache/prebuilt-v8/v0.5.2/libc_v8_14.9.207.35_macos_aarch64.a

$ make download-v8                          # cache hit, no download
V8 ready: .lp-cache/prebuilt-v8/v0.5.2/libc_v8_14.9.207.35_macos_aarch64.a

$ make download-v8 ZIG_V8_TAG=v0.5.1        # tag bump, re-downloads
Downloading prebuilt V8 14.9.207.35 (v0.5.1)...
V8 ready: .lp-cache/prebuilt-v8/v0.5.1/libc_v8_14.9.207.35_macos_aarch64.a
```

The two archives land side by side at 106945984 and 106945416 bytes, matching the release assets. Before this change the third command was a no-op that left the `v0.5.2` bytes in place.

`ZIGFLAGS` auto-detection still resolves, and follows the tag:

```
$ make -n build-v8-snapshot | grep -o '\-Dprebuilt_v8_path=[^ ]*'
-Dprebuilt_v8_path=.lp-cache/prebuilt-v8/v0.5.2/libc_v8_14.9.207.35_macos_aarch64.a

$ make -n build-v8-snapshot ZIG_V8_TAG=v0.5.1 | grep -o '\-Dprebuilt_v8_path=[^ ]*'
-Dprebuilt_v8_path=.lp-cache/prebuilt-v8/v0.5.1/libc_v8_14.9.207.35_macos_aarch64.a
```

The fetched `v0.5.2` archive is byte-identical (sha256 `0a014591…`) to the one I used to complete a `-Doptimize=ReleaseFast` build of `044d5c91`, so this only changes where the file is stored, not which file is used.

## Scope

Local development only. CI installs V8 through `.github/actions/install` and never calls `download-v8`, so no workflow changes.

Anyone who ran the old target keeps an orphaned archive at the flat path. It is inert, and `rm .lp-cache/prebuilt-v8/*.a` reclaims the space. I did not add migration logic for that, since it is a gitignored cache and deleting files on someone's behalf in a Makefile seemed worse than a stale 100 MB.
