### PR TITLE
fix(iframe): navigate on src attribute changes

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1800,10 +1800,14 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
         // the same reason that a "root" frame can't immediately navigate:
         // we could be in the middle of a JS callback or something else that
         // doesn't exit the frame to just suddenly go away.
-        return self.scheduleNavigation(src, .{
+        try self.scheduleNavigation(src, .{
             .reason = .script,
             .kind = .{ .push = null },
         }, .{ .iframe = iframe });
+        // The queued navigation now owns this source change. A later DOM move
+        // must not schedule the same navigation again.
+        iframe._executed = true;
+        return;
     }
 
     iframe._executed = true;

--- a/src/browser/tests/frames/frames.html
+++ b/src/browser/tests/frames/frames.html
@@ -23,6 +23,82 @@
   }
 </script>
 
+<script id=src_attribute_change type=module>
+  const state = await testing.async();
+  const iframe = document.createElement('iframe');
+  let loads = 0;
+
+  const nextLoad = () => new Promise((resolve) => {
+    iframe.onload = () => {
+      loads += 1;
+      resolve();
+    };
+  });
+
+  let loaded = nextLoad();
+  iframe.src = 'support/page.html?initial';
+  document.body.appendChild(iframe);
+  await loaded;
+  loads = 0;
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', 'support/page.html?attribute');
+  await loaded;
+  testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', '');
+  await loaded;
+  testing.expectEqual('', iframe.src);
+  testing.expectEqual('<html><head></head><body></body></html>', iframe.contentDocument.documentElement.outerHTML);
+
+  const document_before_remove = iframe.contentDocument;
+  iframe.removeAttribute('src');
+  await scheduler.postTask(() => {});
+  testing.expectEqual(null, iframe.getAttribute('src'));
+  testing.expectEqual('', iframe.src);
+  testing.expectEqual('<html><head></head><body></body></html>', iframe.contentDocument.documentElement.outerHTML);
+  testing.expectTrue(document_before_remove === iframe.contentDocument);
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', '');
+  await loaded;
+  await scheduler.postTask(() => {});
+  document.body.removeChild(iframe);
+  iframe.removeAttribute('src');
+  loaded = nextLoad();
+  document.body.appendChild(iframe);
+  await loaded;
+
+  loaded = nextLoad();
+  iframe.src = 'support/page.html?property';
+  await loaded;
+
+  loaded = nextLoad();
+  iframe.src = 'support/page.html?property';
+  await loaded;
+
+  // The task boundary lets a queued re-navigation replace contentDocument.
+  const document_before_move = iframe.contentDocument;
+  document.body.appendChild(iframe);
+  await scheduler.postTask(() => {});
+  testing.expectTrue(document_before_move === iframe.contentDocument);
+
+  document.body.removeChild(iframe);
+  iframe.removeAttribute('src');
+  iframe.setAttribute('src', 'support/page.html?detached');
+  loaded = nextLoad();
+  document.body.appendChild(iframe);
+  await loaded;
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(7, loads);
+    testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
+    testing.expectEqual(11, window.length);
+  });
+</script>
+
 <script id="basic">
    // reload it
   $('#f2').src = 'support/sub2.html';
@@ -165,6 +241,6 @@
 
 <script id=count>
   testing.onload(() => {
-    testing.expectEqual(10, window.length);
+    testing.expectEqual(11, window.length);
   });
 </script>

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
@@ -29,12 +30,15 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 
 const HtmlElement = @import("../Html.zig");
 
+const String = lp.String;
 const IFrame = @This();
 
 pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _src: []const u8 = "",
 _executed: bool = false,
+// setSrc lets the reflected attribute update state, then reports navigation errors itself.
+_setting_src: bool = false,
 _window: ?*Window = null,
 
 pub fn asElement(self: *IFrame) *Element {
@@ -66,13 +70,41 @@ pub fn getSrc(self: *IFrame, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *IFrame, src: []const u8, frame: *Frame) !void {
-    const element = self.asElement();
-    try element.setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
-    self._src = element.getAttributeSafe(comptime .wrap("src")) orelse unreachable;
-    if (element.asNode().isConnected()) {
-        // unlike script, an iframe is reloaded every time the src is set
-        // even if it's set to the same URL.
-        self._executed = false;
+    const was_setting_src = self._setting_src;
+    self._setting_src = true;
+    defer self._setting_src = was_setting_src;
+
+    try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
+    if (!was_setting_src) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn srcAttributeChanged(self: *IFrame, frame: *Frame) !void {
+    self._src = self.asElement().getAttributeSafe(comptime .wrap("src")) orelse "";
+    self._executed = false;
+    if (!self._setting_src) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn srcAttributeRemoved(self: *IFrame, frame: *Frame) !void {
+    const was_blank = self._src.len == 0;
+    self._src = "";
+    if (was_blank and self.asNode().isConnected()) {
+        return;
+    }
+
+    self._executed = false;
+    if (!was_blank) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn navigateForSrcChange(self: *IFrame, frame: *Frame) !void {
+    if (self.asNode().isConnected()) {
+        // Unlike script, an iframe is reloaded every time src is set,
+        // even if it is set to the same URL.
         try frame.iframeAddedCallback(self);
     }
 }
@@ -114,5 +146,21 @@ pub const Build = struct {
         const self = node.as(IFrame);
         const element = self.asElement();
         self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+    }
+
+    pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+
+        try element.as(IFrame).srcAttributeChanged(frame);
+    }
+
+    pub fn attributeRemove(element: *Element, name: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+
+        try element.as(IFrame).srcAttributeRemoved(frame);
     }
 };


### PR DESCRIPTION
## Summary

- navigate a connected iframe when its `src` content attribute changes through `setAttribute`
- navigate a connected nonblank iframe to `about:blank` when `src` is removed
- keep removal of an already-empty connected `src` as a no-op instead of reloading `about:blank`
- invalidate detached source state so reinsertion creates the correct fresh document
- prevent a DOM move from rescheduling an iframe navigation that is already queued
- preserve exact-once reload behavior and error propagation for the reflected `.src` property setter

## Why

`HTMLIFrameElement.src = value` updated the reflected content attribute and navigated, but direct `setAttribute("src", value)` and `removeAttribute("src")` did not consistently update the child browsing context. Agent-driven applications frequently mutate iframe attributes through framework DOM code, so the property/attribute mismatch left embedded application state stale.

## Behavior

- a connected `setAttribute("src", value)` schedules navigation
- assigning the same URL through `.src` still reloads exactly once
- removing a connected nonempty `src` schedules `about:blank`
- removing an already-empty connected `src` does not replace the existing blank document
- changing/removing `src` while detached marks the iframe for navigation on reinsertion
- once navigation is queued, moving the iframe does not queue the same navigation again

The regression uses scheduler task boundaries and `contentDocument` identity checks rather than timing-based negative waits.

## Validation

- full debug suite with allocation/leak detection — 1,125/1,125 passed
- focused `WebApi: Frames` suite — 1/1 passed in three consecutive clean runs
- scoped `zig fmt --check`
- `git diff --check`
- independent review — no P0-P2 findings

## Residual scope

Asynchronous navigation cancellation/failure and moving an iframe between different documents are not added by this change.
