### PR TITLE
webapi: Improve getComputedStyle with pseudo

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -136,9 +136,10 @@ _attribute_named_node_map_lookup: std.AutoHashMapUnmanaged(usize, *Element.Attri
 // that actually access these features via JavaScript, saving 24 bytes per element.
 _element_styles: Element.StyleLookup = .empty,
 // Computed-style views handed out by window.getComputedStyle. The computed
-// variant is a stateless lazy view, so one per element suffices — and Chrome
-// returns the same object for repeated calls, so identity is also conformance.
-_element_computed_styles: Element.StyleLookup = .empty,
+// variant is a stateless lazy view, so one per (element, pseudo-element)
+// suffices — and Chrome returns the same object for repeated calls, so
+// identity is also conformance.
+_element_computed_styles: Element.ComputedStyleLookup = .empty,
 _element_datasets: Element.DatasetLookup = .empty,
 _element_class_lists: Element.ClassListLookup = .empty,
 _element_rel_lists: Element.RelListLookup = .empty,

--- a/src/browser/tests/element/styles.html
+++ b/src/browser/tests/element/styles.html
@@ -224,6 +224,17 @@
   div.style.setProperty('text-transform', 'lowercase');
   testing.expectEqual('lowercase', window.getComputedStyle(div).getPropertyValue('text-transform'));
 
+  // Pseudo-elements get their own cache entry, keyed per (element, pseudo);
+  // the legacy single-colon form maps to the same entry as the double-colon
+  // one, and a pseudoElt without a leading colon is ignored (CSSOM).
+  const before = window.getComputedStyle(div, ':before');
+  testing.expectTrue(before === window.getComputedStyle(div, '::before'));
+  testing.expectTrue(before === window.getComputedStyle(div, ':BEFORE'));
+  testing.expectFalse(before === cs);
+  testing.expectFalse(before === window.getComputedStyle(div, '::after'));
+  testing.expectTrue(cs === window.getComputedStyle(div, 'before'));
+  testing.expectTrue(cs === window.getComputedStyle(div, ''));
+
   // A normal declaration must not override an earlier !important one, and the
   // computed and inline (el.style) paths must agree on the resolved value.
   const impDiv = document.createElement('div');

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -51,6 +51,30 @@ pub const Proto = Node;
 
 pub const DatasetLookup = std.AutoHashMapUnmanaged(*Element, *DOMStringMap);
 pub const StyleLookup = std.AutoHashMapUnmanaged(*Element, *CSSStyleProperties);
+pub const ComputedStyleLookup = std.AutoHashMapUnmanaged(ComputedStyleKey, *CSSStyleProperties);
+
+pub const ComputedStyleKey = struct {
+    element: *Element,
+    pseudo: PseudoElement,
+};
+
+pub const PseudoElement = enum {
+    none,
+    before,
+    after,
+    other,
+
+    pub fn parse(pseudo: []const u8) PseudoElement {
+        if (pseudo.len == 0 or pseudo[0] != ':') {
+            return .none;
+        }
+        const name = if (std.mem.startsWith(u8, pseudo, "::")) pseudo[2..] else pseudo[1..];
+        if (std.ascii.eqlIgnoreCase(name, "before")) return .before;
+        if (std.ascii.eqlIgnoreCase(name, "after")) return .after;
+        return .other;
+    }
+};
+
 pub const ClassListLookup = std.AutoHashMapUnmanaged(*Element, *collections.DOMTokenList);
 pub const RelListLookup = std.AutoHashMapUnmanaged(*Element, *collections.DOMTokenList);
 pub const ShadowRootLookup = std.AutoHashMapUnmanaged(*Element, *ShadowRoot);

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -661,16 +661,15 @@ pub fn matchMedia(_: *const Window, query: []const u8, frame: *Frame) !*MediaQue
 }
 
 pub fn getComputedStyle(_: *const Window, element: *Element, pseudo_element: ?[]const u8, frame: *Frame) !*CSSStyleProperties {
-    if (pseudo_element) |pe| {
-        if (pe.len != 0) {
-            log.warn(.not_implemented, "window.GetComputedStyle", .{ .pseudo_element = pe });
-            // Chrome hands out a distinct object per pseudo-element, so these
-            // can't share the per-element cache entry.
-            return CSSStyleProperties.init(element, true, frame);
-        }
-    }
-    const gop = try frame._element_computed_styles.getOrPut(frame.arena, element);
+    // :before/:after get their own cache entry and no warning: our answer
+    // (the element's own computed style) is a reasonable default for the
+    // common probes
+    const pseudo = Element.PseudoElement.parse(pseudo_element orelse "");
+    const gop = try frame._element_computed_styles.getOrPut(frame.arena, .{ .element = element, .pseudo = pseudo });
     if (!gop.found_existing) {
+        if (pseudo == .other) {
+            log.warn(.not_implemented, "window.GetComputedStyle", .{ .pseudo_element = pseudo_element.? });
+        }
         gop.value_ptr.* = try CSSStyleProperties.init(element, true, frame);
     }
     return gop.value_ptr.*;


### PR DESCRIPTION
1. Stop logging not_implemented for :before, :after - they are used a lot and the log is just noise

2. Change the computed style identity map key from element -> (element, pseudo_type). This ensures that the same element+pseudo correctly gets the same CSSStyleProperties, and it avoids needlessly creating more objects for a repeated element/pseudo pair.