### PR TITLE
browser: align Enter activation and form reset semantics

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -208,9 +208,9 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
             // Per spec, only a MouseEvent "click" is an activation event, and
             // the activation target is the nearest inclusive ancestor with
             // activation behavior (ancestors only for bubbling events).
-            if (event.is(@import("webapi/event/MouseEvent.zig")) != null) {
+            if (event.is(@import("webapi/event/MouseEvent.zig"))) |mouse_event| {
                 if (Frame.user_input.findClickActivationTarget(target, event._bubbles)) |activation_target| {
-                    Frame.user_input.handleClick(frame, activation_target) catch |err| {
+                    Frame.user_input.handleClick(frame, activation_target, mouse_event._should_focus_activation) catch |err| {
                         log.warn(.event, "frame.click", .{ .err = err });
                     };
                 }

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -38,6 +38,19 @@ fn dispatchInputAndChangeEvents(el: *Element, frame: *Frame) !void {
     };
 }
 
+fn canFocusForPress(el: *Element, frame: *Frame) bool {
+    if (!el.asNode().isConnected() or el.isDisabled() or !el.checkVisibilityCached(null, frame)) return false;
+    if (el.getTag() == .input and el.as(Element.Html.Input)._input_type == .hidden) return false;
+    if (el.getAttributeSafe(comptime .wrap("tabindex")) != null) return true;
+
+    return switch (el.getTag()) {
+        .button, .select, .textarea, .iframe => true,
+        .input => true,
+        .anchor, .area => el.getAttributeSafe(comptime .wrap("href")) != null,
+        else => false,
+    };
+}
+
 pub fn click(node: *DOMNode, frame: *Frame) !void {
     const el = node.is(Element) orelse return error.InvalidNodeType;
 
@@ -80,11 +93,28 @@ pub fn hover(node: *DOMNode, frame: *Frame) !void {
 }
 
 pub fn press(node: ?*DOMNode, key: []const u8, frame: *Frame) !void {
-    const target_el: ?*Element = if (node) |n|
-        (n.is(Element) orelse return error.InvalidNodeType)
-    else
-        null;
-    const target = if (target_el) |el| el.asEventTarget() else frame.document.asNode().asEventTarget();
+    const target_el = if (node) |n| blk: {
+        const el = n.is(Element) orelse return error.InvalidNodeType;
+        if (!canFocusForPress(el, frame)) return error.ActionFailed;
+        el.focus(frame) catch |err| {
+            lp.log.err(.app, "press focus failed", .{ .err = err });
+            return error.ActionFailed;
+        };
+        if (frame.window._document.getActiveElement() != el) {
+            lp.log.err(.app, "press target could not be focused", .{});
+            return error.ActionFailed;
+        }
+        break :blk el;
+    } else blk: {
+        const document = frame.window._document;
+        if (document._active_element) |active| {
+            if (!canFocusForPress(active, frame)) {
+                document._active_element = null;
+            }
+        }
+        break :blk document.getActiveElement() orelse return error.ActionFailed;
+    };
+    const target = target_el.asEventTarget();
     const canonical = canonicalKey(key);
 
     const keydown_event: *KeyboardEvent = try .initTrusted(comptime .wrap("keydown"), .{
@@ -98,14 +128,6 @@ pub fn press(node: ?*DOMNode, key: []const u8, frame: *Frame) !void {
         lp.log.err(.app, "press keydown failed", .{ .err = err });
         return error.ActionFailed;
     };
-
-    if (std.mem.eql(u8, canonical, "Enter") and !keydown_event.asEvent().getDefaultPrevented()) {
-        if (target_el) |el| implicitFormSubmit(el, frame) catch |err| {
-            // Don't skip keyup on a submit-listener throw — UIs that gate
-            // state on keyup (e.g. clearing a "submitting" flag) would hang.
-            lp.log.warn(.app, "implicit form submit failed", .{ .err = err });
-        };
-    }
 
     const keyup_event: *KeyboardEvent = try .initTrusted(comptime .wrap("keyup"), .{
         .bubbles = true,
@@ -145,28 +167,6 @@ fn canonicalKey(key: []const u8) []const u8 {
         if (std.ascii.eqlIgnoreCase(key, a.in)) return a.out;
     }
     return key;
-}
-
-fn implicitFormSubmit(el: *Element, frame: *Frame) !void {
-    const Input = Element.Html.Input;
-    const Button = Element.Html.Button;
-
-    if (el.is(Input)) |input| {
-        const form = input.getForm(frame) orelse return;
-        const submitter: ?*Element = switch (input._input_type) {
-            .submit, .image => el,
-            // Non-text controls (checkbox, radio, file, ...) don't trigger
-            // implicit submission; only the text-like family does.
-            .text, .password, .email, .url, .tel, .search, .number, .date, .time, .@"datetime-local", .month, .week => null,
-            else => return,
-        };
-        return form.requestSubmit(submitter, frame);
-    }
-    if (el.is(Button)) |button| {
-        if (!std.ascii.eqlIgnoreCase(button.getType(), "submit")) return;
-        const form = button.getForm(frame) orelse return;
-        return form.requestSubmit(el, frame);
-    }
 }
 
 pub fn selectOption(node: *DOMNode, value: []const u8, frame: *Frame) !void {

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -64,6 +64,10 @@ fn dispatchMouseEventOn(frame: *Frame, target: *Element, comptime typ: []const u
     try frame._event_manager.dispatch(target.asEventTarget(), event.asEvent());
 }
 
+fn isSubmitButton(element: *Element) bool {
+    return Element.Html.Form.isSubmitButton(element);
+}
+
 pub fn triggerMousePress(frame: *Frame, x: f64, y: f64, button: i32) !void {
     const target = (try frame.window._document.elementFromPoint(x, y, frame)) orelse return;
     if (comptime lp.IS_DEBUG) {
@@ -322,7 +326,7 @@ const JavascriptUrlTask = struct {
     }
 };
 
-pub fn handleClick(frame: *Frame, target: *Node) !void {
+pub fn handleClick(frame: *Frame, target: *Node, should_focus: bool) !void {
     // TODO: Also support <area> elements when implement
     const element = target.is(Element) orelse return;
     const html_element = element.is(Element.Html) orelse return;
@@ -364,7 +368,7 @@ pub fn handleClick(frame: *Frame, target: *Node) !void {
             }, .{ .anchor = target_frame });
         },
         .input => |input| {
-            try element.focus(frame);
+            if (should_focus) try element.focus(frame);
             // Per HTML §4.10.18.6.4 "Image Button state (type=image)", clicking an
             // image button submits its form. The form-data set already gets the
             // submitter's coordinate fields appended via FormData.collectForm
@@ -372,11 +376,16 @@ pub fn handleClick(frame: *Frame, target: *Node) !void {
             if (input._input_type == .submit or input._input_type == .image) {
                 return frame.submitForm(element, input.getForm(frame), .{});
             }
+            if (input._input_type == .reset) {
+                if (input.getForm(frame)) |form| return form.reset(frame);
+            }
         },
         .button => |button| {
-            try element.focus(frame);
-            if (std.mem.eql(u8, button.getType(), "submit")) {
-                return frame.submitForm(element, button.getForm(frame), .{});
+            if (should_focus) try element.focus(frame);
+            switch (button.getTypeEnum()) {
+                .submit => return frame.submitForm(element, button.getForm(frame), .{}),
+                .reset => if (button.getForm(frame)) |form| return form.reset(frame),
+                .button => {},
             }
         },
         .select, .textarea => try element.focus(frame),
@@ -432,8 +441,52 @@ pub fn triggerKeyboard(frame: *Frame, keyboard_event: *KeyboardEvent) !void {
     try frame._event_manager.dispatch(element.asEventTarget(), event);
 }
 
+fn activateButton(frame: *Frame, button: *Element) !void {
+    if (button.isDisabled()) {
+        return;
+    }
+    const event: *MouseEvent = try .initTrusted(comptime .wrap("click"), .{
+        .bubbles = true,
+        .cancelable = true,
+        .composed = true,
+        .button = mouse_button.main,
+        .detail = 0,
+    }, frame);
+    event._should_focus_activation = false;
+    return frame._event_manager.dispatch(button.asEventTarget(), event.asEvent());
+}
+
+fn blocksImplicitSubmission(input: *Element.Html.Input) bool {
+    return switch (input._input_type) {
+        .text, .search, .tel, .url, .email, .password, .date, .month, .week, .time, .@"datetime-local", .number => true,
+        else => false,
+    };
+}
+
+fn implicitlySubmitInput(frame: *Frame, input: *Element.Html.Input) !void {
+    const form = input.getForm(frame) orelse return;
+
+    var controls = form.iterator(frame);
+    var blocking_fields: usize = 0;
+    while (controls.next()) |control| {
+        if (isSubmitButton(control)) {
+            return activateButton(frame, control);
+        }
+        if (control.is(Element.Html.Input)) |candidate| {
+            if (blocksImplicitSubmission(candidate)) {
+                blocking_fields += 1;
+            }
+        }
+    }
+
+    if (blocking_fields <= 1) {
+        return form.requestSubmit(null, frame);
+    }
+}
+
 pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
     const keyboard_event = event.is(KeyboardEvent) orelse return;
+    if (!event.getIsTrusted()) return;
     const key = keyboard_event.getKey();
 
     if (key == .Dead) {
@@ -447,7 +500,13 @@ pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
 
     if (target.is(Element.Html.Input)) |input| {
         if (key == .Enter) {
-            return frame.submitForm(input.asElement(), input.getForm(frame), .{});
+            if (input._input_type == .button or input._input_type == .reset or input._input_type == .submit or input._input_type == .image) {
+                return activateButton(frame, input.asElement());
+            }
+            if (blocksImplicitSubmission(input)) {
+                return implicitlySubmitInput(frame, input);
+            }
+            return;
         }
 
         // Don't handle text input for radio/checkbox
@@ -463,7 +522,17 @@ pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
         return;
     }
 
+    if (target.is(Element.Html.Button)) |button| {
+        if (key == .Enter) {
+            return activateButton(frame, button.asElement());
+        }
+        return;
+    }
+
     if (target.is(Element.Html.TextArea)) |textarea| {
+        if (textarea.getDisabled() or textarea.getReadonly()) {
+            return;
+        }
         // zig fmt: off
         const append =
             if (key == .Enter) "\n"

--- a/src/browser/tests/cdp/input_file.html
+++ b/src/browser/tests/cdp/input_file.html
@@ -1,1 +1,3 @@
-<input id="upload" type="file">
+<form id="upload-form">
+    <input id="upload" type="file">
+</form>

--- a/src/browser/tests/element/html/select.html
+++ b/src/browser/tests/element/html/select.html
@@ -168,6 +168,43 @@
   }
 </script>
 
+<script id="value_and_selectedIndex_dirtyness">
+  {
+    const sel = document.createElement('select')
+    sel.multiple = true
+    sel.innerHTML = '<option value="same">A</option><option value="same">B</option><option value="other">C</option>'
+    const opts = sel.options
+
+    // value selects and dirties only the first matching option.
+    sel.value = 'same'
+    testing.expectEqual(true, opts[0].selected)
+    testing.expectEqual(false, opts[1].selected)
+    testing.expectEqual(false, opts[2].selected)
+    opts[1].setAttribute('selected', '')
+    testing.expectEqual(true, opts[1].selected)
+
+    // selectedIndex deselects every other option, even in a multiple select,
+    // and dirties only the selected option.
+    sel.selectedIndex = 2
+    testing.expectEqual(false, opts[0].selected)
+    testing.expectEqual(false, opts[1].selected)
+    testing.expectEqual(true, opts[2].selected)
+    opts[0].setAttribute('selected', '')
+    opts[1].removeAttribute('selected')
+    opts[2].removeAttribute('selected')
+    testing.expectEqual(false, opts[0].selected)
+    testing.expectEqual(false, opts[1].selected)
+    testing.expectEqual(true, opts[2].selected)
+
+    const unmatched = document.createElement('select')
+    unmatched.innerHTML = '<option value="a">A</option><option value="b">B</option>'
+    unmatched.value = 'missing'
+    testing.expectEqual(-1, unmatched.selectedIndex)
+    testing.expectEqual(false, unmatched.options[0].selected)
+    testing.expectEqual(false, unmatched.options[1].selected)
+  }
+</script>
+
 <script id="options_collection">
   {
     const sel = $('#select1')

--- a/src/browser/tests/mcp_press_form.html
+++ b/src/browser/tests/mcp_press_form.html
@@ -1,9 +1,350 @@
 <!DOCTYPE html>
 <html>
 <body>
-    <form id="f" onsubmit="window.submitted = true; window.submittedValue = document.getElementById('q').value; event.preventDefault();">
+    <form id="f">
         <input id="q" type="text" name="q">
-        <input type="submit" value="Go">
+        <button id="default-submit" type="submit">Go</button>
     </form>
+
+    <form id="prevent-form">
+        <input id="prevented" type="text">
+        <button id="prevent-submit" type="submit">Prevented</button>
+    </form>
+
+    <form id="textarea-form">
+        <textarea id="notes">line</textarea>
+        <textarea id="prevented-notes">blocked</textarea>
+        <textarea id="readonly-notes" readonly>readonly</textarea>
+        <textarea id="disabled-notes" disabled>disabled</textarea>
+        <button id="textarea-submit" type="submit">Notes</button>
+    </form>
+
+    <form id="nontext-form">
+        <input id="checkbox" type="checkbox">
+        <input id="radio" type="radio">
+        <input id="file" type="file">
+        <button id="nontext-submit" type="submit">Non-text</button>
+    </form>
+
+    <form id="activation-form">
+        <input id="submit-input" type="submit" value="Input submit">
+        <input id="input-button" type="button" value="Input button">
+        <input id="input-reset" type="reset" value="Input reset">
+        <input id="input-image" type="image" alt="Input image">
+        <button id="submit-button" type="submit">Button submit</button>
+        <button id="button-button" type="button">Button</button>
+        <button id="button-reset" type="reset">Button reset</button>
+        <button id="button-default">Button default</button>
+        <button id="button-empty" type="">Button empty</button>
+        <button id="button-uppercase" type="BUTTON">Button uppercase</button>
+        <button id="button-invalid" type="Auto">Button invalid</button>
+        <input id="disabled-input" type="button" disabled value="Disabled input">
+        <button id="disabled-button" type="button" disabled>Disabled button</button>
+        <input id="hidden-input" type="hidden" tabindex="0">
+        <div id="plain-div">Plain div</div>
+        <button id="canceled-button" type="button">Canceled button</button>
+    </form>
+
+    <form id="dirty-reset-form">
+        <input id="reset-text" value="default">
+        <input id="reset-check" type="checkbox" checked>
+        <input id="reset-radio-a" type="radio" name="reset-radio" checked>
+        <input id="reset-radio-b" type="radio" name="reset-radio" checked>
+        <input id="reset-file" type="file">
+        <textarea id="reset-textarea">default area</textarea>
+        <select id="reset-select">
+            <option value="first">First</option>
+            <option value="second" selected>Second</option>
+        </select>
+        <button id="dirty-reset-trigger" type="reset">Reset dirty form</button>
+    </form>
+
+    <form id="canceled-reset-form">
+        <input id="canceled-reset-text" value="default">
+        <button id="canceled-reset-trigger" type="reset">Cancel reset</button>
+    </form>
+
+    <form id="direct-reset-form">
+        <input id="direct-reset-text" value="default">
+        <textarea id="direct-reset-textarea">default area</textarea>
+        <select id="direct-reset-select">
+            <option value="first">First</option>
+            <option value="second" selected>Second</option>
+        </select>
+    </form>
+
+    <form id="untrusted-form">
+        <input id="untrusted-text">
+        <textarea id="untrusted-textarea">line</textarea>
+        <button id="untrusted-button" type="button">Untrusted</button>
+    </form>
+
+    <form id="single-form">
+        <input id="single" type="text">
+    </form>
+
+    <form id="two-form">
+        <input id="two-a" type="text">
+        <input id="two-b" type="email">
+    </form>
+
+    <script>
+        window.submitted = false;
+        window.enterResults = {
+            default: {
+                clicks: 0,
+                submits: 0,
+                clickTrusted: false,
+                focusDuringClick: false,
+                focusDuringSubmit: false,
+                submitter: null,
+                order: []
+            },
+            prevented: {clicks: 0, submits: 0, order: []},
+            textarea: {
+                submits: 0,
+                events: [],
+                preventedBeforeInputs: 0,
+                preventedInputs: 0,
+                readonlyBeforeInputs: 0,
+                readonlyInputs: 0,
+                disabledBeforeInputs: 0,
+                disabledInputs: 0
+            },
+            nontext: {clicks: {checkbox: 0, radio: 0, file: 0}, submits: 0},
+            activation: {controls: {}, submits: 0, resets: 0, submitters: []},
+            reset: {events: 0, trusted: false, bubbles: false, cancelable: false, inputEvents: 0, changeEvents: 0},
+            canceledReset: {events: 0, trusted: false},
+            directReset: {events: 0, trusted: false, bubbles: false, cancelable: false},
+            untrusted: {clicks: 0, submits: 0},
+            unfocusable: {events: 0},
+            bodyTargetedKeydowns: 0,
+            single: {submits: 0, submitterIsNull: false},
+            two: {submits: 0, keydowns: 0}
+        };
+
+        const q = document.getElementById('q');
+        q.addEventListener('keydown', event => {
+            if (event.key === 'Enter') enterResults.default.order.push(event.isTrusted ? 'keydown' : 'keydown-untrusted');
+        });
+        q.addEventListener('keyup', event => {
+            if (event.key === 'Enter') enterResults.default.order.push(event.isTrusted ? 'keyup' : 'keyup-untrusted');
+        });
+        document.getElementById('default-submit').addEventListener('click', event => {
+            enterResults.default.clicks++;
+            enterResults.default.clickTrusted = event.isTrusted;
+            enterResults.default.focusDuringClick = document.activeElement === q;
+            enterResults.default.order.push(event.isTrusted ? 'click' : 'click-untrusted');
+        });
+        document.getElementById('f').addEventListener('submit', event => {
+            window.submitted = true;
+            window.submittedValue = q.value;
+            enterResults.default.submits++;
+            enterResults.default.focusDuringSubmit = document.activeElement === q;
+            enterResults.default.submitter = event.submitter && event.submitter.id;
+            enterResults.default.order.push(event.isTrusted ? 'submit' : 'submit-untrusted');
+            event.preventDefault();
+        });
+
+        const prevented = document.getElementById('prevented');
+        prevented.addEventListener('keydown', event => {
+            if (event.key !== 'Enter') return;
+            enterResults.prevented.order.push('keydown');
+            event.preventDefault();
+        });
+        prevented.addEventListener('keyup', event => {
+            if (event.key === 'Enter') enterResults.prevented.order.push('keyup');
+        });
+        document.getElementById('prevent-submit').addEventListener('click', () => enterResults.prevented.clicks++);
+        document.getElementById('prevent-form').addEventListener('submit', event => {
+            enterResults.prevented.submits++;
+            event.preventDefault();
+        });
+
+        const notes = document.getElementById('notes');
+        notes.addEventListener('beforeinput', event => {
+            enterResults.textarea.events.push([
+                event.type,
+                event.inputType,
+                event.data,
+                event.isTrusted,
+                event.cancelable,
+                event.bubbles,
+                event.composed
+            ]);
+        });
+        notes.addEventListener('input', event => {
+            enterResults.textarea.events.push([
+                event.type,
+                event.inputType,
+                event.data,
+                event.isTrusted,
+                event.cancelable,
+                event.bubbles,
+                event.composed
+            ]);
+        });
+        const preventedNotes = document.getElementById('prevented-notes');
+        preventedNotes.addEventListener('beforeinput', event => {
+            enterResults.textarea.preventedBeforeInputs++;
+            event.preventDefault();
+        });
+        preventedNotes.addEventListener('input', () => enterResults.textarea.preventedInputs++);
+        const readonlyNotes = document.getElementById('readonly-notes');
+        readonlyNotes.readOnly = false;
+        readonlyNotes.readOnly = true;
+        readonlyNotes.addEventListener('beforeinput', () => enterResults.textarea.readonlyBeforeInputs++);
+        readonlyNotes.addEventListener('input', () => enterResults.textarea.readonlyInputs++);
+        const disabledNotes = document.getElementById('disabled-notes');
+        disabledNotes.addEventListener('beforeinput', () => enterResults.textarea.disabledBeforeInputs++);
+        disabledNotes.addEventListener('input', () => enterResults.textarea.disabledInputs++);
+        document.getElementById('textarea-form').addEventListener('submit', event => {
+            enterResults.textarea.submits++;
+            event.preventDefault();
+        });
+
+        for (const id of ['checkbox', 'radio', 'file']) {
+            document.getElementById(id).addEventListener('click', () => enterResults.nontext.clicks[id]++);
+        }
+        document.getElementById('nontext-form').addEventListener('submit', event => {
+            enterResults.nontext.submits++;
+            event.preventDefault();
+        });
+
+        const activationIds = [
+            'submit-input',
+            'input-button',
+            'input-reset',
+            'input-image',
+            'submit-button',
+            'button-button',
+            'button-reset',
+            'button-default',
+            'button-empty',
+            'button-uppercase',
+            'button-invalid',
+            'disabled-input',
+            'disabled-button',
+            'canceled-button',
+            'dirty-reset-trigger',
+            'canceled-reset-trigger'
+        ];
+        let currentActivation = null;
+        for (const id of activationIds) {
+            const state = enterResults.activation.controls[id] = {clicks: 0, order: [], click: null};
+            const element = document.getElementById(id);
+            element.addEventListener('keydown', event => {
+                if (event.key !== 'Enter') return;
+                state.order.push('keydown');
+                if (id === 'canceled-button') event.preventDefault();
+            });
+            element.addEventListener('keyup', event => {
+                if (event.key === 'Enter') state.order.push('keyup');
+            });
+            element.addEventListener('click', event => {
+                currentActivation = id;
+                state.clicks++;
+                state.click = [event.isTrusted, event.bubbles, event.composed, event.cancelable, event.detail];
+                state.order.push('click');
+            });
+        }
+        document.getElementById('hidden-input').addEventListener('keydown', () => enterResults.unfocusable.events++);
+        document.getElementById('hidden-input').addEventListener('keyup', () => enterResults.unfocusable.events++);
+        document.getElementById('plain-div').addEventListener('keydown', () => enterResults.unfocusable.events++);
+        document.getElementById('plain-div').addEventListener('keyup', () => enterResults.unfocusable.events++);
+        document.body.addEventListener('keydown', event => {
+            if (event.target === document.body) enterResults.bodyTargetedKeydowns++;
+        });
+
+        document.getElementById('activation-form').addEventListener('submit', event => {
+            enterResults.activation.submits++;
+            enterResults.activation.submitters.push(event.submitter && event.submitter.id);
+            enterResults.activation.controls[event.submitter.id].order.push('submit');
+            event.preventDefault();
+        });
+        document.getElementById('activation-form').addEventListener('reset', event => {
+            enterResults.activation.resets++;
+            enterResults.activation.controls[currentActivation].order.push('reset');
+        });
+
+        const resetText = document.getElementById('reset-text');
+        const resetCheck = document.getElementById('reset-check');
+        const resetRadioA = document.getElementById('reset-radio-a');
+        const resetRadioB = document.getElementById('reset-radio-b');
+        const resetTextarea = document.getElementById('reset-textarea');
+        const resetSelect = document.getElementById('reset-select');
+        const resetFile = document.getElementById('reset-file');
+        for (const control of [resetText, resetCheck, resetRadioA, resetRadioB, resetTextarea, resetSelect, resetFile]) {
+            control.addEventListener('input', () => enterResults.reset.inputEvents++);
+            control.addEventListener('change', () => enterResults.reset.changeEvents++);
+        }
+        document.getElementById('dirty-reset-form').addEventListener('reset', event => {
+            enterResults.reset.events++;
+            enterResults.reset.trusted = event.isTrusted;
+            enterResults.reset.bubbles = event.bubbles;
+            enterResults.reset.cancelable = event.cancelable;
+            enterResults.activation.controls[currentActivation].order.push('reset');
+        });
+        resetText.value = 'dirty';
+        resetText.setSelectionRange(1, 3);
+        resetText.setCustomValidity('keep');
+        resetText.defaultValue = 'changed default';
+        resetCheck.checked = false;
+        resetCheck.indeterminate = true;
+        resetRadioA.checked = true;
+        resetTextarea.value = 'dirty area';
+        resetTextarea.setSelectionRange(1, 4);
+        resetTextarea.setCustomValidity('keep');
+        resetTextarea.defaultValue = 'changed area';
+        resetSelect.selectedIndex = 1;
+        resetSelect.options[0].setAttribute('selected', '');
+        resetSelect.options[1].removeAttribute('selected');
+        resetSelect.setCustomValidity('keep');
+
+        const canceledResetText = document.getElementById('canceled-reset-text');
+        canceledResetText.value = 'dirty';
+        document.getElementById('canceled-reset-form').addEventListener('reset', event => {
+            enterResults.canceledReset.events++;
+            enterResults.canceledReset.trusted = event.isTrusted;
+            enterResults.activation.controls[currentActivation].order.push('reset');
+            event.preventDefault();
+        });
+
+        const directResetText = document.getElementById('direct-reset-text');
+        const directResetTextarea = document.getElementById('direct-reset-textarea');
+        const directResetSelect = document.getElementById('direct-reset-select');
+        directResetText.value = 'dirty';
+        directResetText.setSelectionRange(1, 3);
+        directResetTextarea.value = 'dirty area';
+        directResetTextarea.setSelectionRange(1, 4);
+        directResetSelect.selectedIndex = 0;
+        document.getElementById('direct-reset-form').addEventListener('reset', event => {
+            enterResults.directReset.events++;
+            enterResults.directReset.trusted = event.isTrusted;
+            enterResults.directReset.bubbles = event.bubbles;
+            enterResults.directReset.cancelable = event.cancelable;
+            document.getElementById('direct-reset-form').reset();
+        });
+
+        document.getElementById('untrusted-button').addEventListener('click', () => enterResults.untrusted.clicks++);
+        document.getElementById('untrusted-form').addEventListener('submit', event => {
+            enterResults.untrusted.submits++;
+            event.preventDefault();
+        });
+
+        document.getElementById('single-form').addEventListener('submit', event => {
+            enterResults.single.submits++;
+            enterResults.single.submitterIsNull = event.submitter === null;
+            event.preventDefault();
+        });
+        const twoA = document.getElementById('two-a');
+        twoA.addEventListener('keydown', event => {
+            if (event.key === 'Enter') enterResults.two.keydowns++;
+        });
+        document.getElementById('two-form').addEventListener('submit', event => {
+            enterResults.two.submits++;
+            event.preventDefault();
+        });
+    </script>
 </body>
 </html>

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -583,7 +583,7 @@ pub const Tool = enum {
                     \\  "properties": {
                     \\    "key": { "type": "string", "description": "The key to press (e.g. 'Enter', 'Tab', 'a')." },
                     \\    "selector": { "type": "string", "description": "Optional CSS selector of the element to target. Preferred over backendNodeId." },
-                    \\    "backendNodeId": { "type": "integer", "description": "Optional backend node ID of the element to target. Defaults to the document when neither selector nor backendNodeId is provided." }
+                    \\    "backendNodeId": { "type": "integer", "description": "Optional backend node ID of the element to target. Defaults to the active element when neither selector nor backendNodeId is provided." }
                     \\  },
                     \\  "required": ["key"]
                     \\}

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -34,6 +34,18 @@ const Button = @This();
 
 pub const Proto = HtmlElement;
 
+pub const Type = enum {
+    submit,
+    reset,
+    button,
+
+    pub fn fromString(value: []const u8) Type {
+        if (std.ascii.eqlIgnoreCase(value, "reset")) return .reset;
+        if (std.ascii.eqlIgnoreCase(value, "button")) return .button;
+        return .submit;
+    }
+};
+
 _proto: *HtmlElement,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,
@@ -70,7 +82,12 @@ pub fn setName(self: *Button, name: []const u8, frame: *Frame) !void {
 }
 
 pub fn getType(self: *const Button) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "submit";
+    return @tagName(self.getTypeEnum());
+}
+
+pub fn getTypeEnum(self: *const Button) Type {
+    const value = self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
+    return Type.fromString(value);
 }
 
 pub fn setType(self: *Button, typ: []const u8, frame: *Frame) !void {

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -22,6 +22,7 @@ const Frame = @import("../../../Frame.zig");
 
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
+const Event = @import("../../Event.zig");
 const HtmlElement = @import("../Html.zig");
 const collections = @import("../../collections.zig");
 
@@ -42,6 +43,7 @@ _firing_submission_events: bool = false,
 // Prevents submission of the form while we're building the entry list for the
 // form. You can imagine an formdata = () => form.submit() endless loop.
 _constructing_entry_list: bool = false,
+_locked_for_reset: bool = false,
 
 pub fn asHtmlElement(self: *Form) *HtmlElement {
     return self._proto;
@@ -175,6 +177,37 @@ pub fn submit(self: *Form, frame: *Frame) !void {
     return frame.submitForm(null, self, .{ .fire_event = false });
 }
 
+pub fn reset(self: *Form, frame: *Frame) !void {
+    if (self._locked_for_reset) return;
+    self._locked_for_reset = true;
+    defer self._locked_for_reset = false;
+
+    const event = try Event.initTrusted(comptime .wrap("reset"), .{
+        .bubbles = true,
+        .cancelable = true,
+    }, frame._page);
+    event.acquireRef();
+    defer _ = event.releaseRef(frame._page);
+
+    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+    if (event._prevent_default) return;
+
+    var controls = self.iterator(frame);
+    while (controls.next()) |control| {
+        if (control.is(Input)) |input| {
+            if (input.getForm(frame) != self) continue;
+            try input.reset(frame);
+        } else if (control.is(TextArea)) |textarea| {
+            if (textarea.getForm(frame) != self) continue;
+            textarea.reset();
+        } else if (control.is(Select)) |select| {
+            if (select.getForm(frame) != self) continue;
+            select.reset();
+        }
+    }
+    frame.domChanged();
+}
+
 /// https://html.spec.whatwg.org/multipage/forms.html#dom-form-requestsubmit
 /// Like submit(), but fires the submit event and validates the form.
 pub fn requestSubmit(self: *Form, submitter: ?*Element, frame: *Frame) !void {
@@ -261,6 +294,7 @@ pub const JsApi = struct {
     pub const elements = bridge.accessor(Form.getElements, null, .{});
     pub const length = bridge.accessor(Form.getLength, null, .{});
     pub const submit = bridge.function(Form.submit, .{});
+    pub const reset = bridge.function(Form.reset, .{});
     pub const requestSubmit = bridge.function(Form.requestSubmit, .{});
     pub const checkValidity = bridge.function(Form.checkValidity, .{});
     pub const reportValidity = bridge.function(Form.reportValidity, .{});

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -84,6 +84,7 @@ _proto: *HtmlElement,
 _default_value: ?[]const u8 = null,
 _default_checked: bool = false,
 _value: ?[]const u8 = null,
+_value_dirty: bool = false,
 _checked: bool = false,
 _checked_dirty: bool = false,
 _input_type: Type = .text,
@@ -158,13 +159,14 @@ pub fn getRedactedValue(self: *const Input) []const u8 {
 }
 
 pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
-    // File inputs: setting to empty string is a no-op, anything else throws
+    // File inputs may only be cleared from script.
     if (self._input_type == .file) {
-        if (value.len == 0) return;
+        if (value.len == 0) return self.clearFiles(frame);
         return error.InvalidStateError;
     }
     // This should _not_ call setAttribute. It updates the current state only
     self._value = try self.sanitizeValue(true, value, frame);
+    self._value_dirty = true;
 }
 
 pub fn getDefaultValue(self: *const Input) []const u8 {
@@ -293,6 +295,41 @@ pub fn setFiles(self: *Input, files: []const *File, frame: *Frame) !void {
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), change_evt);
 }
 
+fn clearFiles(self: *Input, frame: *Frame) void {
+    const fl = self._files orelse return;
+    for (fl._files) |file| {
+        file._proto.releaseRef(frame._page);
+    }
+    fl._files = &.{};
+}
+
+pub fn reset(self: *Input, frame: *Frame) !void {
+    const reset_value = try self.defaultCurrentValue(frame);
+    self._value_dirty = false;
+    self._value = reset_value;
+
+    self._checked = self._default_checked;
+    if (self._checked and self._input_type == .radio) {
+        self.uncheckRadioGroup(frame);
+    }
+    self._checked_dirty = false;
+    self._indeterminate = false;
+    self.clearFiles(frame);
+    self._selection_start = 0;
+    self._selection_end = 0;
+    self._selection_direction = .none;
+}
+
+fn defaultCurrentValue(self: *Input, frame: *Frame) !?[]const u8 {
+    if (self._default_value) |value| {
+        return try self.sanitizeValue(false, value, frame);
+    }
+    return switch (self._input_type) {
+        .checkbox, .radio, .file => null,
+        else => try self.sanitizeValue(false, "", frame),
+    };
+}
+
 /// JS-binding wrapper for the `value` getter: for type=file, return the spec
 /// "C:\\fakepath\\<name>" string; otherwise delegate to plain getValue().
 pub fn getValueForJS(self: *const Input, frame: *Frame) ![]const u8 {
@@ -409,9 +446,8 @@ pub fn suffersPatternMismatch(self: *const Input, frame: *Frame) bool {
 }
 
 pub fn suffersTooLong(self: *const Input) bool {
-    // Per spec, only the dirty value flag triggers tooLong / tooShort. We treat
-    // the presence of an explicit _value (vs. attribute-derived _default_value)
-    // as an approximation of dirty.
+    // The presence of an explicit current value is the existing approximation
+    // of the dirty-value constraint-validation behavior.
     const value = self._value orelse return false;
     const max = self.getMaxLength();
     if (max < 0) return false;
@@ -1500,7 +1536,12 @@ pub const Build = struct {
                     }
                 }
             },
-            .value => self._default_value = try frame.arena.dupe(u8, value.str()),
+            .value => {
+                self._default_value = try frame.arena.dupe(u8, value.str());
+                if (!self._value_dirty) {
+                    self._value = try self.defaultCurrentValue(frame);
+                }
+            },
             .checked => {
                 self._default_checked = true;
                 // Only update checked state if it hasn't been manually modified
@@ -1515,12 +1556,17 @@ pub const Build = struct {
         }
     }
 
-    pub fn attributeRemove(element: *Element, name: String, _: *Frame) !void {
+    pub fn attributeRemove(element: *Element, name: String, frame: *Frame) !void {
         const attribute = std.meta.stringToEnum(enum { type, value, checked }, name.str()) orelse return;
         const self = element.as(Input);
         switch (attribute) {
             .type => self._input_type = .text,
-            .value => self._default_value = null,
+            .value => {
+                self._default_value = null;
+                if (!self._value_dirty) {
+                    self._value = try self.defaultCurrentValue(frame);
+                }
+            },
             .checked => {
                 self._default_checked = false;
                 // Only update checked state if it hasn't been manually modified
@@ -1538,6 +1584,7 @@ pub const Build = struct {
 
         // Copy runtime state from source to clone
         clone._value = source._value;
+        clone._value_dirty = source._value_dirty;
         clone._checked = source._checked;
         clone._checked_dirty = source._checked_dirty;
         clone._selection_direction = source._selection_direction;

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -36,6 +36,7 @@ _proto: *HtmlElement,
 _value: ?[]const u8 = null,
 _selected: bool = false,
 _default_selected: bool = false,
+_selected_dirty: bool = false,
 _disabled: bool = false,
 
 pub fn asElement(self: *Option) *Element {
@@ -82,6 +83,7 @@ pub fn setSelected(self: *Option, selected: bool, frame: *Frame) !void {
     // TODO: When setting selected=true, may need to unselect other options
     // in the parent <select> if it doesn't have multiple attribute
     self._selected = selected;
+    self._selected_dirty = true;
     frame.domChanged();
 }
 
@@ -168,7 +170,7 @@ pub const Build = struct {
             .value => self._value = element.getAttributeSafe(comptime .wrap("value")),
             .selected => {
                 self._default_selected = true;
-                self._selected = true;
+                if (!self._selected_dirty) self._selected = true;
             },
         }
     }
@@ -180,7 +182,7 @@ pub const Build = struct {
             .value => self._value = null,
             .selected => {
                 self._default_selected = false;
-                self._selected = false;
+                if (!self._selected_dirty) self._selected = false;
             },
         }
     }

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -121,12 +121,17 @@ pub fn getValue(self: *Select, frame: *Frame) []const u8 {
 }
 
 pub fn setValue(self: *Select, value: []const u8, frame: *Frame) !void {
-    // Find option with matching value and select it
-    // Note: This updates the current state (_selected), not the default state (attribute)
-    // Setting value always deselects all others, even for multiple selects
+    self._selected_index_set = true;
+
+    var matched = false;
     var it = OptionIterator.init(self);
     while (it.next()) |option| {
-        option._selected = std.mem.eql(u8, option.getValue(frame), value);
+        const selected = !matched and std.mem.eql(u8, option.getValue(frame), value);
+        option._selected = selected;
+        if (selected) {
+            option._selected_dirty = true;
+            matched = true;
+        }
     }
 }
 
@@ -153,19 +158,41 @@ pub fn setSelectedIndex(self: *Select, index: i32) !void {
     // Mark that selectedIndex has been explicitly set
     self._selected_index_set = true;
 
-    // Select option at given index
-    // Note: This updates the current state (_selected), not the default state (attribute)
-    const is_multiple = self.getMultiple();
     var current_index: i32 = 0;
     var it = OptionIterator.init(self);
     while (it.next()) |option| {
-        if (current_index == index) {
-            option._selected = true;
-        } else if (!is_multiple) {
-            // Only deselect others if not multiple
-            option._selected = false;
+        const selected = current_index == index;
+        option._selected = selected;
+        if (selected) {
+            option._selected_dirty = true;
         }
         current_index += 1;
+    }
+}
+
+pub fn reset(self: *Select) void {
+    self._selected_index_set = false;
+
+    var last_selected: ?*Option = null;
+    var first_enabled: ?*Option = null;
+    var it = OptionIterator.init(self);
+    while (it.next()) |option| {
+        option._selected = option._default_selected;
+        option._selected_dirty = false;
+        if (!option.asElement().isDisabled() and first_enabled == null) {
+            first_enabled = option;
+        }
+        if (option._selected) {
+            if (!self.getMultiple()) {
+                if (last_selected) |previous| previous._selected = false;
+            }
+            last_selected = option;
+        }
+    }
+
+    const size = self.getSize();
+    if (!self.getMultiple() and last_selected == null and (size == 0 or size == 1)) {
+        if (first_enabled) |option| option._selected = true;
     }
 }
 

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -66,6 +66,22 @@ fn dispatchInputEvent(self: *TextArea, data: ?[]const u8, input_type: []const u8
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), event.asEvent());
 }
 
+fn dispatchBeforeInputEvent(self: *TextArea, data: ?[]const u8, input_type: []const u8, frame: *Frame) !bool {
+    const input_event = try InputEvent.initTrusted(comptime .wrap("beforeinput"), .{
+        .bubbles = true,
+        .cancelable = true,
+        .composed = true,
+        .data = data,
+        .inputType = input_type,
+    }, frame);
+    const event = input_event.asEvent();
+    event.acquireRef();
+    defer _ = event.releaseRef(frame._page);
+
+    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+    return event.getDefaultPrevented();
+}
+
 pub fn asElement(self: *TextArea) *Element {
     return self._proto.asElement();
 }
@@ -86,6 +102,13 @@ pub fn getValue(self: *const TextArea) []const u8 {
 pub fn setValue(self: *TextArea, value: []const u8, frame: *Frame) !void {
     const owned = try frame.arena.dupe(u8, value);
     self._value = owned;
+}
+
+pub fn reset(self: *TextArea) void {
+    self._value = null;
+    self._selection_start = 0;
+    self._selection_end = 0;
+    self._selection_direction = .none;
 }
 
 pub fn getDefaultValue(self: *const TextArea) []const u8 {
@@ -121,6 +144,18 @@ pub fn setDisabled(self: *TextArea, disabled: bool, frame: *Frame) !void {
         try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
     } else {
         try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
+    }
+}
+
+pub fn getReadonly(self: *const TextArea) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("readonly")) != null;
+}
+
+pub fn setReadonly(self: *TextArea, readonly: bool, frame: *Frame) !void {
+    if (readonly) {
+        try self.asElement().setAttributeSafe(comptime .wrap("readonly"), .wrap(""), frame);
+    } else {
+        try self.asElement().removeAttribute(comptime .wrap("readonly"), frame);
     }
 }
 
@@ -191,6 +226,10 @@ fn howSelected(self: *const TextArea) HowSelected {
 
 pub fn innerInsert(self: *TextArea, str: []const u8, frame: *Frame) !void {
     const arena = frame.arena;
+    const is_line_break = std.mem.eql(u8, str, "\n");
+    const input_type = if (is_line_break) "insertLineBreak" else "insertText";
+    const data: ?[]const u8 = if (is_line_break) null else str;
+    if (try self.dispatchBeforeInputEvent(data, input_type, frame)) return;
 
     switch (self.howSelected()) {
         .full => {
@@ -228,7 +267,7 @@ pub fn innerInsert(self: *TextArea, str: []const u8, frame: *Frame) !void {
             try self.setValue(new_value, frame);
         },
     }
-    try self.dispatchInputEvent(str, "insertText", frame);
+    try self.dispatchInputEvent(data, input_type, frame);
 }
 
 pub fn getSelectionDirection(self: *const TextArea) []const u8 {
@@ -409,6 +448,7 @@ pub const JsApi = struct {
     pub const value = bridge.accessor(TextArea.getValue, TextArea.setValue, .{});
     pub const defaultValue = bridge.accessor(TextArea.getDefaultValue, TextArea.setDefaultValue, .{ .ce_reactions = true });
     pub const disabled = bridge.accessor(TextArea.getDisabled, TextArea.setDisabled, .{ .ce_reactions = true });
+    pub const readOnly = bridge.accessor(TextArea.getReadonly, TextArea.setReadonly, .{ .ce_reactions = true });
     pub const name = bridge.accessor(TextArea.getName, TextArea.setName, .{ .ce_reactions = true });
     pub const required = bridge.accessor(TextArea.getRequired, TextArea.setRequired, .{ .ce_reactions = true });
     pub const maxLength = bridge.accessor(TextArea.getMaxLength, TextArea.setMaxLength, .{ .ce_reactions = true });

--- a/src/browser/webapi/event/InputEvent.zig
+++ b/src/browser/webapi/event/InputEvent.zig
@@ -83,7 +83,7 @@ fn initWithTrusted(arena: *lp.Arena, typ: String, _opts: ?Options, trusted: bool
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event
     const rootevt = event._proto._proto;
     rootevt._bubbles = true;
-    rootevt._cancelable = false;
+    rootevt._cancelable = opts.cancelable;
     rootevt._composed = true;
 
     // Hold a ref on the DataTransfer (when present) for this event's lifetime;

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -66,6 +66,7 @@ _related_target: ?*EventTarget = null,
 _screen_x: f64,
 _screen_y: f64,
 _shift_key: bool,
+_should_focus_activation: bool = true,
 
 pub const MouseEventOptions = struct {
     screenX: f64 = 0.0,

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -932,6 +932,15 @@ test "cdp.dom: setFileInputFiles exposes files to JS" {
         \\window.__evts.join(',') === 'input:false:true:upload,change:false:true:upload'
     , null);
     try testing.expect(result.isTrue());
+
+    // Reset clears the selected files without firing another input/change pair.
+    const reset_result = try ls.local.compileAndRun(
+        \\document.getElementById('upload-form').reset();
+        \\f.files.length === 0 &&
+        \\f.value === '' &&
+        \\window.__evts.join(',') === 'input:false:true:upload,change:false:true:upload'
+    , null);
+    try testing.expect(reset_result.isTrue());
 }
 
 test "cdp.dom: setFileInputFiles rejects non-input node" {

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -1358,11 +1358,231 @@ test "MCP - press Enter on form input triggers submit (lowercase alias)" {
 
     const press_msg = try aa.dupe(u8, "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"press\",\"arguments\":{\"selector\":\"#q\",\"key\":\"enter\"}}}");
     try router.handleMessage(server, aa, press_msg);
+    try expectSuccessfulPress(out.written());
     out.clearRetainingCapacity();
 
-    const evaluate_msg = try aa.dupe(u8, "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"evaluate\",\"arguments\":{\"script\":\"window.submitted === true && window.submittedValue === 'hello'\"}}}");
-    try router.handleMessage(server, aa, evaluate_msg);
-    try testing.expect(std.mem.indexOf(u8, out.written(), "true") != null);
+    const frame = server.active_session.session.currentFrame().?;
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const result = try ls.local.compileAndRun(
+        \\window.submitted === true &&
+        \\window.submittedValue === 'hello' &&
+        \\enterResults.default.clicks === 1 &&
+        \\enterResults.default.submits === 1 &&
+        \\enterResults.default.clickTrusted === true &&
+        \\enterResults.default.focusDuringClick === true &&
+        \\enterResults.default.focusDuringSubmit === true &&
+        \\enterResults.default.submitter === 'default-submit' &&
+        \\JSON.stringify(enterResults.default.order) === '["keydown","click","submit","keyup"]'
+    , null);
+    try testing.expect(result.isTrue());
+}
+
+test "MCP - press Enter follows form default actions exactly once" {
+    const aa = testing.arena_allocator;
+    var out: std.Io.Writer.Allocating = .init(aa);
+    const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_press_form.html", &out.writer);
+    defer server.deinit();
+
+    const selectors = [_][]const u8{
+        "#prevented",
+        "#notes",
+        "#prevented-notes",
+        "#readonly-notes",
+        "#checkbox",
+        "#radio",
+        "#file",
+        "#submit-input",
+        "#input-button",
+        "#input-reset",
+        "#input-image",
+        "#submit-button",
+        "#button-button",
+        "#button-reset",
+        "#button-default",
+        "#button-empty",
+        "#button-uppercase",
+        "#button-invalid",
+        "#canceled-button",
+        "#dirty-reset-trigger",
+        "#canceled-reset-trigger",
+        "#single",
+        "#two-a",
+    };
+    for (selectors, 1..) |selector, id| {
+        try testPressEnter(server, aa, id, selector);
+        try expectSuccessfulPress(out.written());
+        out.clearRetainingCapacity();
+    }
+
+    // With no selector/backendNodeId, press targets the active element left by
+    // the previous explicit press (#two-a), rather than the Document.
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"press","arguments":{"key":"Enter"}}}
+    );
+    try expectSuccessfulPress(out.written());
+    out.clearRetainingCapacity();
+
+    {
+        const frame = server.active_session.session.currentFrame().?;
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.compileAndRun("document.getElementById('two-a').remove()", null);
+    }
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"press","arguments":{"key":"Enter"}}}
+    );
+    try expectSuccessfulPress(out.written());
+    out.clearRetainingCapacity();
+
+    {
+        const frame = server.active_session.session.currentFrame().?;
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.compileAndRun(
+            \\document.getElementById('notes').focus();
+            \\document.getElementById('notes').style.display = 'none';
+        , null);
+    }
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"press","arguments":{"key":"Enter"}}}
+    );
+    try expectSuccessfulPress(out.written());
+    out.clearRetainingCapacity();
+
+    for ([_][]const u8{ "#disabled-notes", "#disabled-input", "#disabled-button", "#hidden-input", "#plain-div" }, 102..) |selector, id| {
+        try testPressEnter(server, aa, id, selector);
+        try expectFailedPress(out.written());
+        out.clearRetainingCapacity();
+    }
+
+    const frame = server.active_session.session.currentFrame().?;
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    const result = try ls.local.compileAndRun(
+        \\(() => {
+        \\  const r = window.enterResults;
+        \\  const c = r.activation.controls;
+        \\  const click = '[true,true,true,true,0]';
+        \\  const activated = (id, order) =>
+        \\    c[id].clicks === 1 &&
+        \\    JSON.stringify(c[id].click) === click &&
+        \\    JSON.stringify(c[id].order) === JSON.stringify(order);
+        \\  const notActivated = id =>
+        \\    c[id].clicks === 0 &&
+        \\    c[id].click === null &&
+        \\    JSON.stringify(c[id].order) === '["keydown","keyup"]';
+        \\
+        \\  document.getElementById('direct-reset-form').reset();
+        \\  const untrusted = {key: 'Enter', bubbles: true, cancelable: true, composed: true};
+        \\  document.getElementById('untrusted-text').dispatchEvent(new KeyboardEvent('keydown', untrusted));
+        \\  document.getElementById('untrusted-textarea').dispatchEvent(new KeyboardEvent('keydown', untrusted));
+        \\  document.getElementById('untrusted-button').dispatchEvent(new KeyboardEvent('keydown', untrusted));
+        \\
+        \\  return r.prevented.clicks === 0 &&
+        \\    r.prevented.submits === 0 &&
+        \\    JSON.stringify(r.prevented.order) === '["keydown","keyup"]' &&
+        \\    document.getElementById('notes').value === 'line\n' &&
+        \\    JSON.stringify(r.textarea.events) ===
+        \\      '[["beforeinput","insertLineBreak",null,true,true,true,true],["input","insertLineBreak",null,true,false,true,true]]' &&
+        \\    document.getElementById('prevented-notes').value === 'blocked' &&
+        \\    r.textarea.preventedBeforeInputs === 1 &&
+        \\    r.textarea.preventedInputs === 0 &&
+        \\    document.getElementById('readonly-notes').value === 'readonly' &&
+        \\    document.getElementById('readonly-notes').readOnly === true &&
+        \\    document.getElementById('readonly-notes').hasAttribute('readonly') &&
+        \\    document.getElementById('disabled-notes').value === 'disabled' &&
+        \\    r.textarea.readonlyBeforeInputs === 0 &&
+        \\    r.textarea.readonlyInputs === 0 &&
+        \\    r.textarea.disabledBeforeInputs === 0 &&
+        \\    r.textarea.disabledInputs === 0 &&
+        \\    r.textarea.submits === 0 &&
+        \\    r.nontext.submits === 0 &&
+        \\    r.nontext.clicks.checkbox === 0 &&
+        \\    r.nontext.clicks.radio === 0 &&
+        \\    r.nontext.clicks.file === 0 &&
+        \\    document.getElementById('checkbox').checked === false &&
+        \\    document.getElementById('radio').checked === false &&
+        \\    activated('submit-input', ['keydown','click','submit','keyup']) &&
+        \\    activated('input-button', ['keydown','click','keyup']) &&
+        \\    activated('input-reset', ['keydown','click','reset','keyup']) &&
+        \\    activated('input-image', ['keydown','click','submit','keyup']) &&
+        \\    activated('submit-button', ['keydown','click','submit','keyup']) &&
+        \\    activated('button-button', ['keydown','click','keyup']) &&
+        \\    activated('button-reset', ['keydown','click','reset','keyup']) &&
+        \\    activated('button-default', ['keydown','click','submit','keyup']) &&
+        \\    activated('button-empty', ['keydown','click','submit','keyup']) &&
+        \\    activated('button-uppercase', ['keydown','click','keyup']) &&
+        \\    activated('button-invalid', ['keydown','click','submit','keyup']) &&
+        \\    c['disabled-input'].clicks === 0 &&
+        \\    c['disabled-input'].order.length === 0 &&
+        \\    c['disabled-button'].clicks === 0 &&
+        \\    c['disabled-button'].order.length === 0 &&
+        \\    r.unfocusable.events === 0 &&
+        \\    r.bodyTargetedKeydowns === 2 &&
+        \\    notActivated('canceled-button') &&
+        \\    r.activation.submits === 6 &&
+        \\    r.activation.resets === 2 &&
+        \\    JSON.stringify(r.activation.submitters) ===
+        \\      '["submit-input","input-image","submit-button","button-default","button-empty","button-invalid"]' &&
+        \\    document.getElementById('button-default').type === 'submit' &&
+        \\    document.getElementById('button-empty').type === 'submit' &&
+        \\    document.getElementById('button-uppercase').type === 'button' &&
+        \\    document.getElementById('button-invalid').type === 'submit' &&
+        \\    activated('dirty-reset-trigger', ['keydown','click','reset','keyup']) &&
+        \\    r.reset.events === 1 &&
+        \\    r.reset.trusted === true &&
+        \\    r.reset.bubbles === true &&
+        \\    r.reset.cancelable === true &&
+        \\    r.reset.inputEvents === 0 &&
+        \\    r.reset.changeEvents === 0 &&
+        \\    document.getElementById('reset-text').value === 'changed default' &&
+        \\    document.getElementById('reset-text').selectionStart === 0 &&
+        \\    document.getElementById('reset-text').selectionEnd === 0 &&
+        \\    document.getElementById('reset-check').checked === true &&
+        \\    document.getElementById('reset-check').indeterminate === false &&
+        \\    document.getElementById('reset-radio-a').checked === false &&
+        \\    document.getElementById('reset-radio-b').checked === true &&
+        \\    document.getElementById('reset-file').files.length === 0 &&
+        \\    document.getElementById('reset-textarea').value === 'changed area' &&
+        \\    document.getElementById('reset-textarea').selectionStart === 0 &&
+        \\    document.getElementById('reset-textarea').selectionEnd === 0 &&
+        \\    document.getElementById('reset-select').selectedIndex === 0 &&
+        \\    document.getElementById('reset-select').options[0].selected === true &&
+        \\    document.getElementById('reset-select').options[1].selected === false &&
+        \\    document.getElementById('reset-text').validationMessage === 'keep' &&
+        \\    document.getElementById('reset-textarea').validationMessage === 'keep' &&
+        \\    document.getElementById('reset-select').validationMessage === 'keep' &&
+        \\    activated('canceled-reset-trigger', ['keydown','click','reset','keyup']) &&
+        \\    r.canceledReset.events === 1 &&
+        \\    r.canceledReset.trusted === true &&
+        \\    document.getElementById('canceled-reset-text').value === 'dirty' &&
+        \\    r.directReset.events === 1 &&
+        \\    r.directReset.trusted === true &&
+        \\    r.directReset.bubbles === true &&
+        \\    r.directReset.cancelable === true &&
+        \\    document.getElementById('direct-reset-text').value === 'default' &&
+        \\    document.getElementById('direct-reset-text').selectionStart === 0 &&
+        \\    document.getElementById('direct-reset-textarea').value === 'default area' &&
+        \\    document.getElementById('direct-reset-textarea').selectionStart === 0 &&
+        \\    document.getElementById('direct-reset-select').selectedIndex === 1 &&
+        \\    document.getElementById('untrusted-text').value === '' &&
+        \\    document.getElementById('untrusted-textarea').value === 'line' &&
+        \\    r.untrusted.clicks === 0 &&
+        \\    r.untrusted.submits === 0 &&
+        \\    r.single.submits === 1 &&
+        \\    r.single.submitterIsNull === true &&
+        \\    r.two.submits === 0 &&
+        \\    r.two.keydowns === 2;
+        \\})()
+    , null);
+    try testing.expect(result.isTrue());
 }
 
 test "MCP - getCookies: defaults to current page, url filter, all flag" {
@@ -1482,6 +1702,29 @@ test "MCP - sessions: new, list, attach isolation, close" {
     );
     try testing.expect(std.mem.indexOf(u8, out.written(), "closed session a") != null);
     try testing.expect(!server.sessions.contains("a"));
+}
+
+fn testPressEnter(server: *Server, allocator: std.mem.Allocator, id: usize, selector: []const u8) !void {
+    const id_string = try std.fmt.allocPrint(allocator, "{d}", .{id});
+    const msg = try std.mem.concat(allocator, u8, &.{
+        "{\"jsonrpc\":\"2.0\",\"id\":",
+        id_string,
+        ",\"method\":\"tools/call\",\"params\":{\"name\":\"press\",\"arguments\":{\"selector\":\"",
+        selector,
+        "\",\"key\":\"Enter\"}}}",
+    });
+    try router.handleMessage(server, allocator, msg);
+}
+
+fn expectSuccessfulPress(output: []const u8) !void {
+    try testing.expect(std.mem.indexOf(u8, output, "Pressed key") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\"isError\":true") == null);
+}
+
+fn expectFailedPress(output: []const u8) !void {
+    try testing.expect(std.mem.indexOf(u8, output, "Pressed key") == null);
+    try testing.expect(std.mem.indexOf(u8, output, "\"error\":") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "InternalError") != null);
 }
 
 fn testLoadPage(url: [:0]const u8, writer: *std.Io.Writer) !*Server {


### PR DESCRIPTION
## Summary

- target press actions at a focusable active element and fail cleanly for invalid explicit targets
- run trusted Enter default actions through click activation, preserving cancellation and event order
- implement submit, reset, textarea beforeinput, readonly, and form-control reset state
- cover default submitters, implicit submission, disabled controls, canceled actions, and untrusted events

## Why

Pressing Enter previously bypassed the normal click activation path and submitted forms directly. That skipped observable browser behavior such as click events, submitter selection, preventDefault, reset handling, focus state, and trusted-event gating.

This is a DOM and automation compatibility fix. It does not alter browser identity surfaces or conceal automation.

## Validation

- make test F="MCP - press Enter" — 2/2 passed
- make test F="WebApi: HTML.Select" — 1/1 passed
- make test F="MCP - Actions" — 2/2 passed
- make test — 1126/1126 passed on the confirmation run
- the first full run had one existing NodeLive timing-threshold failure; its isolated rerun passed
- tracked Zig formatting check passed
- git diff --check passed