### PR TITLE
runner: advance idle notifications outside the wait-condition loop

### DIFF
--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -230,6 +230,18 @@ fn _tick(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
     const network_idle = activity.idle();
     const is_done = browser.hasMacrotasks() == false and network_idle;
 
+    // Outside the condition loop: it skips resolved conditions, but an idle
+    // notification needs a check 500ms+ after the hold starts, and on a quiet
+    // page one tick both starts the hold and resolves the condition. Before
+    // it, so `.networkidle` conditions read fresh state.
+    var page_index: usize = 0;
+    while (page_index < session.pages.items.len) : (page_index += 1) {
+        // Indexed: notifyNetworkIdle dispatches to listeners.
+        const page = session.pages.items[page_index];
+        if (page.replacement != null) continue; // frozen; the replacement is live
+        page.frame.checkIdleNotifications(total_http_activity);
+    }
+
     // _we_ have nothing to run, but v8 is working on background tasks. We'll
     // wait for them. Don't do this for CDP, since new CDP messages can always
     // come in at any time.
@@ -272,8 +284,6 @@ fn _tick(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
                 }
             },
             .html, .complete => {
-                frame.checkIdleNotifications(total_http_activity);
-
                 const met = switch (condition.until) {
                     .done => is_done,
                     .domcontentloaded => frame._load_state == .load or frame._load_state == .complete,
@@ -296,6 +306,8 @@ fn _tick(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
         }
     }
 
+    // Always taken for is_cdp and every exit returns .ok, so _tick never yields
+    // .done to the CDP pump: _wait's .done/is_cdp arm is dormant.
     if ((comptime is_cdp) or want_http_tick) {
         const ms_to_next_task = blk: {
             if (has_runnable_page == false) {
@@ -542,4 +554,32 @@ test "Runner: lazy iframe does not delay the load event" {
     try runner.waitForFrame(page.frame_id, 3000, .{ .until = .done });
     try testing.expectEqual(true, lazy_child._load_state == .complete);
     try testing.expectEqual(true, lazy_child._parent_notified);
+}
+
+test "Runner: idle notifications advance past a resolved condition" {
+    const page = try testing.pageTest("runner/runner1.html", .{});
+    defer page.close();
+
+    const frame = page.frame().?;
+
+    // What a quiet page looks like one tick in: the hold has started, and the
+    // same tick resolved the wait condition. Seeded past the 500ms hold so the
+    // test doesn't spend it.
+    const held_since = lp.datetime.milliTimestamp(.boot) -| 600;
+    frame._notified_network_idle = .{ .triggered = held_since };
+    frame._notified_network_almost_idle = .{ .triggered = held_since };
+
+    var conditions = [_]WaitCondition{.{
+        .frame_id = page.frame_id,
+        .until = .done,
+        .status = .complete,
+    }};
+
+    // is_cdp mirrors CDP.pageWait, which keeps ticking after the condition
+    // resolves.
+    var runner = page.session.runner(.{});
+    _ = try runner._wait(true, 50, &conditions);
+
+    try testing.expectEqual(true, frame._notified_network_idle == .done);
+    try testing.expectEqual(true, frame._notified_network_almost_idle == .done);
 }


### PR DESCRIPTION
## The bug

`Page.lifecycleEvent networkIdle` / `networkAlmostIdle` can be delayed by up to ~2s on pages that go quiet quickly — exactly the pages where it should be fastest. Those events are what puppeteer's `waitUntil: 'networkidle0'`/`'networkidle2'` and playwright's `'networkidle'` / `waitForLoadState('networkidle')` block on.

`Runner._tick` advanced every frame's idle state machine from inside the wait-condition loop, which skips conditions already resolved. But `Frame.IdleNotification` is poll-driven: it fires only when a check lands 500ms+ after the condition first held. The CDP pump (`CDP.pageWait` → `waitForFrameCDP(id, 1000, .done)`) runs one condition per 1s slice, and on a page with no pending macrotasks `is_done` is true on the first tick — so that tick both starts the hold and resolves the condition, killing the only thing that could end the hold. Nothing advances it again until the next slice builds a fresh condition, and since there's one check per slice the hold often misses again.

## The fix

Hoist `checkIdleNotifications` out of the condition loop: run it once per tick for every live page, independent of condition status. Chrome emits lifecycle events as a property of the frame's loading state, not of any client's outstanding wait, so decoupling the two is also the more correct model. It stays before the condition loop so `.networkidle`/`.networkalmostidle` conditions read fresh state in the same tick, and the page filter (`replacement == null`) is exactly the image of `Session.pendingOrLivePage`, so coverage matches what the loop covered and never exceeds it.

## Measured

**Microbenchmark** — puppeteer → `lightpanda serve`, `goto(url, {waitUntil: 'networkidle0'})`, median of 5:

| page | before | after |
| --- | --- | --- |
| example.com (loads in ~100ms) | **2001 ms** | **595 ms** |

~600ms is the floor: load plus the 500ms hold. Every pre-fix run landed in 1999-2195ms — the stall is quantized to whole pump slices, not network variance.

**Real sites** — full scraping task (6 navigations), puppeteer at `networkidle0`, 8 interleaved rotations with Chrome riding along as a drift anchor. `before` is main @b04c99a91 and `after` is this branch, so the only difference is this commit:

| engine | median | runs |
| --- | --- | --- |
| main @b04c99a91 | 12778 ms | 12635 … 15018 |
| this branch | **9372 ms** | 8582 … 10332 |
| Chrome 151 (anchor) | 14476 ms | 12431 … 14808 |

The distributions don't overlap — main's fastest run is slower than the branch's slowest. 3406ms over 6 navigations is ~570ms each, matching the predicted stall. With the fix, `lightpanda serve` goes from losing to Chrome on this task to beating it by ~35%.

Ad-heavy sites (gymshark, apnews) measured **0-3% change**, within noise, which is the result the mechanism predicts: their background timers keep `is_done` false, so their wait conditions never resolved early and never stalled. Only quiet pages were affected. Datasets: `results/waitab-networkidle0` and `results/waitab-attrib` in the benchmarks repo.

## Test

`"Runner: idle notifications advance past a resolved condition"` seeds the hold 600ms in the past and a pre-resolved condition, then drives `_wait` with `is_cdp = true` (mirroring `CDP.pageWait` ticking on after the latch) and asserts both state machines reach `.done`. Verified to fail on the pre-fix tree and pass after; ~50ms, no allocations.

A CDP-level test can't catch this — `cdp/testing.zig`'s retry loop calls `tickForFrame`, building a fresh pending condition each time, which is the same accident production was relying on.

## Notes for review

- **Non-CDP waits are deliberately unchanged**: `waitForFrame(.networkidle)` on a quiet page still resolves immediately via `is_done` rather than serving the 500ms hold. Agent/MCP `waitForState` and `fetch --wait-until networkidle` want "settled now", not chrome's lifecycle heuristic — worth not "fixing" later into a 500ms regression on every agent wait.
- Added a comment at the `is_cdp` tick block noting it always returns `.ok`, so `_tick` never yields `.done` to the CDP pump — which is why `_wait`'s `.done`/`is_cdp` arm is currently dormant. Left the arm in place rather than deleting it: it costs nothing at runtime and removing it would trade a fallback for an invariant enforced nowhere.
- The existing `"Runner: networkidle notifies child frames"` test worked around this bug in its own comment ("Keep ticking (like the CDP serve loop does) until the notifications fire"); it still passes, now converging sooner.

1148/1148 tests, fmt clean.
