### PR TITLE
feat(render): add bounded DOM preview server

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -355,6 +355,22 @@ const Commands = cli.Builder(.{
         .shared_options = CommonOptions,
     },
     .{
+        .name = "render",
+        .options = .{
+            .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .type = u16, .default = 9223 },
+            .{ .name = "auth_token", .type = ?[]const u8 },
+            .{ .name = "cors_origin", .type = ?[]const u8 },
+            .{ .name = "max_connections", .type = ?u16 },
+            .{ .name = "max_request_size", .type = ?usize },
+            .{ .name = "max_response_size", .type = ?usize },
+            .{ .name = "max_wait_ms", .type = ?u32 },
+            .{ .name = "client_timeout_ms", .type = ?u32 },
+            .{ .name = "allow_private_networks", .type = bool },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{
         .name = "mcp",
         .options = .{
             .{ .name = "port", .type = ?u16 },
@@ -434,7 +450,7 @@ pub fn deinit(self: *const Config, allocator: Allocator) void {
 pub fn interactive(self: *const Config) bool {
     return switch (self.mode) {
         .fetch => false,
-        .serve, .mcp => true,
+        .serve, .render, .mcp => true,
         .agent => |opts| opts.script_file == null,
         else => unreachable,
     };
@@ -442,7 +458,7 @@ pub fn interactive(self: *const Config) bool {
 
 pub fn tlsVerifyHost(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,
         // `version --check` talks to the release endpoint; always verify.
         .version => true,
         else => unreachable,
@@ -451,28 +467,28 @@ pub fn tlsVerifyHost(self: *const Config) bool {
 
 pub fn obeyRobots(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.obey_robots,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.obey_robots,
         else => unreachable,
     };
 }
 
 pub fn disableSubframes(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_subframes,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.disable_subframes,
         else => unreachable,
     };
 }
 
 pub fn disableWorkers(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_workers,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.disable_workers,
         else => unreachable,
     };
 }
 
 pub fn watchdogMs(self: *const Config) ?u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| {
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| {
             const ms = opts.watchdog_ms orelse 30000;
             return if (ms == 0) null else ms;
         },
@@ -482,28 +498,28 @@ pub fn watchdogMs(self: *const Config) ?u32 {
 
 pub fn enableExternalStylesheets(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.enable_external_stylesheets,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.enable_external_stylesheets,
         else => unreachable,
     };
 }
 
 pub fn v8Flags(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_flags_unsafe,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.v8_flags_unsafe,
         else => unreachable,
     };
 }
 
 pub fn v8MaxHeapMb(self: *const Config) ?u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_max_heap_mb,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.v8_max_heap_mb,
         else => unreachable,
     };
 }
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_proxy,
         .version => null,
         else => unreachable,
     };
@@ -511,28 +527,28 @@ pub fn httpProxy(self: *const Config) ?[:0]const u8 {
 
 pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.proxy_bearer_token,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.proxy_bearer_token,
         else => null,
     };
 }
 
 pub fn httpMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
         else => unreachable,
     };
 }
 
 pub fn httpMaxHostOpen(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
         else => unreachable,
     };
 }
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
         .version => 0,
         else => unreachable,
     };
@@ -540,7 +556,7 @@ pub fn httpConnectTimeout(self: *const Config) u31 {
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
         .version => 5000,
         else => unreachable,
     };
@@ -552,6 +568,7 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
+        .render => |opts| opts.http_max_response_size orelse 16 * 1024 * 1024,
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size,
         else => unreachable,
     };
@@ -559,7 +576,7 @@ pub fn httpMaxResponseSize(self: *const Config) ?usize {
 
 pub fn wsMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.ws_max_concurrent orelse 8,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.ws_max_concurrent orelse 8,
         else => unreachable,
     };
 }
@@ -571,7 +588,7 @@ pub fn logLevel(self: *const Config) ?log.Level {
             .low, .medium => .err,
             .high => null,
         },
-        inline .serve, .fetch, .mcp => |opts| opts.log_level,
+        inline .serve, .fetch, .render, .mcp => |opts| opts.log_level,
         else => unreachable,
     };
 }
@@ -601,49 +618,49 @@ fn stderrIsTty() bool {
 
 pub fn logFormat(self: *const Config) ?log.Format {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.log_format,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.log_format,
         else => unreachable,
     };
 }
 
 pub fn logFilterScopes(self: *const Config) std.ArrayList(log.FilterRule) {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.log_filter_scopes,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.log_filter_scopes,
         else => unreachable,
     };
 }
 
 pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent_suffix,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.user_agent_suffix,
         else => null,
     };
 }
 
 pub fn userAgent(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.user_agent,
         else => null,
     };
 }
 
 pub fn httpCacheDir(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_dir,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_cache_dir,
         else => null,
     };
 }
 
 pub fn cookieFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.cookie,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.cookie,
         else => null,
     };
 }
 
 pub fn cookieJarFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .fetch, .mcp, .agent => |opts| opts.cookie_jar,
+        inline .fetch, .render, .mcp, .agent => |opts| opts.cookie_jar,
         else => null,
     };
 }
@@ -651,6 +668,7 @@ pub fn cookieJarFile(self: *const Config) ?[]const u8 {
 pub fn port(self: *const Config) u16 {
     return switch (self.mode) {
         .serve => |opts| opts.port,
+        .render => |opts| opts.port,
         .mcp => |opts| opts.cdp_port orelse 0,
         else => unreachable,
     };
@@ -659,6 +677,7 @@ pub fn port(self: *const Config) u16 {
 pub fn advertiseHost(self: *const Config) []const u8 {
     return switch (self.mode) {
         .serve => |opts| opts.advertise_host orelse opts.host,
+        .render => |opts| opts.host,
         .mcp => "127.0.0.1",
         else => unreachable,
     };
@@ -666,7 +685,7 @@ pub fn advertiseHost(self: *const Config) []const u8 {
 
 pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| WebBotAuthConfig{
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| WebBotAuthConfig{
             .key_file = opts.web_bot_auth_key_file orelse return null,
             .keyid = opts.web_bot_auth_keyid orelse return null,
             .domain = opts.web_bot_auth_domain orelse return null,
@@ -677,6 +696,7 @@ pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
 
 pub fn blockPrivateNetworks(self: *const Config) bool {
     return switch (self.mode) {
+        .render => |opts| opts.block_private_networks or !opts.allow_private_networks,
         inline .serve, .fetch, .mcp, .agent => |opts| opts.block_private_networks,
         else => unreachable,
     };
@@ -684,14 +704,14 @@ pub fn blockPrivateNetworks(self: *const Config) bool {
 
 pub fn blockCidrs(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.block_cidrs,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.block_cidrs,
         else => unreachable,
     };
 }
 
 pub fn blockedUrlPatterns(self: *const Config) ?std.mem.SplitIterator(u8, .scalar) {
     const patterns = switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.block_urls,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.block_urls,
         else => unreachable,
     } orelse return null;
     return std.mem.splitScalar(u8, patterns, ',');
@@ -700,6 +720,7 @@ pub fn blockedUrlPatterns(self: *const Config) ?std.mem.SplitIterator(u8, .scala
 pub fn maxConnections(self: *const Config) u16 {
     return switch (self.mode) {
         .serve => |opts| opts.cdp_max_connections,
+        .render => |opts| @max(opts.max_connections orelse 8, 1),
         .mcp => 16,
         .fetch, .agent => 0,
         else => unreachable,
@@ -709,7 +730,50 @@ pub fn maxConnections(self: *const Config) u16 {
 pub fn maxPendingConnections(self: *const Config) u31 {
     return switch (self.mode) {
         .serve => |opts| opts.cdp_max_pending_connections,
+        .render => 64,
         .mcp => 128,
+        else => unreachable,
+    };
+}
+
+pub fn renderCorsOrigin(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        .render => |opts| opts.cors_origin,
+        else => null,
+    };
+}
+
+pub fn renderAuthToken(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        .render => |opts| opts.auth_token,
+        else => null,
+    };
+}
+
+pub fn renderMaxRequestSize(self: *const Config) usize {
+    return switch (self.mode) {
+        .render => |opts| opts.max_request_size orelse 16 * 1024,
+        else => unreachable,
+    };
+}
+
+pub fn renderMaxResponseSize(self: *const Config) usize {
+    return switch (self.mode) {
+        .render => |opts| opts.max_response_size orelse 16 * 1024 * 1024,
+        else => unreachable,
+    };
+}
+
+pub fn renderMaxWaitMs(self: *const Config) u32 {
+    return switch (self.mode) {
+        .render => |opts| @max(opts.max_wait_ms orelse 30_000, 1),
+        else => unreachable,
+    };
+}
+
+pub fn renderClientTimeoutMs(self: *const Config) u32 {
+    return switch (self.mode) {
+        .render => |opts| @max(opts.client_timeout_ms orelse 30_000, 1),
         else => unreachable,
     };
 }
@@ -744,14 +808,14 @@ pub fn cdpMaxHTTPMessageSize(self: *const Config) u14 {
 
 pub fn storageEngine(self: *const Config) ?Storage.EngineType {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.storage_engine,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.storage_engine,
         else => unreachable,
     };
 }
 
 pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.storage_sqlite_path,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.storage_sqlite_path,
         else => unreachable,
     };
 }
@@ -760,7 +824,7 @@ pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
 /// if any was loaded during argument parsing. The caller takes ownership.
 pub fn customCertStore(self: *const Config) ?*crypto.X509_STORE {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| {
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| {
             const store = opts.cert.store orelse return null;
             // Validators guarantee a created store loaded something.
             lp.assert(opts.cert.count > 0, "empty custom cert store", .{});
@@ -877,7 +941,7 @@ pub fn printUsageAndExit(self: *const Config, allocator: Allocator, help_for: Ru
             , .{Help.general});
             break :text try std.fmt.allocPrint(allocator, template, .{exec_name});
         },
-        inline .fetch, .serve, .mcp, .agent, .run => |tag| text: {
+        inline .fetch, .render, .serve, .mcp, .agent, .run => |tag| text: {
             const template = comptimePrint(
                 \\{s}
                 \\
@@ -993,6 +1057,23 @@ test "Config: blockedUrlPatterns splits comma-separated patterns" {
     try std.testing.expectEqualStrings("*doubleclick*", patterns.next().?);
     try std.testing.expectEqualStrings("*://*/*.png", patterns.next().?);
     try std.testing.expectEqual(null, patterns.next());
+}
+
+test "Config: render defaults bound network resources" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .render = .{} });
+    defer config.deinit(std.testing.allocator);
+
+    try std.testing.expect(config.blockPrivateNetworks());
+    try std.testing.expectEqual(@as(?usize, 16 * 1024 * 1024), config.httpMaxResponseSize());
+}
+
+test "Config: render can opt into private network targets" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .render = .{
+        .allow_private_networks = true,
+    } });
+    defer config.deinit(std.testing.allocator);
+
+    try std.testing.expect(!config.blockPrivateNetworks());
 }
 
 pub fn validateUserAgent(ua: []const u8) !void {

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -197,6 +197,9 @@ pub fn closeSession(self: *Browser) void {
         session.deinit();
         self.session = null;
     }
+    // A long-lived Browser can sit between short sessions (for example, the
+    // render server worker). No page work can be running after closeSession.
+    self.http_client.heartbeat.disarm();
     self.flushArenaMemory();
 }
 

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -63,9 +63,24 @@ pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Fra
         }
 
         if (opts.with_base) {
-            const parent = if (html_doc.getHead()) |head| head.asNode() else doc.asNode();
+            const parent = if (html_doc.getHead()) |head|
+                head.asNode()
+            else blk: {
+                const document_element = html_doc.asDocument().getDocumentElement() orelse {
+                    const html = try doc.createElement("html", null, frame);
+                    _ = try doc.asNode().appendChild(html.asNode(), frame);
+                    break :blk html.asNode();
+                };
+                const head = try doc.createElement("head", null, frame);
+                _ = try document_element.asNode().insertBefore(
+                    head.asNode(),
+                    document_element.asNode().firstChild(),
+                    frame,
+                );
+                break :blk head.asNode();
+            };
             const base = try doc.createElement("base", null, frame);
-            try base.setAttributeSafe(comptime .wrap("base"), .wrap(frame.base()), frame);
+            try base.setAttributeSafe(comptime .wrap("href"), .wrap(frame.base()), frame);
             _ = try parent.insertBefore(base.asNode(), parent.firstChild(), frame);
         }
     }
@@ -258,7 +273,7 @@ fn dumpSlotContent(slot: *Slot, opts: Opts, writer: *std.Io.Writer, frame: *Fram
 fn isVoidElement(el: *const Node.Element) bool {
     return switch (el._type) {
         .html => |html| switch (html._type) {
-            .br, .hr, .img, .input, .link, .meta => true,
+            .base, .br, .hr, .img, .input, .link, .meta => true,
             else => false,
         },
         .svg => false,
@@ -401,8 +416,26 @@ test "dump: default dumps the whole document" {
 test "dump: with_base injects a <base> element" {
     try expectDump(.{ .with_base = true },
         \\<!DOCTYPE html>
-        \\<html><head><base base="http://127.0.0.1:9582/src/browser/tests/dump.html"></base><style>.hidden{display:none}</style><link rel="stylesheet" href="data:text/css,"><script>var a=1;</script></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
+        \\<html><head><base href="http://127.0.0.1:9582/src/browser/tests/dump.html"><style>.hidden{display:none}</style><link rel="stylesheet" href="data:text/css,"><script>var a=1;</script></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
     );
+}
+
+test "dump: with_base synthesizes a head after the doctype" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const html_doc = doc.is(Node.Document.HTMLDocument).?;
+    const head = html_doc.getHead().?;
+    _ = try head.asNode().parentNode().?.removeChild(head.asNode(), frame);
+
+    var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    try root(doc, .{ .with_base = true }, &aw.writer, frame);
+    try testing.expectString(
+        \\<!DOCTYPE html>
+        \\<html><head><base href="http://127.0.0.1:9582/src/browser/tests/dump.html"></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
+    , aw.written());
 }
 
 test "dump: strip.js removes script and noscript" {

--- a/src/help.zon
+++ b/src/help.zon
@@ -8,6 +8,7 @@
     \\  fetch       fetches the specified URL
     \\  help        displays this message
     \\  mcp         starts an MCP (Model Context Protocol) server (stdio or HTTP)
+    \\  render      starts a one-shot DOM render server
     \\  run         runs a saved script (no LLM), then exits
     \\  serve       starts a WebSocket CDP server
     \\  version     displays the version of {0s}
@@ -124,6 +125,45 @@
     \\  --with-frames
     \\          Includes the contents of iframes.
     \\          Defaults to false.
+    ,
+    .render =
+    \\usage: {0s} render [OPTIONS] [COMMON_OPTIONS]
+    \\
+    \\Starts a one-shot DOM render server. Lightpanda executes page JavaScript
+    \\and returns an HTML snapshot; the attached browser renders that snapshot.
+    \\The sandboxed preview supports same-frame form submissions. New-window
+    \\and top-level form targets stay blocked.
+    \\
+    \\Endpoints:
+    \\  POST /v1/render                JSON request, HTML snapshot response
+    \\  GET  /lightpanda-renderer.js   browser ESM library
+    \\  GET  /healthz                  liveness check
+    \\
+    \\options:
+    \\  --allow-private-networks
+    \\          Allow render targets on loopback and private/internal networks.
+    \\          By default these targets are blocked after DNS resolution.
+    \\  --auth-token <TOKEN>
+    \\          Bearer token required by POST /v1/render. Must be at least 16
+    \\          bytes. Required when --cors-origin is configured.
+    \\  --client-timeout-ms <INT>
+    \\          Maximum client socket read or write time. Defaults to 30000.
+    \\  --cors-origin <ORIGIN>
+    \\          Exact browser origin allowed to call the render service, or *.
+    \\          Enabling CORS also requires --auth-token.
+    \\  --host <HOST>
+    \\          Loopback address to bind. Defaults to "127.0.0.1".
+    \\  --max-connections <INT>
+    \\          Maximum simultaneous HTTP connections. Defaults to 8.
+    \\  --max-request-size <INT>
+    \\          Maximum JSON request size. Defaults to 16384 (16 KiB).
+    \\  --max-response-size <INT>
+    \\          Maximum HTML snapshot size. Defaults to 16777216 (16 MiB).
+    \\  --max-wait-ms <INT>
+    \\          Maximum total queue and render time for one request. Defaults
+    \\          to 30000.
+    \\  --port <INT>
+    \\          HTTP port. Defaults to 9223.
     ,
     .mcp =
     \\usage: {0s} mcp [OPTIONS] [COMMON_OPTIONS]

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -49,6 +49,7 @@ pub const tools = @import("browser/tools.zig");
 pub const HttpClient = @import("network/HttpClient.zig");
 
 pub const mcp = @import("mcp.zig");
+pub const render = @import("render.zig");
 pub const Agent = @import("agent/Agent.zig");
 pub const Command = @import("script/command.zig").Command;
 pub const Recorder = @import("script/Recorder.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -199,6 +199,26 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
             var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, &ft, urls, fetch_opts });
             worker_thread.join();
         },
+        .render => |opts| {
+            log.debug(.app, "startup", .{
+                .mode = "render",
+                .snapshot = app.snapshot.fromEmbedded(),
+            });
+            const address = std.Io.net.IpAddress.parse(opts.host, opts.port) catch |err| {
+                log.fatal(.app, "invalid render server address", .{
+                    .err = err,
+                    .host = opts.host,
+                    .port = opts.port,
+                });
+                return err;
+            };
+            const server = try lp.render.HttpServer.init(allocator, app);
+            defer server.deinit();
+            server.run(address) catch |err| {
+                log.fatal(.app, "client render server error", .{ .err = err });
+                return err;
+            };
+        },
         .mcp => |opts| {
             log.info(.mcp, "starting server", .{});
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub const HttpServer = @import("render/HttpServer.zig");
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -1,0 +1,772 @@
+// Copyright (C) 2026 Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+//! Bounded HTTP transport for one-shot client-side rendering.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const App = @import("../App.zig");
+const ResponseBuffer = @import("ResponseBuffer.zig");
+const sys_net = @import("../sys/net.zig");
+
+const HttpServer = @This();
+const posix = std.posix;
+
+const worker_stack_size = 4 * 1024 * 1024;
+const connection_stack_size = 512 * 1024;
+const worker_retained_arena_bytes = 64 * 1024;
+const job_poll_interval_ms = 100;
+const ns_per_ms = 1_000_000;
+
+const client_js = @embedFile("client.js");
+const client_etag = blk: {
+    @setEvalBranchQuota(10_000);
+    break :blk std.fmt.comptimePrint("W/\"{x}\"", .{std.hash.Wyhash.hash(0, client_js)});
+};
+
+const Result = enum {
+    ok,
+    bad_request,
+    timeout,
+    navigation_failed,
+    response_too_large,
+    shutting_down,
+    internal_error,
+
+    fn status(self: Result) std.http.Status {
+        return switch (self) {
+            .ok => .ok,
+            .bad_request => .bad_request,
+            .timeout => .gateway_timeout,
+            .navigation_failed => .bad_gateway,
+            .response_too_large => .payload_too_large,
+            .shutting_down => .service_unavailable,
+            .internal_error => .internal_server_error,
+        };
+    }
+
+    fn body(self: Result) []const u8 {
+        return switch (self) {
+            .ok => "",
+            .bad_request => "{\"error\":\"invalid render request\"}\n",
+            .timeout => "{\"error\":\"render deadline exceeded\"}\n",
+            .navigation_failed => "{\"error\":\"page navigation failed\"}\n",
+            .response_too_large => "{\"error\":\"render snapshot too large\"}\n",
+            .shutting_down => "{\"error\":\"render server shutting down\"}\n",
+            .internal_error => "{\"error\":\"render failed\"}\n",
+        };
+    }
+};
+
+const Job = struct {
+    body: []const u8,
+    out: *std.Io.Writer,
+    max_wait_ms: u32,
+    result: Result = .ok,
+    done: std.atomic.Value(bool) = .init(false),
+    done_mutex: std.Io.Mutex = .init,
+    done_cond: std.Io.Condition = .init,
+    cancel_reason: std.atomic.Value(u8) = .init(@intFromEnum(CancelReason.none)),
+    termination_requested: std.atomic.Value(bool) = .init(false),
+    next: ?*Job = null,
+
+    const CancelReason = enum(u8) {
+        none,
+        timeout,
+        disconnected,
+        shutdown,
+    };
+
+    fn cancel(self: *Job, reason: CancelReason) void {
+        if (self.done.load(.acquire)) return;
+        _ = self.cancel_reason.cmpxchgStrong(
+            @intFromEnum(CancelReason.none),
+            @intFromEnum(reason),
+            .acq_rel,
+            .acquire,
+        );
+    }
+
+    fn cancellation(self: *const Job) CancelReason {
+        return @enumFromInt(self.cancel_reason.load(.acquire));
+    }
+
+    fn finish(self: *Job) void {
+        self.done_mutex.lockUncancelable(lp.io);
+        defer self.done_mutex.unlock(lp.io);
+        self.done.store(true, .release);
+        self.done_cond.broadcast(lp.io);
+    }
+
+    fn wait(self: *Job, timeout_ms: u32) bool {
+        self.done_mutex.lockUncancelable(lp.io);
+        defer self.done_mutex.unlock(lp.io);
+        if (self.done.load(.acquire)) return true;
+        lp.timedWait(
+            &self.done_cond,
+            &self.done_mutex,
+            @as(u64, timeout_ms) * ns_per_ms,
+        ) catch {};
+        return self.done.load(.acquire);
+    }
+};
+
+const Queue = struct {
+    mutex: std.Io.Mutex = .init,
+    cond: std.Io.Condition = .init,
+    head: ?*Job = null,
+    tail: ?*Job = null,
+    closed: std.atomic.Value(bool) = .init(false),
+
+    fn push(self: *Queue, job: *Job) bool {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        if (self.closed.load(.acquire)) return false;
+        job.next = null;
+        if (self.tail) |tail| tail.next = job else self.head = job;
+        self.tail = job;
+        self.cond.signal(lp.io);
+        return true;
+    }
+
+    fn pop(self: *Queue) ?*Job {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        while (self.head == null and !self.closed.load(.acquire)) {
+            self.cond.waitUncancelable(lp.io, &self.mutex);
+        }
+        const job = self.head orelse return null;
+        self.head = job.next;
+        if (self.head == null) self.tail = null;
+        return job;
+    }
+
+    fn close(self: *Queue) void {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        self.closed.store(true, .release);
+        self.cond.broadcast(lp.io);
+    }
+};
+
+allocator: std.mem.Allocator,
+app: *App,
+max_connections: u32,
+max_request_size: usize,
+max_response_size: usize,
+max_wait_ms: u32,
+client_timeout_ms: u32,
+cors_origin: ?[]const u8,
+auth_token: ?[]const u8,
+
+queue: Queue = .{},
+active_conns: std.atomic.Value(u32) = .init(0),
+conn_mutex: std.Io.Mutex = .init,
+conns: std.ArrayList(posix.socket_t) = .empty,
+
+worker_thread: std.Thread = undefined,
+worker_ready: std.Io.Event = .unset,
+worker_ok: bool = false,
+browser_mutex: std.Io.Mutex = .init,
+active_browser: ?*lp.Browser = null,
+active_job: ?*Job = null,
+
+pub fn init(allocator: std.mem.Allocator, app: *App) !*HttpServer {
+    const self = try allocator.create(HttpServer);
+    errdefer allocator.destroy(self);
+    self.* = .{
+        .allocator = allocator,
+        .app = app,
+        .max_connections = app.config.maxConnections(),
+        .max_request_size = app.config.renderMaxRequestSize(),
+        .max_response_size = app.config.renderMaxResponseSize(),
+        .max_wait_ms = app.config.renderMaxWaitMs(),
+        .client_timeout_ms = app.config.renderClientTimeoutMs(),
+        .cors_origin = app.config.renderCorsOrigin(),
+        .auth_token = app.config.renderAuthToken(),
+    };
+    if (self.auth_token) |token| {
+        if (token.len < 16) return error.WeakAuthToken;
+    }
+    if (self.cors_origin) |origin| {
+        if (self.auth_token == null) return error.AuthenticationRequired;
+        if (!validHeaderValue(origin)) return error.InvalidCorsOrigin;
+    }
+    errdefer self.conns.deinit(allocator);
+    try self.conns.ensureTotalCapacity(allocator, self.max_connections);
+
+    self.worker_thread = try std.Thread.spawn(.{ .stack_size = worker_stack_size }, worker, .{self});
+    self.worker_ready.waitUncancelable(lp.io);
+    if (!self.worker_ok) {
+        self.worker_thread.join();
+        return error.WorkerInitFailed;
+    }
+    return self;
+}
+
+pub fn deinit(self: *HttpServer) void {
+    self.queue.close();
+    self.cancelActiveJob(.shutdown);
+    {
+        self.conn_mutex.lockUncancelable(lp.io);
+        defer self.conn_mutex.unlock(lp.io);
+        for (self.conns.items) |socket| sys_net.shutdown(socket, .both) catch {};
+    }
+    while (self.active_conns.load(.acquire) > 0) {
+        lp.io.sleep(.fromMilliseconds(10), .awake) catch {};
+    }
+    self.worker_thread.join();
+
+    self.conns.deinit(self.allocator);
+    self.allocator.destroy(self);
+}
+
+pub fn run(self: *HttpServer, address: sys_net.IpAddress) !void {
+    if (!isLoopback(address)) return error.LoopbackRequired;
+    var bound = address;
+    try self.app.network.bind(&bound, self, onAccept);
+    lp.log.note(.app, "client render server running", .{ .address = bound });
+    self.app.network.run();
+}
+
+fn cancelActiveJob(self: *HttpServer, reason: Job.CancelReason) void {
+    self.browser_mutex.lockUncancelable(lp.io);
+    defer self.browser_mutex.unlock(lp.io);
+    const job = self.active_job orelse return;
+    job.cancel(reason);
+    const browser = self.active_browser orelse return;
+    if (!job.termination_requested.swap(true, .acq_rel)) {
+        browser.env.terminate();
+    }
+}
+
+fn cancelJob(self: *HttpServer, job: *Job, reason: Job.CancelReason) void {
+    job.cancel(reason);
+    self.browser_mutex.lockUncancelable(lp.io);
+    defer self.browser_mutex.unlock(lp.io);
+    if (self.active_job != job) return;
+    const browser = self.active_browser orelse return;
+    if (!job.termination_requested.swap(true, .acq_rel)) {
+        browser.env.terminate();
+    }
+}
+
+fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
+    const self: *HttpServer = @ptrCast(@alignCast(ctx));
+    const flags = sys_net.fcntl(socket, posix.F.GETFL, 0) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    _ = sys_net.fcntl(socket, posix.F.SETFL, flags & ~@as(u32, @bitCast(posix.O{ .NONBLOCK = true }))) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    setSocketTimeout(socket, self.client_timeout_ms) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    if (!acquireConnectionSlot(&self.active_conns, self.max_connections)) {
+        _ = std.c.close(socket);
+        return;
+    }
+    {
+        self.conn_mutex.lockUncancelable(lp.io);
+        defer self.conn_mutex.unlock(lp.io);
+        self.conns.appendAssumeCapacity(socket);
+    }
+
+    const thread = std.Thread.spawn(.{ .stack_size = connection_stack_size }, handleConn, .{ self, socket }) catch {
+        _ = self.active_conns.fetchSub(1, .release);
+        self.unregister(socket);
+        _ = std.c.close(socket);
+        return;
+    };
+    thread.detach();
+}
+
+fn setSocketTimeout(socket: posix.socket_t, timeout_ms: u32) !void {
+    const timeout = std.mem.toBytes(posix.timeval{
+        .sec = @intCast(timeout_ms / 1000),
+        .usec = @intCast((timeout_ms % 1000) * 1000),
+    });
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &timeout);
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &timeout);
+}
+
+fn isLoopback(address: sys_net.IpAddress) bool {
+    return switch (address) {
+        .ip4 => |ip4| ip4.bytes[0] == 127,
+        .ip6 => |ip6| ip6.isLoopBack(),
+    };
+}
+
+fn validHeaderValue(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |byte| {
+        if (byte < ' ' or byte == 0x7f) return false;
+    }
+    return true;
+}
+
+fn acquireConnectionSlot(active: *std.atomic.Value(u32), max: u32) bool {
+    var current = active.load(.monotonic);
+    while (current < max) {
+        current = active.cmpxchgWeak(current, current + 1, .monotonic, .monotonic) orelse return true;
+    }
+    return false;
+}
+
+fn unregister(self: *HttpServer, socket: posix.socket_t) void {
+    self.conn_mutex.lockUncancelable(lp.io);
+    defer self.conn_mutex.unlock(lp.io);
+    for (self.conns.items, 0..) |tracked, i| {
+        if (tracked == socket) {
+            _ = self.conns.swapRemove(i);
+            return;
+        }
+    }
+}
+
+fn worker(self: *HttpServer) void {
+    var browser: lp.Browser = undefined;
+    browser.init(self.app, .{}, null) catch |err| {
+        lp.log.err(.app, "client render browser init", .{ .err = err });
+        self.worker_ready.set(lp.io);
+        return;
+    };
+    defer browser.deinit();
+    {
+        self.browser_mutex.lockUncancelable(lp.io);
+        self.active_browser = &browser;
+        self.browser_mutex.unlock(lp.io);
+    }
+    defer {
+        self.browser_mutex.lockUncancelable(lp.io);
+        self.active_browser = null;
+        self.browser_mutex.unlock(lp.io);
+    }
+
+    self.worker_ok = true;
+    self.worker_ready.set(lp.io);
+
+    var arena: std.heap.ArenaAllocator = .init(self.allocator);
+    defer arena.deinit();
+    while (self.queue.pop()) |job| {
+        if (self.queue.closed.load(.acquire)) job.cancel(.shutdown);
+
+        if (job.cancellation() == .none) {
+            self.browser_mutex.lockUncancelable(lp.io);
+            self.active_job = job;
+            self.browser_mutex.unlock(lp.io);
+
+            if (job.cancellation() == .none) {
+                processRender(self, &browser, arena.allocator(), job);
+            }
+
+            self.browser_mutex.lockUncancelable(lp.io);
+            self.active_job = null;
+            self.browser_mutex.unlock(lp.io);
+            if (job.termination_requested.load(.acquire)) {
+                browser.env.cancelTerminate();
+            }
+        }
+
+        job.result = switch (job.cancellation()) {
+            .none => job.result,
+            .timeout => .timeout,
+            .disconnected, .shutdown => .shutting_down,
+        };
+        _ = arena.reset(.{ .retain_with_limit = worker_retained_arena_bytes });
+        job.finish();
+    }
+}
+
+const RenderRequest = struct {
+    url: []const u8,
+    wait_ms: u32 = 5_000,
+    wait_until: ?lp.Config.WaitUntil = null,
+    wait_selector: ?[]const u8 = null,
+    width: u32 = 1280,
+    height: u32 = 720,
+};
+
+fn processRender(self: *HttpServer, browser: *lp.Browser, arena: std.mem.Allocator, job: *Job) void {
+    const request = std.json.parseFromSliceLeaky(RenderRequest, arena, job.body, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        job.result = .bad_request;
+        return;
+    };
+    if (request.url.len == 0 or request.url.len > 8 * 1024 or
+        request.width == 0 or request.width > 8192 or request.height == 0 or request.height > 8192)
+    {
+        job.result = .bad_request;
+        return;
+    }
+    if (request.wait_selector) |selector| {
+        if (selector.len == 0 or selector.len > 1024) {
+            job.result = .bad_request;
+            return;
+        }
+    }
+
+    const canonical = lp.URL.resolveNavigation(arena, request.url, .{}) catch {
+        job.result = .bad_request;
+        return;
+    };
+    const protocol = lp.URL.getProtocol(canonical);
+    if ((!std.mem.eql(u8, protocol, "http:") and !std.mem.eql(u8, protocol, "https:")) or
+        lp.URL.getUsername(canonical).len != 0 or lp.URL.getPassword(canonical).len != 0)
+    {
+        job.result = .bad_request;
+        return;
+    }
+
+    const selector: ?[:0]const u8 = if (request.wait_selector) |value|
+        arena.dupeZ(u8, value) catch {
+            job.result = .internal_error;
+            return;
+        }
+    else
+        null;
+    browser.viewport_override = .{ .width = request.width, .height = request.height };
+
+    var urls = [_][:0]const u8{canonical};
+    lp.fetch(self.app, browser, &urls, .{
+        .wait_ms = @min(request.wait_ms, job.max_wait_ms),
+        .wait_until = request.wait_until,
+        .wait_selector = selector,
+        .dump = .{
+            .with_base = true,
+            .with_frames = false,
+            .strip = .{ .js = true },
+        },
+        .dump_mode = .html,
+        .writer = job.out,
+    }) catch |err| {
+        job.result = if (err == error.Timeout)
+            .timeout
+        else if (err == error.WriteFailed)
+            .response_too_large
+        else switch (err) {
+            error.TypeError, error.InvalidURL => .bad_request,
+            error.OutOfMemory => .internal_error,
+            else => .navigation_failed,
+        };
+        return;
+    };
+}
+
+fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
+    defer _ = self.active_conns.fetchSub(1, .release);
+    const stream: std.Io.net.Stream = .{ .socket = .{ .handle = socket, .address = .{ .ip4 = .unspecified(0) } } };
+    defer stream.close(lp.io);
+    defer self.unregister(socket);
+
+    var recv_buf: [8 * 1024]u8 = undefined;
+    var send_buf: [8 * 1024]u8 = undefined;
+    var stream_reader = stream.reader(lp.io, &recv_buf);
+    var stream_writer = stream.writer(lp.io, &send_buf);
+    var http_server = std.http.Server.init(&stream_reader.interface, &stream_writer.interface);
+
+    var request = http_server.receiveHead() catch return;
+    var arena: std.heap.ArenaAllocator = .init(self.allocator);
+    defer arena.deinit();
+    var out: ResponseBuffer = .init(self.allocator, self.max_response_size);
+    defer out.deinit();
+    self.serve(&out, arena.allocator(), &request, socket) catch {};
+}
+
+fn serve(
+    self: *HttpServer,
+    out: *ResponseBuffer,
+    arena: std.mem.Allocator,
+    request: *std.http.Server.Request,
+    socket: posix.socket_t,
+) !void {
+    if (request.head.expect != null) {
+        return request.respond("", .{ .status = .expectation_failed, .keep_alive = false });
+    }
+    const target = request.head.target;
+    const path = target[0 .. std.mem.indexOfScalar(u8, target, '?') orelse target.len];
+    const origin = headerValue(request, "origin");
+    const cors_value: ?[]const u8 = if (origin != null)
+        self.allowedCorsValue(origin) orelse
+            return respondJson(request, .forbidden, "{\"error\":\"origin not allowed\"}\n", null)
+    else
+        null;
+
+    if (request.head.method == .OPTIONS) return respondPreflight(request, cors_value);
+    if ((request.head.method == .GET or request.head.method == .HEAD) and
+        std.mem.eql(u8, path, "/lightpanda-renderer.js"))
+    {
+        if (headerEquals(request, "if-none-match", client_etag)) return respondNotModified(request, cors_value);
+        return respondBody(request, client_js, .ok, "text/javascript; charset=utf-8", "public,max-age=0,must-revalidate", client_etag, cors_value);
+    }
+    if ((request.head.method == .GET or request.head.method == .HEAD) and std.mem.eql(u8, path, "/healthz")) {
+        return respondBody(request, "ok\n", .ok, "text/plain; charset=utf-8", "no-store", null, cors_value);
+    }
+    if (request.head.method != .POST or !std.mem.eql(u8, path, "/v1/render")) {
+        return respondJson(request, .not_found, "{\"error\":\"not found\"}\n", cors_value);
+    }
+    if (!authorized(request, self.auth_token)) {
+        return respondJson(request, .unauthorized, "{\"error\":\"authentication required\"}\n", cors_value);
+    }
+    const content_type = headerValue(request, "content-type") orelse "";
+    if (!isJsonContentType(content_type)) {
+        return respondJson(request, .unsupported_media_type, "{\"error\":\"application/json required\"}\n", cors_value);
+    }
+
+    const content_length = if (request.head.transfer_encoding == .none)
+        request.head.content_length
+    else
+        null;
+    var body_buf: [8 * 1024]u8 = undefined;
+    const body = readRequestBody(arena, request.readerExpectNone(&body_buf), content_length, self.max_request_size) catch {
+        return respondJson(request, .payload_too_large, "{\"error\":\"request too large\"}\n", cors_value);
+    };
+    var job: Job = .{
+        .body = body,
+        .out = &out.writer,
+        .max_wait_ms = self.max_wait_ms,
+    };
+    if (!self.queue.push(&job)) {
+        return respondJson(request, .service_unavailable, Result.shutting_down.body(), cors_value);
+    }
+    if (self.waitForJob(&job, socket) == .disconnected) {
+        return error.ClientDisconnected;
+    }
+
+    if (out.failed and job.result == .ok) job.result = .response_too_large;
+    if (job.result != .ok) return respondJson(request, job.result.status(), job.result.body(), cors_value);
+    return respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value);
+}
+
+const JobWaitResult = enum { complete, disconnected };
+
+fn waitForJob(self: *HttpServer, job: *Job, socket: posix.socket_t) JobWaitResult {
+    var timer: std.Io.Timestamp = .now(lp.io, .boot);
+    while (!job.done.load(.acquire)) {
+        if (peerDisconnected(socket)) {
+            self.cancelJob(job, .disconnected);
+        }
+
+        const elapsed: u32 = @intCast(@min(
+            timer.untilNow(lp.io, .boot).toMilliseconds(),
+            std.math.maxInt(u32),
+        ));
+        if (elapsed >= job.max_wait_ms) {
+            self.cancelJob(job, .timeout);
+        }
+
+        const remaining = job.max_wait_ms -| elapsed;
+        const wait_ms = @max(@min(remaining, job_poll_interval_ms), 1);
+        _ = job.wait(wait_ms);
+    }
+    return if (job.cancellation() == .disconnected) .disconnected else .complete;
+}
+
+fn peerDisconnected(socket: posix.socket_t) bool {
+    var fds = [_]posix.pollfd{.{
+        .fd = socket,
+        .events = posix.POLL.IN,
+        .revents = 0,
+    }};
+    _ = posix.poll(&fds, 0) catch return true;
+    const fatal_events: i16 = comptime @intCast(posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
+    return fds[0].revents & fatal_events != 0;
+}
+
+fn respondBody(
+    request: *std.http.Server.Request,
+    body: []const u8,
+    status: std.http.Status,
+    content_type: []const u8,
+    cache_control: []const u8,
+    etag: ?[]const u8,
+    cors_value: ?[]const u8,
+) !void {
+    var headers: [7]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "content-type", .value = content_type };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = cache_control };
+    count += 1;
+    headers[count] = .{ .name = "x-content-type-options", .value = "nosniff" };
+    count += 1;
+    headers[count] = .{ .name = "vary", .value = "origin" };
+    count += 1;
+    if (etag) |value| {
+        headers[count] = .{ .name = "etag", .value = value };
+        count += 1;
+    }
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+        headers[count] = .{ .name = "cross-origin-resource-policy", .value = "cross-origin" };
+        count += 1;
+    }
+    return request.respond(body, .{
+        .status = status,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondNotModified(request: *std.http.Server.Request, cors_value: ?[]const u8) !void {
+    var headers: [6]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "etag", .value = client_etag };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = "public,max-age=0,must-revalidate" };
+    count += 1;
+    headers[count] = .{ .name = "vary", .value = "origin" };
+    count += 1;
+    headers[count] = .{ .name = "x-content-type-options", .value = "nosniff" };
+    count += 1;
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+        headers[count] = .{ .name = "cross-origin-resource-policy", .value = "cross-origin" };
+        count += 1;
+    }
+    return request.respond("", .{
+        .status = .not_modified,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondJson(request: *std.http.Server.Request, status: std.http.Status, body: []const u8, cors_value: ?[]const u8) !void {
+    var headers: [3]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "content-type", .value = "application/json; charset=utf-8" };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = "no-store" };
+    count += 1;
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+    }
+    return request.respond(body, .{
+        .status = status,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondPreflight(request: *std.http.Server.Request, cors_value: ?[]const u8) !void {
+    const value = cors_value orelse return respondJson(
+        request,
+        .forbidden,
+        "{\"error\":\"origin not allowed\"}\n",
+        null,
+    );
+    const headers = [_]std.http.Header{
+        .{ .name = "access-control-allow-origin", .value = value },
+        .{ .name = "access-control-allow-methods", .value = "GET, POST, OPTIONS" },
+        .{ .name = "access-control-allow-headers", .value = "content-type, authorization" },
+        .{ .name = "access-control-max-age", .value = "86400" },
+        .{ .name = "vary", .value = "origin" },
+    };
+    return request.respond("", .{
+        .status = .no_content,
+        .keep_alive = false,
+        .extra_headers = &headers,
+    });
+}
+
+fn authorized(request: *std.http.Server.Request, expected: ?[]const u8) bool {
+    const token = expected orelse return true;
+    const value = headerValue(request, "authorization") orelse return false;
+    const prefix = "Bearer ";
+    if (!std.ascii.startsWithIgnoreCase(value, prefix)) return false;
+    const actual = value[prefix.len..];
+    if (actual.len != token.len) return false;
+    var difference: u8 = 0;
+    for (actual, token) |a, b| difference |= a ^ b;
+    return difference == 0;
+}
+
+fn allowedCorsValue(self: *const HttpServer, origin: ?[]const u8) ?[]const u8 {
+    const requested = origin orelse return null;
+    const allowed = self.cors_origin orelse return null;
+    if (std.mem.eql(u8, allowed, "*") or std.mem.eql(u8, allowed, requested)) return allowed;
+    return null;
+}
+
+fn headerValue(request: *std.http.Server.Request, name: []const u8) ?[]const u8 {
+    var it = request.iterateHeaders();
+    while (it.next()) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+    }
+    return null;
+}
+
+fn headerEquals(request: *std.http.Server.Request, name: []const u8, expected: []const u8) bool {
+    const value = headerValue(request, name) orelse return false;
+    return std.mem.eql(u8, value, expected);
+}
+
+fn isJsonContentType(raw: []const u8) bool {
+    const value = std.mem.trimStart(u8, raw, &std.ascii.whitespace);
+    const mime = "application/json";
+    if (value.len < mime.len or !std.ascii.eqlIgnoreCase(value[0..mime.len], mime)) return false;
+    return value.len == mime.len or value[mime.len] == ';' or std.ascii.isWhitespace(value[mime.len]);
+}
+
+fn readRequestBody(
+    arena: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    content_length: ?u64,
+    max_request_size: usize,
+) ![]const u8 {
+    if (content_length) |len64| {
+        const len = std.math.cast(usize, len64) orelse return error.StreamTooLong;
+        if (len > max_request_size) return error.StreamTooLong;
+        if (len <= reader.buffer.len) return try reader.take(len);
+        const body = try arena.alloc(u8, len);
+        try reader.readSliceAll(body);
+        return body;
+    }
+    return reader.allocRemaining(arena, .limited(max_request_size));
+}
+
+test "render server: connection slots are bounded" {
+    var active: std.atomic.Value(u32) = .init(0);
+    try std.testing.expect(acquireConnectionSlot(&active, 2));
+    try std.testing.expect(acquireConnectionSlot(&active, 2));
+    try std.testing.expect(!acquireConnectionSlot(&active, 2));
+}
+
+test "render server: URL schemes and credentials are rejected" {
+    const Request = struct { url: []const u8 };
+    const cases = [_][]const u8{
+        "file:///etc/passwd",
+        "data:text/html,hello",
+        "javascript:alert(1)",
+        "https://user:pass@example.com/",
+    };
+    for (cases) |url| {
+        var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+        defer arena.deinit();
+        const request: Request = .{ .url = url };
+        const canonical = lp.URL.resolveNavigation(arena.allocator(), request.url, .{}) catch continue;
+        const protocol = lp.URL.getProtocol(canonical);
+        const valid = (std.mem.eql(u8, protocol, "http:") or std.mem.eql(u8, protocol, "https:")) and
+            lp.URL.getUsername(canonical).len == 0 and lp.URL.getPassword(canonical).len == 0;
+        try std.testing.expect(!valid);
+    }
+}
+
+test "render server: CORS values cannot inject headers" {
+    try std.testing.expect(validHeaderValue("*"));
+    try std.testing.expect(validHeaderValue("https://preview.example"));
+    try std.testing.expect(!validHeaderValue(""));
+    try std.testing.expect(!validHeaderValue("https://example.test\r\nx-injected: true"));
+}

--- a/src/render/ResponseBuffer.zig
+++ b/src/render/ResponseBuffer.zig
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+//! Dynamically growing response writer with a hard capacity.
+
+const std = @import("std");
+
+const ResponseBuffer = @This();
+
+out: std.Io.Writer.Allocating,
+writer: std.Io.Writer = .{ .buffer = &.{}, .vtable = &vtable },
+limit: usize,
+failed: bool = false,
+
+const vtable: std.Io.Writer.VTable = .{
+    .drain = drain,
+    .flush = flush,
+};
+
+pub fn init(allocator: std.mem.Allocator, limit: usize) ResponseBuffer {
+    return .{ .out = .init(allocator), .limit = limit };
+}
+
+pub fn deinit(self: *ResponseBuffer) void {
+    self.out.deinit();
+}
+
+pub fn buffered(self: *const ResponseBuffer) []const u8 {
+    return self.out.writer.buffered();
+}
+
+fn drain(writer: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+    const self: *ResponseBuffer = @alignCast(@fieldParentPtr("writer", writer));
+    if (self.failed) return error.WriteFailed;
+
+    var additional: usize = 0;
+    for (data[0 .. data.len - 1]) |bytes| {
+        additional = std.math.add(usize, additional, bytes.len) catch return self.fail();
+    }
+    const splat_bytes = std.math.mul(usize, data[data.len - 1].len, splat) catch return self.fail();
+    additional = std.math.add(usize, additional, splat_bytes) catch return self.fail();
+
+    const current = self.out.writer.end;
+    if (additional > self.limit or current > self.limit - additional) return self.fail();
+    const needed = current + additional;
+    if (self.out.writer.buffer.len < needed) {
+        const capacity = @min(std.ArrayList(u8).growCapacity(needed), self.limit);
+        self.out.ensureTotalCapacityPrecise(capacity) catch return self.fail();
+    }
+    return self.out.writer.writeSplat(data, splat) catch return self.fail();
+}
+
+fn flush(_: *std.Io.Writer) std.Io.Writer.Error!void {}
+
+fn fail(self: *ResponseBuffer) error{WriteFailed} {
+    self.failed = true;
+    return error.WriteFailed;
+}
+
+test "ResponseBuffer: limit failure is transactional" {
+    var out: ResponseBuffer = .init(std.testing.allocator, 16);
+    defer out.deinit();
+
+    try out.writer.writeAll("1234567890");
+    try std.testing.expectError(error.WriteFailed, out.writer.writeAll("1234567"));
+    try std.testing.expect(out.failed);
+    try std.testing.expectEqualStrings("1234567890", out.buffered());
+}

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -1,0 +1,194 @@
+const DEFAULT_ENDPOINT = new URL("/v1/render", import.meta.url).href;
+const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+
+function resolveTarget(target) {
+  if (typeof target === "string") target = document.querySelector(target);
+  if (!(target instanceof Element)) throw new TypeError("Lightpanda renderer target not found");
+  return target;
+}
+
+function aborted(signal) {
+  return signal.reason ?? new DOMException("Lightpanda render superseded", "AbortError");
+}
+
+async function readResponseText(response, limit) {
+  const contentLength = Number(response.headers?.get?.("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+  }
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > limit) {
+      throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+    }
+    return text;
+  }
+
+  const chunks = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > limit) {
+      await reader.cancel().catch(() => {});
+      throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function waitForFrame(iframe, html, signal, isCurrent) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      iframe.removeEventListener("load", loaded);
+      iframe.removeEventListener("error", failed);
+      signal.removeEventListener("abort", cancelled);
+    };
+    const loaded = () => {
+      cleanup();
+      if (!isCurrent()) reject(aborted(signal));
+      else resolve();
+    };
+    const failed = () => {
+      cleanup();
+      reject(new Error("Lightpanda iframe failed to load the snapshot"));
+    };
+    const cancelled = () => {
+      cleanup();
+      reject(aborted(signal));
+    };
+
+    if (signal.aborted) return cancelled();
+    iframe.addEventListener("load", loaded, { once: true });
+    iframe.addEventListener("error", failed, { once: true });
+    signal.addEventListener("abort", cancelled, { once: true });
+    iframe.srcdoc = html;
+  });
+}
+
+export class LightpandaRenderer extends EventTarget {
+  #target;
+  #endpoint;
+  #token;
+  #maxResponseBytes;
+  #controller = null;
+  #sequence = 0;
+  #lastRequest = null;
+
+  constructor(target, options = {}) {
+    super();
+    this.#target = resolveTarget(target);
+    this.#endpoint = new URL(options.endpoint ?? DEFAULT_ENDPOINT, document.baseURI).href;
+    this.#token = options.token ?? null;
+    this.#maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    if (!Number.isSafeInteger(this.#maxResponseBytes) || this.#maxResponseBytes < 1) {
+      throw new RangeError("maxResponseBytes must be a positive safe integer");
+    }
+
+    const iframe = document.createElement("iframe");
+    // Same-frame forms remain native. Top-level and new-window targets stay
+    // blocked because the snapshot is not granted popup or top-navigation access.
+    iframe.setAttribute("sandbox", "allow-forms");
+    iframe.title = options.title ?? "Lightpanda rendered page";
+    iframe.loading = "eager";
+    iframe.referrerPolicy = "no-referrer";
+    iframe.style.cssText = options.style ?? "display:block;width:100%;height:100%;border:0";
+    if (options.className) iframe.className = options.className;
+    const supportsCredentialless = "credentialless" in iframe;
+    if (options.requireCredentialless && !supportsCredentialless) {
+      throw new Error("This browser does not support credentialless iframes");
+    }
+    if (options.credentialless !== false && supportsCredentialless) iframe.credentialless = true;
+    this.iframe = iframe;
+
+    if (options.replace === false) this.#target.append(iframe);
+    else this.#target.replaceChildren(iframe);
+  }
+
+  async render(url, options = {}) {
+    const source = new URL(url, document.baseURI).href;
+    const sequence = ++this.#sequence;
+    this.#controller?.abort();
+    const controller = new AbortController();
+    this.#controller = controller;
+
+    const bounds = this.#target.getBoundingClientRect();
+    const request = {
+      url: source,
+      wait_ms: options.waitMs,
+      wait_until: options.waitUntil,
+      wait_selector: options.waitSelector,
+      width: Math.max(1, Math.round((options.width ?? bounds.width) || 1280)),
+      height: Math.max(1, Math.round((options.height ?? bounds.height) || 720)),
+    };
+    for (const key of Object.keys(request)) {
+      if (request[key] == null) delete request[key];
+    }
+    this.#lastRequest = { url: source, options: { ...options } };
+
+    try {
+      const headers = { accept: "text/html", "content-type": "application/json" };
+      if (this.#token) headers.authorization = `Bearer ${this.#token}`;
+      const response = await fetch(this.#endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(request),
+        credentials: "omit",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda render failed (${response.status}): ${detail}`);
+      }
+
+      const html = await readResponseText(response, this.#maxResponseBytes);
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      await waitForFrame(
+        this.iframe,
+        html,
+        controller.signal,
+        () => sequence === this.#sequence,
+      );
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      this.dispatchEvent(new CustomEvent("render", { detail: { url: source } }));
+      return this.iframe;
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        this.dispatchEvent(new CustomEvent("rendererror", { detail: error }));
+      }
+      throw error;
+    } finally {
+      if (this.#controller === controller) this.#controller = null;
+    }
+  }
+
+  refresh(options = undefined) {
+    if (!this.#lastRequest) throw new Error("render() must be called before refresh()");
+    return this.render(
+      this.#lastRequest.url,
+      options ? { ...this.#lastRequest.options, ...options } : this.#lastRequest.options,
+    );
+  }
+
+  destroy() {
+    ++this.#sequence;
+    this.#controller?.abort();
+    this.#controller = null;
+    this.iframe.remove();
+  }
+}
+
+export function attachLightpandaRenderer(target, options) {
+  return new LightpandaRenderer(target, options);
+}

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+let autoLoadFrames = true;
+
+class FakeElement extends EventTarget {
+  attributes = new Map();
+  style = {};
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  replaceChildren(child) {
+    this.child = child;
+  }
+
+  getBoundingClientRect() {
+    return { width: 640, height: 480 };
+  }
+}
+
+class FakeFrame extends FakeElement {
+  set srcdoc(value) {
+    this.snapshot = value;
+    if (autoLoadFrames) queueMicrotask(() => this.dispatchEvent(new Event("load")));
+  }
+
+  remove() {
+    this.removed = true;
+  }
+}
+
+globalThis.Element = FakeElement;
+globalThis.document = {
+  baseURI: "https://preview.example/",
+  querySelector() {
+    return null;
+  },
+  createElement(name) {
+    assert.equal(name, "iframe");
+    return new FakeFrame();
+  },
+};
+
+let fetchImpl;
+globalThis.fetch = (...args) => fetchImpl(...args);
+
+async function waitUntil(predicate) {
+  for (let attempt = 0; attempt < 20; ++attempt) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail("condition did not become ready");
+}
+
+const source = (await readFile(new URL("./client.js", import.meta.url), "utf8")).replace(
+  /^const DEFAULT_ENDPOINT = .*;$/m,
+  'const DEFAULT_ENDPOINT = "https://renderer.example/v1/render";',
+);
+const { attachLightpandaRenderer } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`,
+);
+
+{
+  autoLoadFrames = false;
+  let sent;
+  fetchImpl = async (endpoint, options) => {
+    sent = { endpoint, options };
+    return new Response(
+      '<!doctype html><base href="https://source.example/"><h1>Rendered</h1>',
+      { headers: { "content-type": "text/html" } },
+    );
+  };
+
+  const target = new FakeElement();
+  const renderer = attachLightpandaRenderer(target, { token: "test-token" });
+  const pending = renderer.render("https://source.example/page");
+  await waitUntil(() => renderer.iframe.snapshot);
+  renderer.iframe.dispatchEvent(new Event("load"));
+  const frame = await pending;
+
+  assert.equal(target.child, frame);
+  assert.equal(frame.getAttribute("sandbox"), "allow-forms");
+  assert.equal(frame.getAttribute("sandbox").includes("allow-scripts"), false);
+  assert.equal(frame.getAttribute("sandbox").includes("allow-same-origin"), false);
+  assert.match(frame.snapshot, /<h1>Rendered<\/h1>/);
+  assert.equal(sent.endpoint, "https://renderer.example/v1/render");
+  assert.equal(sent.options.headers.authorization, "Bearer test-token");
+  assert.deepEqual(JSON.parse(sent.options.body), {
+    url: "https://source.example/page",
+    width: 640,
+    height: 480,
+  });
+}
+
+{
+  autoLoadFrames = true;
+  const responses = [];
+  fetchImpl = () => new Promise((resolve) => responses.push(resolve));
+  const renderer = attachLightpandaRenderer(new FakeElement());
+
+  const first = renderer.render("https://source.example/first");
+  const firstRejected = assert.rejects(first, { name: "AbortError" });
+  const second = renderer.render("https://source.example/second");
+  responses[1](new Response("<h1>Second</h1>"));
+  await second;
+  responses[0](new Response("<h1>First</h1>"));
+  await firstRejected;
+  assert.match(renderer.iframe.snapshot, /Second/);
+}
+
+{
+  autoLoadFrames = false;
+  fetchImpl = async () => new Response("<h1>Waiting</h1>");
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  const pending = renderer.render("https://source.example/destroy");
+  const rejected = assert.rejects(pending, { name: "AbortError" });
+  await waitUntil(() => renderer.iframe.snapshot);
+  renderer.destroy();
+  await rejected;
+  assert.equal(renderer.iframe.removed, true);
+}
+
+{
+  autoLoadFrames = true;
+  fetchImpl = async () => new Response("upstream failed", { status: 502 });
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await assert.rejects(
+    renderer.render("https://source.example/fail"),
+    /Lightpanda render failed \(502\): upstream failed/,
+  );
+}
+
+{
+  fetchImpl = async () => new Response("12345");
+  const renderer = attachLightpandaRenderer(new FakeElement(), { maxResponseBytes: 4 });
+  await assert.rejects(
+    renderer.render("https://source.example/large"),
+    /Lightpanda response exceeds 4 bytes/,
+  );
+}

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -80,6 +80,7 @@ pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode
         .mode = switch (run_mode) {
             .fetch => "F",
             .serve => "S",
+            .render => "CR",
             .agent => if (interactive == false) "AR" else "A",
             .run => "R",
             .mcp => "M",


### PR DESCRIPTION
## What changed

- Add `lightpanda render`, a loopback-only HTTP service for one-shot DOM rendering.
- Add `POST /v1/render`, `GET /lightpanda-renderer.js`, and `GET /healthz`.
- Add a small browser client that displays script-stripped snapshots in a sandboxed `srcdoc` iframe.
- Preserve relative resource and same-frame form URLs with a valid injected `<base href>`.
- Reuse one browser on one sequential worker to keep idle CPU and runtime memory low.

## Why

Lightpanda can execute dynamic pages, but embedding the resulting DOM in a normal browser currently requires consumers to build their own transport, isolation, and resource controls. This provides a minimal end-to-end preview path without adding a live-session protocol.

## Safety and resource bounds

- Bind is restricted to loopback.
- Private-network render targets are blocked by default and require explicit opt-in.
- CORS requires a bearer token; origins are exact-match or authenticated wildcard.
- Request bodies default to 16 KiB, upstream responses and DOM snapshots to 16 MiB.
- Connection count, socket time, viewport, selector, URL, and total queue/render time are bounded.
- Client disconnects cancel queued or active jobs; a stuck initial script is terminated at the request deadline.
- The preview iframe allows forms only. Scripts, same-origin access, popups, and top navigation remain blocked.

Non-goals: this does not add WebDriver concealment, fingerprint changes, CAPTCHA/Turnstile handling, compression, or a WebSocket/live-session transport.

## Validation

- `1131/1131` leak-checked Zig tests pass.
- Pinned-V8 `zig build ... -j1 check` passes.
- Changed Zig files pass `zig fmt --check`; `git diff --check` passes.
- `node --check src/render/client.js` and `node --test src/render/client.test.mjs` pass.
- Live deadline smoke: an infinite initial script returns `504` in `0.605s`, then the same worker renders a healthy page with `200`.
- Live disconnect smoke: aborting the stuck client releases the worker; the next render returns `200` in `0.020s`.
- In-app browser smoke verified dynamic DOM, sandbox isolation, relative resources, and native same-frame form submission.
- Idle runtime RSS was approximately `24–26 MiB`; no watchdog stall appeared after 35 seconds idle.

The repository-wide formatting command still reports the unchanged vendored `zig-pkg/boringssl-0.1.0-*/build.zig`; every file changed by this PR is clean.
