### PR TITLE
feat(webapi): support input valueAsNumber

### DIFF
--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -157,6 +157,13 @@
   testing.expectEqual('1969-12-31', date.value);
   date.valueAsNumber = 0;
   testing.expectEqual('1970-01-01', date.value);
+  date.valueAsNumber = 86399999.6;
+  testing.expectEqual('1970-01-01', date.value);
+  date.valueAsNumber = -0.1;
+  testing.expectEqual('1969-12-31', date.value);
+  date.value = '4294967297-01-01';
+  testing.expectEqual('', date.value);
+  testing.expectTrue(Number.isNaN(date.valueAsNumber));
   date.valueAsNumber = NaN;
   testing.expectEqual('', date.value);
   testing.expectError('TypeError', () => { date.valueAsNumber = Infinity; });

--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -135,6 +135,32 @@
   testing.expectEqual('new value', $('#text2').value)
 </script>
 
+<script id="value_as_number">
+{
+  const number = document.createElement('input');
+  number.type = 'number';
+  testing.expectTrue(Number.isNaN(number.valueAsNumber));
+  number.value = '12.5';
+  testing.expectEqual(12.5, number.valueAsNumber);
+  number.valueAsNumber = -4;
+  testing.expectEqual('-4', number.value);
+  number.valueAsNumber = NaN;
+  testing.expectEqual('', number.value);
+  testing.expectError('TypeError', () => { number.valueAsNumber = Infinity; });
+
+  const range = document.createElement('input');
+  range.type = 'range';
+  range.min = '0';
+  range.max = '10';
+  range.valueAsNumber = 12;
+  testing.expectEqual(10, range.valueAsNumber);
+
+  const text = document.createElement('input');
+  testing.expectError('InvalidStateError', () => { void text.valueAsNumber; });
+  testing.expectError('InvalidStateError', () => { text.valueAsNumber = 1; });
+}
+</script>
+
 <script id="checked_initial">
   testing.expectEqual(true, $('#check1').checked)
   testing.expectEqual(false, $('#check2').checked)

--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -148,6 +148,19 @@
   testing.expectEqual('', number.value);
   testing.expectError('TypeError', () => { number.valueAsNumber = Infinity; });
 
+  const date = document.createElement('input');
+  date.type = 'date';
+  testing.expectTrue(Number.isNaN(date.valueAsNumber));
+  date.value = '2024-03-01';
+  testing.expectEqual(1709251200000, date.valueAsNumber);
+  date.valueAsNumber = -1;
+  testing.expectEqual('1969-12-31', date.value);
+  date.valueAsNumber = 0;
+  testing.expectEqual('1970-01-01', date.value);
+  date.valueAsNumber = NaN;
+  testing.expectEqual('', date.value);
+  testing.expectError('TypeError', () => { date.valueAsNumber = Infinity; });
+
   const range = document.createElement('input');
   range.type = 'range';
   range.min = '0';
@@ -156,8 +169,9 @@
   testing.expectEqual(10, range.valueAsNumber);
 
   const text = document.createElement('input');
-  testing.expectError('InvalidStateError', () => { void text.valueAsNumber; });
+  testing.expectTrue(Number.isNaN(text.valueAsNumber));
   testing.expectError('InvalidStateError', () => { text.valueAsNumber = 1; });
+  testing.expectError('TypeError', () => { text.valueAsNumber = Infinity; });
 }
 </script>
 

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -167,6 +167,36 @@ pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
     self._value = try self.sanitizeValue(true, value, frame);
 }
 
+/// The numeric value for number and range controls. Other input states do not
+/// define a number conversion and must reject this API.
+pub fn getValueAsNumber(self: *const Input) !f64 {
+    switch (self._input_type) {
+        .number, .range => {},
+        else => return error.InvalidStateError,
+    }
+
+    const value = self.getValue();
+    if (!isValidFloatingPoint(value)) {
+        return std.math.nan(f64);
+    }
+    return std.fmt.parseFloat(f64, value) catch std.math.nan(f64);
+}
+
+pub fn setValueAsNumber(self: *Input, value: f64, frame: *Frame) !void {
+    switch (self._input_type) {
+        .number, .range => {},
+        else => return error.InvalidStateError,
+    }
+
+    if (std.math.isNan(value)) {
+        return self.setValue("", frame);
+    }
+    if (!std.math.isFinite(value)) {
+        return error.TypeError;
+    }
+    return self.setValue(try formatFloat(frame.local_arena, value), frame);
+}
+
 pub fn getDefaultValue(self: *const Input) []const u8 {
     return self._default_value orelse "";
 }
@@ -1411,6 +1441,7 @@ pub const JsApi = struct {
     pub const onselectionchange = bridge.accessor(Input.getOnSelectionChange, Input.setOnSelectionChange, .{});
     pub const @"type" = bridge.accessor(Input.getType, Input.setType, .{ .ce_reactions = true });
     pub const value = bridge.accessor(Input.getValueForJS, setValueFromJS, .{ .ce_reactions = true });
+    pub const valueAsNumber = bridge.accessor(Input.getValueAsNumber, Input.setValueAsNumber, .{});
     pub const files = bridge.accessor(Input.getFiles, null, .{});
     pub const defaultValue = bridge.accessor(Input.getDefaultValue, Input.setDefaultValue, .{ .ce_reactions = true });
     pub const checked = bridge.accessor(Input.getChecked, Input.setChecked, .{});

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -167,32 +167,35 @@ pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
     self._value = try self.sanitizeValue(true, value, frame);
 }
 
-/// The numeric value for number and range controls. Other input states do not
-/// define a number conversion and must reject this API.
-pub fn getValueAsNumber(self: *const Input) !f64 {
-    switch (self._input_type) {
-        .number, .range => {},
-        else => return error.InvalidStateError,
-    }
-
+/// The numeric value for number, range, and date controls. Getters on other
+/// input states return NaN; their setters reject the API.
+pub fn getValueAsNumber(self: *const Input) f64 {
     const value = self.getValue();
-    if (!isValidFloatingPoint(value)) {
-        return std.math.nan(f64);
-    }
-    return std.fmt.parseFloat(f64, value) catch std.math.nan(f64);
+    return switch (self._input_type) {
+        .number, .range => if (isValidFloatingPoint(value))
+            std.fmt.parseFloat(f64, value) catch std.math.nan(f64)
+        else
+            std.math.nan(f64),
+        .date => dateValueAsNumber(value),
+        else => std.math.nan(f64),
+    };
 }
 
 pub fn setValueAsNumber(self: *Input, value: f64, frame: *Frame) !void {
+    if (std.math.isInf(value)) {
+        return error.TypeError;
+    }
     switch (self._input_type) {
-        .number, .range => {},
+        .number, .range, .date => {},
         else => return error.InvalidStateError,
     }
 
     if (std.math.isNan(value)) {
         return self.setValue("", frame);
     }
-    if (!std.math.isFinite(value)) {
-        return error.TypeError;
+
+    if (self._input_type == .date) {
+        return self.setValue(try dateFromValueAsNumber(frame.local_arena, value), frame);
     }
     return self.setValue(try formatFloat(frame.local_arena, value), frame);
 }
@@ -1122,6 +1125,85 @@ fn isValidFloatingPoint(value: []const u8) bool {
     return !std.math.isInf(f) and !std.math.isNan(f);
 }
 
+const DateComponents = struct {
+    year: u32,
+    month: u32,
+    day: u32,
+};
+
+const CivilDate = struct {
+    year: i64,
+    month: i64,
+    day: i64,
+};
+
+const milliseconds_per_day: f64 = 86_400_000;
+const maximum_time_value: f64 = 8_640_000_000_000_000;
+
+fn dateValueAsNumber(value: []const u8) f64 {
+    const date = parseDateComponents(value) orelse return std.math.nan(f64);
+    const days = daysFromCivil(date.year, date.month, date.day);
+    return @as(f64, @floatFromInt(days)) * milliseconds_per_day;
+}
+
+fn dateFromValueAsNumber(arena: std.mem.Allocator, value: f64) ![]const u8 {
+    // Match the time-value range supported by browser date controls. Values
+    // outside it cannot produce a valid date string and reset to empty.
+    if (@abs(value) > maximum_time_value) return "";
+
+    const milliseconds = @round(value);
+    const days: i64 = @intFromFloat(@floor(milliseconds / milliseconds_per_day));
+    const date = civilFromDays(days);
+    if (date.year < 1) return "";
+    const year: u64 = @intCast(date.year);
+    const month: u64 = @intCast(date.month);
+    const day: u64 = @intCast(date.day);
+    return std.fmt.allocPrint(arena, "{d:0>4}-{d:0>2}-{d:0>2}", .{ year, month, day });
+}
+
+fn parseDateComponents(value: []const u8) ?DateComponents {
+    if (!isValidDate(value)) return null;
+    const year_len = value.len - 6;
+    return .{
+        .year = parseAllDigits(value[0..year_len]) orelse return null,
+        .month = parseAllDigits(value[year_len + 1 .. year_len + 3]) orelse return null,
+        .day = parseAllDigits(value[year_len + 4 ..]) orelse return null,
+    };
+}
+
+/// Days since 1970-01-01 in the proleptic Gregorian calendar.
+fn daysFromCivil(year: u32, month: u32, day: u32) i64 {
+    var y: i64 = year;
+    const m: i64 = month;
+    const d: i64 = day;
+    if (m <= 2) y -= 1;
+    const era = @divFloor(y, 400);
+    const year_of_era = y - era * 400;
+    const month_offset: i64 = if (m > 2) -3 else 9;
+    const day_of_year = @divFloor(153 * (m + month_offset) + 2, 5) + d - 1;
+    const day_of_era = year_of_era * 365 + @divFloor(year_of_era, 4) - @divFloor(year_of_era, 100) + day_of_year;
+    return era * 146_097 + day_of_era - 719_468;
+}
+
+fn civilFromDays(days: i64) CivilDate {
+    const z = days + 719_468;
+    const era = @divFloor(z, 146_097);
+    const day_of_era = z - era * 146_097;
+    const year_of_era = @divFloor(day_of_era - @divFloor(day_of_era, 1_460) + @divFloor(day_of_era, 36_524) - @divFloor(day_of_era, 146_096), 365);
+    var year = year_of_era + era * 400;
+    const day_of_year = day_of_era - (365 * year_of_era + @divFloor(year_of_era, 4) - @divFloor(year_of_era, 100));
+    const month_prime = @divFloor(5 * day_of_year + 2, 153);
+    const day = day_of_year - @divFloor(153 * month_prime + 2, 5) + 1;
+    const month_offset: i64 = if (month_prime < 10) 3 else -9;
+    const month = month_prime + month_offset;
+    if (month <= 2) year += 1;
+    return .{
+        .year = year,
+        .month = month,
+        .day = day,
+    };
+}
+
 /// Validate a WHATWG "valid date string": YYYY-MM-DD
 fn isValidDate(value: []const u8) bool {
     // Minimum: 4-digit year + "-MM-DD" = 10 chars
@@ -1355,13 +1437,15 @@ fn formatFloat(arena: std.mem.Allocator, value: f64) ![]const u8 {
     return std.fmt.allocPrint(arena, "{d}", .{value});
 }
 
-/// Parse a slice that must be ALL ASCII digits into a u32. Returns null if any non-digit or empty.
+/// Parse a slice that must be ALL ASCII digits into a u32. Returns null if any
+/// byte is not a digit, the slice is empty, or the value overflows.
 fn parseAllDigits(s: []const u8) ?u32 {
     if (s.len == 0) return null;
     var result: u32 = 0;
     for (s) |c| {
         if (!std.ascii.isDigit(c)) return null;
-        result = result *% 10 +% (c - '0');
+        result = std.math.mul(u32, result, 10) catch return null;
+        result = std.math.add(u32, result, c - '0') catch return null;
     }
     return result;
 }
@@ -1625,8 +1709,30 @@ test "isValidDate" {
     try testing.expect(!isValidDate("2024-00-01")); // month 0
     try testing.expect(!isValidDate("0000-01-01")); // year 0
     try testing.expect(!isValidDate("2024-1-01")); // single-digit month
+    try testing.expect(!isValidDate("4294967297-01-01")); // unsupported year must not wrap
     try testing.expect(!isValidDate(""));
     try testing.expect(!isValidDate("not-a-date"));
+}
+
+test "date valueAsNumber conversion" {
+    try testing.expectEqual(@as(f64, 0), dateValueAsNumber("1970-01-01"));
+    try testing.expectEqual(@as(f64, 1_709_251_200_000), dateValueAsNumber("2024-03-01"));
+
+    const previous = try dateFromValueAsNumber(testing.allocator, -1);
+    defer testing.allocator.free(previous);
+    try testing.expectEqual("1969-12-31", previous);
+
+    const epoch = try dateFromValueAsNumber(testing.allocator, 0);
+    defer testing.allocator.free(epoch);
+    try testing.expectEqual("1970-01-01", epoch);
+
+    const rounded_before_epoch = try dateFromValueAsNumber(testing.allocator, -0.1);
+    defer testing.allocator.free(rounded_before_epoch);
+    try testing.expectEqual("1970-01-01", rounded_before_epoch);
+
+    const rounded_next_day = try dateFromValueAsNumber(testing.allocator, 86_399_999.6);
+    defer testing.allocator.free(rounded_next_day);
+    try testing.expectEqual("1970-01-02", rounded_next_day);
 }
 
 test "isValidMonth" {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -1151,8 +1151,7 @@ fn dateFromValueAsNumber(arena: std.mem.Allocator, value: f64) ![]const u8 {
     // outside it cannot produce a valid date string and reset to empty.
     if (@abs(value) > maximum_time_value) return "";
 
-    const milliseconds = @round(value);
-    const days: i64 = @intFromFloat(@floor(milliseconds / milliseconds_per_day));
+    const days: i64 = @intFromFloat(@floor(value / milliseconds_per_day));
     const date = civilFromDays(days);
     if (date.year < 1) return "";
     const year: u64 = @intCast(date.year);
@@ -1726,13 +1725,13 @@ test "date valueAsNumber conversion" {
     defer testing.allocator.free(epoch);
     try testing.expectEqual("1970-01-01", epoch);
 
-    const rounded_before_epoch = try dateFromValueAsNumber(testing.allocator, -0.1);
-    defer testing.allocator.free(rounded_before_epoch);
-    try testing.expectEqual("1970-01-01", rounded_before_epoch);
+    const fractional_before_epoch = try dateFromValueAsNumber(testing.allocator, -0.1);
+    defer testing.allocator.free(fractional_before_epoch);
+    try testing.expectEqual("1969-12-31", fractional_before_epoch);
 
-    const rounded_next_day = try dateFromValueAsNumber(testing.allocator, 86_399_999.6);
-    defer testing.allocator.free(rounded_next_day);
-    try testing.expectEqual("1970-01-02", rounded_next_day);
+    const fractional_end_of_day = try dateFromValueAsNumber(testing.allocator, 86_399_999.6);
+    defer testing.allocator.free(fractional_end_of_day);
+    try testing.expectEqual("1970-01-01", fractional_end_of_day);
 }
 
 test "isValidMonth" {
@@ -1806,6 +1805,8 @@ test "parseAllDigits" {
     try testing.expectEqual(@as(?u32, 0), parseAllDigits("0"));
     try testing.expectEqual(@as(?u32, 123), parseAllDigits("123"));
     try testing.expectEqual(@as(?u32, 2024), parseAllDigits("2024"));
+    try testing.expectEqual(@as(?u32, std.math.maxInt(u32)), parseAllDigits("4294967295"));
+    try testing.expectEqual(@as(?u32, null), parseAllDigits("4294967297"));
     try testing.expectEqual(@as(?u32, null), parseAllDigits(""));
     try testing.expectEqual(@as(?u32, null), parseAllDigits("12a"));
     try testing.expectEqual(@as(?u32, null), parseAllDigits("abc"));


### PR DESCRIPTION
## What changed

- Expose `HTMLInputElement.valueAsNumber`.
- Support number, range, and date controls.
- Return `NaN` for empty or unsupported getters.
- Empty the value when assigning `NaN`, reject infinity with `TypeError`, and reject unsupported setters with `InvalidStateError`.
- Convert date controls to and from UTC epoch milliseconds.
- Preserve fractional-millisecond day boundaries without rounding into an adjacent date.
- Reject overflowing year parsing instead of wrapping.

## Why

Forms, date pickers, validation libraries, and application frameworks commonly use `valueAsNumber` instead of manually parsing `input.value`. Lightpanda previously exposed only the string API, so otherwise valid form code failed.

For date controls, the HTML algorithm selects the UTC date current at the supplied offset from the epoch. Thus `86399999.6` remains `1970-01-01`, while `-0.1` belongs to `1969-12-31`.

## Validation

- `1126/1126` leak-checked Zig tests pass.
- `WebApi: HTML.Input` passes.
- `date valueAsNumber conversion` passes.
- `parseAllDigits` passes.
- `zig fmt --check src/browser/webapi/element/html/Input.zig` passes.
- `git diff --check` passes.

Reference: https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)
