### PR TITLE
fix: collection bugs

### DIFF
--- a/src/browser/tests/collections/html_all_collection.html
+++ b/src/browser/tests/collections/html_all_collection.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+<div id=a name=alpha></div>
+<div id=b></div>
+<input name=field>
+<a name=anchor></a>
+<svg><rect name=svg_named /></svg>
+
+<script id=index_then_length>
+  {
+    // Used to trip the HTMLAllCollection.length assert: indexing moves the
+    // cursor, and length has to rewind it before counting. Note document.all
+    // hands back a fresh collection each time, and the index has to come
+    // first - a cached length is returned before the assert is reached.
+    const all = document.all;
+    testing.expectEqual('HTML', all[0].tagName);
+    const len = all.length;
+    testing.expectEqual(true, len > 3);
+
+    testing.expectEqual('HEAD', all[1].tagName);
+    testing.expectEqual(len, all.length);
+    testing.expectEqual(len, all.length);
+
+    const other = document.all;
+    testing.expectEqual('HEAD', other[1].tagName);
+    testing.expectEqual(len, other.length);
+  }
+</script>
+
+<script id=ascending_and_repeated>
+  {
+    const all = document.all;
+    const len = all.length;
+    const acc = [];
+    for (let i = 0; i < len; i++) {
+      acc.push(all[i].tagName);
+      // reading the same index twice must return the same element
+      testing.expectEqual(acc[acc.length - 1], all[i].tagName);
+    }
+    testing.expectEqual(len, acc.length);
+
+    const iterated = [];
+    for (const el of document.all) iterated.push(el.tagName);
+    testing.expectEqual(acc, iterated);
+  }
+</script>
+
+<script id=out_of_range>
+  {
+    const all = document.all;
+    const len = all.length;
+    testing.expectEqual(undefined, all[len]);
+    testing.expectEqual(undefined, all[len + 100]);
+    testing.expectEqual('HTML', all[0].tagName);
+    testing.expectEqual(len, all.length);
+  }
+</script>
+
+<script id=named_and_callable>
+  {
+    const all = document.all;
+    testing.expectEqual('a', all.namedItem('a').id);
+    testing.expectEqual('b', all['b'].id);
+    testing.expectEqual('a', all('a').id);
+    testing.expectEqual('HTML', all(0).tagName);
+
+    // every element is exposed by id, but only a fixed list of tags is
+    // exposed by name: a div and an svg rect are not, an input and an a are
+    testing.expectEqual(null, all.namedItem('alpha'));
+    testing.expectEqual(null, all.namedItem('svg_named'));
+    testing.expectEqual('INPUT', all.namedItem('field').tagName);
+    testing.expectEqual('A', all.namedItem('anchor').tagName);
+
+    // a named lookup walks a clone, so the indexed cursor survives it
+    testing.expectEqual('HTML', all[0].tagName);
+    testing.expectEqual('a', all.namedItem('a').id);
+    testing.expectEqual('HEAD', all[1].tagName);
+  }
+</script>
+
+<script id=invalidation>
+  {
+    const all = document.all;
+    const len = all.length;
+    testing.expectEqual('HTML', all[0].tagName);
+
+    const extra = document.createElement('p');
+    document.body.appendChild(extra);
+    testing.expectEqual(len + 1, all.length);
+    testing.expectEqual('HTML', all[0].tagName);
+    testing.expectEqual(extra, all[len]);
+
+    extra.remove();
+    testing.expectEqual(len, all.length);
+  }
+</script>
+
+<script id=is_htmldda>
+  {
+    // the [[IsHTMLDDA]] weirdness has to survive the refactor
+    testing.expectEqual(true, document.all == undefined);
+    testing.expectEqual('undefined', typeof document.all);
+    testing.expectEqual(false, !!document.all);
+  }
+</script>

--- a/src/browser/tests/collections/live_collections.html
+++ b/src/browser/tests/collections/live_collections.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<div id=box>
+  <span class=x>0</span>
+  <script>
+    // a collection built mid-parse, whose subtree keeps growing afterwards
+    window.parsed_early = document.getElementById('box').getElementsByClassName('x');
+    window.parsed_early_first = parsed_early[0].textContent;
+    window.parsed_early_oob = parsed_early[9];
+  </script>
+  <span class=x>1</span>
+  <span class=x>2</span>
+</div>
+
+<script id=ascending>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('2', list[2].textContent);
+    testing.expectEqual(undefined, list[3]);
+  }
+</script>
+
+<script id=repeated_index>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('2', list[2].textContent);
+    testing.expectEqual('2', list[2].textContent);
+  }
+</script>
+
+<script id=descending>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('2', list[2].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('0', list[0].textContent);
+  }
+</script>
+
+<script id=out_of_range_then_in_range>
+  {
+    // an out of range read walks the collection dry; the cursor has to recover
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual(undefined, list[99]);
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual(undefined, list[99]);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('2', list[2].textContent);
+
+    const skipping = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('2', skipping[2].textContent);
+    testing.expectEqual(undefined, skipping[3]);
+    testing.expectEqual('0', skipping[0].textContent);
+  }
+</script>
+
+<script id=interleaved_length_and_index>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual(3, list.length);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual(3, list.length);
+    testing.expectEqual('2', list[2].textContent);
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual(3, list.length);
+  }
+</script>
+
+<script id=grown_during_parse>
+  {
+    testing.expectEqual('0', parsed_early_first);
+    testing.expectEqual(undefined, parsed_early_oob);
+    testing.expectEqual(3, parsed_early.length);
+    testing.expectEqual('0', parsed_early[0].textContent);
+    testing.expectEqual('1', parsed_early[1].textContent);
+    testing.expectEqual('2', parsed_early[2].textContent);
+  }
+</script>
+
+<script id=invalidated_by_removal>
+  {
+    const box = document.getElementById('box');
+    const list = box.getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('1', list[1].textContent);
+
+    // drop an element the cursor has already walked past
+    const first = list[0];
+    first.remove();
+    testing.expectEqual(2, list.length);
+    testing.expectEqual('1', list[0].textContent);
+    testing.expectEqual('2', list[1].textContent);
+    testing.expectEqual(undefined, list[2]);
+
+    box.insertBefore(first, list[0]);
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('2', list[2].textContent);
+  }
+</script>
+
+<script id=invalidated_by_insert_before_cursor>
+  {
+    const box = document.getElementById('box');
+    const list = box.getElementsByClassName('x');
+    testing.expectEqual('1', list[1].textContent);
+
+    const extra = document.createElement('span');
+    extra.className = 'x';
+    extra.textContent = 'new';
+    box.insertBefore(extra, box.firstElementChild);
+
+    testing.expectEqual('new', list[0].textContent);
+    testing.expectEqual('0', list[1].textContent);
+    testing.expectEqual('1', list[2].textContent);
+    testing.expectEqual('2', list[3].textContent);
+    extra.remove();
+  }
+</script>
+
+<script id=invalidated_by_attribute>
+  {
+    const box = document.getElementById('box');
+    const list = box.getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+
+    // the class attribute decides membership, so this shrinks the collection
+    const second = list[1];
+    second.className = 'y';
+    testing.expectEqual(2, list.length);
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('2', list[1].textContent);
+
+    second.className = 'x';
+    testing.expectEqual(3, list.length);
+  }
+</script>
+
+<script id=iterator_then_index>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    const acc = [];
+    for (const el of list) acc.push(el.textContent);
+    testing.expectEqual(['0', '1', '2'], acc);
+
+    // the for..of walks a clone, so the indexed cursor is untouched
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual('1', list[1].textContent);
+  }
+</script>
+
+<script id=named_lookup_then_index>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('0', list[0].textContent);
+    testing.expectEqual(null, list.namedItem('nope'));
+    testing.expectEqual('1', list[1].textContent);
+    testing.expectEqual('1', list[1].textContent);
+  }
+</script>
+
+<script id=array_materialization>
+  {
+    const list = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual(['0', '1', '2'], Array.from(list).map(e => e.textContent));
+    testing.expectEqual(['0', '1', '2'], Array.prototype.slice.call(list).map(e => e.textContent));
+    testing.expectEqual(['0', '1', '2'], Array.prototype.map.call(list, e => e.textContent));
+  }
+</script>
+
+<script id=independent_cursors>
+  {
+    // two collections over the same root keep separate cursors
+    const a = document.getElementById('box').getElementsByClassName('x');
+    const b = document.getElementById('box').getElementsByClassName('x');
+    testing.expectEqual('0', a[0].textContent);
+    testing.expectEqual('2', b[2].textContent);
+    testing.expectEqual('1', a[1].textContent);
+    testing.expectEqual('0', b[0].textContent);
+  }
+</script>
+
+<select id=sel>
+  <option value=a>A</option>
+  <optgroup><option value=b>B</option></optgroup>
+  <option value=c selected>C</option>
+</select>
+<script id=options_collection>
+  {
+    const opts = document.getElementById('sel').options;
+    testing.expectEqual(3, opts.length);
+    testing.expectEqual('a', opts[0].value);
+    testing.expectEqual('b', opts[1].value);
+    testing.expectEqual('c', opts[2].value);
+    testing.expectEqual('c', opts[2].value);
+    testing.expectEqual('a', opts[0].value);
+
+    const selected = document.getElementById('sel').selectedOptions;
+    testing.expectEqual(1, selected.length);
+    testing.expectEqual('c', selected[0].value);
+    testing.expectEqual('c', selected[0].value);
+  }
+</script>
+
+<form id=f>
+  <input name=one>
+  <input name=two>
+  <input name=three>
+</form>
+<script id=form_controls>
+  {
+    const els = document.getElementById('f').elements;
+    testing.expectEqual(3, els.length);
+    testing.expectEqual('one', els[0].name);
+    testing.expectEqual('two', els[1].name);
+    testing.expectEqual('two', els[1].name);
+    testing.expectEqual('three', els[2].name);
+
+    // namedItem walks a clone, so it must not disturb the indexed cursor
+    testing.expectEqual('two', els.namedItem('two').name);
+    testing.expectEqual('three', els[2].name);
+    testing.expectEqual('one', els[0].name);
+  }
+</script>
+
+<form id=radios>
+  <input type=radio name=r value=1>
+  <input type=radio name=r value=2 checked>
+  <input type=radio name=r value=3>
+  <input name=other>
+</form>
+<script id=radio_node_list>
+  {
+    const form = document.getElementById('radios');
+    const r = form.elements.namedItem('r');
+    testing.expectEqual(3, r.length);
+    testing.expectEqual('1', r[0].value);
+    testing.expectEqual('2', r[1].value);
+    testing.expectEqual('2', r[1].value);
+    testing.expectEqual('3', r[2].value);
+    testing.expectEqual(undefined, r[3]);
+    testing.expectEqual('2', r.value);
+
+    // indexing the radio list must not disturb the form collection's cursor
+    testing.expectEqual('other', form.elements[3].name);
+    testing.expectEqual('1', r[0].value);
+    testing.expectEqual('other', form.elements[3].name);
+  }
+</script>
+
+<script id=get_elements_by_name>
+  {
+    const nl = document.getElementsByName('one');
+    testing.expectEqual(1, nl.length);
+    testing.expectEqual('one', nl[0].name);
+    testing.expectEqual('one', nl[0].name);
+    testing.expectEqual(undefined, nl[1]);
+  }
+</script>
+
+<script id=child_nodes>
+  {
+    const kids = document.getElementById('box').childNodes;
+    const len = kids.length;
+    testing.expectEqual(true, len > 3);
+    testing.expectEqual(kids[1], kids[1]);
+    testing.expectEqual(kids[0], kids[0]);
+    const acc = [];
+    for (let i = 0; i < len; i++) acc.push(kids[i]);
+    testing.expectEqual(len, acc.length);
+    testing.expectEqual(undefined, kids[len]);
+  }
+</script>

--- a/src/browser/tests/document/all_collection.html
+++ b/src/browser/tests/document/all_collection.html
@@ -31,16 +31,18 @@
     testing.expectEqual('P', document.all.third.tagName);
     testing.expectEqual('Third', document.all.third.textContent);
 
-    testing.expectEqual('SPAN', document.all.second.tagName);
-    testing.expectEqual('Second', document.all.second.textContent);
+    // only "all"-named elements are exposed by their name attribute, so the
+    // anchor is and the span isn't
     testing.expectEqual('A', document.all.link.tagName);
+    testing.expectEqual(undefined, document.all.second);
 
     testing.expectEqual('SPAN', document.all.item(5).tagName);
     testing.expectEqual(null, document.all.item(999));
     testing.expectEqual(null, document.all.item(-1));
 
     testing.expectEqual('DIV', document.all.namedItem('first').tagName);
-    testing.expectEqual('SPAN', document.all.namedItem('second').tagName);
+    testing.expectEqual('A', document.all.namedItem('link').tagName);
+    testing.expectEqual(null, document.all.namedItem('second'));
     testing.expectEqual(null, document.all.namedItem('nonexistent'));
 
     // Test callable functionality: document.all(index) and document.all(name)
@@ -49,8 +51,7 @@
     testing.expectEqual('DIV', document.all(4).tagName);
     testing.expectEqual('DIV', document.all('first').tagName);
     testing.expectEqual('First', document.all('first').textContent);
-    testing.expectEqual('SPAN', document.all('second').tagName);
-    testing.expectEqual('Second', document.all('second').textContent);
+    testing.expectEqual(undefined, document.all('second'));
     testing.expectEqual('P', document.all('third').tagName);
     testing.expectEqual(undefined, document.all(999));
     testing.expectEqual(undefined, document.all('nonexistent'));

--- a/src/browser/webapi/collections/HTMLAllCollection.zig
+++ b/src/browser/webapi/collections/HTMLAllCollection.zig
@@ -17,101 +17,46 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
 const Frame = @import("../../Frame.zig");
 const Node = @import("../Node.zig");
 const Element = @import("../Element.zig");
 const TreeWalker = @import("../TreeWalker.zig");
+const NodeLive = @import("node_live.zig").NodeLive;
 const Execution = js.Execution;
 
 const HTMLAllCollection = @This();
 
-_tw: TreeWalker.FullExcludeSelf,
-_last_index: usize,
-_last_length: ?u32,
-_cached_version: usize,
+// Same as getElementsByTagName('*') with the only difference being the name
+// lookup which exposes the name only for a fixed list of tags.
+_nodes: NodeLive(.all_elements),
 
 pub fn init(root: *Node, frame: *Frame) HTMLAllCollection {
-    return .{
-        ._last_index = 0,
-        ._last_length = null,
-        ._tw = TreeWalker.FullExcludeSelf.init(root, .{}),
-        ._cached_version = frame._page.dom_version,
-    };
-}
-
-fn versionCheck(self: *HTMLAllCollection, frame: *const Frame) bool {
-    const current = frame._page.dom_version;
-    if (self._cached_version != current) {
-        self._cached_version = current;
-        self._last_index = 0;
-        self._last_length = null;
-        self._tw.reset();
-        return false;
-    }
-    return true;
+    return .{ ._nodes = .init(root, {}, frame) };
 }
 
 pub fn length(self: *HTMLAllCollection, frame: *const Frame) u32 {
-    if (self.versionCheck(frame)) {
-        if (self._last_length) |cached_length| {
-            return cached_length;
-        }
-    }
-
-    lp.assert(self._last_index == 0, "HTMLAllCollection.length", .{ .last_index = self._last_index });
-
-    var tw = &self._tw;
-    defer tw.reset();
-
-    var l: u32 = 0;
-    while (tw.next()) |node| {
-        if (node.is(Element) != null) {
-            l += 1;
-        }
-    }
-
-    self._last_length = l;
-    return l;
+    return self._nodes.length(frame);
 }
 
 pub fn getAtIndex(self: *HTMLAllCollection, index: usize, frame: *const Frame) ?*Element {
-    _ = self.versionCheck(frame);
-    var current = self._last_index;
-    if (index <= current) {
-        current = 0;
-        self._tw.reset();
-    }
-    defer self._last_index = current + 1;
-
-    const tw = &self._tw;
-    while (tw.next()) |node| {
-        if (node.is(Element)) |el| {
-            if (index == current) {
-                return el;
-            }
-            current += 1;
-        }
-    }
-
-    return null;
+    return self._nodes.getAtIndex(index, frame);
 }
 
 pub fn getByName(self: *HTMLAllCollection, name: []const u8, frame: *Frame) ?*Element {
-    if (frame.getElementByIdFromNode(self._tw._root, name)) |el| {
+    if (frame.getElementByIdFromNode(self._nodes._tw._root, name)) |el| {
         return el;
     }
 
-    // Fall back to searching by name attribute
-    // Clone the tree walker to preserve _last_index optimization
-    _ = self.versionCheck(frame);
-    var tw = self._tw.clone();
-    tw.reset();
-
+    // Fall back to searching by name attribute. Walking a clone leaves the
+    // indexed-access cursor alone.
+    var tw = self._nodes._tw.clone();
     while (tw.next()) |node| {
         if (node.is(Element)) |el| {
+            if (!isAllNamed(el)) {
+                continue;
+            }
             if (el.getAttributeSafe(comptime .wrap("name"))) |attr_name| {
                 if (std.mem.eql(u8, attr_name, name)) {
                     return el;
@@ -121,6 +66,19 @@ pub fn getByName(self: *HTMLAllCollection, name: []const u8, frame: *Frame) ?*El
     }
 
     return null;
+}
+
+// Every element in the collection is exposed by its id, but only these are
+// exposed by their name.
+// https://html.spec.whatwg.org/multipage/dom.html#dom-document-all
+fn isAllNamed(el: *Element) bool {
+    if (el._namespace != .html) {
+        return false;
+    }
+    return switch (el.getTag()) {
+        .anchor, .button, .embed, .form, .frameset, .iframe, .img, .input, .map, .meta, .object, .select, .textarea => true,
+        else => false,
+    };
 }
 
 const CAllAsFunctionArg = union(enum) {
@@ -137,7 +95,7 @@ pub fn callable(self: *HTMLAllCollection, arg: CAllAsFunctionArg, frame: *Frame)
 pub fn iterator(self: *HTMLAllCollection, exec: *const Execution) !*Iterator {
     return Iterator.init(.{
         .list = self,
-        .tw = self._tw.clone(),
+        .tw = self._nodes._tw.clone(),
     }, exec);
 }
 
@@ -147,12 +105,7 @@ pub const Iterator = GenericIterator(struct {
     tw: TreeWalker.FullExcludeSelf,
 
     pub fn next(self: *@This(), _: *const Execution) ?*Element {
-        while (self.tw.next()) |node| {
-            if (node.is(Element)) |el| {
-                return el;
-            }
-        }
-        return null;
+        return self.list._nodes.nextTw(&self.tw);
     }
 }, null);
 
@@ -187,3 +140,8 @@ pub const JsApi = struct {
 
     pub const callable = bridge.callable(HTMLAllCollection.callable, .{ .null_as_undefined = true });
 };
+
+const testing = @import("../../../testing.zig");
+test "WebApi: HTMLAllCollection" {
+    try testing.htmlRunner("collections/html_all_collection.html", .{});
+}

--- a/src/browser/webapi/collections/NodeList.zig
+++ b/src/browser/webapi/collections/NodeList.zig
@@ -75,7 +75,7 @@ pub fn getAtIndex(self: *NodeList, index: usize, frame: *Frame) !?*Node {
     return switch (self._data) {
         .child_nodes => |impl| impl.getAtIndex(index, frame),
         .selector_list => |impl| impl.getAtIndex(index),
-        .radio_node_list => |impl| impl.getAtIndex(index, frame),
+        .radio_node_list => |impl| impl.getAtIndex(index),
         .name => |*impl| if (impl.getAtIndex(index, frame)) |el| el.asNode() else null,
     };
 }

--- a/src/browser/webapi/collections/RadioNodeList.zig
+++ b/src/browser/webapi/collections/RadioNodeList.zig
@@ -44,10 +44,12 @@ pub fn getLength(self: *RadioNodeList) !u32 {
     return i;
 }
 
-pub fn getAtIndex(self: *RadioNodeList, index: usize, frame: *Frame) !?*Node {
-    var i: usize = 0;
+// Walks a cloned iterator, like getLength and getValue do: indexing the form
+// collection directly would rewind its cursor on every call.
+pub fn getAtIndex(self: *RadioNodeList, index: usize) !?*Node {
     var current: usize = 0;
-    while (self._form_collection.getAtIndex(i, frame)) |element| : (i += 1) {
+    var it = try self._form_collection.iterator();
+    while (it.next()) |element| {
         if (!self.matches(element)) {
             continue;
         }

--- a/src/browser/webapi/collections/node_live.zig
+++ b/src/browser/webapi/collections/node_live.zig
@@ -97,6 +97,8 @@ const Filters = union(Mode) {
 // If the DOM version is unchanged and the new index >= the last one, we can do
 // not have to reset our TreeWalker. This optimizes the common case of accessing
 // the collection via incrementing indexes.
+// The element that walk returned is kept alongside its index (see Cursor), so
+// re-reading the same index - `coll[i].a` then `coll[i].b` - is free too.
 
 pub fn NodeLive(comptime mode: Mode) type {
     const Filter = Filters.TypeOf(mode);
@@ -110,15 +112,24 @@ pub fn NodeLive(comptime mode: Mode) type {
     return struct {
         _tw: TW,
         _filter: Filter,
-        _next_index: usize,
+        _cursor: ?Cursor,
         _last_length: ?u32,
         _cached_version: usize,
 
         const Self = @This();
 
+        // The last element we handed out, and the index it was handed out for.
+        // The TreeWalker is parked immediately after it, so the next element it
+        // yields is the one at `index + 1`. A null cursor means the TreeWalker
+        // is back at its start position.
+        const Cursor = struct {
+            index: usize,
+            element: *Element,
+        };
+
         pub fn init(root: *Node, filter: Filter, frame: *Frame) Self {
             return .{
-                ._next_index = 0,
+                ._cursor = null,
                 ._last_length = null,
                 ._filter = filter,
                 ._tw = TW.init(root, .{}),
@@ -136,17 +147,17 @@ pub fn NodeLive(comptime mode: Mode) type {
                 // not ideal, but this can happen if list[x] is called followed
                 // by list.length.
                 self._tw.reset();
-                self._next_index = 0;
+                self._cursor = null;
             }
             // If we're here, it means it's either the first time we're called
             // or the DOM version has changed. Either way, the _tw should be
-            // at the start position. It's important that self._next_index == 0
+            // at the start position. It's important that self._cursor == null
             // (which it always should be in these cases), because we're going to
-            // reset _tw at the end of this, _next_index should always be 0 when
+            // reset _tw at the end of this, the cursor should always be null when
             // _tw is reset. Again, this should always be the case, but we're
             // asserting to make sure, else we'll have weird behavior, namely
             // the wrong item being returned for the wrong index.
-            lp.assert(self._next_index == 0, "NodeLives.length", .{ .next_index = self._next_index });
+            lp.assert(self._cursor == null, "NodeLives.length", .{ .index = if (self._cursor) |c| c.index else 0 });
 
             var tw = &self._tw;
             defer tw.reset();
@@ -175,20 +186,35 @@ pub fn NodeLive(comptime mode: Mode) type {
 
         pub fn getAtIndex(self: *Self, index: usize, frame: *const Frame) ?*Element {
             _ = self.versionCheck(frame);
-            var current = self._next_index;
-            if (index < current) {
-                current = 0;
-                self._tw.reset();
+
+            var current: usize = 0;
+            if (self._cursor) |cursor| {
+                if (index == cursor.index) {
+                    // asking for the element we just handed out
+                    return cursor.element;
+                }
+                if (index > cursor.index) {
+                    // the walker is parked after cursor.element
+                    current = cursor.index + 1;
+                } else {
+                    self._tw.reset();
+                    self._cursor = null;
+                }
             }
-            defer self._next_index = current + 1;
 
             const tw = &self._tw;
             while (self.nextTw(tw)) |el| {
                 if (index == current) {
+                    self._cursor = .{ .index = current, .element = el };
                     return el;
                 }
                 current += 1;
             }
+
+            // Out of range, and the walker is now spent. Rewind, so that a
+            // null cursor keeps meaning "the walker is at its start".
+            tw.reset();
+            self._cursor = null;
             return null;
         }
 
@@ -221,8 +247,13 @@ pub fn NodeLive(comptime mode: Mode) type {
             return null;
         }
 
+        // Advances the shared TreeWalker, keeping the cursor in step with it so
+        // that this can be mixed with getAtIndex.
         pub fn next(self: *Self) ?*Element {
-            return self.nextTw(&self._tw);
+            const el = self.nextTw(&self._tw) orelse return null;
+            const index = if (self._cursor) |cursor| cursor.index + 1 else 0;
+            self._cursor = .{ .index = index, .element = el };
+            return el;
         }
 
         pub fn nextTw(self: *Self, tw: *TW) ?*Element {
@@ -390,7 +421,7 @@ pub fn NodeLive(comptime mode: Mode) type {
             }
 
             self._tw.reset();
-            self._next_index = 0;
+            self._cursor = null;
             self._last_length = null;
             self._cached_version = current;
             return false;
@@ -419,4 +450,83 @@ pub fn NodeLive(comptime mode: Mode) type {
             return frame._factory.create(collection);
         }
     };
+}
+
+const testing = @import("../../../testing.zig");
+test "WebApi: NodeLive" {
+    try testing.htmlRunner("collections/live_collections.html", .{});
+}
+
+// Indexed access is linear when the cursor works and quadratic when it doesn't,
+// which no assertion on the returned elements can tell apart. So scan two
+// collections a factor of TIMES apart and compare: linear work grows by TIMES,
+// quadratic by TIMES squared. Comparing two back-to-back measurements on the
+// same machine keeps this out of reach of how fast that machine is.
+test "NodeLive: indexed reads stay linear" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    const SMALL = 2000;
+    const TIMES = 10;
+    // well above TIMES, well below TIMES squared
+    const LIMIT = TIMES * 3;
+
+    const small = try buildSpans(frame, SMALL);
+    const large = try buildSpans(frame, SMALL * TIMES);
+
+    {
+        const ratio = growth(frame, small, SMALL, large, SMALL * TIMES, ascendingScan);
+        try testing.expect(ratio < LIMIT);
+    }
+
+    {
+        const ratio = growth(frame, small, SMALL, large, SMALL * TIMES, repeatedScan);
+        try testing.expect(ratio < LIMIT);
+    }
+}
+
+fn buildSpans(frame: *Frame, count: usize) !*Node {
+    const div = try frame.window._document.createElement("div", null, frame);
+    const html = try frame.arena.alloc(u8, count * "<span></span>".len);
+    var i: usize = 0;
+    while (i < html.len) : (i += "<span></span>".len) {
+        @memcpy(html[i..][0.."<span></span>".len], "<span></span>");
+    }
+    try Frame.parse.htmlAsChildren(frame, div.asNode(), html);
+    return div.asNode();
+}
+
+fn ascendingScan(root: *Node, count: usize, frame: *Frame) void {
+    var nodes = NodeLive(.tag).init(root, .span, frame);
+    for (0..count) |i| {
+        std.debug.assert(nodes.getAtIndex(i, frame) != null);
+    }
+}
+
+fn repeatedScan(root: *Node, count: usize, frame: *Frame) void {
+    // the shape of `list[i].foo; list[i].bar`
+    var nodes = NodeLive(.tag).init(root, .span, frame);
+    for (0..count) |i| {
+        std.debug.assert(nodes.getAtIndex(i, frame) != null);
+        std.debug.assert(nodes.getAtIndex(i, frame) != null);
+    }
+}
+
+fn growth(
+    frame: *Frame,
+    small: *Node,
+    small_count: usize,
+    large: *Node,
+    large_count: usize,
+    scan: fn (*Node, usize, *Frame) void,
+) f64 {
+    const start_small = lp.datetime.microTimestamp(.awake);
+    scan(small, small_count, frame);
+    const small_us = lp.datetime.microTimestamp(.awake) - start_small;
+
+    const start_large = lp.datetime.microTimestamp(.awake);
+    scan(large, large_count, frame);
+    const large_us = lp.datetime.microTimestamp(.awake) - start_large;
+
+    return @as(f64, @floatFromInt(large_us)) / @as(f64, @floatFromInt(@max(small_us, 1)));
 }


### PR DESCRIPTION
Builds on top of the excellent https://github.com/lightpanda-io/browser/pull/3072

1 - HTMLAllCollection now composes NodeLive to get the performance benefit 
2 - NodeLive now also optimizes for same-index access, e.g. x[i].a, x[i].b. 
3 - NodeLive and RadioNodeList now don't lose their position when different operations types are mixed (e.g. next() wit getAtIndex())