### PR TITLE
forms: close the ancestor dialog on method=dialog submission

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3404,6 +3404,31 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     const method = Element.Html.Form.normalizeMethod(method_attr, "get");
     const is_post = std.mem.eql(u8, method, "post");
 
+    // Per the HTML form-submission algorithm, the dialog method closes the
+    // form's nearest ancestor dialog with the submitter's value and performs no
+    // navigation. Falling through here would submit the form as a GET, which
+    // both reloads the page and leaves the dialog open forever.
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm
+    if (std.mem.eql(u8, method, "dialog")) {
+        var ancestor: ?*Element = form_element;
+        while (ancestor) |el| : (ancestor = el.parentElement()) {
+            const dialog = el.is(Element.Html.Dialog) orelse continue;
+            // A submit button always has a value (empty when the attribute is
+            // absent); with no submitter at all the dialog's existing
+            // returnValue is left untouched.
+            const result: ?[]const u8 = if (submit_button) |s|
+                s.getAttributeSafe(comptime .wrap("value")) orelse ""
+            else
+                null;
+            try dialog.close(result, self);
+            break;
+        }
+        // Nothing is navigated, so the arena reserved for the request body goes
+        // unused — the errdefer above only covers the error path.
+        self._session.releaseArena(arena);
+        return;
+    }
+
     // Get charset from accept-charset attribute or fall back to document charset
     const charset: []const u8 = blk: {
         if (form_element.getAttributeSafe(.wrap("accept-charset"))) |ac| {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3382,9 +3382,6 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     form_data.acquireRef();
     defer form_data.releaseRef(self._page);
 
-    const arena = try self._session.getArena(.medium, "submitForm");
-    errdefer self._session.releaseArena(arena);
-
     // Per HTML spec form-submission algorithm, when the submitter is a submit
     // button, its formaction/formmethod/formenctype attributes override the
     // form's corresponding attributes (matching how formtarget is honored above).
@@ -3402,7 +3399,6 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
         break :blk form_element.getAttributeSafe(comptime .wrap("method"));
     };
     const method = Element.Html.Form.normalizeMethod(method_attr, "get");
-    const is_post = std.mem.eql(u8, method, "post");
 
     // Per the HTML form-submission algorithm, the dialog method closes the
     // form's nearest ancestor dialog with the submitter's value and performs no
@@ -3410,24 +3406,29 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     // both reloads the page and leaves the dialog open forever.
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm
     if (std.mem.eql(u8, method, "dialog")) {
+        // A submit button always has a value (empty when unset); with no
+        // submitter at all the dialog's existing returnValue is left untouched.
+        const result: ?[]const u8 = if (submit_button) |s| blk: {
+            if (s.is(Element.Html.Form.Input)) |input| {
+                break :blk input.getValue();
+            }
+            // if not an Input, it has to be a Button (checked above by isSubmitButton)
+            break :blk s.as(Element.Html.Form.Button).getValue();
+        } else null;
+
         var ancestor: ?*Element = form_element;
         while (ancestor) |el| : (ancestor = el.parentElement()) {
             const dialog = el.is(Element.Html.Dialog) orelse continue;
-            // A submit button always has a value (empty when the attribute is
-            // absent); with no submitter at all the dialog's existing
-            // returnValue is left untouched.
-            const result: ?[]const u8 = if (submit_button) |s|
-                s.getAttributeSafe(comptime .wrap("value")) orelse ""
-            else
-                null;
             try dialog.close(result, self);
             break;
         }
-        // Nothing is navigated, so the arena reserved for the request body goes
-        // unused — the errdefer above only covers the error path.
-        self._session.releaseArena(arena);
         return;
     }
+
+    const is_post = std.mem.eql(u8, method, "post");
+
+    const arena = try self._session.getArena(.medium, "submitForm");
+    errdefer self._session.releaseArena(arena);
 
     // Get charset from accept-charset attribute or fall back to document charset
     const charset: []const u8 = blk: {

--- a/src/browser/tests/element/html/dialog.html
+++ b/src/browser/tests/element/html/dialog.html
@@ -198,3 +198,99 @@
     testing.expectEqual(0, fired)
   }
 </script>
+
+<script id="dialog_method_closes_with_submitter_value">
+  {
+    document.body.insertAdjacentHTML('beforeend',
+      '<dialog id="d_submit"><form method="dialog">' +
+      '<button type="submit" value="confirm" id="b_submit">ok</button>' +
+      '</form></dialog>')
+
+    const dialog = $('#d_submit')
+    dialog.showModal()
+
+    let fired = 0
+    dialog.addEventListener('close', () => fired++)
+
+    $('#b_submit').click()
+
+    testing.expectEqual(1, fired)
+    testing.expectEqual(false, dialog.open)
+    testing.expectEqual('confirm', dialog.returnValue)
+  }
+</script>
+
+<script id="dialog_method_uses_empty_value_when_submitter_has_none">
+  {
+    document.body.insertAdjacentHTML('beforeend',
+      '<dialog id="d_novalue"><form method="dialog">' +
+      '<button type="submit" id="b_novalue">ok</button>' +
+      '</form></dialog>')
+
+    const dialog = $('#d_novalue')
+    dialog.returnValue = 'preset'
+    dialog.showModal()
+
+    $('#b_novalue').click()
+
+    testing.expectEqual(false, dialog.open)
+    testing.expectEqual('', dialog.returnValue)
+  }
+</script>
+
+<script id="dialog_method_closes_nearest_ancestor_dialog">
+  {
+    document.body.insertAdjacentHTML('beforeend',
+      '<dialog id="d_outer"><dialog id="d_inner"><form method="dialog">' +
+      '<button type="submit" value="inner" id="b_nested">ok</button>' +
+      '</form></dialog></dialog>')
+
+    const outer = $('#d_outer')
+    const inner = $('#d_inner')
+    outer.show()
+    inner.show()
+
+    $('#b_nested').click()
+
+    testing.expectEqual(false, inner.open)
+    testing.expectEqual('inner', inner.returnValue)
+    testing.expectEqual(true, outer.open)
+  }
+</script>
+
+<script id="dialog_method_is_inert_without_ancestor_dialog">
+  {
+    // No ancestor dialog: the submission is dropped. It must not fall through
+    // to a GET submission either, so the form's own submit handler is the only
+    // thing that runs.
+    document.body.insertAdjacentHTML('beforeend',
+      '<form method="dialog" id="f_orphan">' +
+      '<button type="submit" value="x" id="b_orphan">ok</button>' +
+      '</form>')
+
+    let submits = 0
+    $('#f_orphan').addEventListener('submit', () => submits++)
+
+    $('#b_orphan').click()
+    testing.expectEqual(1, submits)
+  }
+</script>
+
+<script id="dialog_method_honors_formmethod_on_submitter">
+  {
+    // formmethod on the submit button overrides the form's method, so a GET
+    // form can still close its dialog.
+    document.body.insertAdjacentHTML('beforeend',
+      '<dialog id="d_formmethod"><form method="get">' +
+      '<button type="submit" formmethod="dialog" value="via-formmethod" id="b_formmethod">ok</button>' +
+      '</form></dialog>')
+
+    const dialog = $('#d_formmethod')
+    dialog.showModal()
+
+    $('#b_formmethod').click()
+
+    testing.expectEqual(false, dialog.open)
+    testing.expectEqual('via-formmethod', dialog.returnValue)
+  }
+</script>


### PR DESCRIPTION
Closes #3053

## What

`Form.normalizeMethod` already canonicalizes `method="dialog"`, but `Frame.submitForm` only ever branched on `"post"` — so a dialog submission fell through to the GET path. The document was reloaded, the dialog kept its `open` attribute, `returnValue` was never set, and no `close` event fired.

This adds the branch the [HTML form-submission algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm) calls for: walk up from the form to the nearest ancestor `<dialog>`, close it with the submitter's value via the existing `Dialog.close()`, and return without scheduling a navigation.

It completes the `<dialog>` work from #2435, which implemented `show` / `showModal` / `close` / `returnValue` but left unwired the form submission that drives them in real markup — `<dialog>` with its buttons in a `<form method="dialog">` is the standard confirm-dialog shape.

```mermaid
flowchart TD
    A["submitForm()"] --> B["normalizeMethod(method_attr)"]
    B --> C{"method"}
    C -->|"post"| D["POST body + navigate"]
    C -->|"get"| E["query string + navigate"]
    C -->|"dialog<br/>(before)"| E
    C -->|"dialog<br/>(after)"| F["nearest ancestor &lt;dialog&gt;?"]
    F -->|yes| G["Dialog.close(submitter value)<br/>no navigation"]
    F -->|no| H["drop the submission<br/>no navigation"]

    style E fill:#ffe0e0,stroke:#cc0000
    style G fill:#e0ffe0,stroke:#00aa00
    style H fill:#e0ffe0,stroke:#00aa00
```

## Fix

- `src/browser/Frame.zig` — `submitForm()`: branch on `method == "dialog"` right after the method is canonicalized (which is after the entry list is built and the `submit` event has been dispatched, matching the spec's ordering). Walk `parentElement()` from the form to the nearest `<dialog>` and `close()` it. The arena reserved for the request body is released explicitly, since the early return skips `scheduleNavigationWithArena` and the existing `errdefer` only covers the error path.
- The submitter's value becomes the dialog's `returnValue`. A submit button always has one — empty when the attribute is absent — so it is passed as `""` rather than left unset; with no submitter at all (`requestSubmit()` with no argument) the existing `returnValue` is preserved, per "if submitter has a value".
- `formmethod="dialog"` on the submit button works too, since the branch reads the already-resolved method rather than the form's attribute.

Not covered: the spec's `<input type=image>` sub-case, which sets `result` to `"x,y"` — there is no layout to source coordinates from, so such a submitter falls back to its value like any other.

## Tests

Six cases added to `src/browser/tests/element/html/dialog.html`, the fixture directory `HTMLDialogElement` already owns:

| case | asserts |
| --- | --- |
| `dialog_method_closes_with_submitter_value` | `close` fires once, `open` clears, `returnValue === "confirm"` |
| `dialog_method_uses_empty_value_when_submitter_has_none` | a valueless submit button resets `returnValue` to `""` |
| `dialog_method_closes_nearest_ancestor_dialog` | nested dialogs — the inner one closes, the outer stays open |
| `dialog_method_is_inert_without_ancestor_dialog` | no ancestor dialog: the `submit` event still fires, nothing else happens |
| `dialog_method_honors_formmethod_on_submitter` | `formmethod="dialog"` on the button overrides `method="get"` on the form |

Reverting `Frame.zig` to `main` makes `WebApi: HTML.Dialog` fail; restoring it passes. Full suite: `1073 of 1073 tests passed`.

End-to-end, with the dependency-free reproducer from #3053 (`python3` stdlib + the binary, no CDP client):

```
# nightly 1.0.0-nightly.8285+de85a51d
loads=2, closed=false, returnValue=, open=true          → exit 1

# this branch
loads=1, closed=true, returnValue=confirm, open=false   → exit 0
```
