### PR TITLE
navigator: align client identity metadata

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -791,7 +791,7 @@ pub const WaitUntil = enum {
 pub const HttpHeaders = struct {
     const user_agent_base: [:0]const u8 = "Lightpanda/1.0";
 
-    const Brand = struct {
+    pub const Brand = struct {
         brand: [:0]const u8,
         version: [:0]const u8,
     };
@@ -800,7 +800,14 @@ pub const HttpHeaders = struct {
     /// HTTP header and navigator.userAgentData.brands derive from this
     /// list, so the two sides cannot drift.
     pub const brands = [_]Brand{
+        .{ .brand = "Not/A)Brand", .version = "8" },
         .{ .brand = "Lightpanda", .version = "1" },
+    };
+
+    /// Full versions returned for the UA-CH fullVersionList hint.
+    pub const full_brands = [_]Brand{
+        .{ .brand = "Not/A)Brand", .version = "8.0.0.0" },
+        .{ .brand = "Lightpanda", .version = "1.0.0.0" },
     };
 
     pub const sec_ch_ua: [:0]const u8 = blk: {

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -114,6 +114,15 @@ call_depth: usize = 0,
 // context.localScope
 local: ?*const js.Local = null,
 
+// Captured before page scripts run, so web content cannot replace the
+// intrinsic used to create Web IDL FrozenArray values.
+object_freeze: ?js.Function.Global = null,
+
+// Per-realm FrozenArray caches required by Navigator and NavigatorUAData.
+navigator_brands: ?js.Value.Global = null,
+navigator_full_brands: ?js.Value.Global = null,
+navigator_languages: ?js.Value.Global = null,
+
 origin: *Origin,
 
 // Identity tracking for this context. For main world contexts, this points to
@@ -216,6 +225,23 @@ pub fn deinit(self: *Context) void {
 
     // this can release objects
     self.scheduler.deinit();
+
+    if (self.navigator_brands) |brands| {
+        brands.deinit();
+        self.navigator_brands = null;
+    }
+    if (self.navigator_full_brands) |brands| {
+        brands.deinit();
+        self.navigator_full_brands = null;
+    }
+    if (self.navigator_languages) |languages| {
+        languages.deinit();
+        self.navigator_languages = null;
+    }
+    if (self.object_freeze) |freeze| {
+        freeze.deinit();
+        self.object_freeze = null;
+    }
 
     for (self.global_modules.items) |*global| {
         v8.v8__Global__Reset(global);

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -252,6 +252,11 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
     const T = @TypeOf(global);
     const is_frame = T == *Frame;
 
+    if (self.contexts.items.len >= MAX_CONTEXTS) {
+        return error.TooManyContexts;
+    }
+    try self.contexts.ensureUnusedCapacity(self.allocator, 1);
+
     const context_arena = try self.app.arena_pool.acquire(.medium, params.debug_name);
     errdefer context_arena.release();
 
@@ -288,6 +293,7 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
     // Create the v8::Context and wrap it in a v8::Global
     var context_global: v8.Global = undefined;
     v8.v8__Global__New(isolate.handle, v8_context, &context_global);
+    errdefer v8.v8__Global__Reset(&context_global);
 
     // Get the global object for the context
     const global_obj = v8.v8__Context__Global(v8_context).?;
@@ -358,6 +364,17 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
         ._scheduler = &context.scheduler,
     };
 
+    {
+        var ls: js.Local.Scope = undefined;
+        context.localScope(&ls);
+        defer ls.deinit();
+
+        const object_constructor = (try ls.local.getGlobal().get("Object")).toObject();
+        const freeze = try object_constructor.getFunction("freeze") orelse return error.JsException;
+        context.object_freeze = try freeze.persist();
+    }
+    errdefer if (context.object_freeze) |freeze| freeze.deinit();
+
     // Register in the identity map. Multiple contexts can be created for the
     // same global (via CDP), so we only register the first one.
     const identity_ptr = if (comptime is_frame) @intFromPtr(global.window) else switch (global._type) {
@@ -374,10 +391,7 @@ fn _createContext(self: *Env, global: anytype, params: ContextParams) !*Context 
     // a v8 context, we can get our context out
     v8.v8__Context__SetAlignedPointerInEmbedderData(v8_context, 1, @ptrCast(context));
 
-    if (self.contexts.items.len >= MAX_CONTEXTS) {
-        return error.TooManyContexts;
-    }
-    try self.contexts.append(self.allocator, context);
+    self.contexts.appendAssumeCapacity(context);
 
     return context;
 }

--- a/src/browser/js/Local.zig
+++ b/src/browser/js/Local.zig
@@ -83,6 +83,11 @@ pub fn newObject(self: *const Local) js.Object {
     };
 }
 
+pub fn freeze(self: *const Local, value: anytype) !js.Value {
+    const freeze_function = self.ctx.object_freeze orelse return error.JsException;
+    return freeze_function.local(self).call(js.Value, .{value});
+}
+
 pub fn newDate(self: *const Local, time_ms: f64) !js.Value {
     const handle = v8.v8__Date__New(self.handle, time_ms) orelse return error.JsException;
     return .{ .local = self, .handle = handle };

--- a/src/browser/tests/navigator/navigator.html
+++ b/src/browser/tests/navigator/navigator.html
@@ -1,13 +1,28 @@
 <!DOCTYPE html>
 <script src="../testing.js"></script>
 
+<script id=navigator_frozen_arrays_use_captured_intrinsic>
+  const originalFreeze = Object.freeze;
+  Object.freeze = () => { throw new Error('page replacement must not run'); };
+  try {
+    const capturedLanguages = navigator.languages;
+    const capturedBrands = navigator.userAgentData.brands;
+    const highEntropyPromise = navigator.userAgentData.getHighEntropyValues(['fullVersionList']);
+    testing.expectTrue(Object.isFrozen(capturedLanguages));
+    testing.expectTrue(Object.isFrozen(capturedBrands));
+    testing.expectTrue(highEntropyPromise instanceof Promise);
+  } finally {
+    Object.freeze = originalFreeze;
+  }
+</script>
+
 <script id=navigator>
   // Navigator should be accessible from window
   testing.expectEqual(navigator, window.navigator);
   testing.expectEqual(true, navigator.userAgent.length > 0);
   testing.expectEqual(true, navigator.userAgent.includes('Lightpanda'));
   testing.expectEqual('Netscape', navigator.appName);
-  testing.expectEqual('1.0', navigator.appVersion);
+  testing.expectEqual('', navigator.appVersion);
   testing.expectEqual(true, navigator.platform.length > 0);
 
   // Platform should be one of the known values
@@ -18,6 +33,8 @@
   testing.expectEqual(2, navigator.languages.length);
   testing.expectEqual('en-US', navigator.languages[0]);
   testing.expectEqual('en', navigator.languages[1]);
+  testing.expectTrue(navigator.languages === navigator.languages);
+  testing.expectTrue(Object.isFrozen(navigator.languages));
   testing.expectEqual(true, navigator.onLine);
   testing.expectEqual(true, navigator.cookieEnabled);
   testing.expectEqual(true, navigator.hardwareConcurrency > 0);
@@ -109,17 +126,20 @@
   const validUAPlatforms = ['macOS', 'Windows', 'Linux', 'FreeBSD', 'Unknown'];
   testing.expectEqual(true, validUAPlatforms.includes(navigator.userAgentData.platform));
 
-  testing.expectEqual(1, navigator.userAgentData.brands.length);
-  testing.expectEqual({brand: 'Lightpanda', version: "1"}, navigator.userAgentData.brands[0]);
+  testing.expectEqual(2, navigator.userAgentData.brands.length);
+  testing.expectEqual({brand: 'Not/A)Brand', version: "8"}, navigator.userAgentData.brands[0]);
+  testing.expectEqual({brand: 'Lightpanda', version: "1"}, navigator.userAgentData.brands[1]);
 
   // Same instance returned on repeated access
   testing.expectEqual(true, navigator.userAgentData === navigator.userAgentData);
+  testing.expectEqual(true, navigator.userAgentData.brands === navigator.userAgentData.brands);
+  testing.expectTrue(Object.isFrozen(navigator.userAgentData.brands));
 
   const json = navigator.userAgentData.toJSON();
   testing.expectEqual(false, json.mobile);
   testing.expectEqual(navigator.userAgentData.platform, json.platform);
   testing.expectEqual(true, Array.isArray(json.brands));
-  testing.expectEqual('Lightpanda', json.brands[0].brand);
+  testing.expectEqual('Lightpanda', json.brands[1].brand);
 </script>
 
 <script id=userAgentData_highEntropy type=module>
@@ -128,18 +148,49 @@
     const p = navigator.userAgentData.getHighEntropyValues(['architecture', 'platformVersion', 'fullVersionList']);
     testing.expectTrue(p instanceof Promise);
     const v = await p;
+    const repeated = await navigator.userAgentData.getHighEntropyValues(['fullVersionList']);
     state.resolve();
 
     await state.done(() => {
       testing.expectEqual(false, v.mobile);
       testing.expectEqual(navigator.userAgentData.platform, v.platform);
       testing.expectEqual(true, Array.isArray(v.brands));
+      testing.expectEqual(true, typeof v.architecture === 'string');
+      testing.expectEqual(true, typeof v.platformVersion === 'string');
       testing.expectEqual(true, Array.isArray(v.fullVersionList));
-      testing.expectEqual('Lightpanda', v.fullVersionList[0].brand);
+      testing.expectTrue(Object.isFrozen(v.brands));
+      testing.expectTrue(Object.isFrozen(v.fullVersionList));
+      testing.expectTrue(v.brands === navigator.userAgentData.brands);
+      testing.expectTrue(v.fullVersionList === repeated.fullVersionList);
+      testing.expectEqual('Lightpanda', v.fullVersionList[1].brand);
+      testing.expectEqual('1.0.0.0', v.fullVersionList[1].version);
+      testing.expectEqual(false, 'bitness' in v);
+      testing.expectEqual(false, 'model' in v);
+      testing.expectEqual(false, 'uaFullVersion' in v);
+      testing.expectEqual(false, 'wow64' in v);
+      testing.expectEqual(false, 'formFactors' in v);
+    });
+  }
+</script>
+
+<script id=userAgentData_highEntropy_formFactors type=module>
+  {
+    const state = await testing.async();
+    const v = await navigator.userAgentData.getHighEntropyValues([
+      'formFactors',
+      'uaFullVersion',
+      'wow64',
+    ]);
+    state.resolve();
+
+    await state.done(() => {
+      testing.expectEqual(true, Array.isArray(v.formFactors));
+      testing.expectEqual('Desktop', v.formFactors[0]);
       testing.expectEqual('1.0.0.0', v.uaFullVersion);
       testing.expectEqual(false, v.wow64);
-      testing.expectEqual(true, Array.isArray(v.formFactor));
-      testing.expectEqual('Desktop', v.formFactor[0]);
+      testing.expectEqual(false, 'architecture' in v);
+      testing.expectEqual(false, 'fullVersionList' in v);
+      testing.expectEqual(false, 'platformVersion' in v);
     });
   }
 </script>
@@ -150,4 +201,3 @@
   // rather than a stub that always rejects.
   testing.expectEqual('undefined', typeof navigator.getBattery);
 </script>
-

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -42,8 +42,16 @@ pub fn getUserAgent(_: *const Navigator, exec: *const Execution) []const u8 {
     return exec.session.browser.http_client.getUserAgent();
 }
 
-pub fn getLanguages(_: *const Navigator) [2][]const u8 {
-    return .{ "en-US", "en" };
+pub fn getLanguages(_: *const Navigator, exec: *const Execution) !js.Value {
+    const local = exec.js.local.?;
+    if (exec.js.navigator_languages) |languages| {
+        return languages.local(local);
+    }
+
+    const languages = try local.zigValueToJs([2][]const u8{ "en-US", "en" }, .{});
+    const frozen = try local.freeze(languages);
+    exec.js.navigator_languages = try frozen.persist();
+    return frozen;
 }
 
 pub fn getDoNotTrack(_: *const Navigator) ?[]const u8 {
@@ -58,8 +66,19 @@ pub fn getAppCodeName(_: *const Navigator) []const u8 {
     return "Mozilla";
 }
 
-pub fn getAppVersion(_: *const Navigator) []const u8 {
-    return "1.0";
+pub fn getAppVersion(self: *const Navigator, exec: *const Execution) ![]const u8 {
+    const user_agent = getUserAgent(self, exec);
+    const prefix = "Mozilla/";
+    if (!std.mem.startsWith(u8, user_agent, "Mozilla/5.0 (")) {
+        return "";
+    }
+
+    const trail = user_agent[prefix.len..];
+    if (std.mem.startsWith(u8, trail, "5.0 (Windows")) {
+        return "5.0 (Windows)";
+    }
+    const separator = std.mem.indexOfScalar(u8, trail, ';') orelse return trail;
+    return std.mem.concat(exec.js.local.?.call_arena, u8, &.{ trail[0..separator], ")" });
 }
 
 pub fn getLanguage(_: *const Navigator) []const u8 {

--- a/src/browser/webapi/NavigatorUAData.zig
+++ b/src/browser/webapi/NavigatorUAData.zig
@@ -16,34 +16,30 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+const std = @import("std");
 const builtin = @import("builtin");
 
 const Config = @import("../../Config.zig");
 const js = @import("../js/js.zig");
 const Execution = js.Execution;
 
-const NavigatorUAData = @This();
-
 _pad: bool = false,
 
-const Brand = struct {
-    brand: []const u8,
-    version: []const u8,
-};
+const Brand = Config.HttpHeaders.Brand;
 
-pub fn getBrands(_: *const NavigatorUAData) []const Brand {
-    return brandList();
+pub fn getBrands(_: *const @This(), exec: *const Execution) !js.Value {
+    return frozenBrandList(exec, false);
 }
 
-pub fn getMobile(_: *const NavigatorUAData) bool {
+pub fn getMobile(_: *const @This()) bool {
     return false;
 }
 
-pub fn getPlatform(_: *const NavigatorUAData) []const u8 {
+pub fn getPlatform(_: *const @This()) []const u8 {
     return uaPlatform();
 }
 
-pub fn toJSON(_: *const NavigatorUAData) struct {
+pub fn toJSON(_: *const @This()) struct {
     brands: []const Brand,
     mobile: bool,
     platform: []const u8,
@@ -55,39 +51,56 @@ pub fn toJSON(_: *const NavigatorUAData) struct {
     };
 }
 
-pub fn getHighEntropyValues(_: *const NavigatorUAData, hints: []const []const u8, exec: *const Execution) !js.Promise {
-    // This should always return `brands` + `mobile` + `platform` and then whatever
-    // "hints" field is requested (assuming the browser has permission), but it's
-    // also valid to just return everything.
+pub fn getHighEntropyValues(_: *const @This(), hints: []const []const u8, exec: *const Execution) !js.Promise {
+    const local = exec.js.local.?;
+    const values = local.newObject();
+    _ = try values.set("brands", try frozenBrandList(exec, false), .{});
+    _ = try values.set("mobile", false, .{});
+    _ = try values.set("platform", uaPlatform(), .{});
 
-    _ = hints;
+    for (hints) |hint| {
+        if (std.mem.eql(u8, hint, "architecture")) {
+            _ = try values.set("architecture", uaArchitecture(), .{});
+        } else if (std.mem.eql(u8, hint, "bitness")) {
+            _ = try values.set("bitness", uaBitness(), .{});
+        } else if (std.mem.eql(u8, hint, "formFactors")) {
+            _ = try values.set("formFactors", [_][]const u8{"Desktop"}, .{});
+        } else if (std.mem.eql(u8, hint, "fullVersionList")) {
+            _ = try values.set("fullVersionList", try frozenBrandList(exec, true), .{});
+        } else if (std.mem.eql(u8, hint, "model")) {
+            _ = try values.set("model", "", .{});
+        } else if (std.mem.eql(u8, hint, "platformVersion")) {
+            _ = try values.set("platformVersion", "", .{});
+        } else if (std.mem.eql(u8, hint, "uaFullVersion")) {
+            _ = try values.set("uaFullVersion", "1.0.0.0", .{});
+        } else if (std.mem.eql(u8, hint, "wow64")) {
+            _ = try values.set("wow64", false, .{});
+        }
+    }
 
-    return exec.js.local.?.resolvePromise(.{
-        .brands = brandList(),
-        .mobile = false,
-        .platform = uaPlatform(),
-        .architecture = uaArchitecture(),
-        .bitness = uaBitness(),
-        .model = "",
-        .platformVersion = "",
-        .uaFullVersion = "1.0.0.0",
-        .fullVersionList = brandList(),
-        .wow64 = false,
-        .formFactor = [_][]const u8{"Desktop"},
-    });
+    return local.resolvePromise(values);
 }
 
 fn brandList() []const Brand {
-    const out = comptime blk: {
-        const src = &Config.HttpHeaders.brands;
-        var arr: [src.len]Brand = undefined;
-        for (src, 0..) |b, i| {
-            arr[i] = .{ .brand = b.brand, .version = b.version };
-        }
-        const final = arr;
-        break :blk final;
-    };
-    return &out;
+    return &Config.HttpHeaders.brands;
+}
+
+fn fullBrandList() []const Brand {
+    return &Config.HttpHeaders.full_brands;
+}
+
+fn frozenBrandList(exec: *const Execution, full: bool) !js.Value {
+    const context = exec.js;
+    const local = context.local.?;
+    const cache = if (full) &context.navigator_full_brands else &context.navigator_brands;
+    if (cache.*) |brands| {
+        return brands.local(local);
+    }
+
+    const source = if (full) fullBrandList() else brandList();
+    const frozen = try local.freeze(try local.zigValueToJs(source, .{}));
+    cache.* = try frozen.persist();
+    return frozen;
 }
 
 fn uaPlatform() []const u8 {
@@ -115,8 +128,10 @@ fn uaBitness() []const u8 {
     };
 }
 
+const Self = @This();
+
 pub const JsApi = struct {
-    pub const bridge = js.Bridge(NavigatorUAData);
+    pub const bridge = js.Bridge(Self);
 
     pub const Meta = struct {
         pub const name = "NavigatorUAData";
@@ -125,9 +140,13 @@ pub const JsApi = struct {
         pub const empty_with_no_proto = true;
     };
 
-    pub const brands = bridge.accessor(NavigatorUAData.getBrands, null, .{});
-    pub const mobile = bridge.accessor(NavigatorUAData.getMobile, null, .{});
-    pub const platform = bridge.accessor(NavigatorUAData.getPlatform, null, .{});
-    pub const toJSON = bridge.function(NavigatorUAData.toJSON, .{});
-    pub const getHighEntropyValues = bridge.function(NavigatorUAData.getHighEntropyValues, .{});
+    pub const brands = bridge.accessor(getBrands, null, .{});
+    pub const mobile = bridge.accessor(getMobile, null, .{});
+    pub const platform = bridge.accessor(getPlatform, null, .{});
+    pub const toJSON = bridge.function(toJSONFn, .{});
+    pub const getHighEntropyValues = bridge.function(getHighEntropyValuesFn, .{});
 };
+
+// Aliases avoid JsApi field names shadowing the free functions.
+const toJSONFn = toJSON;
+const getHighEntropyValuesFn = getHighEntropyValues;


### PR DESCRIPTION
## Summary

- derive the network `Sec-CH-UA` header and `navigator.userAgentData` from the same truthful Lightpanda brand metadata
- return stable, per-realm FrozenArrays for `navigator.languages`, low-entropy brands, and `fullVersionList`
- capture the realm's intrinsic `Object.freeze` before page scripts can replace it, and release all persisted handles during context teardown
- return baseline UA data plus only the requested high-entropy hints, with the standard `formFactors` spelling, full versions, and build-target architecture/bitness
- derive `navigator.appVersion` from the configured user agent using the HTML algorithm

This deliberately keeps the identity Lightpanda-specific. It does not impersonate Chrome, change `navigator.webdriver`, or add automation-detector behavior.

## Verification

- `make test F="WebApi: Navigator" ...` — 1/1 passed
- `make test ...` — 1125/1125 passed, including debug leak checks
- tracked Zig sources pass `zig fmt --check`
- `git diff --check`
- independent lifecycle review after moving all fallible context-list work ahead of V8 identity/embedder publication
