### PR TITLE
fix(net): buffer closed ReadableStream bodies for fetch POST

### DIFF
--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -352,9 +352,11 @@
   {
     const state = await testing.async();
     const payload = "name=Streamed&count=9";
+    const enc = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
-        controller.enqueue(new TextEncoder().encode(payload));
+        controller.enqueue(enc.encode("name=Streamed&"));
+        controller.enqueue(enc.encode("count=9"));
         controller.close();
       },
     });
@@ -371,6 +373,44 @@
     await state.done(() => {
       testing.expectEqual(200, response.status);
       testing.expectEqual(payload, text);
+    });
+  }
+</script>
+
+<script id=fetch_readablestream_body_reject type=module>
+  {
+    const state = await testing.async();
+    const url = "http://127.0.0.1:9582/xhr/echo_post_body";
+    const opts = { method: "POST", duplex: "half" };
+
+    let openRejected = false;
+    try {
+      const open = new ReadableStream({
+        start(c) { c.enqueue(new TextEncoder().encode("x")); },
+      });
+      await fetch(url, { ...opts, body: open });
+    } catch (e) {
+      openRejected = e instanceof TypeError;
+    }
+
+    let lockedRejected = false;
+    try {
+      const locked = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("x"));
+          c.close();
+        },
+      });
+      locked.getReader();
+      await fetch(url, { ...opts, body: locked });
+    } catch (e) {
+      lockedRejected = e instanceof TypeError;
+    }
+
+    state.resolve();
+    await state.done(() => {
+      testing.expectEqual(true, openRejected);
+      testing.expectEqual(true, lockedRejected);
     });
   }
 </script>

--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -348,6 +348,33 @@
   }
 </script>
 
+<script id=fetch_readablestream_body type=module>
+  {
+    const state = await testing.async();
+    const payload = "name=Streamed&count=9";
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+        controller.close();
+      },
+    });
+
+    const response = await fetch("http://127.0.0.1:9582/xhr/echo_post_body", {
+      method: "POST",
+      body: stream,
+      duplex: "half",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    const text = await response.text();
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(200, response.status);
+      testing.expectEqual(payload, text);
+    });
+  }
+</script>
+
 <script id=fetch_blob_url_in_worker type=module>
   {
     const state = await testing.async();

--- a/src/browser/tests/net/fetch.html
+++ b/src/browser/tests/net/fetch.html
@@ -361,7 +361,7 @@
       },
     });
 
-    const response = await fetch("http://127.0.0.1:9582/xhr/echo_post_body", {
+    const response = await fetch("http://127.0.0.1:9582/echo_body", {
       method: "POST",
       body: stream,
       duplex: "half",
@@ -380,7 +380,7 @@
 <script id=fetch_readablestream_body_reject type=module>
   {
     const state = await testing.async();
-    const url = "http://127.0.0.1:9582/xhr/echo_post_body";
+    const url = "http://127.0.0.1:9582/echo_body";
     const opts = { method: "POST", duplex: "half" };
 
     let openRejected = false;
@@ -407,10 +407,30 @@
       lockedRejected = e instanceof TypeError;
     }
 
+    // A stream is single-use: draining it for one body must not leave it
+    // looking like a valid (empty) body for the next request.
+    const once = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("x"));
+        c.close();
+      },
+    });
+    const first = await fetch(url, { ...opts, body: once });
+    const firstText = await first.text();
+
+    let reuseRejected = false;
+    try {
+      await fetch(url, { ...opts, body: once });
+    } catch (e) {
+      reuseRejected = e instanceof TypeError;
+    }
+
     state.resolve();
     await state.done(() => {
       testing.expectEqual(true, openRejected);
       testing.expectEqual(true, lockedRejected);
+      testing.expectEqual("x", firstText);
+      testing.expectEqual(true, reuseRejected);
     });
   }
 </script>

--- a/src/browser/webapi/net/body_init.zig
+++ b/src/browser/webapi/net/body_init.zig
@@ -104,14 +104,12 @@ pub const BodyInit = union(enum) {
                     .content_type = null,
                 };
             },
-            .stream => {
-                // A ReadableStream body cannot be serialized synchronously.
-                // Callers that support streaming bodies (Response) special-case
-                // the `.stream` arm before calling extract; the Request/XHR
-                // paths that reach here have no place to store a stream, so
-                // they send an empty body. Like other non-string sources, a
-                // stream carries no default Content-Type.
-                return .{ .bytes = "", .content_type = null };
+            .stream => |stream| {
+                // Response special-cases `.stream` before extract. Request/XHR
+                // paths buffer a closed stream synchronously; open streams and
+                // async-only bodies reject rather than send Content-Length: 0.
+                const bytes = try stream.collectBodyBytes(arena);
+                return .{ .bytes = bytes, .content_type = null };
             },
         }
     }

--- a/src/browser/webapi/net/body_init.zig
+++ b/src/browser/webapi/net/body_init.zig
@@ -106,8 +106,9 @@ pub const BodyInit = union(enum) {
             },
             .stream => |stream| {
                 // Response special-cases `.stream` before extract. Request/XHR
-                // paths buffer a closed stream synchronously; open streams and
-                // async-only bodies reject rather than send Content-Length: 0.
+                // paths buffer a closed stream synchronously; a stream that
+                // can't be drained here - still open, or already used as a
+                // body - rejects rather than send Content-Length: 0.
                 const bytes = try stream.collectBodyBytes(arena);
                 return .{ .bytes = bytes, .content_type = null };
             },

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -53,6 +53,7 @@ _pull_fn: ?js.Function.Global = null,
 _pulling: bool = false,
 _pull_again: bool = false,
 _cancel: ?Cancel = null,
+_collected: bool = false,
 
 const UnderlyingSource = struct {
     start: ?js.Function = null,
@@ -132,39 +133,44 @@ pub fn getLocked(self: *const ReadableStream) bool {
 }
 
 /// Drain a closed stream's internal queue into bytes for outbound HTTP
-/// request bodies. Open, errored, or locked streams, and chunks that cannot
-/// be converted synchronously, return `error.TypeError`.
+/// request bodies. A stream that is locked, already used as a body, still
+/// readable, or errored - or that holds a chunk which isn't string or binary
+/// data - is `error.TypeError`. The queue is only consumed once every chunk
+/// has converted, so a rejected body leaves the stream as it was.
 pub fn collectBodyBytes(self: *ReadableStream, arena: std.mem.Allocator) ![]const u8 {
-    if (self.getLocked()) return error.TypeError;
+    if (self._collected or self.getLocked()) {
+        return error.TypeError;
+    }
     switch (self._state) {
         .errored, .readable => return error.TypeError,
         .closed => {},
     }
 
-    const exec = self._execution;
-    const local = exec.js.local orelse return error.TypeError;
+    const local = self._execution.js.local.?;
 
     var buf = std.Io.Writer.Allocating.init(arena);
-    const controller = self._controller;
-    while (controller.dequeue()) |chunk| {
+    const queue = &self._controller._queue;
+    for (queue.items) |chunk| {
         const bytes: []const u8 = switch (chunk) {
             .string => |s| s,
             .uint8array => |arr| arr.values,
             .js_value => |global| blk: {
                 const value = local.toLocal(global);
-                if (value.isTypedArray() or value.isArrayBufferView() or value.isArrayBuffer()) {
-                    const typed = try local.jsValueToZig([]u8, value);
-                    break :blk try arena.dupe(u8, typed);
-                } else if (value.isString()) |str| {
-                    const slice = try str.toSlice();
-                    break :blk try arena.dupe(u8, slice);
-                } else {
+                // toStringSmart falls back to toString(), which would turn a
+                // stray number or object into "42" / "[object Object]" bytes.
+                if (value.isString() == null and !value.isTypedArray() and
+                    !value.isArrayBufferView() and !value.isArrayBuffer())
+                {
                     return error.TypeError;
                 }
+                break :blk try value.toStringSmart();
             },
         };
         try buf.writer.writeAll(bytes);
     }
+
+    self._collected = true;
+    queue.clearRetainingCapacity();
     return buf.written();
 }
 

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -141,13 +141,32 @@ pub fn collectBodyBytes(self: *ReadableStream, arena: std.mem.Allocator) ![]cons
         .closed => {},
     }
 
+    const exec = self._execution;
+    if (exec.js.local == null) return error.TypeError;
+
+    var ls: js.Local.Scope = undefined;
+    exec.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls;
+
     var buf = std.Io.Writer.Allocating.init(arena);
     const controller = self._controller;
     while (controller.dequeue()) |chunk| {
-        const bytes = switch (chunk) {
+        const bytes: []const u8 = switch (chunk) {
             .string => |s| s,
             .uint8array => |arr| arr.values,
-            .js_value => return error.TypeError,
+            .js_value => |global| blk: {
+                const value = local.toLocal(global);
+                if (value.isTypedArray() or value.isArrayBufferView() or value.isArrayBuffer()) {
+                    const typed = try local.jsValueToZig([]u8, value);
+                    break :blk try arena.dupe(u8, typed);
+                } else if (value.isString()) |str| {
+                    const slice = try str.toSlice();
+                    break :blk try arena.dupe(u8, slice);
+                } else {
+                    return error.TypeError;
+                }
+            },
         };
         try buf.writer.writeAll(bytes);
     }

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -131,6 +131,29 @@ pub fn getLocked(self: *const ReadableStream) bool {
     return self._reader != null;
 }
 
+/// Drain a closed stream's internal queue into bytes for outbound HTTP
+/// request bodies. Open, errored, or locked streams, and chunks that cannot
+/// be converted synchronously, return `error.TypeError`.
+pub fn collectBodyBytes(self: *ReadableStream, arena: std.mem.Allocator) ![]const u8 {
+    if (self.getLocked()) return error.TypeError;
+    switch (self._state) {
+        .errored, .readable => return error.TypeError,
+        .closed => {},
+    }
+
+    var buf = std.Io.Writer.Allocating.init(arena);
+    const controller = self._controller;
+    while (controller.dequeue()) |chunk| {
+        const bytes = switch (chunk) {
+            .string => |s| s,
+            .uint8array => |arr| arr.values,
+            .js_value => return error.TypeError,
+        };
+        try buf.writer.writeAll(bytes);
+    }
+    return buf.written();
+}
+
 pub fn callPullIfNeeded(self: *ReadableStream) !void {
     if (!self.shouldCallPull()) {
         return;

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -142,12 +142,7 @@ pub fn collectBodyBytes(self: *ReadableStream, arena: std.mem.Allocator) ![]cons
     }
 
     const exec = self._execution;
-    if (exec.js.local == null) return error.TypeError;
-
-    var ls: js.Local.Scope = undefined;
-    exec.js.localScope(&ls);
-    defer ls.deinit();
-    const local = &ls;
+    const local = exec.js.local orelse return error.TypeError;
 
     var buf = std.Io.Writer.Allocating.init(arena);
     const controller = self._controller;

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -970,10 +970,12 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
-    if (std.mem.eql(u8, path, "/xhr/echo_post_body")) {
+    if (std.mem.eql(u8, path, "/echo_body")) {
+        // Echo the request body back verbatim, so tests can assert on the bytes
+        // a request actually sent rather than just on its status.
         var body_buf: [4096]u8 = undefined;
         const body = if (req.head.method.requestHasBody())
-            req.readerExpectNone(&body_buf).allocRemaining(arena_allocator, .limited(body_buf.len)) catch ""
+            try req.readerExpectNone(&body_buf).allocRemaining(arena_allocator, .limited(body_buf.len))
         else
             "";
         return req.respond(body, .{

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -970,6 +970,19 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/xhr/echo_post_body")) {
+        var body_buf: [4096]u8 = undefined;
+        const body = if (req.head.method.requestHasBody())
+            req.readerExpectNone(&body_buf).allocRemaining(arena_allocator, .limited(body_buf.len)) catch ""
+        else
+            "";
+        return req.respond(body, .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/plain; charset=utf-8" },
+            },
+        });
+    }
+
     if (std.mem.eql(u8, path, "/redirect_to_echo")) {
         // 302 to /echo_method. Used by the Page.reload-after-redirect test to
         // confirm a POST→302→GET chain doesn't replay POST on reload.


### PR DESCRIPTION
## Summary

- Fixes https://github.com/lightpanda-io/browser/issues/3052 where `fetch()` with a `ReadableStream` request body silently sent `Content-Length: 0` and an empty payload.
- Adds `ReadableStream.collectBodyBytes` to drain a **closed** stream's internal queue synchronously; open, locked, or errored streams reject with `TypeError` instead of sending nothing.
- JS `controller.enqueue` stores chunks as `.js_value` via `enqueueValue`; `collectBodyBytes` now converts TypedArray/ArrayBuffer/string `.js_value` entries (matching `Response.StreamConsumer._onReadFulfilled`) before buffering.
- `BodyInit.extract` `.stream` arm uses that helper instead of returning an empty byte slice.
- HTML fixtures: `fetch_readablestream_body` (multi-chunk success), `fetch_readablestream_body_reject` (open + locked streams → TypeError), plus `/xhr/echo_post_body` test-server endpoint.

## Approach

Implements option **2 (buffer)** from the issue for the common case (stream closed synchronously in `start()` with enqueued chunks), and option **1 (reject)** for streams that cannot be drained synchronously. This matches the issue's expected behavior diagram and avoids silent data loss.

## Test plan

- [x] `zig fmt --check` on changed `.zig` files — clean
- [ ] `TEST_FILTER="fetch_readablestream_body" make test` — **not run locally**: V8 `gclient sync` failed (`_bad_scm` conflicts; also `No space left on device` during llvm artifact extract). Maintainer CI should exercise the HTML fixtures.
- [ ] Full `make test` — blocked by same V8 cache/disk issue locally

## CLA

I will sign the CLA via cla-assistant-lite when prompted on this PR (first contribution to this repo).

Fixes #3052