### PR TITLE
tools: surface unknown tool names in-band

### DIFF
--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -800,7 +800,13 @@ pub fn call(
     tool_name: []const u8,
     arguments: ?std.json.Value,
 ) ToolError!ToolResult {
-    const tool = std.meta.stringToEnum(Tool, tool_name) orelse return ToolError.InvalidParams;
+    // In-band so an LLM that invented a tool name (e.g. OpenAI's internal
+    // `multi_tool_use.parallel` wrapper) learns the name is wrong instead of
+    // retrying it with different arguments.
+    const tool = std.meta.stringToEnum(Tool, tool_name) orelse return .{
+        .text = try std.fmt.allocPrint(arena, "Unknown tool: {s}", .{tool_name}),
+        .is_error = true,
+    };
     if (diagnoseArgs(arena, arguments)) |msg|
         return .{ .text = msg, .is_error = true };
     // Must run before substituteStringArgs so the `key=="value"` secret-
@@ -2223,6 +2229,17 @@ pub fn reverseSubstituteEnvVars(arena: std.mem.Allocator, input: []const u8) err
         changed = true;
     }
     return if (changed) current else input;
+}
+
+test "call: unknown tool name surfaces in-band" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Session/registry are never touched on this branch; the name check is
+    // the first thing `call` does.
+    const r = try call(arena.allocator(), undefined, undefined, "multi_tool_use.parallel", null);
+    try std.testing.expect(r.is_error);
+    try std.testing.expectEqualStrings("Unknown tool: multi_tool_use.parallel", r.text);
 }
 
 test "substituteEnvVars resolves LP_* vars" {


### PR DESCRIPTION
## Problem

When the LLM emits a tool call with a name that isn't in our tool set, `tools.call` returned `ToolError.InvalidParams` — the same error as malformed arguments. The model was effectively told "your params were invalid", so its natural correction is to retry the *same bogus name* with reshuffled arguments instead of dropping it.

This isn't hypothetical: OpenAI models have a known failure mode where their internal parallel-call wrapper `multi_tool_use.parallel` leaks through as a literal tool call instead of being unrolled server-side into the `tool_calls` array ([openai-node#488](https://github.com/openai/openai-node/issues/488), [community thread](https://community.openai.com/t/model-tries-to-call-unknown-function-multi-tool-use-parallel/490653)). When that happens, the real calls are nested inside the wrapper's arguments and get silently dropped; accurate feedback is what lets the model recover on the next turn.

## Change

Unknown names now return an in-band error result — `Unknown tool: <name>` with `is_error = true` — following the existing `diagnoseArgs` pattern, so the model learns the name itself is wrong and can self-correct.

Only the LLM tool-call path is affected: the MCP dispatcher (`stringToEnum` + `MethodNotFound` in `src/mcp/tools.zig`) and the slash-command path (`Schema.findByName` → `error.UnknownTool`) both validate names before reaching `call()`.

## Testing

- New test: `call: unknown tool name surfaces in-band`
- `make test`: 1139/1139 pass
- `zig fmt --check` clean