### PR TITLE
mem: prefer ensureTotalCapacityPrecise to reduce memory usage

### DIFF
--- a/src/browser/Mime.zig
+++ b/src/browser/Mime.zig
@@ -550,7 +550,7 @@ pub fn serialize(arena: Allocator, input: []const u8) ![]const u8 {
 
     // The serialized output is the input length plus quoting overhead; reserve
     // the input length so the common (no-escape) case appends without growing.
-    try out.ensureTotalCapacity(arena, trimmed.len);
+    try out.ensureTotalCapacityPrecise(arena, trimmed.len);
 
     // Lowercased names already emitted, for first-wins dedupe.
     var seen: std.ArrayList([]const u8) = .empty;

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -760,7 +760,7 @@ pub const Script = struct {
 
         var buffer: std.ArrayList(u8) = .empty;
         if (content_length) |cl| {
-            try buffer.ensureTotalCapacity(self.sourceAllocator(), cl);
+            try buffer.ensureTotalCapacityPrecise(self.sourceAllocator(), cl);
         }
         self.source = .{ .remote = buffer };
         return .proceed;

--- a/src/browser/URL.zig
+++ b/src/browser/URL.zig
@@ -579,7 +579,7 @@ pub fn concatQueryString(arena: Allocator, url: []const u8, query_string: []cons
     var buf: std.ArrayList(u8) = .empty;
 
     // the most space well need is the url + ('?' or '&') + the query_string + null terminator
-    try buf.ensureTotalCapacity(arena, url.len + 2 + query_string.len);
+    try buf.ensureTotalCapacityPrecise(arena, url.len + 2 + query_string.len);
     buf.appendSliceAssumeCapacity(url);
 
     if (std.mem.indexOfScalar(u8, url, '?')) |index| {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -2170,7 +2170,7 @@ pub fn reverseSubstituteEnvVars(arena: std.mem.Allocator, input: []const u8) err
     // before its full match is found, leaking a suffix into the recording.
     const Pair = struct { name: []const u8, value: []const u8 };
     var pairs: std.ArrayList(Pair) = .empty;
-    try pairs.ensureTotalCapacity(arena, env_names.len);
+    try pairs.ensureTotalCapacityPrecise(arena, env_names.len);
     for (env_names) |name| {
         const value = lookupLpEnv(name) orelse continue;
         if (value.len < 4) continue;

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -119,7 +119,7 @@ pub fn getTitle(self: *HTMLDocument, frame: *Frame) ![]const u8 {
     var started = false;
     var in_whitespace = false;
     var result: std.ArrayList(u8) = .empty;
-    try result.ensureTotalCapacity(frame.local_arena, text.len);
+    try result.ensureTotalCapacityPrecise(frame.local_arena, text.len);
 
     for (text) |c| {
         const is_ascii_ws = c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == '\x0C';

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -100,7 +100,7 @@ pub fn init() KeyValueList {
 }
 
 pub fn ensureTotalCapacity(self: *KeyValueList, allocator: Allocator, n: usize) !void {
-    return self._entries.ensureTotalCapacity(allocator, n);
+    return self._entries.ensureTotalCapacityPrecise(allocator, n);
 }
 
 pub fn get(self: *const KeyValueList, name: []const u8) ?[]const u8 {

--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -212,7 +212,7 @@ fn httpHeaderCallback(transfer: *Transfer) !Transfer.HeaderResult {
     }
 
     if (transfer.getContentLength()) |cl| {
-        try self._script_buffer.ensureTotalCapacity(self._script_arena.?.allocator(), cl);
+        try self._script_buffer.ensureTotalCapacityPrecise(self._script_arena.?.allocator(), cl);
     }
 
     return .proceed;

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -170,7 +170,7 @@ fn httpHeaderCallback(transfer: *Transfer) !Transfer.HeaderResult {
     }
 
     if (transfer.getContentLength()) |cl| {
-        try self._script_buffer.ensureTotalCapacity(self._script_arena.?.allocator(), cl);
+        try self._script_buffer.ensureTotalCapacityPrecise(self._script_arena.?.allocator(), cl);
     }
 
     return .proceed;

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -353,7 +353,7 @@ pub const List = struct {
 
     pub fn getNames(self: *const List, allocator: Allocator) ![][]const u8 {
         var arr: std.ArrayList([]const u8) = .empty;
-        try arr.ensureTotalCapacity(allocator, self._len);
+        try arr.ensureTotalCapacityPrecise(allocator, self._len);
         for (self.entries()) |*e| {
             arr.appendAssumeCapacity(e.name());
         }

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -81,7 +81,7 @@ fn camelToKebab(arena: Allocator, camel: String) !String {
 
     // Fallback: allocate for longer strings
     var result: std.ArrayList(u8) = .empty;
-    try result.ensureTotalCapacity(arena, output_len);
+    try result.ensureTotalCapacityPrecise(arena, output_len);
     result.appendSliceAssumeCapacity("data-");
 
     for (camel_str, 0..) |c, i| {
@@ -110,7 +110,7 @@ fn kebabToCamel(arena: Allocator, kebab: []const u8) !?[]const u8 {
     const data_part = kebab[5..]; // Skip "data-"
 
     var result: std.ArrayList(u8) = .empty;
-    try result.ensureTotalCapacity(arena, data_part.len);
+    try result.ensureTotalCapacityPrecise(arena, data_part.len);
 
     var i: usize = 0;
     while (i < data_part.len) : (i += 1) {

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -152,7 +152,7 @@ fn httpHeaderDoneCallback(transfer: *Transfer) !Transfer.HeaderResult {
 
     const arena = self._response._arena;
     if (transfer.getContentLength()) |cl| {
-        try self._buf.ensureTotalCapacity(arena.allocator(), cl);
+        try self._buf.ensureTotalCapacityPrecise(arena.allocator(), cl);
     }
 
     const res = self._response;

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -901,7 +901,7 @@ fn _receivedDataCallback(conn: *http.Connection, data: []const u8) !void {
         if (meta.len > self._http_client.max_response_size) {
             return error.MessageTooLarge;
         }
-        try self._recv_buffer.ensureTotalCapacity(self._arena.allocator(), meta.len);
+        try self._recv_buffer.ensureTotalCapacityPrecise(self._arena.allocator(), meta.len);
     }
 
     try self._recv_buffer.appendSlice(self._arena.allocator(), data);

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -541,7 +541,7 @@ fn httpHeaderDoneCallback(transfer: *Transfer) !Transfer.HeaderResult {
     self._response_status = transfer.responseStatus().?;
     if (transfer.getContentLength()) |cl| {
         self._response_len = cl;
-        try self._response_data.ensureTotalCapacity(self._arena.allocator(), cl);
+        try self._response_data.ensureTotalCapacityPrecise(self._arena.allocator(), cl);
     }
     self._response_url = try self._arena.dupeZ(u8, transfer.req.url);
 

--- a/src/browser/webapi/svg/reflected_list.zig
+++ b/src/browser/webapi/svg/reflected_list.zig
@@ -175,7 +175,7 @@ pub fn Mixin(comptime List: type, comptime Item: type, comptime hooks: anytype) 
             self._snapshot.clearRetainingCapacity();
             try self._snapshot.appendSlice(frame.arena, raw);
             try retireAll(self, frame);
-            try self._items.ensureTotalCapacity(frame.arena, parsed.items.len);
+            try self._items.ensureTotalCapacityPrecise(frame.arena, parsed.items.len);
             for (parsed.items) |item| {
                 self._items.appendAssumeCapacity(item);
                 hooks.attach(self, item);

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -1110,7 +1110,7 @@ pub const BrowserContext = struct {
         const message_len = msg.len + session_id.len + 1 + field.len + 10;
 
         var buf: std.ArrayList(u8) = .empty;
-        buf.ensureTotalCapacity(allocator, message_len) catch |err| {
+        buf.ensureTotalCapacityPrecise(allocator, message_len) catch |err| {
             log.err(.cdp, "inspector buffer", .{ .err = err });
             return;
         };

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -1071,7 +1071,7 @@ const SyncContext = struct {
         lp.assert(transfer.responseStatus() != null, "HttpClient.SyncRequest.headerCallback", .{ .value = transfer.responseStatus() });
         self.status = transfer.responseStatus().?;
         if (transfer.getContentLength()) |cl| {
-            try self.body.ensureTotalCapacity(try self.bodyAllocator(cl), cl);
+            try self.body.ensureTotalCapacityPrecise(try self.bodyAllocator(cl), cl);
         }
         return .proceed;
     }
@@ -2761,7 +2761,7 @@ pub const Transfer = struct {
                     res.callback_error = error.ResponseTooLarge;
                     return http.writefunc_error;
                 }
-                res.buffer.ensureTotalCapacity(transfer.arena.allocator(), cl) catch {};
+                res.buffer.ensureTotalCapacityPrecise(transfer.arena.allocator(), cl) catch {};
             }
         }
 

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -214,7 +214,7 @@ const RobotsContext = struct {
         }
         lp.metrics.robots_status.incr(http.statusCategory(self.status));
         if (transfer.getContentLength()) |cl| {
-            try self.buffer.ensureTotalCapacity(self.arena.allocator(), cl);
+            try self.buffer.ensureTotalCapacityPrecise(self.arena.allocator(), cl);
         }
         return .proceed;
     }

--- a/src/script/Schema.zig
+++ b/src/script/Schema.zig
@@ -482,7 +482,7 @@ fn enumValuesOf(arena: std.mem.Allocator, value: std.json.Value) ![]const []cons
 fn jsonStringArray(arena: std.mem.Allocator, value: std.json.Value) ![]const []const u8 {
     if (value != .array) return &.{};
     var out: std.ArrayList([]const u8) = .empty;
-    try out.ensureTotalCapacity(arena, value.array.items.len);
+    try out.ensureTotalCapacityPrecise(arena, value.array.items.len);
     for (value.array.items) |item| {
         if (item != .string) continue;
         out.appendAssumeCapacity(item.string);


### PR DESCRIPTION
When we know the precise final length, prefer ensureTotalCapacityPrecise over ensureTotalCapacity. The latter goes through `growCapacity` which will allocate ~1.5x padding.