### PR TITLE
docs: prefer `lightpanda run` for replaying scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The output of an agent session is a
 [PandaScript](https://lightpanda.io/docs/usage/pandascript): vanilla JavaScript
 with a small set of native browser primitives built directly into Lightpanda.
 Run `/save` to export one from your current session, then replay it with
-`lightpanda agent <script>.js`. Scripts are deterministic and token-free, so
+`lightpanda run <script>.js`. Scripts are deterministic and token-free, so
 you can prototype with the LLM and ship the output to production without a
 model at runtime.
 
@@ -178,7 +178,7 @@ reference.
 ./lightpanda agent                                    # auto-detects API key from env
 ./lightpanda agent --task "top story on news.ycombinator.com?"
 ./lightpanda agent --no-llm                           # basic REPL, no LLM
-./lightpanda agent session.js                         # run a recorded script
+./lightpanda run session.js                           # run a recorded script
 ./lightpanda agent --provider gemini --task "..."     # force a specific provider
 VERTEX_API_KEY=... ./lightpanda agent --provider vertex             # Vertex AI, express mode
 GOOGLE_CLOUD_PROJECT=my-proj ./lightpanda agent --provider vertex   # Vertex AI, token via gcloud auth

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -169,7 +169,7 @@ pub const Command = union(enum) {
         return .{ .tool_call = .{ .tool = s.tool, .args = args } };
     }
 
-    /// JavaScript recorder format for `lightpanda agent <script>.js`.
+    /// JavaScript recorder format for `lightpanda run <script>.js`.
     /// Slash command parsing stays separate; this renders recorded browser
     /// primitives as blocking global function calls in the agent script
     /// runtime.

--- a/src/script/skill.zig
+++ b/src/script/skill.zig
@@ -28,7 +28,7 @@ const browser_tools = lp.tools;
 const Schema = @import("Schema.zig");
 
 pub const name = "pandascript";
-pub const description = "Write PandaScript agent scripts (.js) — Lightpanda's replayable browser-automation format, run token-free with `lightpanda agent script.js`.";
+pub const description = "Write PandaScript agent scripts (.js) — Lightpanda's replayable browser-automation format, run token-free with `lightpanda run script.js`.";
 
 /// Semantics summary for the agent's default system prompt, so the agent
 /// answers user questions about PandaScript from these rules instead of
@@ -210,7 +210,7 @@ const prose_head =
     \\Run with:
     \\
     \\```console
-    \\./lightpanda agent script.js
+    \\./lightpanda run script.js
     \\```
     \\
     \\## Mental model (get this right first)


### PR DESCRIPTION
## Summary

All the places that tell users how to replay a recorded PandaScript said `lightpanda agent script.js`. The `run` subcommand is the better recommendation: it's the same execution path (normalized to `.agent` in `parseArgs`) but carries no LLM options, so it states the intent — replay a script, no model involved.

Updated:
- `src/script/skill.zig` — the generated script-writing skill: its `description` line and the "Run with" block in the prose (consumed by `/save` and the MCP skill).
- `src/script/command.zig` — the recorder-format doc comment.
- `README.md` — the agent-mode section and the CLI examples block.

Interactive-agent usages (`lightpanda agent --task`, `--no-llm`, provider examples) are unchanged — those genuinely are the `agent` subcommand.

## Test plan

- `zig fmt --check` passes on the changed files.
- `make test F="skill"` — 4/4 pass (golden fragments + savePrompt tests cover the emitted skill text).