### PR TITLE
design: rework cdata _type field

### DIFF
--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -318,6 +318,58 @@ pub fn node(self: *Factory, child: anytype) !*@TypeOf(child) {
     ).create(allocator, child);
 }
 
+// CData nodes: {EventTarget, Node, CData, [Text,] Leaf}.
+// CData is special, it's _type is a bare tag, not a tagged union. A website can
+// have tens of thousands of Text nodes, and this allows a few optimization to
+// both reduce the # of allocations and the size
+pub fn cdataNode(self: *Factory, cd: Node.CData, leaf: anytype) !*Node.CData {
+    const types = comptime prototypeTypes(@TypeOf(leaf));
+    comptime assert(types[0] == EventTarget and types[1] == Node and types[2] == Node.CData);
+
+    const chain = try PrototypeChain(types).allocate(self._slab.allocator());
+    chain.setRoot(EventTarget.Type);
+    chain.setMiddle(1, Node.Type);
+
+    const cd_ptr = chain.get(2);
+    cd_ptr.* = cd;
+    cd_ptr._proto = chain.get(1);
+
+    // only the CDATASection chain has a middle here (its Text)
+    inline for (3..types.len - 1) |i| {
+        chain.set(i, .{ ._proto = chain.get(i - 1) });
+    }
+    chain.setLeaf(types.len - 1, leaf);
+    return cd_ptr;
+}
+
+// The full type list for a leaf. Walks the Proto chain.
+// For example CData.Text -> [_]type{EventTarget, Node, CData, Text}).
+pub fn prototypeTypes(comptime Leaf: type) []const type {
+    comptime {
+        var types: []const type = &.{Leaf};
+        var T = Leaf;
+        while (reflect.Proto(T)) |P| {
+            T = P;
+            types = &[_]type{P} ++ types;
+        }
+        return types;
+    }
+}
+
+// Byte offset of T within the chain allocation for `Leaf`. This is what lets
+// a child reach its parent without a stored pointer.
+pub fn chainOffsetOf(comptime Leaf: type, comptime T: type) usize {
+    comptime {
+        var offset: usize = 0;
+        for (prototypeTypes(Leaf)) |C| {
+            offset = std.mem.alignForward(usize, offset, @alignOf(C));
+            if (C == T) return offset;
+            offset += @sizeOf(C);
+        }
+        @compileError(@typeName(T) ++ " is not in the prototype chain of " ++ @typeName(Leaf));
+    }
+}
+
 pub fn document(self: *Factory, child: anytype) !*@TypeOf(child) {
     const allocator = self._slab.allocator();
     return try AutoPrototypeChain(
@@ -375,20 +427,11 @@ pub fn svgElement(self: *Factory, tag_name: []const u8, child: anytype) !*@TypeO
 }
 
 fn svgPrototypeTypes(comptime Child: type) []const type {
-    comptime {
-        var types: []const type = &[_]type{Child};
-        var T = Child;
-
-        while (T != EventTarget) {
-            T = reflect.Proto(T) orelse @compileError(@typeName(T) ++ " does not lead to EventTarget through Proto");
-            types = &[_]type{T} ++ types;
-        }
-
-        if (types.len < 5 or types[3] != Element.Svg) {
-            @compileError(@typeName(Child) ++ " is not an SVG prototype chain");
-        }
-        return types;
+    const types = prototypeTypes(Child);
+    if (types.len < 5 or types[0] != EventTarget or types[3] != Element.Svg) {
+        @compileError(@typeName(Child) ++ " is not an SVG prototype chain");
     }
+    return types;
 }
 
 pub fn xhrEventTarget(_: *const Factory, allocator: Allocator, child: anytype) !*@TypeOf(child) {

--- a/src/browser/Factory.zig
+++ b/src/browser/Factory.zig
@@ -76,13 +76,6 @@ pub fn eventTargetWithAllocator(_: *const Factory, allocator: Allocator, child: 
     return chain.get(1);
 }
 
-pub fn standaloneEventTarget(self: *Factory, child: anytype) !*EventTarget {
-    const allocator = self._slab.allocator();
-    const et = try allocator.create(EventTarget);
-    et.* = .{ ._type = unionInit(EventTarget.Type, child) };
-    return et;
-}
-
 // this is a root object
 pub fn event(_: *const Factory, arena: Allocator, typ: String, child: anytype) !*@TypeOf(child) {
     const chain = try PrototypeChain(
@@ -368,6 +361,53 @@ pub fn chainOffsetOf(comptime Leaf: type, comptime T: type) usize {
         }
         @compileError(@typeName(T) ++ " is not in the prototype chain of " ++ @typeName(Leaf));
     }
+}
+
+// Byte delta from T down to its Proto within any chain allocation containing
+// them (the prefix layout is the same for every leaf).
+pub fn protoOffset(comptime T: type) usize {
+    const P = reflect.Proto(T).?;
+    return chainOffsetOf(T, T) - chainOffsetOf(T, P);
+}
+
+// Generic contiguous chain from explicit values, for chains whose middles
+// can't be default-initialized by AutoPrototypeChain. Callers pass every
+// level's value in root-to-leaf order, with `undefined` for `_proto` and for
+// any field that must point at another chain member, patching the latter on
+// the result.
+pub fn chained(self: *Factory, values: anytype) !*ChainedLeaf(@TypeOf(values)) {
+    return chainedWithAllocator(self._slab.allocator(), values);
+}
+
+pub fn chainedWithAllocator(allocator: Allocator, values: anytype) !*ChainedLeaf(@TypeOf(values)) {
+    const fields = @typeInfo(@TypeOf(values)).@"struct".fields;
+    const types = comptime blk: {
+        var types: [fields.len]type = undefined;
+        for (fields, 0..) |f, i| {
+            types[i] = f.type;
+        }
+        break :blk types;
+    };
+    comptime {
+        for (types[1..], 0..) |T, i| {
+            assert(reflect.Proto(T).? == types[i]);
+        }
+    }
+
+    const chain = try PrototypeChain(&types).allocate(allocator);
+    inline for (0..types.len) |i| {
+        const ptr = chain.get(i);
+        ptr.* = values[i];
+        if (i > 0) {
+            ptr._proto = chain.get(i - 1);
+        }
+    }
+    return chain.get(types.len - 1);
+}
+
+fn ChainedLeaf(comptime Values: type) type {
+    const fields = @typeInfo(Values).@"struct".fields;
+    return fields[fields.len - 1].type;
 }
 
 pub fn document(self: *Factory, child: anytype) !*@TypeOf(child) {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -25,6 +25,8 @@ const App = @import("../App.zig");
 const History = @import("webapi/History.zig");
 const storage = @import("webapi/storage/storage.zig");
 const IdbManager = @import("webapi/storage/idb/idb.zig").Manager;
+const Factory = @import("Factory.zig");
+const EventTarget = @import("webapi/EventTarget.zig");
 const Navigation = @import("webapi/navigation/Navigation.zig");
 
 const Page = @import("Page.zig");
@@ -50,7 +52,7 @@ const Session = @This();
 browser: *Browser,
 arena: Allocator,
 history: History,
-navigation: Navigation,
+navigation: *Navigation,
 storage_shed: storage.Shed,
 // Per-origin IndexedDB engines
 idb: IdbManager,
@@ -161,12 +163,17 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
     const arena = try arena_pool.acquire(.small, "Session");
     errdefer arena_pool.release(arena);
 
+    const navigation = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        Navigation{ ._proto = undefined },
+    });
+    navigation._proto._type = .{ .navigation = navigation };
+
     self.* = .{
         .arena = arena,
         .arena_pool = arena_pool,
         .history = .{},
-        // The prototype (EventTarget) for Navigation is created when a Frame is created.
-        .navigation = .{ ._proto = undefined },
+        .navigation = navigation,
         .storage_shed = .{},
         .idb = IdbManager.init(allocator),
         .browser = browser,
@@ -345,7 +352,6 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     errdefer _ = self.pages.pop();
 
     const frame = &page.frame;
-    try self.navigation.onNewFrame(frame);
     // Inform CDP the main frame has been created such that additional
     // context for other Worlds can be created as well.
     self.notification.dispatch(.frame_created, frame);
@@ -896,9 +902,6 @@ pub fn commitPendingPage(self: *Session, replacement: *Page) !void {
     // set, so the session still reports an in-flight nav and CDP's frameCreated
     // skips the captured_responses / frame_arena reset that would wipe the
     // response we just received.
-    self.navigation.onNewFrame(&replacement.frame) catch |err| {
-        log.err(.browser, "commitPendingPage onNewFrame", .{ .err = err });
-    };
     self.notification.dispatch(.frame_created, &replacement.frame);
 
     // Step 3: promote — clear `replaces` and unlink OLD so  `livePage()`

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -1051,26 +1051,20 @@ pub fn constructCustomElement(frame: *Frame, new_target: JS.Function) !*Element 
 }
 
 pub fn createTextNode(frame: *Frame, text: []const u8) !*Node {
-    const cd = try frame._factory.node(CData{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-        ._type = .{ .text = .{
-            ._proto = undefined,
-        } },
+        ._type = .text,
         ._data = try frame.dupeSSO(text),
-    });
-    cd._type.text._proto = cd;
+    }, CData.Text{ ._proto = undefined });
     return cd.asNode();
 }
 
 pub fn createComment(frame: *Frame, text: []const u8) !*Node {
-    const cd = try frame._factory.node(CData{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-        ._type = .{ .comment = .{
-            ._proto = undefined,
-        } },
+        ._type = .comment,
         ._data = try frame.dupeSSO(text),
-    });
-    cd._type.comment._proto = cd;
+    }, CData.Comment{ ._proto = undefined });
     return cd.asNode();
 }
 
@@ -1080,23 +1074,11 @@ pub fn createCDATASection(frame: *Frame, data: []const u8) !*Node {
         return error.InvalidCharacterError;
     }
 
-    // First allocate the Text node separately
-    const text_node = try frame._factory.create(CData.Text{
+    const cd = try frame._factory.cdataNode(.{
         ._proto = undefined,
-    });
-
-    // Then create the CData with cdata_section variant
-    const cd = try frame._factory.node(CData{
-        ._proto = undefined,
-        ._type = .{ .cdata_section = .{
-            ._proto = text_node,
-        } },
+        ._type = .cdata_section,
         ._data = try frame.dupeSSO(data),
-    });
-
-    // Set up the back pointer from Text to CData
-    text_node._proto = cd;
-
+    }, CData.CDATASection{ ._proto = undefined });
     return cd.asNode();
 }
 
@@ -1114,20 +1096,14 @@ pub fn createProcessingInstruction(frame: *Frame, target: []const u8, data: []co
 
     const owned_target = try frame.dupeString(target);
 
-    const pi = try frame._factory.create(CData.ProcessingInstruction{
+    const cd = try frame._factory.cdataNode(.{
+        ._proto = undefined,
+        ._type = .processing_instruction,
+        ._data = try frame.dupeSSO(data),
+    }, CData.ProcessingInstruction{
         ._proto = undefined,
         ._target = owned_target,
     });
-
-    const cd = try frame._factory.node(CData{
-        ._proto = undefined,
-        ._type = .{ .processing_instruction = pi },
-        ._data = try frame.dupeSSO(data),
-    });
-
-    // Set up the back pointer from ProcessingInstruction to CData
-    pi._proto = cd;
-
     return cd.asNode();
 }
 

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -25,6 +25,7 @@ const Page = @import("../Page.zig");
 
 const js = @import("js.zig");
 const bridge = @import("bridge.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 const Caller = @import("Caller.zig");
 const Context = @import("Context.zig");
@@ -1295,6 +1296,9 @@ pub fn resolveValue(value: anytype) Resolved {
 }
 
 fn resolveT(comptime T: type, value: *T) Resolved {
+    if (comptime IS_DEBUG) {
+        assertChainContiguity(T, value);
+    }
     const Meta = T.JsApi.Meta;
     return .{
         .ptr = value,
@@ -1384,6 +1388,16 @@ fn resolveT(comptime T: type, value: *T) Resolved {
             };
         },
     };
+}
+
+// Every wrapped chain must be contiguous — the TaggedOpaque walk upcasts by
+// pointer arithmetic. The stored _proto fields double as the canary.
+fn assertChainContiguity(comptime T: type, value: *T) void {
+    if (comptime reflect.Proto(T) != null) {
+        const P = comptime reflect.Proto(T).?;
+        std.debug.assert(@intFromPtr(value._proto) == @intFromPtr(value) - comptime Factory.protoOffset(T));
+        assertChainContiguity(P, value._proto);
+    }
 }
 
 // Start at the "resolved" type (the most specific) and work our way up the

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -1259,7 +1259,19 @@ const Resolved = struct {
 };
 pub fn resolveValue(value: anytype) Resolved {
     const T = bridge.Struct(@TypeOf(value));
-    if (!@hasField(T, "_type") or @typeInfo(@TypeOf(value._type)) != .@"union") {
+    if (!@hasField(T, "_type")) {
+        return resolveT(T, value);
+    }
+
+    // A bare-tag _type means the subtypes are chain members, not payloads
+    // (e.g. CData); the type maps the tag to the member's type.
+    if (comptime @typeInfo(@TypeOf(value._type)) == .@"enum" and @hasDecl(T, "Subtype")) {
+        switch (value._type) {
+            inline else => |tag| return resolveValue(value.subtype(T.Subtype(tag))),
+        }
+    }
+
+    if (comptime @typeInfo(@TypeOf(value._type)) != .@"union") {
         return resolveT(T, value);
     }
 

--- a/src/browser/js/TaggedOpaque.zig
+++ b/src/browser/js/TaggedOpaque.zig
@@ -73,7 +73,9 @@ subtype: ?bridge.SubType,
 
 pub const PrototypeChainEntry = struct {
     index: bridge.JsApiLookup.BackingInt,
-    offset: u16, // offset to the _proto field
+    // byte delta from the previous chain member down to this one; every
+    // member of a prototype chain lives in one contiguous factory allocation
+    offset: u16,
 };
 
 // Reverses the mapZigInstanceToJs, making sure that our TaggedOpaque
@@ -125,12 +127,10 @@ pub fn fromJS(comptime R: type, js_obj_handle: *const v8.Object) !R {
     // Ok, let's walk up the chain
     var ptr = @intFromPtr(tao.value);
     for (prototype_chain[1..]) |proto| {
-        ptr += proto.offset; // the offset to the _proto field
-        const proto_ptr: **anyopaque = @ptrFromInt(ptr);
+        ptr -= proto.offset;
         if (proto.index == expected_type_index) {
-            return @ptrCast(@alignCast(proto_ptr.*));
+            return @ptrFromInt(ptr);
         }
-        ptr = @intFromPtr(proto_ptr.*);
     }
     return error.InvalidArgument;
 }

--- a/src/browser/js/Value.zig
+++ b/src/browser/js/Value.zig
@@ -531,12 +531,10 @@ const CloneDelegate = struct {
             // closest cloneable supertype (mirrors TaggedOpaque.fromJS).
             var ptr = @intFromPtr(tao.value);
             for (prototype_chain[1..]) |proto| {
-                ptr += proto.offset;
-                const proto_ptr: **anyopaque = @ptrFromInt(ptr);
-                if (writeCloneable(ctx, proto.index, proto_ptr.*)) |result| {
+                ptr -= proto.offset;
+                if (writeCloneable(ctx, proto.index, @ptrFromInt(ptr))) |result| {
                     return result;
                 }
-                ptr = @intFromPtr(proto_ptr.*);
             }
         }
 

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 const reflect = @import("../reflect.zig");
 
 const js = @import("js.zig");
@@ -109,7 +110,7 @@ pub fn Builder(comptime T: type) type {
                 const Next = PrototypeType(Prototype).?;
                 entry.* = .{
                     .index = JsApiLookup.getId(Next.JsApi),
-                    .offset = @offsetOf(Prototype, "_proto"),
+                    .offset = Factory.protoOffset(Prototype),
                 };
                 Prototype = Next;
             }

--- a/src/browser/webapi/Blob.zig
+++ b/src/browser/webapi/Blob.zig
@@ -84,7 +84,15 @@ pub fn init(parts_: ?[]const js.Value, opts_: ?InitOptions, page: *Page) !*Blob 
     const arena = try session.getArena(.large, "Blob");
     errdefer session.releaseArena(arena);
 
-    const opts: InitOptions = opts_ orelse .{};
+    const self = try arena.create(Blob);
+    self.* = try buildValue(arena, parts_, opts_ orelse .{});
+    return self;
+}
+
+// The Blob value for `parts`, with everything it references copied to
+// `arena`. Callers either arena.create it (init) or embed it as the root of
+// a {Blob, File} chain.
+pub fn buildValue(arena: Allocator, parts_: ?[]const js.Value, opts: InitOptions) !Blob {
     const mime = try Mime.serialize(arena, opts.type);
 
     const data = blk: {
@@ -101,33 +109,32 @@ pub fn init(parts_: ?[]const js.Value, opts_: ?InitOptions, page: *Page) !*Blob 
         break :blk "";
     };
 
-    const self = try arena.create(Blob);
-    self.* = .{
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._slice = data,
         ._mime = mime,
     };
-    return self;
 }
 
-/// Creates a new Blob from raw byte slices (for internal Zig use).
-pub fn initFromBytes(data: []const u8, content_type: []const u8, page: *Page) !*Blob {
-    // + 256 because the arena might also be used by File
-    const arena = try page.getArena(data.len + content_type.len + 256, "Blob");
-    errdefer page.releaseArena(arena);
-
-    const mime = try Mime.serialize(arena, content_type);
-
-    const self = try arena.create(Blob);
-    self.* = .{
+pub fn buildValueFromBytes(arena: Allocator, data: []const u8, content_type: []const u8) !Blob {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._slice = try arena.dupe(u8, data),
-        ._mime = mime,
+        ._mime = try Mime.serialize(arena, content_type),
     };
+}
+
+/// Creates a new Blob from raw byte slices (for internal Zig use).
+pub fn initFromBytes(data: []const u8, content_type: []const u8, page: *Page) !*Blob {
+    const arena = try page.getArena(data.len + content_type.len + 256, "Blob");
+    errdefer page.releaseArena(arena);
+
+    const self = try arena.create(Blob);
+    self.* = try buildValueFromBytes(arena, data, content_type);
     return self;
 }
 

--- a/src/browser/webapi/CData.zig
+++ b/src/browser/webapi/CData.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
 
 const Node = @import("Node.zig");
 pub const Text = @import("cdata/Text.zig");
@@ -29,6 +30,7 @@ pub const CDATASection = @import("cdata/CDATASection.zig");
 pub const ProcessingInstruction = @import("cdata/ProcessingInstruction.zig");
 
 const String = lp.String;
+const IS_DEBUG = @import("builtin").mode == .Debug;
 
 const CData = @This();
 
@@ -38,14 +40,47 @@ _type: Type,
 _proto: *Node,
 _data: String = .empty,
 
-pub const Type = union(enum) {
-    text: Text,
-    comment: Comment,
-    // This should be under Text, but that would require storing a _type union
-    // in text, which would add 8 bytes to every text node.
-    cdata_section: CDATASection,
-    processing_instruction: *ProcessingInstruction,
+// The subtype's struct is not a payload here: it's the member laid out after
+// the CData in the factory chain (see Factory.cdataNode), reachable via
+// `subtype`.
+pub const Type = enum(u8) {
+    text,
+    comment,
+    cdata_section,
+    processing_instruction,
 };
+
+pub fn Subtype(comptime tag: Type) type {
+    return switch (tag) {
+        .text => Text,
+        .comment => Comment,
+        .cdata_section => CDATASection,
+        .processing_instruction => ProcessingInstruction,
+    };
+}
+
+fn tagOf(comptime T: type) Type {
+    if (T == Text) return .text;
+    if (T == Comment) return .comment;
+    if (T == CDATASection) return .cdata_section;
+    if (T == ProcessingInstruction) return .processing_instruction;
+    @compileError(@typeName(T) ++ " is not a CData subtype");
+}
+
+pub fn subtype(self: *CData, comptime T: type) *T {
+    const offset = comptime Factory.chainOffsetOf(T, T) - Factory.chainOffsetOf(T, CData);
+    const sub: *T = @ptrFromInt(@intFromPtr(self) + offset);
+    if (comptime IS_DEBUG) {
+        // the arithmetic rides on factory-chain contiguity; the stored
+        // back-pointer doubles as its canary
+        if (comptime T == CDATASection) {
+            std.debug.assert(sub._proto._proto == self);
+        } else {
+            std.debug.assert(sub._proto == self);
+        }
+    }
+    return sub;
+}
 
 /// Count UTF-16 code units in a UTF-8 string.
 /// 4-byte UTF-8 sequences (codepoints >= U+10000) produce 2 UTF-16 code units (surrogate pair),
@@ -196,17 +231,10 @@ pub fn asNode(self: *CData) *Node {
 }
 
 pub fn is(self: *CData, comptime T: type) ?*T {
-    inline for (@typeInfo(Type).@"union".fields) |f| {
-        if (@field(Type, f.name) == self._type) {
-            if (f.type == T) {
-                return &@field(self._type, f.name);
-            }
-            if (f.type == *T) {
-                return @field(self._type, f.name);
-            }
-        }
+    if (self._type != comptime tagOf(T)) {
+        return null;
     }
-    return null;
+    return self.subtype(T);
 }
 
 pub fn getData(self: *const CData) String {
@@ -297,7 +325,7 @@ pub fn format(self: *const CData, writer: *std.Io.Writer) !void {
         .text => writer.print("<text>{f}</text>", .{self._data}),
         .comment => writer.print("<!-- {f} -->", .{self._data}),
         .cdata_section => writer.print("<![CDATA[{f}]]>", .{self._data}),
-        .processing_instruction => |pi| writer.print("<?{s} {f}?>", .{ pi._target, self._data }),
+        .processing_instruction => writer.print("<?{s} {f}?>", .{ @constCast(self).subtype(ProcessingInstruction)._target, self._data }),
     };
 }
 
@@ -306,13 +334,15 @@ pub fn getLength(self: *const CData) usize {
 }
 
 pub fn isEqualNode(self: *const CData, other: *const CData) bool {
-    if (std.meta.activeTag(self._type) != std.meta.activeTag(other._type)) {
+    if (self._type != other._type) {
         return false;
     }
 
     if (self._type == .processing_instruction) {
         @branchHint(.unlikely);
-        if (std.mem.eql(u8, self._type.processing_instruction._target, other._type.processing_instruction._target) == false) {
+        const self_target = @constCast(self).subtype(ProcessingInstruction)._target;
+        const other_target = @constCast(other).subtype(ProcessingInstruction)._target;
+        if (std.mem.eql(u8, self_target, other_target) == false) {
             return false;
         }
         // if the _targets are equal, we still want to compare the data
@@ -520,7 +550,7 @@ test "WebApi: CData.render" {
         buffer.clearRetainingCapacity();
 
         const cdata = CData{
-            ._type = .{ .text = undefined },
+            ._type = .text,
             ._proto = undefined,
             ._data = .wrap(test_case.value),
         };

--- a/src/browser/webapi/DOMMatrix.zig
+++ b/src/browser/webapi/DOMMatrix.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 const RO = @import("DOMMatrixReadOnly.zig");
 
 const DOMMatrix = @This();
@@ -33,15 +34,15 @@ pub fn init(init_: ?js.Value, exec: *const js.Execution) !*DOMMatrix {
     return create(parsed.m, parsed.is_2d, exec.page);
 }
 
-// Builds the [DOMMatrixReadOnly, DOMMatrix] prototype chain on a single arena
-// (owned by the base) and cross-links them, the same way File wraps Blob.
 pub fn create(m: [16]f64, is_2d: bool, page: *Page) !*DOMMatrix {
-    const proto = try RO.createBare(m, is_2d, page);
-    errdefer proto.deinit(page);
+    const arena = try page.getArena(.tiny, "DOMMatrix");
+    errdefer page.releaseArena(arena);
 
-    const self = try proto._arena.create(DOMMatrix);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
+    const self = try Factory.chainedWithAllocator(arena, .{
+        RO.buildValue(arena, m, is_2d),
+        DOMMatrix{ ._proto = undefined },
+    });
+    self._proto._type = .{ .mutable = self };
     return self;
 }
 

--- a/src/browser/webapi/DOMMatrixReadOnly.zig
+++ b/src/browser/webapi/DOMMatrixReadOnly.zig
@@ -85,14 +85,18 @@ pub fn createBare(m: [16]f64, is_2d: bool, page: *Page) !*DOMMatrixReadOnly {
     errdefer page.releaseArena(arena);
 
     const self = try arena.create(DOMMatrixReadOnly);
-    self.* = .{
+    self.* = buildValue(arena, m, is_2d);
+    return self;
+}
+
+pub fn buildValue(arena: std.mem.Allocator, m: [16]f64, is_2d: bool) DOMMatrixReadOnly {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
         ._m = m,
         ._is_2d = is_2d,
     };
-    return self;
 }
 
 pub fn getState(self: *const DOMMatrixReadOnly) State {

--- a/src/browser/webapi/DOMPoint.zig
+++ b/src/browser/webapi/DOMPoint.zig
@@ -18,6 +18,7 @@
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 const RO = @import("DOMPointReadOnly.zig");
 
 const DOMPoint = @This();
@@ -31,12 +32,14 @@ pub fn init(x_: ?f64, y_: ?f64, z_: ?f64, w_: ?f64, exec: *const js.Execution) !
 }
 
 pub fn create(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPoint {
-    const proto = try RO.createBare(x, y, z, w, page);
-    errdefer proto.deinit(page);
+    const arena = try page.getArena(.tiny, "DOMPoint");
+    errdefer page.releaseArena(arena);
 
-    const self = try proto._arena.create(DOMPoint);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
+    const self = try Factory.chainedWithAllocator(arena, .{
+        RO.buildValue(arena, x, y, z, w),
+        DOMPoint{ ._proto = undefined },
+    });
+    self._proto._type = .{ .mutable = self };
     return self;
 }
 
@@ -50,13 +53,11 @@ pub fn structuredSerialize(self: *const DOMPoint, writer: *js.StructuredWriter) 
 }
 
 pub fn structuredDeserialize(reader: *js.StructuredReader, page: *Page) !*DOMPoint {
-    const proto = try RO.structuredDeserialize(reader, page);
-    errdefer proto.deinit(page);
-
-    const self = try proto._arena.create(DOMPoint);
-    self.* = .{ ._proto = proto };
-    proto._type = .{ .mutable = self };
-    return self;
+    const x: f64 = @bitCast(try reader.readUint64());
+    const y: f64 = @bitCast(try reader.readUint64());
+    const z: f64 = @bitCast(try reader.readUint64());
+    const w: f64 = @bitCast(try reader.readUint64());
+    return create(x, y, z, w, page);
 }
 
 // DOMPoint redeclares x/y/z/w as writable (`inherit attribute` in the IDL), so

--- a/src/browser/webapi/DOMPointReadOnly.zig
+++ b/src/browser/webapi/DOMPointReadOnly.zig
@@ -89,7 +89,12 @@ pub fn createBare(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPointReadOnl
     errdefer page.releaseArena(arena);
 
     const self = try arena.create(DOMPointReadOnly);
-    self.* = .{
+    self.* = buildValue(arena, x, y, z, w);
+    return self;
+}
+
+pub fn buildValue(arena: Allocator, x: f64, y: f64, z: f64, w: f64) DOMPointReadOnly {
+    return .{
         ._rc = .{},
         ._arena = arena,
         ._type = .generic,
@@ -98,7 +103,6 @@ pub fn createBare(x: f64, y: f64, z: f64, w: f64, page: *Page) !*DOMPointReadOnl
         ._z = z,
         ._w = w,
     };
-    return self;
 }
 
 pub fn fromPoint(other_: ?DOMPointInit, page: *Page) !*DOMPointReadOnly {

--- a/src/browser/webapi/DedicatedWorkerGlobalScope.zig
+++ b/src/browser/webapi/DedicatedWorkerGlobalScope.zig
@@ -53,21 +53,19 @@ _on_messageerror: ?js.Function.Global = null,
 _pending_messages: std.ArrayList(?js.Value.Global) = .empty,
 
 pub fn init(worker: *Worker, url: [:0]const u8) !*DedicatedWorkerGlobalScope {
-    const self = try worker._arena.create(DedicatedWorkerGlobalScope);
-    const proto = try WorkerGlobalScope.init(
+    return WorkerGlobalScope.init(
         worker._arena,
         url,
-        .{ .dedicated = self },
+        .dedicated,
+        DedicatedWorkerGlobalScope{
+            ._worker = worker,
+            ._proto = undefined,
+        },
         worker._type == .module,
         worker._frame_id,
         worker._loader_id,
         worker._frame,
     );
-    self.* = .{
-        ._worker = worker,
-        ._proto = proto,
-    };
-    return self;
 }
 
 pub fn deinit(self: *DedicatedWorkerGlobalScope) void {

--- a/src/browser/webapi/File.zig
+++ b/src/browser/webapi/File.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const Factory = @import("../Factory.zig");
 
 const Blob = @import("Blob.zig");
 
@@ -45,20 +46,22 @@ pub fn init(
     page: *Page,
 ) !*File {
     const opts = opts_ orelse InitOptions{};
-    const blob = try Blob.init(parts_, .{
-        .type = opts.type,
-        .endings = opts.endings,
-    }, page);
+    const session = page.session;
+    const arena = try session.getArena(.large, "Blob");
+    errdefer session.releaseArena(arena);
 
-    errdefer blob.deinit(page);
-
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = opts.lastModified orelse @intCast(lp.datetime.milliTimestamp(.real)),
-    };
-    blob._type = .{ .file = file };
+    const file = try Factory.chainedWithAllocator(arena, .{
+        try Blob.buildValue(arena, parts_, .{
+            .type = opts.type,
+            .endings = opts.endings,
+        }),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = opts.lastModified orelse @intCast(lp.datetime.milliTimestamp(.real)),
+        },
+    });
+    file._proto._type = .{ .file = file };
 
     return file;
 }
@@ -82,19 +85,30 @@ pub fn structuredSerialize(self: *const File, writer: *js.StructuredWriter) !voi
 }
 
 pub fn structuredDeserialize(reader: *js.StructuredReader, page: *Page) !*File {
-    const blob = try Blob.structuredDeserialize(reader, page);
-    errdefer blob.deinit(page);
-
+    const mime = try reader.readBytes();
+    const data = try reader.readBytes();
     const name = try reader.readBytes();
     const last_modified = try reader.readUint64();
 
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = @bitCast(last_modified),
-    };
-    blob._type = .{ .file = file };
+    const arena = try page.getArena(data.len + mime.len + name.len + 256, "Blob.clone");
+    errdefer page.releaseArena(arena);
+
+    const file = try Factory.chainedWithAllocator(arena, .{
+        Blob{
+            ._rc = .{},
+            ._arena = arena,
+            ._type = undefined,
+            ._slice = try arena.dupe(u8, data),
+            // the serialized mime is already in normalized form; copy it verbatim
+            ._mime = try arena.dupe(u8, mime),
+        },
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = @bitCast(last_modified),
+        },
+    });
+    file._proto._type = .{ .file = file };
     return file;
 }
 

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -479,7 +479,7 @@ pub fn getNodeName(self: *const Node, buf: []u8) []const u8 {
             .text => "#text",
             .cdata_section => "#cdata-section",
             .comment => "#comment",
-            .processing_instruction => |pi| pi._target,
+            .processing_instruction => cd.subtype(CData.ProcessingInstruction)._target,
         },
         .document => "#document",
         .document_type => |dt| dt.getName(),
@@ -1176,7 +1176,7 @@ pub fn cloneNode(self: *Node, deep_: ?bool, frame: *Frame) CloneError!*Node {
                 .text => Frame.node_factory.createTextNode(frame, data),
                 .cdata_section => Frame.node_factory.createCDATASection(frame, data),
                 .comment => Frame.node_factory.createComment(frame, data),
-                .processing_instruction => |pi| Frame.node_factory.createProcessingInstruction(frame, pi._target, data),
+                .processing_instruction => Frame.node_factory.createProcessingInstruction(frame, cd.subtype(CData.ProcessingInstruction)._target, data),
             };
         },
         .element => |el| return el.clone(deep, frame),

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -460,17 +460,18 @@ pub const Mark = struct {
         }
 
         const detail = if (maybe_detail) |d| try d.persist() else null;
-        const m = try exec._factory.create(Mark{
-            ._proto = undefined,
-            ._detail = detail,
+        const m = try exec._factory.chained(.{
+            Entry{
+                ._start_time = start_time,
+                ._name = try exec.dupeString(name),
+                ._type = undefined,
+            },
+            Mark{
+                ._proto = undefined,
+                ._detail = detail,
+            },
         });
-
-        const entry = try exec._factory.create(Entry{
-            ._start_time = start_time,
-            ._name = try exec.dupeString(name),
-            ._type = .{ .mark = m },
-        });
-        m._proto = entry;
+        m._proto._type = .{ .mark = m };
         return m;
     }
 
@@ -522,18 +523,19 @@ pub const Measure = struct {
         }
 
         const detail = if (maybe_detail) |d| try d.persist() else null;
-        const m = try exec._factory.create(Measure{
-            ._proto = undefined,
-            ._detail = detail,
+        const m = try exec._factory.chained(.{
+            Entry{
+                ._start_time = start_timestamp,
+                ._duration = duration,
+                ._name = try exec.dupeString(name),
+                ._type = undefined,
+            },
+            Measure{
+                ._proto = undefined,
+                ._detail = detail,
+            },
         });
-
-        const entry = try exec._factory.create(Entry{
-            ._start_time = start_timestamp,
-            ._duration = duration,
-            ._name = try exec.dupeString(name),
-            ._type = .{ .measure = m },
-        });
-        m._proto = entry;
+        m._proto._type = .{ .measure = m };
         return m;
     }
 

--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -72,25 +72,27 @@ pub fn init(frame: *Frame, url: [:0]const u8, name: []const u8, worker_type: Wor
     errdefer session.releaseArena(arena);
 
     const owned_url = try arena.dupeZ(u8, url);
-    const self = try arena.create(SharedWorkerGlobalScope);
-    const proto = try WorkerGlobalScope.init(
+    const frame_id = session.nextFrameId();
+    const loader_id = session.nextLoaderId();
+    const self = try WorkerGlobalScope.init(
         arena,
         owned_url,
-        .{ .shared = self },
+        .shared,
+        SharedWorkerGlobalScope{
+            ._proto = undefined,
+            ._arena = arena,
+            ._url = owned_url,
+            ._name = try arena.dupe(u8, name),
+            ._type = worker_type,
+            ._frame_id = frame_id,
+            ._loader_id = loader_id,
+        },
         worker_type == .module,
-        session.nextFrameId(),
-        session.nextLoaderId(),
+        frame_id,
+        loader_id,
         frame,
     );
-    self.* = .{
-        ._proto = proto,
-        ._arena = arena,
-        ._url = owned_url,
-        ._name = try arena.dupe(u8, name),
-        ._type = worker_type,
-        ._frame_id = proto._frame_id,
-        ._loader_id = proto._loader_id,
-    };
+    const proto = self._proto;
     errdefer proto.deinit();
 
     if (!session.worker_loading_enabled) {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -344,7 +344,7 @@ pub fn getHistory(_: *Window, frame: *Frame) *History {
 }
 
 pub fn getNavigation(_: *Window, frame: *Frame) *Navigation {
-    return &frame._session.navigation;
+    return frame._session.navigation;
 }
 
 pub fn setNavigation(self: *Window, value: js.Value) void {

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -125,12 +125,13 @@ pub const Type = union(enum) {
 pub fn init(
     arena: Allocator,
     url: [:0]const u8,
-    child: Type,
+    comptime tag: std.meta.Tag(Type),
+    leaf_value: anytype,
     is_module: bool,
     frame_id: u32,
     loader_id: u32,
     frame: *Frame,
-) !*WorkerGlobalScope {
+) !*@TypeOf(leaf_value) {
     const session = frame._session;
 
     const call_arena = try session.getArena(.small, "WorkerGlobalScope.call_arena");
@@ -140,29 +141,36 @@ pub fn init(
     errdefer session.releaseArena(local_arena);
 
     const factory = frame._factory;
-    const self = try factory.eventTargetWithAllocator(arena, WorkerGlobalScope{
-        .url = url,
-        .arena = arena,
-        .origin = frame.origin,
-        .js = undefined,
-        .call_arena = call_arena,
-        .local_arena = local_arena,
-        ._frame = frame,
-        ._page = frame._page,
-        ._session = session,
-        ._identity = .{},
-        ._type = child,
-        ._proto = undefined,
-        ._factory = factory,
-        ._is_module = is_module,
-        ._frame_id = frame_id,
-        ._loader_id = loader_id,
-        ._event_manager = .init(arena),
-        ._script_manager = undefined,
-        ._location = .{ ._url = url },
-        ._performance = .init(),
-        ._http_owner = undefined,
+    const leaf = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        WorkerGlobalScope{
+            .url = url,
+            .arena = arena,
+            .origin = frame.origin,
+            .js = undefined,
+            .call_arena = call_arena,
+            .local_arena = local_arena,
+            ._frame = frame,
+            ._page = frame._page,
+            ._session = session,
+            ._identity = .{},
+            ._type = undefined,
+            ._proto = undefined,
+            ._factory = factory,
+            ._is_module = is_module,
+            ._frame_id = frame_id,
+            ._loader_id = loader_id,
+            ._event_manager = .init(arena),
+            ._script_manager = undefined,
+            ._location = .{ ._url = url },
+            ._performance = .init(),
+            ._http_owner = undefined,
+        },
+        leaf_value,
     });
+    const self = leaf._proto;
+    self._type = @unionInit(Type, @tagName(tag), leaf);
+    self._proto._type = .{ .worker_global_scope = self };
 
     self._http_owner = .init(&frame._page.blob_urls, &self.origin);
 
@@ -185,7 +193,7 @@ pub fn init(
     // features like BroadcastChannel can reach across the page/worker boundary.
     try self.js.setOrigin(self.origin);
 
-    return self;
+    return leaf;
 }
 
 pub fn deinit(self: *WorkerGlobalScope) void {

--- a/src/browser/webapi/collections/HTMLCollection.zig
+++ b/src/browser/webapi/collections/HTMLCollection.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Factory = @import("../../Factory.zig");
 const Frame = @import("../../Frame.zig");
 const Element = @import("../Element.zig");
 const TreeWalker = @import("../TreeWalker.zig");
@@ -46,6 +47,8 @@ const Mode = enum {
 
 const HTMLCollection = @This();
 
+pub const _prototype_root = true;
+
 _data: union(Mode) {
     tag: NodeLive(.tag),
     tag_name: NodeLive(.tag_name),
@@ -63,9 +66,22 @@ _data: union(Mode) {
     empty: void,
 },
 _rc: lp.RC = .{},
+// The refcount is shared with the chain leaf (when there is one), so the
+// last release can dispatch deinit through either pointer. The root must
+// know its allocation shape to destroy the right thing.
+_chained: enum(u8) { standalone, form_controls, options } = .standalone,
 
 pub fn deinit(self: *HTMLCollection, page: *Page) void {
-    page.factory.destroy(self);
+    switch (self._chained) {
+        .standalone => page.factory.destroyStandalone(self),
+        .form_controls => page.factory.destroy(self.chainLeaf(@import("HTMLFormControlsCollection.zig"))),
+        .options => page.factory.destroy(self.chainLeaf(@import("HTMLOptionsCollection.zig"))),
+    }
+}
+
+fn chainLeaf(self: *HTMLCollection, comptime Leaf: type) *Leaf {
+    const offset = comptime Factory.chainOffsetOf(Leaf, Leaf) - Factory.chainOffsetOf(Leaf, HTMLCollection);
+    return @ptrFromInt(@intFromPtr(self) + offset);
 }
 
 pub fn releaseRef(self: *HTMLCollection, page: *Page) void {

--- a/src/browser/webapi/collections/HTMLFormControlsCollection.zig
+++ b/src/browser/webapi/collections/HTMLFormControlsCollection.zig
@@ -34,13 +34,10 @@ pub const Proto = HTMLCollection;
 
 _proto: *HTMLCollection,
 
-// The refcount lives on the proto, but anchoring the finalizer here lets
-// deinit reclaim this struct's slot along with the proto's.
+// The refcount lives on the proto, but the finalizer anchors here so deinit
+// destroys the whole {HTMLCollection, self} chain from its leaf.
 pub fn deinit(self: *HTMLFormControlsCollection, page: *Page) void {
-    self._proto.deinit(page);
-    // Not destroy(): the proto is a separate slab allocation, not a
-    // contiguous factory chain.
-    page.factory.destroyStandalone(self);
+    page.factory.destroy(self);
 }
 
 pub fn acquireRef(self: *HTMLFormControlsCollection) void {
@@ -99,13 +96,15 @@ pub fn namedItem(self: *HTMLFormControlsCollection, name: []const u8, frame: *Fr
             count += 1;
 
             if (count == 2) {
-                const radio_node_list = try frame._factory.create(RadioNodeList{
-                    ._proto = undefined,
-                    ._form_collection = self,
-                    ._name = try frame.dupeString(name),
+                const radio_node_list = try frame._factory.chained(.{
+                    NodeList{ ._data = undefined },
+                    RadioNodeList{
+                        ._proto = undefined,
+                        ._form_collection = self,
+                        ._name = try frame.dupeString(name),
+                    },
                 });
-
-                radio_node_list._proto = try frame._factory.create(NodeList{ ._data = .{ .radio_node_list = radio_node_list } });
+                radio_node_list._proto._data = .{ .radio_node_list = radio_node_list };
 
                 // The RadioNodeList outlives this call; its NodeList releases
                 // the ref in deinit.

--- a/src/browser/webapi/collections/HTMLOptionsCollection.zig
+++ b/src/browser/webapi/collections/HTMLOptionsCollection.zig
@@ -30,13 +30,10 @@ pub const Proto = HTMLCollection;
 _proto: *HTMLCollection,
 _select: *@import("../element/html/Select.zig"),
 
-// The refcount lives on the proto, but anchoring the finalizer here lets
-// deinit reclaim this struct's slot along with the proto's.
+// The refcount lives on the proto, but the finalizer anchors here so deinit
+// destroys the whole {HTMLCollection, self} chain from its leaf.
 pub fn deinit(self: *HTMLOptionsCollection, page: *Page) void {
-    self._proto.deinit(page);
-    // Not destroy(): the proto is a separate slab allocation, not a
-    // contiguous factory chain.
-    page.factory.destroyStandalone(self);
+    page.factory.destroy(self);
 }
 
 pub fn acquireRef(self: *HTMLOptionsCollection) void {

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -400,23 +400,29 @@ pub fn NodeLive(comptime mode: Mode) type {
         const NodeList = @import("NodeList.zig");
 
         pub fn runtimeGenericWrap(self: Self, frame: *Frame) !if (mode == .name) *NodeList else *HTMLCollection {
-            const collection = switch (mode) {
-                .name => return frame._factory.create(NodeList{ ._data = .{ .name = self } }),
-                .tag => HTMLCollection{ ._data = .{ .tag = self } },
-                .tag_name => HTMLCollection{ ._data = .{ .tag_name = self } },
-                .tag_name_ns => HTMLCollection{ ._data = .{ .tag_name_ns = self } },
-                .class_name => HTMLCollection{ ._data = .{ .class_name = self } },
-                .all_elements => HTMLCollection{ ._data = .{ .all_elements = self } },
-                .child_elements => HTMLCollection{ ._data = .{ .child_elements = self } },
-                .child_tag => HTMLCollection{ ._data = .{ .child_tag = self } },
-                .cells => HTMLCollection{ ._data = .{ .cells = self } },
-                .select_options => HTMLCollection{ ._data = .{ .select_options = self } },
-                .selected_options => HTMLCollection{ ._data = .{ .selected_options = self } },
-                .links => HTMLCollection{ ._data = .{ .links = self } },
-                .anchors => HTMLCollection{ ._data = .{ .anchors = self } },
-                .form => HTMLCollection{ ._data = .{ .form = self } },
+            if (comptime mode == .name) {
+                return frame._factory.create(NodeList{ ._data = .{ .name = self } });
+            }
+            return frame._factory.create(self.htmlCollectionValue());
+        }
+
+        pub fn htmlCollectionValue(self: Self) HTMLCollection {
+            return switch (mode) {
+                .name => @compileError("name mode wraps as a NodeList"),
+                .tag => .{ ._data = .{ .tag = self } },
+                .tag_name => .{ ._data = .{ .tag_name = self } },
+                .tag_name_ns => .{ ._data = .{ .tag_name_ns = self } },
+                .class_name => .{ ._data = .{ .class_name = self } },
+                .all_elements => .{ ._data = .{ .all_elements = self } },
+                .child_elements => .{ ._data = .{ .child_elements = self } },
+                .child_tag => .{ ._data = .{ .child_tag = self } },
+                .cells => .{ ._data = .{ .cells = self } },
+                .select_options => .{ ._data = .{ .select_options = self } },
+                .selected_options => .{ ._data = .{ .selected_options = self } },
+                .links => .{ ._data = .{ .links = self } },
+                .anchors => .{ ._data = .{ .anchors = self } },
+                .form => .{ ._data = .{ .form = self } },
             };
-            return frame._factory.create(collection);
         }
     };
 }

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -35,27 +35,20 @@ _element: ?*Element = null,
 _properties: std.DoublyLinkedList = .{},
 _is_computed: bool = false,
 
-pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleDeclaration {
-    const self = try frame._factory.create(CSSStyleDeclaration{
-        ._element = element,
-        ._is_computed = is_computed,
-    });
-
-    // Parse the element's existing style attribute into _properties so that
-    // subsequent JS reads and writes see all CSS properties, not just newly
-    // added ones.  Computed styles have no inline attribute to parse.
-    if (!is_computed) {
-        if (element) |el| {
-            if (el.getAttributeSafe(comptime .wrap("style"))) |attr_value| {
-                var it = CssParser.parseDeclarationsList(attr_value);
-                while (it.next()) |declaration| {
-                    try self.applyParsedDeclaration(declaration, frame);
-                }
-            }
+// Parse the element's existing style attribute into _properties so that
+// subsequent JS reads and writes see all CSS properties, not just newly
+// added ones.  Computed styles have no inline attribute to parse.
+pub fn parseInlineStyle(self: *CSSStyleDeclaration, frame: *Frame) !void {
+    if (self._is_computed) {
+        return;
+    }
+    const el = self._element orelse return;
+    if (el.getAttributeSafe(comptime .wrap("style"))) |attr_value| {
+        var it = CssParser.parseDeclarationsList(attr_value);
+        while (it.next()) |declaration| {
+            try self.applyParsedDeclaration(declaration, frame);
         }
     }
-
-    return self;
 }
 
 pub fn length(self: *const CSSStyleDeclaration) u32 {

--- a/src/browser/webapi/css/CSSStyleProperties.zig
+++ b/src/browser/webapi/css/CSSStyleProperties.zig
@@ -30,9 +30,15 @@ pub const Proto = CSSStyleDeclaration;
 _proto: *CSSStyleDeclaration,
 
 pub fn init(element: ?*Element, is_computed: bool, frame: *Frame) !*CSSStyleProperties {
-    return frame._factory.create(CSSStyleProperties{
-        ._proto = try CSSStyleDeclaration.init(element, is_computed, frame),
+    const self = try frame._factory.chained(.{
+        CSSStyleDeclaration{
+            ._element = element,
+            ._is_computed = is_computed,
+        },
+        CSSStyleProperties{ ._proto = undefined },
     });
+    try self._proto.parseInlineStyle(frame);
+    return self;
 }
 
 pub fn asCSSStyleDeclaration(self: *CSSStyleProperties) *CSSStyleDeclaration {

--- a/src/browser/webapi/css/CSSStyleRule.zig
+++ b/src/browser/webapi/css/CSSStyleRule.zig
@@ -13,10 +13,11 @@ _selector_text: []const u8 = "",
 _style: ?*CSSStyleProperties = null,
 
 pub fn init(frame: *Frame) !*CSSStyleRule {
-    const style_rule = try frame._factory.create(CSSStyleRule{
-        ._proto = undefined,
+    const style_rule = try frame._factory.chained(.{
+        CSSRule{ ._type = undefined },
+        CSSStyleRule{ ._proto = undefined },
     });
-    style_rule._proto = try CSSRule.init(.{ .style = style_rule }, frame);
+    style_rule._proto._type = .{ .style = style_rule };
     return style_rule;
 }
 

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -98,11 +98,12 @@ pub fn setMethod(self: *Form, method: []const u8, frame: *Frame) !void {
 
 pub fn getElements(self: *Form, frame: *Frame) !*collections.HTMLFormControlsCollection {
     const node_live = self.iterator(frame);
-    const html_collection = try node_live.runtimeGenericWrap(frame);
-
-    return frame._factory.create(collections.HTMLFormControlsCollection{
-        ._proto = html_collection,
+    const elements = try frame._factory.chained(.{
+        node_live.htmlCollectionValue(),
+        collections.HTMLFormControlsCollection{ ._proto = undefined },
     });
+    elements._proto._chained = .form_controls;
+    return elements;
 }
 
 pub fn iterator(self: *Form, frame: *Frame) collections.NodeLive(.form) {

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -247,13 +247,15 @@ pub fn getOptions(self: *Select, frame: *Frame) !*collections.HTMLOptionsCollect
     // select_options mode is the select's list of options: option children
     // plus the option children of optgroup children.
     const node_live = collections.NodeLive(.select_options).init(self.asNode(), {}, frame);
-    const html_collection = try node_live.runtimeGenericWrap(frame);
-
-    // Create and return HTMLOptionsCollection
-    return frame._factory.create(collections.HTMLOptionsCollection{
-        ._proto = html_collection,
-        ._select = self,
+    const options = try frame._factory.chained(.{
+        node_live.htmlCollectionValue(),
+        collections.HTMLOptionsCollection{
+            ._proto = undefined,
+            ._select = self,
+        },
     });
+    options._proto._chained = .options;
+    return options;
 }
 
 pub fn getLength(self: *Select) u32 {

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -22,6 +22,7 @@ const URL = @import("../URL.zig");
 
 const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
+const Factory = @import("../../Factory.zig");
 
 const Event = @import("../Event.zig");
 const EventTarget = @import("../EventTarget.zig");
@@ -57,21 +58,12 @@ fn asEventTarget(self: *Navigation) *EventTarget {
 }
 
 pub fn onRemoveFrame(self: *Navigation) void {
-    self._proto = undefined;
     if (self._on_currententrychange) |cb| cb.release();
     self._on_currententrychange = null;
 
     for (self._entries.items) |entry| {
         if (entry._on_dispose) |cb| cb.release();
         entry._on_dispose = null;
-        entry._proto = undefined;
-    }
-}
-
-pub fn onNewFrame(self: *Navigation, frame: *Frame) !void {
-    self._proto = try frame._factory.standaloneEventTarget(self);
-    for (self._entries.items) |entry| {
-        entry._proto = try frame._factory.standaloneEventTarget(entry);
     }
 }
 
@@ -223,14 +215,17 @@ pub fn pushEntry(
 
     const id_str = try std.fmt.allocPrint(arena, "{d}", .{id});
 
-    const entry = try arena.create(NavigationHistoryEntry);
-    entry.* = NavigationHistoryEntry{
-        ._proto = try frame._factory.standaloneEventTarget(entry),
-        ._id = id_str,
-        ._key = id_str,
-        ._url = url,
-        ._state = state,
-    };
+    const entry = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        NavigationHistoryEntry{
+            ._proto = undefined,
+            ._id = id_str,
+            ._key = id_str,
+            ._url = url,
+            ._state = state,
+        },
+    });
+    entry._proto._type = .{ .navigation_history_entry = entry };
 
     // we don't always have a current entry...
     const previous = if (self._entries.items.len > 0) self.getCurrentEntry() else null;
@@ -267,14 +262,17 @@ pub fn replaceEntry(
     self._next_entry_id += 1;
     const id_str = try std.fmt.allocPrint(arena, "{d}", .{id});
 
-    const entry = try arena.create(NavigationHistoryEntry);
-    entry.* = NavigationHistoryEntry{
-        ._proto = try frame._factory.standaloneEventTarget(entry),
-        ._id = id_str,
-        ._key = previous._key,
-        ._url = url,
-        ._state = state,
-    };
+    const entry = try Factory.chainedWithAllocator(arena, .{
+        EventTarget{ ._type = undefined },
+        NavigationHistoryEntry{
+            ._proto = undefined,
+            ._id = id_str,
+            ._key = previous._key,
+            ._url = url,
+            ._state = state,
+        },
+    });
+    entry._proto._type = .{ .navigation_history_entry = entry };
 
     const old_entry = self._entries.items[self._index];
     self._entries.items[self._index] = entry;

--- a/src/browser/webapi/navigation/NavigationHistoryEntry.zig
+++ b/src/browser/webapi/navigation/NavigationHistoryEntry.zig
@@ -46,7 +46,7 @@ pub fn id(self: *const NavigationHistoryEntry) []const u8 {
 }
 
 pub fn index(self: *const NavigationHistoryEntry, frame: *Frame) i32 {
-    const navigation = &frame._session.navigation;
+    const navigation = frame._session.navigation;
 
     for (navigation._entries.items, 0..) |entry, i| {
         if (std.mem.eql(u8, entry._id, self._id)) {

--- a/src/browser/webapi/net/FormData.zig
+++ b/src/browser/webapi/net/FormData.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Page = @import("../../Page.zig");
+const Factory = @import("../../Factory.zig");
 const Frame = @import("../../Frame.zig");
 const Form = @import("../element/html/Form.zig");
 const Element = @import("../Element.zig");
@@ -208,17 +209,19 @@ pub fn append(self: *FormData, name: []const u8, value: EntryValue, filename: ?[
 // but over bytes we already hold rather than JS parts. Returned at refcount 1:
 // the entry owns that reference and deleteByName releases it.
 fn fileFrom(source: *Blob, name: []const u8, page: *Page) !*File {
-    const blob = try Blob.initFromBytes(source._slice, source._mime, page);
-    errdefer blob.deinit(page);
+    const arena = try page.getArena(source._slice.len + source._mime.len + 256, "Blob");
+    errdefer page.releaseArena(arena);
 
-    const file = try blob._arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try blob._arena.dupe(u8, name),
-        ._last_modified = @intCast(lp.datetime.milliTimestamp(.real)),
-    };
-    blob._type = .{ .file = file };
-    blob.acquireRef();
+    const file = try Factory.chainedWithAllocator(arena, .{
+        try Blob.buildValueFromBytes(arena, source._slice, source._mime),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = @intCast(lp.datetime.milliTimestamp(.real)),
+        },
+    });
+    file._proto._type = .{ .file = file };
+    file._proto.acquireRef();
     return file;
 }
 
@@ -652,14 +655,17 @@ test "FormData: multipart empty body" {
 }
 
 fn buildTestFile(arena: Allocator, page: *@import("../../Page.zig"), name: []const u8, mime: []const u8, body: []const u8) !*File {
-    const blob = try Blob.initFromBytes(body, mime, page);
-    blob.acquireRef();
-    const file = try arena.create(File);
-    file.* = .{
-        ._proto = blob,
-        ._name = try arena.dupe(u8, name),
-        ._last_modified = 0,
-    };
+    const blob_arena = try page.getArena(body.len + mime.len + 256, "Blob");
+    const file = try Factory.chainedWithAllocator(blob_arena, .{
+        try Blob.buildValueFromBytes(blob_arena, body, mime),
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, name),
+            ._last_modified = 0,
+        },
+    });
+    file._proto._type = .{ .file = file };
+    file._proto.acquireRef();
     return file;
 }
 

--- a/src/browser/webapi/storage/idb/IDBCursor.zig
+++ b/src/browser/webapi/storage/idb/IDBCursor.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Page = @import("../../../Page.zig");
+const Factory = @import("../../../Factory.zig");
 
 const Key = @import("Key.zig");
 const Engine = @import("Engine.zig");
@@ -122,8 +123,7 @@ fn _init(store: *IDBObjectStore, txn: *IDBTransaction, index_id: ?i64, source: S
     try txn.assertActive();
 
     const request = try txn.newRequest();
-    const self = try txn._arena.create(IDBCursor);
-    self.* = .{
+    const cursor_value = IDBCursor{
         ._engine = store._engine,
         ._store = store,
         ._txn = txn,
@@ -135,13 +135,23 @@ fn _init(store: *IDBObjectStore, txn: *IDBTransaction, index_id: ?i64, source: S
         ._js = undefined,
         ._source = source,
     };
-    request._cursor = self;
 
     const local = exec.js.local.?;
-    const public: js.Value = if (key_only)
-        try local.zigValueToJs(self, .{})
-    else
-        try local.zigValueToJs(try IDBCursorWithValue.init(self), .{});
+    var self: *IDBCursor = undefined;
+    var public: js.Value = undefined;
+    if (key_only) {
+        self = try txn._arena.create(IDBCursor);
+        self.* = cursor_value;
+        public = try local.zigValueToJs(self, .{});
+    } else {
+        const with_value = try Factory.chainedWithAllocator(txn._arena, .{
+            cursor_value,
+            IDBCursorWithValue{ ._proto = undefined },
+        });
+        self = with_value._proto;
+        public = try local.zigValueToJs(with_value, .{});
+    }
+    request._cursor = self;
 
     // Pre-converted and cached because it's the request value on every iteration,
     // avoiding the bridge's pointer -> js.Value lookup each time.

--- a/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
+++ b/src/browser/webapi/storage/idb/IDBCursorWithValue.zig
@@ -28,12 +28,6 @@ pub const Proto = IDBCursor;
 
 _proto: *IDBCursor,
 
-pub fn init(cursor: *IDBCursor) !*IDBCursorWithValue {
-    const self = try cursor._txn._arena.create(IDBCursorWithValue);
-    self.* = .{ ._proto = cursor };
-    return self;
-}
-
 pub fn getValue(self: *const IDBCursorWithValue, exec: *Execution) !?js.Value {
     return self._proto.getValueJs(exec);
 }

--- a/src/cdp/AXNode.zig
+++ b/src/cdp/AXNode.zig
@@ -988,8 +988,8 @@ fn writeName(
             else => null,
         },
         .cdata => |cd| switch (cd._type) {
-            .text => |*text| {
-                try writeString(text.ownData(), w);
+            .text => {
+                try writeString(cd._data.str(), w);
                 return .contents;
             },
             else => null,
@@ -1108,8 +1108,8 @@ fn writeAccessibleNameFallback(node: *DOMNode, writer: *std.Io.Writer, frame: *F
     while (it.next()) |child| {
         switch (child._type) {
             .cdata => |cd| switch (cd._type) {
-                .text => |*text| {
-                    const content = std.mem.trim(u8, text.ownData(), &std.ascii.whitespace);
+                .text => {
+                    const content = std.mem.trim(u8, cd._data.str(), &std.ascii.whitespace);
                     if (content.len > 0) {
                         try writer.writeAll(content);
                         try writer.writeByte(' ');

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -31,6 +31,7 @@ const xpath = @import("../../browser/xpath/Evaluator.zig");
 const Input = @import("../../browser/webapi/element/html/Input.zig");
 const File = @import("../../browser/webapi/File.zig");
 const Blob = @import("../../browser/webapi/Blob.zig");
+const Factory = @import("../../browser/Factory.zig");
 const Page = @import("../../browser/Page.zig");
 
 const log = lp.log;
@@ -660,20 +661,21 @@ fn fileFromDiskPath(path: []const u8, page: *Page) !*File {
     const stat = try std.Io.Dir.cwd().statFile(lp.io, path, .{});
     const basename = std.fs.path.basename(path);
 
-    const blob = try arena.create(Blob);
-    const file = try arena.create(File);
-    blob.* = .{
-        ._rc = .{},
-        ._arena = arena,
-        ._type = .{ .file = file },
-        ._slice = data,
-        ._mime = mimeFromExtension(basename),
-    };
-    file.* = .{
-        ._proto = blob,
-        ._name = try arena.dupe(u8, basename),
-        ._last_modified = stat.mtime.toMilliseconds(),
-    };
+    const file = try Factory.chainedWithAllocator(arena, .{
+        Blob{
+            ._rc = .{},
+            ._arena = arena,
+            ._type = undefined,
+            ._slice = data,
+            ._mime = mimeFromExtension(basename),
+        },
+        File{
+            ._proto = undefined,
+            ._name = try arena.dupe(u8, basename),
+            ._last_modified = stat.mtime.toMilliseconds(),
+        },
+    });
+    file._proto._type = .{ .file = file };
     return file;
 }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -363,7 +363,7 @@ fn getNavigationHistory(cmd: *CDP.Command) !void {
         return error.SessionIdNotLoaded;
     }
 
-    const nav = &bc.session.navigation;
+    const nav = bc.session.navigation;
     const entries_in = nav._entries.items;
 
     const entries_out = try cmd.arena.alloc(NavigationEntry, entries_in.len);
@@ -398,7 +398,7 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
     }
 
     const session = bc.session;
-    const nav = &session.navigation;
+    const nav = session.navigation;
 
     var target_index: ?usize = null;
     var target_url: ?[:0]const u8 = null;


### PR DESCRIPTION
Ultimately, our goal is to remove the `_proto: *Field`. That would save 24 bytes per Text node (or Element, ...). Large websites have 20K+ nodes, so we're talking 300-500KB savings.

ef756b0c9683f7d0201acb01421664f99100fd47 was the first phase of this. This is the second, and it's targetting at CData for a simple reason: CData currently has an optimization that makes removal of `_proto: *Field` difficult: it directly embeds its empty types (most notably, Text). Zig's @offsetOf doesn't work on tagged unions, so we'd have to jump through hoops to figure it out (it is doable though). Also, CData has a "incorrect" flattened CDATASection specifically so that Text doesn't inherit a _type union..so that's another problem.

The solution is to move to bare unions, which allows us to use our Factory to control the layout of the CData and thus have predictable offsets.

CData is now an inconsistent with the rest, but, at the very least, all Node types will move in this direction.