### PR TITLE
webapi: sync notification permission state

### DIFF
--- a/src/browser/webapi/Notification.zig
+++ b/src/browser/webapi/Notification.zig
@@ -93,8 +93,13 @@ pub fn acquireRef(self: *Notification) void {
 
 pub fn close(_: *Notification) void {}
 
-fn getPermission() []const u8 {
-    return "default";
+fn getPermission(exec: *const Execution) []const u8 {
+    const state = exec.session.browser.permissions.get("notifications") orelse .prompt;
+    return switch (state) {
+        .granted => "granted",
+        .prompt => "default",
+        .denied => "denied",
+    };
 }
 
 fn getMaxActions() u32 {
@@ -102,7 +107,7 @@ fn getMaxActions() u32 {
 }
 
 fn requestPermission(_: ?js.Function, exec: *const Execution) !js.Promise {
-    return exec.js.local.?.resolvePromise("default");
+    return exec.js.local.?.resolvePromise(getPermission(exec));
 }
 
 fn getTitle(self: *const Notification) []const u8 {

--- a/src/cdp/domains/browser.zig
+++ b/src/cdp/domains/browser.zig
@@ -267,6 +267,15 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
 
     const bc = try ctx.loadBrowserContext(.{ .id = "BID-PERM", .url = "cdp/dom1.html" });
     const browser = bc.session.browser;
+    const frame = bc.mainFrame() orelse unreachable;
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    try testing.expect((try ls.local.exec(
+        \\Notification.permission === "default"
+    , null)).isTrue());
 
     // grantPermissions: each listed permission becomes "granted". State lives
     // on the Browser, not the Page.
@@ -281,15 +290,21 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
     // page is replaced.
     try testing.expectEqual(.granted, browser.permissions.get("geolocation").?);
     try testing.expectEqual(.granted, browser.permissions.get("notifications").?);
+    try testing.expect((try ls.local.exec(
+        \\Notification.permission === "granted"
+    , null)).isTrue());
 
     // setPermission: override a single permission to an explicit state.
     try ctx.processMessage(.{
         .id = 41,
         .method = "Browser.setPermission",
-        .params = .{ .permission = .{ .name = "geolocation" }, .setting = "denied" },
+        .params = .{ .permission = .{ .name = "notifications" }, .setting = "denied" },
     });
     try ctx.expectSentResult(null, .{ .id = 41, .session_id = null });
-    try testing.expectEqual(.denied, browser.permissions.get("geolocation").?);
+    try testing.expectEqual(.denied, browser.permissions.get("notifications").?);
+    try testing.expect((try ls.local.exec(
+        \\Notification.permission === "denied"
+    , null)).isTrue());
 
     // resetPermissions: clears everything; query falls back to "prompt".
     try ctx.processMessage(.{
@@ -298,6 +313,9 @@ test "cdp.browser: grant/set/reset permissions reach navigator.permissions" {
     });
     try ctx.expectSentResult(null, .{ .id = 42, .session_id = null });
     try testing.expectEqual(@as(usize, 0), browser.permissions.count());
+    try testing.expect((try ls.local.exec(
+        \\Notification.permission === "default"
+    , null)).isTrue());
 }
 
 test "cdp.browser: setDownloadBehavior stores config on the session" {


### PR DESCRIPTION
## Summary

- derive `Notification.permission` from the browser permission store
- make `Notification.requestPermission()` resolve to the same state
- map the Permissions API `prompt` state to the Notifications API `default` value
- cover CDP grant, deny, and reset transitions through page JavaScript

## Why

`Browser.grantPermissions`, `Browser.setPermission`, and `Browser.resetPermissions` already update `navigator.permissions`, but `Notification.permission` always returned `default`. This keeps the two Web APIs consistent.

## Testing

- `make test` — 1125/1125 passed
- `make test F="cdp.browser: grant/set/reset permissions"` — 1/1 passed
- `make test F="WebApi: Notification"` — 1/1 passed
- `zig fmt --check $(git ls-files "*.zig")`
- `git diff --check`