### PR TITLE
Entry Limit for HTTP Cache

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -191,7 +191,7 @@ const CommonOptions = .{
     .{ .name = "log_filter_scopes", .type = log.FilterRule, .multiple = true, .validator = logFilterScopesValidator },
     .{ .name = "user_agent_suffix", .type = ?[]const u8 },
     .{ .name = "http_cache_dir", .type = ?[]const u8 },
-    .{ .name = "http_cache_entry_limit", .type = ?u32 },
+    .{ .name = "http_cache_entry_limit", .type = ?u32, .default = 1000 },
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
@@ -634,7 +634,7 @@ pub fn httpCacheDir(self: *const Config) ?[]const u8 {
 
 pub fn httpCacheEntryLimit(self: *const Config) u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_entry_limit orelse 1000,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_entry_limit.?,
         else => 1000,
     };
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -191,6 +191,7 @@ const CommonOptions = .{
     .{ .name = "log_filter_scopes", .type = log.FilterRule, .multiple = true, .validator = logFilterScopesValidator },
     .{ .name = "user_agent_suffix", .type = ?[]const u8 },
     .{ .name = "http_cache_dir", .type = ?[]const u8 },
+    .{ .name = "http_cache_entry_limit", .type = ?u32 },
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
@@ -628,6 +629,13 @@ pub fn httpCacheDir(self: *const Config) ?[]const u8 {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_dir,
         else => null,
+    };
+}
+
+pub fn httpCacheEntryLimit(self: *const Config) u32 {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_cache_entry_limit orelse 1000,
+        else => 1000,
     };
 }
 

--- a/src/help.zon
+++ b/src/help.zon
@@ -342,6 +342,9 @@
     \\          Directory used as a filesystem cache for network resources. Omitting
     \\          this disables caching.
     \\          Defaults to no caching.
+    \\  --http-cache-entry-limit <INT>
+    \\          Maximum number of entries that can be stored in the HTTP cache. 0 means no limit.
+    \\          Defaults to 1000.
     \\  --http-connect-timeout <INT>
     \\          Time in ms to establish an HTTP connection before timing out. 0 means
     \\          never.

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -233,7 +233,11 @@ pub fn init(allocator: Allocator, app: *App, config: *const Config) !Network {
     const cache = if (config.httpCacheDir()) |cache_dir_path|
         Cache{
             .kind = .{
-                .sqlite = SqliteCache.init(allocator, .{ .path = cache_dir_path }) catch |e| {
+                .sqlite = SqliteCache.init(
+                    allocator,
+                    .{ .path = cache_dir_path },
+                    config.httpCacheEntryLimit(),
+                ) catch |e| {
                     log.err(.cache, "failed to init", .{
                         .kind = "SqliteCache",
                         .path = cache_dir_path,

--- a/src/network/cache/SqliteCache.zig
+++ b/src/network/cache/SqliteCache.zig
@@ -41,6 +41,7 @@ pub const SqliteCache = @This();
 
 allocator: std.mem.Allocator,
 pool: Pool,
+entry_limit: u32,
 
 const cache_migrations: []const Migration = &.{
     .{ .sql =
@@ -67,6 +68,7 @@ const cache_migrations: []const Migration = &.{
     \\ ) strict
     },
     .{ .sql = "create index header_url on header(url)" },
+    .{ .sql = "create index cache_stored_at on cache(stored_at)" },
 };
 
 pub const SqliteCachePath = union(enum) {
@@ -85,7 +87,7 @@ pub const SqliteCachePath = union(enum) {
     }
 };
 
-pub fn init(allocator: std.mem.Allocator, path: SqliteCachePath) !SqliteCache {
+pub fn init(allocator: std.mem.Allocator, path: SqliteCachePath, entry_limit: u32) !SqliteCache {
     var pool = switch (path) {
         .memory => try Pool.init(allocator, ":memory:"),
         .path => |cache_dir| blk: {
@@ -125,11 +127,23 @@ pub fn init(allocator: std.mem.Allocator, path: SqliteCachePath) !SqliteCache {
     }
 
     log.info(.cache, "sqlite cache initialized", .{ .path = path, .version = version });
-    return .{ .allocator = allocator, .pool = pool };
+    return .{ .allocator = allocator, .pool = pool, .entry_limit = entry_limit };
 }
 
 pub fn deinit(self: *SqliteCache) void {
     self.pool.deinit(self.allocator);
+}
+
+fn evictOverflow(self: *SqliteCache, conn: Conn) !void {
+    const limit = self.entry_limit;
+    if (limit == 0) return;
+
+    try conn.exec(
+        \\ delete from cache
+        \\ where url not in (
+        \\     select url from cache order by stored_at desc limit $1
+        \\ )
+    , .{@as(i64, @intCast(limit))});
 }
 
 pub fn get(self: *SqliteCache, arena: std.mem.Allocator, req: CacheGetRequest) !CacheGetResult {
@@ -270,6 +284,7 @@ pub fn put(self: *SqliteCache, req: CachePutRequest, body: []const u8) !void {
         );
     }
 
+    try self.evictOverflow(conn);
     try conn.commit();
 
     log.debug(.cache, "put", .{ .url = req.url, .body_len = body.len });
@@ -376,7 +391,7 @@ pub fn renew(self: *SqliteCache, _: std.mem.Allocator, req: RenewResponse) !void
 const testing = std.testing;
 
 fn setupCache(allocator: std.mem.Allocator) !Cache {
-    return Cache{ .kind = .{ .sqlite = try .init(allocator, .memory) } };
+    return Cache{ .kind = .{ .sqlite = try .init(allocator, .memory, 0) } };
 }
 
 test "SqliteCache: Migrations" {
@@ -899,4 +914,51 @@ test "SqliteCache: renew preserves body" {
     );
     try testing.expect(result == .hit);
     try testing.expectEqualStrings("original body", result.hit.data.buffer);
+}
+
+test "SqliteCache: evicts oldest entries over the limit" {
+    var cache = Cache{ .kind = .{ .sqlite = try .init(testing.allocator, .memory, 3) } };
+    defer cache.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const now: u64 = @intCast(std.Io.Timestamp.now(testing.io, .boot).toSeconds());
+
+    const urls = [_][:0]const u8{
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+        "https://example.com/d",
+    };
+
+    for (urls, 0..) |url, i| {
+        try cache.put(.{
+            .url = url,
+            .content_type = "text/html",
+            .status = 200,
+            .stored_at = now + i,
+            .age_at_store = 0,
+            .cache_control = .{ .max_age = 600 },
+            .headers = &.{},
+            .vary_headers = &.{},
+        }, url);
+    }
+
+    const evicted = try cache.get(arena.allocator(), .{
+        .url = "https://example.com/a",
+        .timestamp = now,
+        .request_headers = &.{},
+    });
+    try testing.expect(evicted == .miss);
+
+    for (urls[1..]) |url| {
+        const hit = try cache.get(arena.allocator(), .{
+            .url = url,
+            .timestamp = now + urls.len,
+            .request_headers = &.{},
+        });
+        try testing.expect(hit == .hit);
+        try testing.expectEqualStrings(url, hit.hit.data.buffer);
+    }
 }

--- a/src/network/cache/SqliteCache.zig
+++ b/src/network/cache/SqliteCache.zig
@@ -140,8 +140,10 @@ fn evictOverflow(self: *SqliteCache, conn: Conn) !void {
 
     try conn.exec(
         \\ delete from cache
-        \\ where url not in (
-        \\     select url from cache order by stored_at desc limit $1
+        \\ where rowid in (
+        \\     select rowid from cache
+        \\     order by stored_at desc
+        \\     limit -1 offset $1
         \\ )
     , .{@as(i64, @intCast(limit))});
 }

--- a/src/network/cache/SqliteCache.zig
+++ b/src/network/cache/SqliteCache.zig
@@ -126,7 +126,7 @@ pub fn init(allocator: std.mem.Allocator, path: SqliteCachePath, entry_limit: u3
         try conn.exec("pragma foreign_keys=on", .{});
     }
 
-    log.info(.cache, "sqlite cache initialized", .{ .path = path, .version = version });
+    log.info(.cache, "sqlite cache initialized", .{ .path = path, .entry_limit = entry_limit, .version = version });
     return .{ .allocator = allocator, .pool = pool, .entry_limit = entry_limit };
 }
 


### PR DESCRIPTION
This adds a `http_cache_entry_limit` flag that allows you to limit the maximum number of entries that persist in the HTTP Cache. It currently uses `stored_at` times as a heuristic to determine what gets evicted when full.