### PR TITLE
fetch: default --wait-until to load

### DIFF
--- a/src/help.zon
+++ b/src/help.zon
@@ -114,10 +114,13 @@
     \\          --wait-until condition is met.
     \\  --wait-until <UNTIL>
     \\          Wait until the specified event. Checked before other --wait-* options.
-    \\          Defaults to 'done'. If --wait-selector, --wait-script or
+    \\          Defaults to 'load'. If --wait-selector, --wait-script or
     \\          --wait-script-file specified, defaults to none.
     \\          Allowed values: "load", "domcontentloaded", "networkalmostidle",
     \\          "networkidle", "done".
+    \\          'done' waits for full quiescence (no pending scripts or network);
+    \\          pages with constant background activity never reach it and run
+    \\          to --wait-ms.
     \\  --with-base
     \\          Add a <base> tag in dump.
     \\          Defaults to false.

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -189,10 +189,22 @@ pub const FetchOpts = struct {
     writer: ?*std.Io.Writer = null,
     json: bool = false,
 };
+
+/// `.load`, not `.done`: pages with constant background activity never go
+/// quiescent, so `.done` just rides the `wait_ms` cap. A lone
+/// `wait_selector`/`wait_script` is itself the wait, so no level applies
+/// unless given explicitly.
+fn resolveWaitUntil(opts: FetchOpts) ?Config.WaitUntil {
+    if (opts.wait_until) |wu| return wu;
+    if (opts.wait_selector == null and opts.wait_script == null) return .load;
+    return null;
+}
 /// Loads each url in `urls` in a fresh session and waits per `opts`.
 ///
 /// Errors:
-///   - `error.Timeout` if the wait deadline (`opts.wait_ms`) expires.
+///   - `error.Timeout` if the deadline expires while a `wait_selector` or
+///     `wait_script` is still unmet. The `wait_until` phase never raises it:
+///     when the budget runs out the page is dumped as-is.
 ///   - `error.Cancelled` if the embedder installed a `Session.cancel_hook`
 ///     that returned true during the wait. The hook is opt-in via
 ///     `session.cancel_hook = .{...}`; without it, this error never fires.
@@ -239,13 +251,8 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
 
     var timer: std.Io.Timestamp = .now(io, .boot);
 
-    if (opts.wait_until) |wu| {
+    if (resolveWaitUntil(opts)) |wu| {
         try runner.waitForAll(opts.wait_ms, .{ .until = wu });
-    } else if (opts.wait_selector == null and opts.wait_script == null) {
-        // We default to .done if both wait_selector and wait_script are null
-        // This allows the caller to ONLY --wait-selector or ONLY --wait-script
-        // or combine --wait-until WITH --wait-selector/script
-        try runner.waitForAll(opts.wait_ms, .{ .until = .done });
     }
 
     if (opts.wait_selector) |selector| {
@@ -506,6 +513,17 @@ test "writeJsonEnvelope: null frame with dump mode and content" {
         .dump = "html",
         .content = "<html><body>hello</body></html>",
     }, aw.written());
+}
+
+test "fetch: resolveWaitUntil" {
+    try testing.expectEqual(.load, resolveWaitUntil(.{ .dump = .{} }));
+    try testing.expectEqual(.done, resolveWaitUntil(.{ .dump = .{}, .wait_until = .done }));
+    try testing.expectEqual(null, resolveWaitUntil(.{ .dump = .{}, .wait_selector = "#main" }));
+    try testing.expectEqual(null, resolveWaitUntil(.{ .dump = .{}, .wait_script = "true" }));
+    try testing.expectEqual(
+        .networkidle,
+        resolveWaitUntil(.{ .dump = .{}, .wait_until = .networkidle, .wait_selector = "#main" }),
+    );
 }
 
 test {


### PR DESCRIPTION
## What

`lightpanda fetch <url>` with no wait flags now waits for `load` instead of `done` (full quiescence). Explicit `--wait-until`, `--wait-selector` and `--wait-script` behave as before.

## Why

`done` requires no pending macrotasks and a fully idle network. Pages with constant background activity (ad timers, live sockets) never get there, so every default fetch of such a page rode the full `--wait-ms` cap (5s). The cap expiry is non-fatal (`Runner.waitForAll` discards `WaitResult.timeout`), so the previous default was effectively "wait 5s, then dump whatever is there" — wasted wall time with no completeness guarantee behind it.

The agent/MCP tools already default to `load` for exactly this reason (`default_nav_wait` in tools.zig: "on real sites trackers/timers keep the network from ever fully idling, so it just rides the timeout"). This makes fetch consistent with them.

Measured on apnews.com/hub/world-news (ReleaseFast, interleaved runs, `--disable-subframes`):

| wait level | wall time |
| --- | --- |
| domcontentloaded | ~0.9s |
| load (new default) | ~3.2s (one slow-tail run at 6.7s) |
| networkalmostidle | ~3.7s |
| done (old default) / networkidle | pinned at the ~5s cap, every run |

The `load`-time dump also contained slightly *more* of the page's real content than the `done`-time dump (356 vs 346 article refs; the extra seconds of ad-script execution mutate the DOM, they don't add readable content). A quiet page (example.com) dumps byte-identical output under both, at the same speed.

## Trade-off

Pages that populate content via post-`load` XHR will dump less by default. Those cases opt in explicitly: `--wait-until networkidle`, `--wait-until done`, or `--wait-selector` (which was already the reliable way to wait for specific content).

## Changes

- `resolveWaitUntil()` extracted so the default is testable; `.load` when no wait flag is given, none when only `--wait-selector`/`--wait-script` is set (the selector/script is the wait).
- help text updated ('done' documented as running to `--wait-ms` on busy pages).
- `fetch()` doc comment fixed: `error.Timeout` is only raised by the selector/script phases; the `wait_until` phase dumps as-is on cap expiry (that part was already true before this PR).
- Table test for the default resolution.

1140/1140 tests, fmt clean.