### PR TITLE
Custom element creation

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -322,7 +322,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
 
             // Inline handlers (e.g. onclick property) follow the same "report,
             // don't propagate" rule as addEventListener listeners — see Listener.run.
-            var caught: js.TryCatch.Caught = undefined;
+            var caught: js.TryCatch.Caught = .{};
             const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, target_et, .{event}, &caught) catch |err| ret: {
                 if (err == error.ExecutionTerminated) {
                     return error.ExecutionTerminated;
@@ -382,7 +382,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                     event._target = getAdjustedTarget(original_target, current_target);
                 }
 
-                var caught: js.TryCatch.Caught = undefined;
+                var caught: js.TryCatch.Caught = .{};
                 const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, current_target, .{event}, &caught) catch |err| ret: {
                     if (err == error.ExecutionTerminated) {
                         return error.ExecutionTerminated;

--- a/src/browser/EventManagerBase.zig
+++ b/src/browser/EventManagerBase.zig
@@ -287,7 +287,7 @@ pub fn dispatchDirect(
     // Call the property handler (e.g., onmessage) if present
     if (getFunction(handler, &ls.local)) |func| {
         event._current_target = target;
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         _ = func.tryCallWithThis(void, target, .{event}, &caught) catch |err| {
             if (err == error.ExecutionTerminated) {
                 return error.ExecutionTerminated;

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -962,7 +962,7 @@ pub const Script = struct {
             log.debug(.browser, "executed script", .{ .src = url, .success = success });
         }
 
-        if (!success and frame.js.env.isExecutionTerminating()) {
+        if (!success and frame.js.env.terminatePending()) {
             return;
         }
 

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -32,6 +32,7 @@ const Parser = @import("../parser/Parser.zig");
 const Node = @import("../webapi/Node.zig");
 const CData = @import("../webapi/CData.zig");
 const Element = @import("../webapi/Element.zig");
+const CustomElementDefinition = @import("../webapi/CustomElementDefinition.zig");
 
 const log = lp.log;
 const String = lp.String;
@@ -823,54 +824,40 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
             const has_hyphen = std.mem.indexOfScalar(u8, name, '-') != null;
             if (has_hyphen and namespace == .html) {
                 const definition = frame.window._custom_elements._definitions.get(name);
-                const node = try createHtmlElementT(frame, Element.Html.Custom, namespace, attribute_iterator, .{
-                    ._proto = undefined,
-                    ._tag_name = tag_name,
-                    ._definition = definition,
-                });
 
                 // Fragment-parse context element. It will not be inserted and
                 // we should not run the custom element's constructor.
-                if (frame._skip_custom_element_upgrade) {
+                //
+                // Undefined elements are created in the "undefined" state and
+                // upgraded later, when a matching definition is registered.
+                if (frame._skip_custom_element_upgrade or definition == null) {
+                    const node = try createHtmlElementT(frame, Element.Html.Custom, namespace, attribute_iterator, .{
+                        ._proto = undefined,
+                        ._tag_name = tag_name,
+                        ._definition = definition,
+                    });
+                    if (frame._skip_custom_element_upgrade == false) {
+                        try frame._undefined_custom_elements.append(frame.arena, node.as(Element).is(Element.Html.Custom).?);
+                    }
                     return node;
                 }
 
-                const def = definition orelse {
-                    const element = node.as(Element);
-                    const custom = element.is(Element.Html.Custom).?;
-                    try frame._undefined_custom_elements.append(frame.arena, custom);
-                    return node;
+                // https://dom.spec.whatwg.org/#concept-create-element, the
+                // synchronous branch. super() has to create its own element
+                const constructed = constructForToken(frame, definition.?, tag_name, from_parser) catch {
+                    // Construction failed, we fallback to  HTMLUnknownElement
+                    return createHtmlElementT(frame, Element.Html.Unknown, namespace, attribute_iterator, .{
+                        ._proto = undefined,
+                        ._tag_name = tag_name,
+                    });
                 };
 
-                // Save and restore upgrading element to allow nested createElement calls
-                const prev_upgrading = frame._upgrading_element;
-                frame._upgrading_element = node;
-                defer frame._upgrading_element = prev_upgrading;
-
-                var ls: JS.Local.Scope = undefined;
-                frame.js.localScope(&ls);
-                defer ls.deinit();
-
-                if (from_parser) {
-                    // There are some things custom elements aren't allowed to do
-                    // when we're parsing.
-                    frame.document._throw_on_dynamic_markup_insertion_counter += 1;
-                }
-                defer if (from_parser) {
-                    frame.document._throw_on_dynamic_markup_insertion_counter -= 1;
-                };
-
-                var caught: JS.TryCatch.Caught = .{};
-                _ = ls.toLocal(def.constructor).newInstance(&caught) catch |err| {
-                    log.warn(.js, "custom element constructor", .{ .name = name, .err = err, .caught = caught, .type = frame._type, .url = frame.url });
-                    return node;
-                };
-
-                // After constructor runs, invoke attributeChangedCallback for initial attributes
-                const element = node.as(Element);
-                for (element.attributeEntries()) |*attr| {
+                // Attributes are applied after construction, so the constructor
+                // observes none of them and each one enqueues its reaction.
+                try populateElementAttributes(frame, constructed, attribute_iterator);
+                for (constructed.attributeEntries()) |*attr| {
                     Element.Html.Custom.enqueueAttributeChangedCallbackOnElement(
-                        element,
+                        constructed,
                         .wrap(attr.name()),
                         null, // old_value is null for initial attributes
                         .wrap(attr.value()),
@@ -879,7 +866,7 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
                     );
                 }
 
-                return node;
+                return constructed.asNode();
             }
 
             return createHtmlElementT(frame, Element.Html.Unknown, namespace, attribute_iterator, .{ ._proto = undefined, ._tag_name = tag_name });
@@ -958,6 +945,61 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
             return createHtmlElementT(frame, Element.Html.Unknown, namespace, attribute_iterator, .{ ._proto = undefined, ._tag_name = tag_name });
         },
     }
+}
+
+// Runs a custom element constructor for a token being created (parser or
+// createElement), and validates the result against the post-conditions.
+fn constructForToken(frame: *Frame, definition: *CustomElementDefinition, tag_name: String, comptime from_parser: bool) !*Element {
+
+    // This is a creation, not an upgrade. super() ha to build a new element
+    const prev_upgrading = frame._upgrading_element;
+    frame._upgrading_element = null;
+    defer frame._upgrading_element = prev_upgrading;
+
+    var ls: JS.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    if (from_parser) {
+        // There are some things custom elements aren't allowed to do
+        // when we're parsing.
+        frame.document._throw_on_dynamic_markup_insertion_counter += 1;
+    }
+    defer if (from_parser) {
+        frame.document._throw_on_dynamic_markup_insertion_counter -= 1;
+    };
+
+    const name = tag_name.str();
+    var caught: JS.TryCatch.Caught = .{};
+    const object = ls.toLocal(definition.constructor).newInstance(&caught) catch |err| {
+        log.warn(.js, "custom element constructor", .{ .name = name, .err = err, .caught = caught, .type = frame._type, .url = frame.url });
+        return err;
+    };
+
+    const reason: []const u8 = blk: {
+        // validate the result
+        const node = object.toZig(*Node) catch break :blk "not a node";
+        const element = node.is(Element) orelse break :blk "not an element";
+        if (element._namespace != .html) {
+            break :blk "wrong namespace";
+        }
+        if (node._parent != null) {
+            break :blk "has a parent";
+        }
+        if (node.firstChild() != null) {
+            break :blk "has children";
+        }
+        if (element._attributes.isEmpty() == false) {
+            break :blk "has attributes";
+        }
+        if (std.mem.eql(u8, element.getTagNameLower(), name) == false) {
+            break :blk "wrong local name";
+        }
+        return element;
+    };
+
+    log.warn(.js, "custom element not usable", .{ .name = name, .reason = reason, .type = frame._type, .url = frame.url });
+    return error.CustomElementConstructionFailed;
 }
 
 fn createHtmlElementT(frame: *Frame, comptime E: type, namespace: Element.Namespace, attribute_iterator: anytype, html_element: E) !*Node {

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -860,7 +860,7 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
                     frame.document._throw_on_dynamic_markup_insertion_counter -= 1;
                 };
 
-                var caught: JS.TryCatch.Caught = undefined;
+                var caught: JS.TryCatch.Caught = .{};
                 _ = ls.toLocal(def.constructor).newInstance(&caught) catch |err| {
                     log.warn(.js, "custom element constructor", .{ .name = name, .err = err, .caught = caught, .type = frame._type, .url = frame.url });
                     return node;

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -544,13 +544,11 @@ pub fn dumpMemoryStats(self: *Env) void {
 }
 
 pub fn isExecutionTerminating(self: *const Env) bool {
-    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle);
+    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending();
 }
 
-// Whether a forcible terminate has been requested (and not yet cleared by
-// cancelTerminate). Unlike isExecutionTerminating, this is our own sticky
-// flag, so it stays true after V8 consumes the terminate on the JSEntry
-// unwind. Callers about to enter a fresh eval use it to refuse to run.
+// Our sticky terminate flag remains true after V8 consumes the request while
+// unwinding a JSEntry. isExecutionTerminating includes it to block fresh work.
 pub fn terminatePending(self: *const Env) bool {
     return self.terminate_requested.load(.acquire);
 }
@@ -632,7 +630,7 @@ pub fn cancelTerminate(self: *Env) void {
 pub fn performIsolateMicrotasks(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
-    if (v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle)) return;
+    if (self.isExecutionTerminating()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
 }
 

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -412,10 +412,7 @@ pub fn runMicrotasks(self: *Env) void {
 
         const v8_isolate = self.isolate.handle;
 
-        // terminatePending: once a forcible terminate is requested (and not
-        // canceled), refuse to start new work — IsExecutionTerminating alone
-        // goes false again as soon as the killed script finishes unwinding.
-        if (v8.v8__Isolate__IsExecutionTerminating(v8_isolate) or self.terminatePending()) {
+        if (self.terminatePending()) {
             return;
         }
 
@@ -433,7 +430,7 @@ pub fn runMicrotasks(self: *Env) void {
 }
 
 pub fn runMacrotasks(self: *Env) !void {
-    if (v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending()) {
+    if (self.terminatePending()) {
         return;
     }
 
@@ -543,12 +540,11 @@ pub fn dumpMemoryStats(self: *Env) void {
     , .{ stats.total_heap_size, stats.total_heap_size_executable, stats.total_physical_size, stats.total_available_size, stats.used_heap_size, stats.heap_size_limit, stats.malloced_memory, stats.external_memory, stats.peak_malloced_memory, stats.number_of_native_contexts, stats.number_of_detached_contexts, stats.total_global_handles_size, stats.used_global_handles_size, stats.does_zap_garbage });
 }
 
-pub fn isExecutionTerminating(self: *const Env) bool {
-    return v8.v8__Isolate__IsExecutionTerminating(self.isolate.handle) or self.terminatePending();
-}
-
-// Our sticky terminate flag remains true after V8 consumes the request while
-// unwinding a JSEntry. isExecutionTerminating includes it to block fresh work.
+// The single "must not run JS" predicate. We're the only ones who ever call
+// TerminateExecution (here and in terminateInterrupt) and both set this flag,
+// so it's always at least as true as v8__Isolate__IsExecutionTerminating —
+// and it stays true after V8 consumes the terminate on the JSEntry unwind,
+// which is what stops a fresh eval from re-entering mid-teardown.
 pub fn terminatePending(self: *const Env) bool {
     return self.terminate_requested.load(.acquire);
 }
@@ -556,6 +552,7 @@ pub fn terminatePending(self: *const Env) bool {
 pub fn terminate(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
+    self.terminate_requested.store(true, .release);
     v8.v8__Isolate__TerminateExecution(self.isolate.handle);
 }
 
@@ -630,7 +627,7 @@ pub fn cancelTerminate(self: *Env) void {
 pub fn performIsolateMicrotasks(self: *Env) void {
     self.terminate_mutex.lockUncancelable(lp.io);
     defer self.terminate_mutex.unlock(lp.io);
-    if (self.isExecutionTerminating()) return;
+    if (self.terminatePending()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
 }
 

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -66,7 +66,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     }
 
     // See _tryCallWithThis for why a pending termination blocks V8 entry.
-    if (local.ctx.env.isExecutionTerminating()) {
+    if (local.ctx.env.terminatePending()) {
         return error.ExecutionTerminated;
     }
 
@@ -77,7 +77,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     // This creates a new instance using this Function as a constructor.
     // const c_args = @as(?[*]const ?*c.Value, @ptrCast(&.{}));
     const handle = v8.v8__Function__NewInstance(self.handle, local.handle, 0, null) orelse {
-        if (local.ctx.env.isExecutionTerminating()) {
+        if (local.ctx.env.terminatePending()) {
             return error.ExecutionTerminated;
         }
         caught.* = try_catch.caughtOrError(local.call_arena, error.Unknown);
@@ -91,7 +91,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
 }
 
 pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, self.getThis(), args, &caught, .{}) catch |err| {
         log.warn(.js, "call caught", .{ .err = err, .caught = caught });
         return err;
@@ -99,7 +99,7 @@ pub fn call(self: *const Function, comptime T: type, args: anytype) !T {
 }
 
 pub fn callRethrow(self: *const Function, comptime T: type, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, self.getThis(), args, &caught, .{ .rethrow = true }) catch |err| {
         if (err != error.TryCatchRethrow) {
             // error.TryCatchRethrow is a control flow (sorry!), not an actual
@@ -111,7 +111,7 @@ pub fn callRethrow(self: *const Function, comptime T: type, args: anytype) !T {
 }
 
 pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, this, args, &caught, .{}) catch |err| {
         log.warn(.js, "callWithThis caught", .{ .err = err, .caught = caught });
         return err;
@@ -122,7 +122,7 @@ pub fn callWithThis(self: *const Function, comptime T: type, this: anytype, args
 // TryCatch, so an enclosing TryCatch of the caller can observe the exception
 // value itself (e.g. to report it to window.onerror).
 pub fn callWithThisRethrow(self: *const Function, comptime T: type, this: anytype, args: anytype) !T {
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     return self._tryCallWithThis(T, this, args, &caught, .{ .rethrow = true });
 }
 
@@ -138,7 +138,6 @@ const CallOpts = struct {
     rethrow: bool = false,
 };
 fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args: anytype, caught: *js.TryCatch.Caught, comptime opts: CallOpts) !T {
-    caught.* = .{};
     const local = self.local;
 
     if (comptime lp.IS_DEBUG == false) {
@@ -158,7 +157,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     // A pending termination (watchdog / CDP-disconnect kill) must not be
     // followed by another V8 entry. Callers must treat ExecutionTerminated as
     // stop running JS and unwind".
-    if (local.ctx.env.isExecutionTerminating()) {
+    if (local.ctx.env.terminatePending()) {
         return error.ExecutionTerminated;
     }
 
@@ -212,7 +211,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     defer try_catch.deinit();
 
     const handle = v8.v8__Function__Call(self.handle, local.handle, js_this.handle, @as(c_int, @intCast(js_args.len)), c_args) orelse {
-        if (local.ctx.env.isExecutionTerminating()) {
+        if (local.ctx.env.terminatePending()) {
             // Terminated mid-call, not a JS throw: no rethrow, no reporting.
             return error.ExecutionTerminated;
         }
@@ -284,6 +283,7 @@ test "Function: requested termination is classified and blocks re-entry" {
         probe_ran: bool = false,
         kill_err: ?anyerror = null,
         probe_err: ?anyerror = null,
+        nested_probe_err: ?anyerror = null,
 
         fn kill(self: *@This()) void {
             self.env.requestTerminate();
@@ -293,10 +293,16 @@ test "Function: requested termination is classified and blocks re-entry" {
             self.probe_ran = true;
         }
 
+        // Runs at call depth >= 1: the killed inner call must leave the
+        // termination pending, and the follow-up call must refuse to enter V8
+        // (running it would silently clear the pending termination).
         fn nested(self: *@This()) void {
-            var caught: js.TryCatch.Caught = undefined;
+            var caught: js.TryCatch.Caught = .{};
             _ = self.f_kill.?.tryCall(void, .{}, &caught) catch |err| {
                 self.kill_err = err;
+            };
+            _ = self.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
+                self.nested_probe_err = err;
             };
         }
     };
@@ -313,9 +319,10 @@ test "Function: requested termination is classified and blocks re-entry" {
     const driver = try local.exec("(function(n){ n(); })", null);
     const driver_fn = Function{ .local = local, .handle = @ptrCast(driver.handle) };
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, .{nested_cb}, &caught));
     try testing.expectEqual(error.ExecutionTerminated, state.kill_err.?);
+    try testing.expectEqual(error.ExecutionTerminated, state.nested_probe_err.?);
     try testing.expectEqual(true, env.terminatePending());
     try testing.expectEqual(false, v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
 

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -66,7 +66,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     }
 
     // See _tryCallWithThis for why a pending termination blocks V8 entry.
-    if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+    if (local.ctx.env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
 
@@ -77,7 +77,7 @@ pub fn newInstance(self: *const Function, caught: *js.TryCatch.Caught) !js.Objec
     // This creates a new instance using this Function as a constructor.
     // const c_args = @as(?[*]const ?*c.Value, @ptrCast(&.{}));
     const handle = v8.v8__Function__NewInstance(self.handle, local.handle, 0, null) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+        if (local.ctx.env.isExecutionTerminating()) {
             return error.ExecutionTerminated;
         }
         caught.* = try_catch.caughtOrError(local.call_arena, error.Unknown);
@@ -158,7 +158,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     // A pending termination (watchdog / CDP-disconnect kill) must not be
     // followed by another V8 entry. Callers must treat ExecutionTerminated as
     // stop running JS and unwind".
-    if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+    if (local.ctx.env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
 
@@ -212,7 +212,7 @@ fn _tryCallWithThis(self: *const Function, comptime T: type, this: anytype, args
     defer try_catch.deinit();
 
     const handle = v8.v8__Function__Call(self.handle, local.handle, js_this.handle, @as(c_int, @intCast(js_args.len)), c_args) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(local.isolate.handle)) {
+        if (local.ctx.env.isExecutionTerminating()) {
             // Terminated mid-call, not a JS throw: no rethrow, no reporting.
             return error.ExecutionTerminated;
         }
@@ -265,7 +265,7 @@ pub fn persistWithThis(self: *const Function, value: anytype) !Global {
 }
 
 const testing = @import("../../testing.zig");
-test "Function: termination is classified and blocks re-entry" {
+test "Function: requested termination is classified and blocks re-entry" {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();
 
@@ -286,23 +286,17 @@ test "Function: termination is classified and blocks re-entry" {
         probe_err: ?anyerror = null,
 
         fn kill(self: *@This()) void {
-            self.env.terminate();
+            self.env.requestTerminate();
         }
 
         fn probed(self: *@This()) void {
             self.probe_ran = true;
         }
 
-        // Runs at call depth >= 1: the killed inner call must leave the
-        // termination pending, and the follow-up call must refuse to enter V8
-        // (running it would silently clear the pending termination).
         fn nested(self: *@This()) void {
             var caught: js.TryCatch.Caught = undefined;
             _ = self.f_kill.?.tryCall(void, .{}, &caught) catch |err| {
                 self.kill_err = err;
-            };
-            _ = self.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
-                self.probe_err = err;
             };
         }
     };
@@ -322,6 +316,12 @@ test "Function: termination is classified and blocks re-entry" {
     var caught: js.TryCatch.Caught = undefined;
     try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, .{nested_cb}, &caught));
     try testing.expectEqual(error.ExecutionTerminated, state.kill_err.?);
+    try testing.expectEqual(true, env.terminatePending());
+    try testing.expectEqual(false, v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
+
+    _ = state.f_probe.?.tryCall(void, .{}, &caught) catch |err| {
+        state.probe_err = err;
+    };
     try testing.expectEqual(error.ExecutionTerminated, state.probe_err.?);
     try testing.expectEqual(false, state.probe_ran);
 

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -32,12 +32,12 @@ handle: *const v8.Script,
 pub fn run(self: Script) !js.Value {
     // See Function._tryCallWithThis for why a pending termination blocks V8
     // entry and is distinct from a JS throw.
-    const isolate_handle = self.local.isolate.handle;
-    if (v8.v8__Isolate__IsExecutionTerminating(isolate_handle)) {
+    const env = self.local.ctx.env;
+    if (env.isExecutionTerminating()) {
         return error.ExecutionTerminated;
     }
     const result = v8.v8__Script__Run(self.handle, self.local.handle) orelse {
-        if (v8.v8__Isolate__IsExecutionTerminating(isolate_handle)) {
+        if (env.isExecutionTerminating()) {
             return error.ExecutionTerminated;
         }
         return error.JsException;

--- a/src/browser/js/Script.zig
+++ b/src/browser/js/Script.zig
@@ -33,11 +33,11 @@ pub fn run(self: Script) !js.Value {
     // See Function._tryCallWithThis for why a pending termination blocks V8
     // entry and is distinct from a JS throw.
     const env = self.local.ctx.env;
-    if (env.isExecutionTerminating()) {
+    if (env.terminatePending()) {
         return error.ExecutionTerminated;
     }
     const result = v8.v8__Script__Run(self.handle, self.local.handle) orelse {
-        if (env.isExecutionTerminating()) {
+        if (env.terminatePending()) {
             return error.ExecutionTerminated;
         }
         return error.JsException;

--- a/src/browser/tests/custom_elements/context_element_not_reconstructed.html
+++ b/src/browser/tests/custom_elements/context_element_not_reconstructed.html
@@ -20,9 +20,13 @@
         }
         customElements.define('ce-ctor-innerhtml', CeCtorInnerHtml);
 
+        // Adding children during construction violates a post-condition of
+        // "create an element", so the result is a fallback HTMLUnknownElement
+        // rather than the constructed instance. What matters here is that the
+        // constructor ran exactly once instead of recursing.
         const el = document.createElement('ce-ctor-innerhtml');
         testing.expectEqual(1, calls);
-        testing.expectEqual('<span>hi</span>', el.innerHTML);
+        testing.expectEqual(true, el instanceof HTMLUnknownElement);
     }
 </script>
 

--- a/src/browser/tests/custom_elements/create_element_post_conditions.html
+++ b/src/browser/tests/custom_elements/create_element_post_conditions.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id="uses_constructor_return_value">
+    {
+        // https://dom.spec.whatwg.org/#concept-create-element -- creation does
+        // not push onto the construction stack, so super() mints its own
+        // element and the element we keep is whatever the constructor returns.
+        let returned = null;
+        class ReturnsAnother extends HTMLElement {
+            constructor() {
+                super();
+                if (returned === null) {
+                    returned = document.createElement('div');
+                    // A div is not a valid result for this token, so keep it
+                    // simple: return a second instance of ourselves instead.
+                    returned = Reflect.construct(HTMLElement, [], ReturnsAnother);
+                    return returned;
+                }
+            }
+        }
+        customElements.define('ce-returns-another', ReturnsAnother);
+
+        const el = document.createElement('ce-returns-another');
+        testing.expectEqual(true, el === returned);
+    }
+</script>
+
+<script id="rejects_element_with_children">
+    {
+        class AddsChild extends HTMLElement {
+            constructor() {
+                super();
+                this.appendChild(document.createElement('span'));
+            }
+        }
+        customElements.define('ce-adds-child', AddsChild);
+
+        const el = document.createElement('ce-adds-child');
+        testing.expectEqual(true, el instanceof HTMLUnknownElement);
+        testing.expectEqual('ce-adds-child', el.localName);
+    }
+</script>
+
+<script id="allows_child_added_then_removed">
+    {
+        // The post-condition is on the final state, not on what the
+        // constructor touched along the way.
+        class AddsAndRemoves extends HTMLElement {
+            constructor() {
+                super();
+                this.appendChild(document.createElement('span'));
+                this.removeChild(this.firstChild);
+            }
+        }
+        customElements.define('ce-adds-and-removes', AddsAndRemoves);
+
+        const el = document.createElement('ce-adds-and-removes');
+        testing.expectEqual(true, el instanceof AddsAndRemoves);
+    }
+</script>
+
+<script id="rejects_element_with_attribute">
+    {
+        class AddsAttribute extends HTMLElement {
+            constructor() {
+                super();
+                this.setAttribute('id', 'nope');
+            }
+        }
+        customElements.define('ce-adds-attribute', AddsAttribute);
+
+        testing.expectEqual(true, document.createElement('ce-adds-attribute') instanceof HTMLUnknownElement);
+    }
+</script>
+
+<script id="rejects_parented_element">
+    {
+        // The case that crashed the parser: a constructor that attaches its own
+        // element leaves a node with a parent, which the tree builder would
+        // then try to append a second time.
+        const host = document.createElement('div');
+        class AttachesSelf extends HTMLElement {
+            constructor() {
+                super();
+                host.appendChild(this);
+            }
+        }
+        customElements.define('ce-attaches-self', AttachesSelf);
+
+        const el = document.createElement('ce-attaches-self');
+        testing.expectEqual(true, el instanceof HTMLUnknownElement);
+        testing.expectEqual(null, el.parentNode);
+    }
+</script>
+
+<script id="parser_falls_back_without_crashing">
+    {
+        // Same thing, but driven through the fragment parser rather than
+        // createElement: the fallback element is what gets inserted.
+        const host = document.createElement('div');
+        class ParserAttachesSelf extends HTMLElement {
+            constructor() {
+                super();
+                host.appendChild(this);
+            }
+        }
+        customElements.define('ce-parser-attaches-self', ParserAttachesSelf);
+
+        const container = document.createElement('div');
+        container.innerHTML = '<ce-parser-attaches-self></ce-parser-attaches-self>';
+        testing.expectEqual(1, container.children.length);
+        testing.expectEqual(true, container.firstElementChild instanceof HTMLUnknownElement);
+    }
+</script>
+
+<script id="attributes_applied_after_constructor">
+    {
+        // The constructor must not observe the token's attributes; they are
+        // applied afterwards, which is also what enqueues their reactions.
+        let seen = 'unset';
+        class ObservesAttribute extends HTMLElement {
+            static get observedAttributes() { return ['title']; }
+            constructor() {
+                super();
+                seen = this.getAttribute('title');
+            }
+        }
+        customElements.define('ce-observes-attribute', ObservesAttribute);
+
+        const container = document.createElement('div');
+        container.innerHTML = '<ce-observes-attribute title="after"></ce-observes-attribute>';
+        testing.expectEqual(null, seen);
+        testing.expectEqual('after', container.firstElementChild.getAttribute('title'));
+    }
+</script>

--- a/src/browser/webapi/CustomElementRegistry.zig
+++ b/src/browser/webapi/CustomElementRegistry.zig
@@ -205,7 +205,7 @@ pub fn upgradeCustomElement(custom: *Custom, definition: *CustomElementDefinitio
     frame.js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     _ = ls.toLocal(definition.constructor).newInstance(&caught) catch |err| {
         log.warn(.js, "custom element upgrade", .{ .name = definition.name, .err = err, .caught = caught });
         return error.CustomElementUpgradeFailed;

--- a/src/browser/webapi/DataTransferItem.zig
+++ b/src/browser/webapi/DataTransferItem.zig
@@ -81,7 +81,7 @@ pub fn getAsString(self: *const DataTransferItem, cb_: ?js.Function) !void {
         .string => |str| str,
         .file => return,
     };
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     cb.tryCall(void, .{s}, &caught) catch {
         log.debug(.js, "getAsString callback", .{ .caught = caught, .source = "DataTransferItem" });
     };

--- a/src/browser/webapi/EventCounts.zig
+++ b/src/browser/webapi/EventCounts.zig
@@ -116,7 +116,7 @@ pub fn forEach(self: *EventCounts, cb_: js.Function, js_this_: ?js.Object) !void
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
     for (tracked_event_types, self._counts) |event_type, count| {
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ count, event_type, self }, &caught) catch {
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "EventCounts" });
         };

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -302,7 +302,7 @@ pub fn deliverEntries(self: *IntersectionObserver, frame: *Frame) !void {
     }
 
     const entries = try self.takeRecords(frame);
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/webapi/ModelContext.zig
+++ b/src/browser/webapi/ModelContext.zig
@@ -195,7 +195,7 @@ pub const ModelContextClient = struct {
         defer ls.deinit();
         const resolver = ls.local.createPromiseResolver();
 
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         if (callback.tryCall(js.Value, .{}, &caught)) |result| {
             // The callback may itself return a thenable; resolving with its
             // value lets V8's promise resolution machinery unwrap it.

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -348,7 +348,7 @@ pub fn deliverRecords(self: *MutationObserver, frame: *Frame) !void {
     frame.js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     ls.toLocal(self._callback).tryCallWithThis(void, self, .{ records, self }, &caught) catch |err| {
         log.err(.frame, "MutObserver.deliverRecords", .{ .err = err, .caught = caught });
         return err;

--- a/src/browser/webapi/PerformanceObserver.zig
+++ b/src/browser/webapi/PerformanceObserver.zig
@@ -181,7 +181,7 @@ pub fn dispatch(self: *PerformanceObserver) !void {
     self._js.localScope(&ls);
     defer ls.deinit();
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     ls.toLocal(self._callback).tryCall(void, .{ EntryList{ ._entries = records }, self }, &caught) catch |err| {
         log.err(.frame, "PerfObserver.dispatch", .{ .err = err, .caught = caught });
         return err;

--- a/src/browser/webapi/ResizeObserver.zig
+++ b/src/browser/webapi/ResizeObserver.zig
@@ -183,7 +183,7 @@ pub fn deliverEntries(self: *ResizeObserver, frame: *Frame) !void {
         return;
     }
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
 
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);

--- a/src/browser/webapi/collections/DOMTokenList.zig
+++ b/src/browser/webapi/collections/DOMTokenList.zig
@@ -246,7 +246,7 @@ pub fn forEach(self: *DOMTokenList, cb_: js.Function, js_this_: ?js.Object, fram
         if (gop.found_existing) {
             continue;
         }
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ token, i, self }, &caught) catch |err| {
             frame._page.recordJsError(err);
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "DOMTokenList" });

--- a/src/browser/webapi/collections/NodeList.zig
+++ b/src/browser/webapi/collections/NodeList.zig
@@ -97,7 +97,7 @@ pub fn forEach(self: *NodeList, cb: js.Function, frame: *Frame) !void {
     while (true) : (i += 1) {
         const node = try self.getAtIndex(@intCast(i), frame) orelse return;
 
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ node, i, self }, &caught) catch |err| {
             frame._page.recordJsError(err);
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "nodelist" });

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -278,7 +278,7 @@ pub fn checkAndAttachBuiltIn(element: *Element, frame: *Frame) !void {
         _ls.deinit();
     };
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     _ = local.toLocal(definition.constructor).newInstance(&caught) catch |err| {
         log.warn(.js, "custom builtin ctor", .{ .name = is_value, .err = err, .caught = caught });
         return;

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -91,7 +91,7 @@ pub fn forEach(self: *Headers, cb_: js.Function, js_this_: ?js.Object) !void {
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
     for (self._list._entries.items) |entry| {
-        var caught: js.TryCatch.Caught = undefined;
+        var caught: js.TryCatch.Caught = .{};
         cb.tryCall(void, .{ entry.value.str(), entry.name.str(), self }, &caught) catch {
             log.debug(.js, "forEach callback", .{ .caught = caught, .source = "headers" });
         };

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -193,7 +193,7 @@ pub fn terminateFromNetwork(self: *CDP) void {
 // valid for the duration of dispatch.
 pub fn onMessage(self: *CDP, c: *Inbox.Message.Cdp) anyerror!void {
     // Once a terminate is pending, don't dispatch
-    if (self.browser.env.isExecutionTerminating()) {
+    if (self.browser.env.terminatePending()) {
         return;
     }
 

--- a/src/cdp/domains/webmcp.zig
+++ b/src/cdp/domains/webmcp.zig
@@ -141,7 +141,7 @@ fn invokeTool(cmd: *CDP.Command) !void {
 
     const callback = local.toLocal(tool.execute);
 
-    var caught: js.TryCatch.Caught = undefined;
+    var caught: js.TryCatch.Caught = .{};
     const result = callback.tryCall(js.Value, .{ input_value, ModelContextClient{} }, &caught) catch {
         const msg = caught.exception orelse "tool threw";
         try respondError(cmd.cdp, bc, invocation, msg);


### PR DESCRIPTION
Should be merged after https://github.com/lightpanda-io/browser/pull/3130  I can't stack it since that branch isn't in our origin.

Follow up to https://github.com/lightpanda-io/browser/pull/3130

https://mf5ai1-cc.myshopify.com/products/ultimate-blue-raspberry-cyborg-ii-for-lefties-bundle?_fd=0

Loads with various errors, and hits an unreachable in debug mode. The core issue is how we create already-defined custom-elements. We need to run the constructor validate the state (a bunch of post-create conditions we need to check) and, on failure, fallback to a simple HTMLUnknownElement. Without the validation, the constructor can result in a state that we shouldn't allow, and html5ever ends up spitting a result it promises not to (because we fed it an invalid sequence).