### PR TITLE
Single Flight

### DIFF
--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -222,7 +222,11 @@ pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) 
 
         .serve_mode = network.config.mode == .serve,
         .obey_robots = network.config.obeyRobots(),
-        .robots = .{ .allocator = allocator, .network = network },
+        .robots = .{
+            .allocator = allocator,
+            .network = network,
+            .single_flight = .init(allocator),
+        },
         .url_blocklist = url_blocklist,
         .arena_pool = &network.app.arena_pool,
     };
@@ -422,7 +426,7 @@ pub fn abort(self: *Client) void {
         std.debug.assert(self.ws_dispatch_queue.first == null);
         // - self.robots.pending : each robots fetch's shutdown_callback
         //   drops its entry; parked waiters unlink in their own deinit.
-        std.debug.assert(self.robots.pending.count() == 0);
+        std.debug.assert(self.robots.single_flight.count() == 0);
     }
 }
 
@@ -3386,7 +3390,11 @@ fn initTestClient(client: *Client, pool: *ArenaPool) void {
     client.cache = null;
     client.serve_mode = false;
     client.obey_robots = false;
-    client.robots = .{ .allocator = testing.allocator, .network = undefined };
+    client.robots = .{
+        .allocator = testing.allocator,
+        .network = undefined,
+        .single_flight = .init(testing.allocator),
+    };
     client.url_blocklist = null;
 }
 
@@ -3578,8 +3586,8 @@ test "HttpClient: fulfillIntercepted survives a done_callback that tears down th
 }
 
 test "HttpClient: aborting a robots-parked transfer unlinks it from the gate" {
-    // Regression: RobotsGate.pending kept a raw *Transfer with nothing
-    // removing it when a parked transfer was aborted out-of-band
+    // Regression: RobotsGate's single-flight map kept a raw *Transfer with
+    // nothing removing it when a parked transfer was aborted out-of-band
     // (xhr.abort(), owner teardown). The robots.txt resolution would then
     // unpark freed memory.
     var pool = ArenaPool.init(testing.allocator, .{});
@@ -3620,18 +3628,19 @@ test "HttpClient: aborting a robots-parked transfer unlinks it from the gate" {
         try waiting.append(testing.allocator, transfer);
         transfer.park(.robots);
     }
-    try client.robots.pending.putNoClobber(testing.allocator, robots_url, waiting);
 
-    const t1 = client.robots.pending.get(robots_url).?.items[0];
-    const t2 = client.robots.pending.get(robots_url).?.items[1];
+    try client.robots.single_flight.pending.putNoClobber(testing.allocator, robots_url, waiting);
+
+    const t1 = client.robots.single_flight.pending.get(robots_url).?.items[0];
+    const t2 = client.robots.single_flight.pending.get(robots_url).?.items[1];
 
     t1.abort(error.Abort);
-    try testing.expectEqual(1, client.robots.pending.get(robots_url).?.items.len);
-    try testing.expect(client.robots.pending.get(robots_url).?.items[0] == t2);
+    try testing.expectEqual(1, client.robots.single_flight.pending.get(robots_url).?.items.len);
+    try testing.expect(client.robots.single_flight.pending.get(robots_url).?.items[0] == t2);
     try testing.expectEqual(1, client.transfers.count());
 
     t2.abort(error.Abort);
-    try testing.expectEqual(0, client.robots.pending.get(robots_url).?.items.len);
+    try testing.expectEqual(0, client.robots.single_flight.pending.get(robots_url).?.items.len);
     try testing.expectEqual(0, client.transfers.count());
 }
 

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -223,7 +223,6 @@ pub fn init(self: *Client, allocator: Allocator, network: *Network, cdp: ?*CDP) 
         .serve_mode = network.config.mode == .serve,
         .obey_robots = network.config.obeyRobots(),
         .robots = .{
-            .allocator = allocator,
             .network = network,
             .single_flight = .init(allocator),
         },
@@ -3391,7 +3390,6 @@ fn initTestClient(client: *Client, pool: *ArenaPool) void {
     client.serve_mode = false;
     client.obey_robots = false;
     client.robots = .{
-        .allocator = testing.allocator,
         .network = undefined,
         .single_flight = .init(testing.allocator),
     };

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -3602,7 +3602,7 @@ test "HttpClient: aborting a robots-parked transfer unlinks it from the gate" {
 
     const robots_url = "http://example.com/robots.txt";
 
-    var waiting: std.ArrayList(*Transfer) = .empty;
+    var transfers: [2]*Transfer = undefined;
     for (0..2) |i| {
         const arena = try pool.acquire(.small, "test");
         const transfer = try arena.create(Transfer);
@@ -3625,14 +3625,14 @@ test "HttpClient: aborting a robots-parked transfer unlinks it from the gate" {
             .start_time = 0,
         };
         try client.transfers.putNoClobber(testing.allocator, transfer.id, transfer);
-        try waiting.append(testing.allocator, transfer);
-        transfer.park(.robots);
+        transfers[i] = transfer;
     }
 
-    try client.robots.single_flight.pending.putNoClobber(testing.allocator, robots_url, waiting);
+    _ = try client.robots.single_flight.enter(robots_url, transfers[0], .robots);
+    _ = try client.robots.single_flight.enter(robots_url, transfers[1], .robots);
 
-    const t1 = client.robots.single_flight.pending.get(robots_url).?.items[0];
-    const t2 = client.robots.single_flight.pending.get(robots_url).?.items[1];
+    const t1 = transfers[0];
+    const t2 = transfers[1];
 
     t1.abort(error.Abort);
     try testing.expectEqual(1, client.robots.single_flight.pending.get(robots_url).?.items.len);

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -39,7 +39,6 @@ const Allocator = std.mem.Allocator;
 const RobotsGate = @This();
 
 network: *Network,
-allocator: Allocator,
 single_flight: SingleFlight,
 
 pub const Result = enum { allowed, blocked, pending };

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -31,6 +31,7 @@ const http = @import("http.zig");
 const Robots = @import("Robots.zig");
 const Network = @import("Network.zig");
 const Transfer = @import("HttpClient.zig").Transfer;
+const SingleFlight = @import("SingleFlight.zig");
 
 const log = lp.log;
 const Allocator = std.mem.Allocator;
@@ -39,16 +40,12 @@ const RobotsGate = @This();
 
 network: *Network,
 allocator: Allocator,
-pending: std.StringHashMapUnmanaged(std.ArrayList(*Transfer)) = .empty,
+single_flight: SingleFlight,
 
 pub const Result = enum { allowed, blocked, pending };
 
 pub fn deinit(self: *RobotsGate) void {
-    var it = self.pending.iterator();
-    while (it.next()) |entry| {
-        entry.value_ptr.deinit(self.allocator);
-    }
-    self.pending.deinit(self.allocator);
+    self.single_flight.deinit();
 }
 
 pub fn check(self: *RobotsGate, transfer: *Transfer) !Result {
@@ -77,25 +74,10 @@ pub fn check(self: *RobotsGate, transfer: *Transfer) !Result {
 // stays: the in-flight fetch owns it (the key lives on the fetch's context
 // arena) and still resolves the remaining waiters.
 pub fn remove(self: *RobotsGate, transfer: *Transfer) void {
-    var it = self.pending.valueIterator();
-    while (it.next()) |waiting| {
-        for (waiting.items, 0..) |t, i| {
-            if (t == transfer) {
-                _ = waiting.swapRemove(i);
-                return;
-            }
-        }
-    }
+    self.single_flight.remove(transfer);
 }
 
 fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Transfer) !void {
-    if (self.pending.getPtr(robots_url)) |waiting| {
-        // A fetch for this robots.txt is already in flight, queue behind it.
-        try waiting.append(self.allocator, transfer);
-        transfer.park(.robots);
-        return;
-    }
-
     const client = transfer.client;
 
     // The context, the response buffer and the pending-map key live on
@@ -107,6 +89,15 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
     errdefer arena.release();
 
     const owned_url = try arena.dupeZ(u8, robots_url);
+    const result = try self.single_flight.enter(owned_url, transfer, .robots);
+    if (result == .queued) {
+        // Someone else already owns an in-flight fetch for this key
+        // (under its own, earlier-allocated owned_url). This arena was
+        // never handed to a fetch, so release it ourselves.
+        arena.release();
+        return;
+    }
+
     const robots_ctx = try arena.create(RobotsContext);
     robots_ctx.* = .{
         .gate = self,
@@ -115,16 +106,6 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
         .arena_pool = client.arena_pool,
         .robots_url = owned_url,
     };
-
-    var waiting: std.ArrayList(*Transfer) = .empty;
-    try waiting.append(self.allocator, transfer);
-    errdefer waiting.deinit(self.allocator);
-
-    try self.pending.putNoClobber(self.allocator, owned_url, waiting);
-    errdefer _ = self.pending.remove(owned_url);
-
-    transfer.park(.robots);
-    errdefer transfer.unpark();
 
     log.debug(.browser, "fetching robots.txt", .{ .robots_url = owned_url });
 
@@ -161,11 +142,11 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
 // each judged against its own path. No store entry (fetch failed, or a 200
 // whose body never got parsed) fails open.
 fn flushPending(self: *RobotsGate, robots_url: []const u8) void {
-    var queued = self.pending.fetchRemove(robots_url) orelse return;
-    defer queued.value.deinit(self.allocator);
+    var queued = self.single_flight.take(robots_url) orelse return;
+    defer queued.deinit(self.allocator);
 
     const robot_entry = self.network.robot_store.get(robots_url);
-    for (queued.value.items) |transfer| {
+    for (queued.items) |transfer| {
         transfer.unpark();
 
         const allowed = if (robot_entry) |entry| switch (entry) {
@@ -187,15 +168,6 @@ fn flushPending(self: *RobotsGate, robots_url: []const u8) void {
             transfer.abortPipelineError(e);
         };
     }
-}
-
-// shutdown_callback fires when the fetch is kill()'d. The fetch is
-// ownerless, so that only happens at client-wide teardown (Client.abort),
-// where every waiter is being kill()'d by the same loop; their deinit
-// finds no gate entry left (or unlinks itself first) and no-ops.
-fn flushPendingShutdown(self: *RobotsGate, robots_url: []const u8) void {
-    var pending = self.pending.fetchRemove(robots_url) orelse return;
-    pending.value.deinit(self.allocator);
 }
 
 const RobotsContext = struct {
@@ -278,7 +250,7 @@ const RobotsContext = struct {
         log.debug(.http, "robots fetch shutdown", .{});
         const gate = self.gate;
         const arena = self.arena;
-        gate.flushPendingShutdown(self.robots_url);
+        gate.single_flight.discard(self.robots_url);
         arena.release();
     }
 

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -90,6 +90,7 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
 
     const owned_url = try arena.dupeZ(u8, robots_url);
     const result = try self.single_flight.enter(owned_url, transfer, .robots);
+    errdefer self.single_flight.discard(owned_url);
     if (result == .queued) {
         // Someone else already owns an in-flight fetch for this key
         // (under its own, earlier-allocated owned_url). This arena was

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -80,24 +80,15 @@ pub fn remove(self: *RobotsGate, transfer: *Transfer) void {
 fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Transfer) !void {
     const client = transfer.client;
 
-    // The context, the response buffer and the pending-map key live on
-    // their own pooled arena, NOT on transfer.arena — any waiter (this one
-    // included) can be aborted while the fetch is still in flight, and the
-    // fetch's callbacks must survive that. The arena is released by
-    // whichever terminal callback fires (done / error / shutdown).
+    const result = try self.single_flight.enter(robots_url, transfer, .robots);
+    if (result == .queued) return;
+    errdefer {
+        self.single_flight.discard(robots_url);
+        transfer.unpark();
+    }
+
     const arena = try client.arena_pool.acquire(.small, "RobotsGate.RobotsContext");
     errdefer arena.release();
-
-    const owned_url = try arena.dupeZ(u8, robots_url);
-    const result = try self.single_flight.enter(owned_url, transfer, .robots);
-    errdefer self.single_flight.discard(owned_url);
-    if (result == .queued) {
-        // Someone else already owns an in-flight fetch for this key
-        // (under its own, earlier-allocated owned_url). This arena was
-        // never handed to a fetch, so release it ourselves.
-        arena.release();
-        return;
-    }
 
     const robots_ctx = try arena.create(RobotsContext);
     robots_ctx.* = .{
@@ -105,15 +96,15 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
         .buffer = .empty,
         .arena = arena,
         .arena_pool = client.arena_pool,
-        .robots_url = owned_url,
+        .robots_url = robots_url,
     };
 
-    log.debug(.browser, "fetching robots.txt", .{ .robots_url = owned_url });
+    log.debug(.browser, "fetching robots.txt", .{ .robots_url = robots_url });
 
     // Only the parent's frame/loader ids (CDP correlation) and notification
     // carry over — no cookies, credentials, headers, or timeout.
     const fetch_transfer = try client.newRequest(.{
-        .url = owned_url,
+        .url = robots_url,
         .method = .GET,
         .internal = true,
         .resource_type = .fetch,
@@ -122,7 +113,7 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
         .loader_id = transfer.req.loader_id,
         .notification = transfer.req.notification,
         .cookie_jar = null,
-        .cookie_origin = owned_url,
+        .cookie_origin = robots_url,
         .ctx = robots_ctx,
         .header_callback = RobotsContext.headerCallback,
         .data_callback = RobotsContext.dataCallback,

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -90,21 +90,22 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
     const arena = try client.arena_pool.acquire(.small, "RobotsGate.RobotsContext");
     errdefer arena.release();
 
+    const owned_url = try arena.dupeZ(u8, robots_url);
     const robots_ctx = try arena.create(RobotsContext);
     robots_ctx.* = .{
         .gate = self,
         .buffer = .empty,
         .arena = arena,
         .arena_pool = client.arena_pool,
-        .robots_url = robots_url,
+        .robots_url = owned_url,
     };
 
-    log.debug(.browser, "fetching robots.txt", .{ .robots_url = robots_url });
+    log.debug(.browser, "fetching robots.txt", .{ .robots_url = owned_url });
 
     // Only the parent's frame/loader ids (CDP correlation) and notification
     // carry over — no cookies, credentials, headers, or timeout.
     const fetch_transfer = try client.newRequest(.{
-        .url = robots_url,
+        .url = owned_url,
         .method = .GET,
         .internal = true,
         .resource_type = .fetch,
@@ -113,7 +114,7 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
         .loader_id = transfer.req.loader_id,
         .notification = transfer.req.notification,
         .cookie_jar = null,
-        .cookie_origin = robots_url,
+        .cookie_origin = owned_url,
         .ctx = robots_ctx,
         .header_callback = RobotsContext.headerCallback,
         .data_callback = RobotsContext.dataCallback,

--- a/src/network/RobotsGate.zig
+++ b/src/network/RobotsGate.zig
@@ -143,7 +143,7 @@ fn fetchThenResume(self: *RobotsGate, robots_url: [:0]const u8, transfer: *Trans
 // whose body never got parsed) fails open.
 fn flushPending(self: *RobotsGate, robots_url: []const u8) void {
     var queued = self.single_flight.take(robots_url) orelse return;
-    defer queued.deinit(self.allocator);
+    defer queued.deinit(self.single_flight.allocator);
 
     const robot_entry = self.network.robot_store.get(robots_url);
     for (queued.items) |transfer| {

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -1,0 +1,352 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const Transfer = @import("HttpClient.zig").Transfer;
+const Allocator = std.mem.Allocator;
+
+const SingleFlight = @This();
+
+allocator: Allocator,
+pending: std.StringHashMapUnmanaged(std.ArrayList(*Transfer)) = .empty,
+
+pub fn init(allocator: Allocator) SingleFlight {
+    return .{ .allocator = allocator };
+}
+
+pub fn deinit(self: *SingleFlight) void {
+    var it = self.pending.iterator();
+    while (it.next()) |entry| {
+        entry.value_ptr.deinit(self.allocator);
+    }
+    self.pending.deinit(self.allocator);
+}
+
+pub const EnterResult = enum { initial, queued };
+
+pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: Transfer.ParkedBy) !EnterResult {
+    const gop = try self.pending.getOrPut(self.allocator, key);
+    var waiting = gop.value_ptr;
+
+    if (gop.found_existing) {
+        try waiting.append(self.allocator, transfer);
+        transfer.park(reason);
+        return .queued;
+    }
+
+    waiting.* = .empty;
+    try waiting.append(self.allocator, transfer);
+    errdefer waiting.deinit(self.allocator);
+    transfer.park(reason);
+
+    return .initial;
+}
+
+pub fn abort(self: *SingleFlight, key: []const u8) void {
+    var entry = self.pending.fetchRemove(key) orelse return;
+    entry.value.deinit(self.allocator);
+}
+
+pub fn remove(self: *SingleFlight, transfer: *Transfer) void {
+    var it = self.pending.valueIterator();
+    while (it.next()) |waiting| {
+        for (waiting.items, 0..) |t, i| {
+            if (t == transfer) {
+                _ = waiting.swapRemove(i);
+                return;
+            }
+        }
+    }
+}
+
+pub fn take(self: *SingleFlight, key: []const u8) ?std.ArrayList(*Transfer) {
+    const entry = self.pending.fetchRemove(key) orelse return null;
+    return entry.value;
+}
+
+pub fn discard(self: *SingleFlight, key: []const u8) void {
+    var entry = self.pending.fetchRemove(key) orelse return;
+    entry.value.deinit(self.allocator);
+}
+
+pub fn count(self: *SingleFlight) u32 {
+    return self.pending.count();
+}
+
+const testing = @import("../testing.zig");
+const ArenaPool = @import("../ArenaPool.zig");
+const HttpClient = @import("HttpClient.zig");
+const lp = @import("lightpanda");
+
+fn makeTestTransfer(arena: *lp.Arena, client: *HttpClient, id: u32) !*Transfer {
+    const alloc = arena.allocator();
+    const t = try alloc.create(Transfer);
+    t.* = .{
+        .arena = arena,
+        .owner = null,
+        .req = .{
+            .frame_id = 0,
+            .loader_id = 0,
+            .method = .GET,
+            .url = "http://example.com/",
+            .cookie_jar = null,
+            .cookie_origin = "",
+            .resource_type = .document,
+            .notification = undefined,
+            .shutdown_callback = HttpClient.noopShutdown,
+        },
+        .client = client,
+        .id = id,
+        .start_time = 0,
+    };
+    return t;
+}
+
+test "SingleFlight: enter returns initial for the first waiter" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    // Only transfers.remove/pending_queue.remove/etc. touched by deinit
+    // matter here; a minimal zeroed client is enough since these tests
+    // never call transfer.deinit(), only single_flight directly.
+    client = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t2 = try makeTestTransfer(arena, &client, 2);
+    const t3 = try makeTestTransfer(arena, &client, 3);
+
+    try testing.expectEqual(.initial, try sf.enter("key", t1, .robots));
+    try testing.expectEqual(.queued, try sf.enter("key", t2, .robots));
+    try testing.expectEqual(.queued, try sf.enter("key", t3, .robots));
+
+    try testing.expectEqual(1, sf.count());
+    try testing.expectEqual(Transfer.State{ .parked = .robots }, t1.state);
+    try testing.expectEqual(Transfer.State{ .parked = .robots }, t2.state);
+    try testing.expectEqual(Transfer.State{ .parked = .robots }, t3.state);
+}
+
+test "SingleFlight: different keys get independent entries" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t2 = try makeTestTransfer(arena, &client, 2);
+
+    try testing.expectEqual(.initial, try sf.enter("key-a", t1, .robots));
+    try testing.expectEqual(.initial, try sf.enter("key-b", t2, .robots));
+
+    try testing.expectEqual(2, sf.count());
+}
+
+test "SingleFlight: take removes and returns the waiter list" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t2 = try makeTestTransfer(arena, &client, 2);
+
+    _ = try sf.enter("key", t1, .robots);
+    _ = try sf.enter("key", t2, .robots);
+
+    var waiting = sf.take("key") orelse return error.TestUnexpectedResult;
+    defer waiting.deinit(testing.allocator);
+
+    try testing.expectEqual(2, waiting.items.len);
+    try testing.expect(waiting.items[0] == t1);
+    try testing.expect(waiting.items[1] == t2);
+
+    // Entry is gone: a second take on the same key finds nothing.
+    try testing.expectEqual(null, sf.take("key"));
+    try testing.expectEqual(0, sf.count());
+}
+
+test "SingleFlight: take on an unknown key returns null" {
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    try testing.expectEqual(null, sf.take("missing"));
+}
+
+test "SingleFlight: abort drops the pending entry without resolving waiters" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    _ = try sf.enter("key", t1, .robots);
+
+    sf.abort("key");
+
+    try testing.expectEqual(0, sf.count());
+    try testing.expectEqual(null, sf.take("key"));
+}
+
+test "SingleFlight: discard is equivalent to abort for the shutdown path" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t2 = try makeTestTransfer(arena, &client, 2);
+    _ = try sf.enter("key", t1, .robots);
+    _ = try sf.enter("key", t2, .robots);
+
+    sf.discard("key");
+
+    try testing.expectEqual(0, sf.count());
+}
+
+test "SingleFlight: remove unlinks a single waiter from its key's list" {
+    // Regression-style, mirrors "aborting a robots-parked transfer unlinks
+    // it from the gate" but exercised directly against SingleFlight rather
+    // than through RobotsGate.
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t2 = try makeTestTransfer(arena, &client, 2);
+    const t3 = try makeTestTransfer(arena, &client, 3);
+
+    _ = try sf.enter("key", t1, .robots);
+    _ = try sf.enter("key", t2, .robots);
+    _ = try sf.enter("key", t3, .robots);
+
+    sf.remove(t2);
+
+    var waiting = sf.take("key") orelse return error.TestUnexpectedResult;
+    defer waiting.deinit(testing.allocator);
+
+    try testing.expectEqual(2, waiting.items.len);
+    try testing.expect(waiting.items[0] == t1);
+    try testing.expect(waiting.items[1] == t3);
+}
+
+test "SingleFlight: remove on a transfer not in any list is a no-op" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    const stray = try makeTestTransfer(arena, &client, 2);
+
+    _ = try sf.enter("key", t1, .robots);
+
+    // stray was never entered anywhere; remove must not touch t1's entry.
+    sf.remove(stray);
+
+    try testing.expectEqual(1, sf.count());
+    var waiting = sf.take("key") orelse return error.TestUnexpectedResult;
+    defer waiting.deinit(testing.allocator);
+    try testing.expectEqual(1, waiting.items.len);
+}
+
+test "SingleFlight: removing every waiter for a key leaves an empty (but present) list" {
+    // remove() only swapRemoves from the waiter list; it does not delete the
+    // map entry even if the list becomes empty. take()/abort()/discard() are
+    // the only ways the entry itself disappears. This documents that
+    // asymmetry so a future change doesn't accidentally break RobotsGate's
+    // "entry stays, in-flight fetch still owns it" invariant.
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    var client: HttpClient = undefined;
+    client.transfers = .empty;
+    client.intercepted = 0;
+
+    var sf = SingleFlight{ .allocator = testing.allocator };
+    defer sf.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer pool.release(arena);
+
+    const t1 = try makeTestTransfer(arena, &client, 1);
+    _ = try sf.enter("key", t1, .robots);
+
+    sf.remove(t1);
+
+    try testing.expectEqual(1, sf.count());
+    var waiting = sf.take("key") orelse return error.TestUnexpectedResult;
+    defer waiting.deinit(testing.allocator);
+    try testing.expectEqual(0, waiting.items.len);
+}

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -42,22 +42,22 @@ pub const EnterResult = enum { initial, queued };
 
 pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: Transfer.ParkedBy) !EnterResult {
     const gop = try self.pending.getOrPut(self.allocator, key);
-    errdefer _ = self.pending.remove(key);
-
     if (gop.found_existing) {
         const waiting = gop.value_ptr;
         try waiting.append(self.allocator, transfer);
         transfer.park(reason);
         return .queued;
     }
+    errdefer _ = self.pending.remove(key);
 
     const owned_key = try self.allocator.dupe(u8, key);
     errdefer self.allocator.free(owned_key);
-    gop.key_ptr.* = owned_key;
 
     var waiting: std.ArrayList(*Transfer) = .empty;
     errdefer waiting.deinit(self.allocator);
     try waiting.append(self.allocator, transfer);
+
+    gop.key_ptr.* = owned_key;
     gop.value_ptr.* = waiting;
 
     transfer.park(reason);

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -32,6 +32,7 @@ pub fn init(allocator: Allocator) SingleFlight {
 pub fn deinit(self: *SingleFlight) void {
     var it = self.pending.iterator();
     while (it.next()) |entry| {
+        self.allocator.free(entry.key_ptr.*);
         entry.value_ptr.deinit(self.allocator);
     }
     self.pending.deinit(self.allocator);
@@ -40,25 +41,27 @@ pub fn deinit(self: *SingleFlight) void {
 pub const EnterResult = enum { initial, queued };
 
 pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: Transfer.ParkedBy) !EnterResult {
-    const gop = try self.pending.getOrPut(self.allocator, key);
-    var waiting = gop.value_ptr;
-
-    if (gop.found_existing) {
+    if (self.pending.getPtr(key)) |waiting| {
         try waiting.append(self.allocator, transfer);
         transfer.park(reason);
         return .queued;
     }
 
-    waiting.* = .empty;
-    try waiting.append(self.allocator, transfer);
-    errdefer waiting.deinit(self.allocator);
-    transfer.park(reason);
+    const owned_key = try self.allocator.dupe(u8, key);
+    errdefer self.allocator.free(owned_key);
 
+    var waiting: std.ArrayList(*Transfer) = .empty;
+    errdefer waiting.deinit(self.allocator);
+    try waiting.append(self.allocator, transfer);
+
+    try self.pending.put(self.allocator, owned_key, waiting);
+    transfer.park(reason);
     return .initial;
 }
 
 pub fn abort(self: *SingleFlight, key: []const u8) void {
     var entry = self.pending.fetchRemove(key) orelse return;
+    self.allocator.free(entry.key);
     entry.value.deinit(self.allocator);
 }
 
@@ -76,11 +79,13 @@ pub fn remove(self: *SingleFlight, transfer: *Transfer) void {
 
 pub fn take(self: *SingleFlight, key: []const u8) ?std.ArrayList(*Transfer) {
     const entry = self.pending.fetchRemove(key) orelse return null;
+    self.allocator.free(entry.key);
     return entry.value;
 }
 
 pub fn discard(self: *SingleFlight, key: []const u8) void {
     var entry = self.pending.fetchRemove(key) orelse return;
+    self.allocator.free(entry.key);
     entry.value.deinit(self.allocator);
 }
 

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -59,12 +59,6 @@ pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: 
     return .initial;
 }
 
-pub fn abort(self: *SingleFlight, key: []const u8) void {
-    var entry = self.pending.fetchRemove(key) orelse return;
-    self.allocator.free(entry.key);
-    entry.value.deinit(self.allocator);
-}
-
 pub fn remove(self: *SingleFlight, transfer: *Transfer) void {
     var it = self.pending.valueIterator();
     while (it.next()) |waiting| {
@@ -216,30 +210,7 @@ test "SingleFlight: take on an unknown key returns null" {
     try testing.expectEqual(null, sf.take("missing"));
 }
 
-test "SingleFlight: abort drops the pending entry without resolving waiters" {
-    var pool = ArenaPool.init(testing.allocator, .{});
-    defer pool.deinit();
-
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
-
-    var sf = SingleFlight{ .allocator = testing.allocator };
-    defer sf.deinit();
-
-    const arena = try pool.acquire(.small, "test");
-    defer pool.release(arena);
-
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    _ = try sf.enter("key", t1, .robots);
-
-    sf.abort("key");
-
-    try testing.expectEqual(0, sf.count());
-    try testing.expectEqual(null, sf.take("key"));
-}
-
-test "SingleFlight: discard is equivalent to abort for the shutdown path" {
+test "SingleFlight: discard for the shutdown path" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -42,6 +42,8 @@ pub const EnterResult = enum { initial, queued };
 
 pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: Transfer.ParkedBy) !EnterResult {
     const gop = try self.pending.getOrPut(self.allocator, key);
+    errdefer _ = self.pending.remove(key);
+
     if (gop.found_existing) {
         const waiting = gop.value_ptr;
         try waiting.append(self.allocator, transfer);

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -120,13 +120,7 @@ test "SingleFlight: enter returns initial for the first waiter" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    // Only transfers.remove/pending_queue.remove/etc. touched by deinit
-    // matter here; a minimal zeroed client is enough since these tests
-    // never call transfer.deinit(), only single_flight directly.
-    client = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -152,9 +146,7 @@ test "SingleFlight: different keys get independent entries" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -175,9 +167,7 @@ test "SingleFlight: take removes and returns the waiter list" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -214,9 +204,7 @@ test "SingleFlight: discard for the shutdown path" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -241,9 +229,7 @@ test "SingleFlight: remove unlinks a single waiter from its key's list" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -273,9 +259,7 @@ test "SingleFlight: remove on a transfer not in any list is a no-op" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -306,9 +290,7 @@ test "SingleFlight: removing every waiter for a key leaves an empty (but present
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client: HttpClient = undefined;
-    client.transfers = .empty;
-    client.intercepted = 0;
+    var client = testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -120,7 +120,7 @@ test "SingleFlight: enter returns initial for the first waiter" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -128,9 +128,9 @@ test "SingleFlight: enter returns initial for the first waiter" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const t2 = try makeTestTransfer(arena, &client, 2);
-    const t3 = try makeTestTransfer(arena, &client, 3);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const t2 = try makeTestTransfer(arena, client, 2);
+    const t3 = try makeTestTransfer(arena, client, 3);
 
     try testing.expectEqual(.initial, try sf.enter("key", t1, .robots));
     try testing.expectEqual(.queued, try sf.enter("key", t2, .robots));
@@ -146,7 +146,7 @@ test "SingleFlight: different keys get independent entries" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -154,8 +154,8 @@ test "SingleFlight: different keys get independent entries" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const t2 = try makeTestTransfer(arena, &client, 2);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const t2 = try makeTestTransfer(arena, client, 2);
 
     try testing.expectEqual(.initial, try sf.enter("key-a", t1, .robots));
     try testing.expectEqual(.initial, try sf.enter("key-b", t2, .robots));
@@ -167,7 +167,7 @@ test "SingleFlight: take removes and returns the waiter list" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -175,8 +175,8 @@ test "SingleFlight: take removes and returns the waiter list" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const t2 = try makeTestTransfer(arena, &client, 2);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const t2 = try makeTestTransfer(arena, client, 2);
 
     _ = try sf.enter("key", t1, .robots);
     _ = try sf.enter("key", t2, .robots);
@@ -204,7 +204,7 @@ test "SingleFlight: discard for the shutdown path" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -212,8 +212,8 @@ test "SingleFlight: discard for the shutdown path" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const t2 = try makeTestTransfer(arena, &client, 2);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const t2 = try makeTestTransfer(arena, client, 2);
     _ = try sf.enter("key", t1, .robots);
     _ = try sf.enter("key", t2, .robots);
 
@@ -229,7 +229,7 @@ test "SingleFlight: remove unlinks a single waiter from its key's list" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -237,9 +237,9 @@ test "SingleFlight: remove unlinks a single waiter from its key's list" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const t2 = try makeTestTransfer(arena, &client, 2);
-    const t3 = try makeTestTransfer(arena, &client, 3);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const t2 = try makeTestTransfer(arena, client, 2);
+    const t3 = try makeTestTransfer(arena, client, 3);
 
     _ = try sf.enter("key", t1, .robots);
     _ = try sf.enter("key", t2, .robots);
@@ -259,7 +259,7 @@ test "SingleFlight: remove on a transfer not in any list is a no-op" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -267,8 +267,8 @@ test "SingleFlight: remove on a transfer not in any list is a no-op" {
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
-    const stray = try makeTestTransfer(arena, &client, 2);
+    const t1 = try makeTestTransfer(arena, client, 1);
+    const stray = try makeTestTransfer(arena, client, 2);
 
     _ = try sf.enter("key", t1, .robots);
 
@@ -290,7 +290,7 @@ test "SingleFlight: removing every waiter for a key leaves an empty (but present
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
-    var client = testing.test_browser.http_client;
+    const client = &testing.test_browser.http_client;
 
     var sf = SingleFlight{ .allocator = testing.allocator };
     defer sf.deinit();
@@ -298,7 +298,7 @@ test "SingleFlight: removing every waiter for a key leaves an empty (but present
     const arena = try pool.acquire(.small, "test");
     defer pool.release(arena);
 
-    const t1 = try makeTestTransfer(arena, &client, 1);
+    const t1 = try makeTestTransfer(arena, client, 1);
     _ = try sf.enter("key", t1, .robots);
 
     sf.remove(t1);

--- a/src/network/SingleFlight.zig
+++ b/src/network/SingleFlight.zig
@@ -41,7 +41,9 @@ pub fn deinit(self: *SingleFlight) void {
 pub const EnterResult = enum { initial, queued };
 
 pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: Transfer.ParkedBy) !EnterResult {
-    if (self.pending.getPtr(key)) |waiting| {
+    const gop = try self.pending.getOrPut(self.allocator, key);
+    if (gop.found_existing) {
+        const waiting = gop.value_ptr;
         try waiting.append(self.allocator, transfer);
         transfer.park(reason);
         return .queued;
@@ -49,12 +51,13 @@ pub fn enter(self: *SingleFlight, key: []const u8, transfer: *Transfer, reason: 
 
     const owned_key = try self.allocator.dupe(u8, key);
     errdefer self.allocator.free(owned_key);
+    gop.key_ptr.* = owned_key;
 
     var waiting: std.ArrayList(*Transfer) = .empty;
     errdefer waiting.deinit(self.allocator);
     try waiting.append(self.allocator, transfer);
+    gop.value_ptr.* = waiting;
 
-    try self.pending.put(self.allocator, owned_key, waiting);
     transfer.park(reason);
     return .initial;
 }


### PR DESCRIPTION
This adds a `SingleFlight` component that can be reused across future gates, such as the CORS one.