### PR TITLE
webapi: expose datalist options

### DIFF
--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -692,15 +692,18 @@ const PrivateSymbols = struct {
     const Private = @import("Private.zig");
 
     child_nodes: Private,
+    datalist_options: Private,
 
     fn init(isolate: *v8.Isolate) PrivateSymbols {
         return .{
             .child_nodes = Private.init(isolate, "child_nodes"),
+            .datalist_options = Private.init(isolate, "datalist_options"),
         };
     }
 
     fn deinit(self: *PrivateSymbols) void {
         self.child_nodes.deinit();
+        self.datalist_options.deinit();
     }
 };
 

--- a/src/browser/tests/element/html/datalist.html
+++ b/src/browser/tests/element/html/datalist.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<script id="options">
+  {
+    const list = document.createElement('datalist')
+    const options = list.options
+
+    testing.expectEqual('HTMLCollection', options.constructor.name)
+    testing.expectTrue(options === list.options)
+    testing.expectEqual(0, options.length)
+
+    const first = document.createElement('option')
+    first.value = 'first'
+    list.appendChild(first)
+    testing.expectEqual(1, options.length)
+    testing.expectEqual('first', options[0].value)
+
+    const nested = document.createElement('option')
+    nested.value = 'nested'
+    const wrapper = document.createElement('div')
+    wrapper.appendChild(nested)
+    list.appendChild(wrapper)
+    testing.expectEqual(2, options.length)
+    testing.expectEqual('nested', options[1].value)
+
+    list.removeChild(first)
+    testing.expectEqual(1, options.length)
+    testing.expectEqual(nested, options[0])
+  }
+</script>

--- a/src/browser/webapi/element/html/DataList.zig
+++ b/src/browser/webapi/element/html/DataList.zig
@@ -1,7 +1,9 @@
 const js = @import("../../../js/js.zig");
+const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
+const collections = @import("../../collections.zig");
 
 const DataList = @This();
 
@@ -16,6 +18,11 @@ pub fn asNode(self: *DataList) *Node {
     return self.asElement().asNode();
 }
 
+/// The live collection of descendant option elements.
+pub fn getOptions(self: *DataList, frame: *Frame) collections.NodeLive(.tag) {
+    return collections.NodeLive(.tag).init(self.asNode(), .option, frame);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(DataList);
 
@@ -24,4 +31,11 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    pub const options = bridge.accessor(DataList.getOptions, null, .{ .cache = .{ .private = "datalist_options" } });
 };
+
+const testing = @import("../../../../testing.zig");
+test "WebApi: HTML.DataList" {
+    try testing.htmlRunner("element/html/datalist.html", .{});
+}


### PR DESCRIPTION
## Summary

- expose `HTMLDataListElement.options` as a live `HTMLCollection`
- preserve the required `[SameObject]` identity across repeated reads
- cover direct, nested, added, and removed descendant `<option>` elements

## Why

`datalist.options` was missing, so sites could not inspect or react to the options associated with a data list.

## Validation

- `make -j1 test F="WebApi: HTML.DataList"` with the matching prebuilt V8 archive
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`
