### PR TITLE
design: add explicit Proto declaration to every type

### DIFF
--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -318,6 +318,58 @@ pub fn node(self: *Factory, child: anytype) !*@TypeOf(child) {
     ).create(allocator, child);
 }
 
+// CData nodes: {EventTarget, Node, CData, [Text,] Leaf}.
+// CData is special, it's _type is a bare tag, not a tagged union. A website can
+// have tens of thousands of Text nodes, and this allows a few optimization to
+// both reduce the # of allocations and the size
+pub fn cdataNode(self: *Factory, cd: Node.CData, leaf: anytype) !*Node.CData {
+    const types = comptime prototypeTypes(@TypeOf(leaf));
+    comptime assert(types[0] == EventTarget and types[1] == Node and types[2] == Node.CData);
+
+    const chain = try PrototypeChain(types).allocate(self._slab.allocator());
+    chain.setRoot(EventTarget.Type);
+    chain.setMiddle(1, Node.Type);
+
+    const cd_ptr = chain.get(2);
+    cd_ptr.* = cd;
+    cd_ptr._proto = chain.get(1);
+
+    // only the CDATASection chain has a middle here (its Text)
+    inline for (3..types.len - 1) |i| {
+        chain.set(i, .{ ._proto = chain.get(i - 1) });
+    }
+    chain.setLeaf(types.len - 1, leaf);
+    return cd_ptr;
+}
+
+// The full type list for a leaf. Walks the Proto chain.
+// For example CData.Text -> [_]type{EventTarget, Node, CData, Text}).
+pub fn prototypeTypes(comptime Leaf: type) []const type {
+    comptime {
+        var types: []const type = &.{Leaf};
+        var T = Leaf;
+        while (reflect.Proto(T)) |P| {
+            T = P;
+            types = &[_]type{P} ++ types;
+        }
+        return types;
+    }
+}
+
+// Byte offset of T within the chain allocation for `Leaf`. This is what lets
+// a child reach its parent without a stored pointer.
+pub fn chainOffsetOf(comptime Leaf: type, comptime T: type) usize {
+    comptime {
+        var offset: usize = 0;
+        for (prototypeTypes(Leaf)) |C| {
+            offset = std.mem.alignForward(usize, offset, @alignOf(C));
+            if (C == T) return offset;
+            offset += @sizeOf(C);
+        }
+        @compileError(@typeName(T) ++ " is not in the prototype chain of " ++ @typeName(Leaf));
+    }
+}
+
 pub fn document(self: *Factory, child: anytype) !*@TypeOf(child) {
     const allocator = self._slab.allocator();
     return try AutoPrototypeChain(
@@ -375,20 +427,11 @@ pub fn svgElement(self: *Factory, tag_name: []const u8, child: anytype) !*@TypeO
 }
 
 fn svgPrototypeTypes(comptime Child: type) []const type {
-    comptime {
-        var types: []const type = &[_]type{Child};
-        var T = Child;
-
-        while (T != EventTarget) {
-            T = reflect.Proto(T) orelse @compileError(@typeName(T) ++ " does not lead to EventTarget through Proto");
-            types = &[_]type{T} ++ types;
-        }
-
-        if (types.len < 5 or types[3] != Element.Svg) {
-            @compileError(@typeName(Child) ++ " is not an SVG prototype chain");
-        }
-        return types;
+    const types = prototypeTypes(Child);
+    if (types.len < 5 or types[0] != EventTarget or types[3] != Element.Svg) {
+        @compileError(@typeName(Child) ++ " is not an SVG prototype chain");
     }
+    return types;
 }
 
 pub fn xhrEventTarget(_: *const Factory, allocator: Allocator, child: anytype) !*@TypeOf(child) {

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -189,14 +189,22 @@ fn PrototypeChain(comptime types: []const type) type {
             assert(index < types.len);
 
             const ptr = self.get(index);
-            ptr.* = .{ ._proto = self.get(index - 1), ._type = unionInit(T, self.get(index + 1)) };
+            ptr.* = if (comptime @hasField(types[index], "_proto"))
+                .{ ._proto = undefined, ._type = unionInit(T, self.get(index + 1)) }
+            else
+                .{ ._type = unionInit(T, self.get(index + 1)) };
+            setProto(ptr, self.get(index - 1));
         }
 
         fn setMiddleWithValue(self: *const Self, comptime index: usize, comptime T: type, value: anytype) void {
             assert(index >= 1);
 
             const ptr = self.get(index);
-            ptr.* = .{ ._proto = self.get(index - 1), ._type = unionInit(T, value) };
+            ptr.* = if (comptime @hasField(types[index], "_proto"))
+                .{ ._proto = undefined, ._type = unionInit(T, value) }
+            else
+                .{ ._type = unionInit(T, value) };
+            setProto(ptr, self.get(index - 1));
         }
 
         fn setLeaf(self: *const Self, comptime index: usize, value: anytype) void {
@@ -204,7 +212,7 @@ fn PrototypeChain(comptime types: []const type) type {
 
             const ptr = self.get(index);
             ptr.* = value;
-            ptr._proto = self.get(index - 1);
+            setProto(ptr, self.get(index - 1));
         }
     };
 }
@@ -325,7 +333,7 @@ pub fn cdataNode(self: *Factory, cd: Node.CData, leaf: anytype) !*Node.CData {
 
     const cd_ptr = chain.get(2);
     cd_ptr.* = cd;
-    cd_ptr._proto = chain.get(1);
+    setProto(cd_ptr, chain.get(1));
 
     // only the CDATASection chain has a middle here (its Text)
     inline for (3..types.len - 1) |i| {
@@ -363,11 +371,35 @@ pub fn chainOffsetOf(comptime Leaf: type, comptime T: type) usize {
     }
 }
 
-// Byte delta from T down to its Proto within any chain allocation containing
-// them (the prefix layout is the same for every leaf).
+// Offset from T to its Proto
 pub fn protoOffset(comptime T: type) usize {
     const P = reflect.Proto(T).?;
     return chainOffsetOf(T, T) - chainOffsetOf(T, P);
+}
+
+// Get the Proto of a value.
+pub fn protoOf(value: anytype) *reflect.Proto(reflect.Struct(@TypeOf(value))).? {
+    const T = reflect.Struct(@TypeOf(value));
+    const proto: *reflect.Proto(T).? = @ptrFromInt(@intFromPtr(value) - comptime protoOffset(T));
+    if (comptime IS_DEBUG) {
+        // In debug, we'll assert that our offset and the _proto field agree.
+        std.debug.assert(proto == if (comptime hasStoredProto(T)) value._proto else value._proto_canary);
+    }
+    return proto;
+}
+
+// Assigns a chain member's stored `_proto`
+fn setProto(ptr: anytype, proto: anytype) void {
+    const T = reflect.Struct(@TypeOf(ptr));
+    if (comptime hasStoredProto(T)) {
+        ptr._proto = proto;
+    } else if (comptime IS_DEBUG and @hasField(T, "_proto_canary")) {
+        ptr._proto_canary = proto;
+    }
+}
+
+fn hasStoredProto(comptime T: type) bool {
+    return @hasField(T, "_proto") and @FieldType(T, "_proto") != void;
 }
 
 // Generic contiguous chain from explicit values, for chains whose middles
@@ -399,7 +431,7 @@ pub fn chainedWithAllocator(allocator: Allocator, values: anytype) !*ChainedLeaf
         const ptr = chain.get(i);
         ptr.* = values[i];
         if (i > 0) {
-            ptr._proto = chain.get(i - 1);
+            setProto(ptr, chain.get(i - 1));
         }
     }
     return chain.get(types.len - 1);
@@ -532,7 +564,7 @@ fn destroyChain(
     const new_align = std.mem.Alignment.max(old_align, std.mem.Alignment.of(S));
 
     if (comptime reflect.Proto(S) != null) {
-        self.destroyChain(value._proto, new_size, new_align);
+        self.destroyChain(protoOf(value), new_size, new_align);
     } else {
         // no proto so this is the head of the chain.
         // we use this as the ptr to the start of the chain.

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -380,10 +380,7 @@ fn svgPrototypeTypes(comptime Child: type) []const type {
         var T = Child;
 
         while (T != EventTarget) {
-            if (!@hasField(T, "_proto")) {
-                @compileError(@typeName(T) ++ " does not lead to EventTarget through _proto");
-            }
-            T = reflect.Struct(@FieldType(T, "_proto"));
+            T = reflect.Proto(T) orelse @compileError(@typeName(T) ++ " does not lead to EventTarget through Proto");
             types = &[_]type{T} ++ types;
         }
 
@@ -425,7 +422,7 @@ pub fn destroy(self: *Factory, value: anytype) void {
         }
     }
 
-    if (comptime @hasField(S, "_proto")) {
+    if (comptime reflect.Proto(S) != null) {
         self.destroyChain(value, 0, std.mem.Alignment.@"1");
     } else {
         self.destroyStandalone(value);
@@ -451,7 +448,7 @@ fn destroyChain(
     const new_size = current_size + @sizeOf(S);
     const new_align = std.mem.Alignment.max(old_align, std.mem.Alignment.of(S));
 
-    if (@hasField(S, "_proto")) {
+    if (comptime reflect.Proto(S) != null) {
         self.destroyChain(value._proto, new_size, new_align);
     } else {
         // no proto so this is the head of the chain.

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -76,13 +76,6 @@ pub fn eventTargetWithAllocator(_: *const Factory, allocator: Allocator, child: 
     return chain.get(1);
 }
 
-pub fn standaloneEventTarget(self: *Factory, child: anytype) !*EventTarget {
-    const allocator = self._slab.allocator();
-    const et = try allocator.create(EventTarget);
-    et.* = .{ ._type = unionInit(EventTarget.Type, child) };
-    return et;
-}
-
 // this is a root object
 pub fn event(_: *const Factory, arena: Allocator, typ: String, child: anytype) !*@TypeOf(child) {
     const chain = try PrototypeChain(
@@ -368,6 +361,53 @@ pub fn chainOffsetOf(comptime Leaf: type, comptime T: type) usize {
         }
         @compileError(@typeName(T) ++ " is not in the prototype chain of " ++ @typeName(Leaf));
     }
+}
+
+// Byte delta from T down to its Proto within any chain allocation containing
+// them (the prefix layout is the same for every leaf).
+pub fn protoOffset(comptime T: type) usize {
+    const P = reflect.Proto(T).?;
+    return chainOffsetOf(T, T) - chainOffsetOf(T, P);
+}
+
+// Generic contiguous chain from explicit values, for chains whose middles
+// can't be default-initialized by AutoPrototypeChain. Callers pass every
+// level's value in root-to-leaf order, with `undefined` for `_proto` and for
+// any field that must point at another chain member, patching the latter on
+// the result.
+pub fn chained(self: *Factory, values: anytype) !*ChainedLeaf(@TypeOf(values)) {
+    return chainedWithAllocator(self._slab.allocator(), values);
+}
+
+pub fn chainedWithAllocator(allocator: Allocator, values: anytype) !*ChainedLeaf(@TypeOf(values)) {
+    const fields = @typeInfo(@TypeOf(values)).@"struct".fields;
+    const types = comptime blk: {
+        var types: [fields.len]type = undefined;
+        for (fields, 0..) |f, i| {
+            types[i] = f.type;
+        }
+        break :blk types;
+    };
+    comptime {
+        for (types[1..], 0..) |T, i| {
+            assert(reflect.Proto(T).? == types[i]);
+        }
+    }
+
+    const chain = try PrototypeChain(&types).allocate(allocator);
+    inline for (0..types.len) |i| {
+        const ptr = chain.get(i);
+        ptr.* = values[i];
+        if (i > 0) {
+            ptr._proto = chain.get(i - 1);
+        }
+    }
+    return chain.get(types.len - 1);
+}
+
+fn ChainedLeaf(comptime Values: type) type {
+    const fields = @typeInfo(Values).@"struct".fields;
+    return fields[fields.len - 1].type;
 }
 
 pub fn document(self: *Factory, child: anytype) !*@TypeOf(child) {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -25,6 +25,8 @@ const App = @import("../App.zig");
 const History = @import("webapi/History.zig");
 const storage = @import("webapi/storage/storage.zig");
 const IdbManager = @import("webapi/storage/idb/idb.zig").Manager;
+const Factory = @import("Factory.zig");
+const EventTarget = @import("webapi/EventTarget.zig");
 const Navigation = @import("webapi/navigation/Navigation.zig");
 
 const Page = @import("Page.zig");
@@ -50,7 +52,7 @@ const Session = @This();
 browser: *Browser,
 arena: Allocator,
 history: History,
-navigation: Navigation,
+navigation: *Navigation,
 storage_shed: storage.Shed,
 // Per-origin IndexedDB engines
 idb: IdbManager,
@@ -161,12 +163,17 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     const arena = try arena_pool.acquire(.small, "Session");
     errdefer arena_pool.release(arena);
 
+    const navigation = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        Navigation{ ._proto = undefined },
+    });
+    navigation._proto._type = .{ .navigation = navigation };
+
     self.* = .{
         .arena = arena,
         .arena_pool = arena_pool,
         .history = .{},
-        // The prototype (EventTarget) for Navigation is created when a Frame is created.
-        .navigation = .{ ._proto = undefined },
+        .navigation = navigation,
         .storage_shed = .{},
         .idb = IdbManager.init(allocator),
         .browser = browser,
@@ -345,7 +352,6 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     errdefer _ = self.pages.pop();
 
     const frame = &page.frame;
-    try self.navigation.onNewFrame(frame);
     // Inform CDP the main frame has been created such that additional
     // context for other Worlds can be created as well.
     self.notification.dispatch(.frame_created, frame);
@@ -896,9 +902,6 @@ pub fn commitPendingPage(self: *Session, replacement: *Page) !void {
     // set, so the session still reports an in-flight nav and CDP's frameCreated
     // skips the captured_responses / frame_arena reset that would wipe the
     // response we just received.
-    self.navigation.onNewFrame(&replacement.frame) catch |err| {
-        log.err(.browser, "commitPendingPage onNewFrame", .{ .err = err });
-    };
     self.notification.dispatch(.frame_created, &replacement.frame);
 
     // Step 3: promote — clear `replaces` and unlink OLD so  `livePage()`

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -1051,26 +1051,20 @@ pub fn constructCustomElement(frame: *Frame, new_target: JS.Function) !*Element 
 }
 
 pub fn createTextNode(frame: *Frame, text: []const u8) !*Node {
-    const cd = try frame._factory.node(CData{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-        ._type = .{ .text = .{
-            ._proto = undefined,
-        } },
+        ._type = .text,
         ._data = try frame.dupeSSO(text),
-    });
-    cd._type.text._proto = cd;
+    }, CData.Text{ ._proto = undefined });
     return cd.asNode();
 }
 
 pub fn createComment(frame: *Frame, text: []const u8) !*Node {
-    const cd = try frame._factory.node(CData{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-        ._type = .{ .comment = .{
-            ._proto = undefined,
-        } },
+        ._type = .comment,
         ._data = try frame.dupeSSO(text),
-    });
-    cd._type.comment._proto = cd;
+    }, CData.Comment{ ._proto = undefined });
     return cd.asNode();
 }
 
@@ -1080,23 +1074,11 @@ pub fn createCDATASection(frame: *Frame, data: []const u8) !*Node {
         return error.InvalidCharacterError;
     }
 
-    // First allocate the Text node separately
-    const text_node = try frame._factory.create(CData.Text{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-    });
-
-    // Then create the CData with cdata_section variant
-    const cd = try frame._factory.node(CData{
-        ._proto = undefined,
-        ._type = .{ .cdata_section = .{
-            ._proto = text_node,
-        } },
+        ._type = .cdata_section,
         ._data = try frame.dupeSSO(data),
-    });
-
-    // Set up the back pointer from Text to CData
-    text_node._proto = cd;
-
+    }, CData.CDATASection{ ._proto = undefined });
     return cd.asNode();
 }
 
@@ -1114,20 +1096,14 @@ pub fn createProcessingInstruction(frame: *Frame, target: []const u8, data: []co
 
     const owned_target = try frame.dupeString(target);
 
-    const pi = try frame._factory.create(CData.ProcessingInstruction{
+    const cd = try frame._factory.cdataNode(.{
+        ._proto = undefined,
+        ._type = .processing_instruction,
+        ._data = try frame.dupeSSO(data),
+    }, CData.ProcessingInstruction{
         ._proto = undefined,
         ._target = owned_target,
     });
-
-    const cd = try frame._factory.node(CData{
-        ._proto = undefined,
-        ._type = .{ .processing_instruction = pi },
-        ._data = try frame.dupeSSO(data),
-    });
-
-    // Set up the back pointer from ProcessingInstruction to CData
-    pi._proto = cd;
-
     return cd.asNode();
 }
 

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -1052,7 +1052,6 @@ pub fn constructCustomElement(frame: *Frame, new_target: JS.Function) !*Element 
 
 pub fn createTextNode(frame: *Frame, text: []const u8) !*Node {
     const cd = try frame._factory.cdataNode(.{
-        ._proto = undefined,
         ._type = .text,
         ._data = try frame.dupeSSO(text),
     }, CData.Text{ ._proto = undefined });
@@ -1061,7 +1060,6 @@ pub fn createTextNode(frame: *Frame, text: []const u8) !*Node {
 
 pub fn createComment(frame: *Frame, text: []const u8) !*Node {
     const cd = try frame._factory.cdataNode(.{
-        ._proto = undefined,
         ._type = .comment,
         ._data = try frame.dupeSSO(text),
     }, CData.Comment{ ._proto = undefined });
@@ -1075,7 +1073,6 @@ pub fn createCDATASection(frame: *Frame, data: []const u8) !*Node {
     }
 
     const cd = try frame._factory.cdataNode(.{
-        ._proto = undefined,
         ._type = .cdata_section,
         ._data = try frame.dupeSSO(data),
     }, CData.CDATASection{ ._proto = undefined });
@@ -1097,7 +1094,6 @@ pub fn createProcessingInstruction(frame: *Frame, target: []const u8, data: []co
     const owned_target = try frame.dupeString(target);
 
     const cd = try frame._factory.cdataNode(.{
-        ._proto = undefined,
         ._type = .processing_instruction,
         ._data = try frame.dupeSSO(data),
     }, CData.ProcessingInstruction{

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -22,6 +22,7 @@ const string = @import("../../string.zig");
 
 const Page = @import("../Page.zig");
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 
 const js = @import("js.zig");
@@ -555,7 +556,7 @@ fn protoNode(comptime T: type, instance: *T) *@import("../webapi/Node.zig") {
     if (T == @import("../webapi/Node.zig")) {
         return instance;
     }
-    return protoNode(reflect.Proto(T).?, instance._proto);
+    return protoNode(reflect.Proto(T).?, Factory.protoOf(instance));
 }
 
 fn handleError(comptime T: type, comptime F: type, local: *const Local, err: anyerror, info: anytype) void {

--- a/src/browser/js/Caller.zig
+++ b/src/browser/js/Caller.zig
@@ -22,6 +22,7 @@ const string = @import("../../string.zig");
 
 const Page = @import("../Page.zig");
 const Frame = @import("../Frame.zig");
+const reflect = @import("../reflect.zig");
 
 const js = @import("js.zig");
 const Local = @import("Local.zig");
@@ -547,15 +548,14 @@ fn errorLocal(comptime T: type, local: *const Local, info: anytype) Local {
     };
 }
 
-// Upcast a Node-descendant instance to *Node by walking the _proto chain.
+// Upcast a Node-descendant instance to *Node by walking the Proto chain.
 // Not every node type defines an asNode() helper (e.g. Comment, Text), but
 // inheritsOrIs guarantees Node is in the chain
 fn protoNode(comptime T: type, instance: *T) *@import("../webapi/Node.zig") {
     if (T == @import("../webapi/Node.zig")) {
         return instance;
     }
-    const Proto = @typeInfo(std.meta.fieldInfo(T, ._proto).type).pointer.child;
-    return protoNode(Proto, instance._proto);
+    return protoNode(reflect.Proto(T).?, instance._proto);
 }
 
 fn handleError(comptime T: type, comptime F: type, local: *const Local, err: anyerror, info: anytype) void {

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -25,6 +25,7 @@ const Page = @import("../Page.zig");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
+const reflect = @import("../reflect.zig");
 const Caller = @import("Caller.zig");
 const Context = @import("Context.zig");
 const Isolate = @import("Isolate.zig");
@@ -1380,12 +1381,7 @@ fn findFinalizerType(comptime T: type) ?type {
     if (@hasDecl(S, "acquireRef")) {
         return S;
     }
-    if (@hasField(S, "_proto")) {
-        const ProtoPtr = std.meta.fieldInfo(S, ._proto).type;
-        const ProtoChild = @typeInfo(ProtoPtr).pointer.child;
-        return findFinalizerType(ProtoChild);
-    }
-    return null;
+    return findFinalizerType(reflect.Proto(S) orelse return null);
 }
 
 // Generate a function that follows the _proto pointer chain to get to the finalizer type
@@ -1398,10 +1394,8 @@ fn finalizerPtrGetter(comptime T: type, comptime FT: type) *const fn (*T) *FT {
             }
         }.get;
     }
-    if (@hasField(S, "_proto")) {
-        const ProtoPtr = std.meta.fieldInfo(S, ._proto).type;
-        const ProtoChild = @typeInfo(ProtoPtr).pointer.child;
-        const childGetter = comptime finalizerPtrGetter(ProtoChild, FT);
+    if (reflect.Proto(S)) |P| {
+        const childGetter = comptime finalizerPtrGetter(P, FT);
         return struct {
             fn get(v: *T) *FT {
                 return childGetter(v._proto);

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -25,6 +25,7 @@ const Page = @import("../Page.zig");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 const Caller = @import("Caller.zig");
 const Context = @import("Context.zig");
@@ -1295,6 +1296,9 @@ pub fn resolveValue(value: anytype) Resolved {
 }
 
 fn resolveT(comptime T: type, value: *T) Resolved {
+    if (comptime IS_DEBUG) {
+        assertChainContiguity(T, value);
+    }
     const Meta = T.JsApi.Meta;
     return .{
         .ptr = value,
@@ -1384,6 +1388,16 @@ fn resolveT(comptime T: type, value: *T) Resolved {
             };
         },
     };
+}
+
+// Every wrapped chain must be contiguous — the TaggedOpaque walk upcasts by
+// pointer arithmetic. The stored _proto fields double as the canary.
+fn assertChainContiguity(comptime T: type, value: *T) void {
+    if (comptime reflect.Proto(T) != null) {
+        const P = comptime reflect.Proto(T).?;
+        std.debug.assert(@intFromPtr(value._proto) == @intFromPtr(value) - comptime Factory.protoOffset(T));
+        assertChainContiguity(P, value._proto);
+    }
 }
 
 // Start at the "resolved" type (the most specific) and work our way up the

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -1390,13 +1390,12 @@ fn resolveT(comptime T: type, value: *T) Resolved {
     };
 }
 
-// Every wrapped chain must be contiguous — the TaggedOpaque walk upcasts by
-// pointer arithmetic. The stored _proto fields double as the canary.
+// Debug-only check!
+// Walk the full chain at wrap time; protoOf's Debug assert verifies each
+// hop's _proto (or _proto_canary) against the layout arithmetic.
 fn assertChainContiguity(comptime T: type, value: *T) void {
     if (comptime reflect.Proto(T) != null) {
-        const P = comptime reflect.Proto(T).?;
-        std.debug.assert(@intFromPtr(value._proto) == @intFromPtr(value) - comptime Factory.protoOffset(T));
-        assertChainContiguity(P, value._proto);
+        assertChainContiguity(reflect.Proto(T).?, Factory.protoOf(value));
     }
 }
 
@@ -1424,7 +1423,7 @@ fn finalizerPtrGetter(comptime T: type, comptime FT: type) *const fn (*T) *FT {
         const childGetter = comptime finalizerPtrGetter(P, FT);
         return struct {
             fn get(v: *T) *FT {
-                return childGetter(v._proto);
+                return childGetter(Factory.protoOf(v));
             }
         }.get;
     }

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -1259,7 +1259,19 @@ const Resolved = struct {
 };
 pub fn resolveValue(value: anytype) Resolved {
     const T = bridge.Struct(@TypeOf(value));
-    if (!@hasField(T, "_type") or @typeInfo(@TypeOf(value._type)) != .@"union") {
+    if (!@hasField(T, "_type")) {
+        return resolveT(T, value);
+    }
+
+    // A bare-tag _type means the subtypes are chain members, not payloads
+    // (e.g. CData); the type maps the tag to the member's type.
+    if (comptime @typeInfo(@TypeOf(value._type)) == .@"enum" and @hasDecl(T, "Subtype")) {
+        switch (value._type) {
+            inline else => |tag| return resolveValue(value.subtype(T.Subtype(tag))),
+        }
+    }
+
+    if (comptime @typeInfo(@TypeOf(value._type)) != .@"union") {
         return resolveT(T, value);
     }
 

--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
+const reflect = @import("../reflect.zig");
 
 // Not ideal, but its children have special constructor rules (can be extended
 // can't be instantiated). And rather than coming up with a generic definition
@@ -693,11 +694,7 @@ fn protoIndexLookup(comptime JsApi: type) ?u16 {
     @setEvalBranchQuota(100_000);
     comptime {
         const T = JsApi.bridge.type;
-        if (!@hasField(T, "_proto")) {
-            return null;
-        }
-        const Ptr = std.meta.fieldInfo(T, ._proto).type;
-        const F = @typeInfo(Ptr).pointer.child;
+        const F = reflect.Proto(T) orelse return null;
         // Look up in the provided API list
         for (JsApis, 0..) |Api, i| {
             if (Api == F.JsApi) {

--- a/src/browser/js/TaggedOpaque.zig
+++ b/src/browser/js/TaggedOpaque.zig
@@ -73,7 +73,9 @@ subtype: ?bridge.SubType,
 
 pub const PrototypeChainEntry = struct {
     index: bridge.JsApiLookup.BackingInt,
-    offset: u16, // offset to the _proto field
+    // byte delta from the previous chain member down to this one; every
+    // member of a prototype chain lives in one contiguous factory allocation
+    offset: u16,
 };
 
 // Reverses the mapZigInstanceToJs, making sure that our TaggedOpaque
@@ -125,12 +127,10 @@ pub fn fromJS(comptime R: type, js_obj_handle: *const v8.Object) !R {
     // Ok, let's walk up the chain
     var ptr = @intFromPtr(tao.value);
     for (prototype_chain[1..]) |proto| {
-        ptr += proto.offset; // the offset to the _proto field
-        const proto_ptr: **anyopaque = @ptrFromInt(ptr);
+        ptr -= proto.offset;
         if (proto.index == expected_type_index) {
-            return @ptrCast(@alignCast(proto_ptr.*));
+            return @ptrFromInt(ptr);
         }
-        ptr = @intFromPtr(proto_ptr.*);
     }
     return error.InvalidArgument;
 }

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -531,12 +531,10 @@ const CloneDelegate = struct {
             // closest cloneable supertype (mirrors TaggedOpaque.fromJS).
             var ptr = @intFromPtr(tao.value);
             for (prototype_chain[1..]) |proto| {
-                ptr += proto.offset;
-                const proto_ptr: **anyopaque = @ptrFromInt(ptr);
-                if (writeCloneable(ctx, proto.index, proto_ptr.*)) |result| {
+                ptr -= proto.offset;
+                if (writeCloneable(ctx, proto.index, @ptrFromInt(ptr))) |result| {
                     return result;
                 }
-                ptr = @intFromPtr(proto_ptr.*);
             }
         }
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 
 const js = @import("js.zig");
@@ -109,7 +110,7 @@ pub fn Builder(comptime T: type) type {
                 const Next = PrototypeType(Prototype).?;
                 entry.* = .{
                     .index = JsApiLookup.getId(Next.JsApi),
-                    .offset = @offsetOf(Prototype, "_proto"),
+                    .offset = Factory.protoOffset(Prototype),
                 };
                 Prototype = Next;
             }

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Frame = @import("../Frame.zig");
+const reflect = @import("../reflect.zig");
 
 const js = @import("js.zig");
 const Caller = @import("Caller.zig");
@@ -805,10 +806,7 @@ fn prototypeChainLength(comptime T: type) usize {
 
 // Given a Type, gets its prototype Type (if any)
 fn PrototypeType(comptime T: type) ?type {
-    if (!@hasField(T, "_proto")) {
-        return null;
-    }
-    return Struct(std.meta.fieldInfo(T, ._proto).type);
+    return reflect.Proto(T);
 }
 
 fn flattenTypes(comptime Types: []const type) [countFlattenedTypes(Types)]type {
@@ -1305,7 +1303,7 @@ pub const JsApis = blk: {
     break :blk base ++ [_]type{@import("../webapi/WebDriver.zig").JsApi};
 };
 
-// Whether Child is Ancestor or inherits from it, following the _proto chain.
+// Whether Child is Ancestor or inherits from it, following the Proto chain.
 pub fn inheritsOrIs(comptime Child: type, comptime Ancestor: type) bool {
     comptime {
         const target = Ancestor.bridge.type;
@@ -1314,10 +1312,7 @@ pub fn inheritsOrIs(comptime Child: type, comptime Ancestor: type) bool {
             if (T == target) {
                 return true;
             }
-            if (!@hasField(T, "_proto")) {
-                return false;
-            }
-            T = @typeInfo(std.meta.fieldInfo(T, ._proto).type).pointer.child;
+            T = reflect.Proto(T) orelse return false;
         }
     }
 }

--- a/src/browser/reflect.zig
+++ b/src/browser/reflect.zig
@@ -16,6 +16,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// The prototype ("parent") type of T, as declared by its `pub const Proto`.
+// This decl is the single source of truth for prototype-chain discovery;
+// a `_proto` field, where one exists, is only storage and must agree.
+pub fn Proto(comptime T: type) ?type {
+    if (!@hasDecl(T, "Proto")) {
+        return null;
+    }
+    if (@hasField(T, "_proto") and @FieldType(T, "_proto") != *T.Proto) {
+        @compileError(@typeName(T) ++ ": _proto field and Proto decl disagree");
+    }
+    return T.Proto;
+}
+
 // Gets the Parent of child.
 // HtmlElement.of(script) -> *HTMLElement
 pub fn Struct(comptime T: type) type {

--- a/src/browser/reflect.zig
+++ b/src/browser/reflect.zig
@@ -17,14 +17,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // The prototype ("parent") type of T, as declared by its `pub const Proto`.
-// This decl is the single source of truth for prototype-chain discovery;
-// a `_proto` field, where one exists, is only storage and must agree.
+// This decl is the single source of truth for prototype-chain discovery.
 pub fn Proto(comptime T: type) ?type {
     if (!@hasDecl(T, "Proto")) {
         return null;
     }
-    if (@hasField(T, "_proto") and @FieldType(T, "_proto") != *T.Proto) {
-        @compileError(@typeName(T) ++ ": _proto field and Proto decl disagree");
+
+    if (@hasField(T, "_proto")) {
+        // If the field also has a _proto: *Parent field, it must be the same type
+        const F = @FieldType(T, "_proto");
+        if (F != *T.Proto and F != void) {
+            @compileError(@typeName(T) ++ ": _proto field and Proto decl disagree");
+        }
     }
     return T.Proto;
 }

--- a/src/browser/webapi/AbortSignal.zig
+++ b/src/browser/webapi/AbortSignal.zig
@@ -31,6 +31,8 @@ const Execution = js.Execution;
 
 const AbortSignal = @This();
 
+pub const Proto = EventTarget;
+
 const Dependend = union(enum) {
     signal: *AbortSignal,
     model_context_tool: *ModelContextTool,

--- a/src/browser/webapi/Blob.zig
+++ b/src/browser/webapi/Blob.zig
@@ -84,7 +84,15 @@ pub fn init(parts_: ?[]const js.Value, opts_: ?InitOptions, page: *Page) !*Blob 
     const arena = try session.getArena(.large, "Blob");
     errdefer session.releaseArena(arena);
 
-    const opts: InitOptions = opts_ orelse .{};
+    const self = try arena.create(Blob);
+    self.* = try buildValue(arena, parts_, opts_ orelse .{});
+    return self;
+}
+
+// The Blob value for `parts`, with everything it references copied to
+// `arena`. Callers either arena.create it (init) or embed it as the root of
+// a {Blob, File} chain.
+pub fn buildValue(arena: Allocator, parts_: ?[]const js.Value, opts: InitOptions) !Blob {
     const mime = try Mime.serialize(arena, opts.type);
 
     const data = blk: {
@@ -101,33 +109,32 @@ pub fn init(parts_: ?[]const js.Value, opts_: ?InitOptions, page: *Page) !*Blob 
         break :blk "";
     };
 
-    const self = try arena.create(Blob);
-    self.* = .{
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._slice = data,
         ._mime = mime,
     };
-    return self;
 }
 
-/// Creates a new Blob from raw byte slices (for internal Zig use).
-pub fn initFromBytes(data: []const u8, content_type: []const u8, page: *Page) !*Blob {
-    // + 256 because the arena might also be used by File
-    const arena = try page.getArena(data.len + content_type.len + 256, "Blob");
-    errdefer page.releaseArena(arena);
-
-    const mime = try Mime.serialize(arena, content_type);
-
-    const self = try arena.create(Blob);
-    self.* = .{
+pub fn buildValueFromBytes(arena: Allocator, data: []const u8, content_type: []const u8) !Blob {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._slice = try arena.dupe(u8, data),
-        ._mime = mime,
+        ._mime = try Mime.serialize(arena, content_type),
     };
+}
+
+/// Creates a new Blob from raw byte slices (for internal Zig use).
+pub fn initFromBytes(data: []const u8, content_type: []const u8, page: *Page) !*Blob {
+    const arena = try page.getArena(data.len + content_type.len + 256, "Blob");
+    errdefer page.releaseArena(arena);
+
+    const self = try arena.create(Blob);
+    self.* = try buildValueFromBytes(arena, data, content_type);
     return self;
 }
 

--- a/src/browser/webapi/BroadcastChannel.zig
+++ b/src/browser/webapi/BroadcastChannel.zig
@@ -29,6 +29,8 @@ const Execution = js.Execution;
 
 const BroadcastChannel = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _exec: *Execution,
 _name: lp.String,

--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -37,8 +37,11 @@ const CData = @This();
 pub const Proto = Node;
 
 _type: Type,
-_proto: *Node,
 _data: String = .empty,
+// In debug, set so that we can check that we have a proper contiguous block
+// of memory for the entire chain (and thus, simple pointer arithmetics will
+// work to resolve the proto).
+_proto_canary: if (IS_DEBUG) *Node else void = undefined,
 
 // The subtype's struct is not a payload here: it's the member laid out after
 // the CData in the factory chain (see Factory.cdataNode), reachable via
@@ -227,7 +230,7 @@ fn utf16RangeToUtf8(data: []const u8, utf16_start: usize, utf16_end: usize) !str
 }
 
 pub fn asNode(self: *CData) *Node {
-    return self._proto;
+    return Factory.protoOf(self);
 }
 
 pub fn is(self: *CData, comptime T: type) ?*T {
@@ -551,7 +554,6 @@ test "WebApi: CData.render" {
 
         const cdata = CData{
             ._type = .text,
-            ._proto = undefined,
             ._data = .wrap(test_case.value),
         };
 

--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 
 const Node = @import("Node.zig");
 pub const Text = @import("cdata/Text.zig");
@@ -29,6 +30,7 @@ pub const CDATASection = @import("cdata/CDATASection.zig");
 pub const ProcessingInstruction = @import("cdata/ProcessingInstruction.zig");
 
 const String = lp.String;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const CData = @This();
 
@@ -38,14 +40,47 @@ _type: Type,
 _proto: *Node,
 _data: String = .empty,
 
-pub const Type = union(enum) {
-    text: Text,
-    comment: Comment,
-    // This should be under Text, but that would require storing a _type union
-    // in text, which would add 8 bytes to every text node.
-    cdata_section: CDATASection,
-    processing_instruction: *ProcessingInstruction,
+// The subtype's struct is not a payload here: it's the member laid out after
+// the CData in the factory chain (see Factory.cdataNode), reachable via
+// `subtype`.
+pub const Type = enum(u8) {
+    text,
+    comment,
+    cdata_section,
+    processing_instruction,
 };
+
+pub fn Subtype(comptime tag: Type) type {
+    return switch (tag) {
+        .text => Text,
+        .comment => Comment,
+        .cdata_section => CDATASection,
+        .processing_instruction => ProcessingInstruction,
+    };
+}
+
+fn tagOf(comptime T: type) Type {
+    if (T == Text) return .text;
+    if (T == Comment) return .comment;
+    if (T == CDATASection) return .cdata_section;
+    if (T == ProcessingInstruction) return .processing_instruction;
+    @compileError(@typeName(T) ++ " is not a CData subtype");
+}
+
+pub fn subtype(self: *CData, comptime T: type) *T {
+    const offset = comptime Factory.chainOffsetOf(T, T) - Factory.chainOffsetOf(T, CData);
+    const sub: *T = @ptrFromInt(@intFromPtr(self) + offset);
+    if (comptime IS_DEBUG) {
+        // the arithmetic rides on factory-chain contiguity; the stored
+        // back-pointer doubles as its canary
+        if (comptime T == CDATASection) {
+            std.debug.assert(sub._proto._proto == self);
+        } else {
+            std.debug.assert(sub._proto == self);
+        }
+    }
+    return sub;
+}
 
 /// Count UTF-16 code units in a UTF-8 string.
 /// 4-byte UTF-8 sequences (codepoints >= U+10000) produce 2 UTF-16 code units (surrogate pair),
@@ -196,17 +231,10 @@ pub fn asNode(self: *CData) *Node {
 }
 
 pub fn is(self: *CData, comptime T: type) ?*T {
-    inline for (@typeInfo(Type).@"union".fields) |f| {
-        if (@field(Type, f.name) == self._type) {
-            if (f.type == T) {
-                return &@field(self._type, f.name);
-            }
-            if (f.type == *T) {
-                return @field(self._type, f.name);
-            }
-        }
+    if (self._type != comptime tagOf(T)) {
+        return null;
     }
-    return null;
+    return self.subtype(T);
 }
 
 pub fn getData(self: *const CData) String {
@@ -297,7 +325,7 @@ pub fn format(self: *const CData, writer: *std.Io.Writer) !void {
         .text => writer.print("<text>{f}</text>", .{self._data}),
         .comment => writer.print("<!-- {f} -->", .{self._data}),
         .cdata_section => writer.print("<![CDATA[{f}]]>", .{self._data}),
-        .processing_instruction => |pi| writer.print("<?{s} {f}?>", .{ pi._target, self._data }),
+        .processing_instruction => writer.print("<?{s} {f}?>", .{ @constCast(self).subtype(ProcessingInstruction)._target, self._data }),
     };
 }
 
@@ -306,13 +334,15 @@ pub fn getLength(self: *const CData) usize {
 }
 
 pub fn isEqualNode(self: *const CData, other: *const CData) bool {
-    if (std.meta.activeTag(self._type) != std.meta.activeTag(other._type)) {
+    if (self._type != other._type) {
         return false;
     }
 
     if (self._type == .processing_instruction) {
         @branchHint(.unlikely);
-        if (std.mem.eql(u8, self._type.processing_instruction._target, other._type.processing_instruction._target) == false) {
+        const self_target = @constCast(self).subtype(ProcessingInstruction)._target;
+        const other_target = @constCast(other).subtype(ProcessingInstruction)._target;
+        if (std.mem.eql(u8, self_target, other_target) == false) {
             return false;
         }
         // if the _targets are equal, we still want to compare the data
@@ -520,7 +550,7 @@ test "WebApi: CData.render" {
         buffer.clearRetainingCapacity();
 
         const cdata = CData{
-            ._type = .{ .text = undefined },
+            ._type = .text,
             ._proto = undefined,
             ._data = .wrap(test_case.value),
         };

--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -32,9 +32,20 @@ const String = lp.String;
 
 const CData = @This();
 
+pub const Proto = Node;
+
 _type: Type,
 _proto: *Node,
 _data: String = .empty,
+
+pub const Type = union(enum) {
+    text: Text,
+    comment: Comment,
+    // This should be under Text, but that would require storing a _type union
+    // in text, which would add 8 bytes to every text node.
+    cdata_section: CDATASection,
+    processing_instruction: *ProcessingInstruction,
+};
 
 /// Count UTF-16 code units in a UTF-8 string.
 /// 4-byte UTF-8 sequences (codepoints >= U+10000) produce 2 UTF-16 code units (surrogate pair),
@@ -179,15 +190,6 @@ fn utf16RangeToUtf8(data: []const u8, utf16_start: usize, utf16_end: usize) !str
     // End is either exactly at utf16_end or clamped to string end
     return .{ .start = start, .end = i };
 }
-
-pub const Type = union(enum) {
-    text: Text,
-    comment: Comment,
-    // This should be under Text, but that would require storing a _type union
-    // in text, which would add 8 bytes to every text node.
-    cdata_section: CDATASection,
-    processing_instruction: *ProcessingInstruction,
-};
 
 pub fn asNode(self: *CData) *Node {
     return self._proto;

--- a/src/browser/webapi/DOMMatrix.zig
+++ b/src/browser/webapi/DOMMatrix.zig
@@ -24,6 +24,8 @@ const RO = @import("DOMMatrixReadOnly.zig");
 
 const DOMMatrix = @This();
 
+pub const Proto = RO;
+
 _proto: *RO,
 
 pub fn init(init_: ?js.Value, exec: *const js.Execution) !*DOMMatrix {

--- a/src/browser/webapi/DOMMatrix.zig
+++ b/src/browser/webapi/DOMMatrix.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 const RO = @import("DOMMatrixReadOnly.zig");
 
 const DOMMatrix = @This();
@@ -33,15 +34,15 @@ pub fn init(init_: ?js.Value, exec: *const js.Execution) !*DOMMatrix {
     return create(parsed.m, parsed.is_2d, exec.page);
 }
 
-// Builds the [DOMMatrixReadOnly, DOMMatrix] prototype chain on a single arena
-// (owned by the base) and cross-links them, the same way File wraps Blob.
 pub fn create(m: [16]f64, is_2d: bool, page: *Page) !*DOMMatrix {
-    const proto = try RO.createBare(m, is_2d, page);
-    errdefer proto.deinit(page);
+    const arena = try page.getArena(.tiny, "DOMMatrix");
+    errdefer page.releaseArena(arena);
 
-    const self = try proto._arena.create(DOMMatrix);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
+    const self = try Factory.chainedWithAllocator(arena, .{
+        RO.buildValue(arena, m, is_2d),
+        DOMMatrix{ ._proto = undefined },
+    });
+    self._proto._type = .{ .mutable = self };
     return self;
 }
 

--- a/src/browser/webapi/DOMMatrixReadOnly.zig
+++ b/src/browser/webapi/DOMMatrixReadOnly.zig
@@ -85,14 +85,18 @@ pub fn createBare(m: [16]f64, is_2d: bool, page: *Page) !*DOMMatrixReadOnly {
     errdefer page.releaseArena(arena);
 
     const self = try arena.create(DOMMatrixReadOnly);
-    self.* = .{
+    self.* = buildValue(arena, m, is_2d);
+    return self;
+}
+
+pub fn buildValue(arena: std.mem.Allocator, m: [16]f64, is_2d: bool) DOMMatrixReadOnly {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._m = m,
         ._is_2d = is_2d,
     };
-    return self;
 }
 
 pub fn getState(self: *const DOMMatrixReadOnly) State {

--- a/src/browser/webapi/DOMPoint.zig
+++ b/src/browser/webapi/DOMPoint.zig
@@ -22,6 +22,8 @@ const RO = @import("DOMPointReadOnly.zig");
 
 const DOMPoint = @This();
 
+pub const Proto = RO;
+
 _proto: *RO,
 
 pub fn init(x_: ?f64, y_: ?f64, z_: ?f64, w_: ?f64, exec: *const js.Execution) !*DOMPoint {

--- a/src/browser/webapi/DOMPoint.zig
+++ b/src/browser/webapi/DOMPoint.zig
@@ -18,6 +18,7 @@
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 const RO = @import("DOMPointReadOnly.zig");
 
 const DOMPoint = @This();
@@ -31,12 +32,14 @@ pub fn init(x_: ?f64, y_: ?f64, z_: ?f64, w_: ?f64, exec: *const js.Execution) !
 }
 
 pub fn create(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPoint {
-    const proto = try RO.createBare(x, y, z, w, page);
-    errdefer proto.deinit(page);
+    const arena = try page.getArena(.tiny, "DOMPoint");
+    errdefer page.releaseArena(arena);
 
-    const self = try proto._arena.create(DOMPoint);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
+    const self = try Factory.chainedWithAllocator(arena, .{
+        RO.buildValue(arena, x, y, z, w),
+        DOMPoint{ ._proto = undefined },
+    });
+    self._proto._type = .{ .mutable = self };
     return self;
 }
 
@@ -50,13 +53,11 @@ pub fn structuredSerialize(self: *const DOMPoint, writer: *js.StructuredWriter) 
 }
 
 pub fn structuredDeserialize(reader: *js.StructuredReader, page: *Page) !*DOMPoint {
-    const proto = try RO.structuredDeserialize(reader, page);
-    errdefer proto.deinit(page);
-
-    const self = try proto._arena.create(DOMPoint);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
-    return self;
+    const x: f64 = @bitCast(try reader.readUint64());
+    const y: f64 = @bitCast(try reader.readUint64());
+    const z: f64 = @bitCast(try reader.readUint64());
+    const w: f64 = @bitCast(try reader.readUint64());
+    return create(x, y, z, w, page);
 }
 
 // DOMPoint redeclares x/y/z/w as writable (`inherit attribute` in the IDL), so

--- a/src/browser/webapi/DOMPointReadOnly.zig
+++ b/src/browser/webapi/DOMPointReadOnly.zig
@@ -89,7 +89,12 @@ pub fn createBare(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPointReadOnl
     errdefer page.releaseArena(arena);
 
     const self = try arena.create(DOMPointReadOnly);
-    self.* = .{
+    self.* = buildValue(arena, x, y, z, w);
+    return self;
+}
+
+pub fn buildValue(arena: Allocator, x: f64, y: f64, z: f64, w: f64) DOMPointReadOnly {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
@@ -98,7 +103,6 @@ pub fn createBare(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPointReadOnl
         ._z = z,
         ._w = w,
     };
-    return self;
 }
 
 pub fn fromPoint(other_: ?DOMPointInit, page: *Page) !*DOMPointReadOnly {

--- a/src/browser/webapi/DOMRect.zig
+++ b/src/browser/webapi/DOMRect.zig
@@ -26,6 +26,8 @@ pub const Data = RO.Data;
 
 const DOMRect = @This();
 
+pub const Proto = RO;
+
 _proto: *RO,
 
 pub fn init(x_: ?f64, y_: ?f64, width_: ?f64, height_: ?f64, exec: *const js.Execution) !*DOMRect {

--- a/src/browser/webapi/DedicatedWorkerGlobalScope.zig
+++ b/src/browser/webapi/DedicatedWorkerGlobalScope.zig
@@ -53,21 +53,19 @@ _on_messageerror: ?js.Function.Global = null,
 _pending_messages: std.ArrayList(?js.Value.Global) = .empty,
 
 pub fn init(worker: *Worker, url: [:0]const u8) !*DedicatedWorkerGlobalScope {
-    const self = try worker._arena.create(DedicatedWorkerGlobalScope);
-    const proto = try WorkerGlobalScope.init(
+    return WorkerGlobalScope.init(
         worker._arena,
         url,
-        .{ .dedicated = self },
+        .dedicated,
+        DedicatedWorkerGlobalScope{
+            ._worker = worker,
+            ._proto = undefined,
+        },
         worker._type == .module,
         worker._frame_id,
         worker._loader_id,
         worker._frame,
     );
-    self.* = .{
-        ._worker = worker,
-        ._proto = proto,
-    };
-    return self;
 }
 
 pub fn deinit(self: *DedicatedWorkerGlobalScope) void {

--- a/src/browser/webapi/DedicatedWorkerGlobalScope.zig
+++ b/src/browser/webapi/DedicatedWorkerGlobalScope.zig
@@ -37,6 +37,8 @@ const Allocator = std.mem.Allocator;
 
 const DedicatedWorkerGlobalScope = @This();
 
+pub const Proto = WorkerGlobalScope;
+
 _proto: *WorkerGlobalScope,
 _worker: *Worker,
 _closed: bool = false,

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -50,6 +50,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Document = @This();
 
+pub const Proto = Node;
+
 _type: Type,
 _proto: *Node,
 _frame: ?*Frame = null,

--- a/src/browser/webapi/DocumentFragment.zig
+++ b/src/browser/webapi/DocumentFragment.zig
@@ -28,6 +28,8 @@ const Selector = @import("selector/Selector.zig");
 
 const DocumentFragment = @This();
 
+pub const Proto = Node;
+
 _type: Type,
 _proto: *Node,
 

--- a/src/browser/webapi/DocumentType.zig
+++ b/src/browser/webapi/DocumentType.zig
@@ -25,6 +25,8 @@ const Node = @import("Node.zig");
 
 const DocumentType = @This();
 
+pub const Proto = Node;
+
 _proto: *Node,
 _name: []const u8,
 _public_id: []const u8,

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -46,6 +46,8 @@ const String = lp.String;
 
 const Element = @This();
 
+pub const Proto = Node;
+
 pub const DatasetLookup = std.AutoHashMapUnmanaged(*Element, *DOMStringMap);
 pub const StyleLookup = std.AutoHashMapUnmanaged(*Element, *CSSStyleProperties);
 pub const ClassListLookup = std.AutoHashMapUnmanaged(*Element, *collections.DOMTokenList);

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 const StyleManager = @import("../StyleManager.zig");
 const reflect = @import("../reflect.zig");
 
@@ -42,6 +43,7 @@ pub const Attribute = @import("element/Attribute.zig");
 const DOMStringMap = @import("element/DOMStringMap.zig");
 
 const log = lp.log;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 const String = lp.String;
 
 const Element = @This();
@@ -107,9 +109,12 @@ pub const Namespace = enum(u8) {
 };
 
 _type: Type,
-_proto: *Node,
 _namespace: Namespace = .html,
 _attributes: Attribute.List = .{},
+// In debug, set so that we can check that we have a proper contiguous block
+// of memory for the entire chain (and thus, simple pointer arithmetics will
+// work to resolve the proto).
+_proto_canary: if (IS_DEBUG) *Node else void = undefined,
 
 pub const Type = union(enum) {
     html: *Html,
@@ -144,15 +149,15 @@ pub fn as(self: *Element, comptime T: type) *T {
 }
 
 pub fn asNode(self: *Element) *Node {
-    return self._proto;
+    return Factory.protoOf(self);
 }
 
 pub fn asEventTarget(self: *Element) *EventTarget {
-    return self._proto.asEventTarget();
+    return self.asNode().asEventTarget();
 }
 
 pub fn asConstNode(self: *const Element) *const Node {
-    return self._proto;
+    return Factory.protoOf(@constCast(self));
 }
 
 /// TODO: localName and prefix comparison.
@@ -1208,7 +1213,7 @@ pub fn closest(self: *Element, input: []const u8, frame: *Frame) !?*Element {
             return el;
         }
 
-        const parent = el._proto._parent orelse break;
+        const parent = el.asNode()._parent orelse break;
 
         if (parent.is(ShadowRoot) != null) {
             break;
@@ -1220,7 +1225,7 @@ pub fn closest(self: *Element, input: []const u8, frame: *Frame) !?*Element {
 }
 
 pub fn parentElement(self: *Element) ?*Element {
-    return self._proto.parentElement();
+    return self.asNode().parentElement();
 }
 
 /// Cache for visibility checks - re-exported from StyleManager for convenience.
@@ -1991,7 +1996,7 @@ pub fn getTag(self: *const Element) Tag {
 }
 
 pub fn ownerFrame(self: *const Element, default: *Frame) *Frame {
-    return self._proto.ownerFrame(default);
+    return self.asConstNode().ownerFrame(default);
 }
 
 pub const Tag = enum {

--- a/src/browser/webapi/File.zig
+++ b/src/browser/webapi/File.zig
@@ -25,6 +25,8 @@ const Blob = @import("Blob.zig");
 
 const File = @This();
 
+pub const Proto = Blob;
+
 _proto: *Blob,
 _name: []const u8,
 _last_modified: i64,

--- a/src/browser/webapi/File.zig
+++ b/src/browser/webapi/File.zig
@@ -20,6 +20,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 
 const Blob = @import("Blob.zig");
 
@@ -44,20 +45,22 @@ pub fn init(
     page: *Page,
 ) !*File {
     const opts = opts_ orelse InitOptions{};
-    const blob = try Blob.init(parts_, .{
-        .type = opts.type,
-        .endings = opts.endings,
-    }, page);
+    const session = page.session;
+    const arena = try session.getArena(.large, "Blob");
+    errdefer session.releaseArena(arena);
 
-    errdefer blob.deinit(page);
-
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = opts.lastModified orelse @intCast(lp.datetime.milliTimestamp(.real)),
-    };
-    blob._type = .{ .file = file };
+    const file = try Factory.chainedWithAllocator(arena, .{
+        try Blob.buildValue(arena, parts_, .{
+            .type = opts.type,
+            .endings = opts.endings,
+        }),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = opts.lastModified orelse @intCast(lp.datetime.milliTimestamp(.real)),
+        },
+    });
+    file._proto._type = .{ .file = file };
 
     return file;
 }
@@ -81,19 +84,30 @@ pub fn structuredSerialize(self: *const File, writer: *js.StructuredWriter) !voi
 }
 
 pub fn structuredDeserialize(reader: *js.StructuredReader, page: *Page) !*File {
-    const blob = try Blob.structuredDeserialize(reader, page);
-    errdefer blob.deinit(page);
-
+    const mime = try reader.readBytes();
+    const data = try reader.readBytes();
     const name = try reader.readBytes();
     const last_modified = try reader.readUint64();
 
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = @bitCast(last_modified),
-    };
-    blob._type = .{ .file = file };
+    const arena = try page.getArena(data.len + mime.len + name.len + 256, "Blob.clone");
+    errdefer page.releaseArena(arena);
+
+    const file = try Factory.chainedWithAllocator(arena, .{
+        Blob{
+            ._rc = .{},
+            ._arena = arena,
+            ._type = undefined,
+            ._slice = try arena.dupe(u8, data),
+            // the serialized mime is already in normalized form; copy it verbatim
+            ._mime = try arena.dupe(u8, mime),
+        },
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = @bitCast(last_modified),
+        },
+    });
+    file._proto._type = .{ .file = file };
     return file;
 }
 

--- a/src/browser/webapi/FileReader.zig
+++ b/src/browser/webapi/FileReader.zig
@@ -33,6 +33,8 @@ const Allocator = std.mem.Allocator;
 /// https://developer.mozilla.org/en-US/docs/Web/API/FileReader
 const FileReader = @This();
 
+pub const Proto = EventTarget;
+
 _rc: lp.RC = .{},
 _exec: *Execution,
 _proto: *EventTarget,

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -28,6 +28,8 @@ const collections = @import("collections.zig");
 
 const HTMLDocument = @This();
 
+pub const Proto = Document;
+
 _proto: *Document,
 _document_type: ?*DocumentType = null,
 

--- a/src/browser/webapi/MessagePort.zig
+++ b/src/browser/webapi/MessagePort.zig
@@ -29,6 +29,8 @@ const Execution = js.Execution;
 
 const MessagePort = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 
 // The context this port lives in. The two ends of an entangled pair can be in

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -42,6 +42,8 @@ pub const AssignedSlotLookup = std.AutoHashMapUnmanaged(*Node, *Element.Html.Slo
 
 const Node = @This();
 
+pub const Proto = EventTarget;
+
 _type: Type,
 _proto: *EventTarget,
 _parent: ?*Node = null,

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -479,7 +479,7 @@ pub fn getNodeName(self: *const Node, buf: []u8) []const u8 {
             .text => "#text",
             .cdata_section => "#cdata-section",
             .comment => "#comment",
-            .processing_instruction => |pi| pi._target,
+            .processing_instruction => cd.subtype(CData.ProcessingInstruction)._target,
         },
         .document => "#document",
         .document_type => |dt| dt.getName(),
@@ -1176,7 +1176,7 @@ pub fn cloneNode(self: *Node, deep_: ?bool, frame: *Frame) CloneError!*Node {
                 .text => Frame.node_factory.createTextNode(frame, data),
                 .cdata_section => Frame.node_factory.createCDATASection(frame, data),
                 .comment => Frame.node_factory.createComment(frame, data),
-                .processing_instruction => |pi| Frame.node_factory.createProcessingInstruction(frame, pi._target, data),
+                .processing_instruction => Frame.node_factory.createProcessingInstruction(frame, cd.subtype(CData.ProcessingInstruction)._target, data),
             };
         },
         .element => |el| return el.clone(deep, frame),

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -22,6 +22,7 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
 const URL = @import("../URL.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 
 const EventTarget = @import("EventTarget.zig");
@@ -37,6 +38,7 @@ pub const ShadowRoot = @import("ShadowRoot.zig");
 
 const String = lp.String;
 const Allocator = std.mem.Allocator;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 pub const AssignedSlotLookup = std.AutoHashMapUnmanaged(*Node, *Element.Html.Slot);
 
@@ -45,13 +47,16 @@ const Node = @This();
 pub const Proto = EventTarget;
 
 _type: Type,
-_proto: *EventTarget,
 _parent: ?*Node = null,
 // The first child's `_prev` points at the LAST child (keeping lastChild
 // O(1)); the last child's `_next` is null. A detached node has null links.
 _first_child: ?*Node = null,
 _next: ?*Node = null,
 _prev: ?*Node = null,
+// In debug, set so that we can check that we have a proper contiguous block
+// of memory for the entire chain (and thus, simple pointer arithmetics will
+// work to resolve the proto).
+_proto_canary: if (IS_DEBUG) *EventTarget else void = undefined,
 
 // Lookup for nodes that have a different owner document than frame.document
 pub const OwnerDocumentLookup = std.AutoHashMapUnmanaged(*Node, *Document);
@@ -66,7 +71,7 @@ pub const Type = union(enum) {
 };
 
 pub fn asEventTarget(self: *Node) *EventTarget {
-    return self._proto;
+    return Factory.protoOf(self);
 }
 
 // Returns the node as a more specific type. Will crash if node is not a `T`.

--- a/src/browser/webapi/Notification.zig
+++ b/src/browser/webapi/Notification.zig
@@ -29,6 +29,8 @@ const Allocator = std.mem.Allocator;
 
 const Notification = @This();
 
+pub const Proto = EventTarget;
+
 _rc: lp.RC = .{},
 _arena: Allocator,
 _proto: *EventTarget,

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -460,17 +460,18 @@ pub const Mark = struct {
         }
 
         const detail = if (maybe_detail) |d| try d.persist() else null;
-        const m = try exec._factory.create(Mark{
-            ._proto = undefined,
-            ._detail = detail,
+        const m = try exec._factory.chained(.{
+            Entry{
+                ._start_time = start_time,
+                ._name = try exec.dupeString(name),
+                ._type = undefined,
+            },
+            Mark{
+                ._proto = undefined,
+                ._detail = detail,
+            },
         });
-
-        const entry = try exec._factory.create(Entry{
-            ._start_time = start_time,
-            ._name = try exec.dupeString(name),
-            ._type = .{ .mark = m },
-        });
-        m._proto = entry;
+        m._proto._type = .{ .mark = m };
         return m;
     }
 
@@ -522,18 +523,19 @@ pub const Measure = struct {
         }
 
         const detail = if (maybe_detail) |d| try d.persist() else null;
-        const m = try exec._factory.create(Measure{
-            ._proto = undefined,
-            ._detail = detail,
+        const m = try exec._factory.chained(.{
+            Entry{
+                ._start_time = start_timestamp,
+                ._duration = duration,
+                ._name = try exec.dupeString(name),
+                ._type = undefined,
+            },
+            Measure{
+                ._proto = undefined,
+                ._detail = detail,
+            },
         });
-
-        const entry = try exec._factory.create(Entry{
-            ._start_time = start_timestamp,
-            ._duration = duration,
-            ._name = try exec.dupeString(name),
-            ._type = .{ .measure = m },
-        });
-        m._proto = entry;
+        m._proto._type = .{ .measure = m };
         return m;
     }
 

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -444,6 +444,8 @@ pub const Entry = struct {
 };
 
 pub const Mark = struct {
+    pub const Proto = Entry;
+
     _proto: *Entry,
     _detail: ?js.Value.Global,
 
@@ -489,6 +491,8 @@ pub const Mark = struct {
 };
 
 pub const Measure = struct {
+    pub const Proto = Entry;
+
     _proto: *Entry,
     _detail: ?js.Value.Global,
 

--- a/src/browser/webapi/Range.zig
+++ b/src/browser/webapi/Range.zig
@@ -28,6 +28,8 @@ const AbstractRange = @import("AbstractRange.zig");
 
 const Range = @This();
 
+pub const Proto = AbstractRange;
+
 _proto: *AbstractRange,
 
 pub fn init(frame: *Frame) !*Range {

--- a/src/browser/webapi/Screen.zig
+++ b/src/browser/webapi/Screen.zig
@@ -29,6 +29,8 @@ pub fn registerTypes() []const type {
 
 const Screen = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _orientation: ?*Orientation = null,
 
@@ -72,6 +74,8 @@ pub const JsApi = struct {
 };
 
 pub const Orientation = struct {
+    pub const Proto = EventTarget;
+
     _proto: *EventTarget,
 
     pub fn init(frame: *Frame) !*Orientation {

--- a/src/browser/webapi/ShadowRoot.zig
+++ b/src/browser/webapi/ShadowRoot.zig
@@ -26,6 +26,8 @@ const Element = @import("Element.zig");
 
 const ShadowRoot = @This();
 
+pub const Proto = DocumentFragment;
+
 pub const Mode = enum {
     open,
     closed,

--- a/src/browser/webapi/SharedWorker.zig
+++ b/src/browser/webapi/SharedWorker.zig
@@ -42,6 +42,8 @@ const SharedWorkerGlobalScope = @import("SharedWorkerGlobalScope.zig");
 
 const SharedWorker = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _port: *MessagePort,
 _on_error: ?js.Function.Global = null,

--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -35,6 +35,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const SharedWorkerGlobalScope = @This();
 
+pub const Proto = WorkerGlobalScope;
+
 _proto: *WorkerGlobalScope,
 _arena: Allocator,
 

--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -71,25 +71,27 @@ pub fn init(frame: *Frame, url: [:0]const u8, name: []const u8, worker_type: Wor
     errdefer session.releaseArena(arena);
 
     const owned_url = try arena.dupeZ(u8, url);
-    const self = try arena.create(SharedWorkerGlobalScope);
-    const proto = try WorkerGlobalScope.init(
+    const frame_id = session.nextFrameId();
+    const loader_id = session.nextLoaderId();
+    const self = try WorkerGlobalScope.init(
         arena,
         owned_url,
-        .{ .shared = self },
+        .shared,
+        SharedWorkerGlobalScope{
+            ._proto = undefined,
+            ._arena = arena,
+            ._url = owned_url,
+            ._name = try arena.dupe(u8, name),
+            ._type = worker_type,
+            ._frame_id = frame_id,
+            ._loader_id = loader_id,
+        },
         worker_type == .module,
-        session.nextFrameId(),
-        session.nextLoaderId(),
+        frame_id,
+        loader_id,
         frame,
     );
-    self.* = .{
-        ._proto = proto,
-        ._arena = arena,
-        ._url = owned_url,
-        ._name = try arena.dupe(u8, name),
-        ._type = worker_type,
-        ._frame_id = proto._frame_id,
-        ._loader_id = proto._loader_id,
-    };
+    const proto = self._proto;
     errdefer proto.deinit();
 
     if (!session.worker_loading_enabled) {

--- a/src/browser/webapi/StaticRange.zig
+++ b/src/browser/webapi/StaticRange.zig
@@ -24,6 +24,8 @@ const AbstractRange = @import("AbstractRange.zig");
 
 const StaticRange = @This();
 
+pub const Proto = AbstractRange;
+
 // The boundary points and `collapsed` accessor live on the shared AbstractRange
 // prototype. Unlike Range, a StaticRange is *static*: the factory keeps it out
 // of the frame's live-range list, so DOM mutations never move its boundaries.

--- a/src/browser/webapi/VisualViewport.zig
+++ b/src/browser/webapi/VisualViewport.zig
@@ -22,6 +22,8 @@ const EventTarget = @import("EventTarget.zig");
 
 const VisualViewport = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 
 pub fn asEventTarget(self: *VisualViewport) *EventTarget {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -64,6 +64,8 @@ pub fn registerTypes() []const type {
 
 const Window = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _frame: *Frame,
 _document: *Document,

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -344,7 +344,7 @@ pub fn getHistory(_: *Window, frame: *Frame) *History {
 }
 
 pub fn getNavigation(_: *Window, frame: *Frame) *Navigation {
-    return &frame._session.navigation;
+    return frame._session.navigation;
 }
 
 pub fn setNavigation(self: *Window, value: js.Value) void {

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -36,6 +36,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const Worker = @This();
 
+pub const Proto = EventTarget;
+
 pub const WorkerType = enum {
     classic,
     module,

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -125,12 +125,13 @@ pub const Type = union(enum) {
 pub fn init(
     arena: Allocator,
     url: [:0]const u8,
-    child: Type,
+    comptime tag: std.meta.Tag(Type),
+    leaf_value: anytype,
     is_module: bool,
     frame_id: u32,
     loader_id: u32,
     frame: *Frame,
-) !*WorkerGlobalScope {
+) !*@TypeOf(leaf_value) {
     const session = frame._session;
 
     const call_arena = try session.getArena(.small, "WorkerGlobalScope.call_arena");
@@ -140,29 +141,36 @@ pub fn init(
     errdefer session.releaseArena(local_arena);
 
     const factory = frame._factory;
-    const self = try factory.eventTargetWithAllocator(arena, WorkerGlobalScope{
-        .url = url,
-        .arena = arena,
-        .origin = frame.origin,
-        .js = undefined,
-        .call_arena = call_arena,
-        .local_arena = local_arena,
-        ._frame = frame,
-        ._page = frame._page,
-        ._session = session,
-        ._identity = .{},
-        ._type = child,
-        ._proto = undefined,
-        ._factory = factory,
-        ._is_module = is_module,
-        ._frame_id = frame_id,
-        ._loader_id = loader_id,
-        ._event_manager = .init(arena),
-        ._script_manager = undefined,
-        ._location = .{ ._url = url },
-        ._performance = .init(),
-        ._http_owner = undefined,
+    const leaf = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        WorkerGlobalScope{
+            .url = url,
+            .arena = arena,
+            .origin = frame.origin,
+            .js = undefined,
+            .call_arena = call_arena,
+            .local_arena = local_arena,
+            ._frame = frame,
+            ._page = frame._page,
+            ._session = session,
+            ._identity = .{},
+            ._type = undefined,
+            ._proto = undefined,
+            ._factory = factory,
+            ._is_module = is_module,
+            ._frame_id = frame_id,
+            ._loader_id = loader_id,
+            ._event_manager = .init(arena),
+            ._script_manager = undefined,
+            ._location = .{ ._url = url },
+            ._performance = .init(),
+            ._http_owner = undefined,
+        },
+        leaf_value,
     });
+    const self = leaf._proto;
+    self._type = @unionInit(Type, @tagName(tag), leaf);
+    self._proto._type = .{ .worker_global_scope = self };
 
     self._http_owner = .init(&frame._page.blob_urls, &self.origin);
 
@@ -185,7 +193,7 @@ pub fn init(
     // features like BroadcastChannel can reach across the page/worker boundary.
     try self.js.setOrigin(self.origin);
 
-    return self;
+    return leaf;
 }
 
 pub fn deinit(self: *WorkerGlobalScope) void {

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -57,6 +57,8 @@ const Allocator = std.mem.Allocator;
 
 const WorkerGlobalScope = @This();
 
+pub const Proto = EventTarget;
+
 _type: Type,
 _frame: *Frame,
 _is_module: bool,

--- a/src/browser/webapi/XMLDocument.zig
+++ b/src/browser/webapi/XMLDocument.zig
@@ -23,6 +23,8 @@ const Node = @import("Node.zig");
 
 const XMLDocument = @This();
 
+pub const Proto = Document;
+
 _proto: *Document,
 
 pub fn asDocument(self: *XMLDocument) *Document {

--- a/src/browser/webapi/cdata/CDATASection.zig
+++ b/src/browser/webapi/cdata/CDATASection.zig
@@ -22,6 +22,8 @@ const Text = @import("Text.zig");
 
 const CDATASection = @This();
 
+pub const Proto = Text;
+
 _proto: *Text,
 
 pub const JsApi = struct {

--- a/src/browser/webapi/cdata/Comment.zig
+++ b/src/browser/webapi/cdata/Comment.zig
@@ -23,6 +23,8 @@ const CData = @import("../CData.zig");
 
 const Comment = @This();
 
+pub const Proto = CData;
+
 _proto: *CData,
 
 pub fn init(str: ?js.NullableString, frame: *Frame) !*Comment {

--- a/src/browser/webapi/cdata/ProcessingInstruction.zig
+++ b/src/browser/webapi/cdata/ProcessingInstruction.zig
@@ -22,6 +22,8 @@ const CData = @import("../CData.zig");
 
 const ProcessingInstruction = @This();
 
+pub const Proto = CData;
+
 _proto: *CData,
 _target: []const u8,
 

--- a/src/browser/webapi/cdata/Text.zig
+++ b/src/browser/webapi/cdata/Text.zig
@@ -27,6 +27,8 @@ const slotting = @import("../element/slotting.zig");
 
 const Text = @This();
 
+pub const Proto = CData;
+
 _proto: *CData,
 
 pub fn init(str: ?js.NullableString, frame: *Frame) !*Text {

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Factory = @import("../../Factory.zig");
 const Frame = @import("../../Frame.zig");
 const Element = @import("../Element.zig");
 const TreeWalker = @import("../TreeWalker.zig");
@@ -46,6 +47,8 @@ const Mode = enum {
 
 const HTMLCollection = @This();
 
+pub const _prototype_root = true;
+
 _data: union(Mode) {
     tag: NodeLive(.tag),
     tag_name: NodeLive(.tag_name),
@@ -63,9 +66,22 @@ _data: union(Mode) {
     empty: void,
 },
 _rc: lp.RC = .{},
+// The refcount is shared with the chain leaf (when there is one), so the
+// last release can dispatch deinit through either pointer. The root must
+// know its allocation shape to destroy the right thing.
+_chained: enum(u8) { standalone, form_controls, options } = .standalone,
 
 pub fn deinit(self: *HTMLCollection, page: *Page) void {
-    page.factory.destroy(self);
+    switch (self._chained) {
+        .standalone => page.factory.destroyStandalone(self),
+        .form_controls => page.factory.destroy(self.chainLeaf(@import("HTMLFormControlsCollection.zig"))),
+        .options => page.factory.destroy(self.chainLeaf(@import("HTMLOptionsCollection.zig"))),
+    }
+}
+
+fn chainLeaf(self: *HTMLCollection, comptime Leaf: type) *Leaf {
+    const offset = comptime Factory.chainOffsetOf(Leaf, Leaf) - Factory.chainOffsetOf(Leaf, HTMLCollection);
+    return @ptrFromInt(@intFromPtr(self) + offset);
 }
 
 pub fn releaseRef(self: *HTMLCollection, page: *Page) void {

--- a/src/browser/webapi/collections/HTMLFormControlsCollection.zig
+++ b/src/browser/webapi/collections/HTMLFormControlsCollection.zig
@@ -34,13 +34,10 @@ pub const Proto = HTMLCollection;
 
 _proto: *HTMLCollection,
 
-// The refcount lives on the proto, but anchoring the finalizer here lets
-// deinit reclaim this struct's slot along with the proto's.
+// The refcount lives on the proto, but the finalizer anchors here so deinit
+// destroys the whole {HTMLCollection, self} chain from its leaf.
 pub fn deinit(self: *HTMLFormControlsCollection, page: *Page) void {
-    self._proto.deinit(page);
-    // Not destroy(): the proto is a separate slab allocation, not a
-    // contiguous factory chain.
-    page.factory.destroyStandalone(self);
+    page.factory.destroy(self);
 }
 
 pub fn acquireRef(self: *HTMLFormControlsCollection) void {
@@ -99,13 +96,15 @@ pub fn namedItem(self: *HTMLFormControlsCollection, name: []const u8, frame: *Fr
             count += 1;
 
             if (count == 2) {
-                const radio_node_list = try frame._factory.create(RadioNodeList{
-                    ._proto = undefined,
-                    ._form_collection = self,
-                    ._name = try frame.dupeString(name),
+                const radio_node_list = try frame._factory.chained(.{
+                    NodeList{ ._data = undefined },
+                    RadioNodeList{
+                        ._proto = undefined,
+                        ._form_collection = self,
+                        ._name = try frame.dupeString(name),
+                    },
                 });
-
-                radio_node_list._proto = try frame._factory.create(NodeList{ ._data = .{ .radio_node_list = radio_node_list } });
+                radio_node_list._proto._data = .{ .radio_node_list = radio_node_list };
 
                 // The RadioNodeList outlives this call; its NodeList releases
                 // the ref in deinit.

--- a/src/browser/webapi/collections/HTMLFormControlsCollection.zig
+++ b/src/browser/webapi/collections/HTMLFormControlsCollection.zig
@@ -30,6 +30,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const HTMLFormControlsCollection = @This();
 
+pub const Proto = HTMLCollection;
+
 _proto: *HTMLCollection,
 
 // The refcount lives on the proto, but anchoring the finalizer here lets

--- a/src/browser/webapi/collections/HTMLOptionsCollection.zig
+++ b/src/browser/webapi/collections/HTMLOptionsCollection.zig
@@ -30,13 +30,10 @@ pub const Proto = HTMLCollection;
 _proto: *HTMLCollection,
 _select: *@import("../element/html/Select.zig"),
 
-// The refcount lives on the proto, but anchoring the finalizer here lets
-// deinit reclaim this struct's slot along with the proto's.
+// The refcount lives on the proto, but the finalizer anchors here so deinit
+// destroys the whole {HTMLCollection, self} chain from its leaf.
 pub fn deinit(self: *HTMLOptionsCollection, page: *Page) void {
-    self._proto.deinit(page);
-    // Not destroy(): the proto is a separate slab allocation, not a
-    // contiguous factory chain.
-    page.factory.destroyStandalone(self);
+    page.factory.destroy(self);
 }
 
 pub fn acquireRef(self: *HTMLOptionsCollection) void {

--- a/src/browser/webapi/collections/HTMLOptionsCollection.zig
+++ b/src/browser/webapi/collections/HTMLOptionsCollection.zig
@@ -25,6 +25,8 @@ const HTMLCollection = @import("HTMLCollection.zig");
 
 const HTMLOptionsCollection = @This();
 
+pub const Proto = HTMLCollection;
+
 _proto: *HTMLCollection,
 _select: *@import("../element/html/Select.zig"),
 

--- a/src/browser/webapi/collections/RadioNodeList.zig
+++ b/src/browser/webapi/collections/RadioNodeList.zig
@@ -29,6 +29,8 @@ const HTMLFormControlsCollection = @import("HTMLFormControlsCollection.zig");
 
 const RadioNodeList = @This();
 
+pub const Proto = NodeList;
+
 _proto: *NodeList,
 _name: []const u8,
 _form_collection: *HTMLFormControlsCollection,

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -400,23 +400,29 @@ pub fn NodeLive(comptime mode: Mode) type {
         const NodeList = @import("NodeList.zig");
 
         pub fn runtimeGenericWrap(self: Self, frame: *Frame) !if (mode == .name) *NodeList else *HTMLCollection {
-            const collection = switch (mode) {
-                .name => return frame._factory.create(NodeList{ ._data = .{ .name = self } }),
-                .tag => HTMLCollection{ ._data = .{ .tag = self } },
-                .tag_name => HTMLCollection{ ._data = .{ .tag_name = self } },
-                .tag_name_ns => HTMLCollection{ ._data = .{ .tag_name_ns = self } },
-                .class_name => HTMLCollection{ ._data = .{ .class_name = self } },
-                .all_elements => HTMLCollection{ ._data = .{ .all_elements = self } },
-                .child_elements => HTMLCollection{ ._data = .{ .child_elements = self } },
-                .child_tag => HTMLCollection{ ._data = .{ .child_tag = self } },
-                .cells => HTMLCollection{ ._data = .{ .cells = self } },
-                .select_options => HTMLCollection{ ._data = .{ .select_options = self } },
-                .selected_options => HTMLCollection{ ._data = .{ .selected_options = self } },
-                .links => HTMLCollection{ ._data = .{ .links = self } },
-                .anchors => HTMLCollection{ ._data = .{ .anchors = self } },
-                .form => HTMLCollection{ ._data = .{ .form = self } },
+            if (comptime mode == .name) {
+                return frame._factory.create(NodeList{ ._data = .{ .name = self } });
+            }
+            return frame._factory.create(self.htmlCollectionValue());
+        }
+
+        pub fn htmlCollectionValue(self: Self) HTMLCollection {
+            return switch (mode) {
+                .name => @compileError("name mode wraps as a NodeList"),
+                .tag => .{ ._data = .{ .tag = self } },
+                .tag_name => .{ ._data = .{ .tag_name = self } },
+                .tag_name_ns => .{ ._data = .{ .tag_name_ns = self } },
+                .class_name => .{ ._data = .{ .class_name = self } },
+                .all_elements => .{ ._data = .{ .all_elements = self } },
+                .child_elements => .{ ._data = .{ .child_elements = self } },
+                .child_tag => .{ ._data = .{ .child_tag = self } },
+                .cells => .{ ._data = .{ .cells = self } },
+                .select_options => .{ ._data = .{ .select_options = self } },
+                .selected_options => .{ ._data = .{ .selected_options = self } },
+                .links => .{ ._data = .{ .links = self } },
+                .anchors => .{ ._data = .{ .anchors = self } },
+                .form => .{ ._data = .{ .form = self } },
             };
-            return frame._factory.create(collection);
         }
     };
 }

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -35,27 +35,20 @@ _element: ?*Element = null,
 _properties: std.DoublyLinkedList = .{},
 _is_computed: bool = false,
 
-pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleDeclaration {
-    const self = try frame._factory.create(CSSStyleDeclaration{
-        ._element = element,
-        ._is_computed = is_computed,
-    });
-
-    // Parse the element's existing style attribute into _properties so that
-    // subsequent JS reads and writes see all CSS properties, not just newly
-    // added ones.  Computed styles have no inline attribute to parse.
-    if (!is_computed) {
-        if (element) |el| {
-            if (el.getAttributeSafe(comptime .wrap("style"))) |attr_value| {
-                var it = CssParser.parseDeclarationsList(attr_value);
-                while (it.next()) |declaration| {
-                    try self.applyParsedDeclaration(declaration, frame);
-                }
-            }
+// Parse the element's existing style attribute into _properties so that
+// subsequent JS reads and writes see all CSS properties, not just newly
+// added ones.  Computed styles have no inline attribute to parse.
+pub fn parseInlineStyle(self: *CSSStyleDeclaration, frame: *Frame) !void {
+    if (self._is_computed) {
+        return;
+    }
+    const el = self._element orelse return;
+    if (el.getAttributeSafe(comptime .wrap("style"))) |attr_value| {
+        var it = CssParser.parseDeclarationsList(attr_value);
+        while (it.next()) |declaration| {
+            try self.applyParsedDeclaration(declaration, frame);
         }
     }
-
-    return self;
 }
 
 pub fn length(self: *const CSSStyleDeclaration) u32 {

--- a/src/browser/webapi/css/CSSStyleProperties.zig
+++ b/src/browser/webapi/css/CSSStyleProperties.zig
@@ -30,9 +30,15 @@ pub const Proto = CSSStyleDeclaration;
 _proto: *CSSStyleDeclaration,
 
 pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleProperties {
-    return frame._factory.create(CSSStyleProperties{
-        ._proto = try CSSStyleDeclaration.init(element, is_computed, frame),
+    const self = try frame._factory.chained(.{
+        CSSStyleDeclaration{
+            ._element = element,
+            ._is_computed = is_computed,
+        },
+        CSSStyleProperties{ ._proto = undefined },
     });
+    try self._proto.parseInlineStyle(frame);
+    return self;
 }
 
 pub fn asCSSStyleDeclaration(self: *CSSStyleProperties) *CSSStyleDeclaration {

--- a/src/browser/webapi/css/CSSStyleProperties.zig
+++ b/src/browser/webapi/css/CSSStyleProperties.zig
@@ -25,6 +25,8 @@ const CSSStyleDeclaration = @import("CSSStyleDeclaration.zig");
 
 const CSSStyleProperties = @This();
 
+pub const Proto = CSSStyleDeclaration;
+
 _proto: *CSSStyleDeclaration,
 
 pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleProperties {

--- a/src/browser/webapi/css/CSSStyleRule.zig
+++ b/src/browser/webapi/css/CSSStyleRule.zig
@@ -6,6 +6,8 @@ const CSSStyleProperties = @import("CSSStyleProperties.zig");
 
 const CSSStyleRule = @This();
 
+pub const Proto = CSSRule;
+
 _proto: *CSSRule,
 _selector_text: []const u8 = "",
 _style: ?*CSSStyleProperties = null,

--- a/src/browser/webapi/css/CSSStyleRule.zig
+++ b/src/browser/webapi/css/CSSStyleRule.zig
@@ -13,10 +13,11 @@ _selector_text: []const u8 = "",
 _style: ?*CSSStyleProperties = null,
 
 pub fn init(frame: *Frame) !*CSSStyleRule {
-    const style_rule = try frame._factory.create(CSSStyleRule{
-        ._proto = undefined,
+    const style_rule = try frame._factory.chained(.{
+        CSSRule{ ._type = undefined },
+        CSSStyleRule{ ._proto = undefined },
     });
-    style_rule._proto = try CSSRule.init(.{ .style = style_rule }, frame);
+    style_rule._proto._type = .{ .style = style_rule };
     return style_rule;
 }
 

--- a/src/browser/webapi/css/FontFaceSet.zig
+++ b/src/browser/webapi/css/FontFaceSet.zig
@@ -32,6 +32,8 @@ const Allocator = std.mem.Allocator;
 
 const FontFaceSet = @This();
 
+pub const Proto = EventTarget;
+
 _rc: lp.RC = .{},
 _proto: *EventTarget,
 _arena: Allocator,

--- a/src/browser/webapi/css/MediaQueryList.zig
+++ b/src/browser/webapi/css/MediaQueryList.zig
@@ -24,6 +24,8 @@ const MediaQuery = @import("../../css/MediaQuery.zig");
 
 const MediaQueryList = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _media: []const u8,
 

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -41,6 +41,8 @@ pub fn registerTypes() []const type {
 
 pub const Attribute = @This();
 
+pub const Proto = Node;
+
 _proto: *Node,
 _name: String,
 _value: String,

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -220,7 +220,7 @@ pub fn asElement(self: *HtmlElement) *Element {
 }
 
 pub fn asNode(self: *HtmlElement) *Node {
-    return self._proto._proto;
+    return self._proto.asNode();
 }
 
 pub fn asEventTarget(self: *HtmlElement) *@import("../EventTarget.zig") {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -103,6 +103,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const HtmlElement = @This();
 
+pub const Proto = Element;
+
 _type: Type,
 _proto: *Element,
 

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -224,7 +224,7 @@ pub fn asNode(self: *HtmlElement) *Node {
 }
 
 pub fn asEventTarget(self: *HtmlElement) *@import("../EventTarget.zig") {
-    return self._proto._proto._proto;
+    return self.asNode().asEventTarget();
 }
 
 pub fn getInnerText(self: *HtmlElement, writer: *std.Io.Writer, frame: *Frame) !void {

--- a/src/browser/webapi/element/Svg.zig
+++ b/src/browser/webapi/element/Svg.zig
@@ -40,6 +40,8 @@ pub const Stop = @import("svg/Stop.zig");
 const String = lp.String;
 
 const Svg = @This();
+
+pub const Proto = Element;
 _type: Type,
 _proto: *Element,
 _tag_name: String, // Svg elements are case-preserving

--- a/src/browser/webapi/element/html/Anchor.zig
+++ b/src/browser/webapi/element/html/Anchor.zig
@@ -26,6 +26,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Anchor = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Anchor) *Element {

--- a/src/browser/webapi/element/html/Area.zig
+++ b/src/browser/webapi/element/html/Area.zig
@@ -26,6 +26,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Area = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Area) *Element {

--- a/src/browser/webapi/element/html/Audio.zig
+++ b/src/browser/webapi/element/html/Audio.zig
@@ -29,6 +29,8 @@ const String = lp.String;
 
 const Audio = @This();
 
+pub const Proto = Media;
+
 _proto: *Media,
 
 pub fn constructor(maybe_url: ?String, frame: *Frame) !*Media {

--- a/src/browser/webapi/element/html/BR.zig
+++ b/src/browser/webapi/element/html/BR.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const BR = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *BR) *Element {

--- a/src/browser/webapi/element/html/Base.zig
+++ b/src/browser/webapi/element/html/Base.zig
@@ -8,6 +8,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Base = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Base) *Element {

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -29,6 +29,8 @@ const String = lp.String;
 
 const Body = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Body) *Element {

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -32,6 +32,8 @@ const popover = @import("../popover.zig");
 
 const Button = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,

--- a/src/browser/webapi/element/html/Canvas.zig
+++ b/src/browser/webapi/element/html/Canvas.zig
@@ -30,6 +30,8 @@ const OffscreenCanvas = @import("../../canvas/OffscreenCanvas.zig");
 const Execution = js.Execution;
 
 const Canvas = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _cached: ?DrawingContext = null,
 

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -33,6 +33,8 @@ const log = lp.log;
 const String = lp.String;
 
 const Custom = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _tag_name: String,
 _definition: ?*CustomElementDefinition,

--- a/src/browser/webapi/element/html/DList.zig
+++ b/src/browser/webapi/element/html/DList.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const DList = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *DList) *Element {

--- a/src/browser/webapi/element/html/Data.zig
+++ b/src/browser/webapi/element/html/Data.zig
@@ -25,6 +25,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Data = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Data) *Element {

--- a/src/browser/webapi/element/html/DataList.zig
+++ b/src/browser/webapi/element/html/DataList.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const DataList = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *DataList) *Element {

--- a/src/browser/webapi/element/html/Details.zig
+++ b/src/browser/webapi/element/html/Details.zig
@@ -7,6 +7,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Details = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Details) *Element {

--- a/src/browser/webapi/element/html/Dialog.zig
+++ b/src/browser/webapi/element/html/Dialog.zig
@@ -8,6 +8,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Dialog = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Dialog) *Element {

--- a/src/browser/webapi/element/html/Directory.zig
+++ b/src/browser/webapi/element/html/Directory.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Directory = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Directory) *Element {

--- a/src/browser/webapi/element/html/Div.zig
+++ b/src/browser/webapi/element/html/Div.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Div = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Div) *Element {

--- a/src/browser/webapi/element/html/Embed.zig
+++ b/src/browser/webapi/element/html/Embed.zig
@@ -23,6 +23,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Embed = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Embed) *Element {

--- a/src/browser/webapi/element/html/FieldSet.zig
+++ b/src/browser/webapi/element/html/FieldSet.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const FieldSet = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *FieldSet) *Element {

--- a/src/browser/webapi/element/html/Font.zig
+++ b/src/browser/webapi/element/html/Font.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Font = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Font) *Element {

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -31,6 +31,8 @@ pub const Select = @import("Select.zig");
 pub const TextArea = @import("TextArea.zig");
 
 const Form = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 // Prevents submission of the form while we're in the process of submitting

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -98,11 +98,12 @@ pub fn setMethod(self: *Form, method: []const u8, frame: *Frame) !void {
 
 pub fn getElements(self: *Form, frame: *Frame) !*collections.HTMLFormControlsCollection {
     const node_live = self.iterator(frame);
-    const html_collection = try node_live.runtimeGenericWrap(frame);
-
-    return frame._factory.create(collections.HTMLFormControlsCollection{
-        ._proto = html_collection,
+    const elements = try frame._factory.chained(.{
+        node_live.htmlCollectionValue(),
+        collections.HTMLFormControlsCollection{ ._proto = undefined },
     });
+    elements._proto._chained = .form_controls;
+    return elements;
 }
 
 pub fn iterator(self: *Form, frame: *Frame) collections.NodeLive(.form) {

--- a/src/browser/webapi/element/html/FrameSet.zig
+++ b/src/browser/webapi/element/html/FrameSet.zig
@@ -11,6 +11,8 @@ const String = lp.String;
 
 const FrameSet = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *FrameSet) *Element {

--- a/src/browser/webapi/element/html/Generic.zig
+++ b/src/browser/webapi/element/html/Generic.zig
@@ -27,6 +27,8 @@ const HtmlElement = @import("../Html.zig");
 const String = lp.String;
 
 const Generic = @This();
+
+pub const Proto = HtmlElement;
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/HR.zig
+++ b/src/browser/webapi/element/html/HR.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const HR = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *HR) *Element {

--- a/src/browser/webapi/element/html/Head.zig
+++ b/src/browser/webapi/element/html/Head.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Head = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Head) *Element {

--- a/src/browser/webapi/element/html/Heading.zig
+++ b/src/browser/webapi/element/html/Heading.zig
@@ -27,6 +27,8 @@ const HtmlElement = @import("../Html.zig");
 const String = lp.String;
 
 const Heading = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _tag_name: String,
 _tag: Element.Tag,

--- a/src/browser/webapi/element/html/Html.zig
+++ b/src/browser/webapi/element/html/Html.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Html = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Html) *Element {

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -30,6 +30,8 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 const HtmlElement = @import("../Html.zig");
 
 const IFrame = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _src: []const u8 = "",
 _executed: bool = false,

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -6,6 +6,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Image = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn constructor(w_: ?u32, h_: ?u32, frame: *Frame) !*Image {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -38,6 +38,8 @@ const String = lp.String;
 
 const Input = @This();
 
+pub const Proto = HtmlElement;
+
 pub const Type = enum {
     text,
     password,

--- a/src/browser/webapi/element/html/LI.zig
+++ b/src/browser/webapi/element/html/LI.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const LI = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *LI) *Element {

--- a/src/browser/webapi/element/html/Label.zig
+++ b/src/browser/webapi/element/html/Label.zig
@@ -8,6 +8,8 @@ const TreeWalker = @import("../../TreeWalker.zig");
 
 const Label = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Label) *Element {

--- a/src/browser/webapi/element/html/Legend.zig
+++ b/src/browser/webapi/element/html/Legend.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Legend = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Legend) *Element {

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -27,6 +27,8 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 const HtmlElement = @import("../Html.zig");
 
 const Link = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 // Cached CSSStyleSheet for an external `rel=stylesheet` once
 // `Frame.loadExternalStylesheet` has registered it. Re-fetches (href

--- a/src/browser/webapi/element/html/Map.zig
+++ b/src/browser/webapi/element/html/Map.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Map = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Map) *Element {

--- a/src/browser/webapi/element/html/Marquee.zig
+++ b/src/browser/webapi/element/html/Marquee.zig
@@ -8,6 +8,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Marquee = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Marquee) *Element {

--- a/src/browser/webapi/element/html/Media.zig
+++ b/src/browser/webapi/element/html/Media.zig
@@ -30,6 +30,8 @@ const MediaError = @import("../../media/MediaError.zig");
 
 const Media = @This();
 
+pub const Proto = HtmlElement;
+
 pub const ReadyState = enum(u16) {
     HAVE_NOTHING = 0,
     HAVE_METADATA = 1,

--- a/src/browser/webapi/element/html/Meta.zig
+++ b/src/browser/webapi/element/html/Meta.zig
@@ -23,6 +23,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Meta = @This();
+
+pub const Proto = HtmlElement;
 // Because we have a JsApi.Meta, "Meta" can be ambiguous in some scopes.
 // Create a different alias we can use when in such ambiguous cases.
 const MetaElement = Meta;

--- a/src/browser/webapi/element/html/Meter.zig
+++ b/src/browser/webapi/element/html/Meter.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Meter = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Meter) *Element {

--- a/src/browser/webapi/element/html/Mod.zig
+++ b/src/browser/webapi/element/html/Mod.zig
@@ -9,6 +9,8 @@ const String = lp.String;
 
 const Mod = @This();
 
+pub const Proto = HtmlElement;
+
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/OL.zig
+++ b/src/browser/webapi/element/html/OL.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const OL = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *OL) *Element {

--- a/src/browser/webapi/element/html/Object.zig
+++ b/src/browser/webapi/element/html/Object.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Object = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Object) *Element {

--- a/src/browser/webapi/element/html/OptGroup.zig
+++ b/src/browser/webapi/element/html/OptGroup.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const OptGroup = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *OptGroup) *Element {

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -30,6 +30,8 @@ const String = lp.String;
 
 const Option = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _value: ?[]const u8 = null,
 _selected: bool = false,

--- a/src/browser/webapi/element/html/Output.zig
+++ b/src/browser/webapi/element/html/Output.zig
@@ -27,6 +27,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Output = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Output) *Element {

--- a/src/browser/webapi/element/html/Paragraph.zig
+++ b/src/browser/webapi/element/html/Paragraph.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Paragraph = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Paragraph) *Element {

--- a/src/browser/webapi/element/html/Param.zig
+++ b/src/browser/webapi/element/html/Param.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Param = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Param) *Element {

--- a/src/browser/webapi/element/html/Picture.zig
+++ b/src/browser/webapi/element/html/Picture.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Picture = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Picture) *Element {

--- a/src/browser/webapi/element/html/Pre.zig
+++ b/src/browser/webapi/element/html/Pre.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Pre = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Pre) *Element {

--- a/src/browser/webapi/element/html/Progress.zig
+++ b/src/browser/webapi/element/html/Progress.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Progress = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Progress) *Element {

--- a/src/browser/webapi/element/html/Quote.zig
+++ b/src/browser/webapi/element/html/Quote.zig
@@ -10,6 +10,8 @@ const String = lp.String;
 
 const Quote = @This();
 
+pub const Proto = HtmlElement;
+
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -26,6 +26,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Script = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _src: []const u8 = "",
 _executed: bool = false,

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -30,6 +30,8 @@ pub const Option = @import("Option.zig");
 
 const Select = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _selected_index_set: bool = false,
 _custom_validity: ?[]const u8 = null,

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -247,13 +247,15 @@ pub fn getOptions(self: *Select, frame: *Frame) !*collections.HTMLOptionsCollect
     // select_options mode is the select's list of options: option children
     // plus the option children of optgroup children.
     const node_live = collections.NodeLive(.select_options).init(self.asNode(), {}, frame);
-    const html_collection = try node_live.runtimeGenericWrap(frame);
-
-    // Create and return HTMLOptionsCollection
-    return frame._factory.create(collections.HTMLOptionsCollection{
-        ._proto = html_collection,
-        ._select = self,
+    const options = try frame._factory.chained(.{
+        node_live.htmlCollectionValue(),
+        collections.HTMLOptionsCollection{
+            ._proto = undefined,
+            ._select = self,
+        },
     });
+    options._proto._chained = .options;
+    return options;
 }
 
 pub fn getLength(self: *Select) u32 {

--- a/src/browser/webapi/element/html/Slot.zig
+++ b/src/browser/webapi/element/html/Slot.zig
@@ -9,6 +9,8 @@ const slotting = @import("../slotting.zig");
 
 const Slot = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 // DOM spec "assigned nodes". Maintained by slotting.assignSlottables; always
 // empty while the slot isn't in a shadow tree.

--- a/src/browser/webapi/element/html/Source.zig
+++ b/src/browser/webapi/element/html/Source.zig
@@ -7,6 +7,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Source = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Source) *Element {

--- a/src/browser/webapi/element/html/Span.zig
+++ b/src/browser/webapi/element/html/Span.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Span = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Span) *Element {

--- a/src/browser/webapi/element/html/Style.zig
+++ b/src/browser/webapi/element/html/Style.zig
@@ -25,6 +25,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const Style = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _sheet: ?*CSSStyleSheet = null,
 

--- a/src/browser/webapi/element/html/Table.zig
+++ b/src/browser/webapi/element/html/Table.zig
@@ -7,6 +7,8 @@ const collections = @import("../../collections.zig");
 
 const Table = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Table) *Element {

--- a/src/browser/webapi/element/html/TableCaption.zig
+++ b/src/browser/webapi/element/html/TableCaption.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const TableCaption = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *TableCaption) *Element {

--- a/src/browser/webapi/element/html/TableCell.zig
+++ b/src/browser/webapi/element/html/TableCell.zig
@@ -11,6 +11,8 @@ const String = lp.String;
 
 const TableCell = @This();
 
+pub const Proto = HtmlElement;
+
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/TableCol.zig
+++ b/src/browser/webapi/element/html/TableCol.zig
@@ -9,6 +9,8 @@ const String = lp.String;
 
 const TableCol = @This();
 
+pub const Proto = HtmlElement;
+
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/TableRow.zig
+++ b/src/browser/webapi/element/html/TableRow.zig
@@ -7,6 +7,8 @@ const collections = @import("../../collections.zig");
 
 const TableRow = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *TableRow) *Element {

--- a/src/browser/webapi/element/html/TableSection.zig
+++ b/src/browser/webapi/element/html/TableSection.zig
@@ -11,6 +11,8 @@ const String = lp.String;
 
 const TableSection = @This();
 
+pub const Proto = HtmlElement;
+
 _tag_name: String,
 _tag: Element.Tag,
 _proto: *HtmlElement,

--- a/src/browser/webapi/element/html/Template.zig
+++ b/src/browser/webapi/element/html/Template.zig
@@ -32,6 +32,8 @@ const String = lp.String;
 
 const Template = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _content: *DocumentFragment,
 

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -31,6 +31,8 @@ const ValidityState = @import("ValidityState.zig");
 
 const TextArea = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _value: ?[]const u8 = null,
 

--- a/src/browser/webapi/element/html/Time.zig
+++ b/src/browser/webapi/element/html/Time.zig
@@ -6,6 +6,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Time = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Time) *Element {

--- a/src/browser/webapi/element/html/Title.zig
+++ b/src/browser/webapi/element/html/Title.zig
@@ -5,6 +5,8 @@ const HtmlElement = @import("../Html.zig");
 
 const Title = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 
 pub fn asElement(self: *Title) *Element {

--- a/src/browser/webapi/element/html/Track.zig
+++ b/src/browser/webapi/element/html/Track.zig
@@ -29,6 +29,8 @@ const String = lp.String;
 
 const Track = @This();
 
+pub const Proto = HtmlElement;
+
 _proto: *HtmlElement,
 _kind: String,
 _ready_state: ReadyState,

--- a/src/browser/webapi/element/html/UL.zig
+++ b/src/browser/webapi/element/html/UL.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
 const UL = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 
 pub fn asElement(self: *UL) *Element {

--- a/src/browser/webapi/element/html/Unknown.zig
+++ b/src/browser/webapi/element/html/Unknown.zig
@@ -27,6 +27,8 @@ const HtmlElement = @import("../Html.zig");
 const String = lp.String;
 
 const Unknown = @This();
+
+pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _tag_name: String,
 

--- a/src/browser/webapi/element/html/Video.zig
+++ b/src/browser/webapi/element/html/Video.zig
@@ -25,6 +25,8 @@ const Media = @import("Media.zig");
 
 const Video = @This();
 
+pub const Proto = Media;
+
 _proto: *Media,
 
 pub fn asMedia(self: *Video) *Media {

--- a/src/browser/webapi/element/svg/A.zig
+++ b/src/browser/webapi/element/svg/A.zig
@@ -27,6 +27,8 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 const Graphics = @import("Graphics.zig");
 
 const A = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *A) *Element {

--- a/src/browser/webapi/element/svg/Circle.zig
+++ b/src/browser/webapi/element/svg/Circle.zig
@@ -26,6 +26,8 @@ const Geometry = @import("Geometry.zig");
 const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 
 const Circle = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Circle) *Element {

--- a/src/browser/webapi/element/svg/ClipPath.zig
+++ b/src/browser/webapi/element/svg/ClipPath.zig
@@ -28,6 +28,8 @@ const AnimatedTransformList = @import("../../svg/AnimatedTransformList.zig");
 const Svg = @import("../Svg.zig");
 
 const ClipPath = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *ClipPath) *Element {

--- a/src/browser/webapi/element/svg/Defs.zig
+++ b/src/browser/webapi/element/svg/Defs.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Graphics = @import("Graphics.zig");
 
 const Defs = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Defs) *Element {

--- a/src/browser/webapi/element/svg/Desc.zig
+++ b/src/browser/webapi/element/svg/Desc.zig
@@ -22,6 +22,8 @@ const Element = @import("../../Element.zig");
 const Svg = @import("../Svg.zig");
 
 const Desc = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Desc) *Element {

--- a/src/browser/webapi/element/svg/Ellipse.zig
+++ b/src/browser/webapi/element/svg/Ellipse.zig
@@ -26,6 +26,8 @@ const Geometry = @import("Geometry.zig");
 const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 
 const Ellipse = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Ellipse) *Element {

--- a/src/browser/webapi/element/svg/ForeignObject.zig
+++ b/src/browser/webapi/element/svg/ForeignObject.zig
@@ -29,6 +29,8 @@ const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 const Graphics = @import("Graphics.zig");
 
 const ForeignObject = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *ForeignObject) *Element {

--- a/src/browser/webapi/element/svg/G.zig
+++ b/src/browser/webapi/element/svg/G.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Graphics = @import("Graphics.zig");
 
 const G = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *G) *Element {

--- a/src/browser/webapi/element/svg/Generic.zig
+++ b/src/browser/webapi/element/svg/Generic.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Svg = @import("../Svg.zig");
 
 const Generic = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 _tag: Element.Tag,
 

--- a/src/browser/webapi/element/svg/Geometry.zig
+++ b/src/browser/webapi/element/svg/Geometry.zig
@@ -38,6 +38,8 @@ pub const Polygon = @import("Polygon.zig");
 pub const Polyline = @import("Polyline.zig");
 
 const Geometry = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 _type: Type,
 

--- a/src/browser/webapi/element/svg/GradientElement.zig
+++ b/src/browser/webapi/element/svg/GradientElement.zig
@@ -32,6 +32,8 @@ pub const LinearGradient = @import("LinearGradient.zig");
 pub const RadialGradient = @import("RadialGradient.zig");
 
 const GradientElement = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 _type: Type,
 

--- a/src/browser/webapi/element/svg/Graphics.zig
+++ b/src/browser/webapi/element/svg/Graphics.zig
@@ -42,6 +42,8 @@ pub const TextContent = @import("TextContent.zig");
 pub const Geometry = @import("Geometry.zig");
 
 const Graphics = @This();
+
+pub const Proto = SvgElement;
 _proto: *SvgElement,
 _type: Type,
 

--- a/src/browser/webapi/element/svg/Image.zig
+++ b/src/browser/webapi/element/svg/Image.zig
@@ -26,6 +26,8 @@ const AnimatedString = @import("../../svg/AnimatedString.zig");
 const Graphics = @import("Graphics.zig");
 
 const Image = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Image) *Element {

--- a/src/browser/webapi/element/svg/Line.zig
+++ b/src/browser/webapi/element/svg/Line.zig
@@ -26,6 +26,8 @@ const Geometry = @import("Geometry.zig");
 const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 
 const Line = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Line) *Element {

--- a/src/browser/webapi/element/svg/LinearGradient.zig
+++ b/src/browser/webapi/element/svg/LinearGradient.zig
@@ -27,6 +27,8 @@ const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 const GradientElement = @import("GradientElement.zig");
 
 const LinearGradient = @This();
+
+pub const Proto = GradientElement;
 _proto: *GradientElement,
 
 pub fn asElement(self: *LinearGradient) *Element {

--- a/src/browser/webapi/element/svg/Marker.zig
+++ b/src/browser/webapi/element/svg/Marker.zig
@@ -28,6 +28,8 @@ const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 const Svg = @import("../Svg.zig");
 
 const Marker = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Marker) *Element {

--- a/src/browser/webapi/element/svg/Mask.zig
+++ b/src/browser/webapi/element/svg/Mask.zig
@@ -28,6 +28,8 @@ const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 const Svg = @import("../Svg.zig");
 
 const Mask = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Mask) *Element {

--- a/src/browser/webapi/element/svg/Metadata.zig
+++ b/src/browser/webapi/element/svg/Metadata.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Svg = @import("../Svg.zig");
 
 const Metadata = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Metadata) *Element {

--- a/src/browser/webapi/element/svg/Path.zig
+++ b/src/browser/webapi/element/svg/Path.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Geometry = @import("Geometry.zig");
 
 const Path = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Path) *Element {

--- a/src/browser/webapi/element/svg/Pattern.zig
+++ b/src/browser/webapi/element/svg/Pattern.zig
@@ -30,6 +30,8 @@ const AnimatedTransformList = @import("../../svg/AnimatedTransformList.zig");
 const Svg = @import("../Svg.zig");
 
 const Pattern = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Pattern) *Element {

--- a/src/browser/webapi/element/svg/Polygon.zig
+++ b/src/browser/webapi/element/svg/Polygon.zig
@@ -26,6 +26,8 @@ const Geometry = @import("Geometry.zig");
 const PointList = @import("../../svg/PointList.zig");
 
 const Polygon = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Polygon) *Element {

--- a/src/browser/webapi/element/svg/Polyline.zig
+++ b/src/browser/webapi/element/svg/Polyline.zig
@@ -26,6 +26,8 @@ const Geometry = @import("Geometry.zig");
 const PointList = @import("../../svg/PointList.zig");
 
 const Polyline = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Polyline) *Element {

--- a/src/browser/webapi/element/svg/RadialGradient.zig
+++ b/src/browser/webapi/element/svg/RadialGradient.zig
@@ -27,6 +27,8 @@ const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 const GradientElement = @import("GradientElement.zig");
 
 const RadialGradient = @This();
+
+pub const Proto = GradientElement;
 _proto: *GradientElement,
 
 pub fn asElement(self: *RadialGradient) *Element {

--- a/src/browser/webapi/element/svg/Rect.zig
+++ b/src/browser/webapi/element/svg/Rect.zig
@@ -24,6 +24,8 @@ const Geometry = @import("Geometry.zig");
 const AnimatedLength = @import("../../svg/AnimatedLength.zig");
 
 const Rect = @This();
+
+pub const Proto = Geometry;
 _proto: *Geometry,
 
 pub fn asElement(self: *Rect) *Element {

--- a/src/browser/webapi/element/svg/Stop.zig
+++ b/src/browser/webapi/element/svg/Stop.zig
@@ -27,6 +27,8 @@ const AnimatedNumber = @import("../../svg/AnimatedNumber.zig");
 const Svg = @import("../Svg.zig");
 
 const Stop = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Stop) *Element {

--- a/src/browser/webapi/element/svg/Svg.zig
+++ b/src/browser/webapi/element/svg/Svg.zig
@@ -37,6 +37,8 @@ const AnimatedPreserveAspectRatio = @import("../../svg/AnimatedPreserveAspectRat
 const Graphics = @import("Graphics.zig");
 
 const Svg = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Svg) *Element {

--- a/src/browser/webapi/element/svg/Switch.zig
+++ b/src/browser/webapi/element/svg/Switch.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Graphics = @import("Graphics.zig");
 
 const Switch = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Switch) *Element {

--- a/src/browser/webapi/element/svg/Symbol.zig
+++ b/src/browser/webapi/element/svg/Symbol.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Graphics = @import("Graphics.zig");
 
 const Symbol = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Symbol) *Element {

--- a/src/browser/webapi/element/svg/TSpan.zig
+++ b/src/browser/webapi/element/svg/TSpan.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const TextPositioning = @import("TextPositioning.zig");
 
 const TSpan = @This();
+
+pub const Proto = TextPositioning;
 _proto: *TextPositioning,
 
 pub fn asElement(self: *TSpan) *Element {

--- a/src/browser/webapi/element/svg/Text.zig
+++ b/src/browser/webapi/element/svg/Text.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const TextPositioning = @import("TextPositioning.zig");
 
 const Text = @This();
+
+pub const Proto = TextPositioning;
 _proto: *TextPositioning,
 
 pub fn asElement(self: *Text) *Element {

--- a/src/browser/webapi/element/svg/TextContent.zig
+++ b/src/browser/webapi/element/svg/TextContent.zig
@@ -33,6 +33,8 @@ pub const TextPositioning = @import("TextPositioning.zig");
 pub const TextPath = @import("TextPath.zig");
 
 const TextContent = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 _type: Type,
 

--- a/src/browser/webapi/element/svg/TextPath.zig
+++ b/src/browser/webapi/element/svg/TextPath.zig
@@ -29,6 +29,8 @@ const AnimatedString = @import("../../svg/AnimatedString.zig");
 const TextContent = @import("TextContent.zig");
 
 const TextPath = @This();
+
+pub const Proto = TextContent;
 _proto: *TextContent,
 
 pub fn asElement(self: *TextPath) *Element {

--- a/src/browser/webapi/element/svg/TextPositioning.zig
+++ b/src/browser/webapi/element/svg/TextPositioning.zig
@@ -27,6 +27,8 @@ pub const Text = @import("Text.zig");
 pub const TSpan = @import("TSpan.zig");
 
 const TextPositioning = @This();
+
+pub const Proto = TextContent;
 _proto: *TextContent,
 _type: Type,
 

--- a/src/browser/webapi/element/svg/Title.zig
+++ b/src/browser/webapi/element/svg/Title.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Svg = @import("../Svg.zig");
 
 const Title = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *Title) *Element {

--- a/src/browser/webapi/element/svg/Use.zig
+++ b/src/browser/webapi/element/svg/Use.zig
@@ -26,6 +26,8 @@ const AnimatedString = @import("../../svg/AnimatedString.zig");
 const Graphics = @import("Graphics.zig");
 
 const Use = @This();
+
+pub const Proto = Graphics;
 _proto: *Graphics,
 
 pub fn asElement(self: *Use) *Element {

--- a/src/browser/webapi/element/svg/View.zig
+++ b/src/browser/webapi/element/svg/View.zig
@@ -24,6 +24,8 @@ const Element = @import("../../Element.zig");
 const Svg = @import("../Svg.zig");
 
 const View = @This();
+
+pub const Proto = Svg;
 _proto: *Svg,
 
 pub fn asElement(self: *View) *Element {

--- a/src/browser/webapi/event/BeforeUnloadEvent.zig
+++ b/src/browser/webapi/event/BeforeUnloadEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-beforeunloadevent-interface
 const BeforeUnloadEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _return_value: []const u8 = "",
 

--- a/src/browser/webapi/event/CloseEvent.zig
+++ b/src/browser/webapi/event/CloseEvent.zig
@@ -26,6 +26,8 @@ const String = lp.String;
 const Allocator = std.mem.Allocator;
 
 const CloseEvent = @This();
+
+pub const Proto = Event;
 _proto: *Event,
 _code: u16 = 1000,
 _reason: []const u8 = "",

--- a/src/browser/webapi/event/CompositionEvent.zig
+++ b/src/browser/webapi/event/CompositionEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 
 const CompositionEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _data: []const u8 = "",
 

--- a/src/browser/webapi/event/CookieChangeEvent.zig
+++ b/src/browser/webapi/event/CookieChangeEvent.zig
@@ -32,6 +32,8 @@ const Allocator = std.mem.Allocator;
 // https://developer.mozilla.org/en-US/docs/Web/API/CookieChangeEvent
 const CookieChangeEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _changed: []CookieStore.CookieListItem,
 _deleted: []CookieStore.CookieListItem,

--- a/src/browser/webapi/event/CustomEvent.zig
+++ b/src/browser/webapi/event/CustomEvent.zig
@@ -29,6 +29,8 @@ const Allocator = std.mem.Allocator;
 
 const CustomEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _detail: ?js.Value.Global = null,
 _arena: Allocator,

--- a/src/browser/webapi/event/DeviceMotionEvent.zig
+++ b/src/browser/webapi/event/DeviceMotionEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 // https://w3c.github.io/deviceorientation/#devicemotionevent
 const DeviceMotionEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _interval: f64 = 0,
 

--- a/src/browser/webapi/event/DeviceOrientationEvent.zig
+++ b/src/browser/webapi/event/DeviceOrientationEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 // https://w3c.github.io/deviceorientation/#deviceorientationevent
 const DeviceOrientationEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _alpha: ?f64 = null,
 _beta: ?f64 = null,

--- a/src/browser/webapi/event/DragEvent.zig
+++ b/src/browser/webapi/event/DragEvent.zig
@@ -30,6 +30,8 @@ const String = lp.String;
 
 const DragEvent = @This();
 
+pub const Proto = MouseEvent;
+
 _proto: *MouseEvent,
 _data_transfer: ?*DataTransfer,
 

--- a/src/browser/webapi/event/ErrorEvent.zig
+++ b/src/browser/webapi/event/ErrorEvent.zig
@@ -29,6 +29,8 @@ const Allocator = std.mem.Allocator;
 
 const ErrorEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _message: []const u8 = "",
 _filename: []const u8 = "",

--- a/src/browser/webapi/event/FocusEvent.zig
+++ b/src/browser/webapi/event/FocusEvent.zig
@@ -31,6 +31,8 @@ const Allocator = std.mem.Allocator;
 
 const FocusEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _related_target: ?*EventTarget = null,
 

--- a/src/browser/webapi/event/FormDataEvent.zig
+++ b/src/browser/webapi/event/FormDataEvent.zig
@@ -32,6 +32,8 @@ const Allocator = std.mem.Allocator;
 /// https://developer.mozilla.org/en-US/docs/Web/API/FormDataEvent
 const FormDataEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _form_data: ?*FormData = null,
 

--- a/src/browser/webapi/event/GamepadEvent.zig
+++ b/src/browser/webapi/event/GamepadEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 // https://w3c.github.io/gamepad/#gamepadevent-interface
 const GamepadEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 
 const GamepadEventOptions = struct {};

--- a/src/browser/webapi/event/HashChangeEvent.zig
+++ b/src/browser/webapi/event/HashChangeEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 // https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent
 const HashChangeEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _old_url: []const u8,
 _new_url: []const u8,

--- a/src/browser/webapi/event/InputEvent.zig
+++ b/src/browser/webapi/event/InputEvent.zig
@@ -32,6 +32,8 @@ const Allocator = std.mem.Allocator;
 
 const InputEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _data: ?[]const u8,
 _data_transfer: ?*DataTransfer = null,

--- a/src/browser/webapi/event/KeyboardEvent.zig
+++ b/src/browser/webapi/event/KeyboardEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 
 const KeyboardEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _key: Key,
 _code: []const u8,

--- a/src/browser/webapi/event/MessageEvent.zig
+++ b/src/browser/webapi/event/MessageEvent.zig
@@ -32,6 +32,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const MessageEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _data: ?Data = null,
 _origin: []const u8 = "",

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -33,6 +33,8 @@ const Allocator = std.mem.Allocator;
 
 const MouseEvent = @This();
 
+pub const Proto = UIEvent;
+
 pub const MouseButton = enum(u8) {
     main = 0,
     auxiliary = 1,

--- a/src/browser/webapi/event/NavigationCurrentEntryChangeEvent.zig
+++ b/src/browser/webapi/event/NavigationCurrentEntryChangeEvent.zig
@@ -31,6 +31,8 @@ const Allocator = std.mem.Allocator;
 
 const NavigationCurrentEntryChangeEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _from: *NavigationHistoryEntry,
 _navigation_type: ?NavigationType,

--- a/src/browser/webapi/event/PageTransitionEvent.zig
+++ b/src/browser/webapi/event/PageTransitionEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 // https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent
 const PageTransitionEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _persisted: bool,
 

--- a/src/browser/webapi/event/PointerEvent.zig
+++ b/src/browser/webapi/event/PointerEvent.zig
@@ -29,6 +29,8 @@ const String = lp.String;
 
 const PointerEvent = @This();
 
+pub const Proto = MouseEvent;
+
 const PointerType = enum {
     empty,
     mouse,

--- a/src/browser/webapi/event/PopStateEvent.zig
+++ b/src/browser/webapi/event/PopStateEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 // https://developer.mozilla.org/en-US/docs/Web/API/PopStateEvent
 const PopStateEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _state: ?[]const u8,
 

--- a/src/browser/webapi/event/ProgressEvent.zig
+++ b/src/browser/webapi/event/ProgressEvent.zig
@@ -26,6 +26,8 @@ const String = lp.String;
 const Allocator = std.mem.Allocator;
 
 const ProgressEvent = @This();
+
+pub const Proto = Event;
 _proto: *Event,
 _total: usize = 0,
 _loaded: usize = 0,

--- a/src/browser/webapi/event/PromiseRejectionEvent.zig
+++ b/src/browser/webapi/event/PromiseRejectionEvent.zig
@@ -26,6 +26,8 @@ const String = lp.String;
 
 const PromiseRejectionEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _reason: ?js.Value.Global = null,
 _promise: ?js.Promise.Global = null,

--- a/src/browser/webapi/event/StorageEvent.zig
+++ b/src/browser/webapi/event/StorageEvent.zig
@@ -30,6 +30,8 @@ const Allocator = std.mem.Allocator;
 // https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface
 const StorageEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _key: ?[]const u8 = null,
 _old_value: ?[]const u8 = null,

--- a/src/browser/webapi/event/SubmitEvent.zig
+++ b/src/browser/webapi/event/SubmitEvent.zig
@@ -31,6 +31,8 @@ const Allocator = std.mem.Allocator;
 /// https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent
 const SubmitEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _submitter: ?*HtmlElement,
 

--- a/src/browser/webapi/event/TextEvent.zig
+++ b/src/browser/webapi/event/TextEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 
 const TextEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _data: []const u8 = "",
 

--- a/src/browser/webapi/event/ToggleEvent.zig
+++ b/src/browser/webapi/event/ToggleEvent.zig
@@ -31,6 +31,8 @@ const Allocator = std.mem.Allocator;
 /// https://html.spec.whatwg.org/multipage/popover.html#toggleevent
 const ToggleEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _old_state: []const u8 = "",
 _new_state: []const u8 = "",

--- a/src/browser/webapi/event/TouchEvent.zig
+++ b/src/browser/webapi/event/TouchEvent.zig
@@ -30,6 +30,8 @@ const String = lp.String;
 // There is no touch input source: the touch lists are always empty.
 const TouchEvent = @This();
 
+pub const Proto = UIEvent;
+
 _proto: *UIEvent,
 _alt_key: bool = false,
 _meta_key: bool = false,

--- a/src/browser/webapi/event/UIEvent.zig
+++ b/src/browser/webapi/event/UIEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 
 const UIEvent = @This();
 
+pub const Proto = Event;
+
 _type: Type,
 _proto: *Event,
 _detail: u32 = 0,

--- a/src/browser/webapi/event/WheelEvent.zig
+++ b/src/browser/webapi/event/WheelEvent.zig
@@ -28,6 +28,8 @@ const String = lp.String;
 
 const WheelEvent = @This();
 
+pub const Proto = MouseEvent;
+
 _proto: *MouseEvent,
 _delta_x: f64,
 _delta_y: f64,

--- a/src/browser/webapi/media/TextTrackCue.zig
+++ b/src/browser/webapi/media/TextTrackCue.zig
@@ -23,6 +23,8 @@ const EventTarget = @import("../EventTarget.zig");
 
 const TextTrackCue = @This();
 
+pub const Proto = EventTarget;
+
 _type: Type,
 _proto: *EventTarget,
 _id: []const u8 = "",

--- a/src/browser/webapi/media/VTTCue.zig
+++ b/src/browser/webapi/media/VTTCue.zig
@@ -23,6 +23,8 @@ const TextTrackCue = @import("TextTrackCue.zig");
 
 const VTTCue = @This();
 
+pub const Proto = TextTrackCue;
+
 _proto: *TextTrackCue,
 _text: []const u8 = "",
 _region: ?js.Object.Global = null,

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -22,6 +22,7 @@ const URL = @import("../URL.zig");
 
 const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
+const Factory = @import("../../Factory.zig");
 
 const Event = @import("../Event.zig");
 const EventTarget = @import("../EventTarget.zig");
@@ -57,21 +58,12 @@ fn asEventTarget(self: *Navigation) *EventTarget {
 }
 
 pub fn onRemoveFrame(self: *Navigation) void {
-    self._proto = undefined;
     if (self._on_currententrychange) |cb| cb.release();
     self._on_currententrychange = null;
 
     for (self._entries.items) |entry| {
         if (entry._on_dispose) |cb| cb.release();
         entry._on_dispose = null;
-        entry._proto = undefined;
-    }
-}
-
-pub fn onNewFrame(self: *Navigation, frame: *Frame) !void {
-    self._proto = try frame._factory.standaloneEventTarget(self);
-    for (self._entries.items) |entry| {
-        entry._proto = try frame._factory.standaloneEventTarget(entry);
     }
 }
 
@@ -223,14 +215,17 @@ pub fn pushEntry(
 
     const id_str = try std.fmt.allocPrint(arena, "{d}", .{id});
 
-    const entry = try arena.create(NavigationHistoryEntry);
-    entry.* = NavigationHistoryEntry{
-        ._proto = try frame._factory.standaloneEventTarget(entry),
-        ._id = id_str,
-        ._key = id_str,
-        ._url = url,
-        ._state = state,
-    };
+    const entry = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        NavigationHistoryEntry{
+            ._proto = undefined,
+            ._id = id_str,
+            ._key = id_str,
+            ._url = url,
+            ._state = state,
+        },
+    });
+    entry._proto._type = .{ .navigation_history_entry = entry };
 
     // we don't always have a current entry...
     const previous = if (self._entries.items.len > 0) self.getCurrentEntry() else null;
@@ -267,14 +262,17 @@ pub fn replaceEntry(
     self._next_entry_id += 1;
     const id_str = try std.fmt.allocPrint(arena, "{d}", .{id});
 
-    const entry = try arena.create(NavigationHistoryEntry);
-    entry.* = NavigationHistoryEntry{
-        ._proto = try frame._factory.standaloneEventTarget(entry),
-        ._id = id_str,
-        ._key = previous._key,
-        ._url = url,
-        ._state = state,
-    };
+    const entry = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        NavigationHistoryEntry{
+            ._proto = undefined,
+            ._id = id_str,
+            ._key = previous._key,
+            ._url = url,
+            ._state = state,
+        },
+    });
+    entry._proto._type = .{ .navigation_history_entry = entry };
 
     const old_entry = self._entries.items[self._index];
     self._entries.items[self._index] = entry;

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -31,6 +31,8 @@ const log = lp.log;
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigation
 const Navigation = @This();
 
+pub const Proto = EventTarget;
+
 const NavigationKind = @import("root.zig").NavigationKind;
 const NavigationActivation = @import("NavigationActivation.zig");
 const NavigationTransition = @import("root.zig").NavigationTransition;

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -46,7 +46,7 @@ pub fn id(self: *const NavigationHistoryEntry) []const u8 {
 }
 
 pub fn index(self: *const NavigationHistoryEntry, frame: *Frame) i32 {
-    const navigation = &frame._session.navigation;
+    const navigation = frame._session.navigation;
 
     for (navigation._entries.items, 0..) |entry, i| {
         if (std.mem.eql(u8, entry._id, self._id)) {

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -26,6 +26,8 @@ const js = @import("../../js/js.zig");
 
 const NavigationHistoryEntry = @This();
 
+pub const Proto = EventTarget;
+
 // https://developer.mozilla.org/en-US/docs/Web/API/NavigationHistoryEntry
 _proto: *EventTarget,
 _id: []const u8,

--- a/src/browser/webapi/net/EventSource.zig
+++ b/src/browser/webapi/net/EventSource.zig
@@ -39,6 +39,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 // https://html.spec.whatwg.org/multipage/server-sent-events.html
 const EventSource = @This();
 
+pub const Proto = EventTarget;
+
 _rc: lp.RC = .{},
 _exec: *const Execution,
 _proto: *EventTarget,

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Factory = @import("../../Factory.zig");
 const Frame = @import("../../Frame.zig");
 const Form = @import("../element/html/Form.zig");
 const Element = @import("../Element.zig");
@@ -208,17 +209,19 @@ pub fn append(self: *FormData, name: []const u8, value: EntryValue, filename: ?[
 // but over bytes we already hold rather than JS parts. Returned at refcount 1:
 // the entry owns that reference and deleteByName releases it.
 fn fileFrom(source: *Blob, name: []const u8, page: *Page) !*File {
-    const blob = try Blob.initFromBytes(source._slice, source._mime, page);
-    errdefer blob.deinit(page);
+    const arena = try page.getArena(source._slice.len + source._mime.len + 256, "Blob");
+    errdefer page.releaseArena(arena);
 
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = @intCast(lp.datetime.milliTimestamp(.real)),
-    };
-    blob._type = .{ .file = file };
-    blob.acquireRef();
+    const file = try Factory.chainedWithAllocator(arena, .{
+        try Blob.buildValueFromBytes(arena, source._slice, source._mime),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = @intCast(lp.datetime.milliTimestamp(.real)),
+        },
+    });
+    file._proto._type = .{ .file = file };
+    file._proto.acquireRef();
     return file;
 }
 
@@ -652,14 +655,17 @@ test "FormData: multipart empty body" {
 }
 
 fn buildTestFile(arena: Allocator, page: *@import("../../Page.zig"), name: []const u8, mime: []const u8, body: []const u8) !*File {
-    const blob = try Blob.initFromBytes(body, mime, page);
-    blob.acquireRef();
-    const file = try arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try arena.dupe(u8, name),
-        ._last_modified = 0,
-    };
+    const blob_arena = try page.getArena(body.len + mime.len + 256, "Blob");
+    const file = try Factory.chainedWithAllocator(blob_arena, .{
+        try Blob.buildValueFromBytes(blob_arena, body, mime),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = 0,
+        },
+    });
+    file._proto._type = .{ .file = file };
+    file._proto.acquireRef();
     return file;
 }
 

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -40,6 +40,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const WebSocket = @This();
 
+pub const Proto = EventTarget;
+
 _rc: lp.RC = .{},
 _exec: *const Execution,
 _proto: *EventTarget,

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -43,6 +43,8 @@ const Allocator = std.mem.Allocator;
 const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const XMLHttpRequest = @This();
+
+pub const Proto = XMLHttpRequestEventTarget;
 _rc: lp.RC = .{},
 _exec: *const Execution,
 _proto: *XMLHttpRequestEventTarget,

--- a/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
+++ b/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
@@ -26,6 +26,8 @@ const Execution = js.Execution;
 
 const XMLHttpRequestEventTarget = @This();
 
+pub const Proto = EventTarget;
+
 _type: Type,
 _proto: *EventTarget,
 _on_abort: ?js.Function.Global = null,

--- a/src/browser/webapi/net/XMLHttpRequestUpload.zig
+++ b/src/browser/webapi/net/XMLHttpRequestUpload.zig
@@ -32,6 +32,8 @@ const XMLHttpRequestEventTarget = @import("XMLHttpRequestEventTarget.zig");
 // htmx) can call addEventListener on it without throwing.
 const XMLHttpRequestUpload = @This();
 
+pub const Proto = XMLHttpRequestEventTarget;
+
 _proto: *XMLHttpRequestEventTarget,
 _xhr: *XMLHttpRequest,
 

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -34,6 +34,8 @@ const String = lp.String;
 // https://developer.mozilla.org/en-US/docs/Web/API/CookieStore
 const CookieStore = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _on_change: ?js.Function.Global = null,
 _exec: ?*Execution = null,

--- a/src/browser/webapi/storage/idb/IDBCursor.zig
+++ b/src/browser/webapi/storage/idb/IDBCursor.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Page = @import("../../../Page.zig");
+const Factory = @import("../../../Factory.zig");
 
 const Key = @import("Key.zig");
 const Engine = @import("Engine.zig");
@@ -122,8 +123,7 @@ fn _init(store: *IDBObjectStore, txn: *IDBTransaction, index_id: ?i64, source: S
     try txn.assertActive();
 
     const request = try txn.newRequest();
-    const self = try txn._arena.create(IDBCursor);
-    self.* = .{
+    const cursor_value = IDBCursor{
         ._engine = store._engine,
         ._store = store,
         ._txn = txn,
@@ -135,13 +135,23 @@ fn _init(store: *IDBObjectStore, txn: *IDBTransaction, index_id: ?i64, source: S
         ._js = undefined,
         ._source = source,
     };
-    request._cursor = self;
 
     const local = exec.js.local.?;
-    const public: js.Value = if (key_only)
-        try local.zigValueToJs(self, .{})
-    else
-        try local.zigValueToJs(try IDBCursorWithValue.init(self), .{});
+    var self: *IDBCursor = undefined;
+    var public: js.Value = undefined;
+    if (key_only) {
+        self = try txn._arena.create(IDBCursor);
+        self.* = cursor_value;
+        public = try local.zigValueToJs(self, .{});
+    } else {
+        const with_value = try Factory.chainedWithAllocator(txn._arena, .{
+            cursor_value,
+            IDBCursorWithValue{ ._proto = undefined },
+        });
+        self = with_value._proto;
+        public = try local.zigValueToJs(with_value, .{});
+    }
+    request._cursor = self;
 
     // Pre-converted and cached because it's the request value on every iteration,
     // avoiding the bridge's pointer -> js.Value lookup each time.

--- a/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
+++ b/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
@@ -24,6 +24,8 @@ const Execution = js.Execution;
 
 const IDBCursorWithValue = @This();
 
+pub const Proto = IDBCursor;
+
 _proto: *IDBCursor,
 
 pub fn init(cursor: *IDBCursor) !*IDBCursorWithValue {

--- a/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
+++ b/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
@@ -28,12 +28,6 @@ pub const Proto = IDBCursor;
 
 _proto: *IDBCursor,
 
-pub fn init(cursor: *IDBCursor) !*IDBCursorWithValue {
-    const self = try cursor._txn._arena.create(IDBCursorWithValue);
-    self.* = .{ ._proto = cursor };
-    return self;
-}
-
 pub fn getValue(self: *const IDBCursorWithValue, exec: *Execution) !?js.Value {
     return self._proto.getValueJs(exec);
 }

--- a/src/browser/webapi/storage/idb/IDBDatabase.zig
+++ b/src/browser/webapi/storage/idb/IDBDatabase.zig
@@ -36,6 +36,8 @@ const Allocator = std.mem.Allocator;
 
 const IDBDatabase = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _exec: *Execution,
 _engine: *Engine,

--- a/src/browser/webapi/storage/idb/IDBRequest.zig
+++ b/src/browser/webapi/storage/idb/IDBRequest.zig
@@ -41,6 +41,8 @@ const FunctionSetter = idb.FunctionSetter;
 
 const IDBRequest = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _op: Operation = .none,
 _error: ?anyerror = null,

--- a/src/browser/webapi/storage/idb/IDBTransaction.zig
+++ b/src/browser/webapi/storage/idb/IDBTransaction.zig
@@ -41,6 +41,8 @@ const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const IDBTransaction = @This();
 
+pub const Proto = EventTarget;
+
 _proto: *EventTarget,
 _exec: *Execution,
 _db: *IDBDatabase,

--- a/src/browser/webapi/storage/idb/IDBVersionChangeEvent.zig
+++ b/src/browser/webapi/storage/idb/IDBVersionChangeEvent.zig
@@ -29,6 +29,8 @@ const Execution = js.Execution;
 
 const IDBVersionChangeEvent = @This();
 
+pub const Proto = Event;
+
 _proto: *Event,
 _old_version: u64,
 _new_version: ?u64,

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -988,8 +988,8 @@ fn writeName(
             else => null,
         },
         .cdata => |cd| switch (cd._type) {
-            .text => |*text| {
-                try writeString(text.ownData(), w);
+            .text => {
+                try writeString(cd._data.str(), w);
                 return .contents;
             },
             else => null,
@@ -1108,8 +1108,8 @@ fn writeAccessibleNameFallback(node: *DOMNode, writer: *std.Io.Writer, frame: *F
     while (it.next()) |child| {
         switch (child._type) {
             .cdata => |cd| switch (cd._type) {
-                .text => |*text| {
-                    const content = std.mem.trim(u8, text.ownData(), &std.ascii.whitespace);
+                .text => {
+                    const content = std.mem.trim(u8, cd._data.str(), &std.ascii.whitespace);
                     if (content.len > 0) {
                         try writer.writeAll(content);
                         try writer.writeByte(' ');

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -31,6 +31,7 @@ const xpath = @import("../../browser/xpath/Evaluator.zig");
 const Input = @import("../../browser/webapi/element/html/Input.zig");
 const File = @import("../../browser/webapi/File.zig");
 const Blob = @import("../../browser/webapi/Blob.zig");
+const Factory = @import("../../browser/Factory.zig");
 const Page = @import("../../browser/Page.zig");
 
 const log = lp.log;
@@ -660,20 +661,21 @@ fn fileFromDiskPath(path: []const u8, page: *Page) !*File {
     const stat = try std.Io.Dir.cwd().statFile(lp.io, path, .{});
     const basename = std.fs.path.basename(path);
 
-    const blob = try arena.create(Blob);
-    const file = try arena.create(File);
-    blob.* = .{
-        ._rc = .{},
-        ._arena = arena,
-        ._type = .{ .file = file },
-        ._slice = data,
-        ._mime = mimeFromExtension(basename),
-    };
-    file.* = .{
-        ._proto = blob,
-        ._name = try arena.dupe(u8, basename),
-        ._last_modified = stat.mtime.toMilliseconds(),
-    };
+    const file = try Factory.chainedWithAllocator(arena, .{
+        Blob{
+            ._rc = .{},
+            ._arena = arena,
+            ._type = undefined,
+            ._slice = data,
+            ._mime = mimeFromExtension(basename),
+        },
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, basename),
+            ._last_modified = stat.mtime.toMilliseconds(),
+        },
+    });
+    file._proto._type = .{ .file = file };
     return file;
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -363,7 +363,7 @@ fn getNavigationHistory(cmd: *CDP.Command) !void {
         return error.SessionIdNotLoaded;
     }
 
-    const nav = &bc.session.navigation;
+    const nav = bc.session.navigation;
     const entries_in = nav._entries.items;
 
     const entries_out = try cmd.arena.alloc(NavigationEntry, entries_in.len);
@@ -398,7 +398,7 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    const nav = &session.navigation;
+    const nav = session.navigation;
 
     var target_index: ?usize = null;
     var target_url: ?[:0]const u8 = null;


### PR DESCRIPTION
This is groundwork for eventually removing the _proto: *X` field from some types (in order to save 8 bytes per, e.g. Node). For now, all `_proto: *X` fields are untouched, BUT, all compile-time chain walking now happens against this new declaration.