### PR TITLE
browser: use UTF-16 offsets for text editing

### DIFF
--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -754,7 +754,7 @@ pub fn setAutocomplete(self: *Input, autocomplete: []const u8, frame: *Frame) !v
 }
 
 pub fn select(self: *Input, frame: *Frame) !void {
-    const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
+    const len: u32 = @intCast(Node.CData.utf16Len(self.getValue()));
     try self.setSelectionRange(0, len, null, frame);
     const event = try Event.init("select", .{ .bubbles = true }, frame._page);
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
@@ -767,56 +767,34 @@ fn selectionAvailable(self: *const Input) bool {
     }
 }
 
-const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };
-
-fn howSelected(self: *const Input) HowSelected {
-    if (!self.selectionAvailable()) return .none;
-    const value = self._value orelse return .none;
-
-    if (self._selection_start == self._selection_end) return .none;
-    if (self._selection_start == 0 and self._selection_end == value.len) return .full;
-    return .{ .partial = .{ self._selection_start, self._selection_end } };
-}
-
 pub fn innerInsert(self: *Input, str: []const u8, frame: *Frame) !void {
     const arena = frame.arena;
-
-    switch (self.howSelected()) {
-        .full => {
-            // if the input is fully selected, replace the content.
-            const new_value = try arena.dupe(u8, str);
-            try self.setValue(new_value, frame);
-            self._selection_start = @intCast(new_value.len);
-            self._selection_end = @intCast(new_value.len);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .partial => |range| {
-            // if the input is partially selected, replace the selected content.
-            const current_value = self.getValue();
-            const before = current_value[0..range[0]];
-            const remaining = current_value[range[1]..];
-
-            const new_value = try std.mem.concat(
-                arena,
-                u8,
-                &.{ before, str, remaining },
-            );
-            try self.setValue(new_value, frame);
-
-            const new_pos = range[0] + str.len;
-            self._selection_start = @intCast(new_pos);
-            self._selection_end = @intCast(new_pos);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .none => {
-            // if the input is not selected, just insert at cursor.
-            const current_value = self.getValue();
-            const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
-            try self.setValue(new_value, frame);
-        },
+    const current_value = self.getValue();
+    if (!self.selectionAvailable()) {
+        const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
+        try self.setValue(new_value, frame);
+        return self.dispatchInputEvent(str, "insertText", frame);
     }
+
+    const value_len: u32 = @intCast(Node.CData.utf16Len(current_value));
+    var start = @min(self._selection_start, value_len);
+    const end = @min(self._selection_end, value_len);
+    if (end < start) start = end;
+
+    const byte_start = Node.CData.utf16OffsetToUtf8Floor(current_value, start);
+    const byte_end = Node.CData.utf16OffsetToUtf8Floor(current_value, end);
+    const new_value = try std.mem.concat(
+        arena,
+        u8,
+        &.{ current_value[0..byte_start], str, current_value[byte_end..] },
+    );
+    try self.setValue(new_value, frame);
+
+    const new_pos = start + @as(u32, @intCast(Node.CData.utf16Len(str)));
+    self._selection_start = new_pos;
+    self._selection_end = new_pos;
+    self._selection_direction = .none;
+    try self.dispatchSelectionChangeEvent(frame);
     try self.dispatchInputEvent(str, "insertText", frame);
 }
 
@@ -861,14 +839,7 @@ pub fn setSelectionRange(
         } else break :blk .none;
     };
 
-    const value = self._value orelse {
-        self._selection_start = 0;
-        self._selection_end = 0;
-        self._selection_direction = .none;
-        return;
-    };
-
-    const len_u32: u32 = @intCast(value.len);
+    const len_u32: u32 = @intCast(Node.CData.utf16Len(self.getValue()));
     var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
     const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
 

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -173,61 +173,34 @@ pub fn setMinLength(self: *TextArea, min_length: i32, frame: *Frame) !void {
 }
 
 pub fn select(self: *TextArea, frame: *Frame) !void {
-    const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
+    const len: u32 = @intCast(Node.CData.utf16Len(self.getValue()));
     try self.setSelectionRange(0, len, null, frame);
     const event = try Event.init("select", .{ .bubbles = true }, frame._page);
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
-const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };
-
-fn howSelected(self: *const TextArea) HowSelected {
-    const value = self._value orelse return .none;
-
-    if (self._selection_start == self._selection_end) return .none;
-    if (self._selection_start == 0 and self._selection_end == value.len) return .full;
-    return .{ .partial = .{ self._selection_start, self._selection_end } };
-}
-
 pub fn innerInsert(self: *TextArea, str: []const u8, frame: *Frame) !void {
     const arena = frame.arena;
+    const current_value = self.getValue();
+    const value_len: u32 = @intCast(Node.CData.utf16Len(current_value));
+    var start = @min(self._selection_start, value_len);
+    const end = @min(self._selection_end, value_len);
+    if (end < start) start = end;
 
-    switch (self.howSelected()) {
-        .full => {
-            // if the text area is fully selected, replace the content.
-            const new_value = try arena.dupe(u8, str);
-            try self.setValue(new_value, frame);
-            self._selection_start = @intCast(new_value.len);
-            self._selection_end = @intCast(new_value.len);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .partial => |range| {
-            // if the text area is partially selected, replace the selected content.
-            const current_value = self.getValue();
-            const before = current_value[0..range[0]];
-            const remaining = current_value[range[1]..];
+    const byte_start = Node.CData.utf16OffsetToUtf8Floor(current_value, start);
+    const byte_end = Node.CData.utf16OffsetToUtf8Floor(current_value, end);
+    const new_value = try std.mem.concat(
+        arena,
+        u8,
+        &.{ current_value[0..byte_start], str, current_value[byte_end..] },
+    );
+    try self.setValue(new_value, frame);
 
-            const new_value = try std.mem.concat(
-                arena,
-                u8,
-                &.{ before, str, remaining },
-            );
-            try self.setValue(new_value, frame);
-
-            const new_pos = range[0] + str.len;
-            self._selection_start = @intCast(new_pos);
-            self._selection_end = @intCast(new_pos);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .none => {
-            // if the text area is not selected, just insert at cursor.
-            const current_value = self.getValue();
-            const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
-            try self.setValue(new_value, frame);
-        },
-    }
+    const new_pos = start + @as(u32, @intCast(Node.CData.utf16Len(str)));
+    self._selection_start = new_pos;
+    self._selection_end = new_pos;
+    self._selection_direction = .none;
+    try self.dispatchSelectionChangeEvent(frame);
     try self.dispatchInputEvent(str, "insertText", frame);
 }
 
@@ -266,14 +239,7 @@ pub fn setSelectionRange(
         } else break :blk .none;
     };
 
-    const value = self._value orelse {
-        self._selection_start = 0;
-        self._selection_end = 0;
-        self._selection_direction = .none;
-        return;
-    };
-
-    const len_u32: u32 = @intCast(value.len);
+    const len_u32: u32 = @intCast(Node.CData.utf16Len(self.getValue()));
     var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
     const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
 

--- a/src/cdp/domains/input.zig
+++ b/src/cdp/domains/input.zig
@@ -320,6 +320,96 @@ test "cdp.input: dispatchMouseEvent right button fires contextmenu, double-click
     try testing.expect(result.isTrue());
 }
 
+test "cdp.input: insertText uses UTF-16 selection offsets" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
+    const url = "http://localhost:9582/src/browser/tests/mcp_actions.html";
+    try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
+    try testing.waitForPage(bc);
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    var try_catch: lp.js.TryCatch = undefined;
+    try_catch.init(&ls.local);
+    defer try_catch.deinit();
+
+    _ = try ls.local.compileAndRun(
+        \\document.body.innerHTML = '<input id="input"><textarea id="textarea"></textarea>';
+        \\const input = document.getElementById('input');
+        \\const textarea = document.getElementById('textarea');
+        \\window.editEvents = [];
+        \\for (const element of [input, textarea]) {
+        \\  element.addEventListener('input', event => {
+        \\    window.editEvents.push([element.id, event.data, event.inputType]);
+        \\  });
+        \\}
+        \\input.value = 'A👋B';
+        \\input.setSelectionRange(1, 3);
+        \\input.focus();
+    , null);
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Input.insertText",
+        .params = .{ .text = "界" },
+    });
+    try testing.expect((try ls.local.compileAndRun(
+        \\input.value === 'A界B' &&
+        \\input.selectionStart === 2 &&
+        \\input.selectionEnd === 2
+    , null)).isTrue());
+
+    _ = try ls.local.compileAndRun(
+        \\input.value = 'A👋B';
+        \\input.setSelectionRange(1, 1);
+        \\input.focus();
+    , null);
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Input.insertText",
+        .params = .{ .text = "界" },
+    });
+    try testing.expect((try ls.local.compileAndRun(
+        \\input.value === 'A界👋B' &&
+        \\input.selectionStart === 2 &&
+        \\input.selectionEnd === 2
+    , null)).isTrue());
+
+    _ = try ls.local.compileAndRun(
+        \\textarea.value = 'A👋B';
+        \\textarea.setSelectionRange(1, 3);
+        \\textarea.focus();
+    , null);
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Input.insertText",
+        .params = .{ .text = "界" },
+    });
+    try testing.expect((try ls.local.compileAndRun(
+        \\textarea.value === 'A界B' &&
+        \\textarea.selectionStart === 2 &&
+        \\textarea.selectionEnd === 2 &&
+        \\JSON.stringify(window.editEvents) ===
+        \\  '[["input","界","insertText"],["input","界","insertText"],["textarea","界","insertText"]]'
+    , null)).isTrue());
+
+    try testing.expect((try ls.local.compileAndRun(
+        \\input.value = 'A👋B';
+        \\input.select();
+        \\textarea.value = 'A👋B';
+        \\textarea.select();
+        \\input.selectionStart === 0 && input.selectionEnd === 4 &&
+        \\textarea.selectionStart === 0 && textarea.selectionEnd === 4
+    , null)).isTrue());
+}
+
 test "cdp.input: dispatchKeyEvent Tab runs sequential focus navigation" {
     var ctx = try testing.context();
     defer ctx.deinit();


### PR DESCRIPTION
## What changed

- use UTF-16 code-unit offsets for input and textarea selections
- replace the selected range, or insert at a collapsed caret
- keep the existing append behavior for input types without selection APIs
- add CDP coverage for surrogate pairs, collapsed carets, textarea editing, events, and `select()`

## Why

HTML text-control selection offsets are UTF-16 code units. The existing implementation treated them as UTF-8 byte offsets, which could slice multibyte text incorrectly. It also appended text when the selection was collapsed instead of inserting at the caret.

## Impact

`Input.insertText` and keyboard editing now behave consistently for non-ASCII text without adding dependencies or persistent runtime state.

## Validation

- `make test F="cdp.input: insertText uses UTF-16 selection offsets"` — 1/1 passed
- `make test F="cdp.input"` — 6/6 passed
- `make test` — 1,126/1,126 passed
- `git diff --check`
