### PR TITLE
Fix dynamic scripts with src set via setAttribute

### DIFF
--- a/src/browser/tests/element/html/script/dynamic.html
+++ b/src/browser/tests/element/html/script/dynamic.html
@@ -42,3 +42,19 @@
     testing.expectEqual(2, loaded2);
   });
 </script>
+
+<script id=set_attribute_src>
+  loadedByAttribute = 0;
+
+  const attributeBeforeAppend = document.createElement('script');
+  attributeBeforeAppend.setAttribute('src', 'dynamic_attribute.js');
+  document.getElementsByTagName('head')[0].appendChild(attributeBeforeAppend);
+
+  const attributeAfterAppend = document.createElement('script');
+  document.getElementsByTagName('head')[0].appendChild(attributeAfterAppend);
+  attributeAfterAppend.setAttribute('src', 'dynamic_attribute.js');
+
+  testing.onload(() => {
+    testing.expectEqual(2, loadedByAttribute);
+  });
+</script>

--- a/src/browser/tests/element/html/script/dynamic_attribute.js
+++ b/src/browser/tests/element/html/script/dynamic_attribute.js
@@ -1,0 +1,1 @@
+loadedByAttribute += 1;

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
@@ -24,6 +25,7 @@ const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
+const String = lp.String;
 const Script = @This();
 
 _proto: *HtmlElement,
@@ -50,12 +52,7 @@ pub fn getSrc(self: *Script, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *Script, src: []const u8, frame: *Frame) !void {
-    const element = self.asElement();
-    try element.setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
-    self._src = element.getAttributeSafe(comptime .wrap("src")) orelse unreachable;
-    if (element.asNode().isConnected()) {
-        try frame.scriptAddedCallback(false, self);
-    }
+    try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
 }
 
 pub fn getType(self: *const Script) []const u8 {
@@ -162,6 +159,24 @@ pub const Build = struct {
         const self = node.as(Script);
         const element = self.asElement();
         self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+    }
+
+    pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+
+        const self = element.as(Script);
+        self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+        if (element.asNode().isConnected()) {
+            try frame.scriptAddedCallback(false, self);
+        }
+    }
+
+    pub fn attributeRemove(element: *Element, name: String, _: *Frame) !void {
+        if (name.eql(comptime .wrap("src"))) {
+            element.as(Script)._src = "";
+        }
     }
 
     // Per the HTML spec, the "already started" flag must be propagated to the


### PR DESCRIPTION
## Summary

Fix dynamic script loading when `src` is assigned through
`Element.setAttribute()`.

Previously, the `HTMLScriptElement.src` property setter updated the
internal `_src` state and scheduled loading, while the generic
`setAttribute("src", value)` path only updated the DOM attribute.

As a result, dynamically inserted scripts using `setAttribute()` could
be skipped because their internal `_src` remained empty.

## Changes

- Synchronize the internal script source when the `src` attribute changes.
- Trigger script loading when `src` is assigned to a connected script.
- Route the existing `src` property setter through the same attribute path.
- Reset the internal source when the attribute is removed.
- Add regression tests for assigning `src` before and after DOM insertion.

## Testing

```sh
TEST_FILTER="WebApi: Script#dynamic.html" zig build \
  -Dprebuilt_v8_path=v8/libc_v8.a test -freference-trace
```

Result: 1/1 passed on Linux.
