### PR TITLE
feat(webdriver): add initial W3C HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ available to adjust waiting time before dump.
 Once the CDP server started, you can run a Puppeteer script by configuring the
 `browserWSEndpoint`.
 
+### Start a WebDriver server
+
+```console
+./lightpanda serve --webdriver --host 127.0.0.1 --port 9515
+```
+
+This initial W3C WebDriver slice supports `GET /status`, session creation and
+deletion, navigation, reading the current URL, and timeouts. It accepts one
+active session and loopback binds only. Use `browserName: "lightpanda"`;
+unsupported capabilities fail session creation instead of being silently
+ignored. Element commands and script execution are not yet implemented. Pages
+in a WebDriver session report `navigator.webdriver === true`.
+
 <details>
 <summary>Example Puppeteer script</summary>
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ Once the CDP server started, you can run a Puppeteer script by configuring the
 ```
 
 This initial W3C WebDriver slice supports `GET /status`, session creation and
-deletion, navigation, reading the current URL, and timeouts. It accepts one
-active session and loopback binds only. Use `browserName: "lightpanda"`;
-unsupported capabilities fail session creation instead of being silently
-ignored. Element commands and script execution are not yet implemented. Pages
-in a WebDriver session report `navigator.webdriver === true`.
+deletion, navigation, current URL, title, serialized page source, current
+window handle(s), closing the sole window, and timeouts. It accepts one active
+session with one top-level browsing context and loopback binds only; closing
+that context closes the session. Use `browserName: "lightpanda"`; unsupported
+capabilities fail session creation instead of being silently ignored. Element
+commands and script execution are not yet implemented. Pages in a WebDriver
+session report `navigator.webdriver === true`.
 
 <details>
 <summary>Example Puppeteer script</summary>

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ Once the CDP server started, you can run a Puppeteer script by configuring the
 This initial W3C WebDriver slice supports `GET /status`, session creation and
 deletion, navigation, current URL, title, serialized page source, current
 window handle(s), closing the sole window, timeouts, CSS element lookup from
-the document or an element, and element tag name, attribute, selected, and
-enabled state. Element lookup honors the session's implicit timeout. It accepts
-one active session with one top-level browsing context and loopback binds only;
-closing that context closes the session. Use `browserName: "lightpanda"`;
+the document or an element, active element, and element tag name, attribute,
+selected, and enabled state. Element lookup honors the session's implicit
+timeout. It accepts one active session with one top-level browsing context and
+loopback binds only; closing that context closes the session. Use
+`browserName: "lightpanda"`;
 unsupported capabilities fail session creation instead of being silently
 ignored. Non-CSS locator strategies, element interaction, and script execution
 are not yet implemented. Pages in a WebDriver session report

--- a/README.md
+++ b/README.md
@@ -125,12 +125,15 @@ Once the CDP server started, you can run a Puppeteer script by configuring the
 
 This initial W3C WebDriver slice supports `GET /status`, session creation and
 deletion, navigation, current URL, title, serialized page source, current
-window handle(s), closing the sole window, and timeouts. It accepts one active
-session with one top-level browsing context and loopback binds only; closing
-that context closes the session. Use `browserName: "lightpanda"`; unsupported
-capabilities fail session creation instead of being silently ignored. Element
-commands and script execution are not yet implemented. Pages in a WebDriver
-session report `navigator.webdriver === true`.
+window handle(s), closing the sole window, timeouts, CSS element lookup from
+the document or an element, and element tag name, attribute, selected, and
+enabled state. Element lookup honors the session's implicit timeout. It accepts
+one active session with one top-level browsing context and loopback binds only;
+closing that context closes the session. Use `browserName: "lightpanda"`;
+unsupported capabilities fail session creation instead of being silently
+ignored. Non-CSS locator strategies, element interaction, and script execution
+are not yet implemented. Pages in a WebDriver session report
+`navigator.webdriver === true`.
 
 <details>
 <summary>Example Puppeteer script</summary>

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -318,6 +318,7 @@ const Commands = cli.Builder(.{
             // Don't widen this without growing the reader buffer in the HTTP path.
             .{ .name = "cdp_max_http_message_size", .type = u14, .default = 4096 },
             .{ .name = "disable_metrics", .type = bool },
+            .{ .name = "webdriver", .type = bool },
         },
         .shared_options = CommonOptions,
     },
@@ -503,7 +504,13 @@ pub fn v8MaxHeapMb(self: *const Config) ?u32 {
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
+        .serve => |opts| if (opts.webdriver)
+            // A null CURLOPT_PROXY consults ambient proxy environment vars.
+            // The explicit empty value disables that lookup for WebDriver.
+            ""
+        else
+            opts.http_proxy,
+        inline .fetch, .mcp, .agent => |opts| opts.http_proxy,
         .version => null,
         else => unreachable,
     };

--- a/src/Watchdog.zig
+++ b/src/Watchdog.zig
@@ -23,12 +23,18 @@ const Env = @import("browser/js/Env.zig");
 
 const log = lp.log;
 
-// How often the checker thread scans the entries.
+// How often the checker thread scans ordinary liveness heartbeats. Explicit
+// execution deadlines shorten this wait and wake the thread when armed.
 const CHECK_INTERVAL_NS = 1 * std.time.ns_per_s;
+// The condition wait uses the awake clock while command deadlines use boot
+// time (which includes suspend). Rescan active finite deadlines at least once
+// per second so a resume observes an expired boot-time deadline promptly.
+const MAX_DEADLINE_WAIT_NS = std.time.ns_per_s;
 
 const Watchdog = @This();
 
-// null == disabled: no thread, register/unregister no-op.
+// null disables ordinary stall detection. WebDriver explicitly enables the
+// thread before creating a browser so per-command deadlines remain available.
 timeout_ms: ?u32,
 shutdown: bool = false,
 thread: ?std.Thread = null,
@@ -41,6 +47,9 @@ pub const Entry = struct {
     env: *Env,
     heartbeat: *Heartbeat,
     fired: bool = false,
+    execution_active: std.atomic.Value(bool) = .init(false),
+    execution_deadline_ns: std.atomic.Value(u64) = .init(0),
+    execution_deadline_fired: std.atomic.Value(bool) = .init(false),
     registered: bool = false,
     node: std.DoublyLinkedList.Node = .{},
 };
@@ -62,17 +71,21 @@ pub fn deinit(self: *Watchdog) void {
 
 // Call once the Watchdog is at its final address (init returns by value).
 pub fn start(self: *Watchdog) !void {
-    if (self.timeout_ms == null) {
-        return;
-    }
+    if (self.timeout_ms == null) return;
+    self.thread = try std.Thread.spawn(.{}, run, .{self});
+}
+
+/// WebDriver calls this before creating its first browser. This preserves the
+/// thread-free `--watchdog-ms=0` behavior for every other mode.
+pub fn enableExecutionDeadlines(self: *Watchdog) !void {
+    self.mutex.lockUncancelable(lp.io);
+    defer self.mutex.unlock(lp.io);
+    if (self.thread != null) return;
     self.thread = try std.Thread.spawn(.{}, run, .{self});
 }
 
 pub fn register(self: *Watchdog, entry: *Entry) void {
-    if (self.timeout_ms == null) {
-        return;
-    }
-
+    if (self.thread == null) return;
     {
         self.mutex.lockUncancelable(lp.io);
         defer self.mutex.unlock(lp.io);
@@ -89,27 +102,84 @@ pub fn unregister(self: *Watchdog, entry: *Entry) void {
     {
         self.mutex.lockUncancelable(lp.io);
         defer self.mutex.unlock(lp.io);
+        entry.execution_active.store(false, .release);
+        entry.execution_deadline_ns.store(0, .release);
+        entry.execution_deadline_fired.store(false, .release);
         self.entries.remove(&entry.node);
+        self.cond.signal(lp.io);
     }
     entry.registered = false;
 }
 
-fn run(self: *Watchdog) void {
-    const timeout_ms: u64 = self.timeout_ms.?;
+pub fn armExecutionDeadline(self: *Watchdog, entry: *Entry, timeout_ms: ?u64) void {
+    std.debug.assert(self.thread != null);
+    self.mutex.lockUncancelable(lp.io);
+    defer self.mutex.unlock(lp.io);
 
+    entry.execution_active.store(true, .release);
+    entry.execution_deadline_fired.store(false, .release);
+    entry.fired = false;
+    entry.heartbeat.touch();
+    const deadline = if (timeout_ms) |timeout|
+        @as(u64, @intCast(std.Io.Timestamp.now(lp.io, .boot).toNanoseconds())) +| timeout *| std.time.ns_per_ms
+    else
+        0;
+    entry.execution_deadline_ns.store(deadline, .release);
+    self.cond.signal(lp.io);
+}
+
+pub fn executionDeadlineFired(_: *const Watchdog, entry: *const Entry) bool {
+    return entry.execution_deadline_fired.load(.acquire);
+}
+
+pub fn disarmExecutionDeadline(self: *Watchdog, entry: *Entry) bool {
+    self.mutex.lockUncancelable(lp.io);
+    defer self.mutex.unlock(lp.io);
+
+    entry.execution_active.store(false, .release);
+    entry.execution_deadline_ns.store(0, .release);
+    const fired = entry.execution_deadline_fired.swap(false, .acq_rel);
+    entry.fired = false;
+    entry.heartbeat.touch();
+    self.cond.signal(lp.io);
+    return fired;
+}
+
+fn run(self: *Watchdog) void {
     self.mutex.lockUncancelable(lp.io);
     defer self.mutex.unlock(lp.io);
 
     while (true) {
-        lp.timedWait(&self.cond, &self.mutex, CHECK_INTERVAL_NS) catch {};
         if (self.shutdown) {
             return;
         }
 
-        const now = lp.datetime.milliTimestamp(.boot);
+        const now: u64 = @intCast(std.Io.Timestamp.now(lp.io, .boot).toNanoseconds());
+        const now_ms = lp.datetime.milliTimestamp(.boot);
+        var next_wait_ns: ?u64 = if (self.timeout_ms != null) CHECK_INTERVAL_NS else null;
         var node = self.entries.first;
         while (node) |n| : (node = n.next) {
             const entry: *Entry = @fieldParentPtr("node", n);
+            if (entry.execution_active.load(.acquire)) {
+                const execution_deadline = entry.execution_deadline_ns.load(.acquire);
+                if (!entry.execution_deadline_fired.load(.acquire)) {
+                    if (execution_deadline != 0 and now >= execution_deadline) {
+                        entry.execution_deadline_fired.store(true, .release);
+                        entry.env.requestExecutionDeadlineTerminate();
+                    } else if (execution_deadline != 0) {
+                        const remaining_ns = execution_deadline - now;
+                        next_wait_ns = if (next_wait_ns) |current|
+                            @min(current, remaining_ns)
+                        else
+                            remaining_ns;
+                    }
+                }
+                // An explicit command deadline supersedes the generic stall
+                // limit, including a null (infinite) WebDriver timeout.
+                continue;
+            }
+
+            const timeout_ms: u64 = self.timeout_ms orelse continue;
             const heartbeat = entry.heartbeat;
 
             if (heartbeat.wait_depth.load(.acquire) > 0) {
@@ -124,7 +194,7 @@ fn run(self: *Watchdog) void {
                 continue;
             }
 
-            const stalled_ms = now -| last;
+            const stalled_ms = now_ms -| last;
             if (stalled_ms < timeout_ms) {
                 entry.fired = false;
                 continue;
@@ -135,6 +205,15 @@ fn run(self: *Watchdog) void {
                 log.err(.app, "watchdog stall", .{ .stalled_ms = stalled_ms });
                 entry.env.requestTerminate();
             }
+        }
+        const wait_ns: ?u64 = if (next_wait_ns) |ns|
+            @min(@max(ns, 1), MAX_DEADLINE_WAIT_NS)
+        else
+            null;
+        if (wait_ns) |timeout_ns| {
+            lp.timedWait(&self.cond, &self.mutex, timeout_ns) catch {};
+        } else {
+            self.cond.waitUncancelable(lp.io, &self.mutex);
         }
     }
 }
@@ -175,3 +254,13 @@ pub const Heartbeat = struct {
         _ = self.wait_depth.fetchSub(1, .release);
     }
 };
+
+test "Watchdog: disabled mode stays thread-free unless deadlines are enabled" {
+    var disabled = Watchdog.init(null);
+    try disabled.start();
+    defer disabled.deinit();
+    try std.testing.expect(disabled.thread == null);
+
+    try disabled.enableExecutionDeadlines();
+    try std.testing.expect(disabled.thread != null);
+}

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -43,6 +43,10 @@ const Browser = @This();
 env: js.Env,
 app: *App,
 session: ?Session,
+// Set only for sessions created through the W3C WebDriver endpoint. The
+// Navigator getter reads this at call time, so ordinary CDP/MCP sessions keep
+// the standards-required false value.
+webdriver_active: bool = false,
 allocator: Allocator,
 arena_pool: *ArenaPool,
 http_client: HttpClient,
@@ -151,6 +155,18 @@ pub fn deinit(self: *Browser) void {
     self.clearPermissions();
     self.permissions.deinit(allocator);
     self.selector_cache.deinit();
+}
+
+pub fn armExecutionDeadline(self: *Browser, timeout_ms: ?u64) void {
+    self.app.watchdog.armExecutionDeadline(&self.watchdog_entry, timeout_ms);
+}
+
+pub fn executionDeadlineFired(self: *const Browser) bool {
+    return self.app.watchdog.executionDeadlineFired(&self.watchdog_entry);
+}
+
+pub fn disarmExecutionDeadline(self: *Browser) bool {
+    return self.app.watchdog.disarmExecutionDeadline(&self.watchdog_entry);
 }
 
 // Set (or overwrite) the stored state for a permission. The name is duped into

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -918,39 +918,7 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: *lp.Arena, request_url
 
     const session = target._session;
 
-    // Re-navigating to the exact current URL is only a reload when the URL
-    // has no fragment. With a fragment it's a fragment navigation per the
-    // HTML "navigate" steps (url equals the document's URL excluding
-    // fragments and url's fragment is non-null): no reload, and since the
-    // fragment didn't change, no hashchange and no new history entry either.
-    if (!opts.force and
-        opts.kind != .reload and
-        std.mem.eql(u8, target.url, resolved_url) and
-        std.mem.indexOfScalar(u8, resolved_url, '#') != null)
-    {
-        arena.release();
-        return;
-    }
-
-    // Short-circuit only true fragment-only navigations (same path/query, different
-    // fragment). Identical URLs fall through and trigger a real reload.
-    const is_fragment_navigation = !std.mem.eql(u8, target.url, resolved_url) and URL.eqlDocument(target.url, resolved_url);
-    if (!opts.force and is_fragment_navigation) {
-        const old_url = target.url;
-        target.url = try target.arena.dupeZ(u8, resolved_url);
-
-        const location = try Location.init(target.url, target);
-        location.acquireRef();
-        target.window._location.releaseRef(target._page);
-        target.window._location = location;
-
-        if (target.parent == null) {
-            try session.navigation.updateEntries(target.url, opts.kind, target, true);
-        }
-
-        try target.queueHashChange(old_url, target.url);
-
-        // don't defer this, the caller is responsible for freeing it on error
+    if (try target.navigateSameDocument(resolved_url, opts)) {
         arena.release();
         return;
     }
@@ -1004,6 +972,41 @@ fn scheduleNavigationWithArena(originator: *Frame, arena: *lp.Arena, request_url
 
     target._queued_navigation = qn;
     return session.scheduleNavigation(target);
+}
+
+/// Apply a fragment-only navigation without replacing the active document.
+/// Returns true when the URL was handled as a same-document navigation.
+pub fn navigateSameDocument(self: *Frame, resolved_url: [:0]const u8, opts: NavigateOpts) !bool {
+    if (opts.force) return false;
+
+    // Re-navigating to the exact current URL is only a reload when the URL
+    // has no fragment. With a fragment, no hashchange or history entry occurs.
+    if (opts.kind != .reload and
+        std.mem.eql(u8, self.url, resolved_url) and
+        std.mem.indexOfScalar(u8, resolved_url, '#') != null)
+    {
+        return true;
+    }
+
+    // Only a changed fragment with an otherwise-equal URL is same-document.
+    if (std.mem.eql(u8, self.url, resolved_url) or !URL.eqlDocument(self.url, resolved_url)) {
+        return false;
+    }
+
+    const old_url = self.url;
+    self.url = try self.arena.dupeZ(u8, resolved_url);
+
+    const location = try Location.init(self.url, self);
+    location.acquireRef();
+    self.window._location.releaseRef(self._page);
+    self.window._location = location;
+
+    if (self.parent == null) {
+        try self._session.navigation.updateEntries(self.url, opts.kind, self, true);
+    }
+
+    try self.queueHashChange(old_url, self.url);
+    return true;
 }
 
 // A script can have multiple competing navigation events, say it starts off

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -102,6 +102,12 @@ terminate_mutex: std.Io.Mutex = .init,
 // thread making sure terminate hasn't been canceled.
 terminate_requested: std.atomic.Value(bool) = .init(false),
 
+// The caller that owns the outstanding termination request. A deadline may
+// only cancel its own request: a heap limit, shutdown, or ordinary
+// cancellation must remain terminating when a command deadline unwinds.
+terminate_owner: std.atomic.Value(u8) = .init(@intFromEnum(TerminateOwner.none)),
+terminate_owner_mutex: std.Io.Mutex = .init,
+
 pub const InitOpts = struct {
     with_inspector: bool = false,
 };
@@ -558,6 +564,10 @@ pub fn terminatePending(self: *const Env) bool {
 pub fn terminate(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
+    self.terminate_owner_mutex.lockUncancelable(lp.io);
+    defer self.terminate_owner_mutex.unlock(lp.io);
+    self.terminate_owner.store(@intFromEnum(TerminateOwner.generic), .release);
+    self.terminate_requested.store(true, .release);
     v8.v8__Isolate__TerminateExecution(self.isolate.handle);
 }
 
@@ -602,6 +612,30 @@ fn nearHeapLimit(data: ?*anyopaque, current_limit: usize, initial_limit: usize) 
 
 // Called from the network thread, caused v8 to eventually call terminateInterrupt
 pub fn requestTerminate(self: *Env) void {
+    self.requestTerminateOwned(.generic);
+}
+
+/// Request termination for one bounded command. Only
+/// `cancelExecutionDeadlineTerminate` may clear this request; generic
+/// termination wins if it races with the deadline.
+pub fn requestExecutionDeadlineTerminate(self: *Env) void {
+    self.requestTerminateOwned(.execution_deadline);
+}
+
+const TerminateOwner = enum(u8) {
+    none,
+    generic,
+    execution_deadline,
+};
+
+fn requestTerminateOwned(self: *Env, owner: TerminateOwner) void {
+    self.terminate_owner_mutex.lockUncancelable(lp.io);
+    defer self.terminate_owner_mutex.unlock(lp.io);
+
+    if (owner == .execution_deadline and self.terminate_owner.load(.acquire) != @intFromEnum(TerminateOwner.none)) {
+        return;
+    }
+    self.terminate_owner.store(@intFromEnum(owner), .release);
     self.terminate_requested.store(true, .release);
     v8.v8__Isolate__RequestInterrupt(self.isolate.handle, terminateInterrupt, self);
 }
@@ -621,8 +655,27 @@ fn terminateInterrupt(_: ?*v8.Isolate, data: ?*anyopaque) callconv(.c) void {
 pub fn cancelTerminate(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
+    self.terminate_owner_mutex.lockUncancelable(lp.io);
+    defer self.terminate_owner_mutex.unlock(lp.io);
     self.terminate_requested.store(false, .release);
+    self.terminate_owner.store(@intFromEnum(TerminateOwner.none), .release);
     v8.v8__Isolate__CancelTerminateExecution(self.isolate.handle);
+}
+
+/// Clear an execution deadline only when it still owns the request. Returns
+/// false when another subsystem requested termination after the deadline.
+pub fn cancelExecutionDeadlineTerminate(self: *Env) bool {
+    self.terminate_mutex.lockUncancelable(lp.io);
+    defer self.terminate_mutex.unlock(lp.io);
+    self.terminate_owner_mutex.lockUncancelable(lp.io);
+    defer self.terminate_owner_mutex.unlock(lp.io);
+    if (self.terminate_owner.load(.acquire) != @intFromEnum(TerminateOwner.execution_deadline)) {
+        return false;
+    }
+    self.terminate_requested.store(false, .release);
+    self.terminate_owner.store(@intFromEnum(TerminateOwner.none), .release);
+    v8.v8__Isolate__CancelTerminateExecution(self.isolate.handle);
+    return true;
 }
 
 /// Like `runMicrotasks`, but for the isolate-default queue used by contexts

--- a/src/browser/tests/worker/navigator-worker.js
+++ b/src/browser/tests/worker/navigator-worker.js
@@ -38,6 +38,7 @@ onmessage = async function(event) {
 
       // [Exposed=Window] members must NOT leak into the worker realm.
       no_plugins: navigator.plugins === undefined,
+      no_webdriver: navigator.webdriver === undefined,
       no_register_protocol_handler: navigator.registerProtocolHandler === undefined,
       no_model_context: navigator.modelContext === undefined,
     };

--- a/src/browser/tests/worker/worker.html
+++ b/src/browser/tests/worker/worker.html
@@ -290,6 +290,7 @@
 
       // [Exposed=Window] members aren't part of WorkerNavigator.
       testing.expectEqual(true, r.no_plugins);
+      testing.expectEqual(true, r.no_webdriver);
       testing.expectEqual(true, r.no_register_protocol_handler);
       testing.expectEqual(true, r.no_model_context);
     });

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -2036,7 +2036,6 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
 /// `until = null` implements WebDriver's `pageLoadStrategy: "none"`.
 pub fn gotoLiteral(
     session: *lp.Session,
-    registry: *CDPNode.Registry,
     url: [:0]const u8,
     timeout_ms: ?u64,
     until: ?lp.Config.WaitUntil,
@@ -2066,14 +2065,16 @@ pub fn gotoLiteral(
         }
     };
 
-    // A WebDriver navigation replaces the document in the current top-level
-    // browsing context. Keep its frame id, history, and session storage alive,
-    // while invalidating document-scoped node references.
-    registry.reset();
     const navigate_opts: lp.Frame.NavigateOpts = .{
         .reason = .address_bar,
         .kind = .{ .push = null },
     };
+    if (frame.navigateSameDocument(resolved_url, navigate_opts) catch {
+        return ToolError.NavigationFailed;
+    }) {
+        return .completed;
+    }
+
     const replaces_current_document = frame._load_state != .waiting;
     const navigation = if (!replaces_current_document)
         frame.navigate(resolved_url, navigate_opts)

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1397,6 +1397,43 @@ fn runEval(arena: std.mem.Allocator, page: *lp.Frame, script: [:0]const u8, fall
     return .{ .text = text };
 }
 
+fn commandDeadlineReached(
+    browser: *const lp.Browser,
+    timer: std.Io.Timestamp,
+    timeout_ms: ?u64,
+) bool {
+    const timeout = timeout_ms orelse return false;
+    if (browser.executionDeadlineFired()) return true;
+    const elapsed_ns = timer.untilNow(lp.io, .boot).toNanoseconds();
+    const timeout_ns: i96 = @as(i96, @intCast(timeout)) * std.time.ns_per_ms;
+    return elapsed_ns >= timeout_ns;
+}
+
+fn commandDeadlineBudget(timer: std.Io.Timestamp, timeout_ms: ?u64, max_ms: u32) u32 {
+    const timeout = timeout_ms orelse return max_ms;
+    const elapsed_ns = timer.untilNow(lp.io, .boot).toNanoseconds();
+    const timeout_ns: i96 = @as(i96, @intCast(timeout)) * std.time.ns_per_ms;
+    const remaining_ns = @max(timeout_ns - elapsed_ns, 0);
+    const remaining_ms = @divFloor(remaining_ns + std.time.ns_per_ms - 1, std.time.ns_per_ms);
+    return @intCast(@min(@max(remaining_ms, 1), @as(i96, max_ms)));
+}
+
+fn finishCommandDeadline(
+    browser: *lp.Browser,
+    timer: std.Io.Timestamp,
+    timeout_ms: ?u64,
+    armed: *bool,
+) bool {
+    if (!armed.*) return false;
+    armed.* = false;
+    const fired = browser.disarmExecutionDeadline();
+    if (fired) _ = browser.env.cancelExecutionDeadlineTerminate();
+    const timeout = timeout_ms orelse return fired;
+    const elapsed_ns = timer.untilNow(lp.io, .boot).toNanoseconds();
+    const timeout_ns: i96 = @as(i96, @intCast(timeout)) * std.time.ns_per_ms;
+    return fired or elapsed_ns >= timeout_ns;
+}
+
 /// Objects/arrays serialize as JSON so `return obj` prints data, not
 /// `[object Object]`; errors and primitives keep their string form.
 fn evalResultText(arena: std.mem.Allocator, value: lp.js.Value) ![]u8 {
@@ -1943,6 +1980,7 @@ pub const StartedGoto = struct {
 /// right after createPage but navigate can change/null it, so callers re-fetch.
 fn openPage(session: *lp.Session, url: [:0]const u8) ToolError!lp.Session.PageHandle {
     const page = session.createPage() catch return ToolError.NavigationFailed;
+    errdefer page.close();
     _ = page.frame().?.navigate(url, .{
         .reason = .address_bar,
         .kind = .{ .push = null },
@@ -1992,6 +2030,111 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
     const frame = page.frame() orelse return ToolError.NavigationFailed;
     if (frame._last_navigate_error != null) return ToolError.NavigationFailed;
     return result;
+}
+
+/// Navigate to a literal URL without MCP's `$LP_*` argument substitution.
+/// `until = null` implements WebDriver's `pageLoadStrategy: "none"`.
+pub fn gotoLiteral(
+    session: *lp.Session,
+    registry: *CDPNode.Registry,
+    url: [:0]const u8,
+    timeout_ms: ?u64,
+    until: ?lp.Config.WaitUntil,
+) ToolError!lp.Session.Runner.WaitResult {
+    const existing_page = session.primaryPage();
+    const page = existing_page orelse session.createPage() catch return ToolError.NavigationFailed;
+    errdefer if (existing_page == null) page.close();
+
+    const frame = page.frame() orelse return ToolError.FrameNotLoaded;
+    const url_arena = session.getArena(.small, "tools.gotoLiteral") catch return ToolError.OutOfMemory;
+    defer url_arena.release();
+    const resolved_url = lp.URL.resolve(url_arena.allocator(), "", url, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return ToolError.OutOfMemory,
+        error.TypeError => return ToolError.InvalidParams,
+    };
+
+    const wait_until = until;
+    const timer: std.Io.Timestamp = .now(lp.io, .boot);
+    var deadline_armed = false;
+    if (wait_until != null) {
+        session.browser.armExecutionDeadline(timeout_ms);
+        deadline_armed = true;
+    }
+    defer if (deadline_armed) {
+        if (session.browser.disarmExecutionDeadline()) {
+            _ = session.browser.env.cancelExecutionDeadlineTerminate();
+        }
+    };
+
+    // A WebDriver navigation replaces the document in the current top-level
+    // browsing context. Keep its frame id, history, and session storage alive,
+    // while invalidating document-scoped node references.
+    registry.reset();
+    const navigate_opts: lp.Frame.NavigateOpts = .{
+        .reason = .address_bar,
+        .kind = .{ .push = null },
+    };
+    const replaces_current_document = frame._load_state != .waiting;
+    const navigation = if (!replaces_current_document)
+        frame.navigate(resolved_url, navigate_opts)
+    else
+        session.initiateRootNavigation(frame._frame_id, resolved_url, navigate_opts);
+    navigation catch {
+        if (finishCommandDeadline(session.browser, timer, timeout_ms, &deadline_armed)) {
+            return abortPendingNavigation(session, page.frame_id);
+        }
+        return ToolError.NavigationFailed;
+    };
+
+    const required_state = wait_until orelse return .completed;
+    if (commandDeadlineReached(session.browser, timer, timeout_ms)) {
+        _ = finishCommandDeadline(session.browser, timer, timeout_ms, &deadline_armed);
+        return abortPendingNavigation(session, page.frame_id);
+    }
+
+    var runner = session.runner(.{});
+    const condition = lp.Session.Runner.WaitCondition{ .frame_id = page.frame_id, .until = required_state };
+    var conditions = [_]lp.Session.Runner.WaitCondition{condition};
+    const max_wait_chunk_ms: u32 = 1000;
+    const result = while (true) {
+        if (commandDeadlineReached(session.browser, timer, timeout_ms)) {
+            break abortPendingNavigation(session, page.frame_id);
+        }
+        if (session.browser.env.terminatePending()) {
+            if (finishCommandDeadline(session.browser, timer, timeout_ms, &deadline_armed)) {
+                return abortPendingNavigation(session, page.frame_id);
+            }
+            return ToolError.Cancelled;
+        }
+
+        const budget = commandDeadlineBudget(timer, timeout_ms, max_wait_chunk_ms);
+
+        const wait_result = runner.waitResult(budget, &conditions) catch |err| {
+            if (finishCommandDeadline(session.browser, timer, timeout_ms, &deadline_armed)) {
+                return abortPendingNavigation(session, page.frame_id);
+            }
+            return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
+        };
+        if (wait_result == .completed) break @as(lp.Session.Runner.WaitResult, .completed);
+    };
+
+    if (finishCommandDeadline(session.browser, timer, timeout_ms, &deadline_armed)) {
+        return abortPendingNavigation(session, page.frame_id);
+    }
+    const navigated_frame = page.frame() orelse return ToolError.NavigationFailed;
+    if (navigated_frame._last_navigate_error != null) return ToolError.NavigationFailed;
+    // A replacement that failed before receiving headers is discarded by the
+    // frame callback, restoring the old document. It must not look like a
+    // successful navigation merely because that old page is already loaded.
+    if (replaces_current_document and navigated_frame == frame) return ToolError.NavigationFailed;
+    return result;
+}
+
+fn abortPendingNavigation(session: *lp.Session, frame_id: u32) lp.Session.Runner.WaitResult {
+    if (session.livePage(frame_id)) |live| {
+        if (session.replacementOf(live)) |pending| session.discardPendingPage(pending);
+    }
+    return .timeout;
 }
 
 fn resolveNodeAndPage(session: *lp.Session, registry: *CDPNode.Registry, node_id: CDPNode.Id) ToolError!NodeAndPage {

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -701,14 +701,16 @@ pub fn isDisabled(self: *Element) bool {
         const ancestor = node.is(Element) orelse continue;
 
         if (ancestor.getTag() == .fieldset and ancestor.getAttributeSafe(comptime .wrap("disabled")) != null) {
+            var inside_first_legend = false;
             var child = ancestor.firstElementChild();
             while (child) |c| {
                 if (c.getTag() == .legend) {
-                    if (c.asNode().contains(element_node)) return false;
+                    inside_first_legend = c.asNode().contains(element_node);
                     break;
                 }
                 child = c.nextElementSibling();
             }
+            if (inside_first_legend) continue;
             return true;
         }
     }

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -94,8 +94,8 @@ pub fn getProduct(_: *const Navigator) []const u8 {
     return "Gecko";
 }
 
-pub fn getWebdriver(_: *const Navigator) bool {
-    return false;
+pub fn getWebdriver(_: *const Navigator, exec: *const Execution) bool {
+    return exec.session.browser.webdriver_active;
 }
 
 // Default to false: per https://w3c.github.io/gpc/#javascript-property the
@@ -241,7 +241,7 @@ pub const JsApi = struct {
     pub const maxTouchPoints = bridge.accessor(Navigator.getMaxTouchPoints, null, .{});
     pub const vendor = bridge.accessor(Navigator.getVendor, null, .{});
     pub const product = bridge.accessor(Navigator.getProduct, null, .{});
-    pub const webdriver = bridge.accessor(Navigator.getWebdriver, null, .{});
+    pub const webdriver = bridge.accessor(Navigator.getWebdriver, null, .{ .exposed = .window });
     pub const doNotTrack = bridge.accessor(Navigator.getDoNotTrack, null, .{});
     pub const globalPrivacyControl = bridge.accessor(Navigator.getGlobalPrivacyControl, null, .{});
 

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const Node = @import("../Node.zig");
+const TreeWalker = @import("../TreeWalker.zig").Full;
 const Frame = @import("../../Frame.zig");
 const Browser = @import("../../Browser.zig");
 
@@ -115,8 +116,17 @@ pub const Cache = struct {
 
 fn collectAll(arena: *lp.Arena, selectors: []const Selector, root: *Node, frame: *Frame) !*List {
     var nodes: std.AutoArrayHashMapUnmanaged(*Node, void) = .empty;
-    for (selectors) |selector| {
-        try List.collect(arena.allocator(), root, selector, &nodes, frame);
+    if (selectors.len == 1) {
+        try List.collect(arena.allocator(), root, selectors[0], &nodes, frame);
+    } else {
+        var walker = TreeWalker.init(root, .{});
+        _ = walker.next();
+        while (walker.next()) |node| {
+            const element = node.is(Node.Element) orelse continue;
+            if (matchesAny(selectors, element, root, frame)) {
+                try nodes.put(arena.allocator(), node, {});
+            }
+        }
     }
 
     const list = try arena.create(List);
@@ -144,6 +154,44 @@ pub fn querySelectorAll(root: *Node, input: []const u8, frame: *Frame) !*List {
     const arena = try frame.getArena(.small, "querySelectorAll");
     errdefer arena.release();
     return collectAll(arena, try cachedParse(frame._session.browser, input), root, frame);
+}
+
+/// Query with an already parsed selector. Protocol adapters use this to avoid
+/// retaining client-controlled selectors in the browser cache and to reuse one
+/// parse across polling attempts.
+pub fn queryAll(selectors: []const Selector, root: *Node, frame: *Frame) !*List {
+    const arena = try frame.getArena(.small, "queryAll");
+    errdefer arena.release();
+
+    var nodes: std.AutoArrayHashMapUnmanaged(*Node, void) = .empty;
+    var walker = TreeWalker.init(root, .{});
+    _ = walker.next();
+    while (walker.next()) |node| {
+        const element = node.is(Node.Element) orelse continue;
+        if (matchesAny(selectors, element, root, frame)) {
+            try nodes.put(arena.allocator(), node, {});
+        }
+    }
+
+    const list = try arena.create(List);
+    list.* = .{
+        ._arena = arena,
+        ._nodes = nodes.keys(),
+    };
+    return list;
+}
+
+/// Query descendants in tree order without ID anchoring. This is used for
+/// externally supplied selectors, where duplicate IDs and ancestors outside
+/// an element-scoped root must retain standard querySelector semantics.
+pub fn queryInTreeOrder(selectors: []const Selector, root: *Node, frame: *Frame) ?*Node.Element {
+    var walker = TreeWalker.init(root, .{});
+    _ = walker.next();
+    while (walker.next()) |node| {
+        const element = node.is(Node.Element) orelse continue;
+        if (matchesAny(selectors, element, root, frame)) return element;
+    }
+    return null;
 }
 
 pub fn matches(el: *Node.Element, input: []const u8, frame: *Frame) !bool {
@@ -373,6 +421,16 @@ pub const Selector = struct {
 };
 
 pub fn query(selectors: []const Selector, root: *Node, frame: *Frame) !?*Node.Element {
+    if (selectors.len > 1) {
+        var walker = TreeWalker.init(root, .{});
+        _ = walker.next();
+        while (walker.next()) |node| {
+            const element = node.is(Node.Element) orelse continue;
+            if (matchesAny(selectors, element, root, frame)) return element;
+        }
+        return null;
+    }
+
     for (selectors) |selector| {
         // Fast path: single compound with only an ID selector
         if (selector.segments.len == 0 and selector.first.parts.len == 1) {

--- a/src/cdp/Node.zig
+++ b/src/cdp/Node.zig
@@ -69,6 +69,15 @@ pub const Registry = struct {
         _ = self.node_pool.reset(self.allocator, .{ .retain_with_limit = 1024 });
     }
 
+    /// Reset document-scoped nodes without retaining a potentially huge
+    /// one-off query's hash-table capacity.
+    pub fn resetAndFree(self: *Registry) void {
+        self.lookup_by_id.clearAndFree(self.allocator);
+        self.lookup_by_node.clearAndFree(self.allocator);
+        _ = self.arena.reset(.{ .retain_with_limit = 1024 });
+        _ = self.node_pool.reset(self.allocator, .{ .retain_with_limit = 1024 });
+    }
+
     /// Evict only the nodes owned by `frame`'s page, leaving sibling pages' node
     /// IDs valid. Must run before the page's arena is freed — attribution walks
     /// each node's live parent chain.

--- a/src/help.zon
+++ b/src/help.zon
@@ -9,7 +9,7 @@
     \\  help        displays this message
     \\  mcp         starts an MCP (Model Context Protocol) server (stdio or HTTP)
     \\  run         runs a saved script (no LLM), then exits
-    \\  serve       starts a WebSocket CDP server
+    \\  serve       starts a CDP or WebDriver server
     \\  version     displays the version of {0s}
     \\
     \\Use "{0s} help <command>" for more information about a command.
@@ -17,7 +17,7 @@
     .serve =
     \\usage: {0s} serve [OPTIONS] [COMMON_OPTIONS]
     \\
-    \\Starts a WebSocket CDP server.
+    \\Starts a WebSocket CDP server, or a W3C WebDriver server with --webdriver.
     \\
     \\options:
     \\  --advertise-host <HOST>
@@ -46,8 +46,13 @@
     \\          Host of the CDP server.
     \\          Defaults to "127.0.0.1".
     \\  --port <INT>
-    \\          Port of the CDP server.
+    \\          Port of the CDP or WebDriver server.
     \\          Defaults to 9222.
+    \\  --webdriver
+    \\          Serve the W3C WebDriver HTTP endpoint instead of CDP. WebDriver
+    \\          accepts one active session and requires a loopback --host,
+    \\          direct networking, and TLS host verification.
+    \\          Defaults to false.
     ,
     .fetch =
     \\usage: {0s} fetch <url>... [OPTIONS] [COMMON_OPTIONS]

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,23 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 return args.printUsageAndExit(main_arena, .serve, false);
             };
 
+            if (opts.webdriver) {
+                if (!lp.mcp.HttpServer.webdriverNetworkSettingsSupported(
+                    opts.http_proxy,
+                    !opts.insecure_disable_tls_host_verification,
+                )) {
+                    log.fatal(.app, "webdriver requires direct networking and TLS host verification", .{});
+                    return args.printUsageAndExit(main_arena, .serve, false);
+                }
+                if (!lp.mcp.HttpServer.isLoopbackAddress(address)) {
+                    log.fatal(.app, "webdriver requires a loopback host", .{ .host = opts.host });
+                    return args.printUsageAndExit(main_arena, .serve, false);
+                }
+                const http_server = try lp.mcp.HttpServer.init(allocator, app, .webdriver);
+                defer http_server.deinit();
+                return http_server.run(address);
+            }
+
             var server = lp.Server.init(app, address) catch |err| {
                 if (err == error.AddressInUse) {
                     log.fatal(.app, "address already in use", .{
@@ -215,7 +232,7 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                     log.fatal(.mcp, "invalid address", .{ .err = err, .host = opts.host, .port = port });
                     return;
                 };
-                const http_server = try lp.mcp.HttpServer.init(allocator, app);
+                const http_server = try lp.mcp.HttpServer.init(allocator, app, .mcp);
                 defer http_server.deinit();
                 // Shutdown rides the already-registered Network.stop handler:
                 // a signal stops the accept loop, run() returns, deinit joins.

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -7,5 +7,7 @@ pub const Server = @import("mcp/Server.zig");
 pub const HttpServer = @import("mcp/HttpServer.zig");
 
 test {
+    // Pull private WebDriver router tests into the root suite.
+    _ = @import("mcp/webdriver.zig");
     std.testing.refAllDecls(@This());
 }

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! HTTP (MCP "Streamable HTTP") transport for the browser-tools MCP server.
+//! HTTP transport for the browser-tools MCP server and W3C WebDriver endpoint.
 //!
 //! Lets many clients drive one process, each on its own browsing session.
 //! Threading rule: V8 isolates are thread-affine, so ALL browser work — every
@@ -35,17 +35,28 @@ const sys_net = @import("../sys/net.zig");
 
 const Server = @import("Server.zig");
 const router = @import("router.zig");
+const webdriver = @import("webdriver.zig");
 
 const log = lp.log;
 const posix = std.posix;
 
 const HttpServer = @This();
 
+pub const Protocol = enum { mcp, webdriver };
+
 const ns_per_ms = std.time.ns_per_ms;
 
 /// Cap on a single JSON-RPC request body. Generous: agent tool payloads
 /// (e.g. a `save` script) can be large, but this bounds a hostile client.
 const max_request_bytes = 16 * 1024 * 1024;
+const max_webdriver_request_bytes = 1024 * 1024;
+const max_webdriver_connections: u32 = 16;
+const webdriver_retain_bytes = 64 * 1024;
+// Bound every blocking socket read so a partial local request cannot reserve
+// one of the endpoint's 16 connection slots forever.
+const webdriver_socket_timeout_ms: i64 = 10_000;
+const webdriver_forbidden_body =
+    "{\"value\":{\"error\":\"unknown error\",\"message\":\"WebDriver accepts only loopback Host headers and non-browser requests\",\"stacktrace\":\"\"}}";
 
 /// One unit of work handed from a connection thread to the browser worker.
 /// Allocated on the connection thread's stack — safe because that thread
@@ -53,6 +64,8 @@ const max_request_bytes = 16 * 1024 * 1024;
 /// and writes `out`.
 const Job = struct {
     kind: Kind,
+    method: std.http.Method = .GET,
+    target: []const u8 = "",
     body: []const u8,
     session_id: ?[]const u8,
     /// Where the worker writes the response. The connection thread owns the
@@ -64,11 +77,15 @@ const Job = struct {
     /// outlives the worker moving on to the next job.
     assigned_buf: [128]u8 = undefined,
     assigned_len: usize = 0,
+    status: std.http.Status = .ok,
+    // Set by the worker only when this New Session request created the sole
+    // endpoint session. A failed response write then rolls it back on worker.
+    created_webdriver_session_id: ?[36]u8 = null,
 
     done: std.Io.Event = .unset,
     next: ?*Job = null,
 
-    const Kind = enum { rpc, close };
+    const Kind = enum { rpc, close, webdriver, webdriver_rollback };
 
     fn assigned(self: *const Job) []const u8 {
         return self.assigned_buf[0..self.assigned_len];
@@ -123,6 +140,7 @@ const Queue = struct {
 
 allocator: std.mem.Allocator,
 app: *App,
+protocol: Protocol,
 
 queue: Queue = .{},
 
@@ -132,6 +150,11 @@ queue: Queue = .{},
 active_conns: std.atomic.Value(u32) = .init(0),
 conn_mutex: std.Io.Mutex = .init,
 conns: std.ArrayList(posix.socket_t) = .empty,
+active_worker_mutex: std.Io.Mutex = .init,
+active_worker_env: ?*lp.js.Env = null,
+active_worker_termination_sent: bool = false,
+// `/status` uses this rather than queuing behind a stuck browser execution.
+webdriver_ready: std.atomic.Value(bool) = .init(true),
 
 // The worker owns `server`; other threads must not touch it.
 worker_thread: std.Thread = undefined,
@@ -140,12 +163,19 @@ worker_ok: bool = false,
 
 /// Create the server and start its browser worker thread. Returns once the
 /// worker's default session is up (or errors if it failed to initialize).
-pub fn init(allocator: std.mem.Allocator, app: *App) !*HttpServer {
+pub fn init(allocator: std.mem.Allocator, app: *App, protocol: Protocol) !*HttpServer {
+    if (protocol == .webdriver and
+        !webdriverNetworkSettingsSupported(app.config.httpProxy(), app.config.tlsVerifyHost()))
+    {
+        return error.WebDriverNetworkConfigurationUnsupported;
+    }
+
     const self = try allocator.create(HttpServer);
     errdefer allocator.destroy(self);
     self.* = .{
         .allocator = allocator,
         .app = app,
+        .protocol = protocol,
     };
 
     self.worker_thread = try std.Thread.spawn(.{}, worker, .{self});
@@ -154,6 +184,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !*HttpServer {
         self.worker_thread.join();
         return error.WorkerInitFailed;
     }
+    if (protocol == .webdriver) self.webdriver_ready.store(true, .release);
     return self;
 }
 
@@ -170,6 +201,7 @@ pub fn deinit(self: *HttpServer) void {
         }
     }
     while (self.active_conns.load(.monotonic) > 0) {
+        if (self.protocol == .webdriver) self.terminateActiveWorker();
         lp.io.sleep(.fromMilliseconds(10), .awake) catch {};
     }
 
@@ -184,9 +216,17 @@ pub fn deinit(self: *HttpServer) void {
 /// (e.g. by the signal handler). Reuses the shared accept infrastructure;
 /// blocks the calling thread in `Network.run`.
 pub fn run(self: *HttpServer, address: sys_net.IpAddress) !void {
+    if (self.protocol == .webdriver and !isLoopbackAddress(address)) {
+        log.err(.mcp, "webdriver only accepts loopback binds", .{ .address = address });
+        return error.WebDriverLoopbackOnly;
+    }
+
     var bound = address;
     try self.app.network.bind(&bound, self, onAccept);
-    log.note(.mcp, "mcp http server running", .{ .address = bound });
+    switch (self.protocol) {
+        .mcp => log.note(.mcp, "mcp http server running", .{ .address = bound }),
+        .webdriver => log.note(.mcp, "webdriver server running", .{ .address = bound }),
+    }
     self.app.network.run();
 }
 
@@ -212,7 +252,13 @@ fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
             return;
         };
     }
-    _ = self.active_conns.fetchAdd(1, .monotonic);
+    const previous_conns = self.active_conns.fetchAdd(1, .monotonic);
+    if (self.protocol == .webdriver and previous_conns >= max_webdriver_connections) {
+        _ = self.active_conns.fetchSub(1, .monotonic);
+        self.unregister(socket);
+        _ = std.c.close(socket);
+        return;
+    }
 
     const thread = std.Thread.spawn(.{}, handleConn, .{ self, socket }) catch |err| {
         log.warn(.mcp, "mcp spawn", .{ .err = err });
@@ -239,12 +285,20 @@ fn worker(self: *HttpServer) void {
     var placeholder: std.Io.Writer.Allocating = .init(self.allocator);
     defer placeholder.deinit();
 
-    const server = Server.init(self.allocator, self.app, &placeholder.writer) catch |err| {
+    const server = switch (self.protocol) {
+        .mcp => Server.init(self.allocator, self.app, &placeholder.writer),
+        .webdriver => Server.initWebDriver(self.allocator, self.app, &placeholder.writer),
+    } catch |err| {
         log.err(.mcp, "mcp http server init", .{ .err = err });
         self.worker_ready.set(lp.io);
         return;
     };
-    defer server.deinit();
+    defer {
+        // `TerminateExecution` is sticky. Cancel it while the worker still
+        // owns the isolate, before Browser.deinit tears the isolate down.
+        if (self.protocol == .webdriver) server.cancelWebDriverTermination();
+        server.deinit();
+    }
 
     server.enableIsolateParking();
 
@@ -261,18 +315,59 @@ fn worker(self: *HttpServer) void {
     while (true) {
         const job = self.queue.pop(wait_ms) orelse {
             if (self.queue.closed.load(.acquire)) break;
-            wait_ms = server.idle();
+            if (self.protocol == .webdriver) {
+                self.setActiveWorkerEnvironment(server.webdriverEnvironment());
+                wait_ms = server.idle();
+                server.cancelWebDriverTermination();
+                self.setActiveWorkerEnvironment(null);
+            } else {
+                wait_ms = server.idle();
+            }
             continue;
         };
-        _ = arena.reset(.retain_capacity);
-        process(server, arena.allocator(), job);
+        if (self.protocol == .webdriver) {
+            _ = arena.reset(.{ .retain_with_limit = webdriver_retain_bytes });
+        } else {
+            _ = arena.reset(.retain_capacity);
+        }
+        self.process(server, arena.allocator(), job);
+        if (self.protocol == .webdriver) {
+            _ = arena.reset(.{ .retain_with_limit = webdriver_retain_bytes });
+        }
         job.done.set(lp.io);
         wait_ms = 0;
     }
 }
 
-fn process(server: *Server, arena: std.mem.Allocator, job: *Job) void {
+fn process(self: *HttpServer, server: *Server, arena: std.mem.Allocator, job: *Job) void {
     server.transport.retarget(job.out);
+
+    if (job.kind == .webdriver) {
+        const creating_session = isWebDriverNewSession(job.method, job.target);
+        if (creating_session) self.webdriver_ready.store(false, .release);
+        const publishes_environment = job.method != .DELETE;
+        if (publishes_environment) self.setActiveWorkerEnvironment(server.webdriverEnvironment());
+        defer if (publishes_environment) self.setActiveWorkerEnvironment(null);
+        job.status = webdriver.handle(server, arena, job.method, job.target, job.body, job.out) catch |err| blk: {
+            log.err(.mcp, "webdriver handle", .{ .err = err });
+            job.out.writeAll("{\"value\":{\"error\":\"unknown error\",\"message\":\"Internal server error\",\"stacktrace\":\"\"}}") catch {};
+            break :blk .internal_server_error;
+        };
+        if (creating_session and job.status == .ok) {
+            if (server.webdriver_session_id) |id| {
+                job.created_webdriver_session_id = id;
+            }
+        }
+        self.webdriver_ready.store(server.webdriverReady(), .release);
+        return;
+    }
+
+    if (job.kind == .webdriver_rollback) {
+        const id = job.session_id orelse unreachable;
+        _ = server.closeWebDriverSession(id);
+        self.webdriver_ready.store(server.webdriverReady(), .release);
+        return;
+    }
 
     if (job.kind == .close) {
         if (job.session_id) |sid| _ = server.closeSession(sid);
@@ -288,6 +383,27 @@ fn process(server: *Server, arena: std.mem.Allocator, job: *Job) void {
     router.handleMessage(server, arena, job.body) catch |err| {
         log.err(.mcp, "mcp handle", .{ .err = err });
     };
+}
+
+fn setActiveWorkerEnvironment(self: *HttpServer, env: ?*lp.js.Env) void {
+    self.active_worker_mutex.lockUncancelable(lp.io);
+    defer self.active_worker_mutex.unlock(lp.io);
+    self.active_worker_env = env;
+    self.active_worker_termination_sent = false;
+}
+
+fn terminateActiveWorker(self: *HttpServer) void {
+    self.active_worker_mutex.lockUncancelable(lp.io);
+    defer self.active_worker_mutex.unlock(lp.io);
+    if (self.active_worker_termination_sent) return;
+    const env = self.active_worker_env orelse return;
+    self.active_worker_termination_sent = true;
+    env.requestTerminate();
+}
+
+fn isWebDriverNewSession(method: std.http.Method, target: []const u8) bool {
+    const path_end = std.mem.indexOfScalar(u8, target, '?') orelse target.len;
+    return method == .POST and std.mem.eql(u8, target[0..path_end], "/session");
 }
 
 /// Decide which session a request targets and make it active. An explicit
@@ -326,6 +442,13 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
     // never see an fd that has been closed and possibly reused.
     defer self.unregister(socket);
 
+    if (self.protocol == .webdriver) {
+        setWebDriverSocketTimeout(socket) catch |err| {
+            log.warn(.mcp, "webdriver socket timeout", .{ .err = err });
+            return;
+        };
+    }
+
     var recv_buf: [16 * 1024]u8 = undefined;
     var send_buf: [16 * 1024]u8 = undefined;
     var stream_reader = stream.reader(lp.io, &recv_buf);
@@ -340,9 +463,20 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
 
     while (true) {
         var request = http_server.receiveHead() catch return; // peer closed, bad head, or shutdown
-        _ = arena.reset(.retain_capacity);
+        if (self.protocol == .webdriver) {
+            _ = arena.reset(.{ .retain_with_limit = webdriver_retain_bytes });
+        } else {
+            _ = arena.reset(.retain_capacity);
+        }
         out.clearRetainingCapacity();
         self.serve(&out.writer, arena.allocator(), &request) catch return;
+        if (self.protocol == .webdriver) {
+            _ = arena.reset(.{ .retain_with_limit = webdriver_retain_bytes });
+            if (out.writer.buffer.len > webdriver_retain_bytes) {
+                out.deinit();
+                out = .init(self.allocator);
+            }
+        }
         if (!request.head.keep_alive) return;
     }
 }
@@ -351,6 +485,8 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
 /// MCP Streamable HTTP — POST carries a JSON-RPC message; DELETE closes the
 /// session named by `Mcp-Session-Id`. std.http.Server owns the framing.
 fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, request: *std.http.Server.Request) !void {
+    if (self.protocol == .webdriver) return self.serveWebDriver(out, arena, request);
+
     const method = request.head.method;
     if (method != .POST and method != .DELETE) {
         return request.respond("", .{ .status = .method_not_allowed, .keep_alive = false });
@@ -395,6 +531,149 @@ fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, reque
     });
 }
 
+fn serveWebDriver(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, request: *std.http.Server.Request) !void {
+    if (!webDriverRequestHeadersAllowed(request)) {
+        request.head.keep_alive = false;
+        return request.respond(webdriver_forbidden_body, .{
+            .status = .forbidden,
+            .keep_alive = false,
+            .extra_headers = &.{.{ .name = "content-type", .value = "application/json; charset=utf-8" }},
+        });
+    }
+    if (request.head.expect != null) {
+        request.head.keep_alive = false;
+        return request.respond("", .{ .status = .expectation_failed, .keep_alive = false });
+    }
+
+    const method = request.head.method;
+    const target = try arena.dupe(u8, request.head.target);
+    const keep_alive = request.head.keep_alive;
+    if (method == .GET and std.mem.eql(u8, target, "/status")) {
+        return request.respond(if (self.webdriver_ready.load(.acquire))
+            "{\"value\":{\"ready\":true,\"message\":\"Lightpanda WebDriver endpoint is ready\"}}"
+        else
+            "{\"value\":{\"ready\":false,\"message\":\"Lightpanda WebDriver endpoint is busy\"}}", .{
+            .status = .ok,
+            .keep_alive = keep_alive,
+            .extra_headers = &.{
+                .{ .name = "content-type", .value = "application/json; charset=utf-8" },
+                .{ .name = "cache-control", .value = "no-cache" },
+            },
+        });
+    }
+    var body_buf: [8 * 1024]u8 = undefined;
+    const body = request.readerExpectNone(&body_buf).allocRemaining(arena, .limited(max_webdriver_request_bytes)) catch {
+        request.head.keep_alive = false;
+        return request.respond("", .{ .status = .payload_too_large, .keep_alive = false });
+    };
+
+    var job: Job = .{
+        .kind = .webdriver,
+        .method = method,
+        .target = target,
+        .body = body,
+        .session_id = null,
+        .out = out,
+    };
+    self.queue.push(&job);
+    job.done.waitUncancelable(lp.io);
+
+    request.respond(out.buffered(), .{
+        .status = job.status,
+        .keep_alive = keep_alive,
+        .extra_headers = &.{
+            .{ .name = "content-type", .value = "application/json; charset=utf-8" },
+            .{ .name = "cache-control", .value = "no-cache" },
+        },
+    }) catch |err| {
+        self.rollbackWebDriverSession(&job, out);
+        return err;
+    };
+}
+
+fn rollbackWebDriverSession(self: *HttpServer, completed: *const Job, out: *std.Io.Writer) void {
+    const session_id = completed.created_webdriver_session_id orelse return;
+    var rollback: Job = .{
+        .kind = .webdriver_rollback,
+        .body = "",
+        .session_id = &session_id,
+        .out = out,
+    };
+    self.queue.push(&rollback);
+    rollback.done.waitUncancelable(lp.io);
+}
+
+fn setWebDriverSocketTimeout(socket: posix.socket_t) !void {
+    const timeout = std.mem.toBytes(posix.timeval{
+        .sec = @divTrunc(webdriver_socket_timeout_ms, 1000),
+        .usec = @mod(webdriver_socket_timeout_ms, 1000) * 1000,
+    });
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &timeout);
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &timeout);
+}
+
+fn webDriverRequestHeadersAllowed(request: *std.http.Server.Request) bool {
+    // Loopback binding alone is insufficient against DNS rebinding and local
+    // web-page CSRF. Native WebDriver clients send a loopback Host and no
+    // Origin; reject requests that do not have that shape.
+    var found_host = false;
+    var it = request.iterateHeaders();
+    while (it.next()) |header| {
+        if (!webDriverHeaderAllowed(header.name, header.value)) return false;
+        if (!std.ascii.eqlIgnoreCase(header.name, "host")) continue;
+        if (found_host) return false;
+        found_host = true;
+    }
+    return found_host;
+}
+
+fn webDriverHeaderAllowed(name: []const u8, value: []const u8) bool {
+    if (std.ascii.eqlIgnoreCase(name, "origin")) return false;
+    if (std.ascii.eqlIgnoreCase(name, "host")) return isLoopbackHostHeader(value);
+    return true;
+}
+
+fn isLoopbackHostHeader(value: []const u8) bool {
+    var host = value;
+    if (host.len == 0) return false;
+
+    if (host[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, host, ']') orelse return false;
+        if (!validHostPortSuffix(host[close + 1 ..])) return false;
+        host = host[1..close];
+    } else if (std.mem.count(u8, host, ":") == 1) {
+        const colon = std.mem.lastIndexOfScalar(u8, host, ':').?;
+        if (!validHostPortSuffix(host[colon..])) return false;
+        host = host[0..colon];
+    }
+
+    if (std.ascii.eqlIgnoreCase(host, "localhost") or std.ascii.eqlIgnoreCase(host, "localhost.")) {
+        return true;
+    }
+    const address = std.Io.net.IpAddress.parse(host, 0) catch return false;
+    return isLoopbackAddress(address);
+}
+
+fn validHostPortSuffix(suffix: []const u8) bool {
+    if (suffix.len == 0) return true;
+    if (suffix.len == 1 or suffix[0] != ':') return false;
+    _ = std.fmt.parseInt(u16, suffix[1..], 10) catch return false;
+    return true;
+}
+
+pub fn isLoopbackAddress(address: sys_net.IpAddress) bool {
+    return switch (address) {
+        .ip4 => |ip4| ip4.bytes[0] == 127,
+        .ip6 => |ip6| std.mem.eql(u8, &ip6.bytes, &.{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }),
+    };
+}
+
+pub fn webdriverNetworkSettingsSupported(http_proxy: ?[]const u8, tls_verify_host: bool) bool {
+    // An empty CURLOPT_PROXY explicitly disables libcurl's ambient proxy
+    // environment lookup; it is the direct-mode representation at runtime.
+    return (http_proxy == null or http_proxy.?.len == 0) and tls_verify_host;
+}
+
 /// Duplicate the `Mcp-Session-Id` request header into `arena`, or null.
 fn sessionHeader(arena: std.mem.Allocator, request: *std.http.Server.Request) !?[]const u8 {
     var it = request.iterateHeaders();
@@ -413,4 +692,23 @@ test "HttpServer - initialize is detected for session minting" {
     try std.testing.expect(isInitialize(aa, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}"));
     try std.testing.expect(!isInitialize(aa, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\"}"));
     try std.testing.expect(!isInitialize(aa, "not json"));
+}
+
+test "HttpServer - WebDriver binds only to loopback" {
+    try std.testing.expect(isLoopbackAddress(try std.Io.net.IpAddress.parse("127.0.0.1", 9515)));
+    try std.testing.expect(isLoopbackAddress(try std.Io.net.IpAddress.parse("::1", 9515)));
+    try std.testing.expect(!isLoopbackAddress(try std.Io.net.IpAddress.parse("0.0.0.0", 9515)));
+    try std.testing.expect(isLoopbackHostHeader("127.0.0.1:9515"));
+    try std.testing.expect(isLoopbackHostHeader("[::1]:9515"));
+    try std.testing.expect(isLoopbackHostHeader("localhost"));
+    try std.testing.expect(!isLoopbackHostHeader("example.com:9515"));
+    try std.testing.expect(!isLoopbackHostHeader("127.0.0.1:bad"));
+    try std.testing.expect(!webDriverHeaderAllowed("Origin", "https://example.com"));
+    try std.testing.expect(webDriverHeaderAllowed("Host", "127.0.0.1:9515"));
+    try std.testing.expect(webdriverNetworkSettingsSupported(null, true));
+    try std.testing.expect(webdriverNetworkSettingsSupported("", true));
+    try std.testing.expect(!webdriverNetworkSettingsSupported("http://127.0.0.1:8080", true));
+    try std.testing.expect(!webdriverNetworkSettingsSupported(null, false));
+    try std.testing.expect(isWebDriverNewSession(.POST, "/session?trace=true"));
+    try std.testing.expect(!isWebDriverNewSession(.GET, "/session"));
 }

--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -10,6 +10,7 @@ const router = @import("router.zig");
 const tools = @import("tools.zig");
 const Transport = @import("Transport.zig");
 const CDPNode = @import("../cdp/Node.zig");
+const Id = @import("../id.zig");
 
 const Self = @This();
 
@@ -40,6 +41,13 @@ app: *App,
 sessions: std.StringHashMapUnmanaged(*Session) = .empty,
 /// Monotonic counter backing auto-generated session ids (`s1`, `s2`, …).
 session_seq: u32 = 0,
+/// Endpoint nodes may have only one active HTTP WebDriver session.
+webdriver_session: ?*Session = null,
+webdriver_session_id: ?[36]u8 = null,
+webdriver_page_load_wait: ?lp.Config.WaitUntil = .load,
+webdriver_page_load_timeout_ms: ?u64 = 300_000,
+webdriver_script_timeout_ms: ?u64 = 30_000,
+webdriver_implicit_timeout_ms: ?u64 = 0,
 /// When several sessions (each its own V8 isolate) share one thread, V8's
 /// "current isolate" is a per-thread stack, so an isolate must be *entered*
 /// around any use of it and left un-entered otherwise. The HTTP transport
@@ -54,6 +62,24 @@ active_session: *Session = undefined,
 transport: Transport,
 
 pub fn init(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*Self {
+    const self = try initEmpty(allocator, app, writer);
+    errdefer {
+        self.transport.deinit();
+        allocator.destroy(self);
+    }
+
+    self.active_session = try self.createSession(default_session_id);
+    return self;
+}
+
+/// Initialize the WebDriver endpoint without an otherwise-unused default
+/// browser. The first New Session command creates the sole browser lazily.
+pub fn initWebDriver(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*Self {
+    try app.watchdog.enableExecutionDeadlines();
+    return initEmpty(allocator, app, writer);
+}
+
+fn initEmpty(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*Self {
     const self = try allocator.create(Self);
     errdefer allocator.destroy(self);
 
@@ -64,7 +90,6 @@ pub fn init(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*S
     };
     errdefer self.transport.deinit();
 
-    self.active_session = try self.createSession(default_session_id);
     return self;
 }
 
@@ -125,7 +150,7 @@ pub fn createSession(self: *Self, id: []const u8) !*Session {
 /// transport calls this on its worker thread before serving anyone.
 pub fn enableIsolateParking(self: *Self) void {
     self.park_isolates = true;
-    self.exitIsolate(self.defaultSession());
+    if (self.sessions.get(default_session_id)) |entry| self.exitIsolate(entry);
 }
 
 /// Make `entry`'s isolate the current one for this thread. Must bracket any
@@ -177,6 +202,127 @@ pub fn useSession(self: *Self, id: ?[]const u8) !*Session {
     const wanted = id orelse "";
     self.active_session = if (wanted.len == 0) self.defaultSession() else try self.createSession(wanted);
     return self.active_session;
+}
+
+/// Create a W3C WebDriver session with its initial about:blank document.
+/// The browser state is marked before the page is created so navigator.webdriver
+/// is true from the first script execution in that browsing context.
+pub fn createWebDriverSession(
+    self: *Self,
+    id: []const u8,
+    page_load_wait: ?lp.Config.WaitUntil,
+    page_load_timeout_ms: ?u64,
+    script_timeout_ms: ?u64,
+    implicit_timeout_ms: ?u64,
+) !*Session {
+    if (self.webdriver_session != null) {
+        return error.SessionAlreadyExists;
+    }
+    if (id.len != 36) return error.InvalidSessionId;
+
+    const entry = try self.createSession(id);
+    errdefer {
+        const removed = self.sessions.fetchRemove(id).?;
+        self.destroySession(removed.value);
+    }
+
+    self.enterIsolate(entry);
+    defer self.exitIsolate(entry);
+
+    entry.browser.webdriver_active = true;
+    errdefer entry.browser.webdriver_active = false;
+
+    _ = try entry.session.createPage();
+
+    var owned_id: [36]u8 = undefined;
+    @memcpy(&owned_id, id);
+    self.webdriver_page_load_wait = page_load_wait;
+    self.webdriver_page_load_timeout_ms = page_load_timeout_ms;
+    self.webdriver_script_timeout_ms = script_timeout_ms;
+    self.webdriver_implicit_timeout_ms = implicit_timeout_ms;
+    self.webdriver_session = entry;
+    self.webdriver_session_id = owned_id;
+    return entry;
+}
+
+/// Return an existing W3C WebDriver session. This never creates a session for
+/// an unknown id, unlike useSession which is intentionally MCP-friendly.
+pub fn getWebDriverSession(self: *Self, id: []const u8) ?*Session {
+    const entry = self.webdriver_session orelse return null;
+    const active_id = self.webdriver_session_id orelse return null;
+    return if (std.mem.eql(u8, &active_id, id)) entry else null;
+}
+
+pub fn closeWebDriverSession(self: *Self, id: []const u8) bool {
+    const entry = self.getWebDriverSession(id) orelse return false;
+    self.cancelWebDriverTermination();
+    entry.browser.webdriver_active = false;
+
+    self.webdriver_session = null;
+    self.webdriver_session_id = null;
+    self.webdriver_page_load_wait = .load;
+    self.webdriver_page_load_timeout_ms = 300_000;
+    self.webdriver_script_timeout_ms = 30_000;
+    self.webdriver_implicit_timeout_ms = 0;
+    const removed = self.sessions.fetchRemove(id) orelse unreachable;
+    std.debug.assert(removed.value == entry);
+    self.destroySession(entry);
+    return true;
+}
+
+pub fn webdriverReady(self: *const Self) bool {
+    return self.webdriver_session == null;
+}
+
+pub fn webdriverEnvironment(self: *Self) ?*lp.js.Env {
+    const entry = self.webdriver_session orelse return null;
+    return &entry.browser.env;
+}
+
+/// Cancel a transport-requested V8 termination while its isolate is current.
+/// The HTTP worker calls this after idle work and just before teardown.
+pub fn cancelWebDriverTermination(self: *Self) void {
+    const entry = self.webdriver_session orelse return;
+    self.enterIsolate(entry);
+    defer self.exitIsolate(entry);
+    if (entry.browser.env.terminatePending()) entry.browser.env.cancelTerminate();
+}
+
+pub fn webdriverPageLoadWait(self: *const Self) ?lp.Config.WaitUntil {
+    return self.webdriver_page_load_wait;
+}
+
+pub fn webdriverPageLoadTimeout(self: *const Self) ?u64 {
+    return self.webdriver_page_load_timeout_ms;
+}
+
+pub fn webdriverScriptTimeout(self: *const Self) ?u64 {
+    return self.webdriver_script_timeout_ms;
+}
+
+pub fn webdriverImplicitTimeout(self: *const Self) ?u64 {
+    return self.webdriver_implicit_timeout_ms;
+}
+
+pub fn setWebDriverScriptTimeout(self: *Self, timeout_ms: ?u64) void {
+    self.webdriver_script_timeout_ms = timeout_ms;
+}
+
+pub fn setWebDriverPageLoadTimeout(self: *Self, timeout_ms: ?u64) void {
+    self.webdriver_page_load_timeout_ms = timeout_ms;
+}
+
+pub fn setWebDriverImplicitTimeout(self: *Self, timeout_ms: ?u64) void {
+    self.webdriver_implicit_timeout_ms = timeout_ms;
+}
+
+/// Generate the UUID required for a WebDriver session id.
+pub fn nextWebDriverSessionId(self: *Self, arena: std.mem.Allocator) ![]const u8 {
+    while (true) {
+        var uuid: [36]u8 = undefined;
+        Id.uuidv4(&uuid);
+        if (!self.sessions.contains(&uuid)) return arena.dupe(u8, &uuid);
+    }
 }
 
 /// A session id that is not currently in use, formatted into `arena`.

--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -29,9 +29,26 @@ pub const Session = struct {
     session: *lp.Session,
     notification: *lp.Notification,
     node_registry: CDPNode.Registry,
+    webdriver_elements: WebDriverElementRegistry,
 
     fn isDefault(self: *const Session) bool {
         return std.mem.eql(u8, self.id, default_session_id);
+    }
+};
+
+/// Tracks element IDs already returned to the WebDriver client. The CDP node
+/// registry owns live DOM pointers and clears them before document teardown;
+/// the monotonic high-water mark distinguishes a stale past reference from an
+/// unknown ID without retaining one entry per historical element.
+pub const WebDriverElementRegistry = struct {
+    last_issued: CDPNode.Id = 0,
+
+    pub fn register(self: *WebDriverElementRegistry, node_id: CDPNode.Id) void {
+        self.last_issued = @max(self.last_issued, node_id);
+    }
+
+    pub fn isIssued(self: *const WebDriverElementRegistry, node_id: CDPNode.Id) bool {
+        return node_id <= self.last_issued;
     }
 };
 
@@ -126,6 +143,7 @@ fn createSessionWithConsoleCapture(self: *Self, id: []const u8, capture_console:
         .session = undefined,
         .notification = notification,
         .node_registry = CDPNode.Registry.init(self.allocator),
+        .webdriver_elements = .{},
     };
     errdefer entry.node_registry.deinit();
 
@@ -188,6 +206,7 @@ fn destroySession(self: *Self, entry: *Session) void {
     // Re-enter so `Browser.deinit`'s `Env.deinit` exit stays balanced against
     // a parked isolate (and operates on the current one).
     self.enterIsolate(entry);
+    entry.notification.unregisterAll(entry);
     entry.node_registry.deinit();
     entry.browser.deinit();
     entry.notification.deinit();
@@ -233,6 +252,7 @@ pub fn createWebDriverSession(
         const removed = self.sessions.fetchRemove(id).?;
         self.destroySession(removed.value);
     }
+    try entry.notification.register(.frame_remove, entry, onWebDriverFrameRemove);
 
     self.enterIsolate(entry);
     defer self.exitIsolate(entry);
@@ -251,6 +271,11 @@ pub fn createWebDriverSession(
     self.webdriver_session = entry;
     self.webdriver_session_id = owned_id;
     return entry;
+}
+
+fn onWebDriverFrameRemove(ctx: *anyopaque, _: lp.Notification.FrameRemove) !void {
+    const entry: *Session = @ptrCast(@alignCast(ctx));
+    entry.node_registry.resetAndFree();
 }
 
 /// Return an existing W3C WebDriver session. This never creates a session for

--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -73,9 +73,9 @@ pub fn init(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*S
 }
 
 /// Initialize the WebDriver endpoint without an otherwise-unused default
-/// browser. The first New Session command creates the sole browser lazily.
+/// browser. The first New Session command creates the sole browser and starts
+/// deadline enforcement lazily.
 pub fn initWebDriver(allocator: std.mem.Allocator, app: *App, writer: *std.Io.Writer) !*Self {
-    try app.watchdog.enableExecutionDeadlines();
     return initEmpty(allocator, app, writer);
 }
 
@@ -105,6 +105,10 @@ pub fn deinit(self: *Self) void {
 /// Create the session named `id`, or return the existing one. The `id` is
 /// duped, so the caller keeps ownership of its slice.
 pub fn createSession(self: *Self, id: []const u8) !*Session {
+    return self.createSessionWithConsoleCapture(id, true);
+}
+
+fn createSessionWithConsoleCapture(self: *Self, id: []const u8, capture_console: bool) !*Session {
     if (self.sessions.get(id)) |existing| return existing;
 
     const owned_id = try self.allocator.dupe(u8, id);
@@ -129,7 +133,7 @@ pub fn createSession(self: *Self, id: []const u8) !*Session {
     errdefer entry.browser.deinit();
 
     entry.session = try entry.browser.newSession(notification);
-    try entry.session.enableConsoleCapture();
+    if (capture_console) try entry.session.enableConsoleCapture();
 
     // Only the default session is backed by the on-disk cookie file; named
     // sessions start clean so agents stay isolated by default.
@@ -220,7 +224,11 @@ pub fn createWebDriverSession(
     }
     if (id.len != 36) return error.InvalidSessionId;
 
-    const entry = try self.createSession(id);
+    // A disabled global watchdog normally means no checker thread. WebDriver
+    // still needs its per-command execution deadlines, but only after a
+    // client actually asks us to create a browser.
+    try self.app.watchdog.enableExecutionDeadlines();
+    const entry = try self.createSessionWithConsoleCapture(id, false);
     errdefer {
         const removed = self.sessions.fetchRemove(id).?;
         self.destroySession(removed.value);
@@ -411,4 +419,46 @@ test "MCP.Server - Integration: synchronous smoke test" {
     try router.processRequests(server, &in_reader, null);
 
     try testing.expectJson(.{ .jsonrpc = "2.0", .id = 1, .result = .{ .protocolVersion = "2024-11-05" } }, out_alloc.writer.buffered());
+}
+
+test "MCP.Server - WebDriver initialization leaves a disabled watchdog thread-free" {
+    var app: App = undefined;
+    app.watchdog = .init(null);
+    defer app.watchdog.deinit();
+
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+    const server = try Self.initWebDriver(testing.allocator, &app, &out.writer);
+    defer server.deinit();
+
+    try testing.expect(app.watchdog.thread == null);
+}
+
+test "MCP.Server - MCP sessions keep console capture" {
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+    const server = try Self.init(testing.allocator, testing.test_app, &out.writer);
+    defer server.deinit();
+    server.enableIsolateParking();
+
+    try testing.expect(server.defaultSession().session._console_capture);
+    const named = try server.createSession("named");
+    try testing.expect(named.session._console_capture);
+}
+
+test "MCP.Server - WebDriver skips unused console capture" {
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+    const server = try Self.initWebDriver(testing.allocator, testing.test_app, &out.writer);
+    defer server.deinit();
+    server.enableIsolateParking();
+
+    const session = try server.createWebDriverSession(
+        "11111111-1111-4111-8111-111111111111",
+        .load,
+        300_000,
+        30_000,
+        0,
+    );
+    try testing.expect(!session.session._console_capture);
 }

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -5,7 +5,9 @@ const std = @import("std");
 const builtin = @import("builtin");
 const lp = @import("lightpanda");
 
+const cdp_id = @import("../cdp/id.zig");
 const Server = @import("Server.zig");
+const protocol = @import("protocol.zig");
 
 const Allocator = std.mem.Allocator;
 const JsonObject = std.json.ObjectMap;
@@ -49,6 +51,11 @@ const Command = enum {
     delete_session,
     navigate,
     current_url,
+    get_title,
+    get_page_source,
+    get_window_handle,
+    get_window_handles,
+    close_window,
     get_timeouts,
     set_timeouts,
 };
@@ -94,12 +101,20 @@ pub fn handle(
         return sendValue(out, @as(?u8, null));
     }
 
+    // Closing the last WebDriver window destroys its session. Do this before
+    // entering its isolate, so the normal isolate defer cannot outlive it.
+    if (command == .close_window) return closeWindow(server, session_id, session, out);
+
     server.enterIsolate(session);
     defer server.exitIsolate(session);
 
     return switch (command) {
         .navigate => navigate(server, session, arena, body, out),
         .current_url => currentUrl(session, out),
+        .get_title => getTitle(session, out),
+        .get_page_source => getPageSource(session, out),
+        .get_window_handle => getWindowHandle(session, out),
+        .get_window_handles => getWindowHandles(session, out),
         .get_timeouts => getTimeouts(server, out),
         .set_timeouts => setTimeouts(server, arena, body, out),
         else => unreachable,
@@ -561,10 +576,73 @@ fn navigate(
 }
 
 fn currentUrl(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
-    const frame = session.session.currentFrame() orelse
+    const frame = primaryFrame(session) orelse
         return sendError(out, .not_found, "no such window", "Current browsing context has no document");
     return sendValue(out, frame.url);
 }
+
+fn getTitle(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    const title = frame.getTitle() catch |err|
+        return sendError(out, .internal_server_error, "unknown error", @errorName(err));
+    return sendValue(out, title orelse "");
+}
+
+fn getPageSource(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    return sendValue(out, PageSource{ .frame = frame });
+}
+
+fn getWindowHandle(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const page = session.session.primaryPage() orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    return sendValue(out, cdp_id.toFrameId(page.frame_id));
+}
+
+fn getWindowHandles(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const page = session.session.primaryPage() orelse return sendValue(out, [_][]const u8{});
+    const window_handle = cdp_id.toFrameId(page.frame_id);
+    return sendValue(out, [_][]const u8{&window_handle});
+}
+
+fn closeWindow(server: *Server, session_id: []const u8, session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const has_window = blk: {
+        server.enterIsolate(session);
+        defer server.exitIsolate(session);
+        break :blk session.session.primaryPage() != null;
+    };
+    if (!has_window) {
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    }
+    _ = server.closeWebDriverSession(session_id);
+    return sendValue(out, [_][]const u8{});
+}
+
+fn primaryFrame(session: *Server.Session) ?*lp.Frame {
+    const page = session.session.primaryPage() orelse return null;
+    return session.session.findFrameByFrameId(page.frame_id);
+}
+
+const PageSource = struct {
+    frame: *lp.Frame,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.beginWriteRaw();
+        try jw.writer.writeByte('"');
+        var escaped = protocol.JsonEscapingWriter.init(jw.writer);
+        // WebDriver serializes the document element first, not the Document
+        // node, so a doctype is neither preserved nor synthesized here.
+        const node = if (self.frame.document.getDocumentElement()) |document_element|
+            document_element.asNode()
+        else
+            self.frame.document.asNode();
+        lp.dump.deep(node, .{ .shadow = .skip }, &escaped.writer, self.frame) catch return error.WriteFailed;
+        try jw.writer.writeByte('"');
+        jw.endWriteRaw();
+    }
+};
 
 fn getTimeouts(server: *const Server, out: *std.Io.Writer) !std.http.Status {
     return sendValue(out, .{
@@ -619,6 +697,23 @@ fn matchRoute(path: []const u8) ?Route {
         .alternate = .navigate,
         .session_id = session_id,
     };
+    if (std.mem.eql(u8, suffix, "/title")) return .{
+        .command = .get_title,
+        .session_id = session_id,
+    };
+    if (std.mem.eql(u8, suffix, "/source")) return .{
+        .command = .get_page_source,
+        .session_id = session_id,
+    };
+    if (std.mem.eql(u8, suffix, "/window")) return .{
+        .command = .get_window_handle,
+        .alternate = .close_window,
+        .session_id = session_id,
+    };
+    if (std.mem.eql(u8, suffix, "/window/handles")) return .{
+        .command = .get_window_handles,
+        .session_id = session_id,
+    };
     if (std.mem.eql(u8, suffix, "/timeouts")) return .{
         .command = .get_timeouts,
         .alternate = .set_timeouts,
@@ -637,9 +732,9 @@ fn commandForMethod(route: Route, method: std.http.Method) ?Command {
 
 fn commandMethod(command: Command) std.http.Method {
     return switch (command) {
-        .status, .current_url, .get_timeouts => .GET,
+        .status, .current_url, .get_title, .get_page_source, .get_window_handle, .get_window_handles, .get_timeouts => .GET,
         .new_session, .navigate, .set_timeouts => .POST,
-        .delete_session => .DELETE,
+        .delete_session, .close_window => .DELETE,
     };
 }
 
@@ -677,6 +772,12 @@ test "WebDriver: routes use URL paths and distinguish methods" {
     const timeouts_route = matchRoute("/session/id/timeouts").?;
     try std.testing.expectEqual(Command.get_timeouts, commandForMethod(timeouts_route, .GET).?);
     try std.testing.expectEqual(Command.set_timeouts, commandForMethod(timeouts_route, .POST).?);
+    try std.testing.expectEqual(Command.get_title, commandForMethod(matchRoute("/session/id/title").?, .GET).?);
+    try std.testing.expectEqual(Command.get_page_source, commandForMethod(matchRoute("/session/id/source").?, .GET).?);
+    const window_route = matchRoute("/session/id/window").?;
+    try std.testing.expectEqual(Command.get_window_handle, commandForMethod(window_route, .GET).?);
+    try std.testing.expectEqual(Command.close_window, commandForMethod(window_route, .DELETE).?);
+    try std.testing.expectEqual(Command.get_window_handles, commandForMethod(matchRoute("/session/id/window/handles").?, .GET).?);
     try std.testing.expect(matchRoute("/session/id/execute/sync") == null);
     try std.testing.expect(matchRoute("/session/id/unknown") == null);
 }
@@ -772,6 +873,26 @@ test "WebDriver: protocol session validates capabilities and preserves navigatio
     const frame_id_before = active.session.primaryPage().?.frame_id;
     const navigate_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/url", .{session_id});
     defer testing.allocator.free(navigate_path);
+    const title_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/title", .{session_id});
+    defer testing.allocator.free(title_path);
+    const source_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/source", .{session_id});
+    defer testing.allocator.free(source_path);
+    const window_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/window", .{session_id});
+    defer testing.allocator.free(window_path);
+    const window_handles_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/window/handles", .{session_id});
+    defer testing.allocator.free(window_handles_path);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, window_path, "", &out.writer));
+    var initial_window = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer initial_window.deinit();
+    const initial_handle = try testing.allocator.dupe(u8, initial_window.value.object.get("value").?.string);
+    defer testing.allocator.free(initial_handle);
+    try testing.expect(!std.mem.eql(u8, initial_handle, "current"));
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, window_handles_path, "", &out.writer));
+    try testing.expectJson(.{ .value = &.{initial_handle} }, out.writer.buffered());
 
     out.clearRetainingCapacity();
     try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":20,\"pageLoad\":20}", &out.writer));
@@ -807,17 +928,49 @@ test "WebDriver: protocol session validates capabilities and preserves navigatio
     try testing.expect(std.mem.indexOf(u8, navigated_url, "expanded") == null);
 
     out.clearRetainingCapacity();
-    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<title>second</title>\"}", &out.writer));
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<!doctype html><title>escaped &quot;title&quot;</title><body><p>before</p></body>\"}", &out.writer));
     try testing.expectEqual(frame_id_before, active.session.primaryPage().?.frame_id);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, window_path, "", &out.writer));
+    try testing.expectJson(.{ .value = initial_handle }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, title_path, "", &out.writer));
+    const title_json_escape = [_]u8{ '\\', '"' };
+    try testing.expect(std.mem.indexOf(u8, out.writer.buffered(), &title_json_escape) != null);
+    try testing.expectJson(.{ .value = "escaped \"title\"" }, out.writer.buffered());
+
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun("document.body.innerHTML = '<p id=\\\"after\\\">after</p>'", null);
+    }
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, source_path, "", &out.writer));
+    var source = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer source.deinit();
+    const page_source = source.value.object.get("value").?.string;
+    try testing.expect(std.mem.startsWith(u8, page_source, "<html"));
+    try testing.expect(std.mem.indexOf(u8, page_source, "<!DOCTYPE") == null);
+    try testing.expect(std.mem.indexOf(u8, page_source, "id=\"after\"") != null);
+    try testing.expect(std.mem.indexOf(u8, page_source, "before") == null);
 
     try active.session.cookie_jar.populateFromResponse("https://example.com/", "token=secret; Path=/");
     try testing.expectEqual(@as(usize, 1), active.session.cookie_jar.cookies.items.len);
 
-    const delete_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}", .{session_id});
-    defer testing.allocator.free(delete_path);
     out.clearRetainingCapacity();
-    try testing.expectEqual(.ok, try handle(server, request_allocator, .DELETE, delete_path, "", &out.writer));
-    try testing.expectJson(.{ .value = null }, out.writer.buffered());
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .DELETE, window_path, "", &out.writer));
+    try testing.expectString("{\"value\":[]}", out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, window_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "invalid session id" } }, out.writer.buffered());
 
     out.clearRetainingCapacity();
     try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"pageLoadStrategy\":\"none\",\"timeouts\":{\"pageLoad\":0}}}}", &out.writer));

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -6,6 +6,12 @@ const builtin = @import("builtin");
 const lp = @import("lightpanda");
 
 const cdp_id = @import("../cdp/id.zig");
+const Element = @import("../browser/webapi/Element.zig");
+const DOMNode = @import("../browser/webapi/Node.zig");
+const Input = @import("../browser/webapi/element/html/Input.zig");
+const Option = @import("../browser/webapi/element/html/Option.zig");
+const Select = @import("../browser/webapi/element/html/Select.zig");
+const Selector = @import("../browser/webapi/selector/Selector.zig");
 const Server = @import("Server.zig");
 const protocol = @import("protocol.zig");
 
@@ -58,12 +64,22 @@ const Command = enum {
     close_window,
     get_timeouts,
     set_timeouts,
+    find_element,
+    find_elements,
+    find_element_from_element,
+    find_elements_from_element,
+    get_element_tag_name,
+    get_element_attribute,
+    is_element_selected,
+    is_element_enabled,
 };
 
 const Route = struct {
     command: Command,
     alternate: ?Command = null,
     session_id: ?[]const u8 = null,
+    element_id: ?[]const u8 = null,
+    attribute_name: ?[]const u8 = null,
 };
 
 pub fn handle(
@@ -117,6 +133,14 @@ pub fn handle(
         .get_window_handles => getWindowHandles(session, out),
         .get_timeouts => getTimeouts(server, out),
         .set_timeouts => setTimeouts(server, arena, body, out),
+        .find_element => findElement(server, session, arena, body, null, out),
+        .find_elements => findElements(server, session, arena, body, null, out),
+        .find_element_from_element => findElement(server, session, arena, body, route.element_id.?, out),
+        .find_elements_from_element => findElements(server, session, arena, body, route.element_id.?, out),
+        .get_element_tag_name => getElementTagName(session, route.element_id.?, out),
+        .get_element_attribute => getElementAttribute(session, arena, route.element_id.?, route.attribute_name.?, out),
+        .is_element_selected => isElementSelected(session, route.element_id.?, out),
+        .is_element_enabled => isElementEnabled(session, route.element_id.?, out),
         else => unreachable,
     };
 }
@@ -543,6 +567,429 @@ fn platformName() []const u8 {
     };
 }
 
+const element_key = "element-6066-11e4-a52e-4f735466cecf";
+
+const ElementReference = struct {
+    session_id: []const u8,
+    node_id: u32,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        var buffer: [48]u8 = undefined;
+        const id = std.fmt.bufPrint(&buffer, "{s}-{d}", .{ self.session_id, self.node_id }) catch unreachable;
+        try jw.beginObject();
+        try jw.objectField(element_key);
+        try jw.write(id);
+        try jw.endObject();
+    }
+};
+
+const Locator = struct {
+    using: []const u8,
+    value: []const u8,
+};
+
+fn parseLocator(arena: Allocator, body: []const u8, out: *std.Io.Writer) !?Locator {
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, body, .{}) catch {
+        _ = try sendError(out, .bad_request, "invalid argument", "Locator parameters must contain string using and value fields");
+        return null;
+    };
+    if (parsed != .object) {
+        _ = try sendError(out, .bad_request, "invalid argument", "Locator parameters must contain string using and value fields");
+        return null;
+    }
+    const using = parsed.object.get("using") orelse {
+        _ = try sendError(out, .bad_request, "invalid argument", "Locator parameters must contain string using and value fields");
+        return null;
+    };
+    const value = parsed.object.get("value") orelse {
+        _ = try sendError(out, .bad_request, "invalid argument", "Locator parameters must contain string using and value fields");
+        return null;
+    };
+    if (using != .string or value != .string) {
+        _ = try sendError(out, .bad_request, "invalid argument", "Locator parameters must contain string using and value fields");
+        return null;
+    }
+    return .{ .using = using.string, .value = value.string };
+}
+
+fn findElement(
+    server: *Server,
+    session: *Server.Session,
+    arena: Allocator,
+    body: []const u8,
+    parent_id: ?[]const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    const locator = (try parseLocator(arena, body, out)) orelse return .bad_request;
+    const root = (try searchRoot(session, parent_id, out)) orelse return .not_found;
+    if (!std.mem.eql(u8, locator.using, "css selector")) {
+        return sendError(out, .bad_request, "invalid argument", "Only the css selector locator strategy is supported");
+    }
+    const selectors = parseCssSelectors(arena, locator.value) catch |err|
+        return sendSelectorError(out, err);
+    var wait = ImplicitWait.init(session, server.webdriverImplicitTimeout());
+    defer wait.deinit(session);
+
+    while (true) {
+        const frame = (try activeSearchFrame(session, root, out)) orelse return .not_found;
+        const element = Selector.queryInTreeOrder(selectors, root.node, frame);
+        if (element) |found| {
+            return sendValue(out, try elementReference(session, found));
+        }
+
+        if (wait.expired(session)) {
+            _ = wait.finish(session);
+            return sendError(out, .not_found, "no such element", "Unable to locate element");
+        }
+        if (session.browser.env.terminatePending()) {
+            if (wait.finish(session)) {
+                return sendError(out, .not_found, "no such element", "Unable to locate element");
+            }
+            return sendError(out, .internal_server_error, "unknown error", "Element lookup was cancelled");
+        }
+        waitForImplicitPoll(session, root.frame_id, wait.remaining()) catch |err| {
+            if (wait.finish(session)) {
+                return sendError(out, .not_found, "no such element", "Unable to locate element");
+            }
+            return sendError(out, .internal_server_error, "unknown error", @errorName(err));
+        };
+    }
+}
+
+fn findElements(
+    server: *Server,
+    session: *Server.Session,
+    arena: Allocator,
+    body: []const u8,
+    parent_id: ?[]const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    const locator = (try parseLocator(arena, body, out)) orelse return .bad_request;
+    const root = (try searchRoot(session, parent_id, out)) orelse return .not_found;
+    if (!std.mem.eql(u8, locator.using, "css selector")) {
+        return sendError(out, .bad_request, "invalid argument", "Only the css selector locator strategy is supported");
+    }
+    const selectors = parseCssSelectors(arena, locator.value) catch |err|
+        return sendSelectorError(out, err);
+    var wait = ImplicitWait.init(session, server.webdriverImplicitTimeout());
+    defer wait.deinit(session);
+
+    while (true) {
+        const frame = (try activeSearchFrame(session, root, out)) orelse return .not_found;
+        const elements = Selector.queryAll(selectors, root.node, frame) catch
+            return sendError(out, .internal_server_error, "unknown error", "Could not query elements");
+        const references: ?[]ElementReference = blk: {
+            defer elements.deinit(frame._page);
+            if (elements._nodes.len == 0) break :blk null;
+
+            const found = try arena.alloc(ElementReference, elements._nodes.len);
+            for (elements._nodes, found) |node, *reference| {
+                reference.* = try elementReference(session, node.is(Element).?);
+            }
+            break :blk found;
+        };
+        if (references) |found| return sendValue(out, found);
+
+        if (wait.expired(session)) {
+            _ = wait.finish(session);
+            return sendValue(out, [_]ElementReference{});
+        }
+        if (session.browser.env.terminatePending()) {
+            if (wait.finish(session)) return sendValue(out, [_]ElementReference{});
+            return sendError(out, .internal_server_error, "unknown error", "Element lookup was cancelled");
+        }
+        waitForImplicitPoll(session, root.frame_id, wait.remaining()) catch |err| {
+            if (wait.finish(session)) return sendValue(out, [_]ElementReference{});
+            return sendError(out, .internal_server_error, "unknown error", @errorName(err));
+        };
+    }
+}
+
+const SearchRoot = struct {
+    node: *DOMNode,
+    document_node: *DOMNode,
+    frame_id: u32,
+    from_element: bool,
+};
+
+fn searchRoot(session: *Server.Session, parent_id: ?[]const u8, out: *std.Io.Writer) !?SearchRoot {
+    const frame = primaryFrame(session) orelse {
+        _ = try sendError(out, .not_found, "no such window", "Current browsing context has no document");
+        return null;
+    };
+    if (parent_id == null and frame.document.getDocumentElement() == null) {
+        _ = try sendError(out, .not_found, "no such element", "Current document has no document element");
+        return null;
+    }
+    const node = if (parent_id) |id|
+        ((try resolveElement(session, id, out)) orelse return null).asNode()
+    else
+        frame.document.asNode();
+    return .{
+        .node = node,
+        .document_node = frame.document.asNode(),
+        .frame_id = frame._frame_id,
+        .from_element = parent_id != null,
+    };
+}
+
+fn parseCssSelectors(arena: Allocator, value: []const u8) ![]const Selector.Selector {
+    return Selector.parseLeaky(arena, value) catch |err| return Selector.mapErrorToDOM(err);
+}
+
+fn sendSelectorError(out: *std.Io.Writer, err: anyerror) !std.http.Status {
+    return switch (err) {
+        error.SyntaxError => sendError(out, .bad_request, "invalid selector", "Invalid CSS selector"),
+        error.OutOfMemory => sendError(out, .internal_server_error, "unknown error", "Could not parse selector"),
+        else => sendError(out, .internal_server_error, "unknown error", @errorName(err)),
+    };
+}
+
+fn activeSearchFrame(
+    session: *Server.Session,
+    root: SearchRoot,
+    out: *std.Io.Writer,
+) !?*lp.Frame {
+    const frame = primaryFrame(session) orelse {
+        _ = try sendError(out, .not_found, "no such window", "Current browsing context has no document");
+        return null;
+    };
+    if (frame.document.asNode() == root.document_node) return frame;
+
+    const code = if (root.from_element) "stale element reference" else "no such element";
+    _ = try sendError(out, .not_found, code, "Element search started in an inactive document");
+    return null;
+}
+
+fn elementReference(session: *Server.Session, element: *Element) !ElementReference {
+    const node = try session.node_registry.register(element.asNode());
+    session.webdriver_elements.register(node.id);
+    return .{ .session_id = session.id, .node_id = node.id };
+}
+
+fn resolveElement(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !?*Element {
+    const node_id = parseElementId(session, id) orelse {
+        _ = try sendError(out, .not_found, "no such element", "Unknown element reference");
+        return null;
+    };
+    if (!session.webdriver_elements.isIssued(node_id)) {
+        _ = try sendError(out, .not_found, "no such element", "Unknown element reference");
+        return null;
+    }
+    const node = session.node_registry.lookup_by_id.get(node_id) orelse {
+        _ = try sendError(out, .not_found, "stale element reference", "Element belongs to an inactive document");
+        return null;
+    };
+    const element = node.dom.is(Element) orelse {
+        _ = try sendError(out, .not_found, "stale element reference", "Element reference no longer identifies an element");
+        return null;
+    };
+    const frame = primaryFrame(session) orelse {
+        _ = try sendError(out, .not_found, "no such window", "Current browsing context has no document");
+        return null;
+    };
+    const element_node = element.asNode();
+    if (!element_node.isConnected() or element_node.ownerDocument(frame) != frame.document) {
+        _ = try sendError(out, .not_found, "stale element reference", "Element is no longer attached to the DOM");
+        return null;
+    }
+    return element;
+}
+
+fn parseElementId(session: *const Server.Session, id: []const u8) ?u32 {
+    if (id.len <= session.id.len + 1 or
+        !std.mem.startsWith(u8, id, session.id) or
+        id[session.id.len] != '-')
+    {
+        return null;
+    }
+    const suffix = id[session.id.len + 1 ..];
+    if (suffix[0] == '0') return null;
+    for (suffix) |byte| {
+        if (!std.ascii.isDigit(byte)) return null;
+    }
+    return std.fmt.parseUnsigned(u32, suffix, 10) catch null;
+}
+
+const ImplicitWait = struct {
+    timer: std.Io.Timestamp,
+    timeout_ms: ?u64,
+    deadline_armed: bool,
+
+    fn init(session: *Server.Session, timeout_ms: ?u64) ImplicitWait {
+        const deadline_armed = if (timeout_ms) |timeout| timeout > 0 else false;
+        if (deadline_armed) session.browser.armExecutionDeadline(timeout_ms);
+        return .{
+            .timer = .now(lp.io, .boot),
+            .timeout_ms = timeout_ms,
+            .deadline_armed = deadline_armed,
+        };
+    }
+
+    fn deinit(self: *ImplicitWait, session: *Server.Session) void {
+        if (!self.deadline_armed) return;
+        self.deadline_armed = false;
+        if (session.browser.disarmExecutionDeadline()) {
+            _ = session.browser.env.cancelExecutionDeadlineTerminate();
+        }
+    }
+
+    fn remaining(self: *const ImplicitWait) ?u64 {
+        const timeout = self.timeout_ms orelse return null;
+        const elapsed: u64 = @intCast(self.timer.untilNow(lp.io, .boot).toMilliseconds());
+        return timeout -| elapsed;
+    }
+
+    fn expired(self: *const ImplicitWait, session: *const Server.Session) bool {
+        if (session.browser.executionDeadlineFired()) return true;
+        return if (self.remaining()) |milliseconds| milliseconds == 0 else false;
+    }
+
+    fn finish(self: *ImplicitWait, session: *Server.Session) bool {
+        const elapsed = if (self.remaining()) |milliseconds| milliseconds == 0 else false;
+        if (!self.deadline_armed) return elapsed;
+        self.deadline_armed = false;
+        const fired = session.browser.disarmExecutionDeadline();
+        if (fired) _ = session.browser.env.cancelExecutionDeadlineTerminate();
+        return fired or elapsed;
+    }
+};
+
+fn waitForImplicitPoll(session: *Server.Session, frame_id: u32, remaining_ms: ?u64) !void {
+    const poll_ms: u32 = @intCast(@min(remaining_ms orelse 200, 200));
+    if (poll_ms == 0) return;
+
+    var runner = session.session.runner(.{});
+    switch (try runner.tickForFrame(frame_id, poll_ms, .{ .until = .done })) {
+        .done => lp.io.sleep(.fromMilliseconds(@intCast(@min(poll_ms, 50))), .awake) catch {},
+        .ok => |recommended_sleep_ms| {
+            if (recommended_sleep_ms > 0) {
+                lp.io.sleep(.fromMilliseconds(@intCast(@min(recommended_sleep_ms, poll_ms))), .awake) catch {};
+            }
+        },
+    }
+}
+
+fn getElementTagName(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !std.http.Status {
+    const element = (try resolveElement(session, id, out)) orelse return .not_found;
+    return sendValue(out, element.getTagNameLower());
+}
+
+fn getElementAttribute(
+    session: *Server.Session,
+    arena: Allocator,
+    id: []const u8,
+    name: []const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    const element = (try resolveElement(session, id, out)) orelse return .not_found;
+    const decoded_name = try decodePathSegment(arena, name);
+    const html_namespace = "http://www.w3.org/1999/xhtml";
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    const is_html_document = switch (frame.document._type) {
+        .html => true,
+        else => false,
+    };
+    const is_html = is_html_document and if (element.getNamespaceURI()) |namespace|
+        std.mem.eql(u8, namespace, html_namespace)
+    else
+        false;
+    const lookup_name = if (is_html and containsAsciiUpper(decoded_name))
+        try std.ascii.allocLowerString(arena, decoded_name)
+    else
+        decoded_name;
+    const value = element.getAttributeSafe(.wrap(lookup_name)) orelse return sendValue(out, @as(?[]const u8, null));
+    return sendValue(out, if (is_html and isBooleanAttribute(decoded_name)) "true" else value);
+}
+
+fn decodePathSegment(arena: Allocator, value: []const u8) ![]const u8 {
+    if (std.mem.indexOfScalar(u8, value, '%') == null) return value;
+    const owned = try arena.dupe(u8, value);
+    return std.Uri.percentDecodeInPlace(owned);
+}
+
+fn containsAsciiUpper(value: []const u8) bool {
+    for (value) |byte| {
+        if (std.ascii.isUpper(byte)) return true;
+    }
+    return false;
+}
+
+fn isElementSelected(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !std.http.Status {
+    const element = (try resolveElement(session, id, out)) orelse return .not_found;
+    const selected = if (element.is(Input)) |input|
+        (std.mem.eql(u8, input.getType(), "checkbox") or
+            std.mem.eql(u8, input.getType(), "radio")) and input.getChecked()
+    else if (element.is(Option)) |option|
+        optionIsSelected(option)
+    else
+        false;
+    return sendValue(out, selected);
+}
+
+fn optionIsSelected(option: *Option) bool {
+    var parent = option.asNode()._parent;
+    while (parent) |node| : (parent = node._parent) {
+        const element = node.is(Element) orelse continue;
+        const select = element.is(Select) orelse continue;
+        if (select.getMultiple()) return option.getSelected();
+        return select.effectiveOption() == option;
+    }
+    return option.getSelected();
+}
+
+fn isElementEnabled(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !std.http.Status {
+    const element = (try resolveElement(session, id, out)) orelse return .not_found;
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    const is_xml = switch (frame.document._type) {
+        .xml => true,
+        else => false,
+    };
+    return sendValue(out, !is_xml and !isWebDriverDisabled(element));
+}
+
+fn isWebDriverDisabled(element: *Element) bool {
+    if (element.isDisabled()) return true;
+    if (element.getTag() != .option and element.getTag() != .optgroup) return false;
+
+    var parent = element.asNode()._parent;
+    while (parent) |node| : (parent = node._parent) {
+        const ancestor = node.is(Element) orelse continue;
+        if (ancestor.getTag() == .select) return ancestor.isDisabled();
+    }
+    return false;
+}
+
+fn isBooleanAttribute(name: []const u8) bool {
+    const attributes = [_][]const u8{
+        "allowfullscreen",                 "alpha",
+        "async",                           "autofocus",
+        "autoplay",                        "checked",
+        "compact",                         "controls",
+        "declare",                         "default",
+        "defer",                           "disabled",
+        "formnovalidate",                  "headingreset",
+        "hidden",                          "inert",
+        "ismap",                           "itemscope",
+        "loop",                            "multiple",
+        "muted",                           "nohref",
+        "nomodule",                        "noresize",
+        "noshade",                         "novalidate",
+        "nowrap",                          "open",
+        "playsinline",                     "readonly",
+        "required",                        "reversed",
+        "selected",                        "shadowrootclonable",
+        "shadowrootcustomelementregistry", "shadowrootdelegatesfocus",
+        "shadowrootserializable",
+    };
+    for (attributes) |attribute| {
+        if (std.ascii.eqlIgnoreCase(name, attribute)) return true;
+    }
+    return false;
+}
+
 fn navigate(
     server: *Server,
     session: *Server.Session,
@@ -560,7 +1007,6 @@ fn navigate(
 
     const result = lp.tools.gotoLiteral(
         session.session,
-        &session.node_registry,
         parsed.value.url,
         server.webdriverPageLoadTimeout(),
         server.webdriverPageLoadWait(),
@@ -719,7 +1165,50 @@ fn matchRoute(path: []const u8) ?Route {
         .alternate = .set_timeouts,
         .session_id = session_id,
     };
+    if (std.mem.eql(u8, suffix, "/element")) return .{
+        .command = .find_element,
+        .session_id = session_id,
+    };
+    if (std.mem.eql(u8, suffix, "/elements")) return .{
+        .command = .find_elements,
+        .session_id = session_id,
+    };
+    if (matchElementRoute(session_id, suffix)) |route| return route;
     return null;
+}
+
+fn matchElementRoute(session_id: []const u8, suffix: []const u8) ?Route {
+    const prefix = "/element/";
+    if (!std.mem.startsWith(u8, suffix, prefix)) return null;
+    const rest = suffix[prefix.len..];
+    const separator = std.mem.indexOfScalar(u8, rest, '/') orelse return null;
+    if (separator == 0) return null;
+    const element_id = rest[0..separator];
+    const command_suffix = rest[separator..];
+
+    const command: Command, const attribute_name: ?[]const u8 = if (std.mem.eql(u8, command_suffix, "/element"))
+        .{ .find_element_from_element, null }
+    else if (std.mem.eql(u8, command_suffix, "/elements"))
+        .{ .find_elements_from_element, null }
+    else if (std.mem.eql(u8, command_suffix, "/name"))
+        .{ .get_element_tag_name, null }
+    else if (std.mem.eql(u8, command_suffix, "/selected"))
+        .{ .is_element_selected, null }
+    else if (std.mem.eql(u8, command_suffix, "/enabled"))
+        .{ .is_element_enabled, null }
+    else if (std.mem.startsWith(u8, command_suffix, "/attribute/") and
+        command_suffix.len > "/attribute/".len and
+        std.mem.indexOfScalar(u8, command_suffix["/attribute/".len..], '/') == null)
+        .{ .get_element_attribute, command_suffix["/attribute/".len..] }
+    else
+        return null;
+
+    return .{
+        .command = command,
+        .session_id = session_id,
+        .element_id = element_id,
+        .attribute_name = attribute_name,
+    };
 }
 
 fn commandForMethod(route: Route, method: std.http.Method) ?Command {
@@ -732,8 +1221,26 @@ fn commandForMethod(route: Route, method: std.http.Method) ?Command {
 
 fn commandMethod(command: Command) std.http.Method {
     return switch (command) {
-        .status, .current_url, .get_title, .get_page_source, .get_window_handle, .get_window_handles, .get_timeouts => .GET,
-        .new_session, .navigate, .set_timeouts => .POST,
+        .status,
+        .current_url,
+        .get_title,
+        .get_page_source,
+        .get_window_handle,
+        .get_window_handles,
+        .get_timeouts,
+        .get_element_tag_name,
+        .get_element_attribute,
+        .is_element_selected,
+        .is_element_enabled,
+        => .GET,
+        .new_session,
+        .navigate,
+        .set_timeouts,
+        .find_element,
+        .find_elements,
+        .find_element_from_element,
+        .find_elements_from_element,
+        => .POST,
         .delete_session, .close_window => .DELETE,
     };
 }
@@ -778,6 +1285,21 @@ test "WebDriver: routes use URL paths and distinguish methods" {
     try std.testing.expectEqual(Command.get_window_handle, commandForMethod(window_route, .GET).?);
     try std.testing.expectEqual(Command.close_window, commandForMethod(window_route, .DELETE).?);
     try std.testing.expectEqual(Command.get_window_handles, commandForMethod(matchRoute("/session/id/window/handles").?, .GET).?);
+    try std.testing.expectEqual(Command.find_element, commandForMethod(matchRoute("/session/id/element").?, .POST).?);
+    try std.testing.expectEqual(Command.find_elements, commandForMethod(matchRoute("/session/id/elements").?, .POST).?);
+    const child_route = matchRoute("/session/id/element/ref/element").?;
+    try std.testing.expectEqualStrings("ref", child_route.element_id.?);
+    try std.testing.expectEqual(Command.find_element_from_element, commandForMethod(child_route, .POST).?);
+    try std.testing.expectEqual(Command.find_elements_from_element, commandForMethod(matchRoute("/session/id/element/ref/elements").?, .POST).?);
+    try std.testing.expectEqual(Command.get_element_tag_name, commandForMethod(matchRoute("/session/id/element/ref/name").?, .GET).?);
+    const attribute_route = matchRoute("/session/id/element/ref/attribute/data-kind").?;
+    try std.testing.expectEqualStrings("data-kind", attribute_route.attribute_name.?);
+    try std.testing.expectEqual(Command.get_element_attribute, commandForMethod(attribute_route, .GET).?);
+    try std.testing.expectEqual(Command.is_element_selected, commandForMethod(matchRoute("/session/id/element/ref/selected").?, .GET).?);
+    try std.testing.expectEqual(Command.is_element_enabled, commandForMethod(matchRoute("/session/id/element/ref/enabled").?, .GET).?);
+    try std.testing.expect(matchRoute("/session/id/element/ref/attribute/") == null);
+    try std.testing.expect(matchRoute("/session/id/element/ref/attribute/data/kind") == null);
+    try std.testing.expect(commandForMethod(child_route, .GET) == null);
     try std.testing.expect(matchRoute("/session/id/execute/sync") == null);
     try std.testing.expect(matchRoute("/session/id/unknown") == null);
 }
@@ -997,6 +1519,516 @@ test "WebDriver: protocol session validates capabilities and preserves navigatio
     try testing.expectError(error.WriteFailed, handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{}}}", &failure_writer));
     try testing.expect(server.webdriverReady());
     try testing.expectEqual(@as(usize, 0), server.sessions.count());
+}
+
+fn testFindWebDriverElement(
+    server: *Server,
+    request_allocator: Allocator,
+    session_id: []const u8,
+    parent_id: ?[]const u8,
+    selector: []const u8,
+    out: *std.Io.Writer.Allocating,
+) ![]u8 {
+    const testing = @import("../testing.zig");
+    const path = if (parent_id) |id|
+        try std.fmt.allocPrint(testing.allocator, "/session/{s}/element/{s}/element", .{ session_id, id })
+    else
+        try std.fmt.allocPrint(testing.allocator, "/session/{s}/element", .{session_id});
+    defer testing.allocator.free(path);
+    const body = try std.fmt.allocPrint(
+        testing.allocator,
+        "{{\"using\":\"css selector\",\"value\":\"{s}\"}}",
+        .{selector},
+    );
+    defer testing.allocator.free(body);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, path, body, &out.writer));
+    var response = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer response.deinit();
+    const reference = response.value.object.get("value").?.object.get(element_key).?.string;
+    return testing.allocator.dupe(u8, reference);
+}
+
+fn expectWebDriverElementValue(
+    server: *Server,
+    request_allocator: Allocator,
+    session_id: []const u8,
+    element_id: []const u8,
+    suffix: []const u8,
+    out: *std.Io.Writer.Allocating,
+    expected: anytype,
+) !void {
+    const testing = @import("../testing.zig");
+    const path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}{s}",
+        .{ session_id, element_id, suffix },
+    );
+    defer testing.allocator.free(path);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, path, "", &out.writer));
+    try testing.expectJson(.{ .value = expected }, out.writer.buffered());
+}
+
+test "WebDriver: element retrieval returns stable references and W3C state" {
+    const testing = @import("../testing.zig");
+
+    var placeholder: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer placeholder.deinit();
+    const server = try Server.initWebDriver(testing.allocator, testing.test_app, &placeholder.writer);
+    defer server.deinit();
+    server.enableIsolateParking();
+
+    var request_arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer request_arena.deinit();
+    const request_allocator = request_arena.allocator();
+
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+
+    try testing.expectEqual(
+        .ok,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            "/session",
+            "{\"capabilities\":{\"alwaysMatch\":{\"browserName\":\"lightpanda\"}}}",
+            &out.writer,
+        ),
+    );
+    var created = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    const session_id = try testing.allocator.dupe(
+        u8,
+        created.value.object.get("value").?.object.get("sessionId").?.string,
+    );
+    created.deinit();
+    defer testing.allocator.free(session_id);
+
+    const navigate_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/url", .{session_id});
+    defer testing.allocator.free(navigate_path);
+    const timeouts_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/timeouts", .{session_id});
+    defer testing.allocator.free(timeouts_path);
+    const delete_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}", .{session_id});
+    defer testing.allocator.free(delete_path);
+
+    const page_url =
+        "data:text/html," ++
+        "<div id='parent' data-kind='group' data:kind='colon'>" ++
+        "<span class='item'></span><span class='item' id='hidden' hidden></span></div>" ++
+        "<main id='ancestor'><section id='scope'><span class='target'></span></section></main>" ++
+        "<i id='duplicate'></i><b id='duplicate'></b>" ++
+        "<input id='checked' type='checkbox' checked disabled>" ++
+        "<input id='unchecked' type='checkbox' alpha>" ++
+        "<select><option id='selected' selected>one</option></select>" ++
+        "<select><option id='implicit_selected'>implicit</option></select>" ++
+        "<select disabled><optgroup id='disabled_group'><option id='disabled_option'>blocked</option></optgroup></select>" ++
+        "<fieldset disabled><legend><input id='legend_input'></legend>" ++
+        "<input id='fieldset_input'></fieldset>" ++
+        "<fieldset disabled><fieldset disabled><legend><input id='nested_legend_input'></legend></fieldset></fieldset>" ++
+        "<p id='remove'>remove</p><p id='adopt'>adopt</p>";
+    const navigate_body = try std.fmt.allocPrint(testing.allocator, "{{\"url\":\"{s}\"}}", .{page_url});
+    defer testing.allocator.free(navigate_body);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, navigate_body, &out.writer));
+
+    const parent_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#parent", &out);
+    defer testing.allocator.free(parent_id);
+    const parent_again = try testFindWebDriverElement(server, request_allocator, session_id, null, "#parent", &out);
+    defer testing.allocator.free(parent_again);
+    try std.testing.expectEqualStrings(parent_id, parent_again);
+    const selector_list_id = try testFindWebDriverElement(server, request_allocator, session_id, null, ".item, #parent", &out);
+    defer testing.allocator.free(selector_list_id);
+    try std.testing.expectEqualStrings(parent_id, selector_list_id);
+    const root_id = try testFindWebDriverElement(server, request_allocator, session_id, null, ":root", &out);
+    defer testing.allocator.free(root_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, root_id, "/name", &out, "html");
+
+    const child_id = try testFindWebDriverElement(server, request_allocator, session_id, parent_id, ".item", &out);
+    defer testing.allocator.free(child_id);
+    const scope_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#scope", &out);
+    defer testing.allocator.free(scope_id);
+    const target_id = try testFindWebDriverElement(server, request_allocator, session_id, scope_id, "#ancestor .target", &out);
+    defer testing.allocator.free(target_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, parent_id, "/name", &out, "div");
+    try expectWebDriverElementValue(server, request_allocator, session_id, parent_id, "/attribute/data-kind", &out, "group");
+    try expectWebDriverElementValue(server, request_allocator, session_id, parent_id, "/attribute/data%3Akind", &out, "colon");
+    try expectWebDriverElementValue(
+        server,
+        request_allocator,
+        session_id,
+        parent_id,
+        "/attribute/missing",
+        &out,
+        @as(?[]const u8, null),
+    );
+
+    const child_elements_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}/elements",
+        .{ session_id, parent_id },
+    );
+    defer testing.allocator.free(child_elements_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            child_elements_path,
+            "{\"using\":\"css selector\",\"value\":\".item\"}",
+            &out.writer,
+        ),
+    );
+    var children = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer children.deinit();
+    const child_values = children.value.object.get("value").?.array.items;
+    try testing.expectEqual(@as(usize, 2), child_values.len);
+    try std.testing.expectEqualStrings(
+        child_id,
+        child_values[0].object.get(element_key).?.string,
+    );
+
+    const all_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/elements", .{session_id});
+    defer testing.allocator.free(all_path);
+    const find_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/element", .{session_id});
+    defer testing.allocator.free(find_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":\"css selector\",\"value\":\".missing\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = &.{} }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":\"css selector\",\"value\":\".item, #parent\"}",
+            &out.writer,
+        ),
+    );
+    var ordered = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer ordered.deinit();
+    const ordered_values = ordered.value.object.get("value").?.array.items;
+    try testing.expectEqual(@as(usize, 3), ordered_values.len);
+    try std.testing.expectEqualStrings(parent_id, ordered_values[0].object.get(element_key).?.string);
+    try std.testing.expectEqualStrings(child_id, ordered_values[1].object.get(element_key).?.string);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":\"css selector\",\"value\":\"#duplicate\"}",
+            &out.writer,
+        ),
+    );
+    var duplicates = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer duplicates.deinit();
+    try testing.expectEqual(@as(usize, 2), duplicates.value.object.get("value").?.array.items.len);
+
+    const hidden_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#hidden", &out);
+    defer testing.allocator.free(hidden_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, hidden_id, "/attribute/hidden", &out, "true");
+    try expectWebDriverElementValue(server, request_allocator, session_id, hidden_id, "/attribute/HIDDEN", &out, "true");
+
+    const checked_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#checked", &out);
+    defer testing.allocator.free(checked_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, checked_id, "/selected", &out, true);
+    try expectWebDriverElementValue(server, request_allocator, session_id, checked_id, "/enabled", &out, false);
+
+    const unchecked_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#unchecked", &out);
+    defer testing.allocator.free(unchecked_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, unchecked_id, "/selected", &out, false);
+    try expectWebDriverElementValue(server, request_allocator, session_id, unchecked_id, "/attribute/alpha", &out, "true");
+
+    const selected_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#selected", &out);
+    defer testing.allocator.free(selected_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, selected_id, "/selected", &out, true);
+
+    const implicit_selected_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#implicit_selected", &out);
+    defer testing.allocator.free(implicit_selected_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, implicit_selected_id, "/selected", &out, true);
+
+    const disabled_group_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#disabled_group", &out);
+    defer testing.allocator.free(disabled_group_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, disabled_group_id, "/enabled", &out, false);
+
+    const disabled_option_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#disabled_option", &out);
+    defer testing.allocator.free(disabled_option_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, disabled_option_id, "/enabled", &out, false);
+
+    const legend_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#legend_input", &out);
+    defer testing.allocator.free(legend_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, legend_id, "/enabled", &out, true);
+
+    const fieldset_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#fieldset_input", &out);
+    defer testing.allocator.free(fieldset_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, fieldset_id, "/enabled", &out, false);
+
+    const nested_legend_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#nested_legend_input", &out);
+    defer testing.allocator.free(nested_legend_id);
+    try expectWebDriverElementValue(server, request_allocator, session_id, nested_legend_id, "/enabled", &out, false);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .bad_request,
+        try handle(server, request_allocator, .POST, all_path, "{\"using\":\"css selector\"}", &out.writer),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "invalid argument" } }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .bad_request,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":[99,115,115,32,115,101,108,101,99,116,111,114],\"value\":\"div\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "invalid argument" } }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .bad_request,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":\"tag name\",\"value\":\"div\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "invalid argument" } }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .bad_request,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            all_path,
+            "{\"using\":\"css selector\",\"value\":\"#bad[\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "invalid selector" } }, out.writer.buffered());
+
+    const active = server.getWebDriverSession(session_id).?;
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun(
+            "setTimeout(() => { const el = document.createElement('p'); el.id = 'later'; document.body.append(el); }, 25)",
+            null,
+        );
+    }
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"implicit\":250}", &out.writer));
+    const later_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#later", &out);
+    defer testing.allocator.free(later_id);
+
+    const remove_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#remove", &out);
+    defer testing.allocator.free(remove_id);
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun("document.querySelector('#remove').remove()", null);
+    }
+    const removed_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}/name",
+        .{ session_id, remove_id },
+    );
+    defer testing.allocator.free(removed_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, removed_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "stale element reference" } }, out.writer.buffered());
+
+    const unknown_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}-4294967295/name",
+        .{ session_id, session_id },
+    );
+    defer testing.allocator.free(unknown_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, unknown_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such element" } }, out.writer.buffered());
+
+    const unknown_child_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}-4294967295/element",
+        .{ session_id, session_id },
+    );
+    defer testing.allocator.free(unknown_child_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .not_found,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            unknown_child_path,
+            "{\"using\":\"css selector\",\"value\":\"#bad[\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such element" } }, out.writer.buffered());
+
+    const noncanonical_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}-0{s}/name",
+        .{ session_id, session_id, parent_id[session_id.len + 1 ..] },
+    );
+    defer testing.allocator.free(noncanonical_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, noncanonical_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such element" } }, out.writer.buffered());
+
+    const adopt_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#adopt", &out);
+    defer testing.allocator.free(adopt_id);
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun(
+            "globalThis.otherDocument = document.implementation.createHTMLDocument('other'); otherDocument.body.append(document.querySelector('#adopt'))",
+            null,
+        );
+    }
+    const adopted_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}/name",
+        .{ session_id, adopt_id },
+    );
+    defer testing.allocator.free(adopted_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, adopted_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "stale element reference" } }, out.writer.buffered());
+
+    const fragment_body = try std.fmt.allocPrint(testing.allocator, "{{\"url\":\"{s}#fragment\"}}", .{page_url});
+    defer testing.allocator.free(fragment_body);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, fragment_body, &out.writer));
+    try expectWebDriverElementValue(server, request_allocator, session_id, parent_id, "/name", &out, "div");
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"pageLoad\":0}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .internal_server_error,
+        try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,aborted\"}", &out.writer),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "timeout" } }, out.writer.buffered());
+    try expectWebDriverElementValue(server, request_allocator, session_id, parent_id, "/name", &out, "div");
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"implicit\":0}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<p>next</p>\"}", &out.writer),
+    );
+    const stale_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}/name",
+        .{ session_id, parent_id },
+    );
+    defer testing.allocator.free(stale_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, stale_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "stale element reference" } }, out.writer.buffered());
+
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun(
+            "setTimeout(() => { location.href = \"data:text/html,<p id='late_navigation_target'>new</p>\"; }, 1)",
+            null,
+        );
+    }
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"implicit\":100}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .not_found,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            find_path,
+            "{\"using\":\"css selector\",\"value\":\"#late_navigation_target\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such element" } }, out.writer.buffered());
+
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        _ = try scope.local.compileAndRun("setTimeout(() => { while (true) {} }, 1)", null);
+    }
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"implicit\":50}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .not_found,
+        try handle(
+            server,
+            request_allocator,
+            .POST,
+            find_path,
+            "{\"using\":\"css selector\",\"value\":\"#never\"}",
+            &out.writer,
+        ),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such element" } }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .DELETE, delete_path, "", &out.writer));
 }
 
 test "WebDriver: capabilities support version constraints and valid prompt handlers" {

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -1,0 +1,872 @@
+//! Minimal W3C WebDriver remote-end command router. The HTTP transport owns
+//! framing; this module owns command routing and JSON response semantics.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const lp = @import("lightpanda");
+
+const Server = @import("Server.zig");
+
+const Allocator = std.mem.Allocator;
+const JsonObject = std.json.ObjectMap;
+
+const Timeouts = struct {
+    script: ?u64 = 30_000,
+    page_load: ?u64 = 300_000,
+    implicit: ?u64 = 0,
+};
+
+const PageLoadStrategy = enum {
+    none,
+    eager,
+    normal,
+
+    fn waitUntil(self: PageLoadStrategy) ?lp.Config.WaitUntil {
+        return switch (self) {
+            .none => null,
+            .eager => .domcontentloaded,
+            .normal => .load,
+        };
+    }
+};
+
+const EffectiveCapabilities = struct {
+    page_load_strategy: PageLoadStrategy = .normal,
+    timeouts: Timeouts = .{},
+    proxy_direct: bool = false,
+    strict_file_interactability: bool = false,
+    unhandled_prompt_behavior: []const u8 = "dismiss and notify",
+};
+
+const CapabilityValidationError = struct {
+    name: []const u8,
+    unknown: bool = false,
+};
+
+const Command = enum {
+    status,
+    new_session,
+    delete_session,
+    navigate,
+    current_url,
+    get_timeouts,
+    set_timeouts,
+};
+
+const Route = struct {
+    command: Command,
+    alternate: ?Command = null,
+    session_id: ?[]const u8 = null,
+};
+
+pub fn handle(
+    server: *Server,
+    arena: Allocator,
+    method: std.http.Method,
+    target: []const u8,
+    body: []const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    const route = matchRoute(requestPath(target)) orelse
+        return sendError(out, .not_found, "unknown command", "Unknown command");
+    const command = commandForMethod(route, method) orelse {
+        return sendError(out, .method_not_allowed, "unknown method", "Method is not allowed for this command");
+    };
+
+    switch (command) {
+        .status => return sendValue(out, .{
+            .ready = server.webdriverReady(),
+            .message = if (server.webdriverReady())
+                "Lightpanda WebDriver endpoint is ready"
+            else
+                "A WebDriver session is active",
+        }),
+        .new_session => return newSession(server, arena, body, out),
+        else => {},
+    }
+
+    const session_id = route.session_id.?;
+    const session = server.getWebDriverSession(session_id) orelse
+        return sendError(out, .not_found, "invalid session id", "No active session with this id");
+
+    if (command == .delete_session) {
+        _ = server.closeWebDriverSession(session_id);
+        return sendValue(out, @as(?u8, null));
+    }
+
+    server.enterIsolate(session);
+    defer server.exitIsolate(session);
+
+    return switch (command) {
+        .navigate => navigate(server, session, arena, body, out),
+        .current_url => currentUrl(session, out),
+        .get_timeouts => getTimeouts(server, out),
+        .set_timeouts => setTimeouts(server, arena, body, out),
+        else => unreachable,
+    };
+}
+
+fn newSession(server: *Server, arena: Allocator, body: []const u8, out: *std.Io.Writer) !std.http.Status {
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, body, .{}) catch
+        return sendError(out, .bad_request, "invalid argument", "New Session parameters must be a JSON object");
+    defer parsed.deinit();
+    if (parsed.value != .object) {
+        return sendError(out, .bad_request, "invalid argument", "New Session parameters must be a JSON object");
+    }
+    if (!server.webdriverReady()) {
+        return sendError(out, .internal_server_error, "session not created", "The endpoint already has an active WebDriver session");
+    }
+
+    const capabilities_value = parsed.value.object.get("capabilities") orelse
+        return sendError(out, .bad_request, "invalid argument", "New Session requires a capabilities object");
+    if (capabilities_value != .object) {
+        return sendError(out, .bad_request, "invalid argument", "capabilities must be an object");
+    }
+    const capabilities = capabilities_value.object;
+
+    var always_match: ?JsonObject = null;
+    if (capabilities.get("alwaysMatch")) |value| {
+        if (value != .object) {
+            return sendError(out, .bad_request, "invalid argument", "alwaysMatch must be an object");
+        }
+        always_match = value.object;
+        if (validateCapabilities(value.object)) |err| return sendCapabilityValidationError(arena, out, err);
+    }
+
+    var matched: ?EffectiveCapabilities = null;
+    if (capabilities.get("firstMatch")) |value| {
+        if (value != .array or value.array.items.len == 0) {
+            return sendError(out, .bad_request, "invalid argument", "firstMatch must be a non-empty array");
+        }
+
+        for (value.array.items) |candidate| {
+            if (candidate != .object) {
+                return sendError(out, .bad_request, "invalid argument", "Each firstMatch entry must be an object");
+            }
+            if (validateCapabilities(candidate.object)) |err| return sendCapabilityValidationError(arena, out, err);
+            if (hasCapabilityConflict(always_match, candidate.object)) {
+                return sendError(out, .bad_request, "invalid argument", "alwaysMatch and firstMatch contain the same capability");
+            }
+        }
+
+        for (value.array.items) |candidate| {
+            if (mergeAndMatch(always_match, candidate.object)) |effective| {
+                matched = effective;
+                break;
+            }
+        }
+    } else {
+        matched = mergeAndMatch(always_match, null);
+    }
+
+    const effective = matched orelse {
+        return sendError(
+            out,
+            .internal_server_error,
+            "session not created",
+            "No firstMatch entry is supported; this endpoint supports browserName=lightpanda, direct networking, acceptInsecureCerts=false, and standard strict file and prompt capabilities",
+        );
+    };
+
+    const session_id = server.nextWebDriverSessionId(arena) catch
+        return sendError(out, .internal_server_error, "session not created", "Could not allocate a session id");
+    const session = server.createWebDriverSession(
+        session_id,
+        effective.page_load_strategy.waitUntil(),
+        effective.timeouts.page_load,
+        effective.timeouts.script,
+        effective.timeouts.implicit,
+    ) catch
+        return sendError(out, .internal_server_error, "session not created", "Could not create a browser session");
+    errdefer _ = server.closeWebDriverSession(session_id);
+
+    return sendValue(out, .{
+        .sessionId = session_id,
+        .capabilities = .{
+            .browserName = "lightpanda",
+            .browserVersion = lp.build_config.version,
+            .platformName = platformName(),
+            .acceptInsecureCerts = false,
+            .pageLoadStrategy = @tagName(effective.page_load_strategy),
+            .proxy = .{ .proxyType = "direct" },
+            .timeouts = .{
+                .script = effective.timeouts.script,
+                .pageLoad = effective.timeouts.page_load,
+                .implicit = effective.timeouts.implicit,
+            },
+            .strictFileInteractability = effective.strict_file_interactability,
+            .setWindowRect = false,
+            .userAgent = session.browser.http_client.getUserAgent(),
+            .unhandledPromptBehavior = effective.unhandled_prompt_behavior,
+        },
+    });
+}
+
+fn validateCapabilities(capabilities: JsonObject) ?CapabilityValidationError {
+    var it = capabilities.iterator();
+    while (it.next()) |entry| {
+        const name = entry.key_ptr.*;
+        const value = entry.value_ptr.*;
+        if (value == .null) continue;
+
+        const valid = if (std.mem.eql(u8, name, "browserName") or
+            std.mem.eql(u8, name, "browserVersion") or
+            std.mem.eql(u8, name, "platformName"))
+            value == .string
+        else if (std.mem.eql(u8, name, "acceptInsecureCerts") or
+            std.mem.eql(u8, name, "strictFileInteractability"))
+            value == .bool
+        else if (std.mem.eql(u8, name, "pageLoadStrategy"))
+            value == .string and isPageLoadStrategy(value.string)
+        else if (std.mem.eql(u8, name, "proxy"))
+            value == .object and validProxy(value.object)
+        else if (std.mem.eql(u8, name, "timeouts"))
+            value == .object and validTimeouts(value.object)
+        else if (std.mem.eql(u8, name, "unhandledPromptBehavior"))
+            value == .string and isPromptHandler(value.string)
+        else if (std.mem.indexOfScalar(u8, name, ':') != null)
+            true
+        else
+            return .{ .name = name, .unknown = true };
+
+        if (!valid) return .{ .name = name };
+    }
+    return null;
+}
+
+fn sendCapabilityValidationError(
+    arena: Allocator,
+    out: *std.Io.Writer,
+    err: CapabilityValidationError,
+) !std.http.Status {
+    const message = (if (err.unknown)
+        std.fmt.allocPrint(arena, "Unknown capability: {s}", .{err.name})
+    else
+        std.fmt.allocPrint(arena, "Invalid value for capability: {s}", .{err.name})) catch
+        return sendError(out, .internal_server_error, "unknown error", "Could not validate capabilities");
+    return sendError(out, .bad_request, "invalid argument", message);
+}
+
+fn hasCapabilityConflict(always_match: ?JsonObject, first_match: JsonObject) bool {
+    const always = always_match orelse return false;
+    var it = first_match.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.* == .null) continue;
+        const primary = always.get(entry.key_ptr.*) orelse continue;
+        if (primary != .null) return true;
+    }
+    return false;
+}
+
+fn mergeAndMatch(always_match: ?JsonObject, first_match: ?JsonObject) ?EffectiveCapabilities {
+    var effective: EffectiveCapabilities = .{};
+    if (!capabilityObjectMatches(&effective, always_match)) return null;
+    if (!capabilityObjectMatches(&effective, first_match)) return null;
+    return effective;
+}
+
+fn capabilityObjectMatches(effective: *EffectiveCapabilities, capabilities: ?JsonObject) bool {
+    const object = capabilities orelse return true;
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        const name = entry.key_ptr.*;
+        const value = entry.value_ptr.*;
+        if (value == .null) continue;
+
+        if (std.mem.eql(u8, name, "browserName")) {
+            if (!std.mem.eql(u8, value.string, "lightpanda")) return false;
+        } else if (std.mem.eql(u8, name, "browserVersion")) {
+            if (!browserVersionMatches(value.string, lp.build_config.version)) return false;
+        } else if (std.mem.eql(u8, name, "platformName")) {
+            if (!std.mem.eql(u8, value.string, platformName())) return false;
+        } else if (std.mem.eql(u8, name, "acceptInsecureCerts") or
+            std.mem.eql(u8, name, "strictFileInteractability"))
+        {
+            if (std.mem.eql(u8, name, "acceptInsecureCerts") and value.bool) return false;
+            if (std.mem.eql(u8, name, "strictFileInteractability")) {
+                effective.strict_file_interactability = value.bool;
+            }
+        } else if (std.mem.eql(u8, name, "pageLoadStrategy")) {
+            effective.page_load_strategy = std.meta.stringToEnum(PageLoadStrategy, value.string) orelse return false;
+        } else if (std.mem.eql(u8, name, "timeouts")) {
+            effective.timeouts = deserializeTimeouts(value.object) orelse return false;
+        } else if (std.mem.eql(u8, name, "proxy")) {
+            if (value.object.count() != 1 or
+                !std.mem.eql(u8, value.object.get("proxyType").?.string, "direct"))
+            {
+                return false;
+            }
+            effective.proxy_direct = true;
+        } else if (std.mem.eql(u8, name, "unhandledPromptBehavior")) {
+            if (!isPromptHandler(value.string)) return false;
+            effective.unhandled_prompt_behavior = value.string;
+        } else {
+            // Extension capabilities are valid inputs but only match when this
+            // implementation knows how to honor them.
+            return false;
+        }
+    }
+    return true;
+}
+
+fn browserVersionMatches(requested: []const u8, actual: []const u8) bool {
+    var constraints = std.mem.tokenizeAny(u8, requested, " \t\r\n");
+    var found = false;
+    while (constraints.next()) |constraint| {
+        found = true;
+        const comparison = versionComparison(constraint, actual) orelse return false;
+        if (!comparison) return false;
+    }
+    return found;
+}
+
+fn versionComparison(constraint: []const u8, actual: []const u8) ?bool {
+    const Operator = enum { equal, less, less_equal, greater, greater_equal };
+    const operator: Operator, const expected = if (std.mem.startsWith(u8, constraint, ">="))
+        .{ .greater_equal, constraint[2..] }
+    else if (std.mem.startsWith(u8, constraint, "<="))
+        .{ .less_equal, constraint[2..] }
+    else if (std.mem.startsWith(u8, constraint, ">"))
+        .{ .greater, constraint[1..] }
+    else if (std.mem.startsWith(u8, constraint, "<"))
+        .{ .less, constraint[1..] }
+    else
+        .{ .equal, constraint };
+    if (expected.len == 0) return null;
+
+    const ordering = compareVersion(actual, expected) orelse return null;
+    return switch (operator) {
+        .equal => ordering == .eq,
+        .less => ordering == .lt,
+        .less_equal => ordering != .gt,
+        .greater => ordering == .gt,
+        .greater_equal => ordering != .lt,
+    };
+}
+
+fn compareVersion(actual: []const u8, expected: []const u8) ?std.math.Order {
+    const actual_parts = splitVersion(actual) orelse return null;
+    const expected_parts = splitVersion(expected) orelse return null;
+    var actual_segments = std.mem.splitScalar(u8, actual_parts.numeric, '.');
+    var expected_segments = std.mem.splitScalar(u8, expected_parts.numeric, '.');
+    while (true) {
+        const actual_segment = actual_segments.next();
+        const expected_segment = expected_segments.next();
+        if (actual_segment == null and expected_segment == null) break;
+        const lhs = if (actual_segment) |segment| parseVersionSegment(segment) orelse return null else 0;
+        const rhs = if (expected_segment) |segment| parseVersionSegment(segment) orelse return null else 0;
+        const ordering = std.math.order(lhs, rhs);
+        if (ordering != .eq) return ordering;
+    }
+
+    if (actual_parts.pre) |actual_pre| {
+        const expected_pre = expected_parts.pre orelse return .lt;
+        return std.mem.order(u8, actual_pre, expected_pre);
+    }
+    return if (expected_parts.pre == null) .eq else .gt;
+}
+
+fn splitVersion(value: []const u8) ?struct { numeric: []const u8, pre: ?[]const u8 } {
+    const build_start = std.mem.indexOfScalar(u8, value, '+') orelse value.len;
+    const release = value[0..build_start];
+    const pre_start = std.mem.indexOfScalar(u8, release, '-');
+    const numeric = release[0..(pre_start orelse release.len)];
+    if (numeric.len == 0) return null;
+    const pre = if (pre_start) |start| release[start + 1 ..] else null;
+    if (pre) |identifier| if (identifier.len == 0) return null;
+    return .{ .numeric = numeric, .pre = pre };
+}
+
+fn parseVersionSegment(segment: []const u8) ?u64 {
+    if (segment.len == 0) return null;
+    return std.fmt.parseUnsigned(u64, segment, 10) catch null;
+}
+
+fn isPageLoadStrategy(value: []const u8) bool {
+    return std.mem.eql(u8, value, "none") or
+        std.mem.eql(u8, value, "eager") or
+        std.mem.eql(u8, value, "normal");
+}
+
+fn validTimeouts(timeouts: JsonObject) bool {
+    var it = timeouts.iterator();
+    while (it.next()) |entry| {
+        const name = entry.key_ptr.*;
+        if (!std.mem.eql(u8, name, "script") and
+            !std.mem.eql(u8, name, "pageLoad") and
+            !std.mem.eql(u8, name, "implicit"))
+        {
+            continue;
+        }
+        if (entry.value_ptr.* != .null and unsignedSafeInteger(entry.value_ptr.*) == null) return false;
+    }
+    return true;
+}
+
+fn deserializeTimeouts(timeouts: JsonObject) ?Timeouts {
+    var result: Timeouts = .{};
+    var it = timeouts.iterator();
+    while (it.next()) |entry| {
+        const target = if (std.mem.eql(u8, entry.key_ptr.*, "script"))
+            &result.script
+        else if (std.mem.eql(u8, entry.key_ptr.*, "pageLoad"))
+            &result.page_load
+        else if (std.mem.eql(u8, entry.key_ptr.*, "implicit"))
+            &result.implicit
+        else
+            continue;
+
+        if (entry.value_ptr.* == .null) {
+            target.* = null;
+            continue;
+        }
+        const value = unsignedSafeInteger(entry.value_ptr.*) orelse return null;
+        target.* = value;
+    }
+    return result;
+}
+
+fn unsignedSafeInteger(value: std.json.Value) ?u64 {
+    const max_safe_integer: i64 = 9_007_199_254_740_991;
+    return switch (value) {
+        .integer => |number| if (number >= 0 and number <= max_safe_integer) @intCast(number) else null,
+        .float => |number| if (std.math.isFinite(number) and
+            number >= 0 and
+            number <= @as(f64, @floatFromInt(max_safe_integer)) and
+            @floor(number) == number)
+            @intFromFloat(number)
+        else
+            null,
+        else => null,
+    };
+}
+
+fn validProxy(proxy: JsonObject) bool {
+    var proxy_type: ?[]const u8 = null;
+    var has_pac_url = false;
+    var has_socks_proxy = false;
+    var has_socks_version = false;
+
+    var it = proxy.iterator();
+    while (it.next()) |entry| {
+        const name = entry.key_ptr.*;
+        const value = entry.value_ptr.*;
+        if (std.mem.eql(u8, name, "proxyType")) {
+            if (value != .string or !isProxyType(value.string)) return false;
+            proxy_type = value.string;
+        } else if (std.mem.eql(u8, name, "proxyAutoconfigUrl") or
+            std.mem.eql(u8, name, "httpProxy") or
+            std.mem.eql(u8, name, "sslProxy") or
+            std.mem.eql(u8, name, "socksProxy"))
+        {
+            if (value != .string) return false;
+            if (std.mem.eql(u8, name, "proxyAutoconfigUrl")) {
+                if (!lp.URL.canParse(value.string, null)) return false;
+                has_pac_url = true;
+            } else if (!validProxyEndpoint(name, value.string)) {
+                return false;
+            }
+            has_socks_proxy = has_socks_proxy or std.mem.eql(u8, name, "socksProxy");
+        } else if (std.mem.eql(u8, name, "noProxy")) {
+            if (value != .array) return false;
+            for (value.array.items) |item| if (item != .string) return false;
+        } else if (std.mem.eql(u8, name, "socksVersion")) {
+            const version = unsignedSafeInteger(value) orelse return false;
+            if (version > 255) return false;
+            has_socks_version = true;
+        } else {
+            return false;
+        }
+    }
+
+    const typ = proxy_type orelse return false;
+    if (std.mem.eql(u8, typ, "pac") and !has_pac_url) return false;
+    if (has_socks_proxy and !has_socks_version) return false;
+    return true;
+}
+
+fn validProxyEndpoint(name: []const u8, endpoint: []const u8) bool {
+    // The WebDriver value is a host with an optional port, not a URL. Prefix
+    // it with the required scheme so the URL parser validates both parts.
+    if (endpoint.len == 0) return false;
+    for (endpoint) |byte| {
+        if (byte <= ' ' or byte == '/' or byte == '?' or byte == '#' or byte == '\\') return false;
+    }
+    const scheme = if (std.mem.eql(u8, name, "httpProxy"))
+        "http"
+    else if (std.mem.eql(u8, name, "sslProxy"))
+        "https"
+    else
+        "socks5";
+    var buffer: [4096]u8 = undefined;
+    const url = std.fmt.bufPrint(&buffer, "{s}://{s}/", .{ scheme, endpoint }) catch return false;
+    return lp.URL.canParse(url, null);
+}
+
+fn isProxyType(value: []const u8) bool {
+    return std.mem.eql(u8, value, "pac") or
+        std.mem.eql(u8, value, "direct") or
+        std.mem.eql(u8, value, "autodetect") or
+        std.mem.eql(u8, value, "system") or
+        std.mem.eql(u8, value, "manual");
+}
+
+fn isPromptHandler(value: []const u8) bool {
+    return std.mem.eql(u8, value, "dismiss") or
+        std.mem.eql(u8, value, "accept") or
+        std.mem.eql(u8, value, "dismiss and notify") or
+        std.mem.eql(u8, value, "accept and notify") or
+        std.mem.eql(u8, value, "ignore");
+}
+
+fn platformName() []const u8 {
+    return switch (builtin.os.tag) {
+        .linux => "linux",
+        .macos => "mac",
+        .windows => "windows",
+        else => @tagName(builtin.os.tag),
+    };
+}
+
+fn navigate(
+    server: *Server,
+    session: *Server.Session,
+    arena: Allocator,
+    body: []const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    const Params = struct { url: [:0]const u8 };
+    var parsed = std.json.parseFromSlice(Params, arena, body, .{ .ignore_unknown_fields = true }) catch
+        return sendError(out, .bad_request, "invalid argument", "Navigate To requires a URL string");
+    defer parsed.deinit();
+    if (!lp.URL.canParse(parsed.value.url, null)) {
+        return sendError(out, .bad_request, "invalid argument", "Navigate To requires an absolute URL");
+    }
+
+    const result = lp.tools.gotoLiteral(
+        session.session,
+        &session.node_registry,
+        parsed.value.url,
+        server.webdriverPageLoadTimeout(),
+        server.webdriverPageLoadWait(),
+    ) catch |err| {
+        const status: std.http.Status = if (err == error.InvalidParams) .bad_request else .internal_server_error;
+        const code = if (err == error.InvalidParams) "invalid argument" else "unknown error";
+        return sendError(out, status, code, @errorName(err));
+    };
+    if (result == .timeout) {
+        return sendError(out, .internal_server_error, "timeout", "Navigation exceeded the session page load timeout");
+    }
+    return sendValue(out, @as(?u8, null));
+}
+
+fn currentUrl(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const frame = session.session.currentFrame() orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    return sendValue(out, frame.url);
+}
+
+fn getTimeouts(server: *const Server, out: *std.Io.Writer) !std.http.Status {
+    return sendValue(out, .{
+        .script = server.webdriverScriptTimeout(),
+        .pageLoad = server.webdriverPageLoadTimeout(),
+        .implicit = server.webdriverImplicitTimeout(),
+    });
+}
+
+fn setTimeouts(
+    server: *Server,
+    arena: Allocator,
+    body: []const u8,
+    out: *std.Io.Writer,
+) !std.http.Status {
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, body, .{}) catch
+        return sendError(out, .bad_request, "invalid argument", "Set Timeouts parameters must be an object");
+    defer parsed.deinit();
+    if (parsed.value != .object or !validTimeouts(parsed.value.object)) {
+        return sendError(out, .bad_request, "invalid argument", "Timeout values must be null or non-negative safe integers");
+    }
+
+    // WebDriver replaces the complete timeout configuration. Omitted keys
+    // therefore return to their standard defaults; unknown keys are ignored.
+    const timeouts = deserializeTimeouts(parsed.value.object).?;
+    server.setWebDriverScriptTimeout(timeouts.script);
+    server.setWebDriverPageLoadTimeout(timeouts.page_load);
+    server.setWebDriverImplicitTimeout(timeouts.implicit);
+    return sendValue(out, @as(?u8, null));
+}
+
+fn requestPath(target: []const u8) []const u8 {
+    const end = std.mem.indexOfScalar(u8, target, '?') orelse target.len;
+    return target[0..end];
+}
+
+fn matchRoute(path: []const u8) ?Route {
+    if (std.mem.eql(u8, path, "/status")) return .{ .command = .status };
+    if (std.mem.eql(u8, path, "/session")) return .{ .command = .new_session };
+
+    const prefix = "/session/";
+    if (!std.mem.startsWith(u8, path, prefix)) return null;
+    const rest = path[prefix.len..];
+    const separator = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+    if (separator == 0) return null;
+    const session_id = rest[0..separator];
+    const suffix = rest[separator..];
+
+    if (suffix.len == 0) return .{ .command = .delete_session, .session_id = session_id };
+    if (std.mem.eql(u8, suffix, "/url")) return .{
+        .command = .current_url,
+        .alternate = .navigate,
+        .session_id = session_id,
+    };
+    if (std.mem.eql(u8, suffix, "/timeouts")) return .{
+        .command = .get_timeouts,
+        .alternate = .set_timeouts,
+        .session_id = session_id,
+    };
+    return null;
+}
+
+fn commandForMethod(route: Route, method: std.http.Method) ?Command {
+    if (method == commandMethod(route.command)) return route.command;
+    if (route.alternate) |alternate| {
+        if (method == commandMethod(alternate)) return alternate;
+    }
+    return null;
+}
+
+fn commandMethod(command: Command) std.http.Method {
+    return switch (command) {
+        .status, .current_url, .get_timeouts => .GET,
+        .new_session, .navigate, .set_timeouts => .POST,
+        .delete_session => .DELETE,
+    };
+}
+
+fn sendValue(out: *std.Io.Writer, value: anytype) !std.http.Status {
+    try std.json.Stringify.value(.{ .value = value }, .{}, out);
+    return .ok;
+}
+
+fn sendError(out: *std.Io.Writer, status: std.http.Status, code: []const u8, message: []const u8) !std.http.Status {
+    const ErrorResponse = struct {
+        value: struct {
+            @"error": []const u8,
+            message: []const u8,
+            stacktrace: []const u8,
+        },
+    };
+    try std.json.Stringify.value(ErrorResponse{
+        .value = .{
+            .@"error" = code,
+            .message = message,
+            .stacktrace = "",
+        },
+    }, .{}, out);
+    return status;
+}
+
+test "WebDriver: routes use URL paths and distinguish methods" {
+    try std.testing.expectEqualStrings("/status", requestPath("/status?detail=true"));
+    try std.testing.expectEqual(Command.status, matchRoute("/status").?.command);
+    try std.testing.expectEqual(Command.delete_session, matchRoute("/session/id").?.command);
+    const url_route = matchRoute("/session/id/url").?;
+    try std.testing.expectEqual(Command.current_url, commandForMethod(url_route, .GET).?);
+    try std.testing.expectEqual(Command.navigate, commandForMethod(url_route, .POST).?);
+    try std.testing.expect(commandForMethod(url_route, .DELETE) == null);
+    const timeouts_route = matchRoute("/session/id/timeouts").?;
+    try std.testing.expectEqual(Command.get_timeouts, commandForMethod(timeouts_route, .GET).?);
+    try std.testing.expectEqual(Command.set_timeouts, commandForMethod(timeouts_route, .POST).?);
+    try std.testing.expect(matchRoute("/session/id/execute/sync") == null);
+    try std.testing.expect(matchRoute("/session/id/unknown") == null);
+}
+
+test "WebDriver: protocol session validates capabilities and preserves navigation state" {
+    const testing = @import("../testing.zig");
+
+    var placeholder: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer placeholder.deinit();
+    const server = try Server.initWebDriver(testing.allocator, testing.test_app, &placeholder.writer);
+    defer server.deinit();
+    server.enableIsolateParking();
+
+    var request_arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer request_arena.deinit();
+    const request_allocator = request_arena.allocator();
+
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+
+    try testing.expectEqual(.bad_request, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"timeouts\":{\"implicit\":\"bad\"}}}}", &out.writer));
+    try testing.expect(server.webdriverReady());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.bad_request, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"proxy\":{\"proxyType\":\"pac\"}}}}", &out.writer));
+    try testing.expect(server.webdriverReady());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.bad_request, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"proxy\":{\"proxyType\":\"manual\",\"httpProxy\":\"proxy.example:99999\"}}}}", &out.writer));
+    try testing.expect(server.webdriverReady());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"pageLoadStrategy\":\"eager\",\"strictFileInteractability\":true,\"timeouts\":{\"script\":1234,\"pageLoad\":5678,\"implicit\":9007199254740991},\"unhandledPromptBehavior\":\"accept\"},\"firstMatch\":[{\"browserName\":\"other\"},{\"browserName\":\"lightpanda\"}]}}", &out.writer));
+    var created = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer created.deinit();
+    const created_value = created.value.object.get("value").?.object;
+    const session_id = created_value.get("sessionId").?.string;
+    try testing.expectEqual(@as(usize, 36), session_id.len);
+    try testing.expectEqual(lp.Config.WaitUntil.domcontentloaded, server.webdriverPageLoadWait().?);
+    try testing.expectEqual(@as(?u64, 5678), server.webdriverPageLoadTimeout());
+    try testing.expectEqual(@as(?u64, 1234), server.webdriverScriptTimeout());
+    const returned_capabilities = created_value.get("capabilities").?.object;
+    try std.testing.expectEqualStrings("eager", returned_capabilities.get("pageLoadStrategy").?.string);
+    try testing.expect(returned_capabilities.get("strictFileInteractability").?.bool);
+    try std.testing.expectEqualStrings("accept", returned_capabilities.get("unhandledPromptBehavior").?.string);
+    const returned_timeouts = returned_capabilities.get("timeouts").?.object;
+    try testing.expectEqual(@as(i64, 1234), returned_timeouts.get("script").?.integer);
+    try testing.expectEqual(@as(i64, 5678), returned_timeouts.get("pageLoad").?.integer);
+    try testing.expectEqual(@as(i64, 9_007_199_254_740_991), returned_timeouts.get("implicit").?.integer);
+
+    const execute_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/execute/sync", .{session_id});
+    defer testing.allocator.free(execute_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .POST, execute_path, "{\"script\":\"return 1\",\"args\":[]}", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "unknown command" } }, out.writer.buffered());
+
+    const timeouts_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/timeouts", .{session_id});
+    defer testing.allocator.free(timeouts_path);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":null,\"pageLoad\":9007199254740991,\"futureTimeout\":\"ignored\"}", &out.writer));
+    try testing.expectJson(.{ .value = null }, out.writer.buffered());
+    try testing.expectEqual(@as(?u64, null), server.webdriverScriptTimeout());
+    try testing.expectEqual(@as(?u64, 9_007_199_254_740_991), server.webdriverPageLoadTimeout());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, timeouts_path, "", &out.writer));
+    try testing.expectJson(.{
+        .value = .{
+            .script = null,
+            .pageLoad = 9_007_199_254_740_991,
+            .implicit = 0,
+        },
+    }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":20}", &out.writer));
+    try testing.expectEqual(@as(?u64, 20), server.webdriverScriptTimeout());
+    try testing.expectEqual(@as(?u64, 300_000), server.webdriverPageLoadTimeout());
+    try testing.expectEqual(@as(?u64, 0), server.webdriverImplicitTimeout());
+
+    const active = server.getWebDriverSession(session_id).?;
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+
+        const frame = active.session.currentFrame().?;
+        var scope: lp.js.Local.Scope = undefined;
+        frame.js.localScope(&scope);
+        defer scope.deinit();
+        try testing.expect((try scope.local.compileAndRun("navigator.webdriver === true", null)).isTrue());
+    }
+    const frame_id_before = active.session.primaryPage().?.frame_id;
+    const navigate_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/url", .{session_id});
+    defer testing.allocator.free(navigate_path);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":20,\"pageLoad\":20}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.internal_server_error, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<script>while(true){}</script>\"}", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "timeout" } }, out.writer.buffered());
+    try testing.expectEqual(frame_id_before, active.session.primaryPage().?.frame_id);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":20,\"pageLoad\":0}", &out.writer));
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.internal_server_error, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,timeout\"}", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "timeout" } }, out.writer.buffered());
+    try testing.expectEqual(frame_id_before, active.session.primaryPage().?.frame_id);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, timeouts_path, "{\"script\":20}", &out.writer));
+
+    _ = setenv(@constCast("LP_WEBDRIVER_LITERAL"), @constCast("expanded"), 1);
+    defer _ = unsetenv(@constCast("LP_WEBDRIVER_LITERAL"));
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<title>$LP_WEBDRIVER_LITERAL</title>\"}", &out.writer));
+    try testing.expectJson(.{ .value = null }, out.writer.buffered());
+    try testing.expectEqual(frame_id_before, active.session.primaryPage().?.frame_id);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, navigate_path, "", &out.writer));
+    var navigated = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer navigated.deinit();
+    const navigated_url = navigated.value.object.get("value").?.string;
+    try testing.expect(std.mem.indexOf(u8, navigated_url, "$LP_WEBDRIVER_LITERAL") != null);
+    try testing.expect(std.mem.indexOf(u8, navigated_url, "expanded") == null);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<title>second</title>\"}", &out.writer));
+    try testing.expectEqual(frame_id_before, active.session.primaryPage().?.frame_id);
+
+    try active.session.cookie_jar.populateFromResponse("https://example.com/", "token=secret; Path=/");
+    try testing.expectEqual(@as(usize, 1), active.session.cookie_jar.cookies.items.len);
+
+    const delete_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}", .{session_id});
+    defer testing.allocator.free(delete_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .DELETE, delete_path, "", &out.writer));
+    try testing.expectJson(.{ .value = null }, out.writer.buffered());
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{\"pageLoadStrategy\":\"none\",\"timeouts\":{\"pageLoad\":0}}}}", &out.writer));
+    var recreated = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer recreated.deinit();
+    const recreated_id = recreated.value.object.get("value").?.object.get("sessionId").?.string;
+    const recreated_session = server.getWebDriverSession(recreated_id).?;
+    try testing.expectEqual(@as(usize, 0), recreated_session.session.cookie_jar.cookies.items.len);
+    try testing.expect(server.webdriverPageLoadWait() == null);
+
+    const recreated_navigate_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/url", .{recreated_id});
+    defer testing.allocator.free(recreated_navigate_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, recreated_navigate_path, "{\"url\":\"data:text/html,none\"}", &out.writer));
+    try testing.expectJson(.{ .value = null }, out.writer.buffered());
+
+    const recreated_delete_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}", .{recreated_id});
+    defer testing.allocator.free(recreated_delete_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .DELETE, recreated_delete_path, "", &out.writer));
+
+    var failure_buffer: [1]u8 = undefined;
+    var failure_writer: std.Io.Writer = .fixed(&failure_buffer);
+    try testing.expectError(error.WriteFailed, handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{}}}", &failure_writer));
+    try testing.expect(server.webdriverReady());
+    try testing.expectEqual(@as(usize, 0), server.sessions.count());
+}
+
+test "WebDriver: capabilities support version constraints and valid prompt handlers" {
+    try std.testing.expect(browserVersionMatches(">=0.9.0 <2.0.0", "1.0.0-dev"));
+    try std.testing.expect(browserVersionMatches("1.2.0", "1.2"));
+    try std.testing.expect(!browserVersionMatches(">=1.0.0", "1.0.0-dev"));
+    try std.testing.expect(!browserVersionMatches(">=not-a-version", "1.0.0-dev"));
+
+    inline for (.{
+        "dismiss",
+        "accept",
+        "dismiss and notify",
+        "accept and notify",
+        "ignore",
+    }) |handler| try std.testing.expect(isPromptHandler(handler));
+}
+
+test "WebDriver: proxy endpoints reject invalid hosts and ports" {
+    try std.testing.expect(validProxyEndpoint("httpProxy", "proxy.example:8080"));
+    try std.testing.expect(validProxyEndpoint("sslProxy", "user:pass@proxy.example"));
+    try std.testing.expect(!validProxyEndpoint("httpProxy", "proxy.example:99999"));
+    try std.testing.expect(!validProxyEndpoint("socksProxy", "not a host"));
+}
+
+extern fn setenv(name: [*:0]u8, value: [*:0]u8, override: c_int) c_int;
+extern fn unsetenv(name: [*:0]u8) c_int;

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -68,6 +68,7 @@ const Command = enum {
     find_elements,
     find_element_from_element,
     find_elements_from_element,
+    get_active_element,
     get_element_tag_name,
     get_element_attribute,
     is_element_selected,
@@ -137,6 +138,7 @@ pub fn handle(
         .find_elements => findElements(server, session, arena, body, null, out),
         .find_element_from_element => findElement(server, session, arena, body, route.element_id.?, out),
         .find_elements_from_element => findElements(server, session, arena, body, route.element_id.?, out),
+        .get_active_element => getActiveElement(session, out),
         .get_element_tag_name => getElementTagName(session, route.element_id.?, out),
         .get_element_attribute => getElementAttribute(session, arena, route.element_id.?, route.attribute_name.?, out),
         .is_element_selected => isElementSelected(session, route.element_id.?, out),
@@ -1043,6 +1045,14 @@ fn getPageSource(session: *Server.Session, out: *std.Io.Writer) !std.http.Status
     return sendValue(out, PageSource{ .frame = frame });
 }
 
+fn getActiveElement(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    const element = frame.document.getActiveElement() orelse
+        return sendError(out, .not_found, "no such element", "Current document has no active element");
+    return sendValue(out, try elementReference(session, element));
+}
+
 fn getWindowHandle(session: *Server.Session, out: *std.Io.Writer) !std.http.Status {
     const page = session.session.primaryPage() orelse
         return sendError(out, .not_found, "no such window", "Current browsing context has no document");
@@ -1175,6 +1185,10 @@ fn matchRoute(path: []const u8) ?Route {
         .command = .find_elements,
         .session_id = session_id,
     };
+    if (std.mem.eql(u8, suffix, "/element/active")) return .{
+        .command = .get_active_element,
+        .session_id = session_id,
+    };
     if (matchElementRoute(session_id, suffix)) |route| return route;
     return null;
 }
@@ -1230,6 +1244,7 @@ fn commandMethod(command: Command) std.http.Method {
         .get_window_handle,
         .get_window_handles,
         .get_timeouts,
+        .get_active_element,
         .get_element_tag_name,
         .get_element_attribute,
         .is_element_selected,
@@ -1289,6 +1304,7 @@ test "WebDriver: routes use URL paths and distinguish methods" {
     try std.testing.expectEqual(Command.get_window_handles, commandForMethod(matchRoute("/session/id/window/handles").?, .GET).?);
     try std.testing.expectEqual(Command.find_element, commandForMethod(matchRoute("/session/id/element").?, .POST).?);
     try std.testing.expectEqual(Command.find_elements, commandForMethod(matchRoute("/session/id/elements").?, .POST).?);
+    try std.testing.expectEqual(Command.get_active_element, commandForMethod(matchRoute("/session/id/element/active").?, .GET).?);
     const child_route = matchRoute("/session/id/element/ref/element").?;
     try std.testing.expectEqualStrings("ref", child_route.element_id.?);
     try std.testing.expectEqual(Command.find_element_from_element, commandForMethod(child_route, .POST).?);
@@ -1580,6 +1596,12 @@ test "WebDriver: pageless sessions return no such window" {
     try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
     try testing.expectEqual(@as(usize, 0), session.session.pages.items.len);
 
+    const active_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/element/active", .{session_id});
+    defer testing.allocator.free(active_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, active_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+
     var unknown_element_buffer: [48]u8 = undefined;
     const unknown_element_id = try std.fmt.bufPrint(&unknown_element_buffer, "{s}-999999", .{session_id});
     const element_ids = [_][]const u8{ known_element_id, unknown_element_id, "malformed" };
@@ -1620,6 +1642,24 @@ fn testFindWebDriverElement(
 
     out.clearRetainingCapacity();
     try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, path, body, &out.writer));
+    var response = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
+    defer response.deinit();
+    const reference = response.value.object.get("value").?.object.get(element_key).?.string;
+    return testing.allocator.dupe(u8, reference);
+}
+
+fn testGetActiveWebDriverElement(
+    server: *Server,
+    request_allocator: Allocator,
+    session_id: []const u8,
+    out: *std.Io.Writer.Allocating,
+) ![]u8 {
+    const testing = @import("../testing.zig");
+    const path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/element/active", .{session_id});
+    defer testing.allocator.free(path);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.ok, try handle(server, request_allocator, .GET, path, "", &out.writer));
     var response = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.writer.buffered(), .{});
     defer response.deinit();
     const reference = response.value.object.get("value").?.object.get(element_key).?.string;
@@ -1710,6 +1750,26 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
 
     out.clearRetainingCapacity();
     try testing.expectEqual(.ok, try handle(server, request_allocator, .POST, navigate_path, navigate_body, &out.writer));
+
+    const default_active_id = try testGetActiveWebDriverElement(server, request_allocator, session_id, &out);
+    defer testing.allocator.free(default_active_id);
+    const body_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "body", &out);
+    defer testing.allocator.free(body_id);
+    try std.testing.expectEqualStrings(body_id, default_active_id);
+
+    const active = server.getWebDriverSession(session_id).?;
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = primaryFrame(active).?;
+        const input = frame.document.getElementById("unchecked", frame).?;
+        try input.focus(frame);
+    }
+    const focused_active_id = try testGetActiveWebDriverElement(server, request_allocator, session_id, &out);
+    defer testing.allocator.free(focused_active_id);
+    const unchecked_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#unchecked", &out);
+    defer testing.allocator.free(unchecked_id);
+    try std.testing.expectEqualStrings(unchecked_id, focused_active_id);
 
     const parent_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#parent", &out);
     defer testing.allocator.free(parent_id);
@@ -1832,8 +1892,6 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
     try expectWebDriverElementValue(server, request_allocator, session_id, checked_id, "/selected", &out, true);
     try expectWebDriverElementValue(server, request_allocator, session_id, checked_id, "/enabled", &out, false);
 
-    const unchecked_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#unchecked", &out);
-    defer testing.allocator.free(unchecked_id);
     try expectWebDriverElementValue(server, request_allocator, session_id, unchecked_id, "/selected", &out, false);
     try expectWebDriverElementValue(server, request_allocator, session_id, unchecked_id, "/attribute/alpha", &out, "true");
 
@@ -1914,7 +1972,6 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
     );
     try testing.expectJson(.{ .value = .{ .@"error" = "invalid selector" } }, out.writer.buffered());
 
-    const active = server.getWebDriverSession(session_id).?;
     {
         server.enterIsolate(active);
         defer server.exitIsolate(active);

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -70,6 +70,7 @@ const Command = enum {
     find_elements_from_element,
     get_active_element,
     get_element_tag_name,
+    get_element_rect,
     get_element_attribute,
     is_element_selected,
     is_element_enabled,
@@ -140,6 +141,7 @@ pub fn handle(
         .find_elements_from_element => findElements(server, session, arena, body, route.element_id.?, out),
         .get_active_element => getActiveElement(session, out),
         .get_element_tag_name => getElementTagName(session, route.element_id.?, out),
+        .get_element_rect => getElementRect(session, route.element_id.?, out),
         .get_element_attribute => getElementAttribute(session, arena, route.element_id.?, route.attribute_name.?, out),
         .is_element_selected => isElementSelected(session, route.element_id.?, out),
         .is_element_enabled => isElementEnabled(session, route.element_id.?, out),
@@ -877,6 +879,21 @@ fn getElementTagName(session: *Server.Session, id: []const u8, out: *std.Io.Writ
     return sendValue(out, element.getTagNameLower());
 }
 
+fn getElementRect(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !std.http.Status {
+    const element = (try resolveElement(session, id, out)) orelse return .not_found;
+    const frame = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
+    // Engine geometry is currently faux and scroll-stable. Return it directly;
+    // adding window scroll offsets would invent coordinates it does not model.
+    const rect = element.boundingClientRectValues(frame);
+    return sendValue(out, .{
+        .x = rect.x,
+        .y = rect.y,
+        .width = rect.width,
+        .height = rect.height,
+    });
+}
+
 fn getElementAttribute(
     session: *Server.Session,
     arena: Allocator,
@@ -1208,6 +1225,8 @@ fn matchElementRoute(session_id: []const u8, suffix: []const u8) ?Route {
         .{ .find_elements_from_element, null }
     else if (std.mem.eql(u8, command_suffix, "/name"))
         .{ .get_element_tag_name, null }
+    else if (std.mem.eql(u8, command_suffix, "/rect"))
+        .{ .get_element_rect, null }
     else if (std.mem.eql(u8, command_suffix, "/selected"))
         .{ .is_element_selected, null }
     else if (std.mem.eql(u8, command_suffix, "/enabled"))
@@ -1246,6 +1265,7 @@ fn commandMethod(command: Command) std.http.Method {
         .get_timeouts,
         .get_active_element,
         .get_element_tag_name,
+        .get_element_rect,
         .get_element_attribute,
         .is_element_selected,
         .is_element_enabled,
@@ -1310,6 +1330,9 @@ test "WebDriver: routes use URL paths and distinguish methods" {
     try std.testing.expectEqual(Command.find_element_from_element, commandForMethod(child_route, .POST).?);
     try std.testing.expectEqual(Command.find_elements_from_element, commandForMethod(matchRoute("/session/id/element/ref/elements").?, .POST).?);
     try std.testing.expectEqual(Command.get_element_tag_name, commandForMethod(matchRoute("/session/id/element/ref/name").?, .GET).?);
+    const rect_route = matchRoute("/session/id/element/ref/rect").?;
+    try std.testing.expectEqual(Command.get_element_rect, commandForMethod(rect_route, .GET).?);
+    try std.testing.expect(commandForMethod(rect_route, .POST) == null);
     const attribute_route = matchRoute("/session/id/element/ref/attribute/data-kind").?;
     try std.testing.expectEqualStrings("data-kind", attribute_route.attribute_name.?);
     try std.testing.expectEqual(Command.get_element_attribute, commandForMethod(attribute_route, .GET).?);
@@ -1605,17 +1628,20 @@ test "WebDriver: pageless sessions return no such window" {
     var unknown_element_buffer: [48]u8 = undefined;
     const unknown_element_id = try std.fmt.bufPrint(&unknown_element_buffer, "{s}-999999", .{session_id});
     const element_ids = [_][]const u8{ known_element_id, unknown_element_id, "malformed" };
+    const element_suffixes = [_][]const u8{ "enabled", "rect" };
     for (element_ids) |element_id| {
-        const enabled_path = try std.fmt.allocPrint(
-            testing.allocator,
-            "/session/{s}/element/{s}/enabled",
-            .{ session_id, element_id },
-        );
-        defer testing.allocator.free(enabled_path);
+        for (element_suffixes) |element_suffix| {
+            const element_path = try std.fmt.allocPrint(
+                testing.allocator,
+                "/session/{s}/element/{s}/{s}",
+                .{ session_id, element_id, element_suffix },
+            );
+            defer testing.allocator.free(element_path);
 
-        out.clearRetainingCapacity();
-        try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, enabled_path, "", &out.writer));
-        try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+            out.clearRetainingCapacity();
+            try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, element_path, "", &out.writer));
+            try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+        }
     }
 }
 
@@ -1776,6 +1802,43 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
     const parent_again = try testFindWebDriverElement(server, request_allocator, session_id, null, "#parent", &out);
     defer testing.allocator.free(parent_again);
     try std.testing.expectEqualStrings(parent_id, parent_again);
+    try expectWebDriverElementValue(
+        server,
+        request_allocator,
+        session_id,
+        parent_id,
+        "/rect",
+        &out,
+        .{ .x = 20.0, .y = 20.0, .width = 5.0, .height = 5.0 },
+    );
+    const unscrolled_rect = try testing.allocator.dupe(u8, out.writer.buffered());
+    defer testing.allocator.free(unscrolled_rect);
+    {
+        server.enterIsolate(active);
+        defer server.exitIsolate(active);
+        const frame = primaryFrame(active).?;
+        try frame.window.scrollTo(.{ .x = 0 }, 53, frame);
+        try testing.expectEqual(@as(u32, 53), frame.window.getScrollY());
+    }
+    try expectWebDriverElementValue(
+        server,
+        request_allocator,
+        session_id,
+        parent_id,
+        "/rect",
+        &out,
+        .{ .x = 20.0, .y = 20.0, .width = 5.0, .height = 5.0 },
+    );
+    try std.testing.expectEqualStrings(unscrolled_rect, out.writer.buffered());
+    const rect_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/session/{s}/element/{s}/rect",
+        .{ session_id, parent_id },
+    );
+    defer testing.allocator.free(rect_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(.method_not_allowed, try handle(server, request_allocator, .POST, rect_path, "", &out.writer));
+    try testing.expectJson(.{ .value = .{ .@"error" = "unknown method" } }, out.writer.buffered());
     const selector_list_id = try testFindWebDriverElement(server, request_allocator, session_id, null, ".item, #parent", &out);
     defer testing.allocator.free(selector_list_id);
     try std.testing.expectEqualStrings(parent_id, selector_list_id);
@@ -1886,6 +1949,15 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
     defer testing.allocator.free(hidden_id);
     try expectWebDriverElementValue(server, request_allocator, session_id, hidden_id, "/attribute/hidden", &out, "true");
     try expectWebDriverElementValue(server, request_allocator, session_id, hidden_id, "/attribute/HIDDEN", &out, "true");
+    try expectWebDriverElementValue(
+        server,
+        request_allocator,
+        session_id,
+        hidden_id,
+        "/rect",
+        &out,
+        .{ .x = 0.0, .y = 0.0, .width = 0.0, .height = 0.0 },
+    );
 
     const checked_id = try testFindWebDriverElement(server, request_allocator, session_id, null, "#checked", &out);
     defer testing.allocator.free(checked_id);
@@ -2002,7 +2074,7 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
     }
     const removed_path = try std.fmt.allocPrint(
         testing.allocator,
-        "/session/{s}/element/{s}/name",
+        "/session/{s}/element/{s}/rect",
         .{ session_id, remove_id },
     );
     defer testing.allocator.free(removed_path);
@@ -2012,7 +2084,7 @@ test "WebDriver: element retrieval returns stable references and W3C state" {
 
     const unknown_path = try std.fmt.allocPrint(
         testing.allocator,
-        "/session/{s}/element/{s}-4294967295/name",
+        "/session/{s}/element/{s}-4294967295/rect",
         .{ session_id, session_id },
     );
     defer testing.allocator.free(unknown_path);

--- a/src/mcp/webdriver.zig
+++ b/src/mcp/webdriver.zig
@@ -768,6 +768,10 @@ fn elementReference(session: *Server.Session, element: *Element) !ElementReferen
 }
 
 fn resolveElement(session: *Server.Session, id: []const u8, out: *std.Io.Writer) !?*Element {
+    const frame = primaryFrame(session) orelse {
+        _ = try sendError(out, .not_found, "no such window", "Current browsing context has no document");
+        return null;
+    };
     const node_id = parseElementId(session, id) orelse {
         _ = try sendError(out, .not_found, "no such element", "Unknown element reference");
         return null;
@@ -782,10 +786,6 @@ fn resolveElement(session: *Server.Session, id: []const u8, out: *std.Io.Writer)
     };
     const element = node.dom.is(Element) orelse {
         _ = try sendError(out, .not_found, "stale element reference", "Element reference no longer identifies an element");
-        return null;
-    };
-    const frame = primaryFrame(session) orelse {
-        _ = try sendError(out, .not_found, "no such window", "Current browsing context has no document");
         return null;
     };
     const element_node = element.asNode();
@@ -1001,6 +1001,8 @@ fn navigate(
     var parsed = std.json.parseFromSlice(Params, arena, body, .{ .ignore_unknown_fields = true }) catch
         return sendError(out, .bad_request, "invalid argument", "Navigate To requires a URL string");
     defer parsed.deinit();
+    _ = primaryFrame(session) orelse
+        return sendError(out, .not_found, "no such window", "Current browsing context has no document");
     if (!lp.URL.canParse(parsed.value.url, null)) {
         return sendError(out, .bad_request, "invalid argument", "Navigate To requires an absolute URL");
     }
@@ -1519,6 +1521,80 @@ test "WebDriver: protocol session validates capabilities and preserves navigatio
     try testing.expectError(error.WriteFailed, handle(server, request_allocator, .POST, "/session", "{\"capabilities\":{\"alwaysMatch\":{}}}", &failure_writer));
     try testing.expect(server.webdriverReady());
     try testing.expectEqual(@as(usize, 0), server.sessions.count());
+}
+
+test "WebDriver: pageless sessions return no such window" {
+    const testing = @import("../testing.zig");
+
+    var placeholder: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer placeholder.deinit();
+    const server = try Server.initWebDriver(testing.allocator, testing.test_app, &placeholder.writer);
+    defer server.deinit();
+    server.enableIsolateParking();
+
+    var request_arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer request_arena.deinit();
+    const request_allocator = request_arena.allocator();
+
+    var out: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer out.deinit();
+
+    const session_id = "11111111-1111-4111-8111-111111111111";
+    const session = try server.createWebDriverSession(session_id, .load, 300_000, 30_000, 0);
+    const navigate_path = try std.fmt.allocPrint(testing.allocator, "/session/{s}/url", .{session_id});
+    defer testing.allocator.free(navigate_path);
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .ok,
+        try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,<p>element</p>\"}", &out.writer),
+    );
+
+    var known_element_buffer: [48]u8 = undefined;
+    const known_element_id = blk: {
+        server.enterIsolate(session);
+        defer server.exitIsolate(session);
+
+        const page = session.session.primaryPage().?;
+        const element = primaryFrame(session).?.document.getDocumentElement().?;
+        const reference = try elementReference(session, element);
+        const id = try std.fmt.bufPrint(&known_element_buffer, "{s}-{d}", .{ reference.session_id, reference.node_id });
+        page.close();
+        try testing.expect(session.session.primaryPage() == null);
+        break :blk id;
+    };
+    try testing.expect(server.getWebDriverSession(session_id) == session);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .not_found,
+        try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"relative\"}", &out.writer),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+    try testing.expectEqual(@as(usize, 0), session.session.pages.items.len);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(
+        .not_found,
+        try handle(server, request_allocator, .POST, navigate_path, "{\"url\":\"data:text/html,should-not-open\"}", &out.writer),
+    );
+    try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+    try testing.expectEqual(@as(usize, 0), session.session.pages.items.len);
+
+    var unknown_element_buffer: [48]u8 = undefined;
+    const unknown_element_id = try std.fmt.bufPrint(&unknown_element_buffer, "{s}-999999", .{session_id});
+    const element_ids = [_][]const u8{ known_element_id, unknown_element_id, "malformed" };
+    for (element_ids) |element_id| {
+        const enabled_path = try std.fmt.allocPrint(
+            testing.allocator,
+            "/session/{s}/element/{s}/enabled",
+            .{ session_id, element_id },
+        );
+        defer testing.allocator.free(enabled_path);
+
+        out.clearRetainingCapacity();
+        try testing.expectEqual(.not_found, try handle(server, request_allocator, .GET, enabled_path, "", &out.writer));
+        try testing.expectJson(.{ .value = .{ .@"error" = "no such window" } }, out.writer.buffered());
+    }
 }
 
 fn testFindWebDriverElement(


### PR DESCRIPTION
## Summary

- add an opt-in `lightpanda serve --webdriver` W3C WebDriver HTTP endpoint
- implement status, one-session lifecycle, navigation/current URL, timeouts, title, serialized page source, current window handle(s), closing the sole window, active element, and element rectangles
- add CSS element retrieval from documents and elements, plus tag-name, rectangle, attribute, selected, and enabled state commands
- use stable W3C element references with implicit waits, document-order selector lists, duplicate-ID handling, percent-decoded attribute names, and correct unknown/stale behavior across navigation
- set the WebDriver-active flag only for WebDriver window contexts; normal renderer/CDP/MCP contexts remain false and WorkerNavigator does not expose it
- preserve the current browsing context and its opaque handle across same-document navigation while invalidating references on document replacement
- keep the endpoint loopback-only with Host/Origin validation, direct networking, bounded bodies/connections/retained buffers, socket timeouts, and shutdown cancellation

## Protocol behavior

The endpoint validates and matches standard capabilities rather than silently accepting unsupported values. It reports direct proxying and verified TLS, uses UUID session IDs, implements normal/eager/none page-load strategies, and returns W3C-shaped success and error bodies.

Element retrieval uses the standard `element-6066-11e4-a52e-4f735466cecf` key. CSS selector parsing is request-scoped, plural queries preserve document order, element-scoped queries handle ancestors outside the search root, and implicit waits remain deadline-aware even when page JavaScript does not yield. Element references survive fragment navigation and become stale after active-document replacement, detachment, or adoption into an inactive document. Get Active Element returns the active document element reference, while Get Element Rect returns the engine's current scroll-stable geometry without inventing unsupported viewport offsets.

Get Page Source streams JSON-escaped serialization of the current document element, including live DOM mutations. Closing the only top-level context returns an empty handles list, destroys the session, and makes later commands return `invalid session id`.

## Resource behavior

The browser session and WebDriver deadline thread are created lazily, so `GET /status` with `--watchdog-ms=0` does not allocate an unused V8 isolate or checker thread. The first New Session command starts deadline enforcement before the browser registers with it. WebDriver sessions also skip MCP-only console capture, while default and named MCP sessions retain it.

An identical macOS arm64 debug-binary comparison reduced the idle endpoint from 15 to 14 threads and removed 16.3 MiB of virtual stack reservation with unchanged RSS; session-time thread count was unchanged. A five-run 100,000-entry console benchmark fell from 126.8 ms to 69.1 ms median.

The isolated ReleaseSmall low-resource build measured a 66,808,552-byte arm64 binary, 0.03 s median CPU, 22.50 MiB median maximum RSS, and 22.53 MiB peak maximum RSS on the static local fixture.

## Verification

- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`
- current Debug build with the pinned prebuilt V8 archive
- focused WebDriver suite: 6/6 passed with leak detection
- full debug suite: 1,136/1,136 passed with leak detection
- live HTTP smoke for status, session lifecycle, navigation, CSS lookup, selector-list order, duplicate IDs, encoded attribute names, selected state, active element, element rectangles, same-document reference preservation, cross-document staleness, and clean session deletion
- live before/after thread, virtual-memory, RSS, and console-load measurements

## Deliberate initial limits

This remains an incremental Selenium-compatibility slice. It currently supports one top-level browsing context and the CSS selector locator strategy. Geometry is the engine's faux layout model rather than compositor-backed pixels, so Element Click, screenshots, and printing are intentionally not exposed as if fully rendered. Other locator strategies, multi-window creation/switching, script execution, actions, cookies, prompt commands, screenshots, and printing are not implemented yet and return standard errors.
