### PR TITLE
Rework scheduler

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -463,7 +463,7 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, opts: InitOpts) !void {
                     b.runIdleTasks();
                     return 200;
                 }
-            }.runIdleTasks, 200, .{ .name = "frame.runIdleTasks", .low_priority = true });
+            }.runIdleTasks, 200, .{ .name = "frame.runIdleTasks", .blocks_done = false });
         }
     }
 }

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -461,7 +461,7 @@ pub fn runMacrotasks(self: *Env) !void {
 
 pub fn hasMacrotasks(self: *Env) bool {
     for (self.contexts.items) |ctx| {
-        if (ctx.scheduler.high_priority.count() > 0) {
+        if (ctx.scheduler.blocksCompletion()) {
             return true;
         }
     }

--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -20,108 +20,106 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const log = lp.log;
+const Allocator = std.mem.Allocator;
 
-const Queue = std.PriorityQueue(Task, void, struct {
-    fn compare(_: void, a: Task, b: Task) std.math.Order {
-        const time_order = std.math.order(a.run_at, b.run_at);
-        if (time_order != .eq) return time_order;
-        // Break ties with sequence number to maintain FIFO order
-        return std.math.order(a.sequence, b.sequence);
-    }
-}.compare);
+// low bits of a Task.key hold the FIFO sequence; the high 40 hold run_at
+// (~34 years of process uptime).
+const SEQ_BITS = 24;
+const SEQ_MASK = (@as(u64, 1) << SEQ_BITS) - 1;
 
 const Scheduler = @This();
 
 _sequence: u64,
-allocator: std.mem.Allocator,
+allocator: Allocator,
+
+// Tasks queued to be run at a specific time
+timed: Queue,
+
+// Tasks queued to be run at the next (optimization for when .run_at = 0)
+immediate: Immediate,
+
+// Tasks queued to run before anything else (i.e. scheduler.yield)
+front: Immediate,
+
 // Some things (e.g. IndexedDB) can have operations that are only valid for a
 // specific task boundary. So every time we start a task, we increment the
 // scheduler's generation. Code can snapshot this version and then compare it
 // later to see if we're still in the same task.
 generation: u64,
-low_priority: Queue,
-high_priority: Queue,
 
-pub fn init(allocator: std.mem.Allocator) Scheduler {
+// Number of pending tasks with blocks_done=true. While > 0, the page isn't
+// considered done.
+blocking: u32,
+
+pub fn init(allocator: Allocator) Scheduler {
     return .{
         ._sequence = 0,
         .allocator = allocator,
         .generation = 0,
-        .low_priority = Queue.initContext({}),
-        .high_priority = Queue.initContext({}),
+        .blocking = 0,
+        .timed = Queue.initContext({}),
+        .immediate = .{},
+        .front = .{},
     };
 }
 
 pub fn deinit(self: *Scheduler) void {
-    finalizeTasks(&self.low_priority);
-    finalizeTasks(&self.high_priority);
+    self.finalizeTasks();
 }
 
 pub fn reset(self: *Scheduler) void {
-    finalizeTasks(&self.low_priority);
-    finalizeTasks(&self.high_priority);
-    self.low_priority.clearRetainingCapacity();
-    self.high_priority.clearRetainingCapacity();
+    self.finalizeTasks();
+    self.blocking = 0;
+    self.front.clear();
+    self.immediate.clear();
+    self.timed.clearRetainingCapacity();
 }
 
 const AddOpts = struct {
     name: []const u8 = "",
-    front: bool = false, // run before any timed tasks, multi-fronts are FIFO amongst themselves
-    low_priority: bool = false,
+    front: bool = false, // run before any other tasks, multi-fronts are FIFO amongst themselves
+    blocks_done: bool = true,
     finalizer: ?Finalizer = null,
 };
 pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts: AddOpts) !void {
     if (comptime lp.IS_DEBUG) {
-        log.debug(.scheduler, "scheduler.add", .{ .name = opts.name, .run_in_ms = run_in_ms, .low_priority = opts.low_priority });
+        log.debug(.scheduler, "scheduler.add", .{ .name = opts.name, .run_in_ms = run_in_ms, .blocks_done = opts.blocks_done });
     }
-    var queue = if (opts.low_priority) &self.low_priority else &self.high_priority;
-    const seq = self._sequence + 1;
-    self._sequence = seq;
-    return queue.push(self.allocator, .{
+    if (comptime lp.IS_DEBUG) {
+        // run_in_ms is ignored when opts.front == true, but let's enforce this
+        // so that a caller isn't expecting something we don't support
+        std.debug.assert(opts.front == false or run_in_ms == 0);
+    }
+
+    const run_at = lp.datetime.milliTimestamp(.boot) + run_in_ms;
+    const task: Task = .{
         .ctx = ctx,
         .callback = cb,
-        .sequence = seq,
         .name = opts.name,
+        .key = self.nextKey(run_at),
         .finalizer = opts.finalizer,
-        .run_at = if (opts.front) 0 else lp.datetime.milliTimestamp(.boot) + run_in_ms,
-    });
+        .blocks_done = opts.blocks_done,
+    };
+
+    if (opts.front) {
+        try self.front.push(self.allocator, task);
+    } else if (run_in_ms == 0) {
+        try self.immediate.push(self.allocator, task);
+    } else {
+        try self.timed.push(self.allocator, task);
+    }
+
+    if (opts.blocks_done) {
+        self.blocking += 1;
+    }
 }
 
 pub fn run(self: *Scheduler) !void {
-    try self.runQueue(&self.low_priority);
-    try self.runQueue(&self.high_priority);
-}
-
-pub fn hasReadyTasks(self: *Scheduler) bool {
-    const now = lp.datetime.milliTimestamp(.boot);
-    return queueHasReadyTask(&self.low_priority, now) or queueHasReadyTask(&self.high_priority, now);
-}
-
-pub fn msToNext(self: *Scheduler) ?u64 {
-    var next: ?u64 = null;
-    const now = lp.datetime.milliTimestamp(.boot);
-    for ([_]*Queue{ &self.high_priority, &self.low_priority }) |queue| {
-        const task = queue.peek() orelse continue;
-        const ms = if (task.run_at <= now) 0 else task.run_at - now;
-        if (next == null or ms < next.?) {
-            next = ms;
-        }
-    }
-    return next;
-}
-
-fn runQueue(self: *Scheduler, queue: *Queue) !void {
-    if (queue.count() == 0) {
-        return;
-    }
     const start = lp.datetime.milliTimestamp(.boot);
     var now = start;
 
-    while (queue.peek()) |*task_| {
-        if (task_.run_at > now) {
-            return;
-        }
-        var task = queue.pop().?;
+    while (self.popReady(now)) |task_| {
+        var task = task_;
         if (comptime lp.IS_DEBUG) {
             log.debug(.scheduler, "scheduler.runTask", .{ .name = task.name });
         }
@@ -138,8 +136,11 @@ fn runQueue(self: *Scheduler, queue: *Queue) !void {
             if (comptime lp.IS_DEBUG) {
                 std.debug.assert(ms != 0);
             }
-            task.run_at = now + ms;
-            try self.low_priority.push(self.allocator, task);
+            // A task that endlessly reschedules itself would keep the page
+            // alive forever, so repeats never block completion.
+            task.blocks_done = false;
+            task.key = self.nextKey(now + ms);
+            try self.timed.push(self.allocator, task);
         }
 
         now = lp.datetime.milliTimestamp(.boot);
@@ -147,16 +148,81 @@ fn runQueue(self: *Scheduler, queue: *Queue) !void {
             return;
         }
     }
-    return;
 }
 
-fn queueHasReadyTask(queue: *Queue, now: u64) bool {
-    const task = queue.peek() orelse return false;
-    return task.run_at <= now;
+pub fn hasReadyTasks(self: *Scheduler) bool {
+    const ms = self.msToNext() orelse return false;
+    return ms == 0;
 }
 
-fn finalizeTasks(queue: *Queue) void {
-    var it = queue.iterator();
+pub fn blocksCompletion(self: *const Scheduler) bool {
+    return self.blocking > 0;
+}
+
+pub fn msToNext(self: *Scheduler) ?u64 {
+    if (self.immediate.peek() != null or self.front.peek() != null) {
+        return 0;
+    }
+    const task = self.timed.peek() orelse return null;
+    const run_at = task.runAt();
+    const now = lp.datetime.milliTimestamp(.boot);
+    return if (run_at <= now) 0 else run_at - now;
+}
+
+fn nextKey(self: *Scheduler, run_at: u64) u64 {
+    if (comptime lp.IS_DEBUG) {
+        std.debug.assert(run_at >> (64 - SEQ_BITS) == 0);
+    }
+    self._sequence +%= 1;
+    return (run_at << SEQ_BITS) | (self._sequence & SEQ_MASK);
+}
+
+fn popReady(self: *Scheduler, now: u64) ?Task {
+    const task = task: {
+        if (self.front.peek() != null) {
+            break :task self.front.pop();
+        }
+
+        const immediate = self.immediate.peek();
+        const timed = self.timed.peek();
+
+        const pick_immediate = if (immediate == null)
+            false
+        else if (timed == null)
+            true
+        else
+            immediate.?.key < timed.?.key;
+
+        if (pick_immediate) {
+            break :task self.immediate.pop();
+        }
+
+        const candidate = timed orelse return null;
+        if (candidate.runAt() > now) {
+            return null;
+        }
+
+        break :task self.timed.pop().?;
+    };
+
+    if (task.blocks_done) {
+        self.blocking -= 1;
+    }
+    return task;
+}
+
+fn finalizeTasks(self: *Scheduler) void {
+    for (self.front.pending()) |task| {
+        if (task.finalizer) |func| {
+            func(task.ctx);
+        }
+    }
+    for (self.immediate.pending()) |task| {
+        if (task.finalizer) |func| {
+            func(task.ctx);
+        }
+    }
+    var it = self.timed.iterator();
     while (it.next()) |t| {
         if (t.finalizer) |func| {
             func(t.ctx);
@@ -165,13 +231,152 @@ fn finalizeTasks(queue: *Queue) void {
 }
 
 const Task = struct {
-    run_at: u64,
-    sequence: u64,
+    key: u64, // (run_at << SEQ_BITS) | sequence — tasks execute in key order
     ctx: *anyopaque,
     name: []const u8,
+    blocks_done: bool,
     callback: Callback,
     finalizer: ?Finalizer,
+
+    fn runAt(self: Task) u64 {
+        return self.key >> SEQ_BITS;
+    }
+};
+
+const Queue = std.PriorityQueue(Task, void, struct {
+    fn compare(_: void, a: Task, b: Task) std.math.Order {
+        return std.math.order(a.key, b.key);
+    }
+}.compare);
+
+// FIFO for 0-delay and front tasks. They dominate real pages and this avoids
+// the PriorityQueue sorting.
+const Immediate = struct {
+    head: usize = 0,
+    tasks: std.ArrayList(Task) = .empty,
+
+    fn push(self: *Immediate, allocator: Allocator, task: Task) !void {
+        // pop can only reset tasks when its fully drained (which might not
+        // be possible to do per-run in our 500ms budget). To prevent timer loop
+        // from preventing the cleanup from ever happening, we compact on push
+        // once we have enough entries to justify it (16 is arbitrarily chosen).
+        const head = self.head;
+        const live = self.tasks.items.len - head;
+        if (head > 16 and head >= live) {
+            std.mem.copyForwards(Task, self.tasks.items[0..live], self.tasks.items[head..]);
+            self.tasks.shrinkRetainingCapacity(live);
+            self.head = 0;
+        }
+        return self.tasks.append(allocator, task);
+    }
+
+    fn peek(self: *const Immediate) ?Task {
+        if (self.head == self.tasks.items.len) {
+            return null;
+        }
+        return self.tasks.items[self.head];
+    }
+
+    fn pop(self: *Immediate) Task {
+        const task = self.tasks.items[self.head];
+        self.head += 1;
+        if (self.head == self.tasks.items.len) {
+            self.clear();
+        }
+        return task;
+    }
+
+    fn pending(self: *const Immediate) []Task {
+        return self.tasks.items[self.head..];
+    }
+
+    fn clear(self: *Immediate) void {
+        self.head = 0;
+        self.tasks.clearRetainingCapacity();
+    }
 };
 
 const Callback = *const fn (ctx: *anyopaque) anyerror!?u32;
 const Finalizer = *const fn (ctx: *anyopaque) void;
+
+const testing = @import("../../testing.zig");
+test "Scheduler: immediates are FIFO, front runs first" {
+    var s = Scheduler.init(testing.arena_allocator);
+    var ran: std.ArrayList(u8) = .empty;
+    var t1: TestTask = .{ .id = 1, .ran = &ran };
+    var t2: TestTask = .{ .id = 2, .ran = &ran };
+    var t3: TestTask = .{ .id = 3, .ran = &ran };
+    var t4: TestTask = .{ .id = 4, .ran = &ran };
+
+    try s.add(&t1, TestTask.run, 0, .{});
+    try s.add(&t2, TestTask.run, 0, .{});
+    try s.add(&t3, TestTask.run, 0, .{ .front = true });
+    try s.add(&t4, TestTask.run, 0, .{ .front = true });
+    try s.run();
+    try testing.expectEqualSlices(u8, &.{ 3, 4, 1, 2 }, ran.items);
+}
+
+test "Scheduler: due timed tasks run before newer immediates" {
+    var s = Scheduler.init(testing.arena_allocator);
+    var ran: std.ArrayList(u8) = .empty;
+    var t1: TestTask = .{ .id = 1, .ran = &ran };
+    var t2: TestTask = .{ .id = 2, .ran = &ran };
+
+    try s.add(&t1, TestTask.run, 1, .{});
+    lp.io.sleep(.fromMilliseconds(5), .awake) catch {};
+    try s.add(&t2, TestTask.run, 0, .{});
+    try s.run();
+    try testing.expectEqualSlices(u8, &.{ 1, 2 }, ran.items);
+}
+
+test "Scheduler: blocksCompletion" {
+    var s = Scheduler.init(testing.arena_allocator);
+    var ran: std.ArrayList(u8) = .empty;
+    var t1: TestTask = .{ .id = 1, .ran = &ran, .repeat = 20 };
+    var t2: TestTask = .{ .id = 2, .ran = &ran };
+
+    try testing.expectEqual(false, s.blocksCompletion());
+    try s.add(&t1, TestTask.run, 0, .{});
+    try s.add(&t2, TestTask.run, 0, .{ .blocks_done = false });
+    try testing.expectEqual(true, s.blocksCompletion());
+
+    try s.run();
+    try testing.expectEqualSlices(u8, &.{ 1, 2 }, ran.items);
+    // t1 was re-queued 20ms out, but repeats don't block completion
+    try testing.expectEqual(1, s.timed.count());
+    try testing.expectEqual(false, s.blocksCompletion());
+}
+
+test "Scheduler: immediate queue reclaims consumed prefix" {
+    var im: Immediate = .{};
+    const dummy: Task = .{
+        .key = 0,
+        .name = "",
+        .ctx = undefined,
+        .finalizer = null,
+        .blocks_done = false,
+        .callback = undefined,
+    };
+
+    // keep 2 tasks live at all times so pop never fully drains
+    try im.push(testing.arena_allocator, dummy);
+    try im.push(testing.arena_allocator, dummy);
+    for (0..10_000) |_| {
+        _ = im.pop();
+        try im.push(testing.arena_allocator, dummy);
+    }
+    try testing.expect(im.tasks.items.len <= 64);
+}
+
+const TestTask = struct {
+    id: u8,
+    ran: *std.ArrayList(u8),
+    repeat: ?u32 = null,
+
+    fn run(ptr: *anyopaque) anyerror!?u32 {
+        const self: *TestTask = @ptrCast(@alignCast(ptr));
+        try self.ran.append(testing.arena_allocator, self.id);
+        defer self.repeat = null;
+        return self.repeat;
+    }
+};

--- a/src/browser/webapi/BroadcastChannel.zig
+++ b/src/browser/webapi/BroadcastChannel.zig
@@ -103,7 +103,6 @@ pub fn postMessage(self: *BroadcastChannel, message: js.Value, exec: *Execution)
 
     try exec.js.scheduler.add(callback, PostMessageCallback.run, 0, .{
         .name = "BroadcastChannel.postMessage",
-        .low_priority = false,
         .finalizer = PostMessageCallback.cancelled,
     });
 }

--- a/src/browser/webapi/DedicatedWorkerGlobalScope.zig
+++ b/src/browser/webapi/DedicatedWorkerGlobalScope.zig
@@ -161,7 +161,6 @@ fn scheduleMessage(self: *DedicatedWorkerGlobalScope, cloned_data: ?js.Value.Glo
 
     try wgs.js.scheduler.add(callback, ReceiveMessageCallback.run, 0, .{
         .name = "WorkerGlobalScope.receiveMessage",
-        .low_priority = false,
         .finalizer = ReceiveMessageCallback.cancelled,
     });
 }

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1827,7 +1827,7 @@ fn scheduleScrollEvents(self: *Element, frame: *Frame) !void {
     }
     try frame.js.scheduler.add(task, ScrollEventTask.run, 10, .{
         .name = "element.scrollEvents",
-        .low_priority = true,
+        .blocks_done = false,
         .finalizer = ScrollEventTask.cancelled,
     });
 }

--- a/src/browser/webapi/MessagePort.zig
+++ b/src/browser/webapi/MessagePort.zig
@@ -173,7 +173,6 @@ fn scheduleDelivery(self: *MessagePort, message: js.Value.Global) !void {
 
     try exec.js.scheduler.add(callback, DeliverCallback.run, 0, .{
         .name = "MessagePort.postMessage",
-        .low_priority = false,
         .finalizer = DeliverCallback.cancelled,
     });
 }

--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -348,7 +348,6 @@ fn scheduleConnect(self: *SharedWorkerGlobalScope, port: *MessagePort) !void {
 
     try wgs.js.scheduler.add(callback, ConnectCallback.run, 0, .{
         .name = "SharedWorkerGlobalScope.connect",
-        .low_priority = false,
         .finalizer = ConnectCallback.cancelled,
     });
 }

--- a/src/browser/webapi/Timers.zig
+++ b/src/browser/webapi/Timers.zig
@@ -31,6 +31,11 @@ const log = lp.log;
 const CLAMP_MS = 4;
 const CLAMP_NESTING = 5;
 
+// Once we hit this depth, tasks are scheduled with blocks_done = false. This
+// prevents, for example, a setTimeout that sets itself, from blocking the Runner
+// from considering the page "done" forever (more commonly seen with requestAnimationFrame)
+const BLOCKING_NESTING = 10;
+
 // airbnb has 600+ timers
 const MAX_CALLBACKS = 2048;
 
@@ -45,10 +50,10 @@ _repeating: u32 = 0, // # of repeating timers we have
 _callbacks: CallbackHashMap = .{},
 
 // We keep the depth of the timers (a setTimeout calling a setTimeout). When
-// the depth reaches CLAMP_NESTING, the minimum timeout is 4ms. This is per-
-// spec and it's necessary to prevent some sites from virtually breaking because
-// they repeatedly do heavy work in endlessly looping setTimeout with a short
-// timeout (often of 0ms)
+// the timer depth reaches CLAMP_NESTING, the minimum timeout is 4ms. This is
+// per-spec and it's necessary to prevent some sites from virtually breaking
+// because they repeatedly do heavy work in endlessly looping setTimeout with
+// a short timeout (often of 0ms).
 _nesting_level: u8 = 0,
 
 const Key = u32;
@@ -77,7 +82,7 @@ pub const ScheduleOpts = struct {
     repeat: bool,
     params: []js.Value.Global,
     name: []const u8,
-    low_priority: bool = false,
+    blocks_done: bool = true,
     mode: Mode = .normal,
 };
 
@@ -101,7 +106,7 @@ pub fn schedule(
     const timer_id = self._timer_id +% 1;
     self._timer_id = timer_id;
 
-    const nesting = @min(self._nesting_level + 1, CLAMP_NESTING + 1);
+    const nesting = @min(self._nesting_level + 1, BLOCKING_NESTING + 1);
     const delay = if (nesting > CLAMP_NESTING and delay_ms < CLAMP_MS) CLAMP_MS else delay_ms;
 
     var persisted_params: []js.Value.Global = &.{};
@@ -133,7 +138,7 @@ pub fn schedule(
 
     try exec.js.scheduler.add(callback, ScheduleCallback.run, delay, .{
         .name = opts.name,
-        .low_priority = opts.low_priority,
+        .blocks_done = opts.blocks_done and nesting <= BLOCKING_NESTING,
         .finalizer = ScheduleCallback.cancelled,
     });
 
@@ -253,7 +258,7 @@ const ScheduleCallback = struct {
         if (self.repeat_ms) |ms| {
             // each repeat re-enters the timer initialization steps, so the
             // nesting level keeps growing and sub-4ms intervals get clamped.
-            self.nesting = @min(self.nesting + 1, CLAMP_NESTING + 1);
+            self.nesting = @min(self.nesting + 1, BLOCKING_NESTING + 1);
             if (self.nesting > CLAMP_NESTING and ms < CLAMP_MS) {
                 return CLAMP_MS;
             }

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -567,7 +567,7 @@ pub fn requestIdleCallback(self: *Window, cb: js.Function.Global, opts_: ?Reques
         .mode = .idle,
         .repeat = false,
         .params = &.{},
-        .low_priority = true,
+        .blocks_done = false,
         .name = "window.requestIdleCallback",
     });
 }
@@ -858,7 +858,6 @@ pub fn postMessage(self: *Window, message: js.Value, target_origin: ?[]const u8,
 
     try target_frame.js.scheduler.add(callback, PostMessageCallback.run, 0, .{
         .name = "postMessage",
-        .low_priority = false,
         .finalizer = PostMessageCallback.cancelled,
     });
 }
@@ -969,7 +968,7 @@ pub fn scrollTo(self: *Window, opts: ScrollToOpts, y: ?i32, frame: *Frame) !void
             }
         }.dispatch,
         10,
-        .{ .low_priority = true },
+        .{ .blocks_done = false },
     );
     // We dispatch scrollend event asynchronously after 20ms.
     try frame.js.scheduler.add(
@@ -995,7 +994,7 @@ pub fn scrollTo(self: *Window, opts: ScrollToOpts, y: ?i32, frame: *Frame) !void
             }
         }.dispatch,
         20,
-        .{ .low_priority = true },
+        .{ .blocks_done = false },
     );
 }
 

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -365,7 +365,6 @@ pub fn receiveMessage(self: *Worker, data: js.Value) !void {
 
     try frame.js.scheduler.add(callback, ReceiveMessageCallback.run, 0, .{
         .name = "Worker.receiveMessage",
-        .low_priority = false,
         .finalizer = ReceiveMessageCallback.cancelled,
     });
 }

--- a/src/browser/webapi/storage/CookieStore.zig
+++ b/src/browser/webapi/storage/CookieStore.zig
@@ -117,7 +117,6 @@ fn onCookieChanged(ctx: *anyopaque, data: *const Notification.CookieChanged) !vo
 
     try exec.js.scheduler.add(cb, ChangeCallback.run, 0, .{
         .name = "CookieStore.change",
-        .low_priority = false,
         .finalizer = ChangeCallback.cancelled,
     });
 }


### PR DESCRIPTION
This does 2 scheduler-related changes. The first is that the high/low priority queues are gone. These were misleading and hinted at some type of ordering. The point was strictly to help us decide when do we consider a page "done" and that some tasks SHOULD hold up the page (high priority) and some pages SHOULD NOT (low priority).

So, when adding a task, `low_priority == true` is now `blocks_done == false`. But it isn't just a rename:

1 - There two queues are merged, and we keep a blocking count 2 - Past a certain timer depth, blocks_done == true, so it protects against more
    cases than just the previous RAF

The other change relates to the Scheduler's implementation. While low/high have been merged into a single PriorityQueue, "immediate" and "front" tasks get their own distinct queue (so we now have 3). This is an optimization for the very common case where run_at = 0 - it can be a plain FIFO.

Rather than comparing tasks on run_at (u64) and sequence (u64), the key (u64) merges the two.