### PR TITLE
fix(iframe): activate connected shadow frames

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1789,10 +1789,14 @@ pub fn iframeAddedCallback(self: *Frame, iframe: *IFrame) !void {
         // the same reason that a "root" frame can't immediately navigate:
         // we could be in the middle of a JS callback or something else that
         // doesn't exit the frame to just suddenly go away.
-        return self.scheduleNavigation(src, .{
+        try self.scheduleNavigation(src, .{
             .reason = .script,
             .kind = .{ .push = null },
         }, .{ .iframe = iframe });
+        // The queued navigation now owns this source change. A later DOM move
+        // must not schedule the same navigation again.
+        iframe._executed = true;
+        return;
     }
 
     iframe._executed = true;

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2881,20 +2881,37 @@ pub fn updateRangesForNodeRemoval(self: *Frame, parent: *Node, child: *Node, chi
 // children, for its descendants in tree order: appending a subtree
 // containing scripts must execute them all, after the whole insertion.
 fn nodeIsReadySubtree(self: *Frame, node: *Node) !void {
-    if (node._type != .element or node.firstChild() == null) {
-        return self.nodeIsReady(false, node);
-    }
-
     // Scripts can mutate the tree. Safe to do this since nodeIsReady re-checks
     // connectivity.
     var elements: std.ArrayList(*Node) = .empty;
-    var tw = @import("webapi/TreeWalker.zig").Full.Elements.init(node, .{});
-    while (tw.next()) |el| {
-        try elements.append(self.call_arena, el.asNode());
+    var pending: std.ArrayList(*Node) = .empty;
+    try pending.append(self.call_arena, node);
+    while (pending.pop()) |current| {
+        var child = current.lastChild();
+        while (child) |value| {
+            try pending.append(self.call_arena, value);
+            child = value.previousSibling();
+        }
+
+        if (current.is(Element)) |element| {
+            try elements.append(self.call_arena, current);
+            if (self._element_shadow_roots.get(element)) |shadow_root| {
+                var shadow_child = shadow_root.asNode().lastChild();
+                while (shadow_child) |value| {
+                    try pending.append(self.call_arena, value);
+                    shadow_child = value.previousSibling();
+                }
+            }
+        }
     }
     for (elements.items) |el| {
         try self.nodeIsReady(false, el);
     }
+}
+
+pub fn runReadySubtree(self: *Frame, node: *Node) !void {
+    if (!node.isConnected()) return;
+    try self.nodeIsReadySubtree(node);
 }
 
 fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {

--- a/src/browser/tests/frames/frames.html
+++ b/src/browser/tests/frames/frames.html
@@ -23,6 +23,82 @@
   }
 </script>
 
+<script id=src_attribute_change type=module>
+  const state = await testing.async();
+  const iframe = document.createElement('iframe');
+  let loads = 0;
+
+  const nextLoad = () => new Promise((resolve) => {
+    iframe.onload = () => {
+      loads += 1;
+      resolve();
+    };
+  });
+
+  let loaded = nextLoad();
+  iframe.src = 'support/page.html?initial';
+  document.body.appendChild(iframe);
+  await loaded;
+  loads = 0;
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', 'support/page.html?attribute');
+  await loaded;
+  testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', '');
+  await loaded;
+  testing.expectEqual('', iframe.src);
+  testing.expectEqual('<html><head></head><body></body></html>', iframe.contentDocument.documentElement.outerHTML);
+
+  const document_before_remove = iframe.contentDocument;
+  iframe.removeAttribute('src');
+  await scheduler.postTask(() => {});
+  testing.expectEqual(null, iframe.getAttribute('src'));
+  testing.expectEqual('', iframe.src);
+  testing.expectEqual('<html><head></head><body></body></html>', iframe.contentDocument.documentElement.outerHTML);
+  testing.expectTrue(document_before_remove === iframe.contentDocument);
+
+  loaded = nextLoad();
+  iframe.setAttribute('src', '');
+  await loaded;
+  await scheduler.postTask(() => {});
+  document.body.removeChild(iframe);
+  iframe.removeAttribute('src');
+  loaded = nextLoad();
+  document.body.appendChild(iframe);
+  await loaded;
+
+  loaded = nextLoad();
+  iframe.src = 'support/page.html?property';
+  await loaded;
+
+  loaded = nextLoad();
+  iframe.src = 'support/page.html?property';
+  await loaded;
+
+  // The task boundary lets a queued re-navigation replace contentDocument.
+  const document_before_move = iframe.contentDocument;
+  document.body.appendChild(iframe);
+  await scheduler.postTask(() => {});
+  testing.expectTrue(document_before_move === iframe.contentDocument);
+
+  document.body.removeChild(iframe);
+  iframe.removeAttribute('src');
+  iframe.setAttribute('src', 'support/page.html?detached');
+  loaded = nextLoad();
+  document.body.appendChild(iframe);
+  await loaded;
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(7, loads);
+    testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
+    testing.expectEqual(11, window.length);
+  });
+</script>
+
 <script id="basic">
    // reload it
   $('#f2').src = 'support/sub2.html';
@@ -165,6 +241,6 @@
 
 <script id=count>
   testing.onload(() => {
-    testing.expectEqual(10, window.length);
+    testing.expectEqual(11, window.length);
   });
 </script>

--- a/src/browser/tests/frames/frames.html
+++ b/src/browser/tests/frames/frames.html
@@ -95,7 +95,36 @@
   await state.done(() => {
     testing.expectEqual(7, loads);
     testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
-    testing.expectEqual(11, window.length);
+    testing.expectEqual(13, window.length);
+  });
+</script>
+
+<script id=connected_inner_html_iframe type=module>
+  const state = await testing.async();
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  host.innerHTML = '<iframe src="support/page.html?inner-html"></iframe>';
+
+  const iframe = host.firstElementChild;
+  iframe.onload = () => state.resolve();
+
+  await state.done(() => {
+    testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
+  });
+</script>
+
+<script id=connected_shadow_iframe type=module>
+  const state = await testing.async();
+  const host = document.createElement('div');
+  const shadow = host.attachShadow({mode: 'closed'});
+  const iframe = document.createElement('iframe');
+  iframe.src = 'support/page.html?shadow';
+  iframe.onload = () => state.resolve();
+  shadow.appendChild(iframe);
+  document.body.appendChild(host);
+
+  await state.done(() => {
+    testing.expectEqual('a-page\n', iframe.contentDocument.body.textContent);
   });
 </script>
 
@@ -241,6 +270,6 @@
 
 <script id=count>
   testing.onload(() => {
-    testing.expectEqual(11, window.length);
+    testing.expectEqual(13, window.length);
   });
 </script>

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -1602,6 +1602,13 @@ pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, fr
         } else {
             try Frame.parse.htmlAsChildren(frame, self, html);
         }
+
+        if (self.isConnected()) {
+            var child_it = self.childrenIterator();
+            while (child_it.next()) |child| {
+                try frame.runReadySubtree(child);
+            }
+        }
     }
 
     if (notify) {

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -17,6 +17,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
 const Frame = @import("../../../Frame.zig");
@@ -29,12 +30,15 @@ const DOMTokenList = @import("../../collections.zig").DOMTokenList;
 
 const HtmlElement = @import("../Html.zig");
 
+const String = lp.String;
 const IFrame = @This();
 
 pub const Proto = HtmlElement;
 _proto: *HtmlElement,
 _src: []const u8 = "",
 _executed: bool = false,
+// setSrc lets the reflected attribute update state, then reports navigation errors itself.
+_setting_src: bool = false,
 _window: ?*Window = null,
 
 pub fn asElement(self: *IFrame) *Element {
@@ -66,13 +70,41 @@ pub fn getSrc(self: *IFrame, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *IFrame, src: []const u8, frame: *Frame) !void {
-    const element = self.asElement();
-    try element.setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
-    self._src = element.getAttributeSafe(comptime .wrap("src")) orelse unreachable;
-    if (element.asNode().isConnected()) {
-        // unlike script, an iframe is reloaded every time the src is set
-        // even if it's set to the same URL.
-        self._executed = false;
+    const was_setting_src = self._setting_src;
+    self._setting_src = true;
+    defer self._setting_src = was_setting_src;
+
+    try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
+    if (!was_setting_src) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn srcAttributeChanged(self: *IFrame, frame: *Frame) !void {
+    self._src = self.asElement().getAttributeSafe(comptime .wrap("src")) orelse "";
+    self._executed = false;
+    if (!self._setting_src) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn srcAttributeRemoved(self: *IFrame, frame: *Frame) !void {
+    const was_blank = self._src.len == 0;
+    self._src = "";
+    if (was_blank and self.asNode().isConnected()) {
+        return;
+    }
+
+    self._executed = false;
+    if (!was_blank) {
+        try self.navigateForSrcChange(frame);
+    }
+}
+
+fn navigateForSrcChange(self: *IFrame, frame: *Frame) !void {
+    if (self.asNode().isConnected()) {
+        // Unlike script, an iframe is reloaded every time src is set,
+        // even if it is set to the same URL.
         try frame.iframeAddedCallback(self);
     }
 }
@@ -114,5 +146,21 @@ pub const Build = struct {
         const self = node.as(IFrame);
         const element = self.asElement();
         self._src = element.getAttributeSafe(comptime .wrap("src")) orelse "";
+    }
+
+    pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+
+        try element.as(IFrame).srcAttributeChanged(frame);
+    }
+
+    pub fn attributeRemove(element: *Element, name: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+
+        try element.as(IFrame).srcAttributeRemoved(frame);
     }
 };


### PR DESCRIPTION
## Summary

- navigate connected iframes when `src` changes through the generic attribute API
- run post-fragment ready work for connected `innerHTML` content
- include closed shadow-root descendants when a detached host becomes connected
- keep the readiness walk iterative for deeply nested documents

This fixes standards-based dynamic widgets that create a frame in a detached shadow tree and connect the host afterward.

## Tests

- `make test F="WebApi: Frames"` — 1/1 passed
- `make test` — 1125/1125 passed
- tracked Zig formatting and `git diff --check` passed