### PR TITLE
browser: activate dynamically created iframes

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1770,7 +1770,14 @@ pub fn scriptAddedCallback(self: *Frame, comptime from_parser: bool, script: *El
     };
 }
 
-pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
+pub fn iframeAddedCallback(incumbent: *Frame, iframe: *IFrame) !void {
+    // A Document without a browsing context (for example, one created by
+    // DOMParser) cannot host a child browsing context. Resolve without
+    // ownerFrame's incumbent fallback so cross-realm insertions also use the
+    // iframe node document's actual Frame.
+    const owner_document = iframe.asNode().ownerDocument(incumbent) orelse return;
+    const self = owner_document._frame orelse return;
+
     if (self.isGoingAway()) {
         // if we're planning on navigating to another frame, don't load this iframe
         return;
@@ -2881,18 +2888,40 @@ pub fn updateRangesForNodeRemoval(self: *Frame, parent: *Node, child: *Node, chi
 // Runs the "ready" work for an inserted node and, when it's an element with
 // children, for its descendants in tree order: appending a subtree
 // containing scripts must execute them all, after the whole insertion.
-fn nodeIsReadySubtree(self: *Frame, node: *Node) !void {
-    if (node._type != .element or node.firstChild() == null) {
+pub fn nodeIsReadySubtree(self: *Frame, node: *Node) !void {
+    const root = node.is(Element) orelse return self.nodeIsReady(false, node);
+    const owner_frame = node.ownerFrame(self);
+    if (node.firstChild() == null and owner_frame._element_shadow_roots.get(root) == null) {
         return self.nodeIsReady(false, node);
     }
 
     // Scripts can mutate the tree. Safe to do this since nodeIsReady re-checks
     // connectivity.
     var elements: std.ArrayList(*Node) = .empty;
-    var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(node, .{});
-    while (tw.next()) |el| {
-        try elements.append(self.call_arena, el.asNode());
+    const ElementTreeWalker = @import("webapi/TreeWalker.zig").Full.Elements;
+    if (owner_frame._element_shadow_roots.count() == 0) {
+        var tw = ElementTreeWalker.init(node, .{});
+        while (tw.next()) |el| {
+            try elements.append(self.call_arena, el.asNode());
+        }
+    } else {
+        // A shadow root is outside its host's light-DOM children. Stack walkers
+        // so its descendants follow the host in shadow-including tree order.
+        var walkers: std.ArrayList(ElementTreeWalker) = .empty;
+        try walkers.append(self.call_arena, ElementTreeWalker.init(node, .{}));
+        while (walkers.items.len > 0) {
+            const walker = &walkers.items[walkers.items.len - 1];
+            const el = walker.next() orelse {
+                _ = walkers.pop();
+                continue;
+            };
+            try elements.append(self.call_arena, el.asNode());
+            if (owner_frame._element_shadow_roots.get(el)) |shadow_root| {
+                try walkers.append(self.call_arena, ElementTreeWalker.init(shadow_root.asNode(), .{}));
+            }
+        }
     }
+
     for (elements.items) |el| {
         try self.nodeIsReady(false, el);
     }
@@ -2917,8 +2946,9 @@ fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {
     // incumbent frame A, but the script's base URL and execution realm must come
     // from B (its node document). Resolving that owner frame is a parent-chain
     // walk, so we only do it once we've matched a node type that has ready work
-    // (the common text/element insertion does nothing here). The parser inserts
-    // into its own document, so from_parser always uses `self`.
+    // (the common text/element insertion does nothing here). The document
+    // parser inserts into its own document, so from_parser uses `self`;
+    // completed fragment setters enter with from_parser=false.
     // Scripts, iframes, links and styles activate on becoming connected;
     // appending them to a detached parent does nothing (they run/load later
     // if the subtree gets inserted into the document).

--- a/src/browser/tests/domparser.html
+++ b/src/browser/tests/domparser.html
@@ -102,6 +102,27 @@
 }
 </script>
 
+<script id=parsedIframeHasNoBrowsingContext>
+{
+  const before = window.length;
+  const parsed = new DOMParser().parseFromString(
+    '<iframe id="parsed-frame" src="frames/support/page.html"></iframe>',
+    'text/html',
+  );
+  const iframe = parsed.querySelector('#parsed-frame');
+
+  // Connected to its own Document, but that Document has no browsing context.
+  testing.expectTrue(iframe.isConnected);
+  testing.expectEqual(null, iframe.contentWindow);
+  testing.expectEqual(null, iframe.contentDocument);
+  testing.expectEqual(before, window.length);
+
+  iframe.src = 'frames/support/page.html?updated';
+  testing.expectEqual(null, iframe.contentWindow);
+  testing.expectEqual(before, window.length);
+}
+</script>
+
 <script id=malformedHTMLDoesNotThrow>
 {
   const parser = new DOMParser();

--- a/src/browser/tests/frames/cross_realm_fragment_iframe.html
+++ b/src/browser/tests/frames/cross_realm_fragment_iframe.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id="cross_realm_fragment_iframe" type="module">
+  const state = await testing.async();
+  const child = document.createElement('iframe');
+  let nested;
+
+  child.addEventListener('load', () => {
+    child.contentDocument.body.innerHTML = '<iframe id="nested" src="page.html"></iframe>';
+    nested = child.contentDocument.querySelector('#nested');
+
+    testing.expectEqual(1, window.length);
+    testing.expectEqual(1, child.contentWindow.length);
+    testing.expectEqual(testing.BASE_URL + 'frames/support/page.html', nested.src);
+
+    // The initial about:blank load may dispatch synchronously inside the
+    // innerHTML setter, so observe the requested navigation's document.
+    const poll = setInterval(() => {
+      const body = nested.contentDocument && nested.contentDocument.body;
+      if (body && body.textContent === 'a-page\n') {
+        clearInterval(poll);
+        state.resolve();
+      }
+    }, 10);
+  });
+  child.src = 'support/page.html';
+  document.body.appendChild(child);
+
+  await state.done(() => {
+    testing.expectEqual(
+      '<html><head></head><body>a-page\n</body></html>',
+      nested.contentDocument.documentElement.outerHTML,
+    );
+  });
+</script>

--- a/src/browser/tests/frames/iframe_src_attribute.html
+++ b/src/browser/tests/frames/iframe_src_attribute.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id="connected_iframe_src_attribute_navigates" type="module">
+  const state = await testing.async();
+  const iframe = document.createElement('iframe');
+  const onceLoad = () => new Promise((resolve) => {
+    iframe.onload = () => resolve();
+  });
+
+  document.body.appendChild(iframe);
+
+  let loaded = onceLoad();
+  iframe.setAttribute('src', 'support/page.html');
+  await loaded;
+  testing.expectEqual(
+    '<html><head></head><body>a-page\n</body></html>',
+    iframe.contentDocument.documentElement.outerHTML,
+  );
+
+  loaded = onceLoad();
+  iframe.removeAttribute('src');
+  await loaded;
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(null, iframe.getAttribute('src'));
+    testing.expectEqual(
+      '<html><head></head><body></body></html>',
+      iframe.contentDocument.documentElement.outerHTML,
+    );
+  });
+</script>

--- a/src/browser/tests/frames/inner_html_iframe.html
+++ b/src/browser/tests/frames/inner_html_iframe.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<div id="host"></div>
+
+<script id="inner_html_iframe">
+  window.innerHTMLScriptExecuted = false;
+  window.innerHTMLIframeParentAtLoad = null;
+
+  const host = $('#host');
+  host.innerHTML = '<script>window.innerHTMLScriptExecuted = true;<\/script><iframe id="blank" onload="window.innerHTMLIframeParentAtLoad = this.parentNode.id"></iframe><iframe id="child" sandbox="allow-same-origin allow-scripts" src="support/page.html"></iframe>';
+
+  const child = $('#child');
+  testing.expectFalse(window.innerHTMLScriptExecuted);
+  testing.expectEqual('host', window.innerHTMLIframeParentAtLoad);
+  testing.expectTrue(child.contentWindow !== null);
+
+  // A detached fragment marks innerHTML scripts inert, then activates its
+  // iframe when the subtree becomes connected.
+  window.detachedInnerHTMLScriptExecuted = false;
+  const detached = document.createElement('div');
+  detached.innerHTML = '<script>window.detachedInnerHTMLScriptExecuted = true;<\/script><iframe id="detached-child" src="support/page.html"></iframe>';
+  const detachedChild = detached.querySelector('#detached-child');
+  testing.expectEqual(null, detachedChild.contentWindow);
+  document.body.appendChild(detached);
+  testing.expectFalse(window.detachedInnerHTMLScriptExecuted);
+  testing.expectTrue(detachedChild.contentWindow !== null);
+
+  // Resource widgets commonly assemble a closed shadow tree while detached,
+  // then connect its host.
+  const shadowHost = document.createElement('div');
+  const shadowRoot = shadowHost.attachShadow({ mode: 'closed' });
+  const shadowChild = document.createElement('iframe');
+  shadowChild.sandbox = 'allow-same-origin allow-scripts';
+  shadowChild.src = 'support/page.html';
+  shadowRoot.appendChild(shadowChild);
+  testing.expectEqual(null, shadowChild.contentWindow);
+
+  document.body.appendChild(shadowHost);
+  testing.expectTrue(shadowChild.contentWindow !== null);
+  testing.expectEqual(4, window.length);
+
+  testing.onload(() => {
+    testing.expectEqual(
+      '<html><head></head><body>a-page\n</body></html>',
+      child.contentDocument.documentElement.outerHTML,
+    );
+    testing.expectEqual(
+      '<html><head></head><body>a-page\n</body></html>',
+      detachedChild.contentDocument.documentElement.outerHTML,
+    );
+    testing.expectEqual(
+      '<html><head></head><body>a-page\n</body></html>',
+      shadowChild.contentDocument.documentElement.outerHTML,
+    );
+  });
+</script>

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1576,6 +1576,19 @@ pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, fr
             Frame.observers.notifyChildListChange(frame, self, added.items, removed.items, null, null);
         }
     }
+
+    // Fragment parsing builds a temporary <html> wrapper. Run connected-node
+    // ready work only after that wrapper is gone, so synchronous iframe loads
+    // observe the completed tree. Documents made by DOMParser have no browsing
+    // context and must stay inert even though their document node is connected.
+    const owner_document = self.ownerDocument(frame) orelse return;
+    if (owner_document._frame == null or !self.isConnected()) {
+        return;
+    }
+    var child_it = self.childrenIterator();
+    while (child_it.next()) |child| {
+        try frame.nodeIsReadySubtree(child);
+    }
 }
 
 // Writes a JSON representation of the node and its children

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
@@ -29,6 +30,7 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 
 const HtmlElement = @import("../Html.zig");
 
+const String = lp.String;
 const IFrame = @This();
 
 pub const Proto = HtmlElement;
@@ -66,15 +68,7 @@ pub fn getSrc(self: *IFrame, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *IFrame, src: []const u8, frame: *Frame) !void {
-    const element = self.asElement();
-    try element.setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
-    self._src = element.getAttributeSafe(comptime .wrap("src")) orelse unreachable;
-    if (element.asNode().isConnected()) {
-        // unlike script, an iframe is reloaded every time the src is set
-        // even if it's set to the same URL.
-        self._executed = false;
-        try frame.iframeAddedCallback(self);
-    }
+    try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
 }
 
 pub fn getName(self: *IFrame) []const u8 {
@@ -114,5 +108,29 @@ pub const Build = struct {
         const self = node.as(IFrame);
         const element = self.asElement();
         self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+    }
+
+    pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) return;
+
+        const self = element.as(IFrame);
+        self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+        if (element.asNode().isConnected()) {
+            // A connected iframe navigates whenever src is set, including
+            // setAttribute() and assigning the same value again.
+            self._executed = false;
+            try frame.iframeAddedCallback(self);
+        }
+    }
+
+    pub fn attributeRemove(element: *Element, name: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) return;
+
+        const self = element.as(IFrame);
+        self._src = "";
+        if (element.asNode().isConnected()) {
+            self._executed = false;
+            try frame.iframeAddedCallback(self);
+        }
     }
 };


### PR DESCRIPTION
## What changed

- activate iframes inserted through document fragments, shadow roots, parsed markup, and cross-realm fragments
- react to `src` attribute changes on connected iframes, including `setAttribute()` and repeated assignments
- navigate a connected iframe back to `about:blank` when its `src` attribute is removed
- add focused coverage for each dynamic iframe lifecycle path

## Why

Lightpanda only activated some iframe insertion paths. In particular, appending a blank iframe and setting its `src` afterward updated the DOM attribute but never navigated the child frame. Sites that construct embedded content in stages therefore stalled before the child document could load.

The activation walk also skipped fragment, shadow-root, DOMParser, and cross-realm insertion cases. These are normal browser behaviors used by modern component and widget code.

## Impact

Dynamically created iframe content now loads consistently across the supported DOM insertion paths. The existing property setter behavior is preserved while direct attribute mutation follows the same navigation path.

## Validation

- focused connected `src` mutation regression: 1/1 passed
- complete debug suite with allocation/leak detection: 1,125/1,125 passed
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`
