### PR TITLE
`Origin` and (additional) `Host` header validation for CDP conns

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -414,12 +414,86 @@ test "Client: http invalid handshake" {
     );
 }
 
+test "Client: http handshake origin" {
+    testing.silenceLog(&.{.cdp});
+
+    const with_origin =
+        "GET / HTTP/1.1\r\n" ++
+        "Connection: upgrade\r\n" ++
+        "Upgrade: websocket\r\n" ++
+        "sec-websocket-version:13\r\n" ++
+        "sec-websocket-key: this is my key\r\n" ++
+        "Origin: {s}\r\n\r\n";
+
+    for ([_][]const u8{
+        "https://evil.com",
+        // Being served from loopback yourself doesn't make you trusted.
+        "http://127.0.0.1:8080",
+        "http://localhost:8080",
+        // Sandboxed iframes and data: URLs.
+        "null",
+    }) |origin| {
+        var c = try createTestClient();
+        defer c.deinit();
+
+        var buf: [256]u8 = undefined;
+        const res = try c.httpRequest(try std.fmt.bufPrint(&buf, with_origin, .{origin}));
+        try testing.expectEqual("HTTP/1.1 403 \r\n" ++
+            "Connection: Close\r\n" ++
+            "Content-Length: 18\r\n\r\n" ++
+            "Origin not allowed", res);
+    }
+
+    // The first one is enough; we never get far enough to see the second.
+    try assertHTTPError(
+        403,
+        "Origin not allowed",
+        "GET / HTTP/1.1\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "sec-websocket-version:13\r\n" ++
+            "sec-websocket-key: this is my key\r\n" ++
+            "Origin: https://evil.com\r\n" ++
+            "Origin: https://evil.com\r\n\r\n",
+    );
+}
+
+test "Client: http handshake host" {
+    testing.silenceLog(&.{.cdp});
+
+    // Any name in Host means something resolved to us that shouldn't
+    // have (rebinding); only an IP literal gets through.
+    const with_host =
+        "GET / HTTP/1.1\r\n" ++
+        "Connection: upgrade\r\n" ++
+        "Upgrade: websocket\r\n" ++
+        "sec-websocket-version:13\r\n" ++
+        "sec-websocket-key: this is my key\r\n" ++
+        "Host: {s}\r\n\r\n";
+
+    for ([_][]const u8{
+        "rebind.evil.com:9583",
+        // Not even the name that resolves to loopback on every machine.
+        "localhost:9583",
+    }) |host| {
+        var buf: [256]u8 = undefined;
+        try assertHTTPError(
+            403,
+            "Host not allowed",
+            try std.fmt.bufPrint(&buf, with_host, .{host}),
+        );
+    }
+}
+
 test "Client: http valid handshake" {
     var c = try createTestClient();
     defer c.deinit();
 
+    // No Origin (i.e. not a browser) and a Host we're reachable at: what
+    // every CDP driver sends.
     const request =
         "GET /   HTTP/1.1\r\n" ++
+        "Host: 127.0.0.1:9583\r\n" ++
         "Connection: upgrade\r\n" ++
         "Upgrade: websocket\r\n" ++
         "sec-websocket-version:13\r\n" ++

--- a/src/cdp/Connection.zig
+++ b/src/cdp/Connection.zig
@@ -246,6 +246,8 @@ fn processHttpRequest(self: *Connection) !HttpResult {
     return self.handleHttpRequest(request) catch |err| {
         switch (err) {
             error.NotFound => self.sendHttpError(404, "Not found"),
+            error.ForbiddenOrigin => self.sendHttpError(403, "Origin not allowed"),
+            error.ForbiddenHost => self.sendHttpError(403, "Host not allowed"),
             error.InvalidRequest => self.sendHttpError(400, "Invalid request"),
             error.InvalidProtocol => self.sendHttpError(400, "Invalid HTTP protocol"),
             error.MissingHeaders => self.sendHttpError(400, "Missing required header"),
@@ -434,8 +436,6 @@ fn pushCdp(self: *Connection, bytes: []const u8) !bool {
 }
 
 pub fn upgrade(self: *Connection, request: []u8) !void {
-    // We need to extract the `Sec-WebSocket-Key` value.
-    var sec_websocket_key: []const u8 = "";
     // We need to make sure that we got all the necessary headers + values;
     // a bit per required header.
     const FOUND_UPGRADE: u8 = 1 << 0; // Upgrade: websocket
@@ -453,6 +453,8 @@ pub fn upgrade(self: *Connection, request: []u8) !void {
     }
 
     var found_headers: u8 = 0;
+    // We need to extract the `Sec-WebSocket-Key` value.
+    var sec_websocket_key: []const u8 = "";
 
     // A malformed header maps to a 400 in processHttpRequest.
     while (header_iterator.next() catch return error.InvalidRequest) |header| {
@@ -481,6 +483,35 @@ pub fn upgrade(self: *Connection, request: []u8) !void {
         } else if (std.ascii.eqlIgnoreCase(key, "sec-websocket-key")) {
             sec_websocket_key = value;
             found_headers |= FOUND_KEY;
+        } else if (std.ascii.eqlIgnoreCase(key, "origin")) {
+            // Only a browser sends `Origin`, and a browser has no business
+            // driving CDP: whatever page sent this is cross-origin to us by
+            // definition, including one served from loopback itself. Scripted
+            // clients (Puppeteer, Playwright, chromedp, ...) never send it.
+            log.warn(.cdp, "rejected websocket origin", .{
+                .origin = value[0..@min(value.len, 64)],
+            });
+            return error.ForbiddenOrigin;
+        } else if (std.ascii.eqlIgnoreCase(key, "host")) {
+            const host = value;
+            const is_allowed = blk: {
+                _ = std.Io.net.IpAddress.parseLiteral(host) catch break :blk false;
+                break :blk true;
+            };
+
+            // Defense in depth against DNS rebinding: an IP literal is the only
+            // thing that can legitimately reach us, because no name has to be
+            // resolved to produce one. Any name at all - "localhost" included -
+            // means something answered a DNS lookup with our address, which is
+            // exactly what a rebinding attack looks like. A request without a
+            // Host header isn't from a browser, so it can't be the vector.
+            if (!is_allowed) {
+                log.warn(.cdp, "rejected websocket host", .{
+                    .host = host[0..@min(host.len, 64)],
+                    .hint = "connect to the CDP endpoint by IP address",
+                });
+                return error.ForbiddenHost;
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds `Origin` header validation to `Connection.upgrade`; where we validate CDP connections.
1. Any WebSocket upgrade request carrying an Origin header is rejected with 403 Origin not allowed.
2. the Host header must be an IP literal (for example 127.0.0.1:9222). Any host name, including localhost, is rejected with 403 Host not allowed.