### PR TITLE
perf(network): avoid copying cache request headers

### DIFF
--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -920,13 +920,14 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
     transfer._cache_key = req.url;
 
     const arena = transfer.arena;
-    var iter = req.headers.iterator();
-    const req_headers = try iter.collect(arena.allocator());
-
     const cached = cache.get(arena.allocator(), .{
         .url = req.url,
         .timestamp = lp.datetime.timestamp(.real),
-        .request_headers = req_headers.items,
+        .request_headers = &.{},
+        .request_header_lookup = .{
+            .context = @ptrCast(&req.headers),
+            .get = getRequestHeader,
+        },
     }) orelse {
         lp.metrics.http_cache.incr(.miss);
         transfer._cache_intent = .store;
@@ -962,6 +963,11 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
     }
     transfer._cache_intent = .{ .revalidate = cached };
     return false;
+}
+
+fn getRequestHeader(context: *const anyopaque, name: []const u8) ?[]const u8 {
+    const headers: *const http.Headers = @ptrCast(@alignCast(context));
+    return headers.get(name);
 }
 
 // 304 on a revalidation: renew the stored entry from the fresh headers and

--- a/src/network/cache/Cache.zig
+++ b/src/network/cache/Cache.zig
@@ -200,6 +200,28 @@ pub const CacheRequest = struct {
     url: []const u8,
     timestamp: u64,
     request_headers: []const Http.Header,
+    request_header_lookup: ?RequestHeaderLookup = null,
+
+    pub fn getHeader(self: CacheRequest, name: []const u8) ?[]const u8 {
+        if (self.request_header_lookup) |lookup| {
+            return lookup.get(lookup.context, name);
+        }
+
+        for (self.request_headers) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, name)) {
+                return header.value;
+            }
+        }
+        return null;
+    }
+};
+
+// A cache lookup only needs request headers named by the cached response's
+// Vary field. This lets callers borrow a request's native header storage
+// instead of allocating a complete temporary header list on every lookup.
+pub const RequestHeaderLookup = struct {
+    context: *const anyopaque,
+    get: *const fn (context: *const anyopaque, name: []const u8) ?[]const u8,
 };
 
 pub const RenewResponse = struct {

--- a/src/network/cache/FsCache.zig
+++ b/src/network/cache/FsCache.zig
@@ -213,9 +213,7 @@ pub fn get(self: *FsCache, arena: std.mem.Allocator, req: CacheRequest) ?CachedR
         const name = vary_hdr.name;
         const value = vary_hdr.value;
 
-        const incoming = for (req.request_headers) |h| {
-            if (std.ascii.eqlIgnoreCase(h.name, name)) break h.value;
-        } else "";
+        const incoming = req.getHeader(name) orelse "";
 
         if (!std.ascii.eqlIgnoreCase(value, incoming)) {
             log.debug(.cache, "miss", .{
@@ -582,6 +580,18 @@ test "FsCache: garbage file" {
 }
 
 test "FsCache: vary hit and miss" {
+    const Context = struct {
+        accept_encoding: []const u8,
+
+        fn get(context: *const anyopaque, name: []const u8) ?[]const u8 {
+            const self: *const @This() = @ptrCast(@alignCast(context));
+            if (std.ascii.eqlIgnoreCase(name, "Accept-Encoding")) {
+                return self.accept_encoding;
+            }
+            return null;
+        }
+    };
+
     var setup = try setupCache();
     defer {
         setup.cache.deinit();
@@ -632,14 +642,28 @@ test "FsCache: vary hit and miss" {
         .request_headers = &.{},
     }));
 
+    const gzip = Context{ .accept_encoding = "gzip" };
     const result2 = cache.get(arena.allocator(), .{
         .url = "https://example.com",
         .timestamp = now,
-        .request_headers = &.{
-            .{ .name = "Accept-Encoding", .value = "gzip" },
+        .request_headers = &.{},
+        .request_header_lookup = .{
+            .context = @ptrCast(&gzip),
+            .get = Context.get,
         },
     }) orelse return error.CacheMiss;
     result2.data.file.file.close(lp.io);
+
+    const br = Context{ .accept_encoding = "br" };
+    try testing.expectEqual(null, cache.get(arena.allocator(), .{
+        .url = "https://example.com",
+        .timestamp = now,
+        .request_headers = &.{},
+        .request_header_lookup = .{
+            .context = @ptrCast(&br),
+            .get = Context.get,
+        },
+    }));
 }
 
 test "FsCache: vary multiple headers" {

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -193,6 +193,18 @@ pub const Headers = struct {
     pub fn iterator(self: Headers) HeaderIterator {
         return .{ .curl_slist = .{ .header = self.headers } };
     }
+
+    // The curl list owns header storage. Borrow a value while the list lives
+    // instead of materializing every request header for a single lookup.
+    pub fn get(self: Headers, name: []const u8) ?[]const u8 {
+        var it = self.iterator();
+        while (it.next()) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, name)) {
+                return header.value;
+            }
+        }
+        return null;
+    }
 };
 
 // In normal cases, the header iterator comes from the curl linked list.
@@ -1026,6 +1038,15 @@ test "Headers.set adds a new header and preserves defaults" {
     try testing.expectEqual(@as(usize, 1), findHeader(headers, "X-Custom").count);
     try testing.expectEqual(@as(usize, 1), findHeader(headers, "User-Agent").count);
     try testing.expectEqual(@as(usize, 1), findHeader(headers, "Accept-Language").count);
+}
+
+test "Headers.get matches header names case-insensitively" {
+    var headers = try Headers.init("User-Agent: Lightpanda/1.0");
+    defer headers.deinit();
+    try headers.add("Accept-Encoding: gzip");
+
+    try testing.expectEqual("gzip", headers.get("accept-encoding").?);
+    try testing.expectEqual(null, headers.get("missing"));
 }
 
 test "opensocketCallback: private IPv4 returns CURL_SOCKET_BAD" {


### PR DESCRIPTION
## Summary

- avoid collecting and copying every request header during an HTTP cache lookup
- let the cache synchronously query the request's existing curl header list
- preserve the slice-backed lookup path for existing cache callers
- cover case-insensitive lookup and `Vary` cache hits and misses

## Why

The cache only needs headers named by the stored response's `Vary` metadata. Materializing the complete request header list on every lookup added allocations and copies to the hot network path even when most headers were irrelevant.

The borrowed callback is consumed synchronously by `FsCache.get`; no request-header pointer is retained in the cached response.

## Validation

- isolated compile-time test run: `FsCache: vary hit and miss`
- isolated compile-time test run: `Headers.get matches header names case-insensitively`
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`
