### PR TITLE
goto: optional waitUntil + dcl-gated selector waits

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1155,11 +1155,7 @@ fn handleSave(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
         null;
     defer if (new_save_path) |p| self.allocator.free(p);
 
-    const recorded = self.save_buffer.bytes() catch |err| {
-        self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
-        return;
-    };
-    save.writeContentFile(path, recorded, mode) catch |err| {
+    save.writeContentFile(path, self.save_buffer.bytes(), mode) catch |err| {
         self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
         return;
     };
@@ -1229,7 +1225,7 @@ fn bumpedEffort(effort: Config.Effort) Config.Effort {
 fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8, prompt: ?[]const u8) void {
     // With nothing recorded and no prompt, a re-synthesis has nothing to act
     // on — it would just re-roll the previous output.
-    if (self.save_buffer.isEmpty() and prompt == null) {
+    if (self.save_buffer.bytes().len == 0 and prompt == null) {
         if (self.save_path) |saved| {
             self.terminal.printWarning("nothing ran since the last save; run more commands or give a prompt to revise {s}, e.g. /save <what to change>", .{saved});
         } else {
@@ -1356,7 +1352,7 @@ fn buildSaveSynthesisMessage(self: *Agent, arena: std.mem.Allocator, path: []con
         try w.print("\nThe previously saved script in {s}, the base you are revising:\n", .{path});
         try w.writeAll(script);
     }
-    const recorded = try self.save_buffer.bytes();
+    const recorded = self.save_buffer.bytes();
     if (recorded.len > 0) {
         const since: []const u8 = if (previous_script != null) " since the last save" else " this session";
         try w.print("\nCommands and JS that actually ran{s}:\n", .{since});

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1155,7 +1155,11 @@ fn handleSave(self: *Agent, arena: std.mem.Allocator, rest: []const u8) void {
         null;
     defer if (new_save_path) |p| self.allocator.free(p);
 
-    save.writeContentFile(path, self.save_buffer.bytes(), mode) catch |err| {
+    const recorded = self.save_buffer.bytes() catch |err| {
+        self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
+        return;
+    };
+    save.writeContentFile(path, recorded, mode) catch |err| {
         self.terminal.printError("failed to save {s}: {s}", .{ path, @errorName(err) });
         return;
     };
@@ -1225,7 +1229,7 @@ fn bumpedEffort(effort: Config.Effort) Config.Effort {
 fn synthesizeSave(self: *Agent, arena: std.mem.Allocator, filename: ?[]const u8, prompt: ?[]const u8) void {
     // With nothing recorded and no prompt, a re-synthesis has nothing to act
     // on — it would just re-roll the previous output.
-    if (self.save_buffer.bytes().len == 0 and prompt == null) {
+    if (self.save_buffer.isEmpty() and prompt == null) {
         if (self.save_path) |saved| {
             self.terminal.printWarning("nothing ran since the last save; run more commands or give a prompt to revise {s}, e.g. /save <what to change>", .{saved});
         } else {
@@ -1352,7 +1356,7 @@ fn buildSaveSynthesisMessage(self: *Agent, arena: std.mem.Allocator, path: []con
         try w.print("\nThe previously saved script in {s}, the base you are revising:\n", .{path});
         try w.writeAll(script);
     }
-    const recorded = self.save_buffer.bytes();
+    const recorded = try self.save_buffer.bytes();
     if (recorded.len > 0) {
         const since: []const u8 = if (previous_script != null) " since the last save" else " this session";
         try w.print("\nCommands and JS that actually ran{s}:\n", .{since});

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -276,7 +276,10 @@ fn remainingMs(timeout_ms: u32, timer: std.Io.Timestamp) u32 {
 pub fn waitForSelector(selector: [:0]const u8, timeout_ms: u32, frame_id: u32, session: *Session) !*DOMNode {
     const timer: std.Io.Timestamp = .now(lp.io, .boot);
     var runner = session.runner(.{});
-    try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .load });
+    // Only parsing has to be done before polling — gating on `.load` would
+    // re-wait for the late-script tail a `waitUntil: domcontentloaded`
+    // navigation deliberately skipped (#3138).
+    try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .domcontentloaded });
 
     const el = try runner.waitForSelector(frame_id, selector, remainingMs(timeout_ms, timer));
     return el.asNode();
@@ -285,7 +288,7 @@ pub fn waitForSelector(selector: [:0]const u8, timeout_ms: u32, frame_id: u32, s
 pub fn waitForScript(script: [:0]const u8, timeout_ms: u32, frame_id: u32, session: *Session) !void {
     const timer: std.Io.Timestamp = .now(lp.io, .boot);
     var runner = session.runner(.{});
-    try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .load });
+    try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .domcontentloaded });
 
     return runner.waitForScript(frame_id, script, remainingMs(timeout_ms, timer));
 }

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -278,7 +278,7 @@ pub fn waitForSelector(selector: [:0]const u8, timeout_ms: u32, frame_id: u32, s
     var runner = session.runner(.{});
     // Polling needs a parsed document, nothing more. Gating on `.load` would
     // re-wait the late-script tail a `waitUntil: domcontentloaded` navigation
-    // deliberately skipped (#3138).
+    // deliberately skipped.
     try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .domcontentloaded });
 
     const el = try runner.waitForSelector(frame_id, selector, remainingMs(timeout_ms, timer));

--- a/src/browser/actions.zig
+++ b/src/browser/actions.zig
@@ -276,9 +276,9 @@ fn remainingMs(timeout_ms: u32, timer: std.Io.Timestamp) u32 {
 pub fn waitForSelector(selector: [:0]const u8, timeout_ms: u32, frame_id: u32, session: *Session) !*DOMNode {
     const timer: std.Io.Timestamp = .now(lp.io, .boot);
     var runner = session.runner(.{});
-    // Only parsing has to be done before polling — gating on `.load` would
-    // re-wait for the late-script tail a `waitUntil: domcontentloaded`
-    // navigation deliberately skipped (#3138).
+    // Polling needs a parsed document, nothing more. Gating on `.load` would
+    // re-wait the late-script tail a `waitUntil: domcontentloaded` navigation
+    // deliberately skipped (#3138).
     try runner.waitForFrame(frame_id, timeout_ms, .{ .until = .domcontentloaded });
 
     const el = try runner.waitForSelector(frame_id, selector, remainingMs(timeout_ms, timer));

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -538,7 +538,7 @@ pub const Tool = enum {
                     \\  "type": "object",
                     \\  "properties": {
                     \\    "selector": { "type": "string", "description": "The CSS selector to wait for." },
-                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 5000." }
+                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 5000, or 15000 when the page has not reached 'load' yet." }
                     \\  },
                     \\  "required": ["selector"]
                     \\}
@@ -552,7 +552,7 @@ pub const Tool = enum {
                     \\  "type": "object",
                     \\  "properties": {
                     \\    "script": { "type": "string", "description": "JS expression evaluated each tick until truthy. Must be an expression (not a statement)." },
-                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 5000." }
+                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 5000, or 15000 when the page has not reached 'load' yet." }
                     \\  },
                     \\  "required": ["script"]
                     \\}
@@ -1633,6 +1633,13 @@ fn execScroll(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode
 /// already-loaded page rather than a full navigation (which uses 10000).
 const default_wait_timeout_ms: u32 = 5000;
 
+/// A wait entered before `load` also inherits the nav budget: a post-load
+/// selector keeps the wall time it had when `goto` waited for `load` itself.
+fn defaultWaitTimeout(frame: *const lp.Frame) u32 {
+    if (frame._load_state == .complete) return default_wait_timeout_ms;
+    return default_nav_timeout_ms + default_wait_timeout_ms;
+}
+
 fn execWaitForSelector(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
     const Params = struct {
         selector: [:0]const u8,
@@ -1642,7 +1649,7 @@ fn execWaitForSelector(arena: std.mem.Allocator, session: *lp.Session, registry:
 
     const frame = try requireFrame(session);
 
-    const timeout_ms = args.timeout orelse default_wait_timeout_ms;
+    const timeout_ms = args.timeout orelse defaultWaitTimeout(frame);
 
     const node = lp.actions.waitForSelector(args.selector, timeout_ms, frame._frame_id, session) catch |err| switch (err) {
         error.InvalidSelector => return ToolError.InvalidParams,
@@ -1669,7 +1676,7 @@ fn execWaitForScript(arena: std.mem.Allocator, session: *lp.Session, arguments: 
 
     const frame = try requireFrame(session);
 
-    const timeout_ms = args.timeout orelse default_wait_timeout_ms;
+    const timeout_ms = args.timeout orelse defaultWaitTimeout(frame);
 
     lp.actions.waitForScript(args.script, timeout_ms, frame._frame_id, session) catch |err| switch (err) {
         error.Cancelled => return ToolError.Cancelled,

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -276,10 +276,9 @@ pub const Tool = enum {
         };
     }
 
-    /// Waits for page readiness on its own, making a preceding `goto`'s full
-    /// `load` wait redundant — the recorder downgrades such gotos to
-    /// `domcontentloaded` (#3138). Exhaustive like the sibling predicates so a
-    /// new wait tool makes an explicit choice here.
+    /// Waits for page readiness on its own, letting the recorder downgrade a
+    /// preceding `goto` to `domcontentloaded`. Exhaustive like the sibling
+    /// predicates so a new wait tool makes an explicit choice here.
     pub fn waitsForReadiness(self: Tool) bool {
         return switch (self) {
             .waitForSelector, .waitForScript, .waitForState => true,

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -342,7 +342,7 @@ pub const Tool = enum {
                     \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." },
                     \\    "waitUntil": { "type": "string", "enum":
                 ++ lp.Config.tagJsonArray(lp.Config.WaitUntil) ++
-                    \\, "description": "Event that completes the navigation. Defaults to 'load'. Prefer 'domcontentloaded' followed by waitForSelector on pages whose late scripts (ads) hold 'load' back." }
+                    \\, "description": "Event that completes the navigation. Defaults to 'load'. Prefer 'domcontentloaded' followed by waitForSelector on pages whose late scripts (ads) hold 'load' back. Avoid 'done' (full quiescence): on pages with constant background activity it is the slowest choice and can run to the timeout." }
                     \\  },
                     \\  "required": ["url"]
                     \\}

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1635,7 +1635,8 @@ const default_wait_timeout_ms: u32 = 5000;
 
 /// A wait entered before `load` also inherits the nav budget: a post-load
 /// selector keeps the wall time it had when `goto` waited for `load` itself.
-fn defaultWaitTimeout(frame: *const lp.Frame) u32 {
+/// Shared with CDP's `LP.waitForSelector`, which fronts the same action.
+pub fn defaultWaitTimeout(frame: *const lp.Frame) u32 {
     if (frame._load_state == .complete) return default_wait_timeout_ms;
     return default_nav_timeout_ms + default_wait_timeout_ms;
 }

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -329,7 +329,8 @@ pub const Tool = enum {
                     \\  "type": "object",
                     \\  "properties": {
                     \\    "url": { "type": "string", "description": "The URL to navigate to, must be a valid URL." },
-                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." }
+                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." },
+                    \\    "waitUntil": { "type": "string", "enum": ["load", "domcontentloaded", "networkalmostidle", "networkidle"], "description": "Event that completes the navigation. Defaults to 'load'. Prefer 'domcontentloaded' followed by waitForSelector on pages whose late scripts (ads) hold 'load' back." }
                     \\  },
                     \\  "required": ["url"]
                     \\}
@@ -758,6 +759,7 @@ pub const ToolResult = struct {
 pub const GotoParams = struct {
     url: [:0]const u8,
     timeout: ?u32 = null,
+    waitUntil: ?lp.Config.WaitUntil = null,
 };
 
 pub const UrlParams = struct {
@@ -936,7 +938,7 @@ const schema_walker_suffix = ")";
 
 fn execGoto(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
     const args = try parseArgs(GotoParams, arena, arguments);
-    return switch (try performGoto(session, registry, args.url, args.timeout)) {
+    return switch (try performGoto(session, registry, args.url, args.timeout, args.waitUntil)) {
         .completed => "Navigated successfully.",
         .timeout => "Navigation started but the page did not finish loading before the timeout.",
     };
@@ -988,7 +990,7 @@ fn execSearch(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode
         .{encoded},
         0,
     ) catch return ToolError.OutOfMemory;
-    _ = try performGoto(session, registry, ddg_url, args.timeout);
+    _ = try performGoto(session, registry, ddg_url, args.timeout, null);
     const ddg_frame = try requireFrame(session);
     return .{ .text = try renderFrameMarkdown(arena, ddg_frame) };
 }
@@ -1921,7 +1923,7 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
         if (session.currentFrame()) |frame| {
             if (std.mem.eql(u8, frame.url, u)) return frame;
         }
-        _ = try performGoto(session, registry, u, timeout);
+        _ = try performGoto(session, registry, u, timeout, null);
     }
     return session.currentFrame() orelse ToolError.FrameNotLoaded;
 }
@@ -1937,6 +1939,7 @@ const default_nav_timeout_ms: u32 = 10000;
 pub const StartedGoto = struct {
     frame_id: u32,
     timeout_ms: u32,
+    until: lp.Config.WaitUntil,
 };
 
 /// Open a fresh top-level page and start its navigation. The frame is non-null
@@ -1971,10 +1974,14 @@ pub fn startGoto(
         }
     }
     const page = try openPage(session, args.url);
-    return .{ .frame_id = page.frame_id, .timeout_ms = args.timeout orelse default_nav_timeout_ms };
+    return .{
+        .frame_id = page.frame_id,
+        .timeout_ms = args.timeout orelse default_nav_timeout_ms,
+        .until = args.waitUntil orelse default_nav_wait,
+    };
 }
 
-fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32) ToolError!lp.Session.Runner.WaitResult {
+fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32, wait_until: ?lp.Config.WaitUntil) ToolError!lp.Session.Runner.WaitResult {
     if (session.primaryPage()) |old_page| {
         registry.reset();
         old_page.close();
@@ -1982,7 +1989,7 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
     const page = try openPage(session, url);
 
     var runner = session.runner(.{});
-    const condition = lp.Session.Runner.WaitCondition{ .frame_id = page.frame_id, .until = default_nav_wait };
+    const condition = lp.Session.Runner.WaitCondition{ .frame_id = page.frame_id, .until = wait_until orelse default_nav_wait };
     var conditions = [_]lp.Session.Runner.WaitCondition{condition};
     const result = runner.waitResult(timeout orelse default_nav_timeout_ms, &conditions) catch |err| {
         return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -276,6 +276,17 @@ pub const Tool = enum {
         };
     }
 
+    /// Waits for page readiness on its own, making a preceding `goto`'s full
+    /// `load` wait redundant — the recorder downgrades such gotos to
+    /// `domcontentloaded` (#3138). Exhaustive like the sibling predicates so a
+    /// new wait tool makes an explicit choice here.
+    pub fn waitsForReadiness(self: Tool) bool {
+        return switch (self) {
+            .waitForSelector, .waitForScript, .waitForState => true,
+            .goto, .evaluate, .extract, .click, .fill, .scroll, .hover, .press, .selectOption, .setChecked, .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+        };
+    }
+
     /// A read tool that navigates when handed a `url`. The read isn't recorded,
     /// but the navigation is, so the recorder captures it as a `goto`. Excludes
     /// `evaluate` (carries its own `url`), `search` (derived engine URL), and
@@ -330,7 +341,9 @@ pub const Tool = enum {
                     \\  "properties": {
                     \\    "url": { "type": "string", "description": "The URL to navigate to, must be a valid URL." },
                     \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." },
-                    \\    "waitUntil": { "type": "string", "enum": ["load", "domcontentloaded", "networkalmostidle", "networkidle"], "description": "Event that completes the navigation. Defaults to 'load'. Prefer 'domcontentloaded' followed by waitForSelector on pages whose late scripts (ads) hold 'load' back." }
+                    \\    "waitUntil": { "type": "string", "enum":
+                ++ lp.Config.tagJsonArray(lp.Config.WaitUntil) ++
+                    \\, "description": "Event that completes the navigation. Defaults to 'load'. Prefer 'domcontentloaded' followed by waitForSelector on pages whose late scripts (ads) hold 'load' back." }
                     \\  },
                     \\  "required": ["url"]
                     \\}
@@ -759,7 +772,7 @@ pub const ToolResult = struct {
 pub const GotoParams = struct {
     url: [:0]const u8,
     timeout: ?u32 = null,
-    waitUntil: ?lp.Config.WaitUntil = null,
+    waitUntil: lp.Config.WaitUntil = default_nav_wait,
 };
 
 pub const UrlParams = struct {
@@ -938,7 +951,7 @@ const schema_walker_suffix = ")";
 
 fn execGoto(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
     const args = try parseArgs(GotoParams, arena, arguments);
-    return switch (try performGoto(session, registry, args.url, args.timeout, args.waitUntil)) {
+    return switch (try performGoto(session, registry, args.url, .{ .timeout = args.timeout, .wait_until = args.waitUntil })) {
         .completed => "Navigated successfully.",
         .timeout => "Navigation started but the page did not finish loading before the timeout.",
     };
@@ -990,7 +1003,7 @@ fn execSearch(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode
         .{encoded},
         0,
     ) catch return ToolError.OutOfMemory;
-    _ = try performGoto(session, registry, ddg_url, args.timeout, null);
+    _ = try performGoto(session, registry, ddg_url, .{ .timeout = args.timeout });
     const ddg_frame = try requireFrame(session);
     return .{ .text = try renderFrameMarkdown(arena, ddg_frame) };
 }
@@ -1923,7 +1936,7 @@ fn ensurePage(session: *lp.Session, registry: *CDPNode.Registry, url: ?[:0]const
         if (session.currentFrame()) |frame| {
             if (std.mem.eql(u8, frame.url, u)) return frame;
         }
-        _ = try performGoto(session, registry, u, timeout, null);
+        _ = try performGoto(session, registry, u, .{ .timeout = timeout });
     }
     return session.currentFrame() orelse ToolError.FrameNotLoaded;
 }
@@ -1977,11 +1990,16 @@ pub fn startGoto(
     return .{
         .frame_id = page.frame_id,
         .timeout_ms = args.timeout orelse default_nav_timeout_ms,
-        .until = args.waitUntil orelse default_nav_wait,
+        .until = args.waitUntil,
     };
 }
 
-fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, timeout: ?u32, wait_until: ?lp.Config.WaitUntil) ToolError!lp.Session.Runner.WaitResult {
+const PerformGotoOpts = struct {
+    timeout: ?u32 = null,
+    wait_until: lp.Config.WaitUntil = default_nav_wait,
+};
+
+fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const u8, opts: PerformGotoOpts) ToolError!lp.Session.Runner.WaitResult {
     if (session.primaryPage()) |old_page| {
         registry.reset();
         old_page.close();
@@ -1989,9 +2007,9 @@ fn performGoto(session: *lp.Session, registry: *CDPNode.Registry, url: [:0]const
     const page = try openPage(session, url);
 
     var runner = session.runner(.{});
-    const condition = lp.Session.Runner.WaitCondition{ .frame_id = page.frame_id, .until = wait_until orelse default_nav_wait };
+    const condition = lp.Session.Runner.WaitCondition{ .frame_id = page.frame_id, .until = opts.wait_until };
     var conditions = [_]lp.Session.Runner.WaitCondition{condition};
-    const result = runner.waitResult(timeout orelse default_nav_timeout_ms, &conditions) catch |err| {
+    const result = runner.waitResult(opts.timeout orelse default_nav_timeout_ms, &conditions) catch |err| {
         return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
     };
 

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -344,7 +344,7 @@ fn waitForSelector(cmd: anytype) !void {
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
     const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
 
-    const timeout_ms = params.timeout orelse 5000;
+    const timeout_ms = params.timeout orelse lp.tools.defaultWaitTimeout(frame);
     const selector_z = try cmd.arena.dupeZ(u8, params.selector);
 
     const node = lp.actions.waitForSelector(selector_z, timeout_ms, frame._frame_id, bc.session) catch |err| {

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -38,6 +38,17 @@ content: std.Io.Writer.Allocating,
 buf: std.Io.Writer.Allocating,
 /// Reset per write — backs short-lived scrub allocations.
 arena: std.heap.ArenaAllocator,
+/// A recorded `goto` held back one step. If the next recorded call waits on
+/// its own (waitForSelector/waitForState), the `domcontentloaded` variant is
+/// emitted instead of the default load wait — the follow-up wait covers
+/// readiness, and dcl skips the ad chains that hold `load` back (#3138).
+pending_goto: ?PendingGoto,
+
+const PendingGoto = struct {
+    plain: []u8,
+    /// Null when the call carried an explicit waitUntil — the author chose.
+    downgraded: ?[]u8,
+};
 
 pub fn init(allocator: std.mem.Allocator) Recorder {
     return .{
@@ -47,20 +58,28 @@ pub fn init(allocator: std.mem.Allocator) Recorder {
         .content = .init(allocator),
         .buf = .init(allocator),
         .arena = .init(allocator),
+        .pending_goto = null,
     };
 }
 
 pub fn deinit(self: *Recorder) void {
+    self.freePendingGoto();
     self.content.deinit();
     self.buf.deinit();
     self.arena.deinit();
 }
 
-pub fn bytes(self: *Recorder) []const u8 {
+pub fn bytes(self: *Recorder) ![]const u8 {
+    try self.flushPendingGoto(false);
     return self.content.written();
 }
 
+pub fn isEmpty(self: *const Recorder) bool {
+    return self.content.writer.end == 0 and self.pending_goto == null;
+}
+
 pub fn reset(self: *Recorder) void {
+    self.freePendingGoto();
     self.lines = 0;
     self.page_declared = false;
     self.content.clearRetainingCapacity();
@@ -70,32 +89,86 @@ pub fn reset(self: *Recorder) void {
 
 pub fn record(self: *Recorder, cmd: Command) !void {
     if (!cmd.isRecorded()) return;
-    self.buf.clearRetainingCapacity();
-    _ = self.arena.reset(.retain_capacity);
-    // `isRecorded` guarantees `.tool_call`. The page is born once, up front; every
-    // recorded call is then a method on it — `goto` async, the rest sync.
+    // `isRecorded` guarantees `.tool_call`.
+    const tool = cmd.tool_call.tool;
+    try self.flushPendingGoto(tool == .waitForSelector or tool == .waitForState);
+
+    // The page is born once, up front; every recorded call is then a method
+    // on it — `goto` async, the rest sync.
     if (!self.page_declared) {
+        self.buf.clearRetainingCapacity();
         try self.buf.writer.writeAll("const page = new Page();\n");
         self.page_declared = true;
+        try self.appendScrubbed();
     }
-    if (cmd.tool_call.tool.isAsync()) try self.buf.writer.writeAll("await ");
+
+    self.buf.clearRetainingCapacity();
+    _ = self.arena.reset(.retain_capacity);
+    if (tool.isAsync()) try self.buf.writer.writeAll("await ");
     try self.buf.writer.writeAll("page.");
     try cmd.formatJs(self.arena.allocator(), &self.buf.writer);
     try self.buf.writer.writeByte('\n');
+
+    if (tool == .goto) {
+        const plain = try self.allocator.dupe(u8, self.buf.written());
+        errdefer self.allocator.free(plain);
+        self.pending_goto = .{ .plain = plain, .downgraded = try self.renderDowngradedGoto(cmd) };
+        return;
+    }
     try self.appendScrubbed();
 }
 
 pub fn recordComment(self: *Recorder, comment: []const u8) !void {
+    try self.flushPendingGoto(false);
     self.buf.clearRetainingCapacity();
     try writeCommentLines(&self.buf.writer, comment);
     try self.appendScrubbed();
 }
 
 pub fn recordRaw(self: *Recorder, line: []const u8) !void {
+    try self.flushPendingGoto(false);
     self.buf.clearRetainingCapacity();
     try self.buf.writer.writeAll(line);
     try self.buf.writer.writeByte('\n');
     try self.appendScrubbed();
+}
+
+/// The held goto's `domcontentloaded` twin, rendered up front while the
+/// command's args are still alive. Null when there's nothing to downgrade
+/// (explicit waitUntil, or args in a shape the recorder doesn't rewrite).
+fn renderDowngradedGoto(self: *Recorder, cmd: Command) !?[]u8 {
+    const args = cmd.tool_call.args orelse return null;
+    if (args != .object) return null;
+    if (args.object.get("waitUntil") != null) return null;
+
+    const aa = self.arena.allocator();
+    var cloned: std.json.ObjectMap = .empty;
+    try cloned.ensureTotalCapacity(aa, args.object.count() + 1);
+    var it = args.object.iterator();
+    while (it.next()) |entry| try cloned.put(aa, entry.key_ptr.*, entry.value_ptr.*);
+    try cloned.put(aa, "waitUntil", .{ .string = "domcontentloaded" });
+
+    var w: std.Io.Writer.Allocating = .init(self.arena.allocator());
+    try w.writer.writeAll("await page.");
+    try Command.fromToolCall(.goto, .{ .object = cloned }).formatJs(self.arena.allocator(), &w.writer);
+    try w.writer.writeByte('\n');
+    return try self.allocator.dupe(u8, w.written());
+}
+
+fn flushPendingGoto(self: *Recorder, downgrade: bool) !void {
+    const pending = self.pending_goto orelse return;
+    defer self.freePendingGoto();
+    self.buf.clearRetainingCapacity();
+    const line = if (downgrade) pending.downgraded orelse pending.plain else pending.plain;
+    try self.buf.writer.writeAll(line);
+    try self.appendScrubbed();
+}
+
+fn freePendingGoto(self: *Recorder) void {
+    const pending = self.pending_goto orelse return;
+    self.allocator.free(pending.plain);
+    if (pending.downgraded) |d| self.allocator.free(d);
+    self.pending_goto = null;
 }
 
 fn appendScrubbed(self: *Recorder) !void {
@@ -144,16 +217,16 @@ test "record filters state-mutating commands and comments" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto(\"https://example.com\");\npage.click({ selector: \"Login\" });\n// search for login\n",
-        recorder.bytes(),
+        try recorder.bytes(),
     );
     try std.testing.expectEqual(@as(u32, 4), recorder.lines);
 
     recorder.reset();
-    try std.testing.expectEqualStrings("", recorder.bytes());
+    try std.testing.expectEqualStrings("", try recorder.bytes());
     try std.testing.expectEqual(@as(u32, 0), recorder.lines);
 
     try recorder.record(parseLine(aa, "/scroll y=200"));
-    try std.testing.expectEqualStrings("const page = new Page();\npage.scroll({ y: 200 });\n", recorder.bytes());
+    try std.testing.expectEqualStrings("const page = new Page();\npage.scroll({ y: 200 });\n", try recorder.bytes());
     try std.testing.expectEqual(@as(u32, 2), recorder.lines);
 }
 
@@ -164,7 +237,7 @@ test "recordRaw writes the JS line verbatim" {
     try recorder.recordRaw("document.title");
     try recorder.recordRaw("window.scrollTo(0, 100)");
 
-    try std.testing.expectEqualStrings("document.title\nwindow.scrollTo(0, 100)\n", recorder.bytes());
+    try std.testing.expectEqualStrings("document.title\nwindow.scrollTo(0, 100)\n", try recorder.bytes());
 }
 
 test "record emits multi-line extract as JavaScript" {
@@ -180,7 +253,7 @@ test "record emits multi-line extract as JavaScript" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\npage.extract({ title: \"span.title\", desc: \"p.description\" });\n",
-        recorder.bytes(),
+        try recorder.bytes(),
     );
 }
 
@@ -194,7 +267,7 @@ test "recordComment splits embedded newlines into separate comment lines" {
 
     try std.testing.expectEqualStrings(
         "// note\n// /goto https://attacker\n// more\n",
-        recorder.bytes(),
+        try recorder.bytes(),
     );
 }
 
@@ -211,7 +284,73 @@ test "recordComment scrubs literal LP_* values back to placeholders" {
 
     try std.testing.expectEqualStrings(
         "// a user noted that their password is $LP_RECORDER_COMMENT_TEST\n",
-        recorder.bytes(),
+        try recorder.bytes(),
+    );
+}
+
+test "record downgrades goto before waitForSelector to domcontentloaded" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var recorder: Recorder = .init(std.testing.allocator);
+    defer recorder.deinit();
+
+    try recorder.record(parseLine(aa, "/goto https://example.com"));
+    try recorder.record(parseLine(aa, "/waitForSelector .story"));
+
+    try std.testing.expectEqualStrings(
+        "const page = new Page();\nawait page.goto({ url: \"https://example.com\", waitUntil: \"domcontentloaded\" });\npage.waitForSelector(\".story\");\n",
+        try recorder.bytes(),
+    );
+}
+
+test "record keeps the load wait when goto is followed by extract" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var recorder: Recorder = .init(std.testing.allocator);
+    defer recorder.deinit();
+
+    try recorder.record(parseLine(aa, "/goto https://example.com"));
+    try recorder.record(parseLine(aa, "/extract '{\"title\": \"h1\"}'"));
+
+    try std.testing.expectEqualStrings(
+        "const page = new Page();\nawait page.goto(\"https://example.com\");\npage.extract({ title: \"h1\" });\n",
+        try recorder.bytes(),
+    );
+}
+
+test "record preserves an explicit waitUntil on goto" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var recorder: Recorder = .init(std.testing.allocator);
+    defer recorder.deinit();
+
+    try recorder.record(parseLine(aa, "/goto https://example.com waitUntil=networkidle"));
+    try recorder.record(parseLine(aa, "/waitForSelector .story"));
+
+    try std.testing.expectEqualStrings(
+        "const page = new Page();\nawait page.goto({ url: \"https://example.com\", waitUntil: \"networkidle\" });\npage.waitForSelector(\".story\");\n",
+        try recorder.bytes(),
+    );
+}
+
+test "trailing goto is flushed unmodified by bytes" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var recorder: Recorder = .init(std.testing.allocator);
+    defer recorder.deinit();
+
+    try recorder.record(parseLine(aa, "/goto https://example.com"));
+    try std.testing.expectEqualStrings(
+        "const page = new Page();\nawait page.goto(\"https://example.com\");\n",
+        try recorder.bytes(),
     );
 }
 
@@ -231,6 +370,6 @@ test "record scrubs literal LP_* values in JavaScript calls" {
     try recorder.record(parseLine(aa, "/fill selector='#user' value='secret-user'"));
     try std.testing.expectEqualStrings(
         "const page = new Page();\npage.fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
-        recorder.bytes(),
+        try recorder.bytes(),
     );
 }

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -38,18 +38,15 @@ content: std.Io.Writer.Allocating,
 buf: std.Io.Writer.Allocating,
 /// Reset per write — backs short-lived scrub allocations.
 arena: std.heap.ArenaAllocator,
-/// The just-emitted `goto` line stays rewritable for exactly one step: if the
-/// next recorded call waits for readiness on its own (`Tool.waitsForReadiness`),
-/// the line is rewound and re-emitted with `waitUntil: "domcontentloaded"` —
-/// the follow-up wait covers readiness, and dcl skips the ad chains that hold
-/// `load` back (#3138). Anything else recorded in between closes the window.
+/// The just-emitted `goto` line stays rewritable for exactly one step: a
+/// readiness wait recorded next (`Tool.waitsForReadiness`) swaps it for its
+/// `waitUntil: "domcontentloaded"` variant; anything else closes the window.
 pending_goto: ?PendingGoto,
 
 const PendingGoto = struct {
     /// `content` length just before the emitted goto line.
     start: usize,
-    /// Scrubbed replacement line. Null when the call carried an explicit
-    /// waitUntil — the author chose.
+    /// Scrubbed replacement line; null when the call carried an explicit waitUntil.
     downgraded: ?[]u8,
 };
 
@@ -73,8 +70,7 @@ pub fn deinit(self: *Recorder) void {
 }
 
 pub fn bytes(self: *Recorder) []const u8 {
-    // A snapshot closes the rewrite window: the caller may persist this exact
-    // text, so the goto line it contains must not change afterwards.
+    // A snapshot may be persisted verbatim — its goto line must not change afterwards.
     self.freePendingGoto();
     return self.content.written();
 }
@@ -98,7 +94,7 @@ pub fn record(self: *Recorder, cmd: Command) !void {
     }
 
     // The page is born once, up front; every recorded call is then a method
-    // on it — `goto` async, the rest sync. Constant text: skip buf and scrub.
+    // on it — `goto` async, the rest sync.
     if (!self.page_declared) {
         try self.content.writer.writeAll("const page = new Page();\n");
         self.lines += 1;
@@ -132,7 +128,6 @@ pub fn recordRaw(self: *Recorder, line: []const u8) !void {
     try self.appendScrubbed();
 }
 
-/// One recorded call as a script line: receiver, await-ness, terminator.
 fn renderCall(self: *Recorder, cmd: Command, w: *std.Io.Writer) !void {
     if (cmd.tool_call.tool.isAsync()) try w.writeAll("await ");
     try w.writeAll("page.");
@@ -140,11 +135,10 @@ fn renderCall(self: *Recorder, cmd: Command, w: *std.Io.Writer) !void {
     try w.writeByte('\n');
 }
 
-/// The emitted goto's `domcontentloaded` twin, rendered and scrubbed up front
-/// while the command's args are still alive. Null when there's nothing to
-/// downgrade (explicit waitUntil, or non-object args).
+/// Rendered and scrubbed up front — the command's args die with the caller.
+/// Null when there's nothing to downgrade (explicit waitUntil, non-object args).
 fn renderDowngradedGoto(self: *Recorder, cmd: Command) !?[]u8 {
-    // `isRecorded` guaranteed the required `url` arg, so args is present.
+    // `isRecorded` guaranteed the required `url` arg.
     const args = cmd.tool_call.args.?;
     if (args != .object) return null;
     if (args.object.get("waitUntil") != null) return null;
@@ -159,10 +153,9 @@ fn renderDowngradedGoto(self: *Recorder, cmd: Command) !?[]u8 {
     return try self.allocator.dupe(u8, scrubbed);
 }
 
-/// Swap the just-emitted plain goto line for its `domcontentloaded` twin.
-/// Both are exactly one line, so `lines` needs no adjustment.
 fn downgradePendingGoto(self: *Recorder, pending: PendingGoto) !void {
     const line = pending.downgraded orelse return;
+    // Both variants are exactly one line, so `lines` needs no adjustment.
     self.content.shrinkRetainingCapacity(pending.start);
     try self.content.writer.writeAll(line);
 }

--- a/src/script/Recorder.zig
+++ b/src/script/Recorder.zig
@@ -38,15 +38,18 @@ content: std.Io.Writer.Allocating,
 buf: std.Io.Writer.Allocating,
 /// Reset per write — backs short-lived scrub allocations.
 arena: std.heap.ArenaAllocator,
-/// A recorded `goto` held back one step. If the next recorded call waits on
-/// its own (waitForSelector/waitForState), the `domcontentloaded` variant is
-/// emitted instead of the default load wait — the follow-up wait covers
-/// readiness, and dcl skips the ad chains that hold `load` back (#3138).
+/// The just-emitted `goto` line stays rewritable for exactly one step: if the
+/// next recorded call waits for readiness on its own (`Tool.waitsForReadiness`),
+/// the line is rewound and re-emitted with `waitUntil: "domcontentloaded"` —
+/// the follow-up wait covers readiness, and dcl skips the ad chains that hold
+/// `load` back (#3138). Anything else recorded in between closes the window.
 pending_goto: ?PendingGoto,
 
 const PendingGoto = struct {
-    plain: []u8,
-    /// Null when the call carried an explicit waitUntil — the author chose.
+    /// `content` length just before the emitted goto line.
+    start: usize,
+    /// Scrubbed replacement line. Null when the call carried an explicit
+    /// waitUntil — the author chose.
     downgraded: ?[]u8,
 };
 
@@ -69,13 +72,11 @@ pub fn deinit(self: *Recorder) void {
     self.arena.deinit();
 }
 
-pub fn bytes(self: *Recorder) ![]const u8 {
-    try self.flushPendingGoto(false);
+pub fn bytes(self: *Recorder) []const u8 {
+    // A snapshot closes the rewrite window: the caller may persist this exact
+    // text, so the goto line it contains must not change afterwards.
+    self.freePendingGoto();
     return self.content.written();
-}
-
-pub fn isEmpty(self: *const Recorder) bool {
-    return self.content.writer.end == 0 and self.pending_goto == null;
 }
 
 pub fn reset(self: *Recorder) void {
@@ -91,82 +92,83 @@ pub fn record(self: *Recorder, cmd: Command) !void {
     if (!cmd.isRecorded()) return;
     // `isRecorded` guarantees `.tool_call`.
     const tool = cmd.tool_call.tool;
-    try self.flushPendingGoto(tool == .waitForSelector or tool == .waitForState);
+    if (self.pending_goto) |pending| {
+        if (tool.waitsForReadiness()) try self.downgradePendingGoto(pending);
+        self.freePendingGoto();
+    }
 
     // The page is born once, up front; every recorded call is then a method
-    // on it — `goto` async, the rest sync.
+    // on it — `goto` async, the rest sync. Constant text: skip buf and scrub.
     if (!self.page_declared) {
-        self.buf.clearRetainingCapacity();
-        try self.buf.writer.writeAll("const page = new Page();\n");
+        try self.content.writer.writeAll("const page = new Page();\n");
+        self.lines += 1;
         self.page_declared = true;
-        try self.appendScrubbed();
     }
 
     self.buf.clearRetainingCapacity();
     _ = self.arena.reset(.retain_capacity);
-    if (tool.isAsync()) try self.buf.writer.writeAll("await ");
-    try self.buf.writer.writeAll("page.");
-    try cmd.formatJs(self.arena.allocator(), &self.buf.writer);
-    try self.buf.writer.writeByte('\n');
+    try self.renderCall(cmd, &self.buf.writer);
+
+    const start = self.content.written().len;
+    try self.appendScrubbed();
 
     if (tool == .goto) {
-        const plain = try self.allocator.dupe(u8, self.buf.written());
-        errdefer self.allocator.free(plain);
-        self.pending_goto = .{ .plain = plain, .downgraded = try self.renderDowngradedGoto(cmd) };
-        return;
+        self.pending_goto = .{ .start = start, .downgraded = try self.renderDowngradedGoto(cmd) };
     }
-    try self.appendScrubbed();
 }
 
 pub fn recordComment(self: *Recorder, comment: []const u8) !void {
-    try self.flushPendingGoto(false);
+    self.freePendingGoto();
     self.buf.clearRetainingCapacity();
     try writeCommentLines(&self.buf.writer, comment);
     try self.appendScrubbed();
 }
 
 pub fn recordRaw(self: *Recorder, line: []const u8) !void {
-    try self.flushPendingGoto(false);
+    self.freePendingGoto();
     self.buf.clearRetainingCapacity();
     try self.buf.writer.writeAll(line);
     try self.buf.writer.writeByte('\n');
     try self.appendScrubbed();
 }
 
-/// The held goto's `domcontentloaded` twin, rendered up front while the
-/// command's args are still alive. Null when there's nothing to downgrade
-/// (explicit waitUntil, or args in a shape the recorder doesn't rewrite).
+/// One recorded call as a script line: receiver, await-ness, terminator.
+fn renderCall(self: *Recorder, cmd: Command, w: *std.Io.Writer) !void {
+    if (cmd.tool_call.tool.isAsync()) try w.writeAll("await ");
+    try w.writeAll("page.");
+    try cmd.formatJs(self.arena.allocator(), w);
+    try w.writeByte('\n');
+}
+
+/// The emitted goto's `domcontentloaded` twin, rendered and scrubbed up front
+/// while the command's args are still alive. Null when there's nothing to
+/// downgrade (explicit waitUntil, or non-object args).
 fn renderDowngradedGoto(self: *Recorder, cmd: Command) !?[]u8 {
-    const args = cmd.tool_call.args orelse return null;
+    // `isRecorded` guaranteed the required `url` arg, so args is present.
+    const args = cmd.tool_call.args.?;
     if (args != .object) return null;
     if (args.object.get("waitUntil") != null) return null;
 
     const aa = self.arena.allocator();
-    var cloned: std.json.ObjectMap = .empty;
-    try cloned.ensureTotalCapacity(aa, args.object.count() + 1);
-    var it = args.object.iterator();
-    while (it.next()) |entry| try cloned.put(aa, entry.key_ptr.*, entry.value_ptr.*);
-    try cloned.put(aa, "waitUntil", .{ .string = "domcontentloaded" });
+    var cloned = try args.object.clone(aa);
+    try cloned.put(aa, "waitUntil", .{ .string = @tagName(lp.Config.WaitUntil.domcontentloaded) });
 
-    var w: std.Io.Writer.Allocating = .init(self.arena.allocator());
-    try w.writer.writeAll("await page.");
-    try Command.fromToolCall(.goto, .{ .object = cloned }).formatJs(self.arena.allocator(), &w.writer);
-    try w.writer.writeByte('\n');
-    return try self.allocator.dupe(u8, w.written());
+    self.buf.clearRetainingCapacity();
+    try self.renderCall(.fromToolCall(.goto, .{ .object = cloned }), &self.buf.writer);
+    const scrubbed = try lp.tools.reverseSubstituteEnvVars(aa, self.buf.written());
+    return try self.allocator.dupe(u8, scrubbed);
 }
 
-fn flushPendingGoto(self: *Recorder, downgrade: bool) !void {
-    const pending = self.pending_goto orelse return;
-    defer self.freePendingGoto();
-    self.buf.clearRetainingCapacity();
-    const line = if (downgrade) pending.downgraded orelse pending.plain else pending.plain;
-    try self.buf.writer.writeAll(line);
-    try self.appendScrubbed();
+/// Swap the just-emitted plain goto line for its `domcontentloaded` twin.
+/// Both are exactly one line, so `lines` needs no adjustment.
+fn downgradePendingGoto(self: *Recorder, pending: PendingGoto) !void {
+    const line = pending.downgraded orelse return;
+    self.content.shrinkRetainingCapacity(pending.start);
+    try self.content.writer.writeAll(line);
 }
 
 fn freePendingGoto(self: *Recorder) void {
     const pending = self.pending_goto orelse return;
-    self.allocator.free(pending.plain);
     if (pending.downgraded) |d| self.allocator.free(d);
     self.pending_goto = null;
 }
@@ -217,16 +219,16 @@ test "record filters state-mutating commands and comments" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto(\"https://example.com\");\npage.click({ selector: \"Login\" });\n// search for login\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
     try std.testing.expectEqual(@as(u32, 4), recorder.lines);
 
     recorder.reset();
-    try std.testing.expectEqualStrings("", try recorder.bytes());
+    try std.testing.expectEqualStrings("", recorder.bytes());
     try std.testing.expectEqual(@as(u32, 0), recorder.lines);
 
     try recorder.record(parseLine(aa, "/scroll y=200"));
-    try std.testing.expectEqualStrings("const page = new Page();\npage.scroll({ y: 200 });\n", try recorder.bytes());
+    try std.testing.expectEqualStrings("const page = new Page();\npage.scroll({ y: 200 });\n", recorder.bytes());
     try std.testing.expectEqual(@as(u32, 2), recorder.lines);
 }
 
@@ -237,7 +239,7 @@ test "recordRaw writes the JS line verbatim" {
     try recorder.recordRaw("document.title");
     try recorder.recordRaw("window.scrollTo(0, 100)");
 
-    try std.testing.expectEqualStrings("document.title\nwindow.scrollTo(0, 100)\n", try recorder.bytes());
+    try std.testing.expectEqualStrings("document.title\nwindow.scrollTo(0, 100)\n", recorder.bytes());
 }
 
 test "record emits multi-line extract as JavaScript" {
@@ -253,7 +255,7 @@ test "record emits multi-line extract as JavaScript" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\npage.extract({ title: \"span.title\", desc: \"p.description\" });\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -267,7 +269,7 @@ test "recordComment splits embedded newlines into separate comment lines" {
 
     try std.testing.expectEqualStrings(
         "// note\n// /goto https://attacker\n// more\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -284,7 +286,7 @@ test "recordComment scrubs literal LP_* values back to placeholders" {
 
     try std.testing.expectEqualStrings(
         "// a user noted that their password is $LP_RECORDER_COMMENT_TEST\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -301,7 +303,7 @@ test "record downgrades goto before waitForSelector to domcontentloaded" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto({ url: \"https://example.com\", waitUntil: \"domcontentloaded\" });\npage.waitForSelector(\".story\");\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -318,7 +320,7 @@ test "record keeps the load wait when goto is followed by extract" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto(\"https://example.com\");\npage.extract({ title: \"h1\" });\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -335,7 +337,7 @@ test "record preserves an explicit waitUntil on goto" {
 
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto({ url: \"https://example.com\", waitUntil: \"networkidle\" });\npage.waitForSelector(\".story\");\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -350,7 +352,7 @@ test "trailing goto is flushed unmodified by bytes" {
     try recorder.record(parseLine(aa, "/goto https://example.com"));
     try std.testing.expectEqualStrings(
         "const page = new Page();\nawait page.goto(\"https://example.com\");\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }
 
@@ -370,6 +372,6 @@ test "record scrubs literal LP_* values in JavaScript calls" {
     try recorder.record(parseLine(aa, "/fill selector='#user' value='secret-user'"));
     try std.testing.expectEqualStrings(
         "const page = new Page();\npage.fill({ selector: \"#user\", value: \"$LP_RECORDER_COMMAND_TEST\" });\n",
-        try recorder.bytes(),
+        recorder.bytes(),
     );
 }

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -74,6 +74,7 @@ const PendingGoto = struct {
     receiver: v8.Global,
     /// `run_timer` reading (ms) past which the navigation is abandoned.
     deadline_ms: u64,
+    until: lp.Config.WaitUntil,
 
     fn reset(self: *PendingGoto) void {
         v8.v8__Global__Reset(&self.resolver);
@@ -513,6 +514,7 @@ fn invokeGoto(
         .resolver = undefined,
         .receiver = undefined,
         .deadline_ms = @as(u64, @intCast(self.run_timer.untilNow(lp.io, .boot).toMilliseconds())) + started.timeout_ms,
+        .until = started.until,
     };
     v8.v8__Global__New(self.env.isolate.handle, resolver, &pending.resolver);
     v8.v8__Global__New(self.env.isolate.handle, this, &pending.receiver);
@@ -551,7 +553,7 @@ fn driveAsync(self: *Runtime, context: *const v8.Context, try_catch: *const v8.T
             break;
         };
         for (self.pending_gotos.items, conditions) |pending, *condition| {
-            condition.* = .{ .frame_id = pending.frame_id, .until = .load };
+            condition.* = .{ .frame_id = pending.frame_id, .until = pending.until };
         }
 
         // Browser-side tick: run under the browser's isolate, exit before the


### PR DESCRIPTION
Implements #3138.

- `goto` accepts an optional `waitUntil` (`load` | `domcontentloaded` | `networkalmostidle` | `networkidle` | `done`, default `load`). Works from the tool layer (agent/MCP), PandaScript object form (`await page.goto({ url, waitUntil })`), and the REPL (`/goto <url> waitUntil=domcontentloaded`). The schema enum comes from `Config.tagJsonArray` and the description steers away from `done`.
- `waitForSelector`/`waitForScript` gate their poll on `domcontentloaded` instead of `load` (polling needs a parsed document, nothing more). Without this the pre-wait re-waited the exact tail a dcl navigation skips.
- Wait-budget guard from review: a wait entered before `load` defaults to nav-timeout + 5s instead of 5s, so a selector that only appears post-load keeps the wall time it had when goto waited for `load` itself. Applies to the tool layer and to CDP's `LP.waitForSelector` (same underlying action). Explicit timeouts unchanged.
- The recorder rewinds the just-emitted goto line to the `domcontentloaded` variant when the next recorded call waits for readiness on its own (`Tool.waitsForReadiness`, which also covers `waitForScript`). Explicit `waitUntil` is never rewritten; goto followed by a bare `extract` keeps `load` (dcl could miss late-rendered content the session actually saw).

Measured on an ad-heavy apnews article (ReleaseFast at the current head, `--disable-subframes`, fresh cache, identical extracted output):

| variant | wall |
| :--- | ---: |
| `goto` (load) + waitForSelector | 5.2-7.0 s |
| `goto {waitUntil: "domcontentloaded"}` + waitForSelector | 0.9-1.3 s |

1129/1129 tests, `zig fmt --check` clean, main merged in.
