### PR TITLE
`Element`: alias `matches` with `webkitMatchesSelector`

### DIFF
--- a/src/browser/tests/element/matches.html
+++ b/src/browser/tests/element/matches.html
@@ -62,6 +62,26 @@
 }
 </script>
 
+<script id=webkitMatchesSelector>
+{
+  // Legacy alias of matches(): same behaviour, including error handling.
+  const container = $('#test-container');
+  const span = $('#special');
+
+  testing.expectEqual(true, container.webkitMatchesSelector('#test-container'));
+  testing.expectEqual(true, container.webkitMatchesSelector('.container.main'));
+  testing.expectEqual(true, container.webkitMatchesSelector('*'));
+  testing.expectEqual(false, container.webkitMatchesSelector('p'));
+
+  testing.expectEqual(true, span.webkitMatchesSelector('span#special.wrapper'));
+  testing.expectEqual(false, span.webkitMatchesSelector('div'));
+
+  testing.expectError("SyntaxError", () => container.webkitMatchesSelector(''));
+
+  testing.expectEqual(1, Element.prototype.webkitMatchesSelector.length);
+}
+</script>
+
 <script id=errorHandling>
 {
   const container = $('#test-container');

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -2416,6 +2416,7 @@ pub const JsApi = struct {
     pub const previousElementSibling = bridge.accessor(Element.previousElementSibling, null, .{});
     pub const childElementCount = bridge.accessor(Element.getChildElementCount, null, .{});
     pub const matches = bridge.function(Element.matches, .{});
+    pub const webkitMatchesSelector = bridge.function(Element.matches, .{});
     pub const querySelector = bridge.function(Element.querySelector, .{});
     pub const querySelectorAll = bridge.function(Element.querySelectorAll, .{});
     pub const closest = bridge.function(Element.closest, .{});


### PR DESCRIPTION
Adds legacy alias of matches(), kept for compatibility per the DOM spec.