### PR TITLE
feat(render): add bounded live preview sessions

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -355,6 +355,22 @@ const Commands = cli.Builder(.{
         .shared_options = CommonOptions,
     },
     .{
+        .name = "render",
+        .options = .{
+            .{ .name = "host", .type = []const u8, .default = "127.0.0.1" },
+            .{ .name = "port", .type = u16, .default = 9223 },
+            .{ .name = "auth_token", .type = ?[]const u8 },
+            .{ .name = "cors_origin", .type = ?[]const u8 },
+            .{ .name = "max_connections", .type = ?u16 },
+            .{ .name = "max_request_size", .type = ?usize },
+            .{ .name = "max_response_size", .type = ?usize },
+            .{ .name = "max_wait_ms", .type = ?u32 },
+            .{ .name = "client_timeout_ms", .type = ?u32 },
+            .{ .name = "allow_private_networks", .type = bool },
+        },
+        .shared_options = CommonOptions,
+    },
+    .{
         .name = "mcp",
         .options = .{
             .{ .name = "port", .type = ?u16 },
@@ -434,7 +450,7 @@ pub fn deinit(self: *const Config, allocator: Allocator) void {
 pub fn interactive(self: *const Config) bool {
     return switch (self.mode) {
         .fetch => false,
-        .serve, .mcp => true,
+        .serve, .render, .mcp => true,
         .agent => |opts| opts.script_file == null,
         else => unreachable,
     };
@@ -442,7 +458,7 @@ pub fn interactive(self: *const Config) bool {
 
 pub fn tlsVerifyHost(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| !opts.insecure_disable_tls_host_verification,
         // `version --check` talks to the release endpoint; always verify.
         .version => true,
         else => unreachable,
@@ -451,28 +467,28 @@ pub fn tlsVerifyHost(self: *const Config) bool {
 
 pub fn obeyRobots(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.obey_robots,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.obey_robots,
         else => unreachable,
     };
 }
 
 pub fn disableSubframes(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_subframes,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.disable_subframes,
         else => unreachable,
     };
 }
 
 pub fn disableWorkers(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_workers,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.disable_workers,
         else => unreachable,
     };
 }
 
 pub fn watchdogMs(self: *const Config) ?u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| {
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| {
             const ms = opts.watchdog_ms orelse 30000;
             return if (ms == 0) null else ms;
         },
@@ -482,28 +498,28 @@ pub fn watchdogMs(self: *const Config) ?u32 {
 
 pub fn enableExternalStylesheets(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.enable_external_stylesheets,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.enable_external_stylesheets,
         else => unreachable,
     };
 }
 
 pub fn v8Flags(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_flags_unsafe,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.v8_flags_unsafe,
         else => unreachable,
     };
 }
 
 pub fn v8MaxHeapMb(self: *const Config) ?u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_max_heap_mb,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.v8_max_heap_mb,
         else => unreachable,
     };
 }
 
 pub fn httpProxy(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_proxy,
         .version => null,
         else => unreachable,
     };
@@ -511,28 +527,28 @@ pub fn httpProxy(self: *const Config) ?[:0]const u8 {
 
 pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.proxy_bearer_token,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.proxy_bearer_token,
         else => null,
     };
 }
 
 pub fn httpMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
         else => unreachable,
     };
 }
 
 pub fn httpMaxHostOpen(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
         else => unreachable,
     };
 }
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
         .version => 0,
         else => unreachable,
     };
@@ -540,7 +556,7 @@ pub fn httpConnectTimeout(self: *const Config) u31 {
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
         .version => 5000,
         else => unreachable,
     };
@@ -552,6 +568,7 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
+        .render => |opts| opts.http_max_response_size orelse 16 * 1024 * 1024,
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size,
         else => unreachable,
     };
@@ -559,7 +576,7 @@ pub fn httpMaxResponseSize(self: *const Config) ?usize {
 
 pub fn wsMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.ws_max_concurrent orelse 8,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.ws_max_concurrent orelse 8,
         else => unreachable,
     };
 }
@@ -571,7 +588,7 @@ pub fn logLevel(self: *const Config) ?log.Level {
             .low, .medium => .err,
             .high => null,
         },
-        inline .serve, .fetch, .mcp => |opts| opts.log_level,
+        inline .serve, .fetch, .render, .mcp => |opts| opts.log_level,
         else => unreachable,
     };
 }
@@ -601,49 +618,49 @@ fn stderrIsTty() bool {
 
 pub fn logFormat(self: *const Config) ?log.Format {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.log_format,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.log_format,
         else => unreachable,
     };
 }
 
 pub fn logFilterScopes(self: *const Config) std.ArrayList(log.FilterRule) {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.log_filter_scopes,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.log_filter_scopes,
         else => unreachable,
     };
 }
 
 pub fn userAgentSuffix(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent_suffix,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.user_agent_suffix,
         else => null,
     };
 }
 
 pub fn userAgent(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.user_agent,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.user_agent,
         else => null,
     };
 }
 
 pub fn httpCacheDir(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_dir,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.http_cache_dir,
         else => null,
     };
 }
 
 pub fn cookieFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.cookie,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.cookie,
         else => null,
     };
 }
 
 pub fn cookieJarFile(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .fetch, .mcp, .agent => |opts| opts.cookie_jar,
+        inline .fetch, .render, .mcp, .agent => |opts| opts.cookie_jar,
         else => null,
     };
 }
@@ -651,6 +668,7 @@ pub fn cookieJarFile(self: *const Config) ?[]const u8 {
 pub fn port(self: *const Config) u16 {
     return switch (self.mode) {
         .serve => |opts| opts.port,
+        .render => |opts| opts.port,
         .mcp => |opts| opts.cdp_port orelse 0,
         else => unreachable,
     };
@@ -659,6 +677,7 @@ pub fn port(self: *const Config) u16 {
 pub fn advertiseHost(self: *const Config) []const u8 {
     return switch (self.mode) {
         .serve => |opts| opts.advertise_host orelse opts.host,
+        .render => |opts| opts.host,
         .mcp => "127.0.0.1",
         else => unreachable,
     };
@@ -666,7 +685,7 @@ pub fn advertiseHost(self: *const Config) []const u8 {
 
 pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| WebBotAuthConfig{
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| WebBotAuthConfig{
             .key_file = opts.web_bot_auth_key_file orelse return null,
             .keyid = opts.web_bot_auth_keyid orelse return null,
             .domain = opts.web_bot_auth_domain orelse return null,
@@ -677,6 +696,7 @@ pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {
 
 pub fn blockPrivateNetworks(self: *const Config) bool {
     return switch (self.mode) {
+        .render => |opts| opts.block_private_networks or !opts.allow_private_networks,
         inline .serve, .fetch, .mcp, .agent => |opts| opts.block_private_networks,
         else => unreachable,
     };
@@ -684,14 +704,14 @@ pub fn blockPrivateNetworks(self: *const Config) bool {
 
 pub fn blockCidrs(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.block_cidrs,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.block_cidrs,
         else => unreachable,
     };
 }
 
 pub fn blockedUrlPatterns(self: *const Config) ?std.mem.SplitIterator(u8, .scalar) {
     const patterns = switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.block_urls,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.block_urls,
         else => unreachable,
     } orelse return null;
     return std.mem.splitScalar(u8, patterns, ',');
@@ -700,6 +720,7 @@ pub fn blockedUrlPatterns(self: *const Config) ?std.mem.SplitIterator(u8, .scala
 pub fn maxConnections(self: *const Config) u16 {
     return switch (self.mode) {
         .serve => |opts| opts.cdp_max_connections,
+        .render => |opts| @max(opts.max_connections orelse 8, 1),
         .mcp => 16,
         .fetch, .agent => 0,
         else => unreachable,
@@ -709,7 +730,50 @@ pub fn maxConnections(self: *const Config) u16 {
 pub fn maxPendingConnections(self: *const Config) u31 {
     return switch (self.mode) {
         .serve => |opts| opts.cdp_max_pending_connections,
+        .render => 64,
         .mcp => 128,
+        else => unreachable,
+    };
+}
+
+pub fn renderCorsOrigin(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        .render => |opts| opts.cors_origin,
+        else => null,
+    };
+}
+
+pub fn renderAuthToken(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        .render => |opts| opts.auth_token,
+        else => null,
+    };
+}
+
+pub fn renderMaxRequestSize(self: *const Config) usize {
+    return switch (self.mode) {
+        .render => |opts| opts.max_request_size orelse 16 * 1024,
+        else => unreachable,
+    };
+}
+
+pub fn renderMaxResponseSize(self: *const Config) usize {
+    return switch (self.mode) {
+        .render => |opts| opts.max_response_size orelse 16 * 1024 * 1024,
+        else => unreachable,
+    };
+}
+
+pub fn renderMaxWaitMs(self: *const Config) u32 {
+    return switch (self.mode) {
+        .render => |opts| @max(opts.max_wait_ms orelse 30_000, 1),
+        else => unreachable,
+    };
+}
+
+pub fn renderClientTimeoutMs(self: *const Config) u32 {
+    return switch (self.mode) {
+        .render => |opts| @max(opts.client_timeout_ms orelse 30_000, 1),
         else => unreachable,
     };
 }
@@ -744,14 +808,14 @@ pub fn cdpMaxHTTPMessageSize(self: *const Config) u14 {
 
 pub fn storageEngine(self: *const Config) ?Storage.EngineType {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.storage_engine,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.storage_engine,
         else => unreachable,
     };
 }
 
 pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.storage_sqlite_path,
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| opts.storage_sqlite_path,
         else => unreachable,
     };
 }
@@ -760,7 +824,7 @@ pub fn storageSqlitePath(self: *const Config) ?[:0]const u8 {
 /// if any was loaded during argument parsing. The caller takes ownership.
 pub fn customCertStore(self: *const Config) ?*crypto.X509_STORE {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| {
+        inline .serve, .fetch, .render, .mcp, .agent => |opts| {
             const store = opts.cert.store orelse return null;
             // Validators guarantee a created store loaded something.
             lp.assert(opts.cert.count > 0, "empty custom cert store", .{});
@@ -877,7 +941,7 @@ pub fn printUsageAndExit(self: *const Config, allocator: Allocator, help_for: Ru
             , .{Help.general});
             break :text try std.fmt.allocPrint(allocator, template, .{exec_name});
         },
-        inline .fetch, .serve, .mcp, .agent, .run => |tag| text: {
+        inline .fetch, .render, .serve, .mcp, .agent, .run => |tag| text: {
             const template = comptimePrint(
                 \\{s}
                 \\
@@ -993,6 +1057,23 @@ test "Config: blockedUrlPatterns splits comma-separated patterns" {
     try std.testing.expectEqualStrings("*doubleclick*", patterns.next().?);
     try std.testing.expectEqualStrings("*://*/*.png", patterns.next().?);
     try std.testing.expectEqual(null, patterns.next());
+}
+
+test "Config: render defaults bound network resources" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .render = .{} });
+    defer config.deinit(std.testing.allocator);
+
+    try std.testing.expect(config.blockPrivateNetworks());
+    try std.testing.expectEqual(@as(?usize, 16 * 1024 * 1024), config.httpMaxResponseSize());
+}
+
+test "Config: render can opt into private network targets" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .render = .{
+        .allow_private_networks = true,
+    } });
+    defer config.deinit(std.testing.allocator);
+
+    try std.testing.expect(!config.blockPrivateNetworks());
 }
 
 pub fn validateUserAgent(ua: []const u8) !void {

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -197,6 +197,9 @@ pub fn closeSession(self: *Browser) void {
         session.deinit();
         self.session = null;
     }
+    // A long-lived Browser can sit between short sessions (for example, the
+    // render server worker). No page work can be running after closeSession.
+    self.http_client.heartbeat.disarm();
     self.flushArenaMemory();
 }
 

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -173,6 +173,10 @@ pub fn selectOption(node: *DOMNode, value: []const u8, frame: *Frame) !void {
     const el = node.is(Element) orelse return error.InvalidNodeType;
     const select = el.is(Element.Html.Select) orelse return error.InvalidNodeType;
 
+    el.focus(frame) catch |err| {
+        lp.log.err(.app, "select focus failed", .{ .err = err });
+    };
+
     select.setValue(value, frame) catch |err| {
         lp.log.err(.app, "select setValue failed", .{ .err = err });
         return error.ActionFailed;
@@ -216,6 +220,12 @@ pub fn fill(node: *DOMNode, text: []const u8, frame: *Frame) !void {
         lp.log.err(.app, "fill focus failed", .{ .err = err });
     };
 
+    try fillWithoutFocus(node, text, frame);
+}
+
+pub fn fillWithoutFocus(node: *DOMNode, text: []const u8, frame: *Frame) !void {
+    const el = node.is(Element) orelse return error.InvalidNodeType;
+
     if (el.is(Element.Html.Input)) |input| {
         input.setValue(text, frame) catch |err| {
             lp.log.err(.app, "fill input failed", .{ .err = err });
@@ -234,6 +244,24 @@ pub fn fill(node: *DOMNode, text: []const u8, frame: *Frame) !void {
     } else {
         return error.InvalidNodeType;
     }
+
+    try dispatchInputAndChangeEvents(el, frame);
+}
+
+pub fn selectOptionAtIndexWithoutFocus(
+    node: *DOMNode,
+    selected_index: u32,
+    frame: *Frame,
+) !void {
+    const el = node.is(Element) orelse return error.InvalidNodeType;
+    const select = el.is(Element.Html.Select) orelse return error.InvalidNodeType;
+    const index = std.math.cast(i32, selected_index) orelse return error.InvalidNodeType;
+
+    select.setSelectedIndex(index) catch |err| {
+        lp.log.err(.app, "select setSelectedIndex failed", .{ .err = err });
+        return error.ActionFailed;
+    };
+    if (select.getSelectedIndex() != index) return error.InvalidNodeType;
 
     try dispatchInputAndChangeEvents(el, frame);
 }

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -22,12 +22,20 @@ const Frame = @import("Frame.zig");
 const Node = @import("webapi/Node.zig");
 const Slot = @import("webapi/element/html/Slot.zig");
 const IFrame = @import("webapi/element/html/IFrame.zig");
+const Anchor = @import("webapi/element/html/Anchor.zig");
+const Button = @import("webapi/element/html/Button.zig");
+
+pub const DumpError = error{ WriteFailed, OutOfMemory, TargetLimit };
 
 pub const Opts = struct {
     with_base: bool = false,
     with_frames: bool = false,
     strip: Opts.Strip = .{},
     shadow: Opts.Shadow = .rendered,
+    // A render-only target table. The serializer writes opaque numeric markers
+    // without changing the source document.
+    live_targets: ?*LiveTargets = null,
+    strip_refresh: bool = false,
 
     pub const Strip = packed struct(u4) {
         js: bool = false,
@@ -48,8 +56,21 @@ pub const Opts = struct {
     };
 };
 
-pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !void {
-    if (doc.is(Node.Document.HTMLDocument)) |html_doc| {
+pub const LiveTargets = struct {
+    pub const max_elements = 65_535;
+
+    elements: *std.ArrayListUnmanaged(*Node.Element),
+    allocator: std.mem.Allocator,
+
+    fn add(self: *LiveTargets, element: *Node.Element) !usize {
+        if (self.elements.items.len >= max_elements) return error.TargetLimit;
+        try self.elements.append(self.allocator, element);
+        return self.elements.items.len - 1;
+    }
+};
+
+pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
+    if (doc.is(Node.Document.HTMLDocument) != null) {
         blk: {
             // Ideally we just render the doctype which is part of the document
             if (doc.asNode().firstChild()) |first| {
@@ -61,38 +82,16 @@ pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Fra
             // well force it.
             try writer.writeAll("<!DOCTYPE html>");
         }
-
-        if (opts.with_base) {
-            const parent = if (html_doc.getHead()) |head|
-                head.asNode()
-            else blk: {
-                const document_element = html_doc.asDocument().getDocumentElement() orelse {
-                    const html = try doc.createElement("html", null, frame);
-                    _ = try doc.asNode().appendChild(html.asNode(), frame);
-                    break :blk html.asNode();
-                };
-                const head = try doc.createElement("head", null, frame);
-                _ = try document_element.asNode().insertBefore(
-                    head.asNode(),
-                    document_element.asNode().firstChild(),
-                    frame,
-                );
-                break :blk head.asNode();
-            };
-            const base = try doc.createElement("base", null, frame);
-            try base.setAttributeSafe(comptime .wrap("href"), .wrap(frame.base()), frame);
-            _ = try parent.insertBefore(base.asNode(), parent.firstChild(), frame);
-        }
     }
 
     return deep(doc.asNode(), opts, writer, frame);
 }
 
-pub fn deep(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) error{WriteFailed}!void {
+pub fn deep(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
     return _deep(node, opts, false, writer, frame);
 }
 
-fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Writer, frame: *Frame) error{WriteFailed}!void {
+fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
     switch (node._type) {
         .cdata => |cd| {
             if (node.is(Node.CData.Comment)) |_| {
@@ -130,7 +129,15 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
                 }
             }
 
-            try el.format(writer);
+            try formatElement(el, opts, writer, frame);
+
+            if (opts.with_base and isDocumentHead(el, frame)) {
+                try writeBase(frame, writer);
+            } else if (opts.with_base and isDocumentElementWithoutHead(el, frame)) {
+                try writer.writeAll("<head>");
+                try writeBase(frame, writer);
+                try writer.writeAll("</head>");
+            }
 
             if (opts.shadow == .rendered) {
                 if (el.is(Slot)) |slot| {
@@ -211,10 +218,88 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
     }
 }
 
-pub fn children(parent: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !void {
+pub fn children(parent: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
     var it = parent.childrenIterator();
     while (it.next()) |child| {
         try deep(child, opts, writer, frame);
+    }
+}
+
+pub fn isLiveTarget(el: *Node.Element, frame: *Frame) bool {
+    return switch (el.getTag()) {
+        .anchor => if (el.is(Anchor)) |anchor|
+            isLiveAnchor(el, anchor)
+        else
+            false,
+        .button => if (el.is(Button)) |button|
+            !el.isDisabled() and button.getForm(frame) == null
+        else
+            false,
+        else => false,
+    };
+}
+
+fn isLiveAnchor(el: *Node.Element, anchor: *Anchor) bool {
+    const href = el.getAttributeSafe(comptime .wrap("href")) orelse return false;
+    if (href.len == 0 or el.hasAttributeSafe(comptime .wrap("download"))) return false;
+
+    const target = anchor.getTarget();
+    return target.len == 0 or
+        std.ascii.eqlIgnoreCase(target, "_self") or
+        std.ascii.eqlIgnoreCase(target, "_parent") or
+        std.ascii.eqlIgnoreCase(target, "_top");
+}
+
+fn formatElement(el: *Node.Element, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
+    try writer.writeByte('<');
+    try writer.writeAll(el.getTagNameDump());
+
+    for (el.attributeEntries()) |*attr| {
+        if (opts.live_targets != null and std.ascii.eqlIgnoreCase(attr.name(), "data-lp-live-target")) {
+            continue;
+        }
+        try writer.writeByte(' ');
+        try attr.format(writer);
+    }
+
+    if (opts.live_targets) |targets| {
+        if (isLiveTarget(el, frame)) {
+            const id = try targets.add(el);
+            try writer.print(" data-lp-live-target=\"{d}\"", .{id});
+        }
+    }
+    try writer.writeByte('>');
+}
+
+fn isDocumentHead(el: *Node.Element, frame: *Frame) bool {
+    const doc = frame.window._document;
+    const html_doc = doc.is(Node.Document.HTMLDocument) orelse return false;
+    return html_doc.getHead() == el;
+}
+
+fn isDocumentElementWithoutHead(el: *Node.Element, frame: *Frame) bool {
+    const doc = frame.window._document;
+    const html_doc = doc.is(Node.Document.HTMLDocument) orelse return false;
+    return el.getTag() == .html and
+        html_doc.asDocument().getDocumentElement() == el and
+        html_doc.getHead() == null;
+}
+
+fn writeBase(frame: *Frame, writer: *std.Io.Writer) !void {
+    try writer.writeAll("<base href=\"");
+    try writeEscapedAttributeValue(frame.base(), writer);
+    try writer.writeAll("\">");
+}
+
+fn writeEscapedAttributeValue(value: []const u8, writer: *std.Io.Writer) !void {
+    for (value) |byte| {
+        switch (byte) {
+            '&' => try writer.writeAll("&amp;"),
+            '"' => try writer.writeAll("&quot;"),
+            '<' => try writer.writeAll("&lt;"),
+            '>' => try writer.writeAll("&gt;"),
+            else => try writer.writeByte(byte),
+        }
     }
 }
 
@@ -258,7 +343,7 @@ pub fn toJSON(node: *Node, writer: *std.json.Stringify) !void {
     try writer.endObject();
 }
 
-fn dumpSlotContent(slot: *Slot, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !void {
+fn dumpSlotContent(slot: *Slot, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
     const assigned = slot.assignedNodes(null, frame) catch return;
 
     if (assigned.len > 0) {
@@ -282,11 +367,17 @@ fn isVoidElement(el: *const Node.Element) bool {
 
 fn shouldStripElement(el: *Node.Element, opts: Opts, frame: *Frame) bool {
     // Fast path: with no strip flags set (every innerHTML/outerHTML call)
-    if (@as(u4, @bitCast(opts.strip)) == 0) {
+    if (@as(u4, @bitCast(opts.strip)) == 0 and !opts.strip_refresh) {
         return false;
     }
 
     const tag_name = el.getTagNameDump();
+
+    if (opts.strip_refresh and std.mem.eql(u8, tag_name, "meta")) {
+        if (el.getAttributeSafe(comptime .wrap("http-equiv"))) |http_equiv| {
+            if (std.ascii.eqlIgnoreCase(http_equiv, "refresh")) return true;
+        }
+    }
 
     if (opts.strip.js) {
         if (std.mem.eql(u8, tag_name, "script")) return true;
@@ -392,9 +483,7 @@ fn writeEscapedByte(input: []const u8, index: usize, writer: *std.Io.Writer) ![]
 
 const testing = @import("../testing.zig");
 
-// A fresh page per assertion: `with_base` mutates the document (it inserts a
-// <base> element), so reusing one frame across opts would leak that mutation
-// into later dumps.
+// A fresh page per assertion keeps each dump expectation independent.
 fn expectDump(opts: Opts, expected: []const u8) !void {
     var page = try testing.pageTest("dump.html", .{});
     defer page.close();
@@ -429,6 +518,7 @@ test "dump: with_base synthesizes a head after the doctype" {
     const html_doc = doc.is(Node.Document.HTMLDocument).?;
     const head = html_doc.getHead().?;
     _ = try head.asNode().parentNode().?.removeChild(head.asNode(), frame);
+    const dom_version = frame._page.dom_version;
 
     var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
     try root(doc, .{ .with_base = true }, &aw.writer, frame);
@@ -436,6 +526,123 @@ test "dump: with_base synthesizes a head after the doctype" {
         \\<!DOCTYPE html>
         \\<html><head><base href="http://127.0.0.1:9582/src/browser/tests/dump.html"></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
     , aw.written());
+    try testing.expectEqual(dom_version, frame._page.dom_version);
+}
+
+test "dump: live targets replace author markers without mutating the DOM" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const body = doc.is(Node.Document.HTMLDocument).?.getBody().?;
+
+    const anchor = try doc.createElement("a", null, frame);
+    try anchor.setAttributeSafe(comptime .wrap("href"), .wrap("/next"), frame);
+    try anchor.setAttribute(.wrap("DATA-LP-LIVE-TARGET"), .wrap("forged"), frame);
+    _ = try body.asNode().appendChild(anchor.asNode(), frame);
+
+    const blank = try doc.createElement("a", null, frame);
+    try blank.setAttributeSafe(comptime .wrap("href"), .wrap("/blank"), frame);
+    try blank.setAttributeSafe(comptime .wrap("target"), .wrap("_blank"), frame);
+    _ = try body.asNode().appendChild(blank.asNode(), frame);
+
+    const download = try doc.createElement("a", null, frame);
+    try download.setAttributeSafe(comptime .wrap("href"), .wrap("/file"), frame);
+    try download.setAttributeSafe(comptime .wrap("download"), .wrap(""), frame);
+    _ = try body.asNode().appendChild(download.asNode(), frame);
+
+    const named = try doc.createElement("a", null, frame);
+    try named.setAttributeSafe(comptime .wrap("href"), .wrap("/child"), frame);
+    try named.setAttributeSafe(comptime .wrap("target"), .wrap("child"), frame);
+    _ = try body.asNode().appendChild(named.asNode(), frame);
+
+    const empty = try doc.createElement("a", null, frame);
+    try empty.setAttributeSafe(comptime .wrap("href"), .wrap(""), frame);
+    _ = try body.asNode().appendChild(empty.asNode(), frame);
+
+    const button = try doc.createElement("button", null, frame);
+    try button.setAttribute(.wrap("data-lp-live-target"), .wrap("forged"), frame);
+    _ = try body.asNode().appendChild(button.asNode(), frame);
+
+    const disabled = try doc.createElement("button", null, frame);
+    try disabled.setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
+    _ = try body.asNode().appendChild(disabled.asNode(), frame);
+
+    const form = try doc.createElement("form", null, frame);
+    const associated = try doc.createElement("button", null, frame);
+    _ = try form.asNode().appendChild(associated.asNode(), frame);
+    _ = try body.asNode().appendChild(form.asNode(), frame);
+
+    const file = try doc.createElement("input", null, frame);
+    try file.setAttributeSafe(comptime .wrap("type"), .wrap("file"), frame);
+    _ = try body.asNode().appendChild(file.asNode(), frame);
+
+    var elements: std.ArrayListUnmanaged(*Node.Element) = .empty;
+    defer elements.deinit(testing.allocator);
+    var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
+    const dom_version = frame._page.dom_version;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try root(doc, .{ .live_targets = &targets }, &aw.writer, frame);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<a href=\"/next\" data-lp-live-target=\"0\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<button data-lp-live-target=\"1\">") != null);
+    try testing.expectEqual(@as(usize, 2), elements.items.len);
+    try testing.expectEqual(anchor, elements.items[0]);
+    try testing.expectEqual(button, elements.items[1]);
+    try testing.expect(!isLiveTarget(blank, frame));
+    try testing.expect(!isLiveTarget(download, frame));
+    try testing.expect(!isLiveTarget(named, frame));
+    try testing.expect(!isLiveTarget(empty, frame));
+    try testing.expect(!isLiveTarget(disabled, frame));
+    try testing.expect(!isLiveTarget(associated, frame));
+    try testing.expect(!isLiveTarget(file, frame));
+    try testing.expectEqual(dom_version, frame._page.dom_version);
+}
+
+test "dump: live snapshots strip meta refresh without mutating the DOM" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const head = doc.is(Node.Document.HTMLDocument).?.getHead().?;
+    const refresh = try doc.createElement("meta", null, frame);
+    try refresh.setAttributeSafe(comptime .wrap("http-equiv"), .wrap("refresh"), frame);
+    try refresh.setAttributeSafe(comptime .wrap("content"), .wrap("0;url=https://example.test/"), frame);
+    _ = try head.asNode().appendChild(refresh.asNode(), frame);
+    const dom_version = frame._page.dom_version;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try root(doc, .{ .strip_refresh = true }, &aw.writer, frame);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "http-equiv=\"refresh\"") == null);
+    try testing.expectEqual(dom_version, frame._page.dom_version);
+}
+
+test "dump: with_base preserves non-element children without a document element" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const html = doc.getDocumentElement().?;
+    _ = try doc.asNode().removeChild(html.asNode(), frame);
+    const comment = try doc.createComment("still-here", frame);
+    _ = try doc.asNode().appendChild(comment, frame);
+    const dom_version = frame._page.dom_version;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    try root(doc, .{ .with_base = true }, &aw.writer, frame);
+    try testing.expectString(
+        \\<!DOCTYPE html>
+        \\<!--still-here-->
+    , aw.written());
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<base") == null);
+    try testing.expectEqual(dom_version, frame._page.dom_version);
 }
 
 test "dump: strip.js removes script and noscript" {

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -63,9 +63,24 @@ pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Fra
         }
 
         if (opts.with_base) {
-            const parent = if (html_doc.getHead()) |head| head.asNode() else doc.asNode();
+            const parent = if (html_doc.getHead()) |head|
+                head.asNode()
+            else blk: {
+                const document_element = html_doc.asDocument().getDocumentElement() orelse {
+                    const html = try doc.createElement("html", null, frame);
+                    _ = try doc.asNode().appendChild(html.asNode(), frame);
+                    break :blk html.asNode();
+                };
+                const head = try doc.createElement("head", null, frame);
+                _ = try document_element.asNode().insertBefore(
+                    head.asNode(),
+                    document_element.asNode().firstChild(),
+                    frame,
+                );
+                break :blk head.asNode();
+            };
             const base = try doc.createElement("base", null, frame);
-            try base.setAttributeSafe(comptime .wrap("base"), .wrap(frame.base()), frame);
+            try base.setAttributeSafe(comptime .wrap("href"), .wrap(frame.base()), frame);
             _ = try parent.insertBefore(base.asNode(), parent.firstChild(), frame);
         }
     }
@@ -258,7 +273,7 @@ fn dumpSlotContent(slot: *Slot, opts: Opts, writer: *std.Io.Writer, frame: *Fram
 fn isVoidElement(el: *const Node.Element) bool {
     return switch (el._type) {
         .html => |html| switch (html._type) {
-            .br, .hr, .img, .input, .link, .meta => true,
+            .base, .br, .hr, .img, .input, .link, .meta => true,
             else => false,
         },
         .svg => false,
@@ -401,8 +416,26 @@ test "dump: default dumps the whole document" {
 test "dump: with_base injects a <base> element" {
     try expectDump(.{ .with_base = true },
         \\<!DOCTYPE html>
-        \\<html><head><base base="http://127.0.0.1:9582/src/browser/tests/dump.html"></base><style>.hidden{display:none}</style><link rel="stylesheet" href="data:text/css,"><script>var a=1;</script></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
+        \\<html><head><base href="http://127.0.0.1:9582/src/browser/tests/dump.html"><style>.hidden{display:none}</style><link rel="stylesheet" href="data:text/css,"><script>var a=1;</script></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
     );
+}
+
+test "dump: with_base synthesizes a head after the doctype" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const html_doc = doc.is(Node.Document.HTMLDocument).?;
+    const head = html_doc.getHead().?;
+    _ = try head.asNode().parentNode().?.removeChild(head.asNode(), frame);
+
+    var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    try root(doc, .{ .with_base = true }, &aw.writer, frame);
+    try testing.expectString(
+        \\<!DOCTYPE html>
+        \\<html><head><base href="http://127.0.0.1:9582/src/browser/tests/dump.html"></head><body><h1>Title</h1><p class="hidden">secret</p><img><svg></svg><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
+    , aw.written());
 }
 
 test "dump: strip.js removes script and noscript" {

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 const Frame = @import("Frame.zig");
+const interactive = @import("interactive.zig");
 const Node = @import("webapi/Node.zig");
 const Slot = @import("webapi/element/html/Slot.zig");
 const IFrame = @import("webapi/element/html/IFrame.zig");
@@ -62,6 +63,7 @@ pub const LiveTargets = struct {
 
     elements: *std.ArrayListUnmanaged(*Node.Element),
     allocator: std.mem.Allocator,
+    listener_targets: interactive.ListenerTargetMap = .{},
 
     fn add(self: *LiveTargets, element: *Node.Element) !usize {
         if (self.elements.items.len >= max_elements) return error.TargetLimit;
@@ -226,8 +228,12 @@ pub fn children(parent: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame
     }
 }
 
-pub fn isLiveTarget(el: *Node.Element, frame: *Frame) bool {
-    return switch (el.getTag()) {
+pub fn isLiveTarget(
+    el: *Node.Element,
+    frame: *Frame,
+    listener_targets: interactive.ListenerTargetMap,
+) error{OutOfMemory}!bool {
+    const legacy_target = switch (el.getTag()) {
         .anchor => if (el.is(Anchor)) |anchor|
             isLiveAnchor(el, anchor)
         else
@@ -237,6 +243,66 @@ pub fn isLiveTarget(el: *Node.Element, frame: *Frame) bool {
         else
             false,
         .input => liveCheckable(el) != null and !el.isDisabled(),
+        else => false,
+    };
+    if (legacy_target) return true;
+    return isLiveScriptTarget(el, frame, listener_targets);
+}
+
+fn isLiveScriptTarget(
+    el: *Node.Element,
+    frame: *Frame,
+    listener_targets: interactive.ListenerTargetMap,
+) error{OutOfMemory}!bool {
+    const has_click = interactive.hasListenerType(el.asEventTarget(), listener_targets, "click") or
+        try hasInlineClickHandler(el, frame);
+    return has_click and
+        !el.isDisabled() and
+        !hasUnsafeDefaultAction(el, frame) and
+        interactive.isVisibleForInteraction(el, frame) and
+        !el.hasPointerEventsNone(null, frame);
+}
+
+fn hasInlineClickHandler(el: *Node.Element, frame: *Frame) error{OutOfMemory}!bool {
+    const html_el = el.is(Node.Element.Html) orelse return false;
+    const handler = html_el.getAttributeFunction(.onclick, frame) catch |err| switch (err) {
+        error.CompilationError => return false,
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    return handler != null;
+}
+
+fn hasUnsafeDefaultAction(el: *Node.Element, frame: *Frame) bool {
+    const activation_node = Frame.user_input.findClickActivationTarget(el.asNode(), true) orelse return false;
+    const activation_el = activation_node.is(Node.Element) orelse return false;
+    return hasUnsafeActivationTarget(activation_el, frame);
+}
+
+fn hasUnsafeActivationTarget(el: *Node.Element, frame: *Frame) bool {
+    return switch (el.getTag()) {
+        .anchor => if (el.is(Anchor)) |anchor|
+            !isLiveAnchor(el, anchor)
+        else
+            false,
+        .button => if (el.is(Button)) |button|
+            std.mem.eql(u8, button.getType(), "submit") and button.getForm(frame) != null
+        else
+            false,
+        .input => if (el.is(Input)) |input|
+            switch (input._input_type) {
+                .submit, .image => input.getForm(frame) != null,
+                .file => true,
+                else => false,
+            }
+        else
+            false,
+        .label => if (el.is(Node.Element.Html.Label)) |label|
+            if (label.getControl(frame)) |control|
+                hasUnsafeActivationTarget(control, frame)
+            else
+                false
+        else
+            false,
         else => false,
     };
 }
@@ -280,7 +346,7 @@ fn formatElement(el: *Node.Element, opts: Opts, writer: *std.Io.Writer, frame: *
     }
 
     if (opts.live_targets) |targets| {
-        if (isLiveTarget(el, frame)) {
+        if (try isLiveTarget(el, frame, targets.listener_targets)) {
             const id = try targets.add(el);
             try writer.print(" data-lp-live-target=\"{d}\"", .{id});
         }
@@ -595,6 +661,10 @@ test "dump: live targets replace author markers without mutating the DOM" {
     try file.setAttributeSafe(comptime .wrap("type"), .wrap("file"), frame);
     _ = try body.asNode().appendChild(file.asNode(), frame);
 
+    const invalid_inline = try doc.createElement("div", null, frame);
+    try invalid_inline.setAttributeSafe(comptime .wrap("onclick"), .wrap(")"), frame);
+    _ = try body.asNode().appendChild(invalid_inline.asNode(), frame);
+
     var elements: std.ArrayListUnmanaged(*Node.Element) = .empty;
     defer elements.deinit(testing.allocator);
     var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
@@ -606,16 +676,17 @@ test "dump: live targets replace author markers without mutating the DOM" {
 
     try testing.expect(std.mem.indexOf(u8, aw.written(), "<a href=\"/next\" data-lp-live-target=\"0\">") != null);
     try testing.expect(std.mem.indexOf(u8, aw.written(), "<button data-lp-live-target=\"1\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<div onclick=\")\"></div>") != null);
     try testing.expectEqual(@as(usize, 2), elements.items.len);
     try testing.expectEqual(anchor, elements.items[0]);
     try testing.expectEqual(button, elements.items[1]);
-    try testing.expect(!isLiveTarget(blank, frame));
-    try testing.expect(!isLiveTarget(download, frame));
-    try testing.expect(!isLiveTarget(named, frame));
-    try testing.expect(!isLiveTarget(empty, frame));
-    try testing.expect(!isLiveTarget(disabled, frame));
-    try testing.expect(!isLiveTarget(associated, frame));
-    try testing.expect(!isLiveTarget(file, frame));
+    try testing.expect(!try isLiveTarget(blank, frame, .{}));
+    try testing.expect(!try isLiveTarget(download, frame, .{}));
+    try testing.expect(!try isLiveTarget(named, frame, .{}));
+    try testing.expect(!try isLiveTarget(empty, frame, .{}));
+    try testing.expect(!try isLiveTarget(disabled, frame, .{}));
+    try testing.expect(!try isLiveTarget(associated, frame, .{}));
+    try testing.expect(!try isLiveTarget(file, frame, .{}));
     try testing.expectEqual(dom_version, frame._page.dom_version);
 }
 
@@ -670,11 +741,11 @@ test "dump: live checkables serialize current checked state" {
     try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"checkbox\" type=\"checkbox\" data-lp-live-target=\"0\">") != null);
     try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"radio\" type=\"radio\" checked data-lp-live-target=\"1\">") != null);
     try testing.expectEqualSlices(*Node.Element, &.{ checkbox, radio }, elements.items);
-    try testing.expect(!isLiveTarget(disabled, frame));
-    try testing.expect(!isLiveTarget(text, frame));
-    try testing.expect(!isLiveTarget(file, frame));
-    try testing.expect(!isLiveTarget(submit, frame));
-    try testing.expect(!isLiveTarget(select, frame));
+    try testing.expect(!try isLiveTarget(disabled, frame, .{}));
+    try testing.expect(!try isLiveTarget(text, frame, .{}));
+    try testing.expect(!try isLiveTarget(file, frame, .{}));
+    try testing.expect(!try isLiveTarget(submit, frame, .{}));
+    try testing.expect(!try isLiveTarget(select, frame, .{}));
     try testing.expect(checkbox.hasAttributeSafe(comptime .wrap("checked")));
     try testing.expect(!radio.hasAttributeSafe(comptime .wrap("checked")));
 }

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -26,6 +26,9 @@ const IFrame = @import("webapi/element/html/IFrame.zig");
 const Anchor = @import("webapi/element/html/Anchor.zig");
 const Button = @import("webapi/element/html/Button.zig");
 const Input = @import("webapi/element/html/Input.zig");
+const TextArea = @import("webapi/element/html/TextArea.zig");
+const Select = @import("webapi/element/html/Select.zig");
+const Option = @import("webapi/element/html/Option.zig");
 
 pub const DumpError = error{ WriteFailed, OutOfMemory, TargetLimit };
 
@@ -61,13 +64,19 @@ pub const Opts = struct {
 pub const LiveTargets = struct {
     pub const max_elements = 65_535;
 
-    elements: *std.ArrayListUnmanaged(*Node.Element),
+    pub const Kind = enum { activate, value };
+    pub const Target = struct {
+        element: *Node.Element,
+        kind: Kind,
+    };
+
+    elements: *std.ArrayListUnmanaged(Target),
     allocator: std.mem.Allocator,
     listener_targets: interactive.ListenerTargetMap = .{},
 
-    fn add(self: *LiveTargets, element: *Node.Element) !usize {
+    fn add(self: *LiveTargets, element: *Node.Element, kind: Kind) !usize {
         if (self.elements.items.len >= max_elements) return error.TargetLimit;
-        try self.elements.append(self.allocator, element);
+        try self.elements.append(self.allocator, .{ .element = element, .kind = kind });
         return self.elements.items.len - 1;
     }
 };
@@ -132,7 +141,7 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
                 }
             }
 
-            try formatElement(el, opts, writer, frame);
+            const live_kind = try formatElement(el, opts, writer, frame);
 
             if (opts.with_base and isDocumentHead(el, frame)) {
                 try writeBase(frame, writer);
@@ -140,6 +149,14 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
                 try writer.writeAll("<head>");
                 try writeBase(frame, writer);
                 try writer.writeAll("</head>");
+            }
+
+            if (live_kind == .value) {
+                if (el.is(TextArea)) |textarea| {
+                    try writeEscapedText(textarea.getValue(), writer);
+                    try writer.writeAll("</textarea>");
+                    return;
+                }
             }
 
             if (opts.shadow == .rendered) {
@@ -249,6 +266,32 @@ pub fn isLiveTarget(
     return isLiveScriptTarget(el, frame, listener_targets);
 }
 
+pub fn isLiveValueTarget(el: *Node.Element) bool {
+    if (el.isDisabled()) return false;
+    return switch (el.getTag()) {
+        .input => if (el.is(Input)) |input|
+            !input.getReadonly() and switch (input._input_type) {
+                .text, .search, .url, .tel, .email => true,
+                else => false,
+            }
+        else
+            false,
+        .textarea => el.getAttributeSafe(comptime .wrap("readonly")) == null,
+        .select => if (el.is(Select)) |select| !select.getMultiple() else false,
+        else => false,
+    };
+}
+
+pub fn liveTargetKind(
+    el: *Node.Element,
+    frame: *Frame,
+    listener_targets: interactive.ListenerTargetMap,
+) error{OutOfMemory}!?LiveTargets.Kind {
+    if (isLiveValueTarget(el)) return .value;
+    if (try isLiveTarget(el, frame, listener_targets)) return .activate;
+    return null;
+}
+
 fn isLiveScriptTarget(
     el: *Node.Element,
     frame: *Frame,
@@ -326,32 +369,70 @@ fn isLiveAnchor(el: *Node.Element, anchor: *Anchor) bool {
         std.ascii.eqlIgnoreCase(target, "_top");
 }
 
-fn formatElement(el: *Node.Element, opts: Opts, writer: *std.Io.Writer, frame: *Frame) DumpError!void {
+fn formatElement(
+    el: *Node.Element,
+    opts: Opts,
+    writer: *std.Io.Writer,
+    frame: *Frame,
+) DumpError!?LiveTargets.Kind {
     try writer.writeByte('<');
     try writer.writeAll(el.getTagNameDump());
 
+    const live_kind = if (opts.live_targets) |targets|
+        try liveTargetKind(el, frame, targets.listener_targets)
+    else
+        null;
     const live_checkable = if (opts.live_targets != null) liveCheckable(el) else null;
+    const live_input = if (live_kind == .value) el.is(Input) else null;
+    const strip_live_password_value = if (opts.live_targets != null)
+        if (el.is(Input)) |input| input._input_type == .password else false
+    else
+        false;
+    const live_option_selected = if (opts.live_targets != null) currentLiveOptionSelected(el) else null;
     for (el.attributeEntries()) |*attr| {
-        if (opts.live_targets != null and std.ascii.eqlIgnoreCase(attr.name(), "data-lp-live-target")) {
+        if (opts.live_targets != null and
+            (std.ascii.eqlIgnoreCase(attr.name(), "data-lp-live-target") or
+                std.ascii.eqlIgnoreCase(attr.name(), "data-lp-live-kind")))
+        {
             continue;
         }
         if (live_checkable != null and std.ascii.eqlIgnoreCase(attr.name(), "checked")) {
             continue;
         }
+        if ((live_input != null or strip_live_password_value) and
+            std.ascii.eqlIgnoreCase(attr.name(), "value")) continue;
+        if (live_option_selected != null and std.ascii.eqlIgnoreCase(attr.name(), "selected")) continue;
         try writer.writeByte(' ');
         try attr.format(writer);
     }
     if (live_checkable) |input| {
         if (input.getChecked()) try writer.writeAll(" checked");
     }
+    if (live_input) |input| {
+        try writer.writeAll(" value=\"");
+        try writeEscapedAttributeValue(input.getValue(), writer);
+        try writer.writeByte('"');
+    }
+    if (live_option_selected == true) try writer.writeAll(" selected");
 
-    if (opts.live_targets) |targets| {
-        if (try isLiveTarget(el, frame, targets.listener_targets)) {
-            const id = try targets.add(el);
-            try writer.print(" data-lp-live-target=\"{d}\"", .{id});
-        }
+    if (live_kind) |kind| {
+        const targets = opts.live_targets.?;
+        const id = try targets.add(el, kind);
+        try writer.print(" data-lp-live-target=\"{d}\" data-lp-live-kind=\"{s}\"", .{ id, @tagName(kind) });
     }
     try writer.writeByte('>');
+    return live_kind;
+}
+
+fn currentLiveOptionSelected(el: *Node.Element) ?bool {
+    const option = el.is(Option) orelse return null;
+    const parent = el.asNode().parentElement() orelse return null;
+    const select_el = if (parent.is(Node.Element.Html.OptGroup) != null)
+        parent.asNode().parentElement() orelse return null
+    else
+        parent;
+    if (!isLiveValueTarget(select_el)) return null;
+    return option.getSelected();
 }
 
 fn isDocumentHead(el: *Node.Element, frame: *Frame) bool {
@@ -665,7 +746,7 @@ test "dump: live targets replace author markers without mutating the DOM" {
     try invalid_inline.setAttributeSafe(comptime .wrap("onclick"), .wrap(")"), frame);
     _ = try body.asNode().appendChild(invalid_inline.asNode(), frame);
 
-    var elements: std.ArrayListUnmanaged(*Node.Element) = .empty;
+    var elements: std.ArrayListUnmanaged(LiveTargets.Target) = .empty;
     defer elements.deinit(testing.allocator);
     var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
     const dom_version = frame._page.dom_version;
@@ -674,12 +755,12 @@ test "dump: live targets replace author markers without mutating the DOM" {
     defer aw.deinit();
     try root(doc, .{ .live_targets = &targets }, &aw.writer, frame);
 
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "<a href=\"/next\" data-lp-live-target=\"0\">") != null);
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "<button data-lp-live-target=\"1\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<a href=\"/next\" data-lp-live-target=\"0\" data-lp-live-kind=\"activate\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<button data-lp-live-target=\"1\" data-lp-live-kind=\"activate\">") != null);
     try testing.expect(std.mem.indexOf(u8, aw.written(), "<div onclick=\")\"></div>") != null);
     try testing.expectEqual(@as(usize, 2), elements.items.len);
-    try testing.expectEqual(anchor, elements.items[0]);
-    try testing.expectEqual(button, elements.items[1]);
+    try testing.expectEqual(anchor, elements.items[0].element);
+    try testing.expectEqual(button, elements.items[1].element);
     try testing.expect(!try isLiveTarget(blank, frame, .{}));
     try testing.expect(!try isLiveTarget(download, frame, .{}));
     try testing.expect(!try isLiveTarget(named, frame, .{}));
@@ -730,7 +811,7 @@ test "dump: live checkables serialize current checked state" {
     const select = try doc.createElement("select", null, frame);
     _ = try body.asNode().appendChild(select.asNode(), frame);
 
-    var elements: std.ArrayListUnmanaged(*Node.Element) = .empty;
+    var elements: std.ArrayListUnmanaged(LiveTargets.Target) = .empty;
     defer elements.deinit(testing.allocator);
     var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
 
@@ -738,9 +819,10 @@ test "dump: live checkables serialize current checked state" {
     defer aw.deinit();
     try root(doc, .{ .live_targets = &targets }, &aw.writer, frame);
 
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"checkbox\" type=\"checkbox\" data-lp-live-target=\"0\">") != null);
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"radio\" type=\"radio\" checked data-lp-live-target=\"1\">") != null);
-    try testing.expectEqualSlices(*Node.Element, &.{ checkbox, radio }, elements.items);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"checkbox\" type=\"checkbox\" data-lp-live-target=\"0\" data-lp-live-kind=\"activate\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"radio\" type=\"radio\" checked data-lp-live-target=\"1\" data-lp-live-kind=\"activate\">") != null);
+    try testing.expectEqual(checkbox, elements.items[0].element);
+    try testing.expectEqual(radio, elements.items[1].element);
     try testing.expect(!try isLiveTarget(disabled, frame, .{}));
     try testing.expect(!try isLiveTarget(text, frame, .{}));
     try testing.expect(!try isLiveTarget(file, frame, .{}));
@@ -748,6 +830,56 @@ test "dump: live checkables serialize current checked state" {
     try testing.expect(!try isLiveTarget(select, frame, .{}));
     try testing.expect(checkbox.hasAttributeSafe(comptime .wrap("checked")));
     try testing.expect(!radio.hasAttributeSafe(comptime .wrap("checked")));
+}
+
+test "dump: live value targets serialize current state without mutating defaults" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const body = doc.is(Node.Document.HTMLDocument).?.getBody().?;
+    try Frame.parse.htmlAsChildren(frame, body.asNode(),
+        \\<input id="live-input" value="author">
+        \\<input id="live-password" type="password" value="author-password">
+        \\<textarea id="live-textarea">author</textarea>
+        \\<select id="live-select">
+        \\  <option id="live-option-one" value="one" selected>one</option>
+        \\  <option id="live-option-two" value="two&amp;">two</option>
+        \\</select>
+    );
+
+    const input_el = doc.getElementById("live-input", frame).?;
+    const password_el = doc.getElementById("live-password", frame).?;
+    const textarea_el = doc.getElementById("live-textarea", frame).?;
+    const select_el = doc.getElementById("live-select", frame).?;
+    const option_two_el = doc.getElementById("live-option-two", frame).?;
+    try input_el.is(Input).?.setValue("now&\"<", frame);
+    try password_el.is(Input).?.setValue("current-password", frame);
+    try textarea_el.is(TextArea).?.setValue("now&<", frame);
+    try select_el.is(Select).?.setValue("two&", frame);
+    const dom_version = frame._page.dom_version;
+
+    var elements: std.ArrayListUnmanaged(LiveTargets.Target) = .empty;
+    defer elements.deinit(testing.allocator);
+    var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try root(doc, .{ .live_targets = &targets }, &aw.writer, frame);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"live-input\" value=\"now&amp;&quot;&lt;\" data-lp-live-target=\"0\" data-lp-live-kind=\"value\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"live-password\" type=\"password\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "author-password") == null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "current-password") == null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<textarea id=\"live-textarea\" data-lp-live-target=\"1\" data-lp-live-kind=\"value\">now&amp;&lt;</textarea>") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<select id=\"live-select\" data-lp-live-target=\"2\" data-lp-live-kind=\"value\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<option id=\"live-option-two\" value=\"two&amp;\" selected>two</option>") != null);
+    try testing.expectString("author", input_el.getAttributeSafe(comptime .wrap("value")).?);
+    try testing.expectString("author-password", password_el.getAttributeSafe(comptime .wrap("value")).?);
+    try testing.expectString("current-password", password_el.is(Input).?.getValue());
+    try testing.expectString("author", textarea_el.asNode().getTextContentAlloc(frame.call_arena) catch unreachable);
+    try testing.expect(!option_two_el.hasAttributeSafe(comptime .wrap("selected")));
+    try testing.expectEqual(dom_version, frame._page.dom_version);
 }
 
 test "dump: live snapshots strip meta refresh without mutating the DOM" {

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -24,6 +24,7 @@ const Slot = @import("webapi/element/html/Slot.zig");
 const IFrame = @import("webapi/element/html/IFrame.zig");
 const Anchor = @import("webapi/element/html/Anchor.zig");
 const Button = @import("webapi/element/html/Button.zig");
+const Input = @import("webapi/element/html/Input.zig");
 
 pub const DumpError = error{ WriteFailed, OutOfMemory, TargetLimit };
 
@@ -235,7 +236,16 @@ pub fn isLiveTarget(el: *Node.Element, frame: *Frame) bool {
             !el.isDisabled() and button.getForm(frame) == null
         else
             false,
+        .input => liveCheckable(el) != null and !el.isDisabled(),
         else => false,
+    };
+}
+
+fn liveCheckable(el: *Node.Element) ?*Input {
+    const input = el.is(Input) orelse return null;
+    return switch (input._input_type) {
+        .checkbox, .radio => input,
+        else => null,
     };
 }
 
@@ -254,12 +264,19 @@ fn formatElement(el: *Node.Element, opts: Opts, writer: *std.Io.Writer, frame: *
     try writer.writeByte('<');
     try writer.writeAll(el.getTagNameDump());
 
+    const live_checkable = if (opts.live_targets != null) liveCheckable(el) else null;
     for (el.attributeEntries()) |*attr| {
         if (opts.live_targets != null and std.ascii.eqlIgnoreCase(attr.name(), "data-lp-live-target")) {
             continue;
         }
+        if (live_checkable != null and std.ascii.eqlIgnoreCase(attr.name(), "checked")) {
+            continue;
+        }
         try writer.writeByte(' ');
         try attr.format(writer);
+    }
+    if (live_checkable) |input| {
+        if (input.getChecked()) try writer.writeAll(" checked");
     }
 
     if (opts.live_targets) |targets| {
@@ -600,6 +617,66 @@ test "dump: live targets replace author markers without mutating the DOM" {
     try testing.expect(!isLiveTarget(associated, frame));
     try testing.expect(!isLiveTarget(file, frame));
     try testing.expectEqual(dom_version, frame._page.dom_version);
+}
+
+test "dump: live checkables serialize current checked state" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+    const doc = frame.window._document;
+    const body = doc.is(Node.Document.HTMLDocument).?.getBody().?;
+
+    const checkbox = try doc.createElement("input", null, frame);
+    try checkbox.setAttributeSafe(comptime .wrap("id"), .wrap("checkbox"), frame);
+    try checkbox.setAttributeSafe(comptime .wrap("type"), .wrap("checkbox"), frame);
+    try checkbox.setAttributeSafe(comptime .wrap("checked"), .wrap(""), frame);
+    _ = try body.asNode().appendChild(checkbox.asNode(), frame);
+    try checkbox.is(Input).?.setChecked(false, frame);
+
+    const radio = try doc.createElement("input", null, frame);
+    try radio.setAttributeSafe(comptime .wrap("id"), .wrap("radio"), frame);
+    try radio.setAttributeSafe(comptime .wrap("type"), .wrap("radio"), frame);
+    _ = try body.asNode().appendChild(radio.asNode(), frame);
+    try radio.is(Input).?.setChecked(true, frame);
+
+    const disabled = try doc.createElement("input", null, frame);
+    try disabled.setAttributeSafe(comptime .wrap("type"), .wrap("checkbox"), frame);
+    try disabled.setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
+    _ = try body.asNode().appendChild(disabled.asNode(), frame);
+
+    const text = try doc.createElement("input", null, frame);
+    _ = try body.asNode().appendChild(text.asNode(), frame);
+
+    const file = try doc.createElement("input", null, frame);
+    try file.setAttributeSafe(comptime .wrap("type"), .wrap("file"), frame);
+    _ = try body.asNode().appendChild(file.asNode(), frame);
+
+    const submit = try doc.createElement("input", null, frame);
+    try submit.setAttributeSafe(comptime .wrap("type"), .wrap("submit"), frame);
+    _ = try body.asNode().appendChild(submit.asNode(), frame);
+
+    const select = try doc.createElement("select", null, frame);
+    _ = try body.asNode().appendChild(select.asNode(), frame);
+
+    var elements: std.ArrayListUnmanaged(*Node.Element) = .empty;
+    defer elements.deinit(testing.allocator);
+    var targets: LiveTargets = .{ .elements = &elements, .allocator = testing.allocator };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try root(doc, .{ .live_targets = &targets }, &aw.writer, frame);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"checkbox\" type=\"checkbox\" data-lp-live-target=\"0\">") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "<input id=\"radio\" type=\"radio\" checked data-lp-live-target=\"1\">") != null);
+    try testing.expectEqualSlices(*Node.Element, &.{ checkbox, radio }, elements.items);
+    try testing.expect(!isLiveTarget(disabled, frame));
+    try testing.expect(!isLiveTarget(text, frame));
+    try testing.expect(!isLiveTarget(file, frame));
+    try testing.expect(!isLiveTarget(submit, frame));
+    try testing.expect(!isLiveTarget(select, frame));
+    try testing.expect(checkbox.hasAttributeSafe(comptime .wrap("checked")));
+    try testing.expect(!radio.hasAttributeSafe(comptime .wrap("checked")));
 }
 
 test "dump: live snapshots strip meta refresh without mutating the DOM" {

--- a/src/browser/interactive.zig
+++ b/src/browser/interactive.zig
@@ -271,6 +271,18 @@ pub fn buildListenerTargetMap(frame: *Frame, arena: Allocator) !ListenerTargetMa
     return map;
 }
 
+pub fn hasListenerType(target: *EventTarget, listener_targets: ListenerTargetMap, event_type: []const u8) bool {
+    const types = listener_targets.get(@intFromPtr(target)) orelse return false;
+    for (types.items) |typ| {
+        if (std.mem.eql(u8, typ, event_type)) return true;
+    }
+    return false;
+}
+
+pub fn isVisibleForInteraction(el: *Element, frame: *Frame) bool {
+    return !frame._style_manager.isHidden(el, null, .{ .check_visibility = true });
+}
+
 pub fn classifyInteractivity(
     frame: *Frame,
     el: *Element,

--- a/src/browser/tests/render_live.html
+++ b/src/browser/tests/render_live.html
@@ -6,10 +6,17 @@
 <input id="radio-a" type="radio" name="choice" checked>
 <input id="radio-b" type="radio" name="choice">
 <input id="disabled" type="checkbox" disabled>
-<input id="text">
+<input id="text" value="input-before">
 <input id="file" type="file">
 <input id="submit" type="submit">
-<select id="select"><option>one</option></select>
+<select id="select"><option id="option-one" value="one" selected>one</option><option id="option-two-a" value="two">two-a</option><option id="option-two-b" value="two">two-b</option></select>
+<textarea id="textarea">textarea-before</textarea>
+<input id="focus-invalidated" value="focus-before">
+<input id="password" type="password" value="secret">
+<input id="readonly" value="readonly" readonly>
+<textarea id="readonly-textarea" readonly>readonly</textarea>
+<select id="multiple-select" multiple><option selected>one</option></select>
+<div id="editable" contenteditable>editable</div>
 <p id="status">before</p>
 <div id="listener-update">listener</div>
 <div id="inline-update" onclick="document.getElementById('status').textContent = 'inline'">inline</div>
@@ -58,6 +65,20 @@ document.getElementById("removed-listener").addEventListener("click", removedLis
 document.getElementById("removed-listener").removeEventListener("click", removedListener);
 document.getElementById("non-click-listener").addEventListener("mouseover", () => {});
 document.getElementById("uppercase-listener").addEventListener("CLICK", () => {});
+for (const id of ["text", "textarea", "select"]) {
+    const control = document.getElementById(id);
+    control.addEventListener("input", () => control.setAttribute("data-events", "input"));
+    control.addEventListener("change", () => {
+        control.setAttribute("data-events", `${control.getAttribute("data-events")},change`);
+        if (id === "text" && control.value === "navigate") {
+            location.href = "/src/browser/tests/mcp_nav.html";
+        }
+    });
+}
+document.getElementById("focus-invalidated").addEventListener("focus", (event) => {
+    event.currentTarget.readOnly = true;
+});
+document.getElementById("password").value = "current-secret";
 </script>
 </body>
 </html>

--- a/src/browser/tests/render_live.html
+++ b/src/browser/tests/render_live.html
@@ -11,10 +11,53 @@
 <input id="submit" type="submit">
 <select id="select"><option>one</option></select>
 <p id="status">before</p>
+<div id="listener-update">listener</div>
+<div id="inline-update" onclick="document.getElementById('status').textContent = 'inline'">inline</div>
+<a id="inline-anchor" onclick="document.getElementById('status').textContent = 'anchor'">anchor</a>
+<form id="script-form">
+    <button id="form-script-button" type="button" onclick="document.getElementById('status').textContent = 'button'">button</button>
+    <button id="submit-script-button" type="submit"><span id="submit-script-child" onclick="document.getElementById('status').textContent = 'submit child'">submit child</span></button>
+    <input id="label-submit-control" type="submit">
+    <label id="label-submit-script" for="label-submit-control" onclick="document.getElementById('status').textContent = 'label submit'">label submit</label>
+</form>
+<input id="input-script-button" type="button" onclick="document.getElementById('status').textContent = 'input'">
+<input id="file-script" type="file" onclick="document.getElementById('status').textContent = 'file'">
+<div id="delegated-update">delegated</div>
+<button id="disabled-script" disabled onclick="document.getElementById('status').textContent = 'disabled'">disabled script</button>
+<div id="blocked-script" style="pointer-events: none" onclick="document.getElementById('status').textContent = 'blocked'">blocked</div>
+<div id="hidden-listener" hidden>hidden</div>
+<div id="visibility-hidden" style="visibility: hidden" onclick="document.getElementById('status').textContent = 'visibility'">visibility hidden</div>
+<div style="visibility: hidden">
+    <div id="visibility-hidden-ancestor" onclick="document.getElementById('status').textContent = 'visibility ancestor'">visibility hidden ancestor</div>
+</div>
+<div style="display: none">
+    <div id="display-hidden-ancestor" onclick="document.getElementById('status').textContent = 'display ancestor'">display hidden ancestor</div>
+</div>
+<div id="removed-listener">removed</div>
+<div id="non-click-listener">non-click</div>
+<div id="uppercase-listener">uppercase</div>
 <script>
 document.getElementById("update").addEventListener("click", () => {
     document.getElementById("status").textContent = "after";
 });
+const liveListener = () => {
+    document.getElementById("status").textContent = "listener";
+};
+document.getElementById("listener-update").addEventListener("click", liveListener);
+window.removeLiveListener = () => {
+    document.getElementById("listener-update").removeEventListener("click", liveListener);
+};
+document.getElementById("hidden-listener").addEventListener("click", () => {});
+document.addEventListener("click", (event) => {
+    if (event.target.id === "delegated-update") {
+        document.getElementById("status").textContent = "delegated";
+    }
+});
+const removedListener = () => {};
+document.getElementById("removed-listener").addEventListener("click", removedListener);
+document.getElementById("removed-listener").removeEventListener("click", removedListener);
+document.getElementById("non-click-listener").addEventListener("mouseover", () => {});
+document.getElementById("uppercase-listener").addEventListener("CLICK", () => {});
 </script>
 </body>
 </html>

--- a/src/browser/tests/render_live.html
+++ b/src/browser/tests/render_live.html
@@ -2,6 +2,14 @@
 <html>
 <body>
 <button id="update">Update</button>
+<input id="toggle" type="checkbox" checked>
+<input id="radio-a" type="radio" name="choice" checked>
+<input id="radio-b" type="radio" name="choice">
+<input id="disabled" type="checkbox" disabled>
+<input id="text">
+<input id="file" type="file">
+<input id="submit" type="submit">
+<select id="select"><option>one</option></select>
 <p id="status">before</p>
 <script>
 document.getElementById("update").addEventListener("click", () => {

--- a/src/browser/tests/render_live.html
+++ b/src/browser/tests/render_live.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<body>
+<button id="update">Update</button>
+<p id="status">before</p>
+<script>
+document.getElementById("update").addEventListener("click", () => {
+    document.getElementById("status").textContent = "after";
+});
+</script>
+</body>
+</html>

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -518,13 +518,16 @@ pub fn getAttributeFunction(
     }
 
     const attr = element.getAttributeSafe(.wrap(@tagName(listener_type))) orelse return null;
-    const function = frame.js.stringToPersistedFunction(attr, &.{"event"}, &.{}) catch |err| {
-        // Not a valid expression; log this to find out if its something we should be supporting.
-        log.warn(.js, "Html.getAttributeFunction", .{
-            .expression = attr,
-            .err = err,
-        });
-        return null;
+    const function = frame.js.stringToPersistedFunction(attr, &.{"event"}, &.{}) catch |err| switch (err) {
+        error.CompilationError => {
+            // Not a valid expression; log this to find out if its something we should be supporting.
+            log.warn(.js, "Html.getAttributeFunction", .{
+                .expression = attr,
+                .err = err,
+            });
+            return null;
+        },
+        else => return err,
     };
 
     try self.setAttributeListener(listener_type, function, frame);

--- a/src/help.zon
+++ b/src/help.zon
@@ -8,6 +8,7 @@
     \\  fetch       fetches the specified URL
     \\  help        displays this message
     \\  mcp         starts an MCP (Model Context Protocol) server (stdio or HTTP)
+    \\  render      starts a one-shot DOM render server
     \\  run         runs a saved script (no LLM), then exits
     \\  serve       starts a WebSocket CDP server
     \\  version     displays the version of {0s}
@@ -124,6 +125,45 @@
     \\  --with-frames
     \\          Includes the contents of iframes.
     \\          Defaults to false.
+    ,
+    .render =
+    \\usage: {0s} render [OPTIONS] [COMMON_OPTIONS]
+    \\
+    \\Starts a one-shot DOM render server. Lightpanda executes page JavaScript
+    \\and returns an HTML snapshot; the attached browser renders that snapshot.
+    \\The sandboxed preview supports same-frame form submissions. New-window
+    \\and top-level form targets stay blocked.
+    \\
+    \\Endpoints:
+    \\  POST /v1/render                JSON request, HTML snapshot response
+    \\  GET  /lightpanda-renderer.js   browser ESM library
+    \\  GET  /healthz                  liveness check
+    \\
+    \\options:
+    \\  --allow-private-networks
+    \\          Allow render targets on loopback and private/internal networks.
+    \\          By default these targets are blocked after DNS resolution.
+    \\  --auth-token <TOKEN>
+    \\          Bearer token required by POST /v1/render. Must be at least 16
+    \\          bytes. Required when --cors-origin is configured.
+    \\  --client-timeout-ms <INT>
+    \\          Maximum client socket read or write time. Defaults to 30000.
+    \\  --cors-origin <ORIGIN>
+    \\          Exact browser origin allowed to call the render service, or *.
+    \\          Enabling CORS also requires --auth-token.
+    \\  --host <HOST>
+    \\          Loopback address to bind. Defaults to "127.0.0.1".
+    \\  --max-connections <INT>
+    \\          Maximum simultaneous HTTP connections. Defaults to 8.
+    \\  --max-request-size <INT>
+    \\          Maximum JSON request size. Defaults to 16384 (16 KiB).
+    \\  --max-response-size <INT>
+    \\          Maximum HTML snapshot size. Defaults to 16777216 (16 MiB).
+    \\  --max-wait-ms <INT>
+    \\          Maximum total queue and render time for one request. Defaults
+    \\          to 30000.
+    \\  --port <INT>
+    \\          HTTP port. Defaults to 9223.
     ,
     .mcp =
     \\usage: {0s} mcp [OPTIONS] [COMMON_OPTIONS]

--- a/src/help.zon
+++ b/src/help.zon
@@ -136,11 +136,11 @@
     \\
     \\POST /v1/live keeps one worker-owned page for up to five idle minutes.
     \\The renderer library's open() method sends explicit open, activate, and
-    \\close operations. Live snapshots expose anchors, non-form buttons, and
-    \\enabled checkbox/radio inputs as server-side semantic clicks; scripts and
-    \\form submissions stay disabled in the preview. A live session owns the sole
-    \\worker until close or its five-minute idle expiry; /v1/render returns 409
-    \\while it is active.
+    \\close operations. Live snapshots expose anchors, non-form buttons, enabled
+    \\checkbox/radio inputs, and usable elements with direct click handlers as
+    \\server-side semantic clicks; scripts and form submissions stay disabled in
+    \\the preview. A live session owns the sole worker until close or its
+    \\five-minute idle expiry; /v1/render returns 409 while it is active.
     \\
     \\Endpoints:
     \\  POST /v1/render                JSON request, HTML snapshot response

--- a/src/help.zon
+++ b/src/help.zon
@@ -135,11 +135,13 @@
     \\submissions. New-window and top-level form targets stay blocked.
     \\
     \\POST /v1/live keeps one worker-owned page for up to five idle minutes.
-    \\The renderer library's open() method sends explicit open, activate, and
-    \\close operations. Live snapshots expose anchors, non-form buttons, enabled
-    \\checkbox/radio inputs, and usable elements with direct click handlers as
-    \\server-side semantic clicks; scripts and form submissions stay disabled in
-    \\the preview. A live session owns the sole worker until close or its
+    \\The renderer library's open() method sends explicit open, activate,
+    \\set_value, and close operations. Live snapshots expose anchors, non-form
+    \\buttons, enabled checkbox/radio inputs, and usable elements with direct
+    \\click handlers as server-side semantic clicks. Enabled editable text
+    \\controls and single selects send bounded value updates on change; scripts
+    \\and form submissions stay disabled in the preview. A live session owns the
+    \\sole worker until close or its
     \\five-minute idle expiry; /v1/render returns 409 while it is active.
     \\
     \\Endpoints:

--- a/src/help.zon
+++ b/src/help.zon
@@ -129,13 +129,21 @@
     .render =
     \\usage: {0s} render [OPTIONS] [COMMON_OPTIONS]
     \\
-    \\Starts a one-shot DOM render server. Lightpanda executes page JavaScript
-    \\and returns an HTML snapshot; the attached browser renders that snapshot.
-    \\The sandboxed preview supports same-frame form submissions. New-window
-    \\and top-level form targets stay blocked.
+    \\Starts a DOM render server. POST /v1/render is one-shot: Lightpanda
+    \\executes page JavaScript and returns an HTML snapshot; the attached browser
+    \\renders that snapshot. Its sandboxed preview supports same-frame form
+    \\submissions. New-window and top-level form targets stay blocked.
+    \\
+    \\POST /v1/live keeps one worker-owned page for up to five idle minutes.
+    \\The renderer library's open() method sends explicit open, activate, and
+    \\close operations. Live snapshots expose only anchors and non-form buttons
+    \\as server-side semantic clicks; scripts and form submissions stay disabled
+    \\in the preview. A live session owns the sole worker until close or its
+    \\five-minute idle expiry; /v1/render returns 409 while it is active.
     \\
     \\Endpoints:
     \\  POST /v1/render                JSON request, HTML snapshot response
+    \\  POST /v1/live                  JSON live-session operation, snapshot response
     \\  GET  /lightpanda-renderer.js   browser ESM library
     \\  GET  /healthz                  liveness check
     \\
@@ -144,7 +152,7 @@
     \\          Allow render targets on loopback and private/internal networks.
     \\          By default these targets are blocked after DNS resolution.
     \\  --auth-token <TOKEN>
-    \\          Bearer token required by POST /v1/render. Must be at least 16
+    \\          Bearer token required by POST /v1/render and POST /v1/live. Must be at least 16
     \\          bytes. Required when --cors-origin is configured.
     \\  --client-timeout-ms <INT>
     \\          Maximum client socket read or write time. Defaults to 30000.

--- a/src/help.zon
+++ b/src/help.zon
@@ -136,10 +136,11 @@
     \\
     \\POST /v1/live keeps one worker-owned page for up to five idle minutes.
     \\The renderer library's open() method sends explicit open, activate, and
-    \\close operations. Live snapshots expose only anchors and non-form buttons
-    \\as server-side semantic clicks; scripts and form submissions stay disabled
-    \\in the preview. A live session owns the sole worker until close or its
-    \\five-minute idle expiry; /v1/render returns 409 while it is active.
+    \\close operations. Live snapshots expose anchors, non-form buttons, and
+    \\enabled checkbox/radio inputs as server-side semantic clicks; scripts and
+    \\form submissions stay disabled in the preview. A live session owns the sole
+    \\worker until close or its five-minute idle expiry; /v1/render returns 409
+    \\while it is active.
     \\
     \\Endpoints:
     \\  POST /v1/render                JSON request, HTML snapshot response

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -49,6 +49,7 @@ pub const tools = @import("browser/tools.zig");
 pub const HttpClient = @import("network/HttpClient.zig");
 
 pub const mcp = @import("mcp.zig");
+pub const render = @import("render.zig");
 pub const Agent = @import("agent/Agent.zig");
 pub const Command = @import("script/command.zig").Command;
 pub const Recorder = @import("script/Recorder.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -199,6 +199,26 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
             var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, &ft, urls, fetch_opts });
             worker_thread.join();
         },
+        .render => |opts| {
+            log.debug(.app, "startup", .{
+                .mode = "render",
+                .snapshot = app.snapshot.fromEmbedded(),
+            });
+            const address = std.Io.net.IpAddress.parse(opts.host, opts.port) catch |err| {
+                log.fatal(.app, "invalid render server address", .{
+                    .err = err,
+                    .host = opts.host,
+                    .port = opts.port,
+                });
+                return err;
+            };
+            const server = try lp.render.HttpServer.init(allocator, app);
+            defer server.deinit();
+            server.run(address) catch |err| {
+                log.fatal(.app, "client render server error", .{ .err = err });
+                return err;
+            };
+        },
         .mcp => |opts| {
             log.info(.mcp, "starting server", .{});
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const HttpServer = @import("render/HttpServer.zig");
+pub const LiveSession = @import("render/LiveSession.zig");
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub const HttpServer = @import("render/HttpServer.zig");
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -1,0 +1,772 @@
+// Copyright (C) 2026 Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+//! Bounded HTTP transport for one-shot client-side rendering.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const App = @import("../App.zig");
+const ResponseBuffer = @import("ResponseBuffer.zig");
+const sys_net = @import("../sys/net.zig");
+
+const HttpServer = @This();
+const posix = std.posix;
+
+const worker_stack_size = 4 * 1024 * 1024;
+const connection_stack_size = 512 * 1024;
+const worker_retained_arena_bytes = 64 * 1024;
+const job_poll_interval_ms = 100;
+const ns_per_ms = 1_000_000;
+
+const client_js = @embedFile("client.js");
+const client_etag = blk: {
+    @setEvalBranchQuota(10_000);
+    break :blk std.fmt.comptimePrint("W/\"{x}\"", .{std.hash.Wyhash.hash(0, client_js)});
+};
+
+const Result = enum {
+    ok,
+    bad_request,
+    timeout,
+    navigation_failed,
+    response_too_large,
+    shutting_down,
+    internal_error,
+
+    fn status(self: Result) std.http.Status {
+        return switch (self) {
+            .ok => .ok,
+            .bad_request => .bad_request,
+            .timeout => .gateway_timeout,
+            .navigation_failed => .bad_gateway,
+            .response_too_large => .payload_too_large,
+            .shutting_down => .service_unavailable,
+            .internal_error => .internal_server_error,
+        };
+    }
+
+    fn body(self: Result) []const u8 {
+        return switch (self) {
+            .ok => "",
+            .bad_request => "{\"error\":\"invalid render request\"}\n",
+            .timeout => "{\"error\":\"render deadline exceeded\"}\n",
+            .navigation_failed => "{\"error\":\"page navigation failed\"}\n",
+            .response_too_large => "{\"error\":\"render snapshot too large\"}\n",
+            .shutting_down => "{\"error\":\"render server shutting down\"}\n",
+            .internal_error => "{\"error\":\"render failed\"}\n",
+        };
+    }
+};
+
+const Job = struct {
+    body: []const u8,
+    out: *std.Io.Writer,
+    max_wait_ms: u32,
+    result: Result = .ok,
+    done: std.atomic.Value(bool) = .init(false),
+    done_mutex: std.Io.Mutex = .init,
+    done_cond: std.Io.Condition = .init,
+    cancel_reason: std.atomic.Value(u8) = .init(@intFromEnum(CancelReason.none)),
+    termination_requested: std.atomic.Value(bool) = .init(false),
+    next: ?*Job = null,
+
+    const CancelReason = enum(u8) {
+        none,
+        timeout,
+        disconnected,
+        shutdown,
+    };
+
+    fn cancel(self: *Job, reason: CancelReason) void {
+        if (self.done.load(.acquire)) return;
+        _ = self.cancel_reason.cmpxchgStrong(
+            @intFromEnum(CancelReason.none),
+            @intFromEnum(reason),
+            .acq_rel,
+            .acquire,
+        );
+    }
+
+    fn cancellation(self: *const Job) CancelReason {
+        return @enumFromInt(self.cancel_reason.load(.acquire));
+    }
+
+    fn finish(self: *Job) void {
+        self.done_mutex.lockUncancelable(lp.io);
+        defer self.done_mutex.unlock(lp.io);
+        self.done.store(true, .release);
+        self.done_cond.broadcast(lp.io);
+    }
+
+    fn wait(self: *Job, timeout_ms: u32) bool {
+        self.done_mutex.lockUncancelable(lp.io);
+        defer self.done_mutex.unlock(lp.io);
+        if (self.done.load(.acquire)) return true;
+        lp.timedWait(
+            &self.done_cond,
+            &self.done_mutex,
+            @as(u64, timeout_ms) * ns_per_ms,
+        ) catch {};
+        return self.done.load(.acquire);
+    }
+};
+
+const Queue = struct {
+    mutex: std.Io.Mutex = .init,
+    cond: std.Io.Condition = .init,
+    head: ?*Job = null,
+    tail: ?*Job = null,
+    closed: std.atomic.Value(bool) = .init(false),
+
+    fn push(self: *Queue, job: *Job) bool {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        if (self.closed.load(.acquire)) return false;
+        job.next = null;
+        if (self.tail) |tail| tail.next = job else self.head = job;
+        self.tail = job;
+        self.cond.signal(lp.io);
+        return true;
+    }
+
+    fn pop(self: *Queue) ?*Job {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        while (self.head == null and !self.closed.load(.acquire)) {
+            self.cond.waitUncancelable(lp.io, &self.mutex);
+        }
+        const job = self.head orelse return null;
+        self.head = job.next;
+        if (self.head == null) self.tail = null;
+        return job;
+    }
+
+    fn close(self: *Queue) void {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+        self.closed.store(true, .release);
+        self.cond.broadcast(lp.io);
+    }
+};
+
+allocator: std.mem.Allocator,
+app: *App,
+max_connections: u32,
+max_request_size: usize,
+max_response_size: usize,
+max_wait_ms: u32,
+client_timeout_ms: u32,
+cors_origin: ?[]const u8,
+auth_token: ?[]const u8,
+
+queue: Queue = .{},
+active_conns: std.atomic.Value(u32) = .init(0),
+conn_mutex: std.Io.Mutex = .init,
+conns: std.ArrayList(posix.socket_t) = .empty,
+
+worker_thread: std.Thread = undefined,
+worker_ready: std.Io.Event = .unset,
+worker_ok: bool = false,
+browser_mutex: std.Io.Mutex = .init,
+active_browser: ?*lp.Browser = null,
+active_job: ?*Job = null,
+
+pub fn init(allocator: std.mem.Allocator, app: *App) !*HttpServer {
+    const self = try allocator.create(HttpServer);
+    errdefer allocator.destroy(self);
+    self.* = .{
+        .allocator = allocator,
+        .app = app,
+        .max_connections = app.config.maxConnections(),
+        .max_request_size = app.config.renderMaxRequestSize(),
+        .max_response_size = app.config.renderMaxResponseSize(),
+        .max_wait_ms = app.config.renderMaxWaitMs(),
+        .client_timeout_ms = app.config.renderClientTimeoutMs(),
+        .cors_origin = app.config.renderCorsOrigin(),
+        .auth_token = app.config.renderAuthToken(),
+    };
+    if (self.auth_token) |token| {
+        if (token.len < 16) return error.WeakAuthToken;
+    }
+    if (self.cors_origin) |origin| {
+        if (self.auth_token == null) return error.AuthenticationRequired;
+        if (!validHeaderValue(origin)) return error.InvalidCorsOrigin;
+    }
+    errdefer self.conns.deinit(allocator);
+    try self.conns.ensureTotalCapacity(allocator, self.max_connections);
+
+    self.worker_thread = try std.Thread.spawn(.{ .stack_size = worker_stack_size }, worker, .{self});
+    self.worker_ready.waitUncancelable(lp.io);
+    if (!self.worker_ok) {
+        self.worker_thread.join();
+        return error.WorkerInitFailed;
+    }
+    return self;
+}
+
+pub fn deinit(self: *HttpServer) void {
+    self.queue.close();
+    self.cancelActiveJob(.shutdown);
+    {
+        self.conn_mutex.lockUncancelable(lp.io);
+        defer self.conn_mutex.unlock(lp.io);
+        for (self.conns.items) |socket| sys_net.shutdown(socket, .both) catch {};
+    }
+    while (self.active_conns.load(.acquire) > 0) {
+        lp.io.sleep(.fromMilliseconds(10), .awake) catch {};
+    }
+    self.worker_thread.join();
+
+    self.conns.deinit(self.allocator);
+    self.allocator.destroy(self);
+}
+
+pub fn run(self: *HttpServer, address: sys_net.IpAddress) !void {
+    if (!isLoopback(address)) return error.LoopbackRequired;
+    var bound = address;
+    try self.app.network.bind(&bound, self, onAccept);
+    lp.log.note(.app, "client render server running", .{ .address = bound });
+    self.app.network.run();
+}
+
+fn cancelActiveJob(self: *HttpServer, reason: Job.CancelReason) void {
+    self.browser_mutex.lockUncancelable(lp.io);
+    defer self.browser_mutex.unlock(lp.io);
+    const job = self.active_job orelse return;
+    job.cancel(reason);
+    const browser = self.active_browser orelse return;
+    if (!job.termination_requested.swap(true, .acq_rel)) {
+        browser.env.terminate();
+    }
+}
+
+fn cancelJob(self: *HttpServer, job: *Job, reason: Job.CancelReason) void {
+    job.cancel(reason);
+    self.browser_mutex.lockUncancelable(lp.io);
+    defer self.browser_mutex.unlock(lp.io);
+    if (self.active_job != job) return;
+    const browser = self.active_browser orelse return;
+    if (!job.termination_requested.swap(true, .acq_rel)) {
+        browser.env.terminate();
+    }
+}
+
+fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
+    const self: *HttpServer = @ptrCast(@alignCast(ctx));
+    const flags = sys_net.fcntl(socket, posix.F.GETFL, 0) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    _ = sys_net.fcntl(socket, posix.F.SETFL, flags & ~@as(u32, @bitCast(posix.O{ .NONBLOCK = true }))) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    setSocketTimeout(socket, self.client_timeout_ms) catch {
+        _ = std.c.close(socket);
+        return;
+    };
+    if (!acquireConnectionSlot(&self.active_conns, self.max_connections)) {
+        _ = std.c.close(socket);
+        return;
+    }
+    {
+        self.conn_mutex.lockUncancelable(lp.io);
+        defer self.conn_mutex.unlock(lp.io);
+        self.conns.appendAssumeCapacity(socket);
+    }
+
+    const thread = std.Thread.spawn(.{ .stack_size = connection_stack_size }, handleConn, .{ self, socket }) catch {
+        _ = self.active_conns.fetchSub(1, .release);
+        self.unregister(socket);
+        _ = std.c.close(socket);
+        return;
+    };
+    thread.detach();
+}
+
+fn setSocketTimeout(socket: posix.socket_t, timeout_ms: u32) !void {
+    const timeout = std.mem.toBytes(posix.timeval{
+        .sec = @intCast(timeout_ms / 1000),
+        .usec = @intCast((timeout_ms % 1000) * 1000),
+    });
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &timeout);
+    try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &timeout);
+}
+
+fn isLoopback(address: sys_net.IpAddress) bool {
+    return switch (address) {
+        .ip4 => |ip4| ip4.bytes[0] == 127,
+        .ip6 => |ip6| ip6.isLoopBack(),
+    };
+}
+
+fn validHeaderValue(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |byte| {
+        if (byte < ' ' or byte == 0x7f) return false;
+    }
+    return true;
+}
+
+fn acquireConnectionSlot(active: *std.atomic.Value(u32), max: u32) bool {
+    var current = active.load(.monotonic);
+    while (current < max) {
+        current = active.cmpxchgWeak(current, current + 1, .monotonic, .monotonic) orelse return true;
+    }
+    return false;
+}
+
+fn unregister(self: *HttpServer, socket: posix.socket_t) void {
+    self.conn_mutex.lockUncancelable(lp.io);
+    defer self.conn_mutex.unlock(lp.io);
+    for (self.conns.items, 0..) |tracked, i| {
+        if (tracked == socket) {
+            _ = self.conns.swapRemove(i);
+            return;
+        }
+    }
+}
+
+fn worker(self: *HttpServer) void {
+    var browser: lp.Browser = undefined;
+    browser.init(self.app, .{}, null) catch |err| {
+        lp.log.err(.app, "client render browser init", .{ .err = err });
+        self.worker_ready.set(lp.io);
+        return;
+    };
+    defer browser.deinit();
+    {
+        self.browser_mutex.lockUncancelable(lp.io);
+        self.active_browser = &browser;
+        self.browser_mutex.unlock(lp.io);
+    }
+    defer {
+        self.browser_mutex.lockUncancelable(lp.io);
+        self.active_browser = null;
+        self.browser_mutex.unlock(lp.io);
+    }
+
+    self.worker_ok = true;
+    self.worker_ready.set(lp.io);
+
+    var arena: std.heap.ArenaAllocator = .init(self.allocator);
+    defer arena.deinit();
+    while (self.queue.pop()) |job| {
+        if (self.queue.closed.load(.acquire)) job.cancel(.shutdown);
+
+        if (job.cancellation() == .none) {
+            self.browser_mutex.lockUncancelable(lp.io);
+            self.active_job = job;
+            self.browser_mutex.unlock(lp.io);
+
+            if (job.cancellation() == .none) {
+                processRender(self, &browser, arena.allocator(), job);
+            }
+
+            self.browser_mutex.lockUncancelable(lp.io);
+            self.active_job = null;
+            self.browser_mutex.unlock(lp.io);
+            if (job.termination_requested.load(.acquire)) {
+                browser.env.cancelTerminate();
+            }
+        }
+
+        job.result = switch (job.cancellation()) {
+            .none => job.result,
+            .timeout => .timeout,
+            .disconnected, .shutdown => .shutting_down,
+        };
+        _ = arena.reset(.{ .retain_with_limit = worker_retained_arena_bytes });
+        job.finish();
+    }
+}
+
+const RenderRequest = struct {
+    url: []const u8,
+    wait_ms: u32 = 5_000,
+    wait_until: ?lp.Config.WaitUntil = null,
+    wait_selector: ?[]const u8 = null,
+    width: u32 = 1280,
+    height: u32 = 720,
+};
+
+fn processRender(self: *HttpServer, browser: *lp.Browser, arena: std.mem.Allocator, job: *Job) void {
+    const request = std.json.parseFromSliceLeaky(RenderRequest, arena, job.body, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        job.result = .bad_request;
+        return;
+    };
+    if (request.url.len == 0 or request.url.len > 8 * 1024 or
+        request.width == 0 or request.width > 8192 or request.height == 0 or request.height > 8192)
+    {
+        job.result = .bad_request;
+        return;
+    }
+    if (request.wait_selector) |selector| {
+        if (selector.len == 0 or selector.len > 1024) {
+            job.result = .bad_request;
+            return;
+        }
+    }
+
+    const canonical = lp.URL.resolveNavigation(arena, request.url, .{}) catch {
+        job.result = .bad_request;
+        return;
+    };
+    const protocol = lp.URL.getProtocol(canonical);
+    if ((!std.mem.eql(u8, protocol, "http:") and !std.mem.eql(u8, protocol, "https:")) or
+        lp.URL.getUsername(canonical).len != 0 or lp.URL.getPassword(canonical).len != 0)
+    {
+        job.result = .bad_request;
+        return;
+    }
+
+    const selector: ?[:0]const u8 = if (request.wait_selector) |value|
+        arena.dupeZ(u8, value) catch {
+            job.result = .internal_error;
+            return;
+        }
+    else
+        null;
+    browser.viewport_override = .{ .width = request.width, .height = request.height };
+
+    var urls = [_][:0]const u8{canonical};
+    lp.fetch(self.app, browser, &urls, .{
+        .wait_ms = @min(request.wait_ms, job.max_wait_ms),
+        .wait_until = request.wait_until,
+        .wait_selector = selector,
+        .dump = .{
+            .with_base = true,
+            .with_frames = false,
+            .strip = .{ .js = true },
+        },
+        .dump_mode = .html,
+        .writer = job.out,
+    }) catch |err| {
+        job.result = if (err == error.Timeout)
+            .timeout
+        else if (err == error.WriteFailed)
+            .response_too_large
+        else switch (err) {
+            error.TypeError, error.InvalidURL => .bad_request,
+            error.OutOfMemory => .internal_error,
+            else => .navigation_failed,
+        };
+        return;
+    };
+}
+
+fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
+    defer _ = self.active_conns.fetchSub(1, .release);
+    const stream: std.Io.net.Stream = .{ .socket = .{ .handle = socket, .address = .{ .ip4 = .unspecified(0) } } };
+    defer stream.close(lp.io);
+    defer self.unregister(socket);
+
+    var recv_buf: [8 * 1024]u8 = undefined;
+    var send_buf: [8 * 1024]u8 = undefined;
+    var stream_reader = stream.reader(lp.io, &recv_buf);
+    var stream_writer = stream.writer(lp.io, &send_buf);
+    var http_server = std.http.Server.init(&stream_reader.interface, &stream_writer.interface);
+
+    var request = http_server.receiveHead() catch return;
+    var arena: std.heap.ArenaAllocator = .init(self.allocator);
+    defer arena.deinit();
+    var out: ResponseBuffer = .init(self.allocator, self.max_response_size);
+    defer out.deinit();
+    self.serve(&out, arena.allocator(), &request, socket) catch {};
+}
+
+fn serve(
+    self: *HttpServer,
+    out: *ResponseBuffer,
+    arena: std.mem.Allocator,
+    request: *std.http.Server.Request,
+    socket: posix.socket_t,
+) !void {
+    if (request.head.expect != null) {
+        return request.respond("", .{ .status = .expectation_failed, .keep_alive = false });
+    }
+    const target = request.head.target;
+    const path = target[0 .. std.mem.indexOfScalar(u8, target, '?') orelse target.len];
+    const origin = headerValue(request, "origin");
+    const cors_value: ?[]const u8 = if (origin != null)
+        self.allowedCorsValue(origin) orelse
+            return respondJson(request, .forbidden, "{\"error\":\"origin not allowed\"}\n", null)
+    else
+        null;
+
+    if (request.head.method == .OPTIONS) return respondPreflight(request, cors_value);
+    if ((request.head.method == .GET or request.head.method == .HEAD) and
+        std.mem.eql(u8, path, "/lightpanda-renderer.js"))
+    {
+        if (headerEquals(request, "if-none-match", client_etag)) return respondNotModified(request, cors_value);
+        return respondBody(request, client_js, .ok, "text/javascript; charset=utf-8", "public,max-age=0,must-revalidate", client_etag, cors_value);
+    }
+    if ((request.head.method == .GET or request.head.method == .HEAD) and std.mem.eql(u8, path, "/healthz")) {
+        return respondBody(request, "ok\n", .ok, "text/plain; charset=utf-8", "no-store", null, cors_value);
+    }
+    if (request.head.method != .POST or !std.mem.eql(u8, path, "/v1/render")) {
+        return respondJson(request, .not_found, "{\"error\":\"not found\"}\n", cors_value);
+    }
+    if (!authorized(request, self.auth_token)) {
+        return respondJson(request, .unauthorized, "{\"error\":\"authentication required\"}\n", cors_value);
+    }
+    const content_type = headerValue(request, "content-type") orelse "";
+    if (!isJsonContentType(content_type)) {
+        return respondJson(request, .unsupported_media_type, "{\"error\":\"application/json required\"}\n", cors_value);
+    }
+
+    const content_length = if (request.head.transfer_encoding == .none)
+        request.head.content_length
+    else
+        null;
+    var body_buf: [8 * 1024]u8 = undefined;
+    const body = readRequestBody(arena, request.readerExpectNone(&body_buf), content_length, self.max_request_size) catch {
+        return respondJson(request, .payload_too_large, "{\"error\":\"request too large\"}\n", cors_value);
+    };
+    var job: Job = .{
+        .body = body,
+        .out = &out.writer,
+        .max_wait_ms = self.max_wait_ms,
+    };
+    if (!self.queue.push(&job)) {
+        return respondJson(request, .service_unavailable, Result.shutting_down.body(), cors_value);
+    }
+    if (self.waitForJob(&job, socket) == .disconnected) {
+        return error.ClientDisconnected;
+    }
+
+    if (out.failed and job.result == .ok) job.result = .response_too_large;
+    if (job.result != .ok) return respondJson(request, job.result.status(), job.result.body(), cors_value);
+    return respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value);
+}
+
+const JobWaitResult = enum { complete, disconnected };
+
+fn waitForJob(self: *HttpServer, job: *Job, socket: posix.socket_t) JobWaitResult {
+    var timer: std.Io.Timestamp = .now(lp.io, .boot);
+    while (!job.done.load(.acquire)) {
+        if (peerDisconnected(socket)) {
+            self.cancelJob(job, .disconnected);
+        }
+
+        const elapsed: u32 = @intCast(@min(
+            timer.untilNow(lp.io, .boot).toMilliseconds(),
+            std.math.maxInt(u32),
+        ));
+        if (elapsed >= job.max_wait_ms) {
+            self.cancelJob(job, .timeout);
+        }
+
+        const remaining = job.max_wait_ms -| elapsed;
+        const wait_ms = @max(@min(remaining, job_poll_interval_ms), 1);
+        _ = job.wait(wait_ms);
+    }
+    return if (job.cancellation() == .disconnected) .disconnected else .complete;
+}
+
+fn peerDisconnected(socket: posix.socket_t) bool {
+    var fds = [_]posix.pollfd{.{
+        .fd = socket,
+        .events = posix.POLL.IN,
+        .revents = 0,
+    }};
+    _ = posix.poll(&fds, 0) catch return true;
+    const fatal_events: i16 = comptime @intCast(posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
+    return fds[0].revents & fatal_events != 0;
+}
+
+fn respondBody(
+    request: *std.http.Server.Request,
+    body: []const u8,
+    status: std.http.Status,
+    content_type: []const u8,
+    cache_control: []const u8,
+    etag: ?[]const u8,
+    cors_value: ?[]const u8,
+) !void {
+    var headers: [7]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "content-type", .value = content_type };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = cache_control };
+    count += 1;
+    headers[count] = .{ .name = "x-content-type-options", .value = "nosniff" };
+    count += 1;
+    headers[count] = .{ .name = "vary", .value = "origin" };
+    count += 1;
+    if (etag) |value| {
+        headers[count] = .{ .name = "etag", .value = value };
+        count += 1;
+    }
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+        headers[count] = .{ .name = "cross-origin-resource-policy", .value = "cross-origin" };
+        count += 1;
+    }
+    return request.respond(body, .{
+        .status = status,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondNotModified(request: *std.http.Server.Request, cors_value: ?[]const u8) !void {
+    var headers: [6]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "etag", .value = client_etag };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = "public,max-age=0,must-revalidate" };
+    count += 1;
+    headers[count] = .{ .name = "vary", .value = "origin" };
+    count += 1;
+    headers[count] = .{ .name = "x-content-type-options", .value = "nosniff" };
+    count += 1;
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+        headers[count] = .{ .name = "cross-origin-resource-policy", .value = "cross-origin" };
+        count += 1;
+    }
+    return request.respond("", .{
+        .status = .not_modified,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondJson(request: *std.http.Server.Request, status: std.http.Status, body: []const u8, cors_value: ?[]const u8) !void {
+    var headers: [3]std.http.Header = undefined;
+    var count: usize = 0;
+    headers[count] = .{ .name = "content-type", .value = "application/json; charset=utf-8" };
+    count += 1;
+    headers[count] = .{ .name = "cache-control", .value = "no-store" };
+    count += 1;
+    if (cors_value) |value| {
+        headers[count] = .{ .name = "access-control-allow-origin", .value = value };
+        count += 1;
+    }
+    return request.respond(body, .{
+        .status = status,
+        .keep_alive = false,
+        .extra_headers = headers[0..count],
+    });
+}
+
+fn respondPreflight(request: *std.http.Server.Request, cors_value: ?[]const u8) !void {
+    const value = cors_value orelse return respondJson(
+        request,
+        .forbidden,
+        "{\"error\":\"origin not allowed\"}\n",
+        null,
+    );
+    const headers = [_]std.http.Header{
+        .{ .name = "access-control-allow-origin", .value = value },
+        .{ .name = "access-control-allow-methods", .value = "GET, POST, OPTIONS" },
+        .{ .name = "access-control-allow-headers", .value = "content-type, authorization" },
+        .{ .name = "access-control-max-age", .value = "86400" },
+        .{ .name = "vary", .value = "origin" },
+    };
+    return request.respond("", .{
+        .status = .no_content,
+        .keep_alive = false,
+        .extra_headers = &headers,
+    });
+}
+
+fn authorized(request: *std.http.Server.Request, expected: ?[]const u8) bool {
+    const token = expected orelse return true;
+    const value = headerValue(request, "authorization") orelse return false;
+    const prefix = "Bearer ";
+    if (!std.ascii.startsWithIgnoreCase(value, prefix)) return false;
+    const actual = value[prefix.len..];
+    if (actual.len != token.len) return false;
+    var difference: u8 = 0;
+    for (actual, token) |a, b| difference |= a ^ b;
+    return difference == 0;
+}
+
+fn allowedCorsValue(self: *const HttpServer, origin: ?[]const u8) ?[]const u8 {
+    const requested = origin orelse return null;
+    const allowed = self.cors_origin orelse return null;
+    if (std.mem.eql(u8, allowed, "*") or std.mem.eql(u8, allowed, requested)) return allowed;
+    return null;
+}
+
+fn headerValue(request: *std.http.Server.Request, name: []const u8) ?[]const u8 {
+    var it = request.iterateHeaders();
+    while (it.next()) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+    }
+    return null;
+}
+
+fn headerEquals(request: *std.http.Server.Request, name: []const u8, expected: []const u8) bool {
+    const value = headerValue(request, name) orelse return false;
+    return std.mem.eql(u8, value, expected);
+}
+
+fn isJsonContentType(raw: []const u8) bool {
+    const value = std.mem.trimStart(u8, raw, &std.ascii.whitespace);
+    const mime = "application/json";
+    if (value.len < mime.len or !std.ascii.eqlIgnoreCase(value[0..mime.len], mime)) return false;
+    return value.len == mime.len or value[mime.len] == ';' or std.ascii.isWhitespace(value[mime.len]);
+}
+
+fn readRequestBody(
+    arena: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    content_length: ?u64,
+    max_request_size: usize,
+) ![]const u8 {
+    if (content_length) |len64| {
+        const len = std.math.cast(usize, len64) orelse return error.StreamTooLong;
+        if (len > max_request_size) return error.StreamTooLong;
+        if (len <= reader.buffer.len) return try reader.take(len);
+        const body = try arena.alloc(u8, len);
+        try reader.readSliceAll(body);
+        return body;
+    }
+    return reader.allocRemaining(arena, .limited(max_request_size));
+}
+
+test "render server: connection slots are bounded" {
+    var active: std.atomic.Value(u32) = .init(0);
+    try std.testing.expect(acquireConnectionSlot(&active, 2));
+    try std.testing.expect(acquireConnectionSlot(&active, 2));
+    try std.testing.expect(!acquireConnectionSlot(&active, 2));
+}
+
+test "render server: URL schemes and credentials are rejected" {
+    const Request = struct { url: []const u8 };
+    const cases = [_][]const u8{
+        "file:///etc/passwd",
+        "data:text/html,hello",
+        "javascript:alert(1)",
+        "https://user:pass@example.com/",
+    };
+    for (cases) |url| {
+        var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+        defer arena.deinit();
+        const request: Request = .{ .url = url };
+        const canonical = lp.URL.resolveNavigation(arena.allocator(), request.url, .{}) catch continue;
+        const protocol = lp.URL.getProtocol(canonical);
+        const valid = (std.mem.eql(u8, protocol, "http:") or std.mem.eql(u8, protocol, "https:")) and
+            lp.URL.getUsername(canonical).len == 0 and lp.URL.getPassword(canonical).len == 0;
+        try std.testing.expect(!valid);
+    }
+}
+
+test "render server: CORS values cannot inject headers" {
+    try std.testing.expect(validHeaderValue("*"));
+    try std.testing.expect(validHeaderValue("https://preview.example"));
+    try std.testing.expect(!validHeaderValue(""));
+    try std.testing.expect(!validHeaderValue("https://example.test\r\nx-injected: true"));
+}

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -77,9 +77,11 @@ const Result = enum {
 };
 
 const Job = struct {
+    allocator: std.mem.Allocator,
+    refs: std.atomic.Value(u32) = .init(1),
     kind: Kind,
     body: []const u8,
-    out: *std.Io.Writer,
+    out: ResponseBuffer,
     max_wait_ms: u32,
     result: Result = .ok,
     done: std.atomic.Value(bool) = .init(false),
@@ -101,16 +103,52 @@ const Job = struct {
         shutdown,
     };
 
-    fn cancel(self: *Job, reason: CancelReason) void {
+    fn create(
+        allocator: std.mem.Allocator,
+        kind: Kind,
+        body: []const u8,
+        max_wait_ms: u32,
+        max_response_size: usize,
+    ) !*Job {
+        const job = try allocator.create(Job);
+        errdefer allocator.destroy(job);
+        const owned_body = try allocator.dupe(u8, body);
+        errdefer allocator.free(owned_body);
+        job.* = .{
+            .allocator = allocator,
+            .kind = kind,
+            .body = owned_body,
+            .out = .init(allocator, max_response_size),
+            .max_wait_ms = max_wait_ms,
+        };
+        return job;
+    }
+
+    fn retain(self: *Job) void {
+        const previous = self.refs.fetchAdd(1, .monotonic);
+        std.debug.assert(previous > 0);
+    }
+
+    fn release(self: *Job) void {
+        const previous = self.refs.fetchSub(1, .acq_rel);
+        std.debug.assert(previous > 0);
+        if (previous != 1) return;
+        const allocator = self.allocator;
+        self.out.deinit();
+        allocator.free(self.body);
+        allocator.destroy(self);
+    }
+
+    fn cancel(self: *Job, reason: CancelReason) bool {
         self.done_mutex.lockUncancelable(lp.io);
         defer self.done_mutex.unlock(lp.io);
-        if (self.done.load(.acquire)) return;
-        _ = self.cancel_reason.cmpxchgStrong(
+        if (self.done.load(.acquire)) return false;
+        return self.cancel_reason.cmpxchgStrong(
             @intFromEnum(CancelReason.none),
             @intFromEnum(reason),
             .acq_rel,
             .acquire,
-        );
+        ) == null;
     }
 
     fn cancellation(self: *const Job) CancelReason {
@@ -144,6 +182,7 @@ const Queue = struct {
         job.next = null;
         if (self.tail) |tail| tail.next = job else self.head = job;
         self.tail = job;
+        job.retain();
         self.cond.signal(lp.io);
         return true;
     }
@@ -163,6 +202,25 @@ const Queue = struct {
         self.head = job.next;
         if (self.head == null) self.tail = null;
         return job;
+    }
+
+    fn remove(self: *Queue, job: *Job) bool {
+        self.mutex.lockUncancelable(lp.io);
+        defer self.mutex.unlock(lp.io);
+
+        var previous: ?*Job = null;
+        var current = self.head;
+        while (current) |queued| {
+            if (queued == job) {
+                if (previous) |before| before.next = queued.next else self.head = queued.next;
+                if (self.tail == queued) self.tail = previous;
+                queued.next = null;
+                return true;
+            }
+            previous = queued;
+            current = queued.next;
+        }
+        return false;
     }
 
     fn close(self: *Queue) void {
@@ -257,22 +315,24 @@ fn cancelActiveJob(self: *HttpServer, reason: Job.CancelReason) void {
     self.browser_mutex.lockUncancelable(lp.io);
     defer self.browser_mutex.unlock(lp.io);
     const job = self.active_job orelse return;
-    job.cancel(reason);
+    _ = job.cancel(reason);
     const browser = self.active_browser orelse return;
     if (!job.termination_requested.swap(true, .acq_rel)) {
         browser.env.terminate();
     }
 }
 
-fn cancelJob(self: *HttpServer, job: *Job, reason: Job.CancelReason) void {
-    job.cancel(reason);
+fn cancelJob(self: *HttpServer, job: *Job, reason: Job.CancelReason) bool {
+    const cancelled = job.cancel(reason);
+    if (self.queue.remove(job)) job.release();
     self.browser_mutex.lockUncancelable(lp.io);
     defer self.browser_mutex.unlock(lp.io);
-    if (self.active_job != job) return;
-    const browser = self.active_browser orelse return;
+    if (self.active_job != job) return cancelled;
+    const browser = self.active_browser orelse return cancelled;
     if (!job.termination_requested.swap(true, .acq_rel)) {
         browser.env.terminate();
     }
+    return cancelled;
 }
 
 fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
@@ -386,9 +446,9 @@ fn worker(self: *HttpServer) void {
             live.close();
             continue;
         };
-        if (self.queue.closed.load(.acquire)) job.cancel(.shutdown);
+        closeExpiredLiveSession(&live, lp.datetime.milliTimestamp(.boot));
+        if (self.queue.closed.load(.acquire)) _ = job.cancel(.shutdown);
 
-        var processed_live = false;
         if (job.cancellation() == .none) {
             self.browser_mutex.lockUncancelable(lp.io);
             self.active_job = job;
@@ -403,10 +463,7 @@ fn worker(self: *HttpServer) void {
                             processRender(self, &browser, arena.allocator(), job);
                         }
                     },
-                    .live => {
-                        processed_live = true;
-                        processLive(&live, arena.allocator(), job);
-                    },
+                    .live => processLive(&live, arena.allocator(), job),
                     .abandon_live => live.closeForToken(job.live_token[0..]) catch {},
                 }
             }
@@ -423,7 +480,7 @@ fn worker(self: *HttpServer) void {
         // lock is observed and closes live state; a later cancel sees done.
         job.done_mutex.lockUncancelable(lp.io);
         const cancellation = job.cancellation();
-        closeCancelledLiveJob(&live, cancellation, processed_live);
+        closeCancelledLiveJob(&live, job, cancellation);
         job.result = switch (cancellation) {
             .none => job.result,
             .timeout => .timeout,
@@ -433,11 +490,12 @@ fn worker(self: *HttpServer) void {
         job.done.store(true, .release);
         job.done_cond.broadcast(lp.io);
         job.done_mutex.unlock(lp.io);
+        job.release();
     }
 }
 
-fn closeCancelledLiveJob(live: *LiveSession, cancellation: Job.CancelReason, processed_live: bool) void {
-    if (processed_live and cancellation != .none) live.close();
+fn closeCancelledLiveJob(live: *LiveSession, job: *const Job, cancellation: Job.CancelReason) void {
+    if (job.live_snapshot and cancellation != .none) live.close();
 }
 
 fn closeExpiredLiveSession(live: *LiveSession, now_ms: u64) void {
@@ -509,7 +567,7 @@ fn processRender(self: *HttpServer, browser: *lp.Browser, arena: std.mem.Allocat
             .strip = .{ .js = true },
         },
         .dump_mode = .html,
-        .writer = job.out,
+        .writer = &job.out.writer,
     }) catch |err| {
         job.result = if (err == error.Timeout)
             .timeout
@@ -551,7 +609,7 @@ fn processLive(live: *LiveSession, arena: std.mem.Allocator, job: *Job) void {
                 .width = request.width,
                 .height = request.height,
                 .wait_ms = @min(request.wait_ms, job.max_wait_ms),
-            }, job.out) catch |err| {
+            }, &job.out.writer) catch |err| {
                 job.result = mapLiveError(err);
                 return;
             };
@@ -574,7 +632,7 @@ fn processLive(live: *LiveSession, arena: std.mem.Allocator, job: *Job) void {
                 job.result = .unsupported;
                 return;
             };
-            live.activate(session, version, target, @min(request.wait_ms, job.max_wait_ms), job.out) catch |err| {
+            live.activate(session, version, target, @min(request.wait_ms, job.max_wait_ms), &job.out.writer) catch |err| {
                 job.result = mapLiveError(err);
                 return;
             };
@@ -643,14 +701,11 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
     var request = http_server.receiveHead() catch return;
     var arena: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena.deinit();
-    var out: ResponseBuffer = .init(self.allocator, self.max_response_size);
-    defer out.deinit();
-    self.serve(&out, arena.allocator(), &request, socket) catch {};
+    self.serve(arena.allocator(), &request, socket) catch {};
 }
 
 fn serve(
     self: *HttpServer,
-    out: *ResponseBuffer,
     arena: std.mem.Allocator,
     request: *std.http.Server.Request,
     socket: posix.socket_t,
@@ -702,20 +757,22 @@ fn serve(
     const body = readRequestBody(arena, request.readerExpectNone(&body_buf), content_length, self.max_request_size) catch {
         return respondJson(request, .payload_too_large, "{\"error\":\"request too large\"}\n", cors_value);
     };
-    var job: Job = .{
-        .kind = kind,
-        .body = body,
-        .out = &out.writer,
-        .max_wait_ms = self.max_wait_ms,
-    };
-    if (!self.queue.push(&job)) {
+    const job = try Job.create(self.allocator, kind, body, self.max_wait_ms, self.max_response_size);
+    defer job.release();
+    if (!self.queue.push(job)) {
         return respondJson(request, .service_unavailable, Result.shutting_down.body(), cors_value);
     }
-    if (self.waitForJob(&job, socket) == .disconnected) {
-        return error.ClientDisconnected;
+    switch (self.waitForJob(job, socket)) {
+        .complete => {},
+        .disconnected => return error.ClientDisconnected,
+        .disconnected_complete => {
+            if (job.live_snapshot) self.abandonLive(job.live_token);
+            return error.ClientDisconnected;
+        },
+        .timeout => return respondJson(request, Result.timeout.status(), Result.timeout.body(), cors_value),
     }
 
-    if (out.failed and job.result == .ok) job.result = .response_too_large;
+    if (job.out.failed and job.result == .ok) job.result = .response_too_large;
     if (job.result != .ok) return respondJson(request, job.result.status(), job.result.body(), cors_value);
     if (job.live_snapshot) {
         var version_buf: [20]u8 = undefined;
@@ -725,7 +782,7 @@ fn serve(
             .{ .name = "x-lightpanda-live-version", .value = version },
             .{ .name = "access-control-expose-headers", .value = "x-lightpanda-live-session, x-lightpanda-live-version" },
         };
-        respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &headers) catch |err| {
+        respondBody(request, job.out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &headers) catch |err| {
             self.abandonLive(job.live_token);
             return err;
         };
@@ -734,44 +791,49 @@ fn serve(
     if (job.kind == .live) {
         return respondBody(request, "", .no_content, "text/plain; charset=utf-8", "no-store", null, cors_value, &.{});
     }
-    return respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &.{});
+    return respondBody(request, job.out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &.{});
 }
 
-const JobWaitResult = enum { complete, disconnected };
+const JobWaitResult = enum { complete, disconnected, disconnected_complete, timeout };
 
 fn waitForJob(self: *HttpServer, job: *Job, socket: posix.socket_t) JobWaitResult {
     var timer: std.Io.Timestamp = .now(lp.io, .boot);
-    while (!job.done.load(.acquire)) {
+    while (true) {
+        if (job.done.load(.acquire)) {
+            return if (job.cancellation() == .disconnected) .disconnected else .complete;
+        }
         if (peerDisconnected(socket)) {
-            self.cancelJob(job, .disconnected);
+            if (self.cancelJob(job, .disconnected)) return .disconnected;
+            return if (job.done.load(.acquire)) .disconnected_complete else .disconnected;
         }
 
-        const elapsed: u32 = @intCast(@min(
+        const elapsed: u64 = @intCast(@min(
             timer.untilNow(lp.io, .boot).toMilliseconds(),
-            std.math.maxInt(u32),
+            std.math.maxInt(u64),
         ));
-        if (elapsed >= job.max_wait_ms) {
-            self.cancelJob(job, .timeout);
+        if (deadlineExpired(elapsed, job.max_wait_ms)) {
+            if (self.cancelJob(job, .timeout)) return .timeout;
+            if (job.done.load(.acquire)) {
+                return if (job.cancellation() == .disconnected) .disconnected else .complete;
+            }
+            return .timeout;
         }
 
         const remaining = job.max_wait_ms -| elapsed;
-        const wait_ms = @max(@min(remaining, job_poll_interval_ms), 1);
+        const wait_ms: u32 = @intCast(@min(remaining, job_poll_interval_ms));
         _ = job.wait(wait_ms);
     }
-    return if (job.cancellation() == .disconnected) .disconnected else .complete;
+}
+
+fn deadlineExpired(elapsed_ms: u64, max_wait_ms: u32) bool {
+    return elapsed_ms >= max_wait_ms;
 }
 
 fn abandonLive(self: *HttpServer, token: [32]u8) void {
-    var discard_buffer: [1]u8 = undefined;
-    var discard = std.Io.Writer.fixed(&discard_buffer);
-    var job: Job = .{
-        .kind = .abandon_live,
-        .body = "",
-        .out = &discard,
-        .max_wait_ms = self.max_wait_ms,
-        .live_token = token,
-    };
-    if (!self.queue.push(&job)) return;
+    const job = Job.create(self.allocator, .abandon_live, "", self.max_wait_ms, 0) catch return;
+    defer job.release();
+    job.live_token = token;
+    if (!self.queue.push(job)) return;
     while (!job.done.load(.acquire)) {
         _ = job.wait(@max(self.max_wait_ms, 1));
     }
@@ -1089,16 +1151,81 @@ test "render server: cancelled live work releases the worker session" {
         };
         defer live.deinit();
 
-        var job: Job = .{
-            .kind = .live,
-            .body = "",
-            .out = undefined,
-            .max_wait_ms = 1,
-        };
-        job.cancel(reason);
-        closeCancelledLiveJob(&live, job.cancellation(), true);
+        const job = try Job.create(std.testing.allocator, .live, "", 1, 1);
+        defer job.release();
+        job.live_snapshot = true;
+        _ = job.cancel(reason);
+        closeCancelledLiveJob(&live, job, job.cancellation());
         try std.testing.expect(!live.isActive());
     }
+}
+
+test "render server: cancelled live work without a snapshot preserves the worker session" {
+    var live: LiveSession = .{
+        .allocator = std.testing.allocator,
+        .browser = undefined,
+        .page = .{ .frame_id = 0, .session = undefined },
+    };
+    defer live.deinit();
+
+    const job = try Job.create(std.testing.allocator, .live, "", 1, 1);
+    defer job.release();
+    _ = job.cancel(.timeout);
+    closeCancelledLiveJob(&live, job, job.cancellation());
+    try std.testing.expect(live.isActive());
+}
+
+test "render server: queue retains job storage until worker release" {
+    var queue: Queue = .{};
+    const job = try Job.create(std.testing.allocator, .render, "owned body", 1, 1);
+    try std.testing.expect(queue.push(job));
+    job.release();
+
+    const popped = queue.pop(null).?;
+    try std.testing.expectEqualStrings("owned body", popped.body);
+    popped.release();
+}
+
+test "render server: closed queue does not retain rejected job" {
+    var queue: Queue = .{};
+    queue.close();
+
+    const job = try Job.create(std.testing.allocator, .render, "", 1, 1);
+    defer job.release();
+    try std.testing.expect(!queue.push(job));
+    try std.testing.expectEqual(@as(u32, 1), job.refs.load(.acquire));
+}
+
+test "render server: cancelled queued job releases queue ownership" {
+    var queue: Queue = .{};
+    const job = try Job.create(std.testing.allocator, .render, "owned body", 1, 1);
+    defer job.release();
+    try std.testing.expect(queue.push(job));
+    try std.testing.expectEqual(@as(u32, 2), job.refs.load(.acquire));
+
+    try std.testing.expect(queue.remove(job));
+    job.release();
+    try std.testing.expectEqual(@as(u32, 1), job.refs.load(.acquire));
+    try std.testing.expect(queue.head == null);
+    try std.testing.expect(queue.tail == null);
+}
+
+test "render server: completed job rejects late timeout cancellation" {
+    const job = try Job.create(std.testing.allocator, .render, "", 1, 1);
+    defer job.release();
+
+    job.done_mutex.lockUncancelable(lp.io);
+    job.done.store(true, .release);
+    job.done_mutex.unlock(lp.io);
+
+    try std.testing.expect(!job.cancel(.timeout));
+    try std.testing.expectEqual(Job.CancelReason.none, job.cancellation());
+}
+
+test "render server: deadline expires at the wall limit" {
+    try std.testing.expect(!deadlineExpired(9, 10));
+    try std.testing.expect(deadlineExpired(10, 10));
+    try std.testing.expect(deadlineExpired(11, 10));
 }
 
 test "render server: expired live state closes before queued work" {

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -36,6 +36,7 @@ const Result = enum {
     timeout,
     navigation_failed,
     response_too_large,
+    value_too_large,
     not_found,
     conflict,
     live_active,
@@ -50,6 +51,7 @@ const Result = enum {
             .timeout => .gateway_timeout,
             .navigation_failed => .bad_gateway,
             .response_too_large => .payload_too_large,
+            .value_too_large => .payload_too_large,
             .not_found => .not_found,
             .conflict => .conflict,
             .live_active => .conflict,
@@ -66,6 +68,7 @@ const Result = enum {
             .timeout => "{\"error\":\"render deadline exceeded\"}\n",
             .navigation_failed => "{\"error\":\"page navigation failed\"}\n",
             .response_too_large => "{\"error\":\"render snapshot too large\"}\n",
+            .value_too_large => "{\"error\":\"live value too large\"}\n",
             .not_found => "{\"error\":\"live session not found\"}\n",
             .conflict => "{\"error\":\"live snapshot is stale\"}\n",
             .live_active => "{\"error\":\"live session is active\"}\n",
@@ -512,11 +515,13 @@ const RenderRequest = struct {
 };
 
 const LiveRequest = struct {
-    op: enum { open, activate, close },
+    op: enum { open, activate, set_value, close },
     url: ?[]const u8 = null,
     session: ?[]const u8 = null,
     version: ?u64 = null,
     target: ?u64 = null,
+    value: ?[]const u8 = null,
+    selected_index: ?u32 = null,
     wait_ms: u32 = 5_000,
     width: u32 = 1280,
     height: u32 = 720,
@@ -638,6 +643,41 @@ fn processLive(live: *LiveSession, arena: std.mem.Allocator, job: *Job) void {
             };
             setLiveSnapshotHeaders(job, live);
         },
+        .set_value => {
+            const session = request.session orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const version = request.version orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const target64 = request.target orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const value = request.value orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const target = std.math.cast(usize, target64) orelse {
+                job.result = .unsupported;
+                return;
+            };
+            live.setValue(
+                session,
+                version,
+                target,
+                value,
+                request.selected_index,
+                @min(request.wait_ms, job.max_wait_ms),
+                &job.out.writer,
+            ) catch |err| {
+                job.result = mapLiveError(err);
+                return;
+            };
+            setLiveSnapshotHeaders(job, live);
+        },
         .close => {
             const session = request.session orelse {
                 job.result = .bad_request;
@@ -674,6 +714,7 @@ fn mapLiveError(err: anyerror) Result {
         error.UnsupportedTarget => .unsupported,
         error.Timeout => .timeout,
         error.WriteFailed, error.TargetLimit => .response_too_large,
+        error.ValueLimit => .value_too_large,
         error.TypeError, error.InvalidURL => .bad_request,
         error.OutOfMemory => .internal_error,
         else => .navigation_failed,
@@ -1122,6 +1163,19 @@ test "render server: live operations carry a versioned activation" {
     try std.testing.expectEqual(@as(u64, 7), activate.version.?);
     try std.testing.expectEqual(@as(u64, 3), activate.target.?);
 
+    const set_value = try std.json.parseFromSliceLeaky(
+        LiveRequest,
+        arena.allocator(),
+        "{\"op\":\"set_value\",\"session\":\"0123456789abcdef0123456789abcdef\",\"version\":8,\"target\":4,\"value\":\"updated\",\"selected_index\":2,\"wait_ms\":1234}",
+        .{},
+    );
+    try std.testing.expect(set_value.op == .set_value);
+    try std.testing.expectEqual(@as(u64, 8), set_value.version.?);
+    try std.testing.expectEqual(@as(u64, 4), set_value.target.?);
+    try std.testing.expectEqualStrings("updated", set_value.value.?);
+    try std.testing.expectEqual(@as(u32, 2), set_value.selected_index.?);
+    try std.testing.expectEqual(@as(u32, 1234), set_value.wait_ms);
+
     const close = try std.json.parseFromSliceLeaky(
         LiveRequest,
         arena.allocator(),
@@ -1140,6 +1194,10 @@ test "render server: live errors and one-shot conflicts are explicit" {
     try std.testing.expectEqual(Result.not_found, mapLiveError(error.InvalidSession));
     try std.testing.expectEqual(Result.unsupported, mapLiveError(error.UnsupportedTarget));
     try std.testing.expectEqual(Result.response_too_large, mapLiveError(error.TargetLimit));
+    try std.testing.expectEqualStrings("{\"error\":\"render snapshot too large\"}\n", Result.response_too_large.body());
+    try std.testing.expectEqual(Result.value_too_large, mapLiveError(error.ValueLimit));
+    try std.testing.expectEqual(std.http.Status.payload_too_large, mapLiveError(error.ValueLimit).status());
+    try std.testing.expectEqualStrings("{\"error\":\"live value too large\"}\n", mapLiveError(error.ValueLimit).body());
 }
 
 test "render server: cancelled live work releases the worker session" {

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -785,7 +785,17 @@ fn peerDisconnected(socket: posix.socket_t) bool {
     }};
     _ = posix.poll(&fds, 0) catch return true;
     const fatal_events: i16 = comptime @intCast(posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
-    return fds[0].revents & fatal_events != 0;
+    if (fds[0].revents & fatal_events != 0) return true;
+    if (fds[0].revents & posix.POLL.IN == 0) return false;
+
+    var byte: [1]u8 = undefined;
+    const rc = std.c.recv(socket, &byte, byte.len, posix.MSG.PEEK | posix.MSG.DONTWAIT);
+    if (rc == 0) return true;
+    if (rc > 0) return false;
+    return switch (std.c.errno(rc)) {
+        .AGAIN => false,
+        else => true,
+    };
 }
 
 fn respondBody(
@@ -954,6 +964,50 @@ test "render server: connection slots are bounded" {
     try std.testing.expect(acquireConnectionSlot(&active, 2));
     try std.testing.expect(acquireConnectionSlot(&active, 2));
     try std.testing.expect(!acquireConnectionSlot(&active, 2));
+}
+
+test "render server: connected peer stays live" {
+    var pair: [2]posix.socket_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(posix.AF.LOCAL, posix.SOCK.STREAM, 0, &pair));
+    defer _ = std.c.close(pair[0]);
+    defer _ = std.c.close(pair[1]);
+
+    try std.testing.expect(!peerDisconnected(pair[0]));
+}
+
+test "render server: peer close and shutdown are detected" {
+    {
+        var pair: [2]posix.socket_t = undefined;
+        try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(posix.AF.LOCAL, posix.SOCK.STREAM, 0, &pair));
+        defer _ = std.c.close(pair[0]);
+
+        _ = std.c.close(pair[1]);
+        try std.testing.expect(peerDisconnected(pair[0]));
+    }
+
+    {
+        var pair: [2]posix.socket_t = undefined;
+        try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(posix.AF.LOCAL, posix.SOCK.STREAM, 0, &pair));
+        defer _ = std.c.close(pair[0]);
+        defer _ = std.c.close(pair[1]);
+
+        try sys_net.shutdown(pair[1], .send);
+        try std.testing.expect(peerDisconnected(pair[0]));
+    }
+}
+
+test "render server: pending peer byte stays live and is not consumed" {
+    var pair: [2]posix.socket_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(posix.AF.LOCAL, posix.SOCK.STREAM, 0, &pair));
+    defer _ = std.c.close(pair[0]);
+    defer _ = std.c.close(pair[1]);
+
+    try sys_net.writeAll(pair[1], "x");
+    try std.testing.expect(!peerDisconnected(pair[0]));
+
+    var byte: [1]u8 = undefined;
+    try std.testing.expectEqual(@as(isize, 1), std.c.recv(pair[0], &byte, byte.len, 0));
+    try std.testing.expectEqual(@as(u8, 'x'), byte[0]);
 }
 
 test "render server: URL schemes and credentials are rejected" {

--- a/src/render/HttpServer.zig
+++ b/src/render/HttpServer.zig
@@ -5,12 +5,13 @@
 // the Free Software Foundation, either version 3 of the License, or (at your
 // option) any later version.
 
-//! Bounded HTTP transport for one-shot client-side rendering.
+//! Bounded HTTP transport for one-shot and live client-side rendering.
 
 const std = @import("std");
 const lp = @import("lightpanda");
 
 const App = @import("../App.zig");
+const LiveSession = @import("LiveSession.zig");
 const ResponseBuffer = @import("ResponseBuffer.zig");
 const sys_net = @import("../sys/net.zig");
 
@@ -25,7 +26,7 @@ const ns_per_ms = 1_000_000;
 
 const client_js = @embedFile("client.js");
 const client_etag = blk: {
-    @setEvalBranchQuota(10_000);
+    @setEvalBranchQuota(100_000);
     break :blk std.fmt.comptimePrint("W/\"{x}\"", .{std.hash.Wyhash.hash(0, client_js)});
 };
 
@@ -35,6 +36,10 @@ const Result = enum {
     timeout,
     navigation_failed,
     response_too_large,
+    not_found,
+    conflict,
+    live_active,
+    unsupported,
     shutting_down,
     internal_error,
 
@@ -45,6 +50,10 @@ const Result = enum {
             .timeout => .gateway_timeout,
             .navigation_failed => .bad_gateway,
             .response_too_large => .payload_too_large,
+            .not_found => .not_found,
+            .conflict => .conflict,
+            .live_active => .conflict,
+            .unsupported => .unprocessable_entity,
             .shutting_down => .service_unavailable,
             .internal_error => .internal_server_error,
         };
@@ -57,6 +66,10 @@ const Result = enum {
             .timeout => "{\"error\":\"render deadline exceeded\"}\n",
             .navigation_failed => "{\"error\":\"page navigation failed\"}\n",
             .response_too_large => "{\"error\":\"render snapshot too large\"}\n",
+            .not_found => "{\"error\":\"live session not found\"}\n",
+            .conflict => "{\"error\":\"live snapshot is stale\"}\n",
+            .live_active => "{\"error\":\"live session is active\"}\n",
+            .unsupported => "{\"error\":\"live target is not supported\"}\n",
             .shutting_down => "{\"error\":\"render server shutting down\"}\n",
             .internal_error => "{\"error\":\"render failed\"}\n",
         };
@@ -64,6 +77,7 @@ const Result = enum {
 };
 
 const Job = struct {
+    kind: Kind,
     body: []const u8,
     out: *std.Io.Writer,
     max_wait_ms: u32,
@@ -73,7 +87,12 @@ const Job = struct {
     done_cond: std.Io.Condition = .init,
     cancel_reason: std.atomic.Value(u8) = .init(@intFromEnum(CancelReason.none)),
     termination_requested: std.atomic.Value(bool) = .init(false),
+    live_snapshot: bool = false,
+    live_token: [32]u8 = undefined,
+    live_version: u64 = 0,
     next: ?*Job = null,
+
+    const Kind = enum { render, live, abandon_live };
 
     const CancelReason = enum(u8) {
         none,
@@ -83,6 +102,8 @@ const Job = struct {
     };
 
     fn cancel(self: *Job, reason: CancelReason) void {
+        self.done_mutex.lockUncancelable(lp.io);
+        defer self.done_mutex.unlock(lp.io);
         if (self.done.load(.acquire)) return;
         _ = self.cancel_reason.cmpxchgStrong(
             @intFromEnum(CancelReason.none),
@@ -94,13 +115,6 @@ const Job = struct {
 
     fn cancellation(self: *const Job) CancelReason {
         return @enumFromInt(self.cancel_reason.load(.acquire));
-    }
-
-    fn finish(self: *Job) void {
-        self.done_mutex.lockUncancelable(lp.io);
-        defer self.done_mutex.unlock(lp.io);
-        self.done.store(true, .release);
-        self.done_cond.broadcast(lp.io);
     }
 
     fn wait(self: *Job, timeout_ms: u32) bool {
@@ -134,11 +148,16 @@ const Queue = struct {
         return true;
     }
 
-    fn pop(self: *Queue) ?*Job {
+    fn pop(self: *Queue, timeout_ms: ?u64) ?*Job {
         self.mutex.lockUncancelable(lp.io);
         defer self.mutex.unlock(lp.io);
         while (self.head == null and !self.closed.load(.acquire)) {
-            self.cond.waitUncancelable(lp.io, &self.mutex);
+            if (timeout_ms) |ms| {
+                if (ms == 0) return null;
+                lp.timedWait(&self.cond, &self.mutex, ms * ns_per_ms) catch return null;
+            } else {
+                self.cond.waitUncancelable(lp.io, &self.mutex);
+            }
         }
         const job = self.head orelse return null;
         self.head = job.next;
@@ -356,16 +375,40 @@ fn worker(self: *HttpServer) void {
 
     var arena: std.heap.ArenaAllocator = .init(self.allocator);
     defer arena.deinit();
-    while (self.queue.pop()) |job| {
+    var live = LiveSession.init(self.allocator, &browser);
+    defer live.deinit();
+    while (true) {
+        const now_ms = lp.datetime.milliTimestamp(.boot);
+        closeExpiredLiveSession(&live, now_ms);
+        const timeout_ms: ?u64 = if (live.isActive()) live.idleWaitMsAt(now_ms) else null;
+        const job = self.queue.pop(timeout_ms) orelse {
+            if (self.queue.closed.load(.acquire)) break;
+            live.close();
+            continue;
+        };
         if (self.queue.closed.load(.acquire)) job.cancel(.shutdown);
 
+        var processed_live = false;
         if (job.cancellation() == .none) {
             self.browser_mutex.lockUncancelable(lp.io);
             self.active_job = job;
             self.browser_mutex.unlock(lp.io);
 
             if (job.cancellation() == .none) {
-                processRender(self, &browser, arena.allocator(), job);
+                switch (job.kind) {
+                    .render => {
+                        if (live.isActive()) {
+                            job.result = .live_active;
+                        } else {
+                            processRender(self, &browser, arena.allocator(), job);
+                        }
+                    },
+                    .live => {
+                        processed_live = true;
+                        processLive(&live, arena.allocator(), job);
+                    },
+                    .abandon_live => live.closeForToken(job.live_token[0..]) catch {},
+                }
             }
 
             self.browser_mutex.lockUncancelable(lp.io);
@@ -376,14 +419,29 @@ fn worker(self: *HttpServer) void {
             }
         }
 
-        job.result = switch (job.cancellation()) {
+        // Freeze cancellation while finalizing. A disconnect that wins this
+        // lock is observed and closes live state; a later cancel sees done.
+        job.done_mutex.lockUncancelable(lp.io);
+        const cancellation = job.cancellation();
+        closeCancelledLiveJob(&live, cancellation, processed_live);
+        job.result = switch (cancellation) {
             .none => job.result,
             .timeout => .timeout,
             .disconnected, .shutdown => .shutting_down,
         };
         _ = arena.reset(.{ .retain_with_limit = worker_retained_arena_bytes });
-        job.finish();
+        job.done.store(true, .release);
+        job.done_cond.broadcast(lp.io);
+        job.done_mutex.unlock(lp.io);
     }
+}
+
+fn closeCancelledLiveJob(live: *LiveSession, cancellation: Job.CancelReason, processed_live: bool) void {
+    if (processed_live and cancellation != .none) live.close();
+}
+
+fn closeExpiredLiveSession(live: *LiveSession, now_ms: u64) void {
+    if (live.isActive() and live.idleWaitMsAt(now_ms) == 0) live.close();
 }
 
 const RenderRequest = struct {
@@ -391,6 +449,17 @@ const RenderRequest = struct {
     wait_ms: u32 = 5_000,
     wait_until: ?lp.Config.WaitUntil = null,
     wait_selector: ?[]const u8 = null,
+    width: u32 = 1280,
+    height: u32 = 720,
+};
+
+const LiveRequest = struct {
+    op: enum { open, activate, close },
+    url: ?[]const u8 = null,
+    session: ?[]const u8 = null,
+    version: ?u64 = null,
+    target: ?u64 = null,
+    wait_ms: u32 = 5_000,
     width: u32 = 1280,
     height: u32 = 720,
 };
@@ -415,17 +484,10 @@ fn processRender(self: *HttpServer, browser: *lp.Browser, arena: std.mem.Allocat
         }
     }
 
-    const canonical = lp.URL.resolveNavigation(arena, request.url, .{}) catch {
+    const canonical = validTargetUrl(arena, request.url) catch {
         job.result = .bad_request;
         return;
     };
-    const protocol = lp.URL.getProtocol(canonical);
-    if ((!std.mem.eql(u8, protocol, "http:") and !std.mem.eql(u8, protocol, "https:")) or
-        lp.URL.getUsername(canonical).len != 0 or lp.URL.getPassword(canonical).len != 0)
-    {
-        job.result = .bad_request;
-        return;
-    }
 
     const selector: ?[:0]const u8 = if (request.wait_selector) |value|
         arena.dupeZ(u8, value) catch {
@@ -460,6 +522,110 @@ fn processRender(self: *HttpServer, browser: *lp.Browser, arena: std.mem.Allocat
         };
         return;
     };
+}
+
+fn processLive(live: *LiveSession, arena: std.mem.Allocator, job: *Job) void {
+    const request = std.json.parseFromSliceLeaky(LiveRequest, arena, job.body, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        job.result = .bad_request;
+        return;
+    };
+
+    switch (request.op) {
+        .open => {
+            const url = request.url orelse {
+                job.result = .bad_request;
+                return;
+            };
+            if (url.len == 0 or url.len > 8 * 1024 or !validViewport(request.width, request.height)) {
+                job.result = .bad_request;
+                return;
+            }
+            const canonical = validTargetUrl(arena, url) catch {
+                job.result = .bad_request;
+                return;
+            };
+            live.open(.{
+                .url = canonical,
+                .width = request.width,
+                .height = request.height,
+                .wait_ms = @min(request.wait_ms, job.max_wait_ms),
+            }, job.out) catch |err| {
+                job.result = mapLiveError(err);
+                return;
+            };
+            setLiveSnapshotHeaders(job, live);
+        },
+        .activate => {
+            const session = request.session orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const version = request.version orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const target64 = request.target orelse {
+                job.result = .bad_request;
+                return;
+            };
+            const target = std.math.cast(usize, target64) orelse {
+                job.result = .unsupported;
+                return;
+            };
+            live.activate(session, version, target, @min(request.wait_ms, job.max_wait_ms), job.out) catch |err| {
+                job.result = mapLiveError(err);
+                return;
+            };
+            setLiveSnapshotHeaders(job, live);
+        },
+        .close => {
+            const session = request.session orelse {
+                job.result = .bad_request;
+                return;
+            };
+            live.closeForToken(session) catch |err| {
+                job.result = mapLiveError(err);
+                return;
+            };
+        },
+    }
+}
+
+fn validViewport(width: u32, height: u32) bool {
+    return width != 0 and width <= 8192 and height != 0 and height <= 8192;
+}
+
+fn validTargetUrl(arena: std.mem.Allocator, raw: []const u8) ![:0]const u8 {
+    const canonical = try lp.URL.resolveNavigation(arena, raw, .{});
+    const protocol = lp.URL.getProtocol(canonical);
+    if ((!std.mem.eql(u8, protocol, "http:") and !std.mem.eql(u8, protocol, "https:")) or
+        lp.URL.getUsername(canonical).len != 0 or lp.URL.getPassword(canonical).len != 0)
+    {
+        return error.InvalidURL;
+    }
+    return canonical;
+}
+
+fn mapLiveError(err: anyerror) Result {
+    return switch (err) {
+        error.LiveSessionActive => .live_active,
+        error.StaleSnapshot => .conflict,
+        error.InvalidSession => .not_found,
+        error.UnsupportedTarget => .unsupported,
+        error.Timeout => .timeout,
+        error.WriteFailed, error.TargetLimit => .response_too_large,
+        error.TypeError, error.InvalidURL => .bad_request,
+        error.OutOfMemory => .internal_error,
+        else => .navigation_failed,
+    };
+}
+
+fn setLiveSnapshotHeaders(job: *Job, live: *const LiveSession) void {
+    job.live_token = live.tokenText();
+    job.live_version = live.version;
+    job.live_snapshot = true;
 }
 
 fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
@@ -506,12 +672,18 @@ fn serve(
         std.mem.eql(u8, path, "/lightpanda-renderer.js"))
     {
         if (headerEquals(request, "if-none-match", client_etag)) return respondNotModified(request, cors_value);
-        return respondBody(request, client_js, .ok, "text/javascript; charset=utf-8", "public,max-age=0,must-revalidate", client_etag, cors_value);
+        return respondBody(request, client_js, .ok, "text/javascript; charset=utf-8", "public,max-age=0,must-revalidate", client_etag, cors_value, &.{});
     }
     if ((request.head.method == .GET or request.head.method == .HEAD) and std.mem.eql(u8, path, "/healthz")) {
-        return respondBody(request, "ok\n", .ok, "text/plain; charset=utf-8", "no-store", null, cors_value);
+        return respondBody(request, "ok\n", .ok, "text/plain; charset=utf-8", "no-store", null, cors_value, &.{});
     }
-    if (request.head.method != .POST or !std.mem.eql(u8, path, "/v1/render")) {
+    const kind: Job.Kind = if (std.mem.eql(u8, path, "/v1/render"))
+        .render
+    else if (std.mem.eql(u8, path, "/v1/live"))
+        .live
+    else
+        return respondJson(request, .not_found, "{\"error\":\"not found\"}\n", cors_value);
+    if (request.head.method != .POST) {
         return respondJson(request, .not_found, "{\"error\":\"not found\"}\n", cors_value);
     }
     if (!authorized(request, self.auth_token)) {
@@ -531,6 +703,7 @@ fn serve(
         return respondJson(request, .payload_too_large, "{\"error\":\"request too large\"}\n", cors_value);
     };
     var job: Job = .{
+        .kind = kind,
         .body = body,
         .out = &out.writer,
         .max_wait_ms = self.max_wait_ms,
@@ -544,7 +717,24 @@ fn serve(
 
     if (out.failed and job.result == .ok) job.result = .response_too_large;
     if (job.result != .ok) return respondJson(request, job.result.status(), job.result.body(), cors_value);
-    return respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value);
+    if (job.live_snapshot) {
+        var version_buf: [20]u8 = undefined;
+        const version = std.fmt.bufPrint(&version_buf, "{d}", .{job.live_version}) catch unreachable;
+        const headers = [_]std.http.Header{
+            .{ .name = "x-lightpanda-live-session", .value = job.live_token[0..] },
+            .{ .name = "x-lightpanda-live-version", .value = version },
+            .{ .name = "access-control-expose-headers", .value = "x-lightpanda-live-session, x-lightpanda-live-version" },
+        };
+        respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &headers) catch |err| {
+            self.abandonLive(job.live_token);
+            return err;
+        };
+        return;
+    }
+    if (job.kind == .live) {
+        return respondBody(request, "", .no_content, "text/plain; charset=utf-8", "no-store", null, cors_value, &.{});
+    }
+    return respondBody(request, out.buffered(), .ok, "text/html; charset=utf-8", "no-store", null, cors_value, &.{});
 }
 
 const JobWaitResult = enum { complete, disconnected };
@@ -571,6 +761,22 @@ fn waitForJob(self: *HttpServer, job: *Job, socket: posix.socket_t) JobWaitResul
     return if (job.cancellation() == .disconnected) .disconnected else .complete;
 }
 
+fn abandonLive(self: *HttpServer, token: [32]u8) void {
+    var discard_buffer: [1]u8 = undefined;
+    var discard = std.Io.Writer.fixed(&discard_buffer);
+    var job: Job = .{
+        .kind = .abandon_live,
+        .body = "",
+        .out = &discard,
+        .max_wait_ms = self.max_wait_ms,
+        .live_token = token,
+    };
+    if (!self.queue.push(&job)) return;
+    while (!job.done.load(.acquire)) {
+        _ = job.wait(@max(self.max_wait_ms, 1));
+    }
+}
+
 fn peerDisconnected(socket: posix.socket_t) bool {
     var fds = [_]posix.pollfd{.{
         .fd = socket,
@@ -590,8 +796,9 @@ fn respondBody(
     cache_control: []const u8,
     etag: ?[]const u8,
     cors_value: ?[]const u8,
+    extra_headers: []const std.http.Header,
 ) !void {
-    var headers: [7]std.http.Header = undefined;
+    var headers: [10]std.http.Header = undefined;
     var count: usize = 0;
     headers[count] = .{ .name = "content-type", .value = content_type };
     count += 1;
@@ -609,6 +816,11 @@ fn respondBody(
         headers[count] = .{ .name = "access-control-allow-origin", .value = value };
         count += 1;
         headers[count] = .{ .name = "cross-origin-resource-policy", .value = "cross-origin" };
+        count += 1;
+    }
+    std.debug.assert(extra_headers.len <= headers.len - count);
+    for (extra_headers) |header| {
+        headers[count] = header;
         count += 1;
     }
     return request.respond(body, .{
@@ -769,4 +981,81 @@ test "render server: CORS values cannot inject headers" {
     try std.testing.expect(validHeaderValue("https://preview.example"));
     try std.testing.expect(!validHeaderValue(""));
     try std.testing.expect(!validHeaderValue("https://example.test\r\nx-injected: true"));
+}
+
+test "render server: live operations carry a versioned activation" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+
+    const open = try std.json.parseFromSliceLeaky(
+        LiveRequest,
+        arena.allocator(),
+        "{\"op\":\"open\",\"url\":\"https://example.test/\"}",
+        .{},
+    );
+    try std.testing.expect(open.op == .open);
+    try std.testing.expectEqualStrings("https://example.test/", open.url.?);
+
+    const activate = try std.json.parseFromSliceLeaky(
+        LiveRequest,
+        arena.allocator(),
+        "{\"op\":\"activate\",\"session\":\"0123456789abcdef0123456789abcdef\",\"version\":7,\"target\":3}",
+        .{},
+    );
+    try std.testing.expect(activate.op == .activate);
+    try std.testing.expectEqual(@as(u64, 7), activate.version.?);
+    try std.testing.expectEqual(@as(u64, 3), activate.target.?);
+
+    const close = try std.json.parseFromSliceLeaky(
+        LiveRequest,
+        arena.allocator(),
+        "{\"op\":\"close\",\"session\":\"0123456789abcdef0123456789abcdef\"}",
+        .{},
+    );
+    try std.testing.expect(close.op == .close);
+    try std.testing.expectEqualStrings("0123456789abcdef0123456789abcdef", close.session.?);
+}
+
+test "render server: live errors and one-shot conflicts are explicit" {
+    try std.testing.expectEqual(Result.conflict, mapLiveError(error.StaleSnapshot));
+    try std.testing.expectEqual(Result.live_active, mapLiveError(error.LiveSessionActive));
+    try std.testing.expectEqual(std.http.Status.conflict, Result.live_active.status());
+    try std.testing.expect(!std.mem.eql(u8, Result.conflict.body(), Result.live_active.body()));
+    try std.testing.expectEqual(Result.not_found, mapLiveError(error.InvalidSession));
+    try std.testing.expectEqual(Result.unsupported, mapLiveError(error.UnsupportedTarget));
+    try std.testing.expectEqual(Result.response_too_large, mapLiveError(error.TargetLimit));
+}
+
+test "render server: cancelled live work releases the worker session" {
+    inline for (.{ Job.CancelReason.timeout, Job.CancelReason.disconnected }) |reason| {
+        var live: LiveSession = .{
+            .allocator = std.testing.allocator,
+            .browser = undefined,
+            .page = .{ .frame_id = 0, .session = undefined },
+        };
+        defer live.deinit();
+
+        var job: Job = .{
+            .kind = .live,
+            .body = "",
+            .out = undefined,
+            .max_wait_ms = 1,
+        };
+        job.cancel(reason);
+        closeCancelledLiveJob(&live, job.cancellation(), true);
+        try std.testing.expect(!live.isActive());
+    }
+}
+
+test "render server: expired live state closes before queued work" {
+    var live: LiveSession = .{
+        .allocator = std.testing.allocator,
+        .browser = undefined,
+        .page = .{ .frame_id = 0, .session = undefined },
+        .last_activity_ms = 1,
+    };
+    defer live.deinit();
+
+    closeExpiredLiveSession(&live, LiveSession.idle_timeout_ms + 1);
+    try std.testing.expect(!live.isActive());
 }

--- a/src/render/LiveSession.zig
+++ b/src/render/LiveSession.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const js = @import("../browser/js/js.zig");
 const Node = @import("../browser/webapi/Node.zig");
 
 const LiveSession = @This();
@@ -132,7 +133,20 @@ pub fn activate(
         self.close();
         return error.StaleSnapshot;
     };
-    if (!target.asNode().isConnected() or !lp.dump.isLiveTarget(target, frame)) {
+    const target_arena = frame.getArena(.small, "render-live-targets") catch |err| {
+        self.close();
+        return err;
+    };
+    defer target_arena.release();
+    const listener_targets = lp.interactive.buildListenerTargetMap(frame, target_arena.allocator()) catch |err| {
+        self.close();
+        return err;
+    };
+    const valid_target = lp.dump.isLiveTarget(target, frame, listener_targets) catch |err| {
+        self.close();
+        return err;
+    };
+    if (!target.asNode().isConnected() or !valid_target) {
         self.close();
         return error.StaleSnapshot;
     }
@@ -184,12 +198,15 @@ pub fn close(self: *LiveSession) void {
 fn snapshot(self: *LiveSession, writer: *std.Io.Writer) !void {
     const page = self.page orelse return error.FrameNotLoaded;
     const frame = page.frame() orelse return error.FrameNotLoaded;
+    const target_arena = try frame.getArena(.small, "render-live-targets");
+    defer target_arena.release();
     self.targets.clearRetainingCapacity();
     errdefer self.targets.clearRetainingCapacity();
 
     var targets: lp.dump.LiveTargets = .{
         .elements = &self.targets,
         .allocator = self.allocator,
+        .listener_targets = try lp.interactive.buildListenerTargetMap(frame, target_arena.allocator()),
     };
     try lp.dump.root(frame.window._document, .{
         .with_base = true,
@@ -252,13 +269,31 @@ fn liveSessionRoundTrip() !void {
     try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &opened.writer);
     try testing.expect(live.isActive());
     try testing.expectEqual(@as(u64, 1), live.version);
-    try testing.expectEqual(@as(usize, 4), live.targets.items.len);
+    try testing.expectEqual(@as(usize, 9), live.targets.items.len);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"toggle\" type=\"checkbox\" checked data-lp-live-target=\"1\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"disabled\" type=\"checkbox\" disabled>") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"text\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"file\" type=\"file\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"submit\" type=\"submit\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<select id=\"select\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"4\">listener</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"5\">inline</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"6\">anchor</a>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"7\">button</button>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"8\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<span id=\"submit-script-child\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<label id=\"label-submit-script\" for=\"label-submit-control\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"file-script\" type=\"file\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"delegated-update\">delegated</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<button id=\"disabled-script\" disabled onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"blocked-script\" style=\"pointer-events: none\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"hidden-listener\" hidden>hidden</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"visibility-hidden\" style=\"visibility: hidden\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"visibility-hidden-ancestor\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"display-hidden-ancestor\" onclick=") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"removed-listener\">removed</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"non-click-listener\">non-click</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"uppercase-listener\">uppercase</div>") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), ">before<") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<script") == null);
 
@@ -268,7 +303,7 @@ fn liveSessionRoundTrip() !void {
     try live.activate(token[0..], live.version, 1, 2_000, &activated.writer);
     try testing.expectEqual(@as(u64, 2), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"toggle\" type=\"checkbox\" data-lp-live-target=\"1\">") != null);
-    try testing.expectEqual(@as(usize, 4), live.targets.items.len);
+    try testing.expectEqual(@as(usize, 9), live.targets.items.len);
 
     activated.clearRetainingCapacity();
     try live.activate(token[0..], live.version, 3, 2_000, &activated.writer);
@@ -280,9 +315,49 @@ fn liveSessionRoundTrip() !void {
     try live.activate(token[0..], live.version, 0, 2_000, &activated.writer);
     try testing.expectEqual(@as(u64, 4), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">after<") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 4, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 5), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">listener<") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 5, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 6), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">inline<") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 6, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 7), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">anchor<") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 7, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 8), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">button<") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 8, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 9), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">input<") != null);
     try live.closeForToken(token[0..]);
     try testing.expect(!live.isActive());
     try testing.expectEqual(@as(usize, 0), live.targets.capacity);
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const stale_token = live.tokenText();
+    const stale_frame = live.page.?.frame().?;
+    const stale_dom_version = stale_frame._page.dom_version;
+    {
+        var ls: js.Local.Scope = undefined;
+        stale_frame.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("window.removeLiveListener()", null);
+    }
+    try testing.expectEqual(stale_dom_version, stale_frame._page.dom_version);
+    try testing.expectError(error.StaleSnapshot, live.activate(stale_token[0..], live.version, 4, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
 
     var reopened: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
     defer reopened.deinit();

--- a/src/render/LiveSession.zig
+++ b/src/render/LiveSession.zig
@@ -15,6 +15,9 @@ const Node = @import("../browser/webapi/Node.zig");
 const LiveSession = @This();
 
 pub const idle_timeout_ms = 5 * 60 * 1000;
+pub const max_value_bytes = 2_048;
+pub const max_value_updates = 256;
+pub const max_value_update_bytes = 256 * 1024;
 
 pub const OpenOpts = struct {
     url: [:0]const u8,
@@ -28,11 +31,13 @@ browser: *lp.Browser,
 notification: ?*lp.Notification = null,
 page: ?lp.Session.PageHandle = null,
 snapshot_page: ?*lp.Page = null,
-targets: std.ArrayListUnmanaged(*Node.Element) = .empty,
+targets: std.ArrayListUnmanaged(lp.dump.LiveTargets.Target) = .empty,
 token: [16]u8 = undefined,
 version: u64 = 0,
 dom_version: usize = 0,
 last_activity_ms: u64 = 0,
+value_updates: usize = 0,
+value_update_bytes: usize = 0,
 
 pub fn init(allocator: std.mem.Allocator, browser: *lp.Browser) LiveSession {
     return .{ .allocator = allocator, .browser = browser };
@@ -95,6 +100,8 @@ pub fn open(self: *LiveSession, opts: OpenOpts, writer: *std.Io.Writer) !void {
     lp.io.random(&self.token);
     self.version = 0;
     self.dom_version = 0;
+    self.value_updates = 0;
+    self.value_update_bytes = 0;
     try self.snapshot(writer);
     self.last_activity_ms = lp.datetime.milliTimestamp(.boot);
 }
@@ -129,6 +136,7 @@ pub fn activate(
     if (target_index >= self.targets.items.len) return error.UnsupportedTarget;
 
     const target = self.targets.items[target_index];
+    if (target.kind != .activate) return error.UnsupportedTarget;
     const frame = page.frame() orelse {
         self.close();
         return error.StaleSnapshot;
@@ -142,16 +150,16 @@ pub fn activate(
         self.close();
         return err;
     };
-    const valid_target = lp.dump.isLiveTarget(target, frame, listener_targets) catch |err| {
+    const valid_target = lp.dump.isLiveTarget(target.element, frame, listener_targets) catch |err| {
         self.close();
         return err;
     };
-    if (!target.asNode().isConnected() or !valid_target) {
+    if (!target.element.asNode().isConnected() or !valid_target) {
         self.close();
         return error.StaleSnapshot;
     }
 
-    lp.actions.click(target.asNode(), frame) catch |err| {
+    lp.actions.click(target.element.asNode(), frame) catch |err| {
         self.close();
         return err;
     };
@@ -168,6 +176,122 @@ pub fn activate(
     self.last_activity_ms = lp.datetime.milliTimestamp(.boot);
 }
 
+pub fn setValue(
+    self: *LiveSession,
+    session_token: []const u8,
+    expected_version: u64,
+    target_index: usize,
+    value: []const u8,
+    selected_index: ?u32,
+    wait_ms: u32,
+    writer: *std.Io.Writer,
+) !void {
+    if (!self.isActive() or !self.matchesToken(session_token)) return error.InvalidSession;
+    if (expected_version != self.version) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+    if (value.len > max_value_bytes or !std.unicode.utf8ValidateSlice(value) or
+        self.value_updates >= max_value_updates or
+        value.len > max_value_update_bytes -| self.value_update_bytes)
+    {
+        self.close();
+        return error.ValueLimit;
+    }
+
+    const page = self.page.?;
+    const current_page = page.page() orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    const snapshot_page = self.snapshot_page orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    if (current_page != snapshot_page or current_page.dom_version != self.dom_version) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+    if (target_index >= self.targets.items.len) return error.UnsupportedTarget;
+
+    const target = self.targets.items[target_index];
+    if (target.kind != .value) return error.UnsupportedTarget;
+    const frame = page.frame() orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    if (!target.element.asNode().isConnected() or !lp.dump.isLiveValueTarget(target.element)) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+    const select = target.element.is(Node.Element.Html.Select);
+    if (select) |select_element| {
+        const index = selected_index orelse return error.UnsupportedTarget;
+        if (!try validSelectValue(select_element, index, value, frame)) return error.UnsupportedTarget;
+    } else if (selected_index != null) {
+        return error.UnsupportedTarget;
+    }
+
+    target.element.focus(frame) catch |err| {
+        self.close();
+        return err;
+    };
+    const focused_page = page.page() orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    if (focused_page != snapshot_page or focused_page.dom_version != self.dom_version or
+        page.inCommit() or frame._queued_navigation != null or
+        !target.element.asNode().isConnected() or !lp.dump.isLiveValueTarget(target.element))
+    {
+        self.close();
+        return error.StaleSnapshot;
+    }
+    if (select) |select_element| {
+        if (!try validSelectValue(select_element, selected_index.?, value, frame)) {
+            self.close();
+            return error.StaleSnapshot;
+        }
+    }
+
+    self.value_updates += 1;
+    self.value_update_bytes += value.len;
+    if (select != null) {
+        lp.actions.selectOptionAtIndexWithoutFocus(target.element.asNode(), selected_index.?, frame) catch |err| {
+            self.close();
+            return err;
+        };
+    } else {
+        lp.actions.fillWithoutFocus(target.element.asNode(), value, frame) catch |err| {
+            self.close();
+            return err;
+        };
+    }
+
+    var runner = page.session.runner(.{});
+    runner.waitForFrame(page.frame_id, wait_ms, .{ .until = .domcontentloaded }) catch |err| {
+        self.close();
+        return err;
+    };
+    self.snapshot(writer) catch |err| {
+        self.close();
+        return err;
+    };
+    self.last_activity_ms = lp.datetime.milliTimestamp(.boot);
+}
+
+fn validSelectValue(
+    select: *Node.Element.Html.Select,
+    selected_index: u32,
+    value: []const u8,
+    frame: *lp.Frame,
+) !bool {
+    const options = try select.getOptions(frame);
+    const option_element = options.getAtIndex(selected_index, frame) orelse return false;
+    const option = option_element.is(Node.Element.Html.Option) orelse return false;
+    return !option_element.isDisabled() and std.mem.eql(u8, option.getValue(frame), value);
+}
+
 pub fn closeForToken(self: *LiveSession, session_token: []const u8) !void {
     if (!self.isActive() or !self.matchesToken(session_token)) return error.InvalidSession;
     self.close();
@@ -182,6 +306,8 @@ pub fn close(self: *LiveSession) void {
     self.version = 0;
     self.dom_version = 0;
     self.last_activity_ms = 0;
+    self.value_updates = 0;
+    self.value_update_bytes = 0;
 
     if (self.notification) |notification| {
         if (page) |active_page| {
@@ -269,18 +395,26 @@ fn liveSessionRoundTrip() !void {
     try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &opened.writer);
     try testing.expect(live.isActive());
     try testing.expectEqual(@as(u64, 1), live.version);
-    try testing.expectEqual(@as(usize, 9), live.targets.items.len);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"toggle\" type=\"checkbox\" checked data-lp-live-target=\"1\">") != null);
+    try testing.expectEqual(@as(usize, 13), live.targets.items.len);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"toggle\" type=\"checkbox\" checked data-lp-live-target=\"1\" data-lp-live-kind=\"activate\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"disabled\" type=\"checkbox\" disabled>") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"text\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"text\" value=\"input-before\" data-lp-live-target=\"4\" data-lp-live-kind=\"value\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"file\" type=\"file\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"submit\" type=\"submit\">") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "<select id=\"select\">") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"4\">listener</div>") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"5\">inline</div>") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"6\">anchor</a>") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"7\">button</button>") != null);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"8\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<select id=\"select\" data-lp-live-target=\"5\" data-lp-live-kind=\"value\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<textarea id=\"textarea\" data-lp-live-target=\"6\" data-lp-live-kind=\"value\">textarea-before</textarea>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"focus-invalidated\" value=\"focus-before\" data-lp-live-target=\"7\" data-lp-live-kind=\"value\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"password\" type=\"password\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "current-secret") == null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"readonly\" value=\"readonly\" readonly>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<textarea id=\"readonly-textarea\" readonly>readonly</textarea>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<select id=\"multiple-select\" multiple>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<div id=\"editable\" contenteditable=\"\">editable</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"8\" data-lp-live-kind=\"activate\">listener</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"9\" data-lp-live-kind=\"activate\">inline</div>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"10\" data-lp-live-kind=\"activate\">anchor</a>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"11\" data-lp-live-kind=\"activate\">button</button>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"12\" data-lp-live-kind=\"activate\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<span id=\"submit-script-child\" onclick=") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<label id=\"label-submit-script\" for=\"label-submit-control\" onclick=") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"file-script\" type=\"file\" onclick=") != null);
@@ -300,49 +434,116 @@ fn liveSessionRoundTrip() !void {
     const token = live.tokenText();
     var activated: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
     defer activated.deinit();
-    try live.activate(token[0..], live.version, 1, 2_000, &activated.writer);
+    try testing.expectError(error.UnsupportedTarget, live.activate(token[0..], live.version, 4, 2_000, &activated.writer));
+    try testing.expect(live.isActive());
+    try testing.expectError(error.UnsupportedTarget, live.setValue(token[0..], live.version, 0, "wrong", null, 2_000, &activated.writer));
+    try testing.expect(live.isActive());
+    try live.setValue(token[0..], live.version, 4, "input-after", null, 2_000, &activated.writer);
     try testing.expectEqual(@as(u64, 2), live.version);
-    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"toggle\" type=\"checkbox\" data-lp-live-target=\"1\">") != null);
-    try testing.expectEqual(@as(usize, 9), live.targets.items.len);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"text\" data-events=\"input,change\" value=\"input-after\" data-lp-live-target=\"4\" data-lp-live-kind=\"value\">") != null);
+
+    activated.clearRetainingCapacity();
+    try live.setValue(token[0..], live.version, 6, "textarea-after", null, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 3), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "data-events=\"input,change\" data-lp-live-target=\"6\" data-lp-live-kind=\"value\">textarea-after</textarea>") != null);
+
+    activated.clearRetainingCapacity();
+    try testing.expectError(error.UnsupportedTarget, live.setValue(token[0..], live.version, 5, "two", null, 2_000, &activated.writer));
+    try testing.expectError(error.UnsupportedTarget, live.setValue(token[0..], live.version, 5, "one", 2, 2_000, &activated.writer));
+    try testing.expect(live.isActive());
+    try live.setValue(token[0..], live.version, 5, "two", 2, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 4), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<option id=\"option-two-a\" value=\"two\">two-a</option>") != null);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<option id=\"option-two-b\" value=\"two\" selected>two-b</option>") != null);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<select id=\"select\" data-events=\"input,change\" data-lp-live-target=\"5\" data-lp-live-kind=\"value\">") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 1, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 5), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"toggle\" type=\"checkbox\" data-lp-live-target=\"1\" data-lp-live-kind=\"activate\">") != null);
+    try testing.expectEqual(@as(usize, 13), live.targets.items.len);
 
     activated.clearRetainingCapacity();
     try live.activate(token[0..], live.version, 3, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 3), live.version);
-    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-a\" type=\"radio\" name=\"choice\" data-lp-live-target=\"2\">") != null);
-    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-b\" type=\"radio\" name=\"choice\" checked data-lp-live-target=\"3\">") != null);
+    try testing.expectEqual(@as(u64, 6), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-a\" type=\"radio\" name=\"choice\" data-lp-live-target=\"2\" data-lp-live-kind=\"activate\">") != null);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-b\" type=\"radio\" name=\"choice\" checked data-lp-live-target=\"3\" data-lp-live-kind=\"activate\">") != null);
 
     activated.clearRetainingCapacity();
     try live.activate(token[0..], live.version, 0, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 4), live.version);
+    try testing.expectEqual(@as(u64, 7), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">after<") != null);
 
     activated.clearRetainingCapacity();
-    try live.activate(token[0..], live.version, 4, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 5), live.version);
+    try live.activate(token[0..], live.version, 8, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 8), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">listener<") != null);
 
     activated.clearRetainingCapacity();
-    try live.activate(token[0..], live.version, 5, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 6), live.version);
+    try live.activate(token[0..], live.version, 9, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 9), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">inline<") != null);
 
     activated.clearRetainingCapacity();
-    try live.activate(token[0..], live.version, 6, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 7), live.version);
+    try live.activate(token[0..], live.version, 10, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 10), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">anchor<") != null);
 
     activated.clearRetainingCapacity();
-    try live.activate(token[0..], live.version, 7, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 8), live.version);
+    try live.activate(token[0..], live.version, 11, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 11), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">button<") != null);
 
     activated.clearRetainingCapacity();
-    try live.activate(token[0..], live.version, 8, 2_000, &activated.writer);
-    try testing.expectEqual(@as(u64, 9), live.version);
+    try live.activate(token[0..], live.version, 12, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 12), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">input<") != null);
     try live.closeForToken(token[0..]);
     try testing.expect(!live.isActive());
     try testing.expectEqual(@as(usize, 0), live.targets.capacity);
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const navigation_token = live.tokenText();
+    activated.clearRetainingCapacity();
+    try live.setValue(navigation_token[0..], live.version, 4, "navigate", null, 2_000, &activated.writer);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<base href=\"http://127.0.0.1:9582/src/browser/tests/mcp_nav.html\">") != null);
+    try testing.expectEqual(@as(usize, 1), live.targets.items.len);
+    try live.closeForToken(navigation_token[0..]);
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const focus_token = live.tokenText();
+    try testing.expectError(error.StaleSnapshot, live.setValue(focus_token[0..], live.version, 7, "focus-after", null, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const limit_token = live.tokenText();
+    live.value_updates = max_value_updates;
+    try testing.expectError(error.ValueLimit, live.setValue(limit_token[0..], live.version, 4, "", null, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const byte_limit_token = live.tokenText();
+    live.value_update_bytes = max_value_update_bytes;
+    try testing.expectError(error.ValueLimit, live.setValue(byte_limit_token[0..], live.version, 4, "x", null, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const size_limit_token = live.tokenText();
+    var oversized_value: [max_value_bytes + 1]u8 = undefined;
+    @memset(&oversized_value, 'x');
+    try testing.expectError(error.ValueLimit, live.setValue(size_limit_token[0..], live.version, 4, &oversized_value, null, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
+
+    activated.clearRetainingCapacity();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
+    const value_stale_token = live.tokenText();
+    try testing.expectError(error.StaleSnapshot, live.setValue(value_stale_token[0..], 0, 4, "stale", null, 2_000, &opened.writer));
+    try testing.expect(!live.isActive());
 
     activated.clearRetainingCapacity();
     try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &activated.writer);
@@ -356,7 +557,7 @@ fn liveSessionRoundTrip() !void {
         _ = try ls.local.exec("window.removeLiveListener()", null);
     }
     try testing.expectEqual(stale_dom_version, stale_frame._page.dom_version);
-    try testing.expectError(error.StaleSnapshot, live.activate(stale_token[0..], live.version, 4, 2_000, &opened.writer));
+    try testing.expectError(error.StaleSnapshot, live.activate(stale_token[0..], live.version, 8, 2_000, &opened.writer));
     try testing.expect(!live.isActive());
 
     var reopened: std.Io.Writer.Allocating = .init(testing.test_app.allocator);

--- a/src/render/LiveSession.zig
+++ b/src/render/LiveSession.zig
@@ -252,18 +252,34 @@ fn liveSessionRoundTrip() !void {
     try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &opened.writer);
     try testing.expect(live.isActive());
     try testing.expectEqual(@as(u64, 1), live.version);
-    try testing.expectEqual(@as(usize, 1), live.targets.items.len);
-    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"0\"") != null);
+    try testing.expectEqual(@as(usize, 4), live.targets.items.len);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"toggle\" type=\"checkbox\" checked data-lp-live-target=\"1\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"disabled\" type=\"checkbox\" disabled>") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"text\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"file\" type=\"file\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<input id=\"submit\" type=\"submit\">") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<select id=\"select\">") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), ">before<") != null);
     try testing.expect(std.mem.indexOf(u8, opened.written(), "<script") == null);
 
     const token = live.tokenText();
     var activated: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
     defer activated.deinit();
-    try live.activate(token[0..], live.version, 0, 2_000, &activated.writer);
+    try live.activate(token[0..], live.version, 1, 2_000, &activated.writer);
     try testing.expectEqual(@as(u64, 2), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"toggle\" type=\"checkbox\" data-lp-live-target=\"1\">") != null);
+    try testing.expectEqual(@as(usize, 4), live.targets.items.len);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 3, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 3), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-a\" type=\"radio\" name=\"choice\" data-lp-live-target=\"2\">") != null);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<input id=\"radio-b\" type=\"radio\" name=\"choice\" checked data-lp-live-target=\"3\">") != null);
+
+    activated.clearRetainingCapacity();
+    try live.activate(token[0..], live.version, 0, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 4), live.version);
     try testing.expect(std.mem.indexOf(u8, activated.written(), ">after<") != null);
-    try testing.expectEqual(@as(usize, 1), live.targets.items.len);
     try live.closeForToken(token[0..]);
     try testing.expect(!live.isActive());
     try testing.expectEqual(@as(usize, 0), live.targets.capacity);

--- a/src/render/LiveSession.zig
+++ b/src/render/LiveSession.zig
@@ -1,0 +1,293 @@
+// Copyright (C) 2026 Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+//! Worker-owned state for a bounded interactive render snapshot.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+const Node = @import("../browser/webapi/Node.zig");
+
+const LiveSession = @This();
+
+pub const idle_timeout_ms = 5 * 60 * 1000;
+
+pub const OpenOpts = struct {
+    url: [:0]const u8,
+    width: u32,
+    height: u32,
+    wait_ms: u32,
+};
+
+allocator: std.mem.Allocator,
+browser: *lp.Browser,
+notification: ?*lp.Notification = null,
+page: ?lp.Session.PageHandle = null,
+snapshot_page: ?*lp.Page = null,
+targets: std.ArrayListUnmanaged(*Node.Element) = .empty,
+token: [16]u8 = undefined,
+version: u64 = 0,
+dom_version: usize = 0,
+last_activity_ms: u64 = 0,
+
+pub fn init(allocator: std.mem.Allocator, browser: *lp.Browser) LiveSession {
+    return .{ .allocator = allocator, .browser = browser };
+}
+
+pub fn deinit(self: *LiveSession) void {
+    self.close();
+    self.targets.deinit(self.allocator);
+}
+
+pub fn isActive(self: *const LiveSession) bool {
+    return self.page != null;
+}
+
+pub fn idleWaitMs(self: *const LiveSession) u64 {
+    return self.idleWaitMsAt(lp.datetime.milliTimestamp(.boot));
+}
+
+pub fn idleWaitMsAt(self: *const LiveSession, now_ms: u64) u64 {
+    if (!self.isActive()) return 0;
+    const elapsed = now_ms -| self.last_activity_ms;
+    return idle_timeout_ms -| elapsed;
+}
+
+pub fn tokenText(self: *const LiveSession) [32]u8 {
+    return std.fmt.bytesToHex(self.token, .lower);
+}
+
+pub fn open(self: *LiveSession, opts: OpenOpts, writer: *std.Io.Writer) !void {
+    if (self.isActive()) return error.LiveSessionActive;
+
+    self.browser.viewport_override = .{ .width = opts.width, .height = opts.height };
+    const notification = try lp.Notification.init(self.allocator);
+    errdefer notification.deinit();
+
+    const session = try self.browser.newSession(notification);
+    errdefer self.browser.closeSession();
+
+    if (self.browser.app.config.cookieFile()) |cookie_path| {
+        lp.cookies.loadFromFile(session, cookie_path);
+    }
+
+    const page = try session.createPage();
+    const frame = page.frame() orelse return error.FrameNotLoaded;
+    const url = try lp.URL.resolveNavigation(frame.call_arena, opts.url, .{});
+    try frame.navigate(url, .{ .reason = .address_bar, .kind = .{ .push = null } });
+
+    var runner = session.runner(.{});
+    try runner.waitForFrame(page.frame_id, opts.wait_ms, .{ .until = .domcontentloaded });
+
+    self.notification = notification;
+    self.page = page;
+    errdefer {
+        self.notification = null;
+        self.page = null;
+        self.snapshot_page = null;
+        self.targets.deinit(self.allocator);
+        self.targets = .empty;
+    }
+    lp.io.random(&self.token);
+    self.version = 0;
+    self.dom_version = 0;
+    try self.snapshot(writer);
+    self.last_activity_ms = lp.datetime.milliTimestamp(.boot);
+}
+
+pub fn activate(
+    self: *LiveSession,
+    session_token: []const u8,
+    expected_version: u64,
+    target_index: usize,
+    wait_ms: u32,
+    writer: *std.Io.Writer,
+) !void {
+    if (!self.isActive() or !self.matchesToken(session_token)) return error.InvalidSession;
+    if (expected_version != self.version) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+
+    const page = self.page.?;
+    const current_page = page.page() orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    const snapshot_page = self.snapshot_page orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    if (current_page != snapshot_page or current_page.dom_version != self.dom_version) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+    if (target_index >= self.targets.items.len) return error.UnsupportedTarget;
+
+    const target = self.targets.items[target_index];
+    const frame = page.frame() orelse {
+        self.close();
+        return error.StaleSnapshot;
+    };
+    if (!target.asNode().isConnected() or !lp.dump.isLiveTarget(target, frame)) {
+        self.close();
+        return error.StaleSnapshot;
+    }
+
+    lp.actions.click(target.asNode(), frame) catch |err| {
+        self.close();
+        return err;
+    };
+    var runner = page.session.runner(.{});
+    runner.waitForFrame(page.frame_id, wait_ms, .{ .until = .domcontentloaded }) catch |err| {
+        self.close();
+        return err;
+    };
+
+    self.snapshot(writer) catch |err| {
+        self.close();
+        return err;
+    };
+    self.last_activity_ms = lp.datetime.milliTimestamp(.boot);
+}
+
+pub fn closeForToken(self: *LiveSession, session_token: []const u8) !void {
+    if (!self.isActive() or !self.matchesToken(session_token)) return error.InvalidSession;
+    self.close();
+}
+
+pub fn close(self: *LiveSession) void {
+    const page = self.page;
+    self.targets.deinit(self.allocator);
+    self.targets = .empty;
+    self.page = null;
+    self.snapshot_page = null;
+    self.version = 0;
+    self.dom_version = 0;
+    self.last_activity_ms = 0;
+
+    if (self.notification) |notification| {
+        if (page) |active_page| {
+            if (self.browser.app.config.cookieJarFile()) |cookie_jar_path| {
+                lp.cookies.saveToFile(&active_page.session.cookie_jar, cookie_jar_path);
+            }
+        }
+        self.notification = null;
+        self.browser.closeSession();
+        notification.deinit();
+    }
+}
+
+fn snapshot(self: *LiveSession, writer: *std.Io.Writer) !void {
+    const page = self.page orelse return error.FrameNotLoaded;
+    const frame = page.frame() orelse return error.FrameNotLoaded;
+    self.targets.clearRetainingCapacity();
+    errdefer self.targets.clearRetainingCapacity();
+
+    var targets: lp.dump.LiveTargets = .{
+        .elements = &self.targets,
+        .allocator = self.allocator,
+    };
+    try lp.dump.root(frame.window._document, .{
+        .with_base = true,
+        .with_frames = false,
+        .strip = .{ .js = true },
+        .live_targets = &targets,
+        .strip_refresh = true,
+    }, writer, frame);
+
+    self.snapshot_page = page.page() orelse return error.FrameNotLoaded;
+    self.dom_version = self.snapshot_page.?.dom_version;
+    self.version +%= 1;
+}
+
+fn matchesToken(self: *const LiveSession, candidate: []const u8) bool {
+    if (candidate.len != 32) return false;
+    const expected = self.tokenText();
+    var difference: u8 = 0;
+    for (candidate, expected) |actual, wanted| difference |= actual ^ wanted;
+    return difference == 0;
+}
+
+const testing = @import("../testing.zig");
+
+test "LiveSession: opaque token is 128-bit lowercase hex" {
+    var token: [16]u8 = undefined;
+    for (&token, 0..) |*byte, i| byte.* = @intCast(i);
+
+    const live: LiveSession = .{
+        .allocator = std.testing.allocator,
+        .browser = undefined,
+        .token = token,
+    };
+    const text = live.tokenText();
+    try std.testing.expectEqualStrings("000102030405060708090a0b0c0d0e0f", &text);
+}
+
+const LiveSessionTestResult = struct {
+    err: ?anyerror = null,
+};
+
+fn runLiveSessionRoundTrip(result: *LiveSessionTestResult) void {
+    liveSessionRoundTrip() catch |err| {
+        result.err = err;
+    };
+}
+
+fn liveSessionRoundTrip() !void {
+    var browser: lp.Browser = undefined;
+    try browser.init(testing.test_app, .{}, null);
+    defer browser.deinit();
+
+    var live = LiveSession.init(testing.test_app.allocator, &browser);
+    defer live.deinit();
+
+    const button_url: [:0]const u8 = "http://127.0.0.1:9582/src/browser/tests/render_live.html";
+    const nav_url: [:0]const u8 = "http://127.0.0.1:9582/src/browser/tests/mcp_nav.html";
+    var opened: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
+    defer opened.deinit();
+    try live.open(.{ .url = button_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &opened.writer);
+    try testing.expect(live.isActive());
+    try testing.expectEqual(@as(u64, 1), live.version);
+    try testing.expectEqual(@as(usize, 1), live.targets.items.len);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "data-lp-live-target=\"0\"") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), ">before<") != null);
+    try testing.expect(std.mem.indexOf(u8, opened.written(), "<script") == null);
+
+    const token = live.tokenText();
+    var activated: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
+    defer activated.deinit();
+    try live.activate(token[0..], live.version, 0, 2_000, &activated.writer);
+    try testing.expectEqual(@as(u64, 2), live.version);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), ">after<") != null);
+    try testing.expectEqual(@as(usize, 1), live.targets.items.len);
+    try live.closeForToken(token[0..]);
+    try testing.expect(!live.isActive());
+    try testing.expectEqual(@as(usize, 0), live.targets.capacity);
+
+    var reopened: std.Io.Writer.Allocating = .init(testing.test_app.allocator);
+    defer reopened.deinit();
+    try live.open(.{ .url = nav_url, .width = 640, .height = 480, .wait_ms = 2_000 }, &reopened.writer);
+    const retry_token = live.tokenText();
+    var wrong_token = retry_token;
+    wrong_token[0] = if (wrong_token[0] == '0') '1' else '0';
+    try testing.expectError(error.InvalidSession, live.activate(wrong_token[0..], live.version, 0, 2_000, &activated.writer));
+    try testing.expect(live.isActive());
+    activated.clearRetainingCapacity();
+    try live.activate(retry_token[0..], live.version, 0, 2_000, &activated.writer);
+    try testing.expect(std.mem.indexOf(u8, activated.written(), "<base href=\"about:blank\">") != null);
+    try testing.expectEqual(@as(usize, 0), live.targets.items.len);
+    try testing.expectError(error.StaleSnapshot, live.activate(retry_token[0..], 1, 0, 2_000, &activated.writer));
+    try testing.expect(!live.isActive());
+    try testing.expectEqual(@as(usize, 0), live.targets.capacity);
+}
+
+test "LiveSession: worker-owned page opens activates and closes" {
+    var result: LiveSessionTestResult = .{};
+    const thread = try std.Thread.spawn(.{}, runLiveSessionRoundTrip, .{&result});
+    thread.join();
+    if (result.err) |err| return err;
+}

--- a/src/render/ResponseBuffer.zig
+++ b/src/render/ResponseBuffer.zig
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+
+//! Dynamically growing response writer with a hard capacity.
+
+const std = @import("std");
+
+const ResponseBuffer = @This();
+
+out: std.Io.Writer.Allocating,
+writer: std.Io.Writer = .{ .buffer = &.{}, .vtable = &vtable },
+limit: usize,
+failed: bool = false,
+
+const vtable: std.Io.Writer.VTable = .{
+    .drain = drain,
+    .flush = flush,
+};
+
+pub fn init(allocator: std.mem.Allocator, limit: usize) ResponseBuffer {
+    return .{ .out = .init(allocator), .limit = limit };
+}
+
+pub fn deinit(self: *ResponseBuffer) void {
+    self.out.deinit();
+}
+
+pub fn buffered(self: *const ResponseBuffer) []const u8 {
+    return self.out.writer.buffered();
+}
+
+fn drain(writer: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+    const self: *ResponseBuffer = @alignCast(@fieldParentPtr("writer", writer));
+    if (self.failed) return error.WriteFailed;
+
+    var additional: usize = 0;
+    for (data[0 .. data.len - 1]) |bytes| {
+        additional = std.math.add(usize, additional, bytes.len) catch return self.fail();
+    }
+    const splat_bytes = std.math.mul(usize, data[data.len - 1].len, splat) catch return self.fail();
+    additional = std.math.add(usize, additional, splat_bytes) catch return self.fail();
+
+    const current = self.out.writer.end;
+    if (additional > self.limit or current > self.limit - additional) return self.fail();
+    const needed = current + additional;
+    if (self.out.writer.buffer.len < needed) {
+        const capacity = @min(std.ArrayList(u8).growCapacity(needed), self.limit);
+        self.out.ensureTotalCapacityPrecise(capacity) catch return self.fail();
+    }
+    return self.out.writer.writeSplat(data, splat) catch return self.fail();
+}
+
+fn flush(_: *std.Io.Writer) std.Io.Writer.Error!void {}
+
+fn fail(self: *ResponseBuffer) error{WriteFailed} {
+    self.failed = true;
+    return error.WriteFailed;
+}
+
+test "ResponseBuffer: limit failure is transactional" {
+    var out: ResponseBuffer = .init(std.testing.allocator, 16);
+    defer out.deinit();
+
+    try out.writer.writeAll("1234567890");
+    try std.testing.expectError(error.WriteFailed, out.writer.writeAll("1234567"));
+    try std.testing.expect(out.failed);
+    try std.testing.expectEqualStrings("1234567890", out.buffered());
+}

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -1,0 +1,194 @@
+const DEFAULT_ENDPOINT = new URL("/v1/render", import.meta.url).href;
+const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+
+function resolveTarget(target) {
+  if (typeof target === "string") target = document.querySelector(target);
+  if (!(target instanceof Element)) throw new TypeError("Lightpanda renderer target not found");
+  return target;
+}
+
+function aborted(signal) {
+  return signal.reason ?? new DOMException("Lightpanda render superseded", "AbortError");
+}
+
+async function readResponseText(response, limit) {
+  const contentLength = Number(response.headers?.get?.("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+  }
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > limit) {
+      throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+    }
+    return text;
+  }
+
+  const chunks = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > limit) {
+      await reader.cancel().catch(() => {});
+      throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function waitForFrame(iframe, html, signal, isCurrent) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      iframe.removeEventListener("load", loaded);
+      iframe.removeEventListener("error", failed);
+      signal.removeEventListener("abort", cancelled);
+    };
+    const loaded = () => {
+      cleanup();
+      if (!isCurrent()) reject(aborted(signal));
+      else resolve();
+    };
+    const failed = () => {
+      cleanup();
+      reject(new Error("Lightpanda iframe failed to load the snapshot"));
+    };
+    const cancelled = () => {
+      cleanup();
+      reject(aborted(signal));
+    };
+
+    if (signal.aborted) return cancelled();
+    iframe.addEventListener("load", loaded, { once: true });
+    iframe.addEventListener("error", failed, { once: true });
+    signal.addEventListener("abort", cancelled, { once: true });
+    iframe.srcdoc = html;
+  });
+}
+
+export class LightpandaRenderer extends EventTarget {
+  #target;
+  #endpoint;
+  #token;
+  #maxResponseBytes;
+  #controller = null;
+  #sequence = 0;
+  #lastRequest = null;
+
+  constructor(target, options = {}) {
+    super();
+    this.#target = resolveTarget(target);
+    this.#endpoint = new URL(options.endpoint ?? DEFAULT_ENDPOINT, document.baseURI).href;
+    this.#token = options.token ?? null;
+    this.#maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    if (!Number.isSafeInteger(this.#maxResponseBytes) || this.#maxResponseBytes < 1) {
+      throw new RangeError("maxResponseBytes must be a positive safe integer");
+    }
+
+    const iframe = document.createElement("iframe");
+    // Same-frame forms remain native. Top-level and new-window targets stay
+    // blocked because the snapshot is not granted popup or top-navigation access.
+    iframe.setAttribute("sandbox", "allow-forms");
+    iframe.title = options.title ?? "Lightpanda rendered page";
+    iframe.loading = "eager";
+    iframe.referrerPolicy = "no-referrer";
+    iframe.style.cssText = options.style ?? "display:block;width:100%;height:100%;border:0";
+    if (options.className) iframe.className = options.className;
+    const supportsCredentialless = "credentialless" in iframe;
+    if (options.requireCredentialless && !supportsCredentialless) {
+      throw new Error("This browser does not support credentialless iframes");
+    }
+    if (options.credentialless !== false && supportsCredentialless) iframe.credentialless = true;
+    this.iframe = iframe;
+
+    if (options.replace === false) this.#target.append(iframe);
+    else this.#target.replaceChildren(iframe);
+  }
+
+  async render(url, options = {}) {
+    const source = new URL(url, document.baseURI).href;
+    const sequence = ++this.#sequence;
+    this.#controller?.abort();
+    const controller = new AbortController();
+    this.#controller = controller;
+
+    const bounds = this.#target.getBoundingClientRect();
+    const request = {
+      url: source,
+      wait_ms: options.waitMs,
+      wait_until: options.waitUntil,
+      wait_selector: options.waitSelector,
+      width: Math.max(1, Math.round((options.width ?? bounds.width) || 1280)),
+      height: Math.max(1, Math.round((options.height ?? bounds.height) || 720)),
+    };
+    for (const key of Object.keys(request)) {
+      if (request[key] == null) delete request[key];
+    }
+    this.#lastRequest = { url: source, options: { ...options } };
+
+    try {
+      const headers = { accept: "text/html", "content-type": "application/json" };
+      if (this.#token) headers.authorization = `Bearer ${this.#token}`;
+      const response = await fetch(this.#endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(request),
+        credentials: "omit",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda render failed (${response.status}): ${detail}`);
+      }
+
+      const html = await readResponseText(response, this.#maxResponseBytes);
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      await waitForFrame(
+        this.iframe,
+        html,
+        controller.signal,
+        () => sequence === this.#sequence,
+      );
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      this.dispatchEvent(new CustomEvent("render", { detail: { url: source } }));
+      return this.iframe;
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        this.dispatchEvent(new CustomEvent("rendererror", { detail: error }));
+      }
+      throw error;
+    } finally {
+      if (this.#controller === controller) this.#controller = null;
+    }
+  }
+
+  refresh(options = undefined) {
+    if (!this.#lastRequest) throw new Error("render() must be called before refresh()");
+    return this.render(
+      this.#lastRequest.url,
+      options ? { ...this.#lastRequest.options, ...options } : this.#lastRequest.options,
+    );
+  }
+
+  destroy() {
+    ++this.#sequence;
+    this.#controller?.abort();
+    this.#controller = null;
+    this.iframe.remove();
+  }
+}
+
+export function attachLightpandaRenderer(target, options) {
+  return new LightpandaRenderer(target, options);
+}

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -124,6 +124,7 @@ export class LightpandaRenderer extends EventTarget {
   #liveClose = null;
   #liveActivation = false;
   #liveClickHandler;
+  #liveChangeHandler;
 
   constructor(target, options = {}) {
     super();
@@ -153,6 +154,7 @@ export class LightpandaRenderer extends EventTarget {
     }
     this.iframe = iframe;
     this.#liveClickHandler = (event) => this.#activateFromClick(event);
+    this.#liveChangeHandler = (event) => this.#setValueFromChange(event);
     this.#setLiveMode(false);
 
     if (options.replace === false) this.#target.append(iframe);
@@ -345,9 +347,17 @@ export class LightpandaRenderer extends EventTarget {
       throw new Error("Lightpanda cannot access the live snapshot document");
     }
     snapshot.addEventListener("click", this.#liveClickHandler);
+    snapshot.addEventListener("change", this.#liveChangeHandler);
+  }
+
+  #setLiveInteractionBusy(busy) {
+    this.iframe.inert = busy;
+    const root = this.iframe.contentDocument?.documentElement;
+    if (root) root.inert = busy;
   }
 
   #activateFromClick(event) {
+    if (event.target?.closest?.('[data-lp-live-kind="value"]')) return;
     const target = event.target?.closest?.("[data-lp-live-target]");
     if (!target || !this.#live) return;
     const index = Number(target.getAttribute("data-lp-live-target"));
@@ -360,6 +370,7 @@ export class LightpandaRenderer extends EventTarget {
     if (this.#liveActivation || this.#liveClose) return;
 
     this.#liveActivation = true;
+    this.#setLiveInteractionBusy(true);
     void this.#activate(index)
       .catch((error) => {
         if (error?.name !== "AbortError") {
@@ -369,6 +380,34 @@ export class LightpandaRenderer extends EventTarget {
       })
       .finally(() => {
         this.#liveActivation = false;
+        this.#setLiveInteractionBusy(false);
+      });
+  }
+
+  #setValueFromChange(event) {
+    const target = event.target?.closest?.('[data-lp-live-kind="value"]');
+    if (!target || !this.#live || this.#liveActivation || this.#liveClose) return;
+    const rawIndex = target.getAttribute("data-lp-live-target");
+    if (rawIndex === null) return;
+    const index = Number(rawIndex);
+    if (!Number.isSafeInteger(index) || index < 0 || typeof target.value !== "string") return;
+    const selectedIndex =
+      Number.isSafeInteger(target.selectedIndex) && target.selectedIndex >= 0
+        ? target.selectedIndex
+        : null;
+
+    this.#liveActivation = true;
+    this.#setLiveInteractionBusy(true);
+    void this.#setValue(index, target.value, selectedIndex)
+      .catch((error) => {
+        if (error?.name !== "AbortError") {
+          void this.#closeLive().catch(() => {});
+          this.dispatchEvent(new CustomEvent("liveerror", { detail: error }));
+        }
+      })
+      .finally(() => {
+        this.#liveActivation = false;
+        this.#setLiveInteractionBusy(false);
       });
   }
 
@@ -402,6 +441,43 @@ export class LightpandaRenderer extends EventTarget {
         controller.signal,
         () => sequence === this.#sequence,
       );
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      this.#live = { ...live, ...metadata };
+      this.#bindLiveClicks();
+      this.dispatchEvent(new CustomEvent("live", { detail: { url: live.url, version: metadata.version, target } }));
+    } finally {
+      if (this.#controller === controller) this.#controller = null;
+    }
+  }
+
+  async #setValue(target, value, selectedIndex) {
+    const live = this.#live;
+    if (!live) return;
+    const sequence = ++this.#sequence;
+    this.#controller?.abort();
+    const controller = new AbortController();
+    this.#controller = controller;
+
+    try {
+      const request = {
+        op: "set_value",
+        session: live.session,
+        version: live.version,
+        target,
+        value,
+        wait_ms: live.options.waitMs,
+      };
+      if (selectedIndex !== null) request.selected_index = selectedIndex;
+      const response = await this.#postLive(request, controller.signal);
+      if (!response.ok) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda live value update failed (${response.status}): ${detail}`);
+      }
+
+      const metadata = liveHeaders(response);
+      const html = await readResponseText(response, this.#maxResponseBytes);
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      await waitForFrame(this.iframe, html, controller.signal, () => sequence === this.#sequence);
       if (sequence !== this.#sequence) throw aborted(controller.signal);
       this.#live = { ...live, ...metadata };
       this.#bindLiveClicks();

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -77,19 +77,36 @@ function waitForFrame(iframe, html, signal, isCurrent) {
   });
 }
 
+function liveHeaders(response) {
+  const session = response.headers?.get?.("x-lightpanda-live-session");
+  const version = Number(response.headers?.get?.("x-lightpanda-live-version"));
+  if (!/^[0-9a-f]{32}$/.test(session ?? "") || !Number.isSafeInteger(version) || version < 1) {
+    throw new Error("Lightpanda live response is missing session metadata");
+  }
+  return { session, version };
+}
+
 export class LightpandaRenderer extends EventTarget {
   #target;
   #endpoint;
+  #liveEndpoint;
   #token;
   #maxResponseBytes;
+  #credentialless;
+  #supportsCredentialless;
   #controller = null;
   #sequence = 0;
   #lastRequest = null;
+  #live = null;
+  #liveClose = null;
+  #liveActivation = false;
+  #liveClickHandler;
 
   constructor(target, options = {}) {
     super();
     this.#target = resolveTarget(target);
     this.#endpoint = new URL(options.endpoint ?? DEFAULT_ENDPOINT, document.baseURI).href;
+    this.#liveEndpoint = new URL(options.liveEndpoint ?? "/v1/live", this.#endpoint).href;
     this.#token = options.token ?? null;
     this.#maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
     if (!Number.isSafeInteger(this.#maxResponseBytes) || this.#maxResponseBytes < 1) {
@@ -97,20 +114,19 @@ export class LightpandaRenderer extends EventTarget {
     }
 
     const iframe = document.createElement("iframe");
-    // Same-frame forms remain native. Top-level and new-window targets stay
-    // blocked because the snapshot is not granted popup or top-navigation access.
-    iframe.setAttribute("sandbox", "allow-forms");
     iframe.title = options.title ?? "Lightpanda rendered page";
     iframe.loading = "eager";
     iframe.referrerPolicy = "no-referrer";
     iframe.style.cssText = options.style ?? "display:block;width:100%;height:100%;border:0";
     if (options.className) iframe.className = options.className;
-    const supportsCredentialless = "credentialless" in iframe;
-    if (options.requireCredentialless && !supportsCredentialless) {
+    this.#supportsCredentialless = "credentialless" in iframe;
+    this.#credentialless = options.credentialless !== false;
+    if (options.requireCredentialless && !this.#supportsCredentialless) {
       throw new Error("This browser does not support credentialless iframes");
     }
-    if (options.credentialless !== false && supportsCredentialless) iframe.credentialless = true;
     this.iframe = iframe;
+    this.#liveClickHandler = (event) => this.#activateFromClick(event);
+    this.#setLiveMode(false);
 
     if (options.replace === false) this.#target.append(iframe);
     else this.#target.replaceChildren(iframe);
@@ -122,6 +138,17 @@ export class LightpandaRenderer extends EventTarget {
     this.#controller?.abort();
     const controller = new AbortController();
     this.#controller = controller;
+    try {
+      await this.#closeLive();
+      if (sequence !== this.#sequence || controller.signal.aborted) throw aborted(controller.signal);
+    } catch (error) {
+      if (this.#controller === controller) this.#controller = null;
+      if (error?.name !== "AbortError") {
+        this.dispatchEvent(new CustomEvent("rendererror", { detail: error }));
+      }
+      throw error;
+    }
+    this.#setLiveMode(false);
 
     const bounds = this.#target.getBoundingClientRect();
     const request = {
@@ -181,11 +208,202 @@ export class LightpandaRenderer extends EventTarget {
     );
   }
 
+  async open(url, options = {}) {
+    if (this.#credentialless && !this.#supportsCredentialless) {
+      throw new Error(
+        "Live rendering requires credentialless iframe support; set credentialless:false to opt into credentialed subresources",
+      );
+    }
+
+    const source = new URL(url, document.baseURI).href;
+    const previousSandbox = this.iframe.getAttribute("sandbox");
+    const sequence = ++this.#sequence;
+    this.#controller?.abort();
+    const controller = new AbortController();
+    this.#controller = controller;
+    try {
+      await this.#closeLive();
+      if (sequence !== this.#sequence || controller.signal.aborted) throw aborted(controller.signal);
+    } catch (error) {
+      if (this.#controller === controller) this.#controller = null;
+      if (error?.name !== "AbortError") {
+        this.dispatchEvent(new CustomEvent("liveerror", { detail: error }));
+      }
+      throw error;
+    }
+    this.#setLiveMode(true);
+
+    const bounds = this.#target.getBoundingClientRect();
+    const request = {
+      op: "open",
+      url: source,
+      wait_ms: options.waitMs,
+      width: Math.max(1, Math.round((options.width ?? bounds.width) || 1280)),
+      height: Math.max(1, Math.round((options.height ?? bounds.height) || 720)),
+    };
+    for (const key of Object.keys(request)) {
+      if (request[key] == null) delete request[key];
+    }
+
+    try {
+      const response = await this.#postLive(request, controller.signal);
+      if (!response.ok) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda live render failed (${response.status}): ${detail}`);
+      }
+
+      const metadata = liveHeaders(response);
+      const live = { ...metadata, url: source, options: { ...options } };
+      // Install the provisional session before reading/loading the snapshot.
+      // A superseding render can now await its close before sending new work.
+      this.#live = live;
+      const html = await readResponseText(response, this.#maxResponseBytes);
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      await waitForFrame(
+        this.iframe,
+        html,
+        controller.signal,
+        () => sequence === this.#sequence,
+      );
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      this.#bindLiveClicks();
+      this.dispatchEvent(new CustomEvent("live", { detail: { url: source, version: metadata.version } }));
+      return this.iframe;
+    } catch (error) {
+      await this.#closeLive().catch(() => {});
+      if (sequence === this.#sequence) this.iframe.setAttribute("sandbox", previousSandbox);
+      if (error?.name !== "AbortError") {
+        this.dispatchEvent(new CustomEvent("liveerror", { detail: error }));
+      }
+      throw error;
+    } finally {
+      if (this.#controller === controller) this.#controller = null;
+    }
+  }
+
   destroy() {
     ++this.#sequence;
     this.#controller?.abort();
     this.#controller = null;
+    void this.#closeLive().catch(() => {});
     this.iframe.remove();
+  }
+
+  #setLiveMode(live) {
+    // Live snapshots have no scripts or forms. Same-origin access lets this
+    // library capture semantic target clicks from the replacement document.
+    this.iframe.setAttribute("sandbox", live ? "allow-same-origin" : "allow-forms");
+    if (this.#supportsCredentialless) this.iframe.credentialless = this.#credentialless;
+  }
+
+  #headers() {
+    const headers = { accept: "text/html", "content-type": "application/json" };
+    if (this.#token) headers.authorization = `Bearer ${this.#token}`;
+    return headers;
+  }
+
+  #postLive(request, signal) {
+    return fetch(this.#liveEndpoint, {
+      method: "POST",
+      headers: this.#headers(),
+      body: JSON.stringify(request),
+      credentials: "omit",
+      signal,
+    });
+  }
+
+  #bindLiveClicks() {
+    const snapshot = this.iframe.contentDocument;
+    if (!snapshot?.addEventListener) {
+      throw new Error("Lightpanda cannot access the live snapshot document");
+    }
+    snapshot.addEventListener("click", this.#liveClickHandler);
+  }
+
+  #activateFromClick(event) {
+    const target = event.target?.closest?.("[data-lp-live-target]");
+    if (!target || !this.#live) return;
+    const index = Number(target.getAttribute("data-lp-live-target"));
+    if (!Number.isSafeInteger(index) || index < 0) return;
+    if (event.button != null && event.button !== 0) return;
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.#liveActivation || this.#liveClose) return;
+
+    this.#liveActivation = true;
+    void this.#activate(index)
+      .catch((error) => {
+        if (error?.name !== "AbortError") {
+          void this.#closeLive().catch(() => {});
+          this.dispatchEvent(new CustomEvent("liveerror", { detail: error }));
+        }
+      })
+      .finally(() => {
+        this.#liveActivation = false;
+      });
+  }
+
+  async #activate(target) {
+    const live = this.#live;
+    if (!live) return;
+    const sequence = ++this.#sequence;
+    this.#controller?.abort();
+    const controller = new AbortController();
+    this.#controller = controller;
+
+    try {
+      const response = await this.#postLive({
+        op: "activate",
+        session: live.session,
+        version: live.version,
+        target,
+        wait_ms: live.options.waitMs,
+      }, controller.signal);
+      if (!response.ok) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda live activation failed (${response.status}): ${detail}`);
+      }
+
+      const metadata = liveHeaders(response);
+      const html = await readResponseText(response, this.#maxResponseBytes);
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      await waitForFrame(
+        this.iframe,
+        html,
+        controller.signal,
+        () => sequence === this.#sequence,
+      );
+      if (sequence !== this.#sequence) throw aborted(controller.signal);
+      this.#live = { ...live, ...metadata };
+      this.#bindLiveClicks();
+      this.dispatchEvent(new CustomEvent("live", { detail: { url: live.url, version: metadata.version, target } }));
+    } finally {
+      if (this.#controller === controller) this.#controller = null;
+    }
+  }
+
+  async #closeLive() {
+    if (this.#liveClose) return this.#liveClose;
+    const live = this.#live;
+    if (!live) return;
+
+    this.#liveActivation = false;
+    const closing = (async () => {
+      const response = await this.#postLive({ op: "close", session: live.session });
+      if (!response.ok && response.status !== 404) {
+        const detail = await readResponseText(response, 512).catch((error) => error.message);
+        throw new Error(`Lightpanda live close failed (${response.status}): ${detail}`);
+      }
+      if (this.#live?.session === live.session) this.#live = null;
+    })();
+    this.#liveClose = closing;
+    try {
+      await closing;
+    } finally {
+      if (this.#liveClose === closing) this.#liveClose = null;
+    }
   }
 }
 

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -13,10 +13,18 @@ function aborted(signal) {
 }
 
 async function readResponseText(response, limit) {
-  const contentLength = Number(response.headers?.get?.("content-length"));
-  if (Number.isFinite(contentLength) && contentLength > limit) {
+  const contentLengthHeader = response.headers?.get?.("content-length");
+  const parsedContentLength =
+    typeof contentLengthHeader === "string" && /^\d+$/.test(contentLengthHeader)
+      ? Number(contentLengthHeader)
+      : null;
+  const contentLength = Number.isSafeInteger(parsedContentLength) ? parsedContentLength : null;
+  if (contentLength !== null && contentLength > limit) {
     throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
   }
+  const contentEncoding = response.headers?.get?.("content-encoding")?.trim().toLowerCase();
+  const expectedLength =
+    !contentEncoding || contentEncoding === "identity" ? contentLength : null;
 
   const reader = response.body?.getReader?.();
   if (!reader) {
@@ -27,8 +35,10 @@ async function readResponseText(response, limit) {
     return text;
   }
 
-  const chunks = [];
+  let bytes = expectedLength === null ? null : new Uint8Array(expectedLength);
+  let chunks = bytes ? null : [];
   let length = 0;
+  let offset = 0;
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -37,11 +47,22 @@ async function readResponseText(response, limit) {
       await reader.cancel().catch(() => {});
       throw new RangeError(`Lightpanda response exceeds ${limit} bytes`);
     }
-    chunks.push(value);
+    if (bytes && length <= bytes.byteLength) {
+      bytes.set(value, offset);
+      offset = length;
+    } else {
+      if (bytes) {
+        chunks = [bytes.subarray(0, offset)];
+        bytes = null;
+      }
+      chunks.push(value);
+    }
   }
 
-  const bytes = new Uint8Array(length);
-  let offset = 0;
+  if (bytes) return new TextDecoder().decode(bytes.subarray(0, length));
+
+  bytes = new Uint8Array(length);
+  offset = 0;
   for (const chunk of chunks) {
     bytes.set(chunk, offset);
     offset += chunk.byteLength;

--- a/src/render/client.js
+++ b/src/render/client.js
@@ -1,5 +1,6 @@
 const DEFAULT_ENDPOINT = new URL("/v1/render", import.meta.url).href;
 const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+const DEFAULT_CLOSE_TIMEOUT_MS = 30_000;
 
 function resolveTarget(target) {
   if (typeof target === "string") target = document.querySelector(target);
@@ -92,6 +93,7 @@ export class LightpandaRenderer extends EventTarget {
   #liveEndpoint;
   #token;
   #maxResponseBytes;
+  #closeTimeoutMs;
   #credentialless;
   #supportsCredentialless;
   #controller = null;
@@ -111,6 +113,10 @@ export class LightpandaRenderer extends EventTarget {
     this.#maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
     if (!Number.isSafeInteger(this.#maxResponseBytes) || this.#maxResponseBytes < 1) {
       throw new RangeError("maxResponseBytes must be a positive safe integer");
+    }
+    this.#closeTimeoutMs = options.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.#closeTimeoutMs) || this.#closeTimeoutMs < 1) {
+      throw new RangeError("closeTimeoutMs must be a positive safe integer");
     }
 
     const iframe = document.createElement("iframe");
@@ -390,8 +396,12 @@ export class LightpandaRenderer extends EventTarget {
     if (!live) return;
 
     this.#liveActivation = false;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort(new DOMException("Lightpanda live close timed out", "TimeoutError"));
+    }, this.#closeTimeoutMs);
     const closing = (async () => {
-      const response = await this.#postLive({ op: "close", session: live.session });
+      const response = await this.#postLive({ op: "close", session: live.session }, controller.signal);
       if (!response.ok && response.status !== 404) {
         const detail = await readResponseText(response, 512).catch((error) => error.message);
         throw new Error(`Lightpanda live close failed (${response.status}): ${detail}`);
@@ -402,6 +412,7 @@ export class LightpandaRenderer extends EventTarget {
     try {
       await closing;
     } finally {
+      clearTimeout(timeout);
       if (this.#liveClose === closing) this.#liveClose = null;
     }
   }

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -378,3 +378,53 @@ const { attachLightpandaRenderer } = await import(
   assert.deepEqual(operations, ["open", "close", "close", "render"]);
   assert.match(renderer.iframe.snapshot, /Recovered/);
 }
+
+{
+  autoLoadFrames = true;
+  const operations = [];
+  let closeAttempts = 0;
+  let timedOutSignal;
+  fetchImpl = async (_endpoint, options) => {
+    const request = JSON.parse(options.body);
+    operations.push(request.op ?? "render");
+    if (request.op === "open") {
+      return new Response("<p>Live</p>", {
+        headers: {
+          "x-lightpanda-live-session": "ffeeddccbbaa99887766554433221100",
+          "x-lightpanda-live-version": "1",
+        },
+      });
+    }
+    if (request.op === "close") {
+      closeAttempts += 1;
+      if (closeAttempts === 1) {
+        timedOutSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+          const aborted = () => reject(options.signal.reason);
+          if (options.signal.aborted) aborted();
+          else options.signal.addEventListener("abort", aborted, { once: true });
+        });
+      }
+      return new Response(null, { status: 204 });
+    }
+    return new Response("<h1>Recovered after timeout</h1>");
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement(), { closeTimeoutMs: 5 });
+  await renderer.open("https://source.example/live");
+  await assert.rejects(
+    renderer.render("https://source.example/static"),
+    { name: "TimeoutError" },
+  );
+  assert.equal(timedOutSignal.aborted, true);
+  assert.deepEqual(operations, ["open", "close"]);
+
+  await renderer.render("https://source.example/static");
+  assert.deepEqual(operations, ["open", "close", "close", "render"]);
+  assert.match(renderer.iframe.snapshot, /Recovered after timeout/);
+}
+
+assert.throws(
+  () => attachLightpandaRenderer(new FakeElement(), { closeTimeoutMs: 0 }),
+  /closeTimeoutMs must be a positive safe integer/,
+);

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -7,6 +7,7 @@ let supportCredentialless = true;
 class FakeElement extends EventTarget {
   attributes = new Map();
   style = {};
+  value = "";
 
   setAttribute(name, value) {
     this.attributes.set(name, value);
@@ -28,12 +29,19 @@ class FakeElement extends EventTarget {
     if (selector === "[data-lp-live-target]" && this.getAttribute("data-lp-live-target") !== null) {
       return this;
     }
+    if (
+      selector === '[data-lp-live-kind="value"]'
+      && this.getAttribute("data-lp-live-kind") === "value"
+    ) {
+      return this;
+    }
     return this.parent?.closest(selector) ?? null;
   }
 }
 
 class FakeDocument {
   listeners = new Map();
+  documentElement = new FakeElement();
 
   addEventListener(type, listener) {
     this.listeners.set(type, listener);
@@ -54,6 +62,14 @@ class FakeDocument {
     };
     this.listeners.get("click")?.(event);
     return event;
+  }
+
+  dispatchChange(target) {
+    this.listeners.get("change")?.({ target });
+  }
+
+  dispatchInput(target) {
+    this.listeners.get("input")?.({ target });
   }
 }
 
@@ -345,7 +361,7 @@ const { attachLightpandaRenderer } = await import(
     const request = JSON.parse(options.body);
     requests.push({ endpoint, request, authorization: options.headers.authorization });
     if (request.op === "open") {
-      return new Response('<a href="/next" data-lp-live-target="0">Next</a>', {
+      return new Response('<a href="/next" data-lp-live-target="0" data-lp-live-kind="activate">Next</a>', {
         headers: {
           "x-lightpanda-live-session": "0123456789abcdef0123456789abcdef",
           "x-lightpanda-live-version": "1",
@@ -353,7 +369,7 @@ const { attachLightpandaRenderer } = await import(
       });
     }
     if (request.op === "activate") {
-      return new Response('<button data-lp-live-target="0">Updated</button>', {
+      return new Response('<button data-lp-live-target="0" data-lp-live-kind="activate">Updated</button>', {
         headers: {
           "x-lightpanda-live-session": "0123456789abcdef0123456789abcdef",
           "x-lightpanda-live-version": "2",
@@ -387,6 +403,7 @@ const { attachLightpandaRenderer } = await import(
 
   const target = new FakeElement();
   target.setAttribute("data-lp-live-target", "0");
+  target.setAttribute("data-lp-live-kind", "activate");
   const modified = renderer.iframe.contentDocument.dispatchClick(target, { ctrlKey: true });
   assert.equal(modified.prevented, false);
   assert.equal(modified.stopped, false);
@@ -417,6 +434,118 @@ const { attachLightpandaRenderer } = await import(
     op: "close",
     session: "0123456789abcdef0123456789abcdef",
   });
+}
+
+{
+  autoLoadFrames = true;
+  const requests = [];
+  let finishSetValue;
+  fetchImpl = async (_endpoint, options) => {
+    const request = JSON.parse(options.body);
+    requests.push(request);
+    if (request.op === "open") {
+      return new Response(
+        '<select data-lp-live-target="4" data-lp-live-kind="value"><option>before</option></select>',
+        {
+          headers: {
+            "x-lightpanda-live-session": "11223344556677889900aabbccddeeff",
+            "x-lightpanda-live-version": "1",
+          },
+        },
+      );
+    }
+    if (request.op === "set_value") {
+      return new Promise((resolve) => {
+        finishSetValue = () => resolve(new Response(
+          '<select data-lp-live-target="4" data-lp-live-kind="value"><option>after</option></select>',
+          {
+            headers: {
+              "x-lightpanda-live-session": "11223344556677889900aabbccddeeff",
+              "x-lightpanda-live-version": "2",
+            },
+          },
+        ));
+      });
+    }
+    assert.equal(request.op, "close");
+    return new Response(null, { status: 204 });
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await renderer.open("https://source.example/live-values", { waitMs: 1234 });
+  const snapshot = renderer.iframe.contentDocument;
+  const target = new FakeElement();
+  target.setAttribute("data-lp-live-target", "4");
+  target.setAttribute("data-lp-live-kind", "value");
+  target.value = "after";
+  target.selectedIndex = 2;
+
+  const click = snapshot.dispatchClick(target);
+  assert.equal(click.prevented, false);
+  assert.equal(click.stopped, false);
+  const nestedTarget = new FakeElement();
+  nestedTarget.parent = target;
+  nestedTarget.setAttribute("data-lp-live-target", "7");
+  nestedTarget.setAttribute("data-lp-live-kind", "activate");
+  const nestedClick = snapshot.dispatchClick(nestedTarget);
+  assert.equal(nestedClick.prevented, false);
+  assert.equal(nestedClick.stopped, false);
+  snapshot.dispatchInput(target);
+  assert.equal(requests.length, 1);
+
+  snapshot.dispatchChange(target);
+  await waitUntil(() => finishSetValue);
+  assert.equal(renderer.iframe.inert, true);
+  assert.equal(snapshot.documentElement.inert, true);
+  snapshot.dispatchChange(target);
+  assert.equal(requests.length, 2);
+  assert.deepEqual(requests[1], {
+    op: "set_value",
+    session: "11223344556677889900aabbccddeeff",
+    version: 1,
+    target: 4,
+    value: "after",
+    wait_ms: 1234,
+    selected_index: 2,
+  });
+
+  finishSetValue();
+  await waitUntil(() => />after</.test(renderer.iframe.snapshot));
+  await waitUntil(() => renderer.iframe.inert === false);
+  assert.equal(renderer.iframe.contentDocument.documentElement.inert, false);
+  renderer.destroy();
+  await waitUntil(() => requests.length === 3);
+}
+
+{
+  autoLoadFrames = true;
+  const operations = [];
+  fetchImpl = async (_endpoint, options) => {
+    const request = JSON.parse(options.body);
+    operations.push(request.op);
+    if (request.op === "open") {
+      return new Response('<input data-lp-live-target="1" data-lp-live-kind="value">', {
+        headers: {
+          "x-lightpanda-live-session": "22334455667788990011aabbccddeeff",
+          "x-lightpanda-live-version": "1",
+        },
+      });
+    }
+    if (request.op === "set_value") return new Response("failed", { status: 500 });
+    assert.equal(request.op, "close");
+    return new Response(null, { status: 204 });
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await renderer.open("https://source.example/live-value-failure");
+  const target = new FakeElement();
+  target.setAttribute("data-lp-live-target", "1");
+  target.setAttribute("data-lp-live-kind", "value");
+  target.value = "failed";
+  renderer.iframe.contentDocument.dispatchChange(target);
+  await waitUntil(() => operations.includes("close"));
+  await waitUntil(() => renderer.iframe.inert === false);
+  assert.equal(renderer.iframe.contentDocument.documentElement.inert, false);
 }
 
 {

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 let autoLoadFrames = true;
+let supportCredentialless = true;
 
 class FakeElement extends EventTarget {
   attributes = new Map();
@@ -22,11 +23,52 @@ class FakeElement extends EventTarget {
   getBoundingClientRect() {
     return { width: 640, height: 480 };
   }
+
+  closest(selector) {
+    if (selector === "[data-lp-live-target]" && this.getAttribute("data-lp-live-target") !== null) {
+      return this;
+    }
+    return this.parent?.closest(selector) ?? null;
+  }
+}
+
+class FakeDocument {
+  listeners = new Map();
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener);
+  }
+
+  dispatchClick(target, init = {}) {
+    const event = {
+      target,
+      ...init,
+      prevented: false,
+      stopped: false,
+      preventDefault() {
+        this.prevented = true;
+      },
+      stopPropagation() {
+        this.stopped = true;
+      },
+    };
+    this.listeners.get("click")?.(event);
+    return event;
+  }
 }
 
 class FakeFrame extends FakeElement {
+  credentialless = false;
+  contentDocument = new FakeDocument();
+
+  constructor() {
+    super();
+    if (!supportCredentialless) delete this.credentialless;
+  }
+
   set srcdoc(value) {
     this.snapshot = value;
+    this.contentDocument = new FakeDocument();
     if (autoLoadFrames) queueMicrotask(() => this.dispatchEvent(new Event("load")));
   }
 
@@ -88,6 +130,7 @@ const { attachLightpandaRenderer } = await import(
   assert.equal(frame.getAttribute("sandbox"), "allow-forms");
   assert.equal(frame.getAttribute("sandbox").includes("allow-scripts"), false);
   assert.equal(frame.getAttribute("sandbox").includes("allow-same-origin"), false);
+  assert.equal(frame.credentialless, true);
   assert.match(frame.snapshot, /<h1>Rendered<\/h1>/);
   assert.equal(sent.endpoint, "https://renderer.example/v1/render");
   assert.equal(sent.options.headers.authorization, "Bearer test-token");
@@ -107,9 +150,9 @@ const { attachLightpandaRenderer } = await import(
   const first = renderer.render("https://source.example/first");
   const firstRejected = assert.rejects(first, { name: "AbortError" });
   const second = renderer.render("https://source.example/second");
-  responses[1](new Response("<h1>Second</h1>"));
+  await waitUntil(() => responses.length === 1);
+  responses[0](new Response("<h1>Second</h1>"));
   await second;
-  responses[0](new Response("<h1>First</h1>"));
   await firstRejected;
   assert.match(renderer.iframe.snapshot, /Second/);
 }
@@ -143,4 +186,195 @@ const { attachLightpandaRenderer } = await import(
     renderer.render("https://source.example/large"),
     /Lightpanda response exceeds 4 bytes/,
   );
+}
+
+{
+  supportCredentialless = false;
+  let requested = false;
+  fetchImpl = async () => {
+    requested = true;
+    return new Response();
+  };
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await assert.rejects(
+    renderer.open("https://source.example/live"),
+    /Live rendering requires credentialless iframe support/,
+  );
+  assert.equal(requested, false);
+  supportCredentialless = true;
+}
+
+{
+  autoLoadFrames = true;
+  let phase = "render";
+  fetchImpl = async () => {
+    if (phase === "render") return new Response("<h1>One shot</h1>");
+    return new Response("open failed", { status: 502 });
+  };
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await renderer.render("https://source.example/static");
+  assert.equal(renderer.iframe.getAttribute("sandbox"), "allow-forms");
+  phase = "open";
+  await assert.rejects(
+    renderer.open("https://source.example/live"),
+    /Lightpanda live render failed \(502\): open failed/,
+  );
+  assert.equal(renderer.iframe.getAttribute("sandbox"), "allow-forms");
+}
+
+{
+  autoLoadFrames = false;
+  const operations = [];
+  let finishClose;
+  fetchImpl = async (_endpoint, options) => {
+    const request = JSON.parse(options.body);
+    operations.push(request.op ?? "render");
+    if (request.op === "open") {
+      return new Response('<a href="/next" data-lp-live-target="0">Next</a>', {
+        headers: {
+          "x-lightpanda-live-session": "fedcba9876543210fedcba9876543210",
+          "x-lightpanda-live-version": "1",
+        },
+      });
+    }
+    if (request.op === "close") {
+      return new Promise((resolve) => {
+        finishClose = () => resolve(new Response(null, { status: 204 }));
+      });
+    }
+    return new Response("<h1>Replacement</h1>");
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  const opened = renderer.open("https://source.example/live");
+  const openRejected = assert.rejects(opened, { name: "AbortError" });
+  await waitUntil(() => renderer.iframe.snapshot);
+
+  const replacement = renderer.render("https://source.example/replacement");
+  await waitUntil(() => finishClose);
+  assert.deepEqual(operations, ["open", "close"]);
+
+  autoLoadFrames = true;
+  finishClose();
+  await replacement;
+  await openRejected;
+  assert.deepEqual(operations, ["open", "close", "render"]);
+  assert.match(renderer.iframe.snapshot, /Replacement/);
+}
+
+{
+  autoLoadFrames = true;
+  const requests = [];
+  fetchImpl = async (endpoint, options) => {
+    const request = JSON.parse(options.body);
+    requests.push({ endpoint, request, authorization: options.headers.authorization });
+    if (request.op === "open") {
+      return new Response('<a href="/next" data-lp-live-target="0">Next</a>', {
+        headers: {
+          "x-lightpanda-live-session": "0123456789abcdef0123456789abcdef",
+          "x-lightpanda-live-version": "1",
+        },
+      });
+    }
+    if (request.op === "activate") {
+      return new Response('<button data-lp-live-target="0">Updated</button>', {
+        headers: {
+          "x-lightpanda-live-session": "0123456789abcdef0123456789abcdef",
+          "x-lightpanda-live-version": "2",
+        },
+      });
+    }
+    assert.equal(request.op, "close");
+    return new Response(null, { status: 204 });
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement(), {
+    endpoint: "https://custom-renderer.example/api/render",
+    token: "live-token",
+  });
+  await renderer.open("https://source.example/live");
+  assert.equal(renderer.iframe.getAttribute("sandbox"), "allow-same-origin");
+  assert.equal(renderer.iframe.getAttribute("sandbox").includes("allow-scripts"), false);
+  assert.equal(renderer.iframe.getAttribute("sandbox").includes("allow-forms"), false);
+  assert.equal(renderer.iframe.credentialless, true);
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0], {
+    endpoint: "https://custom-renderer.example/v1/live",
+    request: {
+      op: "open",
+      url: "https://source.example/live",
+      width: 640,
+      height: 480,
+    },
+    authorization: "Bearer live-token",
+  });
+
+  const target = new FakeElement();
+  target.setAttribute("data-lp-live-target", "0");
+  const modified = renderer.iframe.contentDocument.dispatchClick(target, { ctrlKey: true });
+  assert.equal(modified.prevented, false);
+  assert.equal(modified.stopped, false);
+  assert.equal(requests.length, 1);
+  const auxiliary = renderer.iframe.contentDocument.dispatchClick(target, { button: 1 });
+  assert.equal(auxiliary.prevented, false);
+  assert.equal(auxiliary.stopped, false);
+  assert.equal(requests.length, 1);
+
+  const firstClick = renderer.iframe.contentDocument.dispatchClick(target);
+  const secondClick = renderer.iframe.contentDocument.dispatchClick(target);
+  assert.equal(firstClick.prevented, true);
+  assert.equal(secondClick.prevented, true);
+  assert.equal(firstClick.stopped, true);
+  assert.equal(secondClick.stopped, true);
+  assert.equal(requests.length, 2);
+  await waitUntil(() => requests.length === 2);
+  await waitUntil(() => /Updated/.test(renderer.iframe.snapshot));
+  assert.deepEqual(requests[1].request, {
+    op: "activate",
+    session: "0123456789abcdef0123456789abcdef",
+    version: 1,
+    target: 0,
+  });
+  renderer.destroy();
+  await waitUntil(() => requests.length === 3);
+  assert.deepEqual(requests[2].request, {
+    op: "close",
+    session: "0123456789abcdef0123456789abcdef",
+  });
+}
+
+{
+  autoLoadFrames = true;
+  const operations = [];
+  let closeAttempts = 0;
+  fetchImpl = async (_endpoint, options) => {
+    const request = JSON.parse(options.body);
+    operations.push(request.op ?? "render");
+    if (request.op === "open") {
+      return new Response("<p>Live</p>", {
+        headers: {
+          "x-lightpanda-live-session": "00112233445566778899aabbccddeeff",
+          "x-lightpanda-live-version": "1",
+        },
+      });
+    }
+    if (request.op === "close") {
+      closeAttempts += 1;
+      if (closeAttempts === 1) return new Response("busy", { status: 500 });
+      return new Response(null, { status: 204 });
+    }
+    return new Response("<h1>Recovered</h1>");
+  };
+
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await renderer.open("https://source.example/live");
+  await assert.rejects(
+    renderer.render("https://source.example/static"),
+    /Lightpanda live close failed \(500\): busy/,
+  );
+  assert.deepEqual(operations, ["open", "close"]);
+
+  await renderer.render("https://source.example/static");
+  assert.deepEqual(operations, ["open", "close", "close", "render"]);
+  assert.match(renderer.iframe.snapshot, /Recovered/);
 }

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -100,6 +100,38 @@ async function waitUntil(predicate) {
   assert.fail("condition did not become ready");
 }
 
+function streamingResponse(parts, headers = {}, { mutateFirstBeforeSecond = false } = {}) {
+  const encoder = new TextEncoder();
+  const chunks = parts.map((part) => encoder.encode(part));
+  let index = 0;
+  let cancelled = false;
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (index === chunks.length) return { done: true };
+            const value = chunks[index++];
+            if (mutateFirstBeforeSecond && index === 2) {
+              chunks[0][0] = "X".charCodeAt(0);
+            }
+            return { done: false, value };
+          },
+          async cancel() {
+            cancelled = true;
+          },
+        };
+      },
+    },
+    get cancelled() {
+      return cancelled;
+    },
+  };
+}
+
 const source = (await readFile(new URL("./client.js", import.meta.url), "utf8")).replace(
   /^const DEFAULT_ENDPOINT = .*;$/m,
   'const DEFAULT_ENDPOINT = "https://renderer.example/v1/render";',
@@ -186,6 +218,50 @@ const { attachLightpandaRenderer } = await import(
     renderer.render("https://source.example/large"),
     /Lightpanda response exceeds 4 bytes/,
   );
+}
+
+{
+  const response = streamingResponse(
+    ["abc", "def"],
+    { "content-length": "6" },
+    { mutateFirstBeforeSecond: true },
+  );
+  fetchImpl = async () => response;
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await renderer.render("https://source.example/preallocated");
+  assert.equal(renderer.iframe.snapshot, "abcdef");
+}
+
+{
+  const cases = [
+    [streamingResponse(["short"], { "content-length": "8" }), "short"],
+    [streamingResponse(["abc", "def"], { "content-length": "3" }), "abcdef"],
+    [streamingResponse(["abc", "def"], { "content-length": "invalid" }), "abcdef"],
+    [
+      streamingResponse(["abc", "def"], {
+        "content-length": "3",
+        "content-encoding": "gzip",
+      }),
+      "abcdef",
+    ],
+  ];
+  for (const [response, expected] of cases) {
+    fetchImpl = async () => response;
+    const renderer = attachLightpandaRenderer(new FakeElement());
+    await renderer.render("https://source.example/fallback");
+    assert.equal(renderer.iframe.snapshot, expected);
+  }
+}
+
+{
+  const response = streamingResponse(["123", "45"]);
+  fetchImpl = async () => response;
+  const renderer = attachLightpandaRenderer(new FakeElement(), { maxResponseBytes: 4 });
+  await assert.rejects(
+    renderer.render("https://source.example/streaming-large"),
+    /Lightpanda response exceeds 4 bytes/,
+  );
+  assert.equal(response.cancelled, true);
 }
 
 {

--- a/src/render/client.test.mjs
+++ b/src/render/client.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+let autoLoadFrames = true;
+
+class FakeElement extends EventTarget {
+  attributes = new Map();
+  style = {};
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  replaceChildren(child) {
+    this.child = child;
+  }
+
+  getBoundingClientRect() {
+    return { width: 640, height: 480 };
+  }
+}
+
+class FakeFrame extends FakeElement {
+  set srcdoc(value) {
+    this.snapshot = value;
+    if (autoLoadFrames) queueMicrotask(() => this.dispatchEvent(new Event("load")));
+  }
+
+  remove() {
+    this.removed = true;
+  }
+}
+
+globalThis.Element = FakeElement;
+globalThis.document = {
+  baseURI: "https://preview.example/",
+  querySelector() {
+    return null;
+  },
+  createElement(name) {
+    assert.equal(name, "iframe");
+    return new FakeFrame();
+  },
+};
+
+let fetchImpl;
+globalThis.fetch = (...args) => fetchImpl(...args);
+
+async function waitUntil(predicate) {
+  for (let attempt = 0; attempt < 20; ++attempt) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail("condition did not become ready");
+}
+
+const source = (await readFile(new URL("./client.js", import.meta.url), "utf8")).replace(
+  /^const DEFAULT_ENDPOINT = .*;$/m,
+  'const DEFAULT_ENDPOINT = "https://renderer.example/v1/render";',
+);
+const { attachLightpandaRenderer } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`,
+);
+
+{
+  autoLoadFrames = false;
+  let sent;
+  fetchImpl = async (endpoint, options) => {
+    sent = { endpoint, options };
+    return new Response(
+      '<!doctype html><base href="https://source.example/"><h1>Rendered</h1>',
+      { headers: { "content-type": "text/html" } },
+    );
+  };
+
+  const target = new FakeElement();
+  const renderer = attachLightpandaRenderer(target, { token: "test-token" });
+  const pending = renderer.render("https://source.example/page");
+  await waitUntil(() => renderer.iframe.snapshot);
+  renderer.iframe.dispatchEvent(new Event("load"));
+  const frame = await pending;
+
+  assert.equal(target.child, frame);
+  assert.equal(frame.getAttribute("sandbox"), "allow-forms");
+  assert.equal(frame.getAttribute("sandbox").includes("allow-scripts"), false);
+  assert.equal(frame.getAttribute("sandbox").includes("allow-same-origin"), false);
+  assert.match(frame.snapshot, /<h1>Rendered<\/h1>/);
+  assert.equal(sent.endpoint, "https://renderer.example/v1/render");
+  assert.equal(sent.options.headers.authorization, "Bearer test-token");
+  assert.deepEqual(JSON.parse(sent.options.body), {
+    url: "https://source.example/page",
+    width: 640,
+    height: 480,
+  });
+}
+
+{
+  autoLoadFrames = true;
+  const responses = [];
+  fetchImpl = () => new Promise((resolve) => responses.push(resolve));
+  const renderer = attachLightpandaRenderer(new FakeElement());
+
+  const first = renderer.render("https://source.example/first");
+  const firstRejected = assert.rejects(first, { name: "AbortError" });
+  const second = renderer.render("https://source.example/second");
+  responses[1](new Response("<h1>Second</h1>"));
+  await second;
+  responses[0](new Response("<h1>First</h1>"));
+  await firstRejected;
+  assert.match(renderer.iframe.snapshot, /Second/);
+}
+
+{
+  autoLoadFrames = false;
+  fetchImpl = async () => new Response("<h1>Waiting</h1>");
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  const pending = renderer.render("https://source.example/destroy");
+  const rejected = assert.rejects(pending, { name: "AbortError" });
+  await waitUntil(() => renderer.iframe.snapshot);
+  renderer.destroy();
+  await rejected;
+  assert.equal(renderer.iframe.removed, true);
+}
+
+{
+  autoLoadFrames = true;
+  fetchImpl = async () => new Response("upstream failed", { status: 502 });
+  const renderer = attachLightpandaRenderer(new FakeElement());
+  await assert.rejects(
+    renderer.render("https://source.example/fail"),
+    /Lightpanda render failed \(502\): upstream failed/,
+  );
+}
+
+{
+  fetchImpl = async () => new Response("12345");
+  const renderer = attachLightpandaRenderer(new FakeElement(), { maxResponseBytes: 4 });
+  await assert.rejects(
+    renderer.render("https://source.example/large"),
+    /Lightpanda response exceeds 4 bytes/,
+  );
+}

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -80,6 +80,7 @@ pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode
         .mode = switch (run_mode) {
             .fetch => "F",
             .serve => "S",
+            .render => "CR",
             .agent => if (interactive == false) "AR" else "A",
             .run => "R",
             .mcp => "M",


### PR DESCRIPTION
## Summary

- add a bounded `POST /v1/live` protocol with explicit open, activate, value-update, and close operations
- keep one worker-owned page alive for semantic anchors, script-backed controls, checkbox/radio activation, and editable form state
- synchronize enabled text-like inputs, textareas, and single-select controls on `change`
- serialize current checked/value/selected state without mutating source DOM defaults
- strip scripts, meta refresh, and password values from live snapshots while preserving a safe `<base>`
- extend the browser client with race-safe cleanup, credentialless previews, bounded streamed response reads, and inert interaction while an operation is pending
- release client slots immediately on timeout or disconnect using heap-owned, reference-counted jobs
- preallocate known uncompressed response bodies so the client does not retain every chunk plus a second full byte buffer

## Why

The one-shot renderer from #3119 executes page JavaScript once, then returns a static DOM snapshot. The earlier live-session commits made clicks round-trip to the worker-owned page, but edited form values still existed only in the preview iframe.

This change adds bounded form-state synchronization without introducing per-keystroke traffic, a raster stream, polling, or layout-dependent coordinate input. It also closes lifecycle and allocation issues around abandoned render work.

## Behavior and limits

- a live session owns the renderer's sole worker; one-shot requests return `409` while it is active
- every successful activation or value update returns one complete, versioned HTML snapshot
- value synchronization happens once on `change`, not on every `input` event
- supported value controls are enabled, non-readonly text/search/url/tel/email inputs, textareas, and single selects
- password/file inputs, multiple selects, contenteditable, and unsupported input types are excluded
- selects transmit and revalidate the exact selected index, including duplicate-valued options
- the remote control is focused first, then connectivity, eligibility, page identity, DOM version, and selected option are revalidated before writing
- value-triggered navigation waits through DOMContentLoaded before the replacement snapshot is returned
- the preview iframe and snapshot root are inert while a request is pending, preventing a second stale edit from being silently overwritten
- values are limited to 2,048 UTF-8 bytes; a session is limited to 256 updates and 256 KiB cumulative value bytes
- password author/current values are removed from every live snapshot
- actionable click controls remain same-context anchors, enabled non-form buttons, enabled checkbox/radio inputs, and visible enabled elements with a direct active `click` listener or valid inline `onclick`
- scripts and form submissions remain disabled in the preview iframe
- live mode requires credentialless iframe support by default; callers can explicitly opt into credentialed subresources
- stale versions fail closed instead of replaying an action
- malformed or conflicting live requests cannot close an incumbent session they do not own

This is state synchronization, not keystroke fidelity: it does not reproduce every `keydown`, `beforeinput`, caret, composition, or per-key `input` event. Each operation still transmits a complete HTML snapshot and reloads the preview iframe.

## Validation

- full debug suite with allocation/leak detection — 1,152/1,152 passed
- focused live dump tests — passed
- focused live-session tests — passed
- focused render-server tests — passed
- `node --test src/render/client.test.mjs`
- scoped `zig fmt --check`
- `git diff --check`
- independent lifecycle/resource/security review — no P0-P2 findings
- lifecycle head: an infinite-script render with `--max-wait-ms 150` returned `504` in 0.152 s; health remained responsive and the next render returned `200` in 0.009 s
- lifecycle head: disconnecting a client after approximately 53 ms left health responsive and the next render returned `200` in 0.008 s
- lifecycle head: ReleaseSmall with `--v8-max-heap-mb 32` measured 32.1 MiB maximum RSS and 0.23 seconds total CPU across a 73.95-second open/activate/close run; idle CPU time did not advance during sampled idle windows

## Dependency

This PR is stacked on #3119. Merge #3119 first; GitHub will then reduce this PR to the live-session changes above.
