### PR TITLE
cdp: fall back to loopback when /json/version bind host is a wildcard

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -677,7 +677,7 @@ pub fn advertiseHost(self: *const Config) []const u8 {
 // For remote hosts, users can still pin the URL with --advertise-host.
 // See issue #1922.
 fn advertiseHostFallback(host: []const u8) []const u8 {
-    if (std.mem.eql(u8, host, "0.0.0.0") or std.mem.eql(u8, host, "::")) {
+    if (isHostWildcard(host)) {
         return "127.0.0.1";
     }
     return host;
@@ -689,9 +689,13 @@ fn advertiseHostFallback(host: []const u8) []const u8 {
 // resolvable, but the caller still benefits from emitting a guidance log.
 pub fn bindIsWildcard(self: *const Config) bool {
     return switch (self.mode) {
-        .serve => |opts| std.mem.eql(u8, opts.host, "0.0.0.0") or std.mem.eql(u8, opts.host, "::"),
+        .serve => |opts| isHostWildcard(opts.host),
         else => false,
     };
+}
+
+fn isHostWildcard(host: []const u8) bool {
+    return std.mem.eql(u8, host, "0.0.0.0") or std.mem.eql(u8, host, "::");
 }
 
 pub fn webBotAuth(self: *const Config) ?WebBotAuthConfig {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -663,9 +663,34 @@ pub fn port(self: *const Config) u16 {
 
 pub fn advertiseHost(self: *const Config) []const u8 {
     return switch (self.mode) {
-        .serve => |opts| opts.advertise_host orelse opts.host,
+        .serve => |opts| opts.advertise_host orelse advertiseHostFallback(opts.host),
         .mcp => "127.0.0.1",
         else => unreachable,
+    };
+}
+
+// Wildcard bind addresses (0.0.0.0, ::) are not routable for clients
+// resolving /json/version. Fall back to a loopback address so the
+// advertised webSocketDebuggerUrl is at least connectable from the same
+// host (covers the official Docker image, which exposes 9222 via the
+// container's published port, and the WSL localhost bridge).
+// For remote hosts, users can still pin the URL with --advertise-host.
+// See issue #1922.
+fn advertiseHostFallback(host: []const u8) []const u8 {
+    if (std.mem.eql(u8, host, "0.0.0.0") or std.mem.eql(u8, host, "::")) {
+        return "127.0.0.1";
+    }
+    return host;
+}
+
+// True when serve is binding a wildcard address (e.g. Docker --host
+// 0.0.0.0) without an explicit --advertise-host. /json/version replaces
+// the wildcard with 127.0.0.1 in advertiseHostFallback so the URL stays
+// resolvable, but the caller still benefits from emitting a guidance log.
+pub fn bindIsWildcard(self: *const Config) bool {
+    return switch (self.mode) {
+        .serve => |opts| std.mem.eql(u8, opts.host, "0.0.0.0") or std.mem.eql(u8, opts.host, "::"),
+        else => false,
     };
 }
 
@@ -978,6 +1003,47 @@ test "Config: blockedUrlPatterns splits comma-separated patterns" {
     try std.testing.expectEqualStrings("*doubleclick*", patterns.next().?);
     try std.testing.expectEqualStrings("*://*/*.png", patterns.next().?);
     try std.testing.expectEqual(null, patterns.next());
+}
+
+// /json/version must never advertise a wildcard bind address because
+// clients (Chromedp, Playwright MCP, etc.) cannot dial 0.0.0.0/::. See
+// issue #1922.
+test "Config: advertiseHost falls back to loopback for wildcard binds" {
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .host = "0.0.0.0",
+        } });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expect(config.bindIsWildcard());
+        try std.testing.expectEqualStrings("127.0.0.1", config.advertiseHost());
+    }
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .host = "::",
+        } });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expect(config.bindIsWildcard());
+        try std.testing.expectEqualStrings("127.0.0.1", config.advertiseHost());
+    }
+}
+
+test "Config: advertiseHost honors explicit --advertise-host override" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .host = "0.0.0.0",
+        .advertise_host = "192.168.0.5",
+    } });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expect(config.bindIsWildcard());
+    try std.testing.expectEqualStrings("192.168.0.5", config.advertiseHost());
+}
+
+test "Config: advertiseHost preserves concrete host when not a wildcard" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .host = "127.0.0.1",
+    } });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expect(!config.bindIsWildcard());
+    try std.testing.expectEqualStrings("127.0.0.1", config.advertiseHost());
 }
 
 pub fn validateUserAgent(ua: []const u8) !void {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -689,7 +689,7 @@ fn advertiseHostFallback(host: []const u8) []const u8 {
 // resolvable, but the caller still benefits from emitting a guidance log.
 pub fn bindIsWildcard(self: *const Config) bool {
     return switch (self.mode) {
-        .serve => |opts| isHostWildcard(opts.host),
+        .serve => |opts| opts.advertise_host == null and isHostWildcard(opts.host),
         else => false,
     };
 }
@@ -1037,7 +1037,8 @@ test "Config: advertiseHost honors explicit --advertise-host override" {
         .advertise_host = "192.168.0.5",
     } });
     defer config.deinit(std.testing.allocator);
-    try std.testing.expect(config.bindIsWildcard());
+    // The explicit --advertise-host silences the wildcard guidance log.
+    try std.testing.expect(!config.bindIsWildcard());
     try std.testing.expectEqualStrings("192.168.0.5", config.advertiseHost());
 }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -282,9 +282,13 @@ fn handleConnection(self: *Server, socket: posix.socket_t) void {
 
 fn buildJSONVersionResponse(app: *const App, port: u16) ![]const u8 {
     const host = app.config.advertiseHost();
-    if (std.mem.eql(u8, host, "0.0.0.0")) {
-        log.info(.cdp, "unreachable advertised host", .{
-            .message = "when --host is set to 0.0.0.0 consider setting --advertise-host to a reachable address",
+    if (app.config.bindIsWildcard()) {
+        // Serve is bound to INADDR_ANY but no --advertise-host was given;
+        // advertiseHost() falls back to 127.0.0.1 so clients can still
+        // connect locally. Surface the trade-off so users running
+        // outside the same host know they have to opt in.
+        log.note(.cdp, "advertising loopback for wildcard bind", .{
+            .message = "--host is a wildcard (0.0.0.0 / ::) without --advertise-host; clients on other hosts will need --advertise-host to reach the CDP endpoint",
         });
     }
     const body_format =


### PR DESCRIPTION
Closes #1922.

When `serve` is started with `--host 0.0.0.0` (or `::`) and no explicit `--advertise-host`, `/json/version` was returning `webSocketDebuggerUrl: ws://0.0.0.0:9222/`. That URL is unroutable by any client (Chromedp, Playwright MCP, etc.) and surfaces as `ECONNREFUSED` on the very next dial. This is exactly the failure mode reported in #1922 when the official Docker image (`Dockerfile` `--host 0.0.0.0 --port 9222`) is used from another host.

The existing `--advertise-host` flag added in #1955 was a workaround, not a fix: the default behavior is still unsafe and operators have to know to set it.

This PR makes the default safe:

- `Config.advertiseHost()` substitutes `127.0.0.1` for wildcard binds when no `--advertise-host` is provided. Same-host clients (the Docker host loopback via the published port, or the WSL localhost bridge) now get a connectable URL out of the box.
- Operators serving CDP on a dedicated interface still pin the URL explicitly via `--advertise-host <reachable>`; the wildcard fallback only kicks in when nothing is set.
- `Server.buildJSONVersionResponse` keeps emitting a guidance log when the bind is a wildcard, so multi-host setups are still surfaced.

Unit tests cover the four relevant branches:
- `--host 0.0.0.0` and `--host ::` fall back to `127.0.0.1`
- explicit `--advertise-host` overrides the bind host
- concrete bind host (`127.0.0.1`) is preserved unchanged

The existing `server: buildJSONVersionResponse` and `server: get /json/version` tests are untouched because the test harness binds to `127.0.0.1:9583`, which is not a wildcard.

Validation notes:
- I edited the upstream `main` snapshot (`upstream/main` HEAD `6312d43d97`); the local `/Users/ming/code/lightpanda-io/browser` main is 314 commits behind, so I used a worktree at `upstream/main` to keep the diff base correct.
- I do not have Zig 0.15+ / `v8` toolchain installed locally, so I have not run `zig build test`. The change is two line-flip-class edits + three test cases; upstream CI on the PR should validate.
- Branch: `guyua9:fix/advertise-host-wildcard`
- Head SHA: `8be30d56f8032c12520d7a0cef115928fda37c22`
- Account: `guyua9` (registered in `github-accounts.json`, browserProfile `hm11`)