### PR TITLE
chore: remove cacheable field from ScriptManager log

### DIFF
--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -915,7 +915,6 @@ pub const Script = struct {
         log.info(.browser, "executing script", .{
             .src = url,
             .kind = fe.kind,
-            .cacheable = cacheable,
         });
 
         var ls: js.Local.Scope = undefined;
@@ -941,7 +940,6 @@ pub const Script = struct {
                     .err = err,
                     .src = url,
                     .kind = fe.kind,
-                    .cacheable = cacheable,
                 });
                 self.executeCallback(comptime .wrap("error"));
                 return;
@@ -999,7 +997,6 @@ pub const Script = struct {
         log.warn(.js, "eval script", .{
             .url = url,
             .caught = caught,
-            .cacheable = cacheable,
         });
 
         if (try_catch.exceptionValue()) |exc| {


### PR DESCRIPTION
Cacheable for ScriptManager means something very specific (should the js.Context cache the module for subsequent loads). With HTTP caching coming, I'm removing this field from the ScriptManager logs because (a) it isn't very useful anyways and (b) it doesn't mean what most people who see it would think it means.