### PR TITLE
webapi: improve events from shadowroot

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -134,18 +134,24 @@ pub fn hasDirectListeners(self: *EventManager, target: *EventTarget, typ: []cons
 }
 
 fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
-    {
-        const et = target.asEventTarget();
-        event._target = et;
-        event._dispatch_target = et; // Store original target for composedPath()
+    const target_et = target.asEventTarget();
+    event._target = target_et;
+    event._dispatch_target = target_et; // Store original target for composedPath()
 
-        // Retarget the relatedTarget against the dispatch target up front
-        // (DOM dispatch step 4); listeners observe the retargeted value and
-        // it survives the dispatch.
-        if (event.relatedTargetPtr()) |related_ptr| {
-            if (related_ptr.*) |related| {
-                related_ptr.* = getAdjustedTarget(related, et);
-            }
+    // The relatedTarget as authored. Every invocation sees it retargeted
+    // against its own currentTarget (DOM dispatch step 5.7), so the event
+    // keeps the unadjusted value between invocations.
+    const original_related: ?*EventTarget = if (event.relatedTargetPtr()) |p| p.* else null;
+    event._dispatch_related_target = original_related;
+    if (original_related) |related| {
+        if (rootIsShadowRoot(related)) {
+            event._needs_retargeting = true;
+        }
+        // DOM dispatch step 5: an event whose relatedTarget retargets onto the
+        // target itself isn't dispatched at all.
+        const adjusted = getAdjustedTarget(related, target_et);
+        if (adjusted == target_et and related != target_et) {
+            return;
         }
     }
 
@@ -193,8 +199,12 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                 related_ptr.* = null;
             }
         } else if (event._needs_retargeting and node_path_len > 0) {
-            const adjusted = getAdjustedTarget(event._dispatch_target, path_buffer[node_path_len - 1]);
+            const last = path_buffer[node_path_len - 1];
+            const adjusted = getAdjustedTarget(event._dispatch_target, last);
             event._target = if (rootIsShadowRoot(adjusted)) null else adjusted;
+            if (event.relatedTargetPtr()) |related_ptr| {
+                related_ptr.* = getAdjustedTarget(original_related, last);
+            }
         }
         // Handle checkbox/radio activation rollback or commit
         if (activation_state) |state| {
@@ -222,38 +232,12 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
         }
     }
 
-    const target_root = target.getRootNode(.{});
-    var node: ?*Node = target;
-    while (node) |n| {
-        if (path_len >= path_buffer.len) break;
-        path_buffer[path_len] = n.asEventTarget();
-        path_len += 1;
-
-        // Check if this node is a shadow root
-        if (n.is(ShadowRoot)) |shadow| {
-            event._needs_retargeting = true;
-
-            // A non-composed event stops at its own tree's root.
-            if (!event._composed and n == target_root) {
-                break;
-            }
-
-            // Otherwise, jump to the shadow host and continue
-            node = shadow._host.asNode();
-            continue;
-        }
-
-        // an assigned slottable's event-path parent is its assigned slot,
-        // routing the event into the slot's shadow tree
-        if (frame._assigned_slots.get(n)) |slot| {
-            node = slot.asNode();
-            continue;
-        }
-
-        node = n._parent;
-    }
-
+    const built = buildEventPath(target, event, frame, &path_buffer);
+    path_len = built.len;
     node_path_len = path_len;
+    if (built.crosses_shadow_root) {
+        event._needs_retargeting = true;
+    }
 
     // Even though the window isn't part of the DOM, most events propagate
     // through it in the capture phase. It only participates when the tree's
@@ -308,7 +292,6 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
     // Phase 2: At target
     if (event._stop_propagation) return;
     event._event_phase = .at_target;
-    const target_et = target.asEventTarget();
 
     blk: {
         // Get inline handler (e.g., onclick property) for this target
@@ -319,6 +302,8 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
             const prev_current_event = window._current_event;
             window._current_event = currentEventForTarget(target_et, event);
             defer window._current_event = prev_current_event;
+
+            const adjusted: ?AdjustedTargets = if (event._needs_retargeting) .apply(event, target_et) else null;
 
             // Inline handlers (e.g. onclick property) follow the same "report,
             // don't propagate" rule as addEventListener listeners — see Listener.run.
@@ -332,6 +317,10 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                 break :ret null;
             };
             processHandlerReturnValue(event, handler_return);
+
+            if (adjusted) |a| {
+                a.restore(event);
+            }
 
             if (event._stop_propagation) {
                 return;
@@ -377,10 +366,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                 window._current_event = currentEventForTarget(current_target, event);
                 defer window._current_event = prev_current_event;
 
-                const original_target = event._target;
-                if (event._needs_retargeting) {
-                    event._target = getAdjustedTarget(original_target, current_target);
-                }
+                const adjusted: ?AdjustedTargets = if (event._needs_retargeting) .apply(event, current_target) else null;
 
                 var caught: js.TryCatch.Caught = .{};
                 const handler_return: ?js.Value = ls.toLocal(inline_handler).tryCallWithThis(js.Value, current_target, .{event}, &caught) catch |err| ret: {
@@ -393,8 +379,8 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
                 };
                 processHandlerReturnValue(event, handler_return);
 
-                if (event._needs_retargeting) {
-                    event._target = original_target;
+                if (adjusted) |a| {
+                    a.restore(event);
                 }
 
                 if (event._stop_propagation) {
@@ -493,19 +479,15 @@ fn dispatchPhase(self: *EventManager, list: *std.DoublyLinkedList, current_targe
         event._current_target = current_target;
         event._in_passive_listener = listener.passive;
 
-        // Compute adjusted target for shadow DOM retargeting (only if needed)
-        const original_target = event._target;
-        if (event._needs_retargeting) {
-            event._target = getAdjustedTarget(original_target, current_target);
-        }
+        // Compute adjusted targets for shadow DOM retargeting (only if needed)
+        const adjusted: ?AdjustedTargets = if (event._needs_retargeting) .apply(event, current_target) else null;
 
         try listener.run(frame.call_arena, local, event, "listener");
 
         event._in_passive_listener = false;
 
-        // Restore original target (only if we changed it)
-        if (event._needs_retargeting) {
-            event._target = original_target;
+        if (adjusted) |a| {
+            a.restore(event);
         }
 
         if (event._stop_immediate_propagation) {
@@ -545,6 +527,113 @@ fn getInlineHandler(self: *EventManager, target: *EventTarget, event: *Event) ?j
         log.warn(.event, "inline html callback", .{ .type = handler_type, .err = err });
         return null;
     };
+}
+
+// An invocation sees the target and the relatedTarget retargeted against its
+// own currentTarget (DOM dispatch step 5.7). The event carries the unadjusted
+// values in between, so each invocation adjusts and then restores them.
+const AdjustedTargets = struct {
+    target: ?*EventTarget,
+    related: ?*EventTarget,
+    related_ptr: ?*?*EventTarget,
+
+    fn apply(event: *Event, current_target: *EventTarget) AdjustedTargets {
+        const related_ptr = event.relatedTargetPtr();
+        const original: AdjustedTargets = .{
+            .target = event._target,
+            .related = if (related_ptr) |p| p.* else null,
+            .related_ptr = related_ptr,
+        };
+
+        event._target = getAdjustedTarget(original.target, current_target);
+        if (related_ptr) |p| {
+            p.* = getAdjustedTarget(original.related, current_target);
+        }
+        return original;
+    }
+
+    fn restore(self: AdjustedTargets, event: *Event) void {
+        event._target = self.target;
+        if (self.related_ptr) |p| {
+            p.* = self.related;
+        }
+    }
+};
+
+pub const EventPath = struct {
+    len: usize,
+    // Whether a shadow root sits on the path, i.e. whether an invocation can
+    // see a target other than the one the event was dispatched at.
+    crosses_shadow_root: bool,
+};
+
+// Builds the node portion of an event's propagation path (DOM dispatch step
+// 5.7) into `buffer`. Window, which follows the document at the end of the
+// path, is left to the caller: the rules for including it differ between
+// dispatch and composedPath().
+pub fn buildEventPath(target: *Node, event: *Event, frame: ?*Frame, buffer: []*EventTarget) EventPath {
+    if (buffer.len == 0) {
+        return .{ .len = 0, .crosses_shadow_root = false };
+    }
+
+    const target_root = target.getRootNode(.{});
+    const related = event._dispatch_related_target;
+
+    // The root of the spec's `target` variable, which moves to each host we
+    // cross on the way out. A node it still contains is inside the current
+    // target's tree, where the event always propagates; the first node beyond
+    // it is where the relatedTarget can cut the path short.
+    var scope_root = target_root;
+
+    buffer[0] = target.asEventTarget();
+    var path: EventPath = .{ .len = 1, .crosses_shadow_root = target.is(ShadowRoot) != null };
+
+    var node = eventPathParent(target, event, target_root, frame);
+    while (node) |n| {
+        if (path.len == buffer.len) {
+            break;
+        }
+
+        const et = n.asEventTarget();
+        if (!isShadowIncludingInclusiveAncestor(scope_root, n)) {
+            // DOM dispatch step 5.7: the path stops at the relatedTarget.
+            if (related != null and getAdjustedTarget(related, et) == et) {
+                break;
+            }
+            scope_root = n.getRootNode(.{});
+        }
+
+        if (n.is(ShadowRoot) != null) {
+            path.crosses_shadow_root = true;
+        }
+        buffer[path.len] = et;
+        path.len += 1;
+
+        node = eventPathParent(n, event, target_root, frame);
+    }
+
+    return path;
+}
+
+// DOM spec "get the parent" for a node on the event path: an assigned
+// slottable's parent is its slot, routing the event into the slot's shadow
+// tree, and a shadow root's is its host — except for a non-composed event,
+// which stops at the root of the tree it was dispatched in.
+fn eventPathParent(node: *Node, event: *Event, target_root: *Node, frame: ?*Frame) ?*Node {
+    if (node.is(ShadowRoot)) |shadow| {
+        if (!event._composed and node == target_root) {
+            return null;
+        }
+        return shadow._host.asNode();
+    }
+
+    if (frame) |f| {
+        if (f._assigned_slots.get(node)) |slot| {
+            return slot.asNode();
+        }
+    }
+
+    return node._parent;
 }
 
 // DOM spec "retarget": walk original_target out of shadow trees until the
@@ -589,14 +678,10 @@ fn isShadowIncludingInclusiveAncestor(ancestor: *Node, node: *Node) bool {
 // shadow root. Used for the spec's post-dispatch "clear targets" step.
 fn rootIsShadowRoot(target_: ?*EventTarget) bool {
     const target = target_ orelse return false;
-    var current: *Node = switch (target._type) {
-        .node => |n| n,
-        else => return false,
+    return switch (target._type) {
+        .node => |n| n.containingShadowRoot() != null,
+        else => false,
     };
-    while (current._parent) |p| {
-        current = p;
-    }
-    return current.is(ShadowRoot) != null;
 }
 
 // Check if ancestor is an ancestor of (or the same as) node

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2578,6 +2578,15 @@ pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpt
         return;
     }
 
+    // Focus goes with the removed subtree. The focused element can be inside a
+    // shadow tree hanging off it, which the walk below doesn't descend into,
+    // so ask it directly whether it's still in the document.
+    if (self.document._active_element) |active| {
+        if (active.asNode().isConnected() == false) {
+            self.document._active_element = null;
+        }
+    }
+
     // The child was connected and now it no longer is. We need to "disconnect"
     // it and all of its descendants. For now "disconnect" just means updating
     // the ID map and invoking disconnectedCallback for custom elements
@@ -2809,7 +2818,7 @@ pub fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *No
         return;
     }
 
-    const parent_in_shadow = parent.is(ShadowRoot) != null or parent.isInShadowTree();
+    const parent_in_shadow = parent.containingShadowRoot() != null;
 
     if (!parent_in_shadow and !parent_is_connected) {
         return;

--- a/src/browser/tests/shadowroot/events.html
+++ b/src/browser/tests/shadowroot/events.html
@@ -326,3 +326,141 @@
     host.remove();
 }
 </script>
+
+<script id="related_target_stops_path">
+{
+    // DOM dispatch: the path stops at the node the relatedTarget retargets
+    // onto, so the event never reaches the host or anything above it.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const target = document.createElement('span');
+    shadow.appendChild(target);
+
+    const seen = [];
+    const watch = (node, name) => node.addEventListener('my-event', () => seen.push(name));
+    watch(target, 'target');
+    watch(shadow, 'shadow');
+    watch(host, 'host');
+    watch(document.body, 'body');
+    watch(document, 'document');
+
+    target.dispatchEvent(new MouseEvent('my-event', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: host,
+    }));
+
+    testing.expectEqual('target,shadow', seen.join(','));
+
+    host.remove();
+}
+</script>
+
+<script id="related_target_equal_to_target_skips_dispatch">
+{
+    // When the relatedTarget retargets onto the target itself, the event is
+    // not dispatched at all.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const inner = document.createElement('span');
+    shadow.appendChild(inner);
+
+    let hostCalled = false;
+    host.addEventListener('my-event', () => hostCalled = true);
+
+    // relatedTarget lives in host's own shadow tree, so it retargets to host.
+    host.dispatchEvent(new MouseEvent('my-event', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: inner,
+    }));
+
+    testing.expectEqual(false, hostCalled);
+
+    host.remove();
+}
+</script>
+
+<script id="related_target_retargeted_per_listener">
+{
+    // Each listener sees the relatedTarget retargeted against its own
+    // currentTarget: the slot is inside the shadow tree and sees the real
+    // node, everything in the document tree sees the host.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const slot = document.createElement('slot');
+    const related = document.createElement('i');
+    shadow.appendChild(slot);
+    shadow.appendChild(related);
+
+    const target = document.createElement('span');
+    host.appendChild(target);
+
+    const seen = [];
+    const watch = (node, name) => node.addEventListener('my-event', (e) => {
+        seen.push(name + '=' + (e.relatedTarget === related ? 'related' : (e.relatedTarget === host ? 'host' : '?')));
+    });
+    watch(target, 'target');
+    watch(slot, 'slot');
+    watch(host, 'host');
+
+    target.dispatchEvent(new MouseEvent('my-event', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: related,
+    }));
+
+    testing.expectEqual('target=host,slot=related,host=host', seen.join(','));
+
+    host.remove();
+}
+</script>
+
+<script id="related_target_post_dispatch">
+{
+    // Post-dispatch the relatedTarget is left retargeted against the outermost
+    // node the event reached, or cleared when it would expose a shadow tree.
+    const makeHost = (tag) => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({ mode: 'open' });
+        const inner = document.createElement(tag);
+        shadow.appendChild(inner);
+        return { host: host, inner: inner };
+    };
+
+    // target and relatedTarget in different shadow trees: each is exposed as
+    // its own host.
+    const a = makeHost('span');
+    const b = makeHost('i');
+    const across = new MouseEvent('my-event', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: b.inner,
+    });
+    a.inner.dispatchEvent(across);
+    testing.expectEqual(a.host, across.target);
+    testing.expectEqual(b.host, across.relatedTarget);
+
+    // target and relatedTarget in the same shadow tree: the event never leaves
+    // it, so both are cleared rather than leaking a shadow node.
+    const c = makeHost('span');
+    const sibling = document.createElement('i');
+    c.inner.parentNode.appendChild(sibling);
+    const within = new MouseEvent('my-event', {
+        bubbles: true,
+        composed: true,
+        relatedTarget: sibling,
+    });
+    c.inner.dispatchEvent(within);
+    testing.expectEqual(null, within.target);
+    testing.expectEqual(null, within.relatedTarget);
+
+    a.host.remove();
+    b.host.remove();
+    c.host.remove();
+}
+</script>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -728,7 +728,15 @@ pub fn getReadyState(self: *const Document) []const u8 {
 
 pub fn getActiveElement(self: *Document) ?*Element {
     if (self._active_element) |el| {
-        return el;
+        // A focused element inside a shadow tree is exposed as its outermost
+        // host; one in a detached tree isn't exposed at all.
+        var candidate = el;
+        while (candidate.asNode().containingShadowRoot()) |shadow| {
+            candidate = shadow._host;
+        }
+        if (candidate.asNode().getRootNode(.{}) == self.asNode()) {
+            return candidate;
+        }
     }
 
     // Default to body if it exists
@@ -764,6 +772,9 @@ pub fn getFonts(self: *Document, frame: *Frame) !*FontFaceSet {
 pub fn adoptNode(self: *Document, node: *Node, frame: *Frame) !*Node {
     if (node._type == .document) {
         return error.NotSupported;
+    }
+    if (node.is(Node.ShadowRoot) != null) {
+        return error.HierarchyError;
     }
 
     const old_owner = node.ownerDocument(frame) orelse frame.document;

--- a/src/browser/webapi/Event.zig
+++ b/src/browser/webapi/Event.zig
@@ -21,6 +21,7 @@ const lp = @import("lightpanda");
 
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
+const EventManager = @import("../EventManager.zig");
 
 const Node = @import("Node.zig");
 const EventTarget = @import("EventTarget.zig");
@@ -40,6 +41,7 @@ _type_string: String,
 _target: ?*EventTarget = null,
 _current_target: ?*EventTarget = null,
 _dispatch_target: ?*EventTarget = null, // Original target for composedPath()
+_dispatch_related_target: ?*EventTarget = null,
 _prevent_default: bool = false,
 _stop_propagation: bool = false,
 _stop_immediate_propagation: bool = false,
@@ -325,111 +327,59 @@ pub fn composedPath(self: *Event, exec: *Execution) ![]const *EventTarget {
         else => return &.{},
     };
 
-    // Build the path by walking up from target
-    var path_len: usize = 0;
-    var path_buffer: [128]*EventTarget = undefined;
-    var stopped_at_shadow_boundary = false;
-
-    // Track closed shadow boundaries (position in path and host position)
-    var closed_shadow_boundary: ?struct { shadow_end: usize, host_start: usize } = null;
-
     const frame_ = switch (exec.js.global) {
         .frame => |frame| frame,
         else => null,
     };
 
-    const target_root = target_node.getRootNode(.{});
-    var node: ?*Node = target_node;
-    while (node) |n| {
-        if (path_len >= path_buffer.len) {
-            break;
-        }
-        path_buffer[path_len] = n.asEventTarget();
-        path_len += 1;
-
-        // Check if this node is a shadow root
-        if (n._type == .document_fragment) {
-            const df = n.subtype(Node.DocumentFragment);
-            if (df._type == .shadow_root) {
-                const shadow = df._type.shadow_root;
-
-                if (!self._composed and n == target_root) {
-                    stopped_at_shadow_boundary = true;
-                    break;
-                }
-
-                // Track the first closed shadow boundary we encounter
-                if (shadow._mode == .closed and closed_shadow_boundary == null) {
-                    // Mark where the shadow root is in the path
-                    // The next element will be the host
-                    closed_shadow_boundary = .{
-                        .shadow_end = path_len - 1, // index of shadow root
-                        .host_start = path_len, // index where host will be
-                    };
-                }
-
-                // Jump to the shadow host and continue
-                node = shadow._host.asNode();
-                continue;
-            }
-        }
-
-        // an assigned slottable's event-path parent is its assigned slot,
-        // routing the event into the slot's shadow tree
-        if (frame_) |frame| {
-            if (frame._assigned_slots.get(n)) |slot| {
-                node = slot.asNode();
-                continue;
-            }
-        }
-
-        node = n._parent;
+    var path_buffer: [128]*EventTarget = undefined;
+    var path_len = EventManager.buildEventPath(target_node, self, frame_, &path_buffer).len;
+    if (path_len == 0) {
+        return &.{};
     }
 
-    // Add window at the end. It only participates when propagation did not stop
-    // at a shadow boundary...
-    if (stopped_at_shadow_boundary == false) {
-        // ... AND when the tree's root is a document
-        const root_is_document = path_len > 0 and switch (path_buffer[path_len - 1]._type) {
-            .node => |n| n._type == .document,
-            else => false,
+    // Window follows the document at the end of the path. A path that stopped
+    // early — at a shadow boundary, or at the relatedTarget — doesn't end on
+    // the document and so doesn't reach it.
+    const root_is_document = switch (path_buffer[path_len - 1]._type) {
+        .node => |n| n._type == .document,
+        else => false,
+    };
+    if (root_is_document and path_len < path_buffer.len) {
+        if (frame_) |frame| {
+            path_buffer[path_len] = frame.window.asEventTarget();
+            path_len += 1;
+        }
+    }
+
+    // The host of the first closed shadow root on the path. Everything before
+    // it is inside that root and hidden from a currentTarget outside it.
+    var closed_host_index: ?usize = null;
+    for (path_buffer[0..path_len], 0..) |entry, i| {
+        const node = switch (entry._type) {
+            .node => |n| n,
+            else => continue,
         };
-        if (root_is_document) {
-            if (path_len < path_buffer.len) {
-                switch (exec.js.global) {
-                    .worker => {},
-                    .frame => |frame| {
-                        path_buffer[path_len] = frame.window.asEventTarget();
-                        path_len += 1;
-                    },
-                }
-            }
+        const shadow = node.is(Node.ShadowRoot) orelse continue;
+        if (shadow._mode == .closed) {
+            closed_host_index = i + 1;
+            break;
         }
     }
 
     // Determine visible path based on current_target and closed shadow boundaries
     var visible_start_index: usize = 0;
 
-    if (closed_shadow_boundary) |boundary| {
-        // Check if current_target is outside the closed shadow
-        // If current_target is null or is at/after the host position, hide shadow internals
-        const current_target = self._current_target;
-
-        if (current_target) |ct| {
-            // Find current_target in the path
-            var ct_index: ?usize = null;
+    if (closed_host_index) |host_index| {
+        // Find current_target in the path; if it's at or after the host, it's
+        // outside the closed shadow and must not see the nodes inside it.
+        if (self._current_target) |ct| {
             for (path_buffer[0..path_len], 0..) |elem, i| {
                 if (elem == ct) {
-                    ct_index = i;
+                    if (i >= host_index) {
+                        visible_start_index = host_index;
+                    }
                     break;
-                }
-            }
-
-            // If current_target is at or after the host (outside the closed shadow),
-            // hide everything from target up to the host
-            if (ct_index) |idx| {
-                if (idx >= boundary.host_start) {
-                    visible_start_index = boundary.host_start;
                 }
             }
         }

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -636,15 +636,15 @@ pub fn isEqualChildren(a: *Node, b: *Node) bool {
     return a_count == b_count;
 }
 
+// The shadow root whose tree this node belongs to, or null when it belongs to
+// a document tree or a detached one. Inclusive: a shadow root is in its own
+// tree.
+pub fn containingShadowRoot(self: *Node) ?*ShadowRoot {
+    return self.getRootNode(.{}).is(ShadowRoot);
+}
+
 pub fn isInShadowTree(self: *Node) bool {
-    var node = self._parent;
-    while (node) |n| {
-        if (n.is(ShadowRoot) != null) {
-            return true;
-        }
-        node = n._parent;
-    }
-    return false;
+    return self.containingShadowRoot() != null;
 }
 
 pub fn isConnected(self: *const Node) bool {
@@ -1209,6 +1209,10 @@ const CloneError = error{
     ExecutionTerminated,
 };
 pub fn cloneNode(self: *Node, deep_: ?bool, frame: *Frame) CloneError!*Node {
+    if (self.is(ShadowRoot) != null) {
+        return error.NotSupported;
+    }
+
     const deep = deep_ orelse false;
     switch (self._type) {
         .cdata => {

--- a/src/browser/webapi/ShadowRoot.zig
+++ b/src/browser/webapi/ShadowRoot.zig
@@ -124,6 +124,23 @@ pub fn setOnSlotChange(self: *ShadowRoot, callback: ?js.Function.Global, frame: 
     }
 }
 
+pub fn getActiveElement(self: *ShadowRoot, frame: *Frame) ?*Element {
+    const root = self.asNode();
+    const document = root.ownerDocument(frame) orelse frame.document;
+
+    // This is answering two questions:
+    // 1 - is the active element contained by me (if not, return null)
+    // 2 - if it is, is there 1+ other shadowroot between us
+    //     a - if there is, return the nearest (to self) shadowroot's host
+    //     b - if there isn't, return the active element
+    var candidate = document._active_element orelse return null;
+    while (candidate.asNode().getRootNode(.{}) != root) {
+        const shadow = candidate.asNode().containingShadowRoot() orelse return null;
+        candidate = shadow._host;
+    }
+    return candidate;
+}
+
 pub fn getElementById(self: *ShadowRoot, id: []const u8, frame: *Frame) ?*Element {
     if (id.len == 0) {
         return null;
@@ -177,6 +194,7 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    pub const activeElement = bridge.accessor(ShadowRoot.getActiveElement, null, .{});
     pub const mode = bridge.accessor(ShadowRoot.getMode, null, .{});
     pub const host = bridge.accessor(ShadowRoot.getHost, null, .{});
     pub const delegatesFocus = bridge.accessor(ShadowRoot.getDelegatesFocus, null, .{});

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -892,6 +892,20 @@ pub fn getLabels(self: *Input, frame: *Frame) !js.Array {
     return @import("Label.zig").getControlLabels(self.asElement(), frame);
 }
 
+pub fn getList(self: *Input, frame: *Frame) ?*HtmlElement.DataList {
+    switch (self._input_type) {
+        .hidden, .password, .checkbox, .radio, .file, .submit, .image, .reset, .button => return null,
+        else => {},
+    }
+
+    const element = self.asElement();
+    const list_id = element.getAttributeSafe(comptime .wrap("list")) orelse return null;
+
+    // list= resolves in the input's own tree (shadow root or document).
+    const target = frame.getElementByIdFromNode(element.asNode(), list_id) orelse return null;
+    return target.is(HtmlElement.DataList);
+}
+
 pub fn getForm(self: *Input, frame: *Frame) ?*Form {
     const element = self.asElement();
 
@@ -1427,6 +1441,7 @@ pub const JsApi = struct {
     pub const size = bridge.accessor(Input.getSize, Input.setSize, .{ .ce_reactions = true });
     pub const src = bridge.accessor(Input.getSrc, Input.setSrc, .{ .ce_reactions = true });
     pub const form = bridge.accessor(Input.getForm, null, .{});
+    pub const list = bridge.accessor(Input.getList, null, .{});
     pub const formAction = bridge.accessor(Input.getFormAction, Input.setFormAction, .{});
     pub const formEnctype = bridge.accessor(Input.getFormEnctype, Input.setFormEnctype, .{});
     pub const formMethod = bridge.accessor(Input.getFormMethod, Input.setFormMethod, .{});

--- a/src/browser/webapi/element/html/Slot.zig
+++ b/src/browser/webapi/element/html/Slot.zig
@@ -6,7 +6,6 @@ const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
-const ShadowRoot = @import("../../ShadowRoot.zig");
 const slotting = @import("../slotting.zig");
 
 const Slot = @This();
@@ -76,7 +75,7 @@ fn CollectionType(comptime elements: bool) type {
 
 // DOM spec "find flattened slottables"
 fn collectFlattened(self: *Slot, comptime elements: bool, coll: CollectionType(elements), frame: *Frame) error{OutOfMemory}!void {
-    if (self.asNode().getRootNode(.{}).is(ShadowRoot) == null) {
+    if (self.asNode().containingShadowRoot() == null) {
         return;
     }
 
@@ -101,7 +100,7 @@ fn appendFlattened(comptime elements: bool, coll: CollectionType(elements), node
     if (node.is(Slot)) |nested| {
         // a slottable (or fallback child) that is itself a slot in a shadow
         // tree flattens to its own flattened slottables
-        if (nested.asNode().getRootNode(.{}).is(ShadowRoot) != null) {
+        if (nested.asNode().containingShadowRoot() != null) {
             return nested.collectFlattened(elements, coll, frame);
         }
     }
@@ -153,9 +152,8 @@ pub fn assign(self: *Slot, values: []const js.Value, frame: *Frame) !void {
         try self._manually_assigned.append(frame.arena, node);
     }
 
-    const root = self.asNode().getRootNode(.{});
-    if (root.is(ShadowRoot) != null) {
-        slotting.assignSlottablesForTree(root, frame);
+    if (self.asNode().containingShadowRoot()) |shadow_root| {
+        slotting.assignSlottablesForTree(shadow_root.asNode(), frame);
     }
 }
 

--- a/src/browser/webapi/element/slotting.zig
+++ b/src/browser/webapi/element/slotting.zig
@@ -23,7 +23,6 @@ const Frame = @import("../../Frame.zig");
 
 const Node = @import("../Node.zig");
 const Element = @import("../Element.zig");
-const ShadowRoot = @import("../ShadowRoot.zig");
 const TreeWalker = @import("../TreeWalker.zig");
 
 const Text = @import("../cdata/Text.zig");
@@ -93,7 +92,7 @@ fn assignSlottables(slot: *Slot, frame: *Frame) void {
 
 fn _assignSlottables(slot: *Slot, frame: *Frame) !void {
     var slottables: std.ArrayList(*Node) = .empty;
-    if (slot.asNode().getRootNode(.{}).is(ShadowRoot)) |shadow_root| {
+    if (slot.asNode().containingShadowRoot()) |shadow_root| {
         const host = shadow_root.getHost();
         if (shadow_root._slot_assignment == .manual) {
             // manual assignment preserves the assign(...) order, not tree order
@@ -184,7 +183,7 @@ pub fn insertionSteps(parent: *Node, child: *Node, in_fragment_parse: bool, fram
     // assignment they were parsed with.
     if (in_fragment_parse == false) {
         if (parent.is(Slot)) |parent_slot| {
-            if (parent_slot._assigned.items.len == 0 and parent.getRootNode(.{}).is(ShadowRoot) != null) {
+            if (parent_slot._assigned.items.len == 0 and parent.containingShadowRoot() != null) {
                 frame.signalSlotChange(parent_slot);
             }
         }
@@ -192,9 +191,8 @@ pub fn insertionSteps(parent: *Node, child: *Node, in_fragment_parse: bool, fram
 
     // A subtree containing slots was inserted into a shadow tree.
     if (subtreeHasSlot(child)) {
-        const root = child.getRootNode(.{});
-        if (root.is(ShadowRoot) != null) {
-            assignSlottablesForTree(root, frame);
+        if (child.containingShadowRoot()) |shadow_root| {
+            assignSlottablesForTree(shadow_root.asNode(), frame);
         }
     }
 }
@@ -213,7 +211,7 @@ pub fn removalSteps(parent: *Node, child: *Node, frame: *Frame) void {
 
     // Fallback content was removed from a slot that renders its fallback.
     if (parent.is(Slot)) |parent_slot| {
-        if (parent_slot._assigned.items.len == 0 and parent.getRootNode(.{}).is(ShadowRoot) != null) {
+        if (parent_slot._assigned.items.len == 0 and parent.containingShadowRoot() != null) {
             frame.signalSlotChange(parent_slot);
         }
     }
@@ -221,9 +219,8 @@ pub fn removalSteps(parent: *Node, child: *Node, frame: *Frame) void {
     // A subtree containing slots was removed: update assignments in the old
     // tree, and clear assignments held by slots in the detached subtree.
     if (subtreeHasSlot(child)) {
-        const root = parent.getRootNode(.{});
-        if (root.is(ShadowRoot) != null) {
-            assignSlottablesForTree(root, frame);
+        if (parent.containingShadowRoot()) |shadow_root| {
+            assignSlottablesForTree(shadow_root.asNode(), frame);
         }
         assignSlottablesForTree(child, frame);
     }
@@ -248,8 +245,7 @@ pub fn nameAttributeChanged(slot: *Slot, old_value: []const u8, value: []const u
     if (std.mem.eql(u8, old_value, value)) {
         return;
     }
-    const root = slot.asNode().getRootNode(.{});
-    if (root.is(ShadowRoot) != null) {
-        assignSlottablesForTree(root, frame);
+    if (slot.asNode().containingShadowRoot()) |shadow_root| {
+        assignSlottablesForTree(shadow_root.asNode(), frame);
     }
 }


### PR DESCRIPTION
Correctly encapsulate events that happen within a shadowroot to stop from leaking out. This involves calculating the related_target relative to the potential node receiving the event.

Also Event.composedPath now re-uses the same path-building logic as EventManager (previously, the same-ish algo in both places, that were out of sync).

Some smaller changes:
- input.list getter (showed up in the shadow dom wpt tests)
- activeElement getter added to ShadowDOM
- document activeElement is ShadowDOM-aware and won't cross