### PR TITLE
Replace @cImport with build-system translateC

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -325,6 +325,13 @@ fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is
     }
 
     mod.linkLibrary(lib);
+
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = lib.getEmittedIncludeTree().path(b, "sqlite3.h"),
+        .target = mod.resolved_target.?,
+        .optimize = mod.optimize.?,
+    });
+    mod.addImport("sqlite3", translate_c.createModule());
 }
 
 fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
@@ -332,6 +339,15 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
 
     const curl = buildCurl(b, target, mod.optimize.?, is_tsan);
     mod.linkLibrary(curl);
+
+    const dep = b.dependency("curl", .{});
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = dep.path("include/curl/curl.h"),
+        .target = target,
+        .optimize = mod.optimize.?,
+    });
+    translate_c.addIncludePath(dep.path("include"));
+    mod.addImport("curl", translate_c.createModule());
 
     const zlib = buildZlib(b, target, mod.optimize.?, is_tsan);
     curl.root_module.linkLibrary(zlib);
@@ -833,6 +849,13 @@ fn linkIsocline(b: *Build, mod: *Build.Module) void {
     mod.addCSourceFile(.{
         .file = dep.path("src/isocline.c"),
     });
+
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = dep.path("include/isocline.h"),
+        .target = mod.resolved_target.?,
+        .optimize = mod.optimize.?,
+    });
+    mod.addImport("isocline", translate_c.createModule());
 }
 
 /// Resolves the semantic version of the build.

--- a/src/agent/Terminal.zig
+++ b/src/agent/Terminal.zig
@@ -25,9 +25,7 @@ const Spinner = @import("Spinner.zig");
 const md_term = @import("md_term.zig");
 const prompt_assist = @import("prompt_assist.zig");
 const ansi = @import("ansi.zig");
-const c = @cImport({
-    @cInclude("isocline.h");
-});
+const c = @import("isocline");
 
 const Terminal = @This();
 

--- a/src/agent/prompt_assist.zig
+++ b/src/agent/prompt_assist.zig
@@ -27,9 +27,7 @@ const browser_tools = lp.tools;
 const Schema = lp.Schema;
 const SlashCommand = @import("SlashCommand.zig");
 const js_highlight = @import("js_highlight.zig");
-const c = @cImport({
-    @cInclude("isocline.h");
-});
+const c = @import("isocline");
 
 const style_slash = "ps-slash";
 const style_string = "ps-string";

--- a/src/storage/sqlite/Sqlite.zig
+++ b/src/storage/sqlite/Sqlite.zig
@@ -20,7 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Pool = @import("Pool.zig");
-pub const c = @cImport(@cInclude("sqlite3.h"));
+pub const c = @import("sqlite3");
 
 const log = lp.log;
 const Allocator = std.mem.Allocator;

--- a/src/sys/libcurl.zig
+++ b/src/sys/libcurl.zig
@@ -21,9 +21,7 @@ const builtin = @import("builtin");
 
 const crypto = @import("libcrypto.zig");
 
-const c = @cImport({
-    @cInclude("curl/curl.h");
-});
+const c = @import("curl");
 
 const IS_DEBUG = builtin.mode == .Debug;
 


### PR DESCRIPTION
Zig 0.17 removes @cImport in favor of translate-c steps in the build system. Each library's link function now creates an addTranslateC step exposed as a module import: curl and isocline translate their headers straight from the dependency tree, while sqlite3 uses the artifact's emitted include tree since the amalgamation lives in a sub-dependency.

Terminal.zig and prompt_assist.zig previously instantiated two independent @cImport namespaces for isocline; they now share one translated module, so its types are identical across both files.