### PR TITLE
main: propagate worker-thread failures to the exit code

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -196,8 +196,10 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 try sighandler.deadline(ms);
             }
 
-            var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, &ft, urls, fetch_opts });
+            var fetch_err: ?anyerror = null;
+            var worker_thread = try std.Thread.spawn(.{}, fetchThread, .{ app, &ft, urls, fetch_opts, &fetch_err });
             worker_thread.join();
+            if (fetch_err) |err| return err;
         },
         .mcp => |opts| {
             log.info(.mcp, "starting server", .{});
@@ -209,11 +211,11 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
             if (opts.port) |port| {
                 if (opts.cdp_port != null) {
                     log.fatal(.mcp, "port conflicts with cdp-port", .{ .hint = "both need the single network listener" });
-                    return;
+                    return error.InvalidArgument;
                 }
                 const address = std.Io.net.IpAddress.parse(opts.host, port) catch |err| {
                     log.fatal(.mcp, "invalid address", .{ .err = err, .host = opts.host, .port = port });
-                    return;
+                    return err;
                 };
                 const http_server = try lp.mcp.HttpServer.init(allocator, app);
                 defer http_server.deinit();
@@ -221,6 +223,7 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 // a signal stops the accept loop, run() returns, deinit joins.
                 http_server.run(address) catch |err| {
                     log.fatal(.mcp, "mcp http error", .{ .err = err });
+                    return err;
                 };
                 return;
             }
@@ -236,15 +239,19 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
             }
             defer if (cdp_server) |s| s.deinit();
 
-            var worker_thread = try std.Thread.spawn(.{}, mcpThread, .{ allocator, app });
-            defer worker_thread.join();
+            var mcp_err: ?anyerror = null;
+            {
+                var worker_thread = try std.Thread.spawn(.{}, mcpThread, .{ allocator, app, &mcp_err });
+                defer worker_thread.join();
 
-            // mcp talks over stdio on mcpThread. Only run the CDP accept/read
-            // loop when an optional CDP server was started; otherwise the main
-            // thread just waits for the worker.
-            if (cdp_server != null) {
-                app.network.run();
+                // mcp talks over stdio on mcpThread. Only run the CDP accept/read
+                // loop when an optional CDP server was started; otherwise the main
+                // thread just waits for the worker.
+                if (cdp_server != null) {
+                    app.network.run();
+                }
             }
+            if (mcp_err) |err| return err;
         },
         .agent => |opts| {
             log.info(.app, "starting agent", .{});
@@ -343,11 +350,12 @@ const FetchTerminator = struct {
     }
 };
 
-fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetch_opts: lp.FetchOpts) void {
+fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetch_opts: lp.FetchOpts, err_out: *?anyerror) void {
     defer app.network.stop();
 
     var browser: lp.Browser = undefined;
     browser.init(app, .{}, null) catch |err| {
+        err_out.* = err;
         log.fatal(.app, "browser init error", .{ .err = err });
         return;
     };
@@ -360,15 +368,17 @@ fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetc
     defer ft.releaseBrowser();
 
     lp.fetch(app, &browser, urls, fetch_opts) catch |err| {
+        err_out.* = err;
         log.fatal(.app, "fetch error", .{ .err = err, .url_count = urls.len });
     };
 }
 
-fn mcpThread(allocator: std.mem.Allocator, app: *App) void {
+fn mcpThread(allocator: std.mem.Allocator, app: *App, err_out: *?anyerror) void {
     defer app.network.stop();
 
     var stdout = std.Io.File.stdout().writerStreaming(lp.io, &.{});
     var mcp_server: *lp.mcp.Server = lp.mcp.Server.init(allocator, app, &stdout.interface) catch |err| {
+        err_out.* = err;
         log.fatal(.mcp, "mcp init error", .{ .err = err });
         return;
     };
@@ -377,6 +387,7 @@ fn mcpThread(allocator: std.mem.Allocator, app: *App) void {
     var stdin_buf: [64 * 1024]u8 = undefined;
     var stdin = std.Io.File.stdin().readerStreaming(lp.io, &stdin_buf);
     lp.mcp.router.processRequests(mcp_server, &stdin.interface, std.Io.File.stdin()) catch |err| {
+        err_out.* = err;
         log.fatal(.mcp, "mcp error", .{ .err = err });
     };
 }


### PR DESCRIPTION
## What

Errors that end a fetch or mcp run now reach the process exit code. Before, `fetchThread` and `mcpThread` caught their errors, logged `$level=fatal`, and returned void — the main thread joined the worker and exited 0. Concretely:

```
$ lightpanda fetch --wait-selector '#no-such-thing' --wait-ms 1500 https://example.com; echo $?
$time=... $scope=app $level=fatal $msg="fetch error" err=Timeout url_count=1
0
```

Any script or CI step checking fetch's exit code sees success on failure. The same held for browser-init errors in fetch, mcp stdio errors, and three fatal paths in the mcp HTTP branch (port conflict, bad address, server run error) that run on the main thread and returned void.

## How

The `agentThread` pattern already in main.zig (out-pointer set in the thread, checked after join): `fetchThread`/`mcpThread` get an `err_out: *?anyerror`, the dispatch returns the error after `join()`. The mcp HTTP-branch paths return their errors directly, like serve already does.

Clean mcp stdin EOF is unaffected: `processRequests` returns normally on EOF (`takeDelimiter ... orelse break`), so a client disconnect still exits 0.

## Verified

| case | before | after |
| --- | --- | --- |
| fetch, selector timeout | 0 | 1 |
| fetch, success | 0 | 0 |
| mcp, --port + --cdp-port conflict | 0 | 1 |
| mcp, clean stdin EOF | 0 | 0 |

1139/1139 tests, fmt clean.

Deliberately unchanged: a failed navigation in fetch still exits 0 — that path renders the synthetic "Navigation failed" error page and dumps it as the document (no fatal raised), and `--json` carries the status. Whether that should also fail the exit code is a separate question.