### PR TITLE
fix(cdp): report all same-document navigations

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -33,6 +33,7 @@ const h5e = @import("parser/html5ever.zig");
 
 const CustomElementReactions = @import("CustomElementReactions.zig");
 
+const Notification = @import("../Notification.zig");
 const URL = @import("URL.zig");
 const Blob = @import("webapi/Blob.zig");
 const FileList = @import("webapi/FileList.zig");
@@ -637,6 +638,17 @@ pub fn isSameOrigin(self: *const Frame, url: [:0]const u8) bool {
     return std.mem.eql(u8, URL.getHost(url), URL.getHost(current_origin));
 }
 
+pub fn notifyNavigatedWithinDocument(
+    self: *Frame,
+    navigation_type: Notification.FrameNavigatedWithinDocument.NavigationType,
+) void {
+    self._session.notification.dispatch(.frame_navigated_within_document, &.{
+        .frame_id = self._frame_id,
+        .url = self.url,
+        .navigation_type = navigation_type,
+    });
+}
+
 pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !void {
     lp.assert(self._load_state == .waiting, "frame.renavigate", .{});
     const session = self._session;
@@ -948,6 +960,7 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: *lp.Arena, request_url
             try session.navigation.updateEntries(target.url, opts.kind, target, true);
         }
 
+        target.notifyNavigatedWithinDocument(.fragment);
         try target.queueHashChange(old_url, target.url);
 
         // don't defer this, the caller is responsible for freeing it on error

--- a/src/browser/webapi/History.zig
+++ b/src/browser/webapi/History.zig
@@ -20,8 +20,7 @@ const std = @import("std");
 
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
-
-const PopStateEvent = @import("event/PopStateEvent.zig");
+const URL = @import("../URL.zig");
 
 const History = @This();
 
@@ -65,11 +64,7 @@ pub fn pushState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
 
-    session.notification.dispatch(.frame_navigated_within_document, &.{
-        .url = url,
-        .frame_id = frame._frame_id,
-        .navigation_type = .historyApi,
-    });
+    frame.notifyNavigatedWithinDocument(.historyApi);
 }
 
 pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const u8, frame: *Frame) !void {
@@ -87,37 +82,28 @@ pub fn replaceState(_: *History, state: js.Value, _: ?[]const u8, _url: ?[]const
     // setHref == reinitializing.
     try frame.window._location._url.setHref(url, &frame.js.execution);
 
-    session.notification.dispatch(.frame_navigated_within_document, &.{
-        .url = url,
-        .frame_id = frame._frame_id,
-        .navigation_type = .historyApi,
-    });
+    frame.notifyNavigatedWithinDocument(.historyApi);
 }
 
 fn goInner(delta: i32, frame: *Frame) !void {
     // 0 behaves the same as no argument, both reloading the frame.
 
-    const current = frame._session.navigation._index;
+    const navigation = frame._session.navigation;
+    const current = navigation._index;
+    const len = navigation._entries.items.len;
     const index_s: i64 = @intCast(@as(i64, @intCast(current)) + @as(i64, @intCast(delta)));
-    if (index_s < 0 or index_s > frame._session.navigation._entries.items.len - 1) {
+    const len_s: i64 = @intCast(len);
+    if (len == 0 or index_s < 0 or index_s >= len_s) {
         return;
     }
 
     const index = @as(usize, @intCast(index_s));
-    const entry = frame._session.navigation._entries.items[index];
-
-    if (entry._url) |url| {
-        if (frame.isSameOrigin(url)) {
-            const target = frame.window.asEventTarget();
-            if (frame._event_manager.hasDirectListeners(target, "popstate", frame.window._on_popstate)) {
-                const event = (try PopStateEvent.initTrusted(comptime .wrap("popstate"), .{ .state = entry._state.value }, frame)).asEvent();
-                try frame._event_manager.dispatchDirect(target, event, frame.window._on_popstate, .{ .context = "Pop State" });
-            }
-            // hashchange is queued by navigateInner.
-        }
+    const url = try navigation.resolveEntryURL(index, frame, frame.local_arena);
+    if (URL.eqlDocument(frame.url, url)) {
+        return navigation.traverseSameDocument(index, url, frame);
     }
 
-    _ = try frame._session.navigation.navigateInner(entry._url, .{ .traverse = index }, frame);
+    return frame.scheduleNavigation(url, .{ .reason = .navigation, .kind = .{ .traverse = index } }, .{ .script = frame });
 }
 
 pub fn back(_: *History, frame: *Frame) !void {

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -28,6 +28,7 @@ const Event = @import("../Event.zig");
 const EventTarget = @import("../EventTarget.zig");
 
 const log = lp.log;
+const Allocator = std.mem.Allocator;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigation
 const Navigation = @This();
@@ -35,12 +36,14 @@ const Navigation = @This();
 pub const Proto = EventTarget;
 
 const NavigationKind = @import("root.zig").NavigationKind;
+const NavigationType = @import("root.zig").NavigationType;
 const NavigationActivation = @import("NavigationActivation.zig");
 const NavigationTransition = @import("root.zig").NavigationTransition;
 const NavigationState = @import("root.zig").NavigationState;
 
 const NavigationHistoryEntry = @import("NavigationHistoryEntry.zig");
 const NavigationCurrentEntryChangeEvent = @import("../event/NavigationCurrentEntryChangeEvent.zig");
+const PopStateEvent = @import("../event/PopStateEvent.zig");
 
 _proto: *EventTarget,
 _on_currententrychange: ?js.Function.Global = null,
@@ -148,6 +151,87 @@ pub fn updateEntries(
             self._index = index;
         },
         .reload => {},
+    }
+}
+
+pub fn resolveEntryURL(self: *Navigation, index: usize, frame: *Frame, allocator: Allocator) ![:0]const u8 {
+    const url = self._entries.items[index]._url orelse return error.MissingURL;
+    if (lp.URL.isCompleteHTTPUrl(url) or std.mem.eql(u8, url, "about:blank")) {
+        return url;
+    }
+    return URL.resolve(allocator, frame.url, url, .{});
+}
+
+pub fn traverseSameDocument(
+    self: *Navigation,
+    index: usize,
+    url: [:0]const u8,
+    frame: *Frame,
+) !void {
+    const previous = self.getCurrentEntry();
+    const entry = self._entries.items[index];
+    const old_url = frame.url;
+
+    try updateSameDocumentURL(old_url, url, frame);
+    self._index = index;
+
+    dispatchPopState(entry, frame) catch |err| {
+        log.warn(.event, "popstate", .{ .err = err });
+    };
+
+    self._activation = .{
+        ._from = previous,
+        ._entry = entry,
+        ._type = .traverse,
+    };
+    self.dispatchCurrentEntryChange(previous, .traverse, frame) catch |err| {
+        log.warn(.event, "currententrychange", .{ .err = err });
+    };
+}
+
+fn updateSameDocumentURL(old_url: [:0]const u8, url: [:0]const u8, frame: *Frame) !void {
+    try frame.window._location._url.setHref(url, &frame.js.execution);
+    const retained_url = frame.arena.dupeZ(u8, url) catch |err| {
+        frame.window._location._url.setHref(old_url, &frame.js.execution) catch |restore_err| {
+            log.err(.event, "restore location", .{ .err = restore_err });
+        };
+        return err;
+    };
+    frame.url = retained_url;
+
+    if (!std.mem.eql(u8, old_url, url)) {
+        frame.queueHashChange(old_url, retained_url) catch |err| {
+            log.warn(.event, "queue hashchange", .{ .err = err });
+        };
+    }
+    frame.notifyNavigatedWithinDocument(.historyApi);
+}
+
+fn dispatchPopState(entry: *NavigationHistoryEntry, frame: *Frame) !void {
+    const target = frame.window.asEventTarget();
+    if (frame._event_manager.hasDirectListeners(target, "popstate", frame.window._on_popstate)) {
+        const event = (try PopStateEvent.initTrusted(
+            comptime .wrap("popstate"),
+            .{ .state = entry._state.value },
+            frame,
+        )).asEvent();
+        try frame._event_manager.dispatchDirect(target, event, frame.window._on_popstate, .{ .context = "Pop State" });
+    }
+}
+
+fn dispatchCurrentEntryChange(
+    self: *Navigation,
+    previous: *NavigationHistoryEntry,
+    navigation_type: NavigationType,
+    frame: *Frame,
+) !void {
+    if (self._on_currententrychange) |cec| {
+        const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
+            .wrap("currententrychange"),
+            .{ .from = previous, .navigationType = @tagName(navigation_type) },
+            frame,
+        )).asEvent();
+        try self.dispatch(cec, event, frame);
     }
 }
 
@@ -309,6 +393,16 @@ pub fn navigateInner(
     kind: NavigationKind,
     frame: *Frame,
 ) !NavigationReturn {
+    return self.navigateInnerLocal(_url, kind, frame, frame.js.local.?);
+}
+
+fn navigateInnerLocal(
+    self: *Navigation,
+    _url: ?[:0]const u8,
+    kind: NavigationKind,
+    frame: *Frame,
+    local: *const js.Local,
+) !NavigationReturn {
     const arena = frame._session.arena;
     const url = _url orelse return error.MissingURL;
 
@@ -316,7 +410,6 @@ pub fn navigateInner(
     //
     // These will only settle on same-origin navigation (mostly intended for SPAs).
     // It is fine (and expected) for these to not settle on cross-origin requests :)
-    const local = frame.js.local.?;
     const committed = local.createPromiseResolver();
     const finished = local.createPromiseResolver();
 
@@ -330,8 +423,6 @@ pub fn navigateInner(
         new_url = try arena.dupeZ(u8, new_url);
     }
 
-    // Captured before the switch overwrites frame.url in the same_document
-    // branches; used to queue the hashchange once below.
     const old_url = frame.url;
 
     const previous = self.getCurrentEntry();
@@ -339,40 +430,37 @@ pub fn navigateInner(
     switch (kind) {
         .push => |state| {
             if (is_same_document) {
-                frame.url = new_url;
+                _ = try self.pushEntry(url, .{ .source = .navigation, .value = state }, frame, false);
+                try updateSameDocumentURL(old_url, new_url, frame);
 
                 committed.resolve("navigation push", {});
                 // todo: Fire navigate event
                 finished.resolve("navigation push", {});
-
-                _ = try self.pushEntry(url, .{ .source = .navigation, .value = state }, frame, true);
             } else {
                 try frame.scheduleNavigation(url, .{ .reason = .navigation, .kind = kind }, .{ .script = frame });
             }
         },
         .replace => |state| {
             if (is_same_document) {
-                frame.url = new_url;
+                _ = try self.replaceEntry(url, .{ .source = .navigation, .value = state }, frame, false);
+                try updateSameDocumentURL(old_url, new_url, frame);
 
                 committed.resolve("navigation replace", {});
                 // todo: Fire navigate event
                 finished.resolve("navigation replace", {});
-
-                _ = try self.replaceEntry(url, .{ .source = .navigation, .value = state }, frame, true);
             } else {
                 try frame.scheduleNavigation(url, .{ .reason = .navigation, .kind = kind }, .{ .script = frame });
             }
         },
         .traverse => |index| {
-            self._index = index;
-
             if (is_same_document) {
-                frame.url = new_url;
+                try self.traverseSameDocument(index, new_url, frame);
 
                 committed.resolve("navigation traverse", {});
                 // todo: Fire navigate event
                 finished.resolve("navigation traverse", {});
             } else {
+                self._index = index;
                 try frame.scheduleNavigation(url, .{ .reason = .navigation, .kind = kind }, .{ .script = frame });
             }
         },
@@ -381,18 +469,8 @@ pub fn navigateInner(
         },
     }
 
-    if (is_same_document and !std.mem.eql(u8, old_url, new_url)) {
-        try frame.queueHashChange(old_url, new_url);
-    }
-
-    if (self._on_currententrychange) |cec| {
-        // If we haven't navigated off, let us fire off an a currententrychange.
-        const event = (try NavigationCurrentEntryChangeEvent.initTrusted(
-            .wrap("currententrychange"),
-            .{ .from = previous, .navigationType = @tagName(kind) },
-            frame,
-        )).asEvent();
-        try self.dispatch(cec, event, frame);
+    if (!is_same_document or std.meta.activeTag(kind) != .traverse) {
+        try self.dispatchCurrentEntryChange(previous, std.meta.activeTag(kind), frame);
     }
 
     _ = try committed.persist();

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -412,9 +412,15 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
     }
 
     const idx = target_index orelse return error.InvalidParams;
-    const url = target_url orelse return error.InvalidParams;
+    if (target_url == null) return error.InvalidParams;
 
     const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
+    const resolved_url = try nav.resolveEntryURL(idx, frame, cmd.arena);
+
+    if (URL.eqlDocument(frame.url, resolved_url)) {
+        try nav.traverseSameDocument(idx, resolved_url, frame);
+        return cmd.sendResult(null, .{});
+    }
 
     const opts = Frame.NavigateOpts{
         .reason = .history,
@@ -423,10 +429,10 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
     };
 
     if (frame._load_state == .waiting) {
-        return frame.navigate(url, opts);
+        return frame.navigate(resolved_url, opts);
     }
 
-    try session.initiateRootNavigation(frame._frame_id, url, opts);
+    try session.initiateRootNavigation(frame._frame_id, resolved_url, opts);
 }
 
 pub fn frameNavigate(bc: *CDP.BrowserContext, event: *const Notification.FrameNavigate) !void {
@@ -1853,4 +1859,146 @@ test "cdp.frame: history.pushState emits Page.navigatedWithinDocument" {
         .navigationType = "historyApi",
         .url = "http://127.0.0.1:9582/next",
     }, .{});
+}
+
+test "cdp.frame: fragment navigation emits Page.navigatedWithinDocument" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-FRAGMENT", .url = "hi.html", .target_id = "FID-00000000FR".* });
+    const frame = bc.mainFrame() orelse unreachable;
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("location.hash = '#section'", null);
+    }
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "fragment",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html#section",
+    }, .{});
+}
+
+test "cdp.frame: Navigation API traversal emits Page.navigatedWithinDocument" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-NAVIGATION", .url = "hi.html", .target_id = "FID-00000000NA".* });
+    const frame = bc.mainFrame() orelse unreachable;
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("window.__popstate_url = ''; window.onpopstate = () => window.__popstate_url = location.href; navigation.navigate('#section')", null);
+    }
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html#section",
+    }, .{});
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const value = try ls.local.exec("location.href", null);
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html#section", try value.toStringSlice());
+    }
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("navigation.back()", null);
+    }
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html",
+    }, .{});
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const value = try ls.local.exec("location.href + '|' + window.__popstate_url", null);
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html|http://127.0.0.1:9582/src/browser/tests/hi.html", try value.toStringSlice());
+    }
+}
+
+test "cdp.frame: Page.navigateToHistoryEntry emits Page.navigatedWithinDocument" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-HISTORY-ENTRY", .url = "hi.html", .target_id = "FID-00000000HE".* });
+    const frame = bc.mainFrame() orelse unreachable;
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("window.__popstate_urls = []; window.onpopstate = () => window.__popstate_urls.push(location.href); navigation.navigate('#section')", null);
+    }
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html#section",
+    }, .{});
+
+    const nav = bc.session.navigation;
+    try testing.expect(nav._index > 0);
+    const fragment_entry_id = try std.fmt.parseInt(
+        i64,
+        nav._entries.items[nav._index]._id,
+        10,
+    );
+    const base_entry_id = try std.fmt.parseInt(i64, nav._entries.items[0]._id, 10);
+    try ctx.processMessage(.{
+        .id = 60,
+        .method = "Page.navigateToHistoryEntry",
+        .params = .{ .entryId = base_entry_id },
+    });
+    try ctx.expectSentResult(null, .{ .id = 60 });
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html",
+    }, .{});
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const value = try ls.local.exec("location.href + '|' + JSON.stringify(window.__popstate_urls)", null);
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html|[\"http://127.0.0.1:9582/src/browser/tests/hi.html\"]", try value.toStringSlice());
+    }
+
+    try ctx.processMessage(.{
+        .id = 61,
+        .method = "Page.navigateToHistoryEntry",
+        .params = .{ .entryId = fragment_entry_id },
+    });
+    try ctx.expectSentResult(null, .{ .id = 61 });
+
+    try ctx.expectSentEvent("Page.navigatedWithinDocument", .{
+        .frameId = "FID-0000000001",
+        .navigationType = "historyApi",
+        .url = "http://127.0.0.1:9582/src/browser/tests/hi.html#section",
+    }, .{});
+
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const value = try ls.local.exec("location.href + '|' + JSON.stringify(window.__popstate_urls)", null);
+        try testing.expectEqualSlices(u8, "http://127.0.0.1:9582/src/browser/tests/hi.html#section|[\"http://127.0.0.1:9582/src/browser/tests/hi.html\",\"http://127.0.0.1:9582/src/browser/tests/hi.html#section\"]", try value.toStringSlice());
+    }
 }


### PR DESCRIPTION
## Summary

- emit `Page.navigatedWithinDocument` for fragment, History API, Navigation API, and CDP history traversal
- keep `frame.url`, the existing Location object, history index/state, and navigation entries synchronized
- dispatch `popstate`, `hashchange`, and `currententrychange` without replacing the top-level browsing context
- implement `Page.navigateToHistoryEntry` for same-document entries

## Verification

- `make -j1 test F="navigatedWithinDocument"` — 4/4 passed
- `zig fmt --check` on changed Zig files
- `git diff --check`
- independent static review: clean
