### PR TITLE
stability: block V8 re-entry after requested termination

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -322,7 +322,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
 
             // Inline handlers (e.g. onclick property) follow the same "report,
             // don't propagate" rule as addEventListener listeners — see Listener.run.
-            var caught: js.TryCatch.Caught = undefined;
+            var caught: js.TryCatch.Caught = .{};
             const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, target_et, .{event}, &caught) catch |err| ret: {
                 if (err == error.ExecutionTerminated) {
                     return error.ExecutionTerminated;
@@ -382,7 +382,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                     event._target = getAdjustedTarget(original_target, current_target);
                 }
 
-                var caught: js.TryCatch.Caught = undefined;
+                var caught: js.TryCatch.Caught = .{};
                 const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, current_target, .{event}, &caught) catch |err| ret: {
                     if (err == error.ExecutionTerminated) {
                         return error.ExecutionTerminated;

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -287,7 +287,7 @@ pub fn dispatchDirect(
     // Call the property handler (e.g., onmessage) if present
     if (getFunction(handler, &ls.local)) |func| {
         event._current_target = target;
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         _ = func.tryCallWithThis(void, target, .{event}, &caught) catch |err| {
             if (err == error.ExecutionTerminated) {
                 return error.ExecutionTerminated;

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -962,7 +962,7 @@ pub const Script = struct {
             log.debug(.browser, "executed script", .{ .src = url, .success = success });
         }
 
-        if (!success and frame.js.env.isExecutionTerminating()) {
+        if (!success and frame.js.env.terminatePending()) {
             return;
         }
 

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -860,7 +860,7 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
                     frame.document._throw_on_dynamic_markup_insertion_counter -= 1;
                 };
 
-                var caught: JS.TryCatch.Caught = undefined;
+                var caught: JS.TryCatch.Caught = .{};
                 _ = ls.toLocal(def.constructor).newInstance(&caught) catch |err| {
                     log.warn(.js, "custom element constructor", .{ .name = name, .err = err, .caught = caught, .type = frame._type, .url = frame.url });
                     return node;

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -544,13 +544,11 @@ pub fn dumpMemoryStats(self: *Env) void {
 }
 
 pub fn isExecutionTerminating(self: *const Env) bool {
-    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle);
+    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending();
 }
 
-// Whether a forcible terminate has been requested (and not yet cleared by
-// cancelTerminate). Unlike isExecutionTerminating, this is our own sticky
-// flag, so it stays true after V8 consumes the terminate on the JSEntry
-// unwind. Callers about to enter a fresh eval use it to refuse to run.
+// Our sticky terminate flag remains true after V8 consumes the request while
+// unwinding a JSEntry. isExecutionTerminating includes it to block fresh work.
 pub fn terminatePending(self: *const Env) bool {
     return self.terminate_requested.load(.acquire);
 }
@@ -632,7 +630,7 @@ pub fn cancelTerminate(self: *Env) void {
 pub fn performIsolateMicrotasks(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
-    if (v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle)) return;
+    if (self.isExecutionTerminating()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
 }
 

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -412,10 +412,7 @@ pub fn runMicrotasks(self: *Env) void {
 
         const v8_isolate = self.isolate.handle;
 
-        // terminatePending: once a forcible terminate is requested (and not
-        // canceled), refuse to start new work — IsExecutionTerminating alone
-        // goes false again as soon as the killed script finishes unwinding.
-        if (v8.v8__Isolate__IsExecutionTerminating(v8_isolate) or self.terminatePending()) {
+        if (self.terminatePending()) {
             return;
         }
 
@@ -433,7 +430,7 @@ pub fn runMicrotasks(self: *Env) void {
 }
 
 pub fn runMacrotasks(self: *Env) !void {
-    if (v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending()) {
+    if (self.terminatePending()) {
         return;
     }
 
@@ -543,12 +540,11 @@ pub fn dumpMemoryStats(self: *Env) void {
     , .{ stats.total_heap_size, stats.total_heap_size_executable, stats.total_physical_size, stats.total_available_size, stats.used_heap_size, stats.heap_size_limit, stats.malloced_memory, stats.external_memory, stats.peak_malloced_memory, stats.number_of_native_contexts, stats.number_of_detached_contexts, stats.total_global_handles_size, stats.used_global_handles_size, stats.does_zap_garbage });
 }
 
-pub fn isExecutionTerminating(self: *const Env) bool {
-    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending();
-}
-
-// Our sticky terminate flag remains true after V8 consumes the request while
-// unwinding a JSEntry. isExecutionTerminating includes it to block fresh work.
+// The single "must not run JS" predicate. We're the only ones who ever call
+// TerminateExecution (here and in terminateInterrupt) and both set this flag,
+// so it's always at least as true as v8__Isolate__IsExecutionTerminating —
+// and it stays true after V8 consumes the terminate on the JSEntry unwind,
+// which is what stops a fresh eval from re-entering mid-teardown.
 pub fn terminatePending(self: *const Env) bool {
     return self.terminate_requested.load(.acquire);
 }
@@ -556,6 +552,7 @@ pub fn terminatePending(self: *const Env) bool {
 pub fn terminate(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
+    self.terminate_requested.store(true, .release);
     v8.v8__Isolate__TerminateExecution(self.isolate.handle);
 }
 
@@ -630,7 +627,7 @@ pub fn cancelTerminate(self: *Env) void {
 pub fn performIsolateMicrotasks(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
-    if (self.isExecutionTerminating()) return;
+    if (self.terminatePending()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
 }
 

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -66,7 +66,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     }
 
     // See _tryCallWithThis for why a pending termination blocks V8 entry.
-    if (local.ctx.env.isExecutionTerminating()) {
+    if (local.ctx.env.terminatePending()) {
         return error.ExecutionTerminated;
     }
 
@@ -77,7 +77,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     // This creates a new instance using this Function as a constructor.
     // const c_args = @as(?[*]const ?*c.Value, @ptrCast(&.{}));
     const handle = v8.v8__Function__NewInstance(self.handle, local.handle, 0, null) orelse {
-        if (local.ctx.env.isExecutionTerminating()) {
+        if (local.ctx.env.terminatePending()) {
             return error.ExecutionTerminated;
         }
         caught.* = try_catch.caughtOrError(local.call_arena, error.Unknown);
@@ -91,7 +91,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
 }
 
 pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, self.getThis(), args, &caught, .{}) catch |err| {
         log.warn(.js, "call caught", .{ .err = err, .caught = caught });
         return err;
@@ -99,7 +99,7 @@ pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
 }
 
 pub fn callRethrow(self: *const Function, comptime T: type, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, self.getThis(), args, &caught, .{ .rethrow = true }) catch |err| {
         if (err != error.TryCatchRethrow) {
             // error.TryCatchRethrow is a control flow (sorry!), not an actual
@@ -111,7 +111,7 @@ pub fn callRethrow(self: *const Function, comptime T: type, args: anytype) !T {
 }
 
 pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, this, args, &caught, .{}) catch |err| {
         log.warn(.js, "callWithThis caught", .{ .err = err, .caught = caught });
         return err;
@@ -122,7 +122,7 @@ pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args
 // TryCatch, so an enclosing TryCatch of the caller can observe the exception
 // value itself (e.g. to report it to window.onerror).
 pub fn callWithThisRethrow(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, this, args, &caught, .{ .rethrow = true });
 }
 
@@ -138,7 +138,6 @@ const CallOpts = struct {
     rethrow: bool = false,
 };
 fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype, caught: *js.TryCatch.Caught, comptime opts: CallOpts) !T {
-    caught.* = .{};
     const local = self.local;
 
     if (comptime lp.IS_DEBUG == false) {
@@ -158,7 +157,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     // A pending termination (watchdog / CDP-disconnect kill) must not be
     // followed by another V8 entry. Callers must treat ExecutionTerminated as
     // stop running JS and unwind".
-    if (local.ctx.env.isExecutionTerminating()) {
+    if (local.ctx.env.terminatePending()) {
         return error.ExecutionTerminated;
     }
 
@@ -212,7 +211,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     defer try_catch.deinit();
 
     const handle = v8.v8__Function__Call(self.handle, local.handle, js_this.handle, @as(c_int, @intCast(js_args.len)), c_args) orelse {
-        if (local.ctx.env.isExecutionTerminating()) {
+        if (local.ctx.env.terminatePending()) {
             // Terminated mid-call, not a JS throw: no rethrow, no reporting.
             return error.ExecutionTerminated;
         }
@@ -284,6 +283,7 @@ test "Function: requested termination is classified and blocks re-entry" {
         probe_ran: bool = false,
         kill_err: ?anyerror = null,
         probe_err: ?anyerror = null,
+        nested_probe_err: ?anyerror = null,
 
         fn kill(self: *@This()) void {
             self.env.requestTerminate();
@@ -293,10 +293,16 @@ test "Function: requested termination is classified and blocks re-entry" {
             self.probe_ran = true;
         }
 
+        // Runs at call depth >= 1: the killed inner call must leave the
+        // termination pending, and the follow-up call must refuse to enter V8
+        // (running it would silently clear the pending termination).
         fn nested(self: *@This()) void {
-            var caught: js.TryCatch.Caught = undefined;
+            var caught: js.TryCatch.Caught = .{};
             _ = self.f_kill.?.tryCall(void, .{}, &caught) catch |err| {
                 self.kill_err = err;
+            };
+            _ = self.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
+                self.nested_probe_err = err;
             };
         }
     };
@@ -313,9 +319,10 @@ test "Function: requested termination is classified and blocks re-entry" {
     const driver = try local.exec("(function(n){ n(); })", null);
     const driver_fn = Function{ .local = local, .handle = @ptrCast(driver.handle) };
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, .{nested_cb}, &caught));
     try testing.expectEqual(error.ExecutionTerminated, state.kill_err.?);
+    try testing.expectEqual(error.ExecutionTerminated, state.nested_probe_err.?);
     try testing.expectEqual(true, env.terminatePending());
     try testing.expectEqual(false, v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
 

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -66,7 +66,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     }
 
     // See _tryCallWithThis for why a pending termination blocks V8 entry.
-    if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+    if (local.ctx.env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
 
@@ -77,7 +77,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     // This creates a new instance using this Function as a constructor.
     // const c_args = @as(?[*]const ?*c.Value, @ptrCast(&.{}));
     const handle = v8.v8__Function__NewInstance(self.handle, local.handle, 0, null) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+        if (local.ctx.env.isExecutionTerminating()) {
             return error.ExecutionTerminated;
         }
         caught.* = try_catch.caughtOrError(local.call_arena, error.Unknown);
@@ -158,7 +158,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     // A pending termination (watchdog / CDP-disconnect kill) must not be
     // followed by another V8 entry. Callers must treat ExecutionTerminated as
     // stop running JS and unwind".
-    if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+    if (local.ctx.env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
 
@@ -212,7 +212,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     defer try_catch.deinit();
 
     const handle = v8.v8__Function__Call(self.handle, local.handle, js_this.handle, @as(c_int, @intCast(js_args.len)), c_args) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+        if (local.ctx.env.isExecutionTerminating()) {
             // Terminated mid-call, not a JS throw: no rethrow, no reporting.
             return error.ExecutionTerminated;
         }
@@ -265,7 +265,7 @@ pub fn persistWithThis(self: *const Function, value: anytype) !Global {
 }
 
 const testing = @import("../../testing.zig");
-test "Function: termination is classified and blocks re-entry" {
+test "Function: requested termination is classified and blocks re-entry" {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();
 
@@ -286,23 +286,17 @@ test "Function: termination is classified and blocks re-entry" {
         probe_err: ?anyerror = null,
 
         fn kill(self: *@This()) void {
-            self.env.terminate();
+            self.env.requestTerminate();
         }
 
         fn probed(self: *@This()) void {
             self.probe_ran = true;
         }
 
-        // Runs at call depth >= 1: the killed inner call must leave the
-        // termination pending, and the follow-up call must refuse to enter V8
-        // (running it would silently clear the pending termination).
         fn nested(self: *@This()) void {
             var caught: js.TryCatch.Caught = undefined;
             _ = self.f_kill.?.tryCall(void, .{}, &caught) catch |err| {
                 self.kill_err = err;
-            };
-            _ = self.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
-                self.probe_err = err;
             };
         }
     };
@@ -322,6 +316,12 @@ test "Function: termination is classified and blocks re-entry" {
     var caught: js.TryCatch.Caught = undefined;
     try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, .{nested_cb}, &caught));
     try testing.expectEqual(error.ExecutionTerminated, state.kill_err.?);
+    try testing.expectEqual(true, env.terminatePending());
+    try testing.expectEqual(false, v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
+
+    _ = state.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
+        state.probe_err = err;
+    };
     try testing.expectEqual(error.ExecutionTerminated, state.probe_err.?);
     try testing.expectEqual(false, state.probe_ran);
 

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -32,12 +32,12 @@ handle: *const v8.Script,
 pub fn run(self: Script) !js.Value {
     // See Function._tryCallWithThis for why a pending termination blocks V8
     // entry and is distinct from a JS throw.
-    const isolate_handle = self.local.isolate.handle;
-    if (v8.v8__Isolate__IsExecutionTerminating(isolate_handle)) {
+    const env = self.local.ctx.env;
+    if (env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
     const result = v8.v8__Script__Run(self.handle, self.local.handle) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(isolate_handle)) {
+        if (env.isExecutionTerminating()) {
             return error.ExecutionTerminated;
         }
         return error.JsException;

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -33,11 +33,11 @@ pub fn run(self: Script) !js.Value {
     // See Function._tryCallWithThis for why a pending termination blocks V8
     // entry and is distinct from a JS throw.
     const env = self.local.ctx.env;
-    if (env.isExecutionTerminating()) {
+    if (env.terminatePending()) {
         return error.ExecutionTerminated;
     }
     const result = v8.v8__Script__Run(self.handle, self.local.handle) orelse {
-        if (env.isExecutionTerminating()) {
+        if (env.terminatePending()) {
             return error.ExecutionTerminated;
         }
         return error.JsException;

--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -205,7 +205,7 @@ pub fn upgradeCustomElement(custom: *Custom, definition: *CustomElementDefinitio
     frame.js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     _ = ls.toLocal(definition.constructor).newInstance(&caught) catch |err| {
         log.warn(.js, "custom element upgrade", .{ .name = definition.name, .err = err, .caught = caught });
         return error.CustomElementUpgradeFailed;

--- a/src/browser/webapi/DataTransferItem.zig
+++ b/src/browser/webapi/DataTransferItem.zig
@@ -81,7 +81,7 @@ pub fn getAsString(self: *const DataTransferItem, cb_: ?js.Function) !void {
         .string => |str| str,
         .file => return,
     };
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     cb.tryCall(void, .{s}, &caught) catch {
         log.debug(.js, "getAsString callback", .{ .caught = caught, .source = "DataTransferItem" });
     };

--- a/src/browser/webapi/EventCounts.zig
+++ b/src/browser/webapi/EventCounts.zig
@@ -116,7 +116,7 @@ pub fn forEach(self: *EventCounts, cb_: js.Function, js_this_: ?js.Object) !void
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
     for (tracked_event_types, self._counts) |event_type, count| {
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ count, event_type, self }, &caught) catch {
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "EventCounts" });
         };

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -302,7 +302,7 @@ pub fn deliverEntries(self: *IntersectionObserver, frame: *Frame) !void {
     }
 
     const entries = try self.takeRecords(frame);
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/webapi/ModelContext.zig
+++ b/src/browser/webapi/ModelContext.zig
@@ -195,7 +195,7 @@ pub const ModelContextClient = struct {
         defer ls.deinit();
         const resolver = ls.local.createPromiseResolver();
 
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         if (callback.tryCall(js.Value, .{}, &caught)) |result| {
             // The callback may itself return a thenable; resolving with its
             // value lets V8's promise resolution machinery unwrap it.

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -348,7 +348,7 @@ pub fn deliverRecords(self: *MutationObserver, frame: *Frame) !void {
     frame.js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     ls.toLocal(self._callback).tryCallWithThis(void, self, .{ records, self }, &caught) catch |err| {
         log.err(.frame, "MutObserver.deliverRecords", .{ .err = err, .caught = caught });
         return err;

--- a/src/browser/webapi/PerformanceObserver.zig
+++ b/src/browser/webapi/PerformanceObserver.zig
@@ -181,7 +181,7 @@ pub fn dispatch(self: *PerformanceObserver) !void {
     self._js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     ls.toLocal(self._callback).tryCall(void, .{ EntryList{ ._entries = records }, self }, &caught) catch |err| {
         log.err(.frame, "PerfObserver.dispatch", .{ .err = err, .caught = caught });
         return err;

--- a/src/browser/webapi/ResizeObserver.zig
+++ b/src/browser/webapi/ResizeObserver.zig
@@ -183,7 +183,7 @@ pub fn deliverEntries(self: *ResizeObserver, frame: *Frame) !void {
         return;
     }
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/webapi/collections/DOMTokenList.zig
+++ b/src/browser/webapi/collections/DOMTokenList.zig
@@ -246,7 +246,7 @@ pub fn forEach(self: *DOMTokenList, cb_: js.Function, js_this_: ?js.Object, fram
         if (gop.found_existing) {
             continue;
         }
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ token, i, self }, &caught) catch |err| {
             frame._page.recordJsError(err);
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "DOMTokenList" });

--- a/src/browser/webapi/collections/NodeList.zig
+++ b/src/browser/webapi/collections/NodeList.zig
@@ -97,7 +97,7 @@ pub fn forEach(self: *NodeList, cb: js.Function, frame: *Frame) !void {
     while (true) : (i += 1) {
         const node = try self.getAtIndex(@intCast(i), frame) orelse return;
 
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ node, i, self }, &caught) catch |err| {
             frame._page.recordJsError(err);
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "nodelist" });

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -278,7 +278,7 @@ pub fn checkAndAttachBuiltIn(element: *Element, frame: *Frame) !void {
         _ls.deinit();
     };
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     _ = local.toLocal(definition.constructor).newInstance(&caught) catch |err| {
         log.warn(.js, "custom builtin ctor", .{ .name = is_value, .err = err, .caught = caught });
         return;

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -91,7 +91,7 @@ pub fn forEach(self: *Headers, cb_: js.Function, js_this_: ?js.Object) !void {
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
     for (self._list._entries.items) |entry| {
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ entry.value.str(), entry.name.str(), self }, &caught) catch {
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "headers" });
         };

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -193,7 +193,7 @@ pub fn terminateFromNetwork(self: *CDP) void {
 // valid for the duration of dispatch.
 pub fn onMessage(self: *CDP, c: *Inbox.Message.Cdp) anyerror!void {
     // Once a terminate is pending, don't dispatch
-    if (self.browser.env.isExecutionTerminating()) {
+    if (self.browser.env.terminatePending()) {
         return;
     }
 

--- a/src/cdp/domains/webmcp.zig
+++ b/src/cdp/domains/webmcp.zig
@@ -141,7 +141,7 @@ fn invokeTool(cmd: *CDP.Command) !void {
 
     const callback = local.toLocal(tool.execute);
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     const result = callback.tryCall(js.Value, .{ input_value, ModelContextClient{} }, &caught) catch {
         const msg = caught.exception orelse "tool threw";
         try respondError(cmd.cdp, bc, invocation, msg);


### PR DESCRIPTION
## Summary

Treat Lightpanda's sticky `terminate_requested` flag as part of `Env.isExecutionTerminating()`, and use that combined state at the function, constructor, script, and isolate-microtask V8 entry gates.

`v8::Isolate::IsExecutionTerminating()` becomes false after V8 consumes a requested termination while unwinding its `JSEntry`. The Lightpanda request remains pending, but the previous guards then allowed a subsequent callback or eval to re-enter V8 before the CDP worker unwound. On a production-observed custom-element clone workload, that ended in SIGSEGV immediately after `watchdog stall` and `ExecutionTerminated`.

## Reproduction

On current `main`, I reproduced this with `--watchdog-ms 30000` by loading:

```
https://mf5ai1-cc.myshopify.com/products/ultimate-blue-raspberry-cyborg-ii-for-lefties-bundle?_fd=0
```

and evaluating:

```js
document.documentElement.cloneNode(true).outerHTML.length
```

The clone repeatedly invokes custom-element constructors until the watchdog fires. Current `main` logs `watchdog stall`, then `ExecutionTerminated`, and exits with SIGSEGV/139.

The updated unit test isolates the same state transition without network access: it requests termination, lets the V8 termination state clear during unwind, verifies Lightpanda's sticky request remains set, and attempts another function call. Before this change the probe enters V8 and the assertion fails; after this change it returns `ExecutionTerminated` without running.

With this patch, the live reproduction returns `Execution was terminated`, the server stays alive, and a subsequent CDP context successfully loads `https://example.com`.

## Checks

- `make test` (1125 tests)
- `zig fmt --check ./*.zig ./**/*.zig`
- Release build live watchdog reproduction followed by a successful new context
