### PR TITLE
mem: Change more call_arenas to local_arenas

### DIFF
--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -437,7 +437,7 @@ pub fn composedPath(self: *Event, exec: *Execution) ![]const *EventTarget {
     const visible_path_len = if (path_len > visible_start_index) path_len - visible_start_index else 0;
 
     // Allocate and return the visible path using call_arena (short-lived)
-    const path = try exec.call_arena.alloc(*EventTarget, visible_path_len);
+    const path = try exec.local_arena.alloc(*EventTarget, visible_path_len);
     @memcpy(path, path_buffer[visible_start_index..path_len]);
     return path;
 }

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -332,11 +332,11 @@ pub fn setOnUnhandledRejection(self: *WorkerGlobalScope, setter: ?FunctionSetter
 
 const base64 = @import("encoding/base64.zig");
 pub fn btoa(_: *const WorkerGlobalScope, input: base64.BinInput, exec: *JS.Execution) ![]const u8 {
-    return base64.encode(exec.call_arena, input);
+    return base64.encode(exec.local_arena, input);
 }
 
 pub fn atob(_: *const WorkerGlobalScope, input: base64.BinInput, exec: *JS.Execution) !JS.String.OneByte {
-    const bytes = try base64.decode(exec.call_arena, input);
+    const bytes = try base64.decode(exec.local_arena, input);
     return .{ .bytes = bytes };
 }
 

--- a/src/browser/webapi/WorkerLocation.zig
+++ b/src/browser/webapi/WorkerLocation.zig
@@ -54,7 +54,7 @@ pub fn getHash(self: *const WorkerLocation) []const u8 {
 }
 
 pub fn getOrigin(self: *const WorkerLocation, exec: *const js.Execution) ![]const u8 {
-    return (try U.getOrigin(exec.call_arena, self._url)) orelse "null";
+    return (try U.getOrigin(exec.local_arena, self._url)) orelse "null";
 }
 
 pub fn toString(self: *const WorkerLocation) [:0]const u8 {

--- a/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/CanvasRenderingContext2D.zig
@@ -43,7 +43,7 @@ pub fn getCanvas(self: *const CanvasRenderingContext2D) *Canvas {
 }
 
 pub fn getFillStyle(self: *const CanvasRenderingContext2D, exec: *Execution) ![]const u8 {
-    var w = std.Io.Writer.Allocating.init(exec.call_arena);
+    var w = std.Io.Writer.Allocating.init(exec.local_arena);
     try self._fill_style.format(&w.writer);
     return w.written();
 }

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -1726,7 +1726,7 @@ pub const JsApi = struct {
 
     pub const innerText = bridge.accessor(_innerText, _setInnerText, .{ .ce_reactions = true });
     fn _innerText(self: *HtmlElement, frame: *Frame) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+        var buf = std.Io.Writer.Allocating.init(frame.local_arena);
         try self.getInnerText(&buf.writer, frame);
         return buf.written();
     }

--- a/src/browser/webapi/element/html/Anchor.zig
+++ b/src/browser/webapi/element/html/Anchor.zig
@@ -216,7 +216,7 @@ pub fn setName(self: *Anchor, value: []const u8, frame: *Frame) !void {
 }
 
 pub fn getText(self: *Anchor, frame: *Frame) ![:0]const u8 {
-    return self.asNode().getTextContentAlloc(frame.call_arena);
+    return self.asNode().getTextContentAlloc(frame.local_arena);
 }
 
 pub fn setText(self: *Anchor, value: []const u8, frame: *Frame) !void {

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -53,7 +53,7 @@ pub fn getValue(self: *Option, frame: *Frame) []const u8 {
     }
 
     const node = self.asNode();
-    const text = node.getTextContentAlloc(frame.call_arena) catch return "";
+    const text = node.getTextContentAlloc(frame.local_arena) catch return "";
     return std.mem.trim(u8, text, &std.ascii.whitespace);
 }
 

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -145,13 +145,13 @@ pub const JsApi = struct {
     pub const supports = bridge.function(Script.supports, .{ .static = true });
     pub const innerText = bridge.accessor(_innerText, Script.setInnerText, .{ .ce_reactions = true });
     fn _innerText(self: *Script, frame: *const Frame) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+        var buf = std.Io.Writer.Allocating.init(frame.local_arena);
         try self.asNode().getTextContent(&buf.writer);
         return buf.written();
     }
     pub const text = bridge.accessor(_text, Script.setInnerText, .{ .ce_reactions = true });
     fn _text(self: *Script, frame: *const Frame) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+        var buf = std.Io.Writer.Allocating.init(frame.local_arena);
         try self.asNode().getChildTextContent(&buf.writer);
         return buf.written();
     }

--- a/src/browser/webapi/element/html/Template.zig
+++ b/src/browser/webapi/element/html/Template.zig
@@ -108,7 +108,7 @@ pub const JsApi = struct {
     pub const innerHTML = bridge.accessor(_getInnerHTML, _setInnerHTML, .{ .ce_reactions = true });
 
     fn _getInnerHTML(self: *Template, frame: *Frame) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+        var buf = std.Io.Writer.Allocating.init(frame.local_arena);
         try self._content.getInnerHTML(&buf.writer, frame);
         return buf.written();
     }
@@ -119,7 +119,7 @@ pub const JsApi = struct {
 
     pub const outerHTML = bridge.accessor(_getOuterHTML, null, .{});
     fn _getOuterHTML(self: *Template, frame: *Frame) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(frame.call_arena);
+        var buf = std.Io.Writer.Allocating.init(frame.local_arena);
         try self.getOuterHTML(&buf.writer, frame);
         return buf.written();
     }

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -55,7 +55,7 @@ pub fn delete(self: *Headers, name: []const u8, exec: *const Execution) void {
 
 pub fn get(self: *const Headers, name: []const u8, exec: *const Execution) !?[]const u8 {
     const normalized_name = normalizeHeaderName(name, exec.buf);
-    const all_values = try self._list.getAll(exec.call_arena, normalized_name);
+    const all_values = try self._list.getAll(exec.local_arena, normalized_name);
 
     if (all_values.len == 0) {
         return null;
@@ -63,7 +63,7 @@ pub fn get(self: *const Headers, name: []const u8, exec: *const Execution) !?[]c
     if (all_values.len == 1) {
         return all_values[0];
     }
-    return try std.mem.join(exec.call_arena, ", ", all_values);
+    return try std.mem.join(exec.local_arena, ", ", all_values);
 }
 
 pub fn has(self: *const Headers, name: []const u8, exec: *const Execution) bool {

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -119,7 +119,7 @@ pub fn get(self: *const URLSearchParams, name: []const u8) ?[]const u8 {
 }
 
 pub fn getAll(self: *const URLSearchParams, name: []const u8, exec: *const Execution) ![]const []const u8 {
-    return self._params.getAll(exec.call_arena, name);
+    return self._params.getAll(exec.local_arena, name);
 }
 
 pub fn has(self: *const URLSearchParams, name: []const u8) bool {
@@ -378,7 +378,7 @@ pub const JsApi = struct {
 
     pub const toString = bridge.function(_toString, .{});
     fn _toString(self: *const URLSearchParams, exec: *const Execution) ![]const u8 {
-        var buf = std.Io.Writer.Allocating.init(exec.call_arena);
+        var buf = std.Io.Writer.Allocating.init(exec.local_arena);
         try self.toString(&buf.writer);
         return buf.written();
     }

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -354,7 +354,7 @@ pub fn getAllResponseHeaders(self: *const XMLHttpRequest, exec: *const Execution
         return "";
     }
 
-    var buf = std.Io.Writer.Allocating.init(exec.call_arena);
+    var buf = std.Io.Writer.Allocating.init(exec.local_arena);
     for (self._response_headers.items) |entry| {
         try buf.writer.writeAll(entry);
         try buf.writer.writeAll("\r\n");


### PR DESCRIPTION
local_arena should always be used when it's safe. It's released earlier and thus helps reduce peak memory.