### PR TITLE
build: add a small native profile

### DIFF
--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - ".github/**"
       - "src/**"
+      - "Makefile"
       - "build.zig"
       - "build.zig.zon"
 
@@ -27,6 +28,7 @@ on:
     paths:
       - ".github/**"
       - "src/**"
+      - "Makefile"
       - "build.zig"
       - "build.zig.zon"
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ F=
 # to point at a prebuilt V8 archive and skip the multi-minute source rebuild:
 #   ZIGFLAGS=-Dprebuilt_v8_path=/path/to/libc_v8.a make test
 ZIGFLAGS ?=
+PI_OPTIMIZE ?= ReleaseSmall
+PI_JOBS ?= 1
 
 # OS and ARCH
 kernel = $(shell uname -ms)
@@ -79,7 +81,7 @@ help:
 
 # $(ZIG) commands
 # ------------
-.PHONY: build build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
+.PHONY: build build-pi build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
 
 ## Download the prebuilt V8 archive (skips the 10+ min source build)
 download-v8:
@@ -102,6 +104,14 @@ build: build-v8-snapshot
 	@printf "\033[36mBuilding (release fast)...\033[0m\n"
 	@$(ZIG) build $(ZIGFLAGS) -Doptimize=ReleaseFast -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mBuild ERROR\033[0m\n"; exit 1;)
 	@printf "\033[33mBuild OK\033[0m\n"
+
+## Build a low-memory, size-optimized binary for Raspberry Pi
+build-pi: download-v8
+	@printf "\033[36mGenerating V8 snapshot ($(PI_JOBS) job)...\033[0m\n"
+	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
+	@printf "\033[36mBuilding Raspberry Pi profile ($(PI_OPTIMIZE), $(PI_JOBS) job)...\033[0m\n"
+	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=$(PI_OPTIMIZE) -Dlink_gc_sections=true -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mPi build ERROR\033[0m\n"; exit 1;)
+	@printf "\033[33mPi build OK: zig-out/bin/lightpanda\033[0m\n"
 
 ## Build in debug mode
 build-dev:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ F=
 # to point at a prebuilt V8 archive and skip the multi-minute source rebuild:
 #   ZIGFLAGS=-Dprebuilt_v8_path=/path/to/libc_v8.a make test
 ZIGFLAGS ?=
-PI_OPTIMIZE ?= ReleaseSmall
-PI_JOBS ?= 1
+SMALL_OPTIMIZE ?= ReleaseSmall
+SMALL_JOBS ?= 1
 
 # OS and ARCH
 kernel = $(shell uname -ms)
@@ -81,7 +81,7 @@ help:
 
 # $(ZIG) commands
 # ------------
-.PHONY: build build-pi build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
+.PHONY: build build-small build-pi build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
 
 ## Download the prebuilt V8 archive (skips the 10+ min source build)
 download-v8:
@@ -105,13 +105,16 @@ build: build-v8-snapshot
 	@$(ZIG) build $(ZIGFLAGS) -Doptimize=ReleaseFast -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mBuild ERROR\033[0m\n"; exit 1;)
 	@printf "\033[33mBuild OK\033[0m\n"
 
-## Build a low-memory, size-optimized binary for Raspberry Pi
-build-pi: download-v8
-	@printf "\033[36mGenerating V8 snapshot ($(PI_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
-	@printf "\033[36mBuilding Raspberry Pi profile ($(PI_OPTIMIZE), $(PI_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=$(PI_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mPi build ERROR\033[0m\n"; exit 1;)
-	@printf "\033[33mPi build OK: zig-out/bin/lightpanda\033[0m\n"
+## Build a low-parallelism, size-optimized native binary
+build-small: download-v8
+	@printf "\033[36mGenerating V8 snapshot ($(SMALL_JOBS) job)...\033[0m\n"
+	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
+	@printf "\033[36mBuilding small native profile ($(SMALL_OPTIMIZE), $(SMALL_JOBS) job)...\033[0m\n"
+	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(ZIGFLAGS) -Doptimize=$(SMALL_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mSmall build ERROR\033[0m\n"; exit 1;)
+	@printf "\033[33mSmall build OK: zig-out/bin/lightpanda\033[0m\n"
+
+## Build natively on a supported 64-bit Raspberry Pi (not cross-compilation)
+build-pi: build-small
 
 ## Build in debug mode
 build-dev:

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build: build-v8-snapshot
 ## Build a low-parallelism, size-optimized native binary
 build-small: $(SMALL_V8_DEP)
 	@printf "\033[36mGenerating V8 snapshot ($(SMALL_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(SMALL_ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
+	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(SMALL_ZIGFLAGS) -Doptimize=$(SMALL_OPTIMIZE) snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
 	@printf "\033[36mBuilding small native profile ($(SMALL_OPTIMIZE), $(SMALL_JOBS) job)...\033[0m\n"
 	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(SMALL_ZIGFLAGS) -Doptimize=$(SMALL_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mSmall build ERROR\033[0m\n"; exit 1;)
 	@strip -x zig-out/bin/lightpanda || (printf "\033[33mStrip ERROR\033[0m\n"; exit 1;)

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ build-pi: download-v8
 	@printf "\033[36mGenerating V8 snapshot ($(PI_JOBS) job)...\033[0m\n"
 	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
 	@printf "\033[36mBuilding Raspberry Pi profile ($(PI_OPTIMIZE), $(PI_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=$(PI_OPTIMIZE) -Dlink_gc_sections=true -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mPi build ERROR\033[0m\n"; exit 1;)
+	@CARGO_BUILD_JOBS=$(PI_JOBS) $(ZIG) build -j$(PI_JOBS) $(ZIGFLAGS) -Doptimize=$(PI_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mPi build ERROR\033[0m\n"; exit 1;)
 	@printf "\033[33mPi build OK: zig-out/bin/lightpanda\033[0m\n"
 
 ## Build in debug mode

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,13 @@ ifeq ($(strip $(ZIGFLAGS)),)
   endif
 endif
 
+# `build-small` always uses a prebuilt V8 archive. Reuse an explicit path when
+# supplied; otherwise download and select the archive for this host.
+SMALL_ZIGFLAGS := $(ZIGFLAGS)
+ifeq ($(filter -Dprebuilt_v8_path=%,$(SMALL_ZIGFLAGS)),)
+  SMALL_ZIGFLAGS += -Dprebuilt_v8_path=$(V8_CACHE)
+  SMALL_V8_DEP := download-v8
+endif
 
 # Infos
 # -----
@@ -106,12 +113,14 @@ build: build-v8-snapshot
 	@printf "\033[33mBuild OK\033[0m\n"
 
 ## Build a low-parallelism, size-optimized native binary
-build-small: download-v8
+build-small: $(SMALL_V8_DEP)
 	@printf "\033[36mGenerating V8 snapshot ($(SMALL_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
+	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(SMALL_ZIGFLAGS) -Doptimize=ReleaseSmall snapshot_creator -- src/snapshot.bin || (printf "\033[33mSnapshot build ERROR\033[0m\n"; exit 1;)
 	@printf "\033[36mBuilding small native profile ($(SMALL_OPTIMIZE), $(SMALL_JOBS) job)...\033[0m\n"
-	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(ZIGFLAGS) -Doptimize=$(SMALL_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mSmall build ERROR\033[0m\n"; exit 1;)
-	@printf "\033[33mSmall build OK: zig-out/bin/lightpanda\033[0m\n"
+	@CARGO_BUILD_JOBS=$(SMALL_JOBS) $(ZIG) build -j$(SMALL_JOBS) $(SMALL_ZIGFLAGS) -Doptimize=$(SMALL_OPTIMIZE) -Dsnapshot_path=../../snapshot.bin || (printf "\033[33mSmall build ERROR\033[0m\n"; exit 1;)
+	@strip -x zig-out/bin/lightpanda || (printf "\033[33mStrip ERROR\033[0m\n"; exit 1;)
+	@if [ "$(OS)" = "macos" ]; then codesign --force --sign - zig-out/bin/lightpanda || (printf "\033[33mCodesign ERROR\033[0m\n"; exit 1;); fi
+	@printf "\033[33mSmall build OK: %s bytes\033[0m\n" "$$(wc -c < zig-out/bin/lightpanda | tr -d ' ')"
 
 ## Build natively on a supported 64-bit Raspberry Pi (not cross-compilation)
 build-pi: build-small

--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,11 @@ pub fn build(b: *Build) !void {
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
     const snapshot_path = b.option([]const u8, "snapshot_path", "Path to v8 snapshot");
     const wpt_extensions = b.option(bool, "wpt_extensions", "Extend WebAPI with WPT driver behavior") orelse false;
+    const link_gc_sections = b.option(
+        bool,
+        "link_gc_sections",
+        "Place functions and data in separate sections, then remove unreachable sections",
+    ) orelse false;
 
     const version = resolveVersion(b);
     std.debug.print("Lightpanda {f}\n", .{version});
@@ -83,8 +88,8 @@ pub fn build(b: *Build) !void {
         // Set default behavior
         b.default_step.dependOn(fmt_step);
 
-        try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path);
-        try linkCurl(b, mod, enable_tsan);
+        try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path, link_gc_sections);
+        try linkCurl(b, mod, enable_tsan, link_gc_sections);
         try linkHtml5Ever(b, mod);
         linkZenai(b, mod);
         linkIsocline(b, mod);
@@ -92,7 +97,7 @@ pub fn build(b: *Build) !void {
         break :blk mod;
     };
 
-    linkSqlite(b, lightpanda_module, enable_csan, enable_tsan);
+    linkSqlite(b, lightpanda_module, enable_csan, enable_tsan, link_gc_sections);
 
     // Check compilation
     const check = b.step("check", "Check if lightpanda compiles");
@@ -124,6 +129,7 @@ pub fn build(b: *Build) !void {
                 },
             }),
         });
+        enableLinkTimeGarbageCollection(exe, link_gc_sections);
         b.installArtifact(exe);
 
         const exe_check = b.addLibrary(.{
@@ -226,6 +232,7 @@ fn linkV8(
     is_asan: bool,
     is_tsan: bool,
     prebuilt_v8_path: ?[]const u8,
+    link_gc_sections: bool,
 ) !void {
     const target = mod.resolved_target.?;
 
@@ -240,6 +247,14 @@ fn linkV8(
         .prebuilt_v8_path = prebuilt_v8_path,
     });
     mod.addImport("v8", dep.module("v8"));
+}
+
+fn enableLinkTimeGarbageCollection(compile: *Build.Step.Compile, enabled: bool) void {
+    if (!enabled) return;
+
+    compile.link_function_sections = true;
+    compile.link_data_sections = true;
+    compile.link_gc_sections = true;
 }
 
 fn linkHtml5Ever(b: *Build, mod: *Build.Module) !void {
@@ -276,7 +291,7 @@ fn linkHtml5Ever(b: *Build, mod: *Build.Module) !void {
     mod.addObjectFile(obj);
 }
 
-fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is_tsan: bool) void {
+fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is_tsan: bool, link_gc_sections: bool) void {
     const dep = b.dependency("sqlite3", .{
         .target = mod.resolved_target.?,
         .optimize = mod.optimize.?,
@@ -285,6 +300,7 @@ fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is
     const lib = dep.artifact("sqlite3");
     lib.root_module.sanitize_c = enable_csan;
     lib.root_module.sanitize_thread = is_tsan;
+    enableLinkTimeGarbageCollection(lib, link_gc_sections);
 
     const macros = [_]struct { []const u8, []const u8 }{
         .{ "SQLITE_DEFAULT_FILE_PERMISSIONS", "0600" },
@@ -334,10 +350,10 @@ fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is
     mod.addImport("sqlite3", translate_c.createModule());
 }
 
-fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
+fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool, link_gc_sections: bool) !void {
     const target = mod.resolved_target.?;
 
-    const curl = buildCurl(b, target, mod.optimize.?, is_tsan);
+    const curl = buildCurl(b, target, mod.optimize.?, is_tsan, link_gc_sections);
     mod.linkLibrary(curl);
 
     const dep = b.dependency("curl", .{});
@@ -349,16 +365,16 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
     translate_c.addIncludePath(dep.path("include"));
     mod.addImport("curl", translate_c.createModule());
 
-    const zlib = buildZlib(b, target, mod.optimize.?, is_tsan);
+    const zlib = buildZlib(b, target, mod.optimize.?, is_tsan, link_gc_sections);
     curl.root_module.linkLibrary(zlib);
 
-    const brotli = buildBrotli(b, target, mod.optimize.?, is_tsan);
+    const brotli = buildBrotli(b, target, mod.optimize.?, is_tsan, link_gc_sections);
     for (brotli) |lib| curl.root_module.linkLibrary(lib);
 
-    const nghttp2 = buildNghttp2(b, target, mod.optimize.?, is_tsan);
+    const nghttp2 = buildNghttp2(b, target, mod.optimize.?, is_tsan, link_gc_sections);
     curl.root_module.linkLibrary(nghttp2);
 
-    const boringssl = buildBoringSsl(b, target, mod.optimize.?);
+    const boringssl = buildBoringSsl(b, target, mod.optimize.?, link_gc_sections);
     for (boringssl) |lib| curl.root_module.linkLibrary(lib);
 
     switch (target.result.os.tag) {
@@ -372,7 +388,7 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
     }
 }
 
-fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) *Build.Step.Compile {
+fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) *Build.Step.Compile {
     const dep = b.dependency("zlib", .{});
 
     const mod = b.createModule(.{
@@ -383,6 +399,7 @@ fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Opti
     });
 
     const lib = b.addLibrary(.{ .name = "z", .root_module = mod });
+    enableLinkTimeGarbageCollection(lib, link_gc_sections);
     lib.installHeadersDirectory(dep.path(""), "", .{});
     mod.addCSourceFiles(.{
         .root = dep.path(""),
@@ -404,7 +421,7 @@ fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Opti
     return lib;
 }
 
-fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) [3]*Build.Step.Compile {
+fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) [3]*Build.Step.Compile {
     const dep = b.dependency("brotli", .{});
 
     const mod = b.createModule(.{
@@ -418,6 +435,9 @@ fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Op
     const brotlicmn = b.addLibrary(.{ .name = "brotlicommon", .root_module = mod });
     const brotlidec = b.addLibrary(.{ .name = "brotlidec", .root_module = mod });
     const brotlienc = b.addLibrary(.{ .name = "brotlienc", .root_module = mod });
+    inline for (.{ brotlicmn, brotlidec, brotlienc }) |lib| {
+        enableLinkTimeGarbageCollection(lib, link_gc_sections);
+    }
 
     brotlicmn.installHeadersDirectory(dep.path("c/include/brotli"), "brotli", .{});
     mod.addCSourceFiles(.{
@@ -451,7 +471,7 @@ fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Op
     return .{ brotlicmn, brotlidec, brotlienc };
 }
 
-fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) [2]*Build.Step.Compile {
+fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, link_gc_sections: bool) [2]*Build.Step.Compile {
     const dep = b.dependency("boringssl-zig", .{
         .target = target,
         .optimize = optimize,
@@ -464,10 +484,13 @@ fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin
     const crypto = dep.artifact("crypto");
     crypto.bundle_ubsan_rt = false;
 
+    enableLinkTimeGarbageCollection(ssl, link_gc_sections);
+    enableLinkTimeGarbageCollection(crypto, link_gc_sections);
+
     return .{ ssl, crypto };
 }
 
-fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) *Build.Step.Compile {
+fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) *Build.Step.Compile {
     const dep = b.dependency("nghttp2", .{});
 
     const mod = b.createModule(.{
@@ -488,6 +511,7 @@ fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.O
     mod.addConfigHeader(config);
 
     const lib = b.addLibrary(.{ .name = "nghttp2", .root_module = mod });
+    enableLinkTimeGarbageCollection(lib, link_gc_sections);
 
     lib.installConfigHeader(config);
     lib.installHeadersDirectory(dep.path("lib/includes/nghttp2"), "nghttp2", .{});
@@ -520,6 +544,7 @@ fn buildCurl(
     target: Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     is_tsan: bool,
+    link_gc_sections: bool,
 ) *Build.Step.Compile {
     const dep = b.dependency("curl", .{});
 
@@ -774,6 +799,7 @@ fn buildCurl(
     curl_config.addValues(config);
 
     const lib = b.addLibrary(.{ .name = "curl", .root_module = mod });
+    enableLinkTimeGarbageCollection(lib, link_gc_sections);
     mod.addConfigHeader(curl_config);
     lib.installHeadersDirectory(dep.path("include/curl"), "curl", .{});
     mod.addCSourceFiles(.{

--- a/build.zig
+++ b/build.zig
@@ -42,11 +42,6 @@ pub fn build(b: *Build) !void {
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
     const snapshot_path = b.option([]const u8, "snapshot_path", "Path to v8 snapshot");
     const wpt_extensions = b.option(bool, "wpt_extensions", "Extend WebAPI with WPT driver behavior") orelse false;
-    const link_gc_sections = b.option(
-        bool,
-        "link_gc_sections",
-        "Place functions and data in separate sections, then remove unreachable sections",
-    ) orelse false;
 
     const version = resolveVersion(b);
     std.debug.print("Lightpanda {f}\n", .{version});
@@ -89,7 +84,7 @@ pub fn build(b: *Build) !void {
         b.default_step.dependOn(fmt_step);
 
         try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path);
-        try linkCurl(b, mod, enable_tsan, link_gc_sections);
+        try linkCurl(b, mod, enable_tsan);
         try linkHtml5Ever(b, mod);
         linkZenai(b, mod);
         linkIsocline(b, mod);
@@ -97,7 +92,7 @@ pub fn build(b: *Build) !void {
         break :blk mod;
     };
 
-    linkSqlite(b, lightpanda_module, enable_csan, enable_tsan, link_gc_sections);
+    linkSqlite(b, lightpanda_module, enable_csan, enable_tsan);
 
     // Check compilation
     const check = b.step("check", "Check if lightpanda compiles");
@@ -129,7 +124,6 @@ pub fn build(b: *Build) !void {
                 },
             }),
         });
-        enableLinkTimeGarbageCollection(exe, link_gc_sections);
         b.installArtifact(exe);
 
         const exe_check = b.addLibrary(.{
@@ -248,14 +242,6 @@ fn linkV8(
     mod.addImport("v8", dep.module("v8"));
 }
 
-fn enableLinkTimeGarbageCollection(compile: *Build.Step.Compile, enabled: bool) void {
-    if (!enabled) return;
-
-    compile.link_function_sections = true;
-    compile.link_data_sections = true;
-    compile.link_gc_sections = true;
-}
-
 fn linkHtml5Ever(b: *Build, mod: *Build.Module) !void {
     const is_debug = if (mod.optimize.? == .Debug) true else false;
 
@@ -290,7 +276,7 @@ fn linkHtml5Ever(b: *Build, mod: *Build.Module) !void {
     mod.addObjectFile(obj);
 }
 
-fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is_tsan: bool, link_gc_sections: bool) void {
+fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is_tsan: bool) void {
     const dep = b.dependency("sqlite3", .{
         .target = mod.resolved_target.?,
         .optimize = mod.optimize.?,
@@ -299,7 +285,6 @@ fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is
     const lib = dep.artifact("sqlite3");
     lib.root_module.sanitize_c = enable_csan;
     lib.root_module.sanitize_thread = is_tsan;
-    enableLinkTimeGarbageCollection(lib, link_gc_sections);
 
     const macros = [_]struct { []const u8, []const u8 }{
         .{ "SQLITE_DEFAULT_FILE_PERMISSIONS", "0600" },
@@ -349,10 +334,10 @@ fn linkSqlite(b: *Build, mod: *Build.Module, enable_csan: ?std.zig.SanitizeC, is
     mod.addImport("sqlite3", translate_c.createModule());
 }
 
-fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool, link_gc_sections: bool) !void {
+fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool) !void {
     const target = mod.resolved_target.?;
 
-    const curl = buildCurl(b, target, mod.optimize.?, is_tsan, link_gc_sections);
+    const curl = buildCurl(b, target, mod.optimize.?, is_tsan);
     mod.linkLibrary(curl);
 
     const dep = b.dependency("curl", .{});
@@ -364,16 +349,16 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool, link_gc_sections: bool
     translate_c.addIncludePath(dep.path("include"));
     mod.addImport("curl", translate_c.createModule());
 
-    const zlib = buildZlib(b, target, mod.optimize.?, is_tsan, link_gc_sections);
+    const zlib = buildZlib(b, target, mod.optimize.?, is_tsan);
     curl.root_module.linkLibrary(zlib);
 
-    const brotli = buildBrotli(b, target, mod.optimize.?, is_tsan, link_gc_sections);
+    const brotli = buildBrotli(b, target, mod.optimize.?, is_tsan);
     for (brotli) |lib| curl.root_module.linkLibrary(lib);
 
-    const nghttp2 = buildNghttp2(b, target, mod.optimize.?, is_tsan, link_gc_sections);
+    const nghttp2 = buildNghttp2(b, target, mod.optimize.?, is_tsan);
     curl.root_module.linkLibrary(nghttp2);
 
-    const boringssl = buildBoringSsl(b, target, mod.optimize.?, link_gc_sections);
+    const boringssl = buildBoringSsl(b, target, mod.optimize.?);
     for (boringssl) |lib| curl.root_module.linkLibrary(lib);
 
     switch (target.result.os.tag) {
@@ -387,7 +372,7 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool, link_gc_sections: bool
     }
 }
 
-fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) *Build.Step.Compile {
+fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) *Build.Step.Compile {
     const dep = b.dependency("zlib", .{});
 
     const mod = b.createModule(.{
@@ -398,7 +383,6 @@ fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Opti
     });
 
     const lib = b.addLibrary(.{ .name = "z", .root_module = mod });
-    enableLinkTimeGarbageCollection(lib, link_gc_sections);
     lib.installHeadersDirectory(dep.path(""), "", .{});
     mod.addCSourceFiles(.{
         .root = dep.path(""),
@@ -420,7 +404,7 @@ fn buildZlib(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Opti
     return lib;
 }
 
-fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) [3]*Build.Step.Compile {
+fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) [3]*Build.Step.Compile {
     const dep = b.dependency("brotli", .{});
 
     const mod = b.createModule(.{
@@ -434,9 +418,6 @@ fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Op
     const brotlicmn = b.addLibrary(.{ .name = "brotlicommon", .root_module = mod });
     const brotlidec = b.addLibrary(.{ .name = "brotlidec", .root_module = mod });
     const brotlienc = b.addLibrary(.{ .name = "brotlienc", .root_module = mod });
-    inline for (.{ brotlicmn, brotlidec, brotlienc }) |lib| {
-        enableLinkTimeGarbageCollection(lib, link_gc_sections);
-    }
 
     brotlicmn.installHeadersDirectory(dep.path("c/include/brotli"), "brotli", .{});
     mod.addCSourceFiles(.{
@@ -470,7 +451,7 @@ fn buildBrotli(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.Op
     return .{ brotlicmn, brotlidec, brotlienc };
 }
 
-fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, link_gc_sections: bool) [2]*Build.Step.Compile {
+fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) [2]*Build.Step.Compile {
     const dep = b.dependency("boringssl-zig", .{
         .target = target,
         .optimize = optimize,
@@ -483,13 +464,10 @@ fn buildBoringSsl(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin
     const crypto = dep.artifact("crypto");
     crypto.bundle_ubsan_rt = false;
 
-    enableLinkTimeGarbageCollection(ssl, link_gc_sections);
-    enableLinkTimeGarbageCollection(crypto, link_gc_sections);
-
     return .{ ssl, crypto };
 }
 
-fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool, link_gc_sections: bool) *Build.Step.Compile {
+fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, is_tsan: bool) *Build.Step.Compile {
     const dep = b.dependency("nghttp2", .{});
 
     const mod = b.createModule(.{
@@ -510,7 +488,6 @@ fn buildNghttp2(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.O
     mod.addConfigHeader(config);
 
     const lib = b.addLibrary(.{ .name = "nghttp2", .root_module = mod });
-    enableLinkTimeGarbageCollection(lib, link_gc_sections);
 
     lib.installConfigHeader(config);
     lib.installHeadersDirectory(dep.path("lib/includes/nghttp2"), "nghttp2", .{});
@@ -543,7 +520,6 @@ fn buildCurl(
     target: Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     is_tsan: bool,
-    link_gc_sections: bool,
 ) *Build.Step.Compile {
     const dep = b.dependency("curl", .{});
 
@@ -798,7 +774,6 @@ fn buildCurl(
     curl_config.addValues(config);
 
     const lib = b.addLibrary(.{ .name = "curl", .root_module = mod });
-    enableLinkTimeGarbageCollection(lib, link_gc_sections);
     mod.addConfigHeader(curl_config);
     lib.installHeadersDirectory(dep.path("include/curl"), "curl", .{});
     mod.addCSourceFiles(.{

--- a/build.zig
+++ b/build.zig
@@ -88,7 +88,7 @@ pub fn build(b: *Build) !void {
         // Set default behavior
         b.default_step.dependOn(fmt_step);
 
-        try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path, link_gc_sections);
+        try linkV8(b, mod, enable_asan, enable_tsan, prebuilt_v8_path);
         try linkCurl(b, mod, enable_tsan, link_gc_sections);
         try linkHtml5Ever(b, mod);
         linkZenai(b, mod);
@@ -232,7 +232,6 @@ fn linkV8(
     is_asan: bool,
     is_tsan: bool,
     prebuilt_v8_path: ?[]const u8,
-    link_gc_sections: bool,
 ) !void {
     const target = mod.resolved_target.?;
 


### PR DESCRIPTION
## What changed

- Add `make build-small` for a native, size-optimized build with one Zig and
  Cargo job by default.
- Add `make build-pi` as the native 64-bit Raspberry Pi entry point.
- Use the matching prebuilt V8 archive instead of compiling V8 from source.
- Build the snapshot creator and final binary with the same configurable
  optimization mode.
- Strip local symbols and restore an ad-hoc signature on macOS.
- Make Makefile-only changes trigger the Zig workflow.

## Why

The normal native build prioritizes runtime speed and can launch several
compiler jobs. That is a poor fit for constrained machines and produces a
substantially larger binary. The new profile makes the low-resource tradeoff
explicit without changing the default build.

## Impact

On macOS arm64, the final binary changed from 65,939,864 bytes to 50,610,016
bytes, saving 15,329,848 bytes (23.25%). The recipe limits Zig and Cargo to one
build job. It remains a native build rather than a cross-compilation path.

Stripping local symbols reduces native crash-symbol detail. The one-job setting
lowers build concurrency but does not guarantee a low peak compiler RSS;
Raspberry Pi hardware validation is still required.

## Validation

- `make build-small ZIGFLAGS=-Dprebuilt_v8_path=...`
- a warm independent rebuild produced the same `50,610,016` byte output
- final size: `50,610,016` bytes
- `codesign --verify --deep --strict --verbose=2 zig-out/bin/lightpanda`
- `./zig-out/bin/lightpanda version`
- stripped binary HTTPS fetch smoke test: exit 0
- `make -n build-small SMALL_OPTIMIZE=Debug ...` confirms both stages use
  `Debug`
- `git diff --check upstream/main..HEAD`

## Limits

- This is native compilation, not cross-compilation, and does not target
  32-bit Raspberry Pi OS.
- Raspberry Pi hardware validation is still pending.
- `-j1` bounds compiler concurrency, not linker memory; a cold
  snapshot-creator link was observed at roughly 972 MiB peak RSS.
- The small runtime RSS delta measured locally was below 1% and is not claimed
  as a general runtime-memory improvement.
