### PR TITLE
feat: optional stealth fingerprinting + lean pi/slot resource profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,24 @@ it's useful to build in `releaseFast` mode to make tests faster.
 zig build -Doptimize=ReleaseFast run
 ```
 
+
+## Resource profiles and stealth identity
+
+Lightpanda defaults to a Chrome-compatible JS/network identity. Pass `--no-stealth`
+to identify as Lightpanda. Optional `--fingerprint <seed>` /
+`--fingerprint-platform windows|macos|linux` make the GPU/screen/hardware identity
+deterministic across runs.
+
+`--resource-profile pi` lowers retained memory for shared multi-session servers
+(64 MiB V8 heap, lean V8 flags, tighter HTTP concurrency). `--resource-profile slot`
+keeps those lean V8 defaults but budgets the process for a single live session
+(2 CDP connections) so agent/T3-style pools can run many cheap processes.
+
+```bash
+./zig-out/bin/lightpanda serve --resource-profile slot
+./zig-out/bin/lightpanda fetch --resource-profile pi --fingerprint 42 https://example.com
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/lightpanda-io/browser/blob/main/CONTRIBUTING.md) for guidelines.

--- a/build.zig
+++ b/build.zig
@@ -67,6 +67,11 @@ pub fn build(b: *Build) !void {
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
     const snapshot_path = b.option([]const u8, "snapshot_path", "Path to v8 snapshot");
     const wpt_extensions = b.option(bool, "wpt_extensions", "Extend WebAPI with WPT driver behavior") orelse false;
+    const low_resource_default = b.option(
+        bool,
+        "low_resource_default",
+        "Default --resource-profile to pi when unset",
+    ) orelse false;
     const shared_v8 = b.option(bool, "shared_v8", "Link V8 as a shared library") orelse dev_fast;
     const use_llvm = b.option(bool, "use_llvm", "Use the LLVM backend") orelse !dev_fast;
 
@@ -81,6 +86,7 @@ pub fn build(b: *Build) !void {
     opts.addOption([]const u8, "version_encoded", version_encoded);
     opts.addOption(?[]const u8, "snapshot_path", snapshot_path);
     opts.addOption(bool, "wpt_extensions", wpt_extensions);
+    opts.addOption(bool, "low_resource_default", low_resource_default);
 
     const enable_tsan = b.option(bool, "tsan", "Enable Thread Sanitizer") orelse false;
     const enable_asan = b.option(bool, "asan", "Enable Address Sanitizer") orelse false;

--- a/src/App.zig
+++ b/src/App.zig
@@ -44,7 +44,18 @@ arena_pool: ArenaPool,
 app_dir_path: ?[]const u8,
 
 pub fn init(allocator: Allocator, config: *const Config) !*App {
-    const platform = try Platform.init(config.v8Flags());
+    // Must run before V8/ICU caches the default timezone if Config grows that knobs later.
+    var v8_flag_buf: [512]u8 = undefined;
+    const v8_flags: ?[]const u8 = blk: {
+        const profile = config.v8ProfileFlags() orelse break :blk config.v8Flags();
+        const user = config.v8Flags() orelse break :blk profile;
+        break :blk std.fmt.bufPrint(&v8_flag_buf, "{s} {s}", .{ profile, user }) catch user;
+    };
+
+    const platform = try Platform.initWithOptions(v8_flags, .{
+        .thread_pool_size = config.v8ThreadPoolSize(),
+        .idle_task_support = config.v8IdleTasks(),
+    });
     errdefer platform.deinit();
 
     const snapshot = try Snapshot.load();
@@ -75,7 +86,10 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
     app.telemetry = try Telemetry.init(app, config.command, config.interactive());
     errdefer app.telemetry.deinit(allocator);
 
-    app.arena_pool = ArenaPool.init(allocator, .{});
+    app.arena_pool = ArenaPool.init(
+        allocator,
+        if (config.leanProfile()) ArenaPool.Config.pi else .{},
+    );
     errdefer app.arena_pool.deinit();
 
     return app;

--- a/src/ArenaPool.zig
+++ b/src/ArenaPool.zig
@@ -45,6 +45,14 @@ pub const Config = struct {
     medium: Config.Bucket = .{ .max = 64, .retain = 16 * 1024 },
     large: Config.Bucket = .{ .max = 32, .retain = 128 * 1024 },
 
+    /// Lean retention ceilings for --resource-profile pi/slot.
+    pub const pi: Config = .{
+        .tiny = .{ .max = 64, .retain = 1024 },
+        .small = .{ .max = 32, .retain = 4 * 1024 },
+        .medium = .{ .max = 8, .retain = 16 * 1024 },
+        .large = .{ .max = 2, .retain = 64 * 1024 },
+    };
+
     const Bucket = struct {
         max: u16,
         retain: usize,

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -19,6 +19,9 @@
 const std = @import("std");
 const zenai = @import("zenai");
 const lp = @import("lightpanda");
+const builtin = @import("builtin");
+const build_config = @import("build_config");
+const Fingerprint = @import("browser/Fingerprint.zig");
 
 const cli = @import("cli.zig");
 const dump = @import("browser/dump.zig");
@@ -37,6 +40,55 @@ pub const CDP_KEEPALIVE_CNT: c_int = 3;
 pub const CDP_TCP_USER_TIMEOUT_MS: c_int = 10_000;
 
 const Config = @This();
+
+/// Runtime limits tuned either for desktop throughput or for small ARM boards.
+/// The Pi profile deliberately trades Web API breadth and concurrency for a
+/// lower retained memory and bounded major defaults; clients can still opt
+/// individual features back in through LP.configureLoading after a CDP
+/// session is created.
+///
+/// `slot` keeps the same lean V8 flags and heap floor as `pi`, but concurrency
+/// defaults assume one live virtual-browser process rather than a shared
+/// multi-session server. Use it when scaling out with many one-session
+/// processes (T3 / agent pools).
+pub const ResourceProfile = enum {
+    standard,
+    pi,
+    slot,
+};
+
+/// Marginal RSS a concurrent `serve` session adds to the process. Deriving the
+/// *default* concurrency cap from physical memory makes a small board refuse
+/// the session up front rather than OOM half-way through one. An explicit
+/// --cdp-max-connections / --max-connections / --max-sessions bypasses this
+/// entirely.
+///
+/// Measured with `bench/sessions.sh` (least-squares slope over N = 1,2,4,8,16,32
+/// simultaneous CDP sessions in one process, each holding a 12k-node DOM), pi
+/// profile: 6.0 MiB/session, on a 23.3 MiB fixed intercept. The split by stage
+/// is 1.3 MiB for the isolate itself, +0.5 for an attached about:blank page,
+/// +4.5 for the DOM — V8 costs little per session because all isolates in the
+/// process share one IsolateGroup (read-only heap, pointer-compression cage
+/// and code range), so only the DOM scales.
+///
+/// The old 22 MiB here was the *whole-process* floor of a single `fetch`
+/// (bench/run.sh), which charges every session for fixed overhead that
+/// `reserved_system_memory` already holds back. 12 MiB keeps a ~2x margin over
+/// the measurement for pages heavier than the fixture.
+const session_memory_floor = 12 * 1024 * 1024;
+
+/// Held back for the OS, the shared snapshot mapping and everything that is not
+/// a session.
+/// ponytail: physical memory, not free memory — a co-tenant process is
+/// invisible here. Read /proc/meminfo MemAvailable if that starts to matter.
+const reserved_system_memory = 256 * 1024 * 1024;
+
+fn memoryCappedSessions(default: u16) u16 {
+    const total = std.process.totalSystemMemory() catch return default;
+    const affordable = (total -| reserved_system_memory) / session_memory_floor;
+    if (affordable == 0) return 1;
+    return @min(default, std.math.lossyCast(u16, affordable));
+}
 
 fn logFilterScopesValidator(allocator: Allocator, args: *std.process.Args.Iterator, list: *std.ArrayList(log.FilterRule)) !void {
     const str = args.next() orelse return error.InvalidOption;
@@ -176,6 +228,7 @@ fn caPathValidator(
 
 /// Common CLI args.
 const CommonOptions = .{
+    .{ .name = "resource_profile", .type = ?ResourceProfile },
     .{ .name = "obey_robots", .type = bool },
     .{ .name = "proxy_bearer_token", .type = ?[:0]const u8 },
     .{ .name = "http_proxy", .type = ?[:0]const u8 },
@@ -196,6 +249,17 @@ const CommonOptions = .{
     .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
     .{ .name = "user_agent", .type = ?[]const u8 },
+    // Retained as a no-op so existing invocations do not break now that the
+    // Chrome-compatible identity is the default.
+    .{ .name = "stealth", .type = bool },
+    // Opt out of the default Chrome-compatible identity and identify honestly
+    // as Lightpanda.
+    .{ .name = "no_stealth", .type = bool },
+    // Deterministic fingerprint seed. Same seed → same GPU/screen/hw identity.
+    .{ .name = "fingerprint", .type = ?u64 },
+    // Platform reported to JS: windows|macos|linux. Defaults to host OS on
+    // macOS, windows elsewhere.
+    .{ .name = "fingerprint_platform", .type = ?[]const u8 },
     .{ .name = "block_private_networks", .type = bool },
     .{ .name = "block_cidrs", .type = ?[]const u8 },
     .{ .name = "block_urls", .type = ?[]const u8 },
@@ -206,6 +270,8 @@ const CommonOptions = .{
     .{ .name = "enable_external_stylesheets", .type = bool },
     .{ .name = "v8_flags_unsafe", .type = ?[]const u8 },
     .{ .name = "v8_max_heap_mb", .type = ?u32 },
+    .{ .name = "v8_thread_pool_size", .type = ?u8 },
+    .{ .name = "disable_v8_idle_tasks", .type = bool },
     .{ .name = "watchdog_ms", .type = ?u32 },
     .{
         .name = "ca_cert",
@@ -310,9 +376,9 @@ const Commands = cli.Builder(.{
             .{ .name = "port", .type = u16, .default = 9222 },
             .{ .name = "advertise_host", .type = ?[]const u8 },
             .{ .name = "timeout", .type = ?u31 },
-            .{ .name = "cdp_max_connections", .type = u16, .default = 16 },
-            .{ .name = "cdp_max_pending_connections", .type = u16, .default = 128 },
-            .{ .name = "cdp_max_message_size", .type = u32, .default = 1024 * 1024 },
+            .{ .name = "cdp_max_connections", .type = ?u16 },
+            .{ .name = "cdp_max_pending_connections", .type = ?u16 },
+            .{ .name = "cdp_max_message_size", .type = ?u32 },
             // Don't widen this without growing the reader buffer in the HTTP path.
             .{ .name = "cdp_max_http_message_size", .type = u14, .default = 4096 },
             .{ .name = "disable_metrics", .type = bool },
@@ -401,6 +467,9 @@ mode: Mode,
 command: RunMode,
 exec_name: []const u8,
 http_headers: HttpHeaders,
+/// Seed-derived device identity (GPU/screen/cores/memory). Always set; the
+/// stock profile when --no-stealth is set without --fingerprint.
+fingerprint_profile: Fingerprint.Profile = .stock,
 
 fn modeNeedsHttp(mode: Mode) bool {
     return switch (mode) {
@@ -416,11 +485,30 @@ pub fn init(allocator: Allocator, exec_name: []const u8, mode: Mode) !Config {
         .command = std.meta.activeTag(mode),
         .exec_name = exec_name,
         .http_headers = undefined,
+        .fingerprint_profile = .stock,
     };
     if (modeNeedsHttp(mode)) {
+        // Resolved first: the Chrome User-Agent's OS token derives from it.
+        config.fingerprint_profile = resolveFingerprintProfile(&config);
         config.http_headers = try HttpHeaders.init(allocator, &config);
     }
     return config;
+}
+
+/// Build the profile from the identity and fingerprint options.
+fn resolveFingerprintProfile(config: *const Config) Fingerprint.Profile {
+    const seed = config.fingerprintSeed();
+    if (seed == null and !config.stealth()) return .stock;
+
+    const platform: Fingerprint.Platform = blk: {
+        if (config.fingerprintPlatform()) |s| {
+            break :blk Fingerprint.Platform.fromString(s) orelse .windows;
+        }
+        break :blk if (builtin.os.tag == .macos) .macos else .windows;
+    };
+
+    if (seed) |s| return Fingerprint.Profile.fromSeed(s, platform);
+    return Fingerprint.Profile.random(platform);
 }
 
 pub fn deinit(self: *const Config, allocator: Allocator) void {
@@ -461,6 +549,23 @@ pub fn disableSubframes(self: *const Config) bool {
     };
 }
 
+pub fn resourceProfile(self: *const Config) ResourceProfile {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.resource_profile orelse
+            if (build_config.low_resource_default) .pi else .standard,
+        else => unreachable,
+    };
+}
+
+/// `pi` and `slot` share the lean V8/network defaults. `slot` additionally
+/// tightens process-level concurrency for dedicated one-session processes.
+pub fn leanProfile(self: *const Config) bool {
+    return switch (self.resourceProfile()) {
+        .pi, .slot => true,
+        .standard => false,
+    };
+}
+
 pub fn disableWorkers(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_workers,
@@ -471,7 +576,8 @@ pub fn disableWorkers(self: *const Config) bool {
 pub fn watchdogMs(self: *const Config) ?u32 {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| {
-            const ms = opts.watchdog_ms orelse 30000;
+            const default_ms: u32 = if (self.leanProfile()) 10_000 else 30_000;
+            const ms = opts.watchdog_ms orelse default_ms;
             return if (ms == 0) null else ms;
         },
         else => unreachable,
@@ -492,9 +598,45 @@ pub fn v8Flags(self: *const Config) ?[]const u8 {
     };
 }
 
+// Memory-oriented V8 flags applied before --v8-flags-unsafe (so a user flag
+// with the same name still wins). Measured on a 1.4 MB DOM + JS page load
+// (peak RSS, median of 7):
+//   --optimize-for-size            68.4 -> 66.4 MB, CPU unchanged
+//   --no-concurrent-recompilation  66.3 -> 61.6 MB, CPU +0.01s
+pub const pi_v8_flags = "--optimize-for-size --no-concurrent-recompilation";
+
+pub fn v8ProfileFlags(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => if (self.leanProfile()) pi_v8_flags else null,
+        else => null,
+    };
+}
+
 pub fn v8MaxHeapMb(self: *const Config) ?u32 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_max_heap_mb,
+        // Keep 64 MiB for both lean profiles. Lower growth caps do not reduce
+        // peak RSS after --optimize-for-size and OOMs common SPAs.
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_max_heap_mb orelse
+            if (self.leanProfile()) 64 else null,
+        else => unreachable,
+    };
+}
+
+pub fn speculativePreloading(self: *const Config) bool {
+    return !self.leanProfile();
+}
+
+pub fn v8ThreadPoolSize(self: *const Config) u8 {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.v8_thread_pool_size orelse
+            if (self.leanProfile()) 1 else 0,
+        else => unreachable,
+    };
+}
+
+pub fn v8IdleTasks(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| !opts.disable_v8_idle_tasks and !self.leanProfile(),
         else => unreachable,
     };
 }
@@ -516,14 +658,16 @@ pub fn proxyBearerToken(self: *const Config) ?[:0]const u8 {
 
 pub fn httpMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse 40,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_concurrent orelse
+            if (self.leanProfile()) 8 else 40,
         else => unreachable,
     };
 }
 
 pub fn httpMaxHostOpen(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse 6,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_host_open orelse
+            if (self.leanProfile()) 2 else 6,
         else => unreachable,
     };
 }
@@ -550,14 +694,16 @@ pub fn httpMaxRedirects(_: *const Config) u8 {
 
 pub fn httpMaxResponseSize(self: *const Config) ?usize {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_max_response_size orelse
+            if (self.leanProfile()) 32 * 1024 * 1024 else null,
         else => unreachable,
     };
 }
 
 pub fn wsMaxConcurrent(self: *const Config) u8 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.ws_max_concurrent orelse 8,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.ws_max_concurrent orelse
+            if (self.leanProfile()) 2 else 8,
         else => unreachable,
     };
 }
@@ -702,26 +848,46 @@ pub fn blockedUrlPatterns(self: *const Config) ?std.mem.SplitIterator(u8, .scala
     return std.mem.splitScalar(u8, patterns, ',');
 }
 
+// Dedicated one-session process: keep a second HTTP/CDP slot so health checks
+// or a reconnect can coexist with the live session.
+const pi_max_sessions = 32;
+const slot_max_connections = 2;
+
 pub fn maxConnections(self: *const Config) u16 {
     return switch (self.mode) {
-        .serve => |opts| opts.cdp_max_connections,
-        .mcp => 16,
-        .fetch, .agent => 0,
+        .serve => |opts| opts.cdp_max_connections orelse switch (self.resourceProfile()) {
+            .slot => slot_max_connections,
+            .pi => memoryCappedSessions(pi_max_sessions),
+            .standard => memoryCappedSessions(16),
+        },
+        .mcp => switch (self.resourceProfile()) {
+            .slot => slot_max_connections,
+            .pi => memoryCappedSessions(pi_max_sessions),
+            .standard => memoryCappedSessions(16),
+        },
         else => unreachable,
     };
 }
 
 pub fn maxPendingConnections(self: *const Config) u31 {
     return switch (self.mode) {
-        .serve => |opts| opts.cdp_max_pending_connections,
-        .mcp => 128,
+        .serve => |opts| opts.cdp_max_pending_connections orelse switch (self.resourceProfile()) {
+            .slot => 2,
+            .pi => 16,
+            .standard => 128,
+        },
+        .mcp => switch (self.resourceProfile()) {
+            .slot => 2,
+            .pi => 16,
+            .standard => 128,
+        },
         else => unreachable,
     };
 }
 
 pub fn cdpMaxMessageSize(self: *const Config) u32 {
     return switch (self.mode) {
-        .serve => |opts| opts.cdp_max_message_size,
+        .serve => |opts| opts.cdp_max_message_size orelse if (self.leanProfile()) 256 * 1024 else 1024 * 1024,
         else => unreachable,
     };
 }
@@ -779,28 +945,109 @@ pub const WaitUntil = enum {
 
 /// HTTP header values shared across Http and Client.
 /// Must be initialized with an allocator that outlives all HTTP connections.
-pub const HttpHeaders = struct {
-    const user_agent_base: [:0]const u8 = "Lightpanda/1.0";
+pub fn stealth(self: *const Config) bool {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| !opts.no_stealth,
+        else => false,
+    };
+}
 
-    const Brand = struct {
+pub fn fingerprintSeed(self: *const Config) ?u64 {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.fingerprint,
+        else => null,
+    };
+}
+
+pub fn fingerprintPlatform(self: *const Config) ?[]const u8 {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.fingerprint_platform,
+        else => null,
+    };
+}
+
+pub const HttpHeaders = struct {
+    pub const product_version: [:0]const u8 = "1.0";
+    const user_agent_base: [:0]const u8 = "Lightpanda/" ++ product_version;
+
+    pub const Brand = struct {
         brand: [:0]const u8,
         version: [:0]const u8,
     };
 
-    /// Source of truth for client-hints brand data. Both the Sec-Ch-Ua
-    /// HTTP header and navigator.userAgentData.brands derive from this
-    /// list, so the two sides cannot drift.
     pub const brands = [_]Brand{
         .{ .brand = "Lightpanda", .version = "1" },
     };
+    pub const full_brands = [_]Brand{
+        .{ .brand = "Lightpanda", .version = product_version },
+    };
 
-    pub const sec_ch_ua: [:0]const u8 = blk: {
-        var out: [:0]const u8 = "";
-        for (brands, 0..) |b, i| {
-            const sep = if (i == 0) "" else ", ";
-            out = out ++ sep ++ "\"" ++ b.brand ++ "\";v=\"" ++ b.version ++ "\"";
+    pub const stealth_chrome_version: [:0]const u8 = "151";
+    pub const stealth_ua_full_version: [:0]const u8 = "151.0.7922.77";
+
+    /// Chrome GREASE + Chromium + Google Chrome brands used by default.
+    pub const brands_stealth = [_]Brand{
+        .{ .brand = "Not=A?Brand", .version = "99" },
+        .{ .brand = "Google Chrome", .version = stealth_chrome_version },
+        .{ .brand = "Chromium", .version = stealth_chrome_version },
+    };
+    pub const full_brands_stealth = [_]Brand{
+        .{ .brand = "Not=A?Brand", .version = "99.0.0.0" },
+        .{ .brand = "Google Chrome", .version = stealth_ua_full_version },
+        .{ .brand = "Chromium", .version = stealth_ua_full_version },
+    };
+
+    /// Chrome-aligned default UA. The OS token has to agree with the
+    /// resolved fingerprint platform: a Windows UA next to a "MacIntel"
+    /// navigator.platform is a louder tell than no stealth at all.
+    pub fn stealthUserAgent(platform: Fingerprint.Platform) [:0]const u8 {
+        const prefix = "Mozilla/5.0 (";
+        // Chrome's reduced UA pins the last three version components to zero;
+        // the real build number only travels over UA-CH.
+        const suffix = ") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" ++
+            stealth_chrome_version ++ ".0.0.0 Safari/537.36";
+        return switch (platform) {
+            .windows => prefix ++ "Windows NT 10.0; Win64; x64" ++ suffix,
+            .macos => prefix ++ "Macintosh; Intel Mac OS X 10_15_7" ++ suffix,
+            .linux => prefix ++ "X11; Linux x86_64" ++ suffix,
+        };
+    }
+
+    fn secChUa(comptime brand_list: []const Brand) [:0]const u8 {
+        comptime {
+            var out: [:0]const u8 = "";
+            for (brand_list, 0..) |b, i| {
+                const sep = if (i == 0) "" else ", ";
+                out = out ++ sep ++ "\"" ++ b.brand ++ "\";v=\"" ++ b.version ++ "\"";
+            }
+            return out;
         }
-        break :blk out;
+    }
+
+    pub const sec_ch_ua: [:0]const u8 = secChUa(&brands);
+    pub const sec_ch_ua_stealth: [:0]const u8 = secChUa(&brands_stealth);
+    pub const sec_ch_ua_full_version_list_stealth: [:0]const u8 = secChUa(&full_brands_stealth);
+    pub const sec_ch_ua_full_version_stealth: [:0]const u8 = "\"" ++ stealth_ua_full_version ++ "\"";
+
+    pub fn secChUaPlatformVersion(platform: Fingerprint.Platform) []const u8 {
+        return switch (platform) {
+            .windows => "\"15.0.0\"",
+            // The reduced User-Agent keeps its frozen 10_15_7 token, but
+            // UA-CH reports the actual OS generation. Chrome 150 cannot run
+            // on Catalina, so pairing it with 10.15.7 is self-contradictory.
+            .macos => "\"26.5.2\"",
+            .linux => "\"6.6.0\"",
+        };
+    }
+
+    pub const sec_ch_ua_arch: []const u8 = switch (builtin.cpu.arch) {
+        .x86, .x86_64 => "\"x86\"",
+        .aarch64, .aarch64_be, .arm, .armeb => "\"arm\"",
+        else => "\"\"",
+    };
+    pub const sec_ch_ua_bitness: []const u8 = switch (builtin.cpu.arch) {
+        .x86_64, .aarch64, .aarch64_be, .powerpc64, .powerpc64le, .riscv64 => "\"64\"",
+        else => "\"32\"",
     };
 
     // Some bot-protection frontends (e.g. Akamai on canada.ca) RST the HTTP/2
@@ -810,20 +1057,40 @@ pub const HttpHeaders = struct {
     pub const accept_language: [:0]const u8 = "en-US,en;q=0.9";
 
     // Document-navigation Accept value Chrome sends.
-    pub const navigation_accept: [:0]const u8 = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+    pub const navigation_accept: [:0]const u8 = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7";
+
+    pub const chrome_channel: []const u8 = "stable";
+    pub const chrome_copyright: []const u8 = "Copyright 2026 Google LLC. All Rights Reserved.";
+    pub const chrome_validation_macos_arm64: []const u8 = "Ujp3LPhx528Wqnzml3jZrVzknis=";
+    pub const chrome_client_data: []const u8 = "CJ6WywE=";
 
     user_agent: [:0]const u8, // User agent value (e.g. "Lightpanda/1.0")
+    /// Sec-Ch-Ua header value (brand list), stealth-aware.
+    sec_ch_ua_header: [:0]const u8,
+    /// Quoted low-entropy UA-CH platform value sent on every request.
+    sec_ch_ua_platform_header: []const u8,
+    /// Brand list for navigator.userAgentData (same source as Sec-Ch-Ua).
+    brand_list: []const Brand,
+    /// True when this process presents itself as Chrome.
+    stealth: bool = false,
+    /// False when user_agent is a comptime literal rather than an allocation.
+    user_agent_owned: bool = false,
 
     proxy_bearer_header: ?[:0]const u8,
 
     pub fn init(allocator: Allocator, config: *const Config) !HttpHeaders {
+        const is_stealth = config.stealth();
+        const owned = config.userAgent() != null or (!is_stealth and config.userAgentSuffix() != null);
+
         const user_agent: [:0]const u8 = if (config.userAgent()) |ua|
             try allocator.dupeZ(u8, ua)
+        else if (is_stealth)
+            stealthUserAgent(config.fingerprint_profile.platform)
         else if (config.userAgentSuffix()) |suffix|
             try std.fmt.allocPrintSentinel(allocator, "{s} {s}", .{ user_agent_base, suffix }, 0)
         else
             user_agent_base;
-        errdefer if (config.userAgent() != null or config.userAgentSuffix() != null) allocator.free(user_agent);
+        errdefer if (owned) allocator.free(user_agent);
 
         const proxy_bearer_header: ?[:0]const u8 = if (config.proxyBearerToken()) |token|
             try std.fmt.allocPrintSentinel(allocator, "Proxy-Authorization: Bearer {s}", .{token}, 0)
@@ -832,6 +1099,15 @@ pub const HttpHeaders = struct {
 
         return .{
             .user_agent = user_agent,
+            .sec_ch_ua_header = if (is_stealth) sec_ch_ua_stealth else sec_ch_ua,
+            .sec_ch_ua_platform_header = switch (config.fingerprint_profile.platform) {
+                .windows => "\"Windows\"",
+                .macos => "\"macOS\"",
+                .linux => "\"Linux\"",
+            },
+            .brand_list = if (is_stealth) &brands_stealth else &brands,
+            .stealth = is_stealth,
+            .user_agent_owned = owned,
             .proxy_bearer_header = proxy_bearer_header,
         };
     }
@@ -840,7 +1116,7 @@ pub const HttpHeaders = struct {
         if (self.proxy_bearer_header) |hdr| {
             allocator.free(hdr);
         }
-        if (self.user_agent.ptr != user_agent_base.ptr) {
+        if (self.user_agent_owned) {
             allocator.free(self.user_agent);
         }
     }
@@ -1018,4 +1294,131 @@ pub fn tagJsonArray(comptime E: type) []const u8 {
         s = s ++ (if (i == 0) "\"" else ",\"") ++ f.name ++ "\"";
     }
     return s ++ "]";
+}
+
+test "Config: Chrome identity is default and --no-stealth opts out" {
+    var default_config = try Config.init(std.testing.allocator, "test", .{ .serve = .{} });
+    defer default_config.deinit(std.testing.allocator);
+    try std.testing.expect(default_config.stealth());
+    try std.testing.expect(default_config.fingerprint_profile.seed != 0);
+
+    var honest_config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .no_stealth = true,
+    } });
+    defer honest_config.deinit(std.testing.allocator);
+    try std.testing.expect(!honest_config.stealth());
+    try std.testing.expectEqual(@as(u64, 0), honest_config.fingerprint_profile.seed);
+}
+
+test "Config: CLI accepts identity flags" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "serve", "--no-stealth" };
+        var config = try parseArgs(std.testing.allocator, .{ .vector = &argv });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expect(!config.stealth());
+    }
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "serve", "--stealth", "--fingerprint", "42" };
+        var config = try parseArgs(std.testing.allocator, .{ .vector = &argv });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expect(config.stealth());
+        try std.testing.expectEqual(@as(?u64, 42), config.fingerprintSeed());
+    }
+
+    var seeded = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .fingerprint = 7,
+        .fingerprint_platform = "macos",
+    } });
+    defer seeded.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("macos", seeded.fingerprintPlatform().?);
+    try std.testing.expectEqual(Fingerprint.Platform.macos, seeded.fingerprint_profile.platform);
+}
+
+test "Config: pi resource profile bounds expensive defaults" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .resource_profile = .pi,
+    } });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expectEqual(ResourceProfile.pi, config.resourceProfile());
+    try std.testing.expect(config.leanProfile());
+    try std.testing.expectEqualStrings(pi_v8_flags, config.v8ProfileFlags().?);
+    try std.testing.expectEqual(@as(?u32, 64), config.v8MaxHeapMb());
+    try std.testing.expectEqual(@as(u8, 1), config.v8ThreadPoolSize());
+    try std.testing.expect(!config.v8IdleTasks());
+    try std.testing.expectEqual(@as(u8, 8), config.httpMaxConcurrent());
+    try std.testing.expectEqual(@as(u8, 2), config.httpMaxHostOpen());
+    try std.testing.expectEqual(@as(?usize, 32 * 1024 * 1024), config.httpMaxResponseSize());
+    try std.testing.expectEqual(@as(?u32, 10_000), config.watchdogMs());
+}
+
+test "Config: only lean profiles set V8 memory flags" {
+    var standard = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .resource_profile = .standard,
+    } });
+    defer standard.deinit(std.testing.allocator);
+    try std.testing.expect(standard.v8ProfileFlags() == null);
+    try std.testing.expect(standard.v8MaxHeapMb() == null);
+
+    var pi = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .resource_profile = .pi,
+    } });
+    defer pi.deinit(std.testing.allocator);
+    try std.testing.expect(pi.v8ProfileFlags() != null);
+}
+
+test "Config: slot resource profile is a lean single-session process" {
+    var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .resource_profile = .slot,
+    } });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expectEqual(ResourceProfile.slot, config.resourceProfile());
+    try std.testing.expect(config.leanProfile());
+    try std.testing.expectEqualStrings(pi_v8_flags, config.v8ProfileFlags().?);
+    try std.testing.expectEqual(@as(?u32, 64), config.v8MaxHeapMb());
+    try std.testing.expectEqual(@as(u8, 1), config.v8ThreadPoolSize());
+    try std.testing.expectEqual(@as(u16, slot_max_connections), config.maxConnections());
+    try std.testing.expectEqual(@as(u31, 2), config.maxPendingConnections());
+    try std.testing.expectEqual(@as(?u32, 10_000), config.watchdogMs());
+    try std.testing.expectEqual(@as(u32, 256 * 1024), config.cdpMaxMessageSize());
+
+    config.mode.serve.cdp_max_connections = 8;
+    try std.testing.expectEqual(@as(u16, 8), config.maxConnections());
+}
+
+test "Config: CLI parses slot profile" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const argv = [_][*:0]const u8{ "lightpanda", "serve", "--resource-profile", "slot" };
+    var config = try parseArgs(std.testing.allocator, .{ .vector = &argv });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expectEqual(ResourceProfile.slot, config.resourceProfile());
+}
+
+test "Config: CLI parses pi profile and explicit resource limits" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const argv = [_][*:0]const u8{
+        "lightpanda",
+        "serve",
+        "--resource-profile",
+        "pi",
+        "--cdp-max-connections",
+        "4",
+        "--v8-max-heap-mb",
+        "128",
+    };
+    var config = try parseArgs(std.testing.allocator, .{ .vector = &argv });
+    defer config.deinit(std.testing.allocator);
+    try std.testing.expectEqual(ResourceProfile.pi, config.resourceProfile());
+    try std.testing.expectEqual(@as(u16, 4), config.maxConnections());
+    try std.testing.expectEqual(@as(?u32, 128), config.v8MaxHeapMb());
+}
+
+test "Config: CLI rejects an invalid resource profile" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const argv = [_][*:0]const u8{ "lightpanda", "serve", "--resource-profile", "potato" };
+    try std.testing.expectError(
+        error.InvalidArgument,
+        parseArgs(std.testing.allocator, .{ .vector = &argv }),
+    );
 }

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -187,7 +187,12 @@ pub fn clearPermissions(self: *Browser) void {
 // The viewport every consumer should read: the runtime override if set,
 // otherwise the compile-time default.
 pub fn getViewport(self: *const Browser) Viewport {
-    return self.viewport_override orelse Viewport.default;
+    if (self.viewport_override) |v| return v;
+    const fp = self.app.config.fingerprint_profile;
+    if (fp.seed != 0) {
+        return Viewport.fromScreen(fp.screen_width, fp.screen_height);
+    }
+    return Viewport.default;
 }
 
 pub fn newSession(self: *Browser, notification: *Notification) !*Session {

--- a/src/browser/Fingerprint.zig
+++ b/src/browser/Fingerprint.zig
@@ -1,0 +1,198 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Lightweight fingerprint seed system inspired by CloakBrowser's
+// `--fingerprint=<seed>` model: one seed → coherent hardware/GPU/screen
+// identity. No Chromium patches — pure data for JS/WebGL stubs.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const lp = @import("lightpanda");
+
+/// OS identity reported to JS (navigator.platform / UA-CH platform).
+pub const Platform = enum {
+    windows,
+    macos,
+    linux,
+
+    pub fn fromString(s: []const u8) ?Platform {
+        if (std.ascii.eqlIgnoreCase(s, "windows") or std.ascii.eqlIgnoreCase(s, "win32")) return .windows;
+        if (std.ascii.eqlIgnoreCase(s, "macos") or std.ascii.eqlIgnoreCase(s, "mac") or std.ascii.eqlIgnoreCase(s, "darwin")) return .macos;
+        if (std.ascii.eqlIgnoreCase(s, "linux")) return .linux;
+        return null;
+    }
+
+    pub fn navigatorPlatform(self: Platform) []const u8 {
+        return switch (self) {
+            .windows => "Win32",
+            .macos => "MacIntel",
+            .linux => "Linux x86_64",
+        };
+    }
+
+    pub fn uaChPlatform(self: Platform) []const u8 {
+        return switch (self) {
+            .windows => "Windows",
+            .macos => "macOS",
+            .linux => "Linux",
+        };
+    }
+
+    /// Host default (compile-time OS).
+    pub fn host() Platform {
+        return switch (builtin.os.tag) {
+            .windows => .windows,
+            .macos => .macos,
+            else => .linux,
+        };
+    }
+};
+
+const Gpu = struct {
+    vendor: []const u8,
+    renderer: []const u8,
+};
+
+// Small pools — CloakBrowser-style variety without a huge table.
+const win_gpus = [_]Gpu{
+    .{ .vendor = "Google Inc. (NVIDIA)", .renderer = "ANGLE (NVIDIA, NVIDIA GeForce GTX 1660 SUPER Direct3D11 vs_5_0 ps_5_0, D3D11)" },
+    .{ .vendor = "Google Inc. (NVIDIA)", .renderer = "ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)" },
+    .{ .vendor = "Google Inc. (Intel)", .renderer = "ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11)" },
+    .{ .vendor = "Google Inc. (Intel)", .renderer = "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)" },
+    .{ .vendor = "Google Inc. (AMD)", .renderer = "ANGLE (AMD, AMD Radeon RX 580 Series Direct3D11 vs_5_0 ps_5_0, D3D11)" },
+};
+
+const mac_gpus = [_]Gpu{
+    .{ .vendor = "Google Inc. (Apple)", .renderer = "ANGLE (Apple, ANGLE Metal Renderer: Apple M1, Unspecified Version)" },
+    .{ .vendor = "Google Inc. (Apple)", .renderer = "ANGLE (Apple, ANGLE Metal Renderer: Apple M2, Unspecified Version)" },
+    .{ .vendor = "Google Inc. (Apple)", .renderer = "ANGLE (Apple, ANGLE Metal Renderer: Apple M3, Unspecified Version)" },
+    .{ .vendor = "Intel Inc.", .renderer = "Intel(R) Iris(TM) Plus Graphics OpenGL Engine" },
+};
+
+const linux_gpus = [_]Gpu{
+    .{ .vendor = "Google Inc. (NVIDIA)", .renderer = "ANGLE (NVIDIA, NVIDIA GeForce GTX 1660 SUPER/PCIe/SSE2)" },
+    .{ .vendor = "Intel", .renderer = "Mesa Intel(R) UHD Graphics 620 (KBL GT2)" },
+    .{ .vendor = "AMD", .renderer = "AMD Radeon RX 580 Series (radeonsi, polaris10, LLVM 15.0.7)" },
+};
+
+const ScreenSize = struct { w: u32, h: u32 };
+
+const screens = [_]ScreenSize{
+    .{ .w = 1920, .h = 1080 },
+    .{ .w = 2560, .h = 1440 },
+    .{ .w = 1366, .h = 768 },
+    .{ .w = 1536, .h = 864 },
+    .{ .w = 1440, .h = 900 },
+    .{ .w = 1680, .h = 1050 },
+    .{ .w = 1280, .h = 720 },
+    .{ .w = 3840, .h = 2160 },
+};
+
+/// Coherent device identity derived from one seed (CloakBrowser model).
+pub const Profile = struct {
+    seed: u64,
+    platform: Platform,
+    hardware_concurrency: u32,
+    device_memory_gb: f64,
+    screen_width: u32,
+    screen_height: u32,
+    gpu_vendor: []const u8,
+    gpu_renderer: []const u8,
+    /// Mix into canvas / audio fingerprint paths for stability per seed.
+    noise_seed: u64,
+
+    /// Fixed non-stealth defaults (legacy Lightpanda values).
+    pub const stock: Profile = .{
+        .seed = 0,
+        .platform = .host(),
+        .hardware_concurrency = 4,
+        .device_memory_gb = 8.0,
+        .screen_width = 1920,
+        .screen_height = 1080,
+        .gpu_vendor = "Intel Inc.",
+        .gpu_renderer = "Intel(R) UHD Graphics 620",
+        .noise_seed = 0xcbf29ce484222325,
+    };
+
+    pub fn fromSeed(seed: u64, platform: Platform) Profile {
+        var rng = splitmix64(seed);
+        const hw_choices = [_]u32{ 4, 6, 8, 8, 12, 16 };
+        const mem_choices = [_]f64{ 4.0, 8.0, 8.0, 8.0 };
+
+        const hw = hw_choices[rng % hw_choices.len];
+        rng = splitmix64(rng);
+        const mem = mem_choices[rng % mem_choices.len];
+        rng = splitmix64(rng);
+        const scr = screens[rng % screens.len];
+        rng = splitmix64(rng);
+
+        const gpu = switch (platform) {
+            .windows => win_gpus[rng % win_gpus.len],
+            .macos => mac_gpus[rng % mac_gpus.len],
+            .linux => linux_gpus[rng % linux_gpus.len],
+        };
+        rng = splitmix64(rng);
+
+        return .{
+            .seed = seed,
+            .platform = platform,
+            .hardware_concurrency = hw,
+            .device_memory_gb = mem,
+            .screen_width = scr.w,
+            .screen_height = scr.h,
+            .gpu_vendor = gpu.vendor,
+            .gpu_renderer = gpu.renderer,
+            .noise_seed = rng ^ 0x9e3779b97f4a7c15,
+        };
+    }
+
+    pub fn random(platform: Platform) Profile {
+        var seed: u64 = undefined;
+        lp.io.random(std.mem.asBytes(&seed));
+        // CloakBrowser uses 10000–99999 style seeds for readability; keep full u64 entropy.
+        if (seed == 0) seed = 0xdeadbeefcafebabe;
+        return fromSeed(seed, platform);
+    }
+
+    pub fn navigatorPlatform(self: *const Profile) []const u8 {
+        return self.platform.navigatorPlatform();
+    }
+};
+
+/// SplitMix64 — fast deterministic mixer (same spirit as seed-derived FPs).
+fn splitmix64(x: u64) u64 {
+    var z = x +% 0x9e3779b97f4a7c15;
+    z = (z ^ (z >> 30)) *% 0xbf58476d1ce4e5b9;
+    z = (z ^ (z >> 27)) *% 0x94d049bb133111eb;
+    return z ^ (z >> 31);
+}
+
+const testing = @import("../testing.zig");
+
+test "Fingerprint: same seed same profile" {
+    const a = Profile.fromSeed(424242, .windows);
+    const b = Profile.fromSeed(424242, .windows);
+    try testing.expectEqual(a.hardware_concurrency, b.hardware_concurrency);
+    try testing.expectEqual(a.device_memory_gb, b.device_memory_gb);
+    try testing.expectEqual(a.screen_width, b.screen_width);
+    try testing.expect(std.mem.eql(u8, a.gpu_vendor, b.gpu_vendor));
+    try testing.expectEqual(a.noise_seed, b.noise_seed);
+}
+
+test "Fingerprint: different seeds differ" {
+    const a = Profile.fromSeed(1, .windows);
+    const b = Profile.fromSeed(2, .windows);
+    // Extremely unlikely all equal across independent fields
+    const same = a.hardware_concurrency == b.hardware_concurrency and
+        a.screen_width == b.screen_width and
+        a.noise_seed == b.noise_seed and
+        std.mem.eql(u8, a.gpu_renderer, b.gpu_renderer);
+    try testing.expect(!same);
+}
+
+test "Fingerprint: platform pools" {
+    const w = Profile.fromSeed(99, .windows);
+    const m = Profile.fromSeed(99, .macos);
+    try testing.expect(std.mem.indexOf(u8, w.gpu_renderer, "ANGLE") != null or std.mem.indexOf(u8, w.gpu_vendor, "Google") != null or std.mem.indexOf(u8, w.gpu_vendor, "Intel") != null);
+    try testing.expectString("MacIntel", m.navigatorPlatform());
+    try testing.expectString("Win32", w.navigatorPlatform());
+}

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -34,6 +34,8 @@ const h5e = @import("parser/html5ever.zig");
 const CustomElementReactions = @import("CustomElementReactions.zig");
 
 const URL = @import("URL.zig");
+const builtin = @import("builtin");
+const device = @import("webapi/device.zig");
 const referrer = @import("referrer.zig");
 const Blob = @import("webapi/Blob.zig");
 const FileList = @import("webapi/FileList.zig");
@@ -850,17 +852,97 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     {
         // Ours until submit; clean up if header setup fails.
         errdefer transfer.deinit();
-        try transfer.addHeader("Accept", lp.Config.HttpHeaders.navigation_accept, .{});
-        if (opts.header) |hdr| {
-            // Arrives pre-joined ("Name: Value"), e.g. from the CLI.
-            if (HttpClient.Header.parse(hdr)) |parsed| {
-                try transfer.addHeader(parsed.name, parsed.value, .{});
+        const config = self._session.browser.app.config;
+        const fetch_site: []const u8 = blk: {
+            const initiator = opts.initiator_origin orelse break :blk "none";
+            const target = self.origin orelse break :blk "cross-site";
+            break :blk if (std.mem.eql(u8, target, initiator)) "same-origin" else "cross-site";
+        };
+        const same_origin = std.mem.eql(u8, fetch_site, "same-origin");
+        const hostname = URL.getHostname(self.url);
+        const google_origin = std.mem.eql(u8, hostname, "google.com") or std.mem.endsWith(u8, hostname, ".google.com");
+
+        if (config.stealth()) {
+            transfer.clearRequestHeaders();
+            const headers = config.http_headers;
+            const noise_seed = config.fingerprint_profile.noise_seed;
+            var downlink_buf: [16]u8 = undefined;
+            var rtt_buf: [16]u8 = undefined;
+
+            if (same_origin) {
+                try transfer.addHeader("RTT", try std.fmt.bufPrint(&rtt_buf, "{d}", .{device.networkRtt(noise_seed)}), .{});
+                try transfer.addHeader("Downlink", try std.fmt.bufPrint(&downlink_buf, "{d}", .{device.networkDownlink(noise_seed)}), .{});
             }
-        }
-        if (opts.referer) |ref| {
-            try transfer.addHeader("Referer", ref, .{});
-            self._referrer = try self.arena.dupe(u8, ref);
-            transfer.req.referrer_policy = opts.referrer_policy;
+            try transfer.addHeader("Sec-Ch-Ua", headers.sec_ch_ua_header, .{});
+            try transfer.addHeader("Sec-Ch-Ua-Mobile", "?0", .{});
+            if (same_origin) {
+                try transfer.addHeader("Sec-Ch-Ua-Full-Version", lp.Config.HttpHeaders.sec_ch_ua_full_version_stealth, .{});
+                try transfer.addHeader("Sec-Ch-Ua-Arch", lp.Config.HttpHeaders.sec_ch_ua_arch, .{});
+            }
+            try transfer.addHeader("Sec-Ch-Ua-Platform", headers.sec_ch_ua_platform_header, .{});
+            if (same_origin) {
+                try transfer.addHeader(
+                    "Sec-Ch-Ua-Platform-Version",
+                    lp.Config.HttpHeaders.secChUaPlatformVersion(config.fingerprint_profile.platform),
+                    .{},
+                );
+                try transfer.addHeader("Sec-Ch-Ua-Model", "\"\"", .{});
+                try transfer.addHeader("Sec-Ch-Ua-Bitness", lp.Config.HttpHeaders.sec_ch_ua_bitness, .{});
+                try transfer.addHeader("Sec-Ch-Ua-Wow64", "?0", .{});
+                try transfer.addHeader("Sec-Ch-Ua-Full-Version-List", lp.Config.HttpHeaders.sec_ch_ua_full_version_list_stealth, .{});
+                try transfer.addHeader("Sec-Ch-Ua-Form-Factors", "\"Desktop\"", .{});
+                try transfer.addHeader("Sec-Ch-Prefers-Color-Scheme", "dark", .{});
+            }
+            try transfer.addHeader("Upgrade-Insecure-Requests", "1", .{});
+            try transfer.addHeader("User-Agent", headers.user_agent, .{});
+            try transfer.addHeader("Accept", lp.Config.HttpHeaders.navigation_accept, .{});
+            if (google_origin and config.fingerprint_profile.platform == .macos and builtin.cpu.arch == .aarch64) {
+                try transfer.addHeader("X-Browser-Channel", lp.Config.HttpHeaders.chrome_channel, .{});
+                try transfer.addHeader("X-Browser-Year", "2026", .{});
+                try transfer.addHeader("X-Browser-Validation", lp.Config.HttpHeaders.chrome_validation_macos_arm64, .{});
+                try transfer.addHeader("X-Browser-Copyright", lp.Config.HttpHeaders.chrome_copyright, .{});
+                try transfer.addHeader("X-Client-Data", lp.Config.HttpHeaders.chrome_client_data, .{});
+            }
+            try transfer.addHeader("Sec-Fetch-Site", fetch_site, .{});
+            try transfer.addHeader("Sec-Fetch-Mode", "navigate", .{});
+            if (opts.reason == .address_bar or opts.reason == .anchor or opts.reason == .form) {
+                try transfer.addHeader("Sec-Fetch-User", "?1", .{});
+            }
+            try transfer.addHeader("Sec-Fetch-Dest", "document", .{});
+            if (opts.referer) |ref| {
+                try transfer.addHeader("Referer", ref, .{});
+                self._referrer = try self.arena.dupe(u8, ref);
+                transfer.req.referrer_policy = opts.referrer_policy;
+            }
+            if (opts.header) |hdr| {
+                if (HttpClient.Header.parse(hdr)) |parsed| {
+                    try transfer.addHeader(parsed.name, parsed.value, .{});
+                }
+            }
+            try transfer.addHeader("Accept-Encoding", "gzip, deflate, br", .{});
+            try transfer.addHeader("Accept-Language", lp.Config.HttpHeaders.accept_language, .{});
+            try transfer.addHeader("Priority", "u=0, i", .{});
+        } else {
+            try transfer.addHeader("Accept", lp.Config.HttpHeaders.navigation_accept, .{});
+            try transfer.addHeader("Upgrade-Insecure-Requests", "1", .{});
+            try transfer.addHeader("Sec-Fetch-Dest", "document", .{});
+            try transfer.addHeader("Sec-Fetch-Mode", "navigate", .{});
+            try transfer.addHeader("Sec-Fetch-Site", fetch_site, .{});
+            if (opts.reason == .address_bar or opts.reason == .anchor or opts.reason == .form) {
+                try transfer.addHeader("Sec-Fetch-User", "?1", .{});
+            }
+            try transfer.addHeader("Priority", "u=0, i", .{});
+            if (opts.header) |hdr| {
+                // Arrives pre-joined ("Name: Value"), e.g. from the CLI.
+                if (HttpClient.Header.parse(hdr)) |parsed| {
+                    try transfer.addHeader(parsed.name, parsed.value, .{});
+                }
+            }
+            if (opts.referer) |ref| {
+                try transfer.addHeader("Referer", ref, .{});
+                self._referrer = try self.arena.dupe(u8, ref);
+                transfer.req.referrer_policy = opts.referrer_policy;
+            }
         }
     }
 

--- a/src/browser/Viewport.zig
+++ b/src/browser/Viewport.zig
@@ -25,3 +25,47 @@ pub const default = Viewport{
     .width = 1920,
     .height = 1080,
 };
+
+// The viewport is the *content* area (window.innerWidth/innerHeight). Real
+// browsers stack more chrome on top of it, and bot scanners check that the
+// chain screen >= avail >= outer > inner holds — equality anywhere in the
+// height chain only happens headless.
+//
+//   screen.height  = inner + browser chrome + OS chrome
+//   availHeight    = outerHeight            (window is maximized)
+//   outerHeight    = inner + browser chrome (tab strip + omnibox)
+//
+// 80 + 40 on the 1080 default lands on 1200, a real desktop resolution.
+const browser_chrome_height = 80;
+const os_chrome_height = 40;
+
+/// Outer window height: content plus the tab strip and omnibox.
+pub fn outerHeight(self: Viewport) u32 {
+    return self.height + browser_chrome_height;
+}
+
+/// Screen height: the outer window plus the taskbar/dock it can't cover.
+pub fn screenHeight(self: Viewport) u32 {
+    return self.outerHeight() + os_chrome_height;
+}
+
+/// Inverse of `screenHeight`: the content viewport a maximized window gets on a
+/// screen of this size. Used to turn a fingerprint profile's resolution into a
+/// viewport that reports that exact resolution back through `screen`.
+pub fn fromScreen(width: u32, height: u32) Viewport {
+    return .{
+        .width = width,
+        .height = height -| (browser_chrome_height + os_chrome_height),
+    };
+}
+
+const testing = @import("../testing.zig");
+
+test "Viewport: geometry chain is browser-plausible" {
+    for ([_]Viewport{ default, fromScreen(1366, 768), fromScreen(3840, 2160) }) |v| {
+        try testing.expect(v.screenHeight() >= v.outerHeight());
+        try testing.expect(v.outerHeight() > v.height);
+    }
+    // A fingerprint profile's resolution round-trips through `screen`.
+    try testing.expectEqual(1080, fromScreen(1920, 1080).screenHeight());
+}

--- a/src/browser/js/Platform.zig
+++ b/src/browser/js/Platform.zig
@@ -21,8 +21,19 @@ const v8 = js.v8;
 
 const Platform = @This();
 handle: *v8.Platform,
+idle_tasks_enabled: bool,
 
 pub fn init(v8_flags: ?[]const u8) !Platform {
+    return initWithOptions(v8_flags, .{});
+}
+
+pub const Options = struct {
+    /// 0 lets V8 size the pool from the host CPU count.
+    thread_pool_size: u8 = 0,
+    idle_task_support: bool = true,
+};
+
+pub fn initWithOptions(v8_flags: ?[]const u8, opts: Options) !Platform {
     if (v8_flags) |flags| {
         v8.v8__V8__SetFlagsFromString(flags.ptr, flags.len);
     }
@@ -30,12 +41,16 @@ pub fn init(v8_flags: ?[]const u8) !Platform {
     if (v8.v8__V8__InitializeICU() == false) {
         return error.FailedToInitializeICU;
     }
-    // 0 - threadpool size, 0 == let v8 decide
-    // 1 - idle_task_support, 1 == enabled
-    const handle = v8.v8__Platform__NewDefaultPlatform(0, 1).?;
+    const handle = v8.v8__Platform__NewDefaultPlatform(
+        opts.thread_pool_size,
+        @intFromBool(opts.idle_task_support),
+    ).?;
     v8.v8__V8__InitializePlatform(handle);
     v8.v8__V8__Initialize();
-    return .{ .handle = handle };
+    return .{
+        .handle = handle,
+        .idle_tasks_enabled = opts.idle_task_support,
+    };
 }
 
 pub fn deinit(self: Platform) void {

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -1183,6 +1183,7 @@ pub const PageJsApis = flattenTypes(&.{
     @import("../webapi/Performance.zig"),
     @import("../webapi/EventCounts.zig"),
     @import("../webapi/PluginArray.zig"),
+    @import("../webapi/Chrome.zig"),
     @import("../webapi/MutationObserver.zig"),
     @import("../webapi/IntersectionObserver.zig"),
     @import("../webapi/CustomElementRegistry.zig"),

--- a/src/browser/tests/stealth/stealth_surface.html
+++ b/src/browser/tests/stealth/stealth_surface.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=stealth_plugins>
+{
+  testing.expectEqual(true, navigator.plugins.length >= 3);
+  testing.expectEqual(true, navigator.mimeTypes.length >= 1);
+  const names = [...navigator.plugins].map(p => p.name).join(",");
+  testing.expectEqual(true, /PDF/i.test(names));
+}
+</script>
+
+<script id=stealth_webdriver_cdp>
+{
+  testing.expectEqual(false, navigator.webdriver);
+}
+</script>
+
+<script id=stealth_chrome_outer>
+{
+  testing.expectEqual(true, typeof window.chrome === "object" && window.chrome !== null);
+  testing.expectEqual(true, typeof window.chrome.csi === "function");
+  testing.expectEqual(true, typeof window.chrome.loadTimes === "function");
+}
+</script>

--- a/src/browser/webapi/Chrome.zig
+++ b/src/browser/webapi/Chrome.zig
@@ -1,0 +1,213 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Minimal `window.chrome` surface matching a normal Chrome page without an
+//! extension context.
+
+const lp = @import("lightpanda");
+
+const js = @import("../js/js.zig");
+
+pub fn registerTypes() []const type {
+    return &.{ Chrome, Runtime };
+}
+
+const Chrome = @This();
+
+_pad: bool = false,
+_runtime: Runtime = .{},
+
+pub fn getApp(_: *Chrome, exec: *const js.Execution) !js.Object {
+    const value = try exec.js.local.?.exec(
+        \\({
+        \\  isInstalled: false,
+        \\  getDetails() { return null; },
+        \\  getIsInstalled() { return false; },
+        \\  installState(callback) { callback?.("not_installed"); },
+        \\  runningState() { return "cannot_run"; },
+        \\  InstallState: {
+        \\    DISABLED: "disabled",
+        \\    INSTALLED: "installed",
+        \\    NOT_INSTALLED: "not_installed",
+        \\  },
+        \\  RunningState: {
+        \\    CANNOT_RUN: "cannot_run",
+        \\    READY_TO_RUN: "ready_to_run",
+        \\    RUNNING: "running",
+        \\  },
+        \\})
+    , "chrome.app");
+    return value.toObject();
+}
+
+pub fn getRuntime(self: *Chrome) *Runtime {
+    return &self._runtime;
+}
+
+/// Navigation timing as Chrome's legacy `chrome.*` APIs report it: wall-clock
+/// epoch for the origin, milliseconds-since-origin for the milestones.
+const Timing = struct {
+    nav_start_ms: f64,
+    page_t: f64,
+    dcl_t: f64,
+    load_t: f64,
+
+    fn get(exec: *const js.Execution) Timing {
+        const perf = exec.performance();
+        const page_t = perf.now();
+        const epoch_ms: f64 = @floatFromInt(lp.datetime.milliTimestamp(.real));
+        // Upstream Performance does not yet expose discrete DCL/load milestones
+        // for chrome.csi/loadTimes; approximate with performance.now() so the
+        // surface stays present and monotone for detectors.
+        return .{
+            .nav_start_ms = epoch_ms - page_t,
+            .page_t = page_t,
+            .dcl_t = page_t,
+            .load_t = page_t,
+        };
+    }
+
+    fn epochSeconds(self: *const Timing, offset_ms: f64) f64 {
+        return (self.nav_start_ms + offset_ms) / 1000.0;
+    }
+};
+
+const Runtime = struct {
+    _pad: bool = false,
+
+    fn getUndefined(_: *Runtime) void {}
+    fn connect(_: *Runtime) void {}
+    fn sendMessage(_: *Runtime) void {}
+
+    fn object(exec: *const js.Execution, source: []const u8) !js.Object {
+        const value = try exec.js.local.?.exec(source, "chrome.runtime enum");
+        return value.toObject();
+    }
+
+    fn getContextType(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ BACKGROUND: 'BACKGROUND', DEVELOPER_TOOLS: 'DEVELOPER_TOOLS', OFFSCREEN_DOCUMENT: 'OFFSCREEN_DOCUMENT', POPUP: 'POPUP', SIDE_PANEL: 'SIDE_PANEL', TAB: 'TAB' })");
+    }
+
+    fn getOnInstalledReason(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ CHROME_UPDATE: 'chrome_update', INSTALL: 'install', SHARED_MODULE_UPDATE: 'shared_module_update', UPDATE: 'update' })");
+    }
+
+    fn getOnRestartRequiredReason(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ APP_UPDATE: 'app_update', OS_UPDATE: 'os_update', PERIODIC: 'periodic' })");
+    }
+
+    fn getPlatformArch(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ ARM: 'arm', ARM64: 'arm64', MIPS: 'mips', MIPS64: 'mips64', RISCV64: 'riscv64', X86_32: 'x86-32', X86_64: 'x86-64' })");
+    }
+
+    fn getPlatformNaclArch(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ ARM: 'arm', MIPS: 'mips', MIPS64: 'mips64', X86_32: 'x86-32', X86_64: 'x86-64' })");
+    }
+
+    fn getPlatformOs(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ ANDROID: 'android', CROS: 'cros', LINUX: 'linux', MAC: 'mac', OPENBSD: 'openbsd', WIN: 'win' })");
+    }
+
+    fn getRequestUpdateCheckStatus(_: *Runtime, exec: *const js.Execution) !js.Object {
+        return object(exec, "({ NO_UPDATE: 'no_update', THROTTLED: 'throttled', UPDATE_AVAILABLE: 'update_available' })");
+    }
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(Runtime);
+
+        pub const Meta = struct {
+            pub const name = "ChromeRuntime";
+            pub const no_interface_object = true;
+            pub const no_to_string_tag = true;
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+            pub const own_properties = true;
+        };
+
+        pub const dynamicId = bridge.accessor(Runtime.getUndefined, null, .{});
+        pub const id = bridge.accessor(Runtime.getUndefined, null, .{});
+        pub const connect = bridge.function(Runtime.connect, .{});
+        pub const sendMessage = bridge.function(Runtime.sendMessage, .{});
+        pub const ContextType = bridge.accessor(Runtime.getContextType, null, .{ .cache = .{ .internal = 1 } });
+        pub const OnInstalledReason = bridge.accessor(Runtime.getOnInstalledReason, null, .{ .cache = .{ .internal = 2 } });
+        pub const OnRestartRequiredReason = bridge.accessor(Runtime.getOnRestartRequiredReason, null, .{ .cache = .{ .internal = 3 } });
+        pub const PlatformArch = bridge.accessor(Runtime.getPlatformArch, null, .{ .cache = .{ .internal = 4 } });
+        pub const PlatformNaclArch = bridge.accessor(Runtime.getPlatformNaclArch, null, .{ .cache = .{ .internal = 5 } });
+        pub const PlatformOs = bridge.accessor(Runtime.getPlatformOs, null, .{ .cache = .{ .internal = 6 } });
+        pub const RequestUpdateCheckStatus = bridge.accessor(Runtime.getRequestUpdateCheckStatus, null, .{ .cache = .{ .internal = 7 } });
+    };
+};
+
+pub fn csi(_: *const Chrome, exec: *const js.Execution) !js.Object {
+    const t: Timing = .get(exec);
+    const obj = exec.js.local.?.newObject();
+    _ = try obj.set("startE", @floor(t.nav_start_ms), .{});
+    _ = try obj.set("onloadT", @floor(t.nav_start_ms + t.load_t), .{});
+    _ = try obj.set("pageT", t.page_t, .{});
+    _ = try obj.set("tran", @as(i32, 15), .{});
+    return obj;
+}
+
+pub fn loadTimes(_: *const Chrome, exec: *const js.Execution) !js.Object {
+    const t: Timing = .get(exec);
+    const obj = exec.js.local.?.newObject();
+    // ponytail: connect/commit/paint aren't recorded separately, so they're
+    // fractions of the DOMContentLoaded offset. Swap for real resource timing
+    // if a scanner ever checks the individual gaps rather than "non-zero and
+    // ordered".
+    _ = try obj.set("requestTime", t.epochSeconds(0), .{});
+    _ = try obj.set("startLoadTime", t.epochSeconds(0), .{});
+    _ = try obj.set("commitLoadTime", t.epochSeconds(t.dcl_t * 0.25), .{});
+    _ = try obj.set("finishDocumentLoadTime", t.epochSeconds(t.dcl_t), .{});
+    _ = try obj.set("finishLoadTime", t.epochSeconds(t.load_t), .{});
+    _ = try obj.set("firstPaintTime", @as(f64, 0), .{});
+    _ = try obj.set("firstPaintAfterLoadTime", @as(f64, 0), .{});
+    _ = try obj.set("navigationType", "Other", .{});
+    _ = try obj.set("wasFetchedViaSpdy", true, .{});
+    _ = try obj.set("wasNpnNegotiated", true, .{});
+    _ = try obj.set("npnNegotiatedProtocol", "h3", .{});
+    _ = try obj.set("wasAlternateProtocolAvailable", false, .{});
+    _ = try obj.set("connectionInfo", "h3", .{});
+    return obj;
+}
+
+pub const JsApi = struct {
+    pub const bridge = js.Bridge(Chrome);
+
+    pub const Meta = struct {
+        pub const name = "Chrome";
+        // Real Chrome has no `window.Chrome` interface object.
+        pub const no_interface_object = true;
+        // `window.chrome` is a plain object, not a Web IDL interface instance.
+        pub const no_to_string_tag = true;
+        pub const prototype_chain = bridge.prototypeChain();
+        pub var class_id: bridge.ClassId = undefined;
+        pub const own_properties = true;
+    };
+
+    pub const loadTimes = bridge.function(Chrome.loadTimes, .{});
+    pub const csi = bridge.function(Chrome.csi, .{});
+    pub const app = bridge.accessor(Chrome.getApp, null, .{ .cache = .{ .internal = 1 } });
+    pub const runtime = bridge.accessor(Chrome.getRuntime, null, .{ .cache = .{ .internal = 2 } });
+};
+
+const testing = @import("../../testing.zig");
+
+test "WebApi: stealth" {
+    try testing.htmlRunner("stealth", .{});
+}

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -23,7 +23,9 @@ const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
 const Execution = js.Execution;
 
-const PluginArray = @import("PluginArray.zig");
+const plugin_mod = @import("PluginArray.zig");
+const PluginArray = plugin_mod.PluginArray;
+const MimeTypeArray = plugin_mod.MimeTypeArray;
 const Permissions = @import("Permissions.zig");
 const StorageManager = @import("StorageManager.zig");
 const NavigatorUAData = @import("NavigatorUAData.zig");
@@ -32,6 +34,7 @@ const ModelContext = @import("ModelContext.zig");
 const Navigator = @This();
 _pad: bool = false,
 _plugins: PluginArray = .{},
+_mime_types: MimeTypeArray = .{},
 _permissions: Permissions = .{},
 _storage: StorageManager = .{},
 _ua_data: NavigatorUAData = .{},
@@ -74,11 +77,17 @@ pub fn getCookieEnabled(_: *const Navigator) bool {
     return true;
 }
 
-pub fn getHardwareConcurrency(_: *const Navigator) u32 {
+pub fn getHardwareConcurrency(_: *const Navigator, exec: *const Execution) u32 {
+    const config = exec.session.browser.app.config;
+    if (config.fingerprint_profile.seed != 0) {
+        return config.fingerprint_profile.hardware_concurrency;
+    }
     return 4;
 }
 
-pub fn getDeviceMemory(_: *const Navigator) f64 {
+pub fn getDeviceMemory(_: *const Navigator, exec: *const Execution) f64 {
+    const fp = exec.session.browser.app.config.fingerprint_profile;
+    if (fp.seed != 0) return fp.device_memory_gb;
     return 8.0;
 }
 
@@ -86,7 +95,8 @@ pub fn getMaxTouchPoints(_: *const Navigator) u32 {
     return 0;
 }
 
-pub fn getVendor(_: *const Navigator) []const u8 {
+pub fn getVendor(_: *const Navigator, exec: *const Execution) []const u8 {
+    if (exec.session.browser.app.config.stealth()) return "Google Inc.";
     return "";
 }
 
@@ -107,7 +117,15 @@ pub fn getGlobalPrivacyControl(_: *const Navigator) bool {
     return false;
 }
 
-pub fn getPlatform(_: *const Navigator) []const u8 {
+pub fn getPlatform(_: *const Navigator, exec: *const Execution) []const u8 {
+    const fp = exec.session.browser.app.config.fingerprint_profile;
+    if (fp.seed != 0) {
+        return switch (fp.platform) {
+            .windows => "Win32",
+            .macos => "MacIntel",
+            .linux => "Linux x86_64",
+        };
+    }
     return switch (builtin.os.tag) {
         .macos => "MacIntel",
         .windows => "Win32",
@@ -131,6 +149,10 @@ pub fn sendBeacon(_: *const Navigator, url: js.Value, data: ?js.Value) bool {
 
 pub fn getPlugins(self: *Navigator) *PluginArray {
     return &self._plugins;
+}
+
+pub fn getMimeTypes(self: *Navigator) *MimeTypeArray {
+    return &self._mime_types;
 }
 
 pub fn getPermissions(self: *Navigator) *Permissions {
@@ -253,6 +275,7 @@ pub const JsApi = struct {
 
     // window only
     pub const plugins = bridge.accessor(Navigator.getPlugins, null, .{ .exposed = .window });
+    pub const mimeTypes = bridge.accessor(Navigator.getMimeTypes, null, .{ .exposed = .window });
     pub const modelContext = bridge.accessor(Navigator.getModelContext, null, .{ .exposed = .window });
     pub const registerProtocolHandler = bridge.function(Navigator.registerProtocolHandler, .{ .exposed = .window });
     pub const unregisterProtocolHandler = bridge.function(Navigator.unregisterProtocolHandler, .{ .exposed = .window });

--- a/src/browser/webapi/NavigatorUAData.zig
+++ b/src/browser/webapi/NavigatorUAData.zig
@@ -31,27 +31,27 @@ const Brand = struct {
     version: []const u8,
 };
 
-pub fn getBrands(_: *const NavigatorUAData) []const Brand {
-    return brandList();
+pub fn getBrands(_: *const NavigatorUAData, exec: *const Execution) []const Brand {
+    return brandList(exec);
 }
 
 pub fn getMobile(_: *const NavigatorUAData) bool {
     return false;
 }
 
-pub fn getPlatform(_: *const NavigatorUAData) []const u8 {
-    return uaPlatform();
+pub fn getPlatform(_: *const NavigatorUAData, exec: *const Execution) []const u8 {
+    return platformName(exec);
 }
 
-pub fn toJSON(_: *const NavigatorUAData) struct {
+pub fn toJSON(_: *const NavigatorUAData, exec: *const Execution) struct {
     brands: []const Brand,
     mobile: bool,
     platform: []const u8,
 } {
     return .{
         .mobile = false,
-        .brands = brandList(),
-        .platform = uaPlatform(),
+        .brands = brandList(exec),
+        .platform = platformName(exec),
     };
 }
 
@@ -62,22 +62,37 @@ pub fn getHighEntropyValues(_: *const NavigatorUAData, hints: []const []const u8
 
     _ = hints;
 
+    const stealth = exec.session.browser.app.config.stealth();
+    const fp = exec.session.browser.app.config.fingerprint_profile;
     return exec.js.local.?.resolvePromise(.{
-        .brands = brandList(),
+        .brands = brandList(exec),
         .mobile = false,
-        .platform = uaPlatform(),
+        .platform = platformName(exec),
         .architecture = uaArchitecture(),
         .bitness = uaBitness(),
         .model = "",
-        .platformVersion = "",
-        .uaFullVersion = "1.0.0.0",
-        .fullVersionList = brandList(),
+        .platformVersion = if (stealth) Config.HttpHeaders.secChUaPlatformVersion(fp.platform) else "",
+        .uaFullVersion = if (stealth) Config.HttpHeaders.stealth_ua_full_version else "1.0.0.0",
+        .fullVersionList = brandList(exec),
         .wow64 = false,
         .formFactor = [_][]const u8{"Desktop"},
     });
 }
 
-fn brandList() []const Brand {
+fn brandList(exec: *const Execution) []const Brand {
+    const stealth = exec.session.browser.app.config.stealth();
+    if (stealth) {
+        const out = comptime blk: {
+            const src = &Config.HttpHeaders.brands_stealth;
+            var arr: [src.len]Brand = undefined;
+            for (src, 0..) |b, i| {
+                arr[i] = .{ .brand = b.brand, .version = b.version };
+            }
+            const final = arr;
+            break :blk final;
+        };
+        return &out;
+    }
     const out = comptime blk: {
         const src = &Config.HttpHeaders.brands;
         var arr: [src.len]Brand = undefined;
@@ -88,6 +103,14 @@ fn brandList() []const Brand {
         break :blk final;
     };
     return &out;
+}
+
+fn platformName(exec: *const Execution) []const u8 {
+    return switch (exec.session.browser.app.config.fingerprint_profile.platform) {
+        .windows => "Windows",
+        .macos => "macOS",
+        .linux => "Linux",
+    };
 }
 
 fn uaPlatform() []const u8 {

--- a/src/browser/webapi/PluginArray.zig
+++ b/src/browser/webapi/PluginArray.zig
@@ -16,61 +16,403 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+const std = @import("std");
 const js = @import("../js/js.zig");
 
+/// Chrome's built-in PDF viewer surface. Chrome reports exactly these five
+/// plugins and two MIME types on every desktop build; an empty navigator.plugins
+/// is one of the oldest headless tells there is.
 pub fn registerTypes() []const type {
-    return &.{ PluginArray, Plugin };
+    return &.{ PluginArray, Plugin, MimeTypeArray, MimeType, PluginArray.Iterator, Plugin.Iterator, MimeTypeArray.Iterator };
 }
 
-const PluginArray = @This();
+const plugin_defs = [_]PluginDef{
+    .{ .name = "PDF Viewer", .filename = "internal-pdf-viewer", .description = "Portable Document Format" },
+    .{ .name = "Chrome PDF Viewer", .filename = "internal-pdf-viewer", .description = "Portable Document Format" },
+    .{ .name = "Chromium PDF Viewer", .filename = "internal-pdf-viewer", .description = "Portable Document Format" },
+    .{ .name = "Microsoft Edge PDF Viewer", .filename = "internal-pdf-viewer", .description = "Portable Document Format" },
+    .{ .name = "WebKit built-in PDF", .filename = "internal-pdf-viewer", .description = "Portable Document Format" },
+};
 
-_pad: bool = false,
+const mime_defs = [_]MimeDef{
+    .{ .type_name = "application/pdf", .suffixes = "pdf", .description = "Portable Document Format" },
+    .{ .type_name = "text/pdf", .suffixes = "pdf", .description = "Portable Document Format" },
+};
 
-pub fn refresh(_: *const PluginArray) void {}
-pub fn getAtIndex(_: *const PluginArray, index: usize) ?*Plugin {
-    _ = index;
-    return null;
+const PluginDef = struct {
+    name: []const u8,
+    filename: []const u8,
+    description: []const u8,
+};
+
+const MimeDef = struct {
+    type_name: []const u8,
+    suffixes: []const u8,
+    description: []const u8,
+};
+
+fn pluginsStorage() *[plugin_defs.len]Plugin {
+    const S = struct {
+        var storage: [plugin_defs.len]Plugin = blk: {
+            var arr: [plugin_defs.len]Plugin = undefined;
+            for (&arr, plugin_defs, 0..) |*p, def, i| {
+                p.* = .{
+                    ._index = i,
+                    ._name = def.name,
+                    ._filename = def.filename,
+                    ._description = def.description,
+                };
+            }
+            break :blk arr;
+        };
+    };
+    return &S.storage;
 }
 
-pub fn getByName(_: *const PluginArray, name: []const u8) ?*Plugin {
-    _ = name;
-    return null;
+fn mimesStorage() *[mime_defs.len]MimeType {
+    const S = struct {
+        var storage: [mime_defs.len]MimeType = blk: {
+            var arr: [mime_defs.len]MimeType = undefined;
+            for (&arr, mime_defs, 0..) |*m, def, i| {
+                m.* = .{
+                    ._index = i,
+                    ._plugin_index = 0,
+                    ._type = def.type_name,
+                    ._suffixes = def.suffixes,
+                    ._description = def.description,
+                };
+            }
+            break :blk arr;
+        };
+    };
+    return &S.storage;
 }
 
-// Cannot be constructed, and we currently never return any, so no reason to
-// implement anything on it (for now)
-const Plugin = struct {
+fn pluginMimesStorage() *[plugin_defs.len * mime_defs.len]MimeType {
+    const S = struct {
+        var storage: [plugin_defs.len * mime_defs.len]MimeType = blk: {
+            var arr: [plugin_defs.len * mime_defs.len]MimeType = undefined;
+            for (0..plugin_defs.len) |plugin_index| {
+                for (mime_defs, 0..) |def, mime_index| {
+                    arr[plugin_index * mime_defs.len + mime_index] = .{
+                        ._index = mime_index,
+                        ._plugin_index = plugin_index,
+                        ._type = def.type_name,
+                        ._suffixes = def.suffixes,
+                        ._description = def.description,
+                    };
+                }
+            }
+            break :blk arr;
+        };
+    };
+    return &S.storage;
+}
+
+pub const PluginArray = struct {
+    _pad: bool = false,
+
+    pub fn getLength(_: *const PluginArray) u32 {
+        return plugin_defs.len;
+    }
+
+    pub fn refresh(_: *const PluginArray) void {}
+
+    pub fn getAtIndex(_: *const PluginArray, index: usize) ?*Plugin {
+        const storage = pluginsStorage();
+        if (index >= storage.len) return null;
+        return &storage[index];
+    }
+
+    pub fn getByName(_: *const PluginArray, name: []const u8) ?*Plugin {
+        for (pluginsStorage()) |*p| {
+            if (std.mem.eql(u8, p._name, name)) return p;
+        }
+        return null;
+    }
+
+    pub fn iterator(self: *PluginArray, exec: *const js.Execution) !*Iterator {
+        return Iterator.init(.{ .index = 0, .list = self }, exec);
+    }
+
+    const GenericIterator = @import("collections/iterator.zig").Entry;
+    pub const Iterator = GenericIterator(struct {
+        index: u32,
+        list: *PluginArray,
+
+        pub fn next(self: *@This(), _: *const js.Execution) ?*Plugin {
+            const plugin = self.list.getAtIndex(self.index) orelse return null;
+            self.index += 1;
+            return plugin;
+        }
+    }, null);
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(PluginArray);
+
+        pub const Meta = struct {
+            pub const name = "PluginArray";
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+            pub const empty_with_no_proto = true;
+        };
+
+        pub const length = bridge.accessor(PluginArray.getLength, null, .{});
+        pub const refresh = bridge.function(PluginArray.refresh, .{});
+        pub const @"[int]" = bridge.indexedReadWrite(PluginArray.getAtIndex, null, null, queryIndex, getIndexes, .{ .null_as_undefined = true });
+        pub const @"[str]" = bridge.namedIndexed(PluginArray.getByName, null, null, getNames, queryName, .{ .null_as_undefined = true });
+        pub const item = bridge.function(_item, .{});
+        fn _item(self: *const PluginArray, index: i32) ?*Plugin {
+            if (index < 0) return null;
+            return self.getAtIndex(@intCast(index));
+        }
+        pub const namedItem = bridge.function(PluginArray.getByName, .{});
+        pub const symbol_iterator = bridge.iterator(PluginArray.iterator, .{});
+
+        fn getIndexes(_: *const PluginArray, exec: *const js.Execution) !js.Array {
+            return indexArray(plugin_defs.len, exec);
+        }
+
+        fn getNames(_: *const PluginArray, exec: *const js.Execution) !js.Array {
+            var arr = exec.js.local.?.newArray(plugin_defs.len);
+            for (plugin_defs, 0..) |plugin, i| {
+                _ = try arr.set(@intCast(i), plugin.name, .{});
+            }
+            return arr;
+        }
+
+        fn queryName(self: *const PluginArray, key: []const u8) !u32 {
+            if (self.getByName(key) != null) return js.v8.ReadOnly | js.v8.DontEnum;
+            return error.NotHandled;
+        }
+
+        fn queryIndex(_: *const PluginArray, index: u32) !u32 {
+            if (index < plugin_defs.len) return js.v8.ReadOnly;
+            return error.NotHandled;
+        }
+    };
+};
+
+pub const Plugin = struct {
+    _index: usize,
+    _name: []const u8,
+    _filename: []const u8,
+    _description: []const u8,
+
+    pub fn getLength(_: *const Plugin) u32 {
+        return mime_defs.len;
+    }
+
+    pub fn getName(self: *const Plugin) []const u8 {
+        return self._name;
+    }
+
+    pub fn getFilename(self: *const Plugin) []const u8 {
+        return self._filename;
+    }
+
+    pub fn getDescription(self: *const Plugin) []const u8 {
+        return self._description;
+    }
+
+    pub fn getAtIndex(self: *const Plugin, index: usize) ?*MimeType {
+        if (index >= mime_defs.len) return null;
+        return &pluginMimesStorage()[self._index * mime_defs.len + index];
+    }
+
+    pub fn getByName(self: *const Plugin, name: []const u8) ?*MimeType {
+        const start = self._index * mime_defs.len;
+        for (pluginMimesStorage()[start .. start + mime_defs.len]) |*m| {
+            if (std.mem.eql(u8, m._type, name)) return m;
+        }
+        return null;
+    }
+
+    pub fn iterator(self: *Plugin, exec: *const js.Execution) !*Iterator {
+        return Iterator.init(.{ .index = 0, .plugin = self }, exec);
+    }
+
+    const GenericIterator = @import("collections/iterator.zig").Entry;
+    pub const Iterator = GenericIterator(struct {
+        index: u32,
+        plugin: *Plugin,
+
+        pub fn next(self: *@This(), _: *const js.Execution) ?*MimeType {
+            const mime = self.plugin.getAtIndex(self.index) orelse return null;
+            self.index += 1;
+            return mime;
+        }
+    }, null);
+
     pub const JsApi = struct {
         pub const bridge = js.Bridge(Plugin);
         pub const Meta = struct {
             pub const name = "Plugin";
             pub const prototype_chain = bridge.prototypeChain();
             pub var class_id: bridge.ClassId = undefined;
-            pub const empty_with_no_proto = true;
         };
+
+        pub const name = bridge.accessor(Plugin.getName, null, .{});
+        pub const filename = bridge.accessor(Plugin.getFilename, null, .{});
+        pub const description = bridge.accessor(Plugin.getDescription, null, .{});
+        pub const length = bridge.accessor(Plugin.getLength, null, .{});
+        pub const @"[int]" = bridge.indexedReadWrite(Plugin.getAtIndex, null, null, queryIndex, getIndexes, .{ .null_as_undefined = true });
+        pub const @"[str]" = bridge.namedIndexed(Plugin.getByName, null, null, getNames, queryName, .{ .null_as_undefined = true });
+        pub const item = bridge.function(_item, .{});
+        fn _item(self: *const Plugin, index: i32) ?*MimeType {
+            if (index < 0) return null;
+            return self.getAtIndex(@intCast(index));
+        }
+        pub const namedItem = bridge.function(Plugin.getByName, .{});
+        pub const symbol_iterator = bridge.iterator(Plugin.iterator, .{});
+
+        fn getIndexes(_: *const Plugin, exec: *const js.Execution) !js.Array {
+            return indexArray(mime_defs.len, exec);
+        }
+
+        fn getNames(_: *const Plugin, exec: *const js.Execution) !js.Array {
+            var arr = exec.js.local.?.newArray(mime_defs.len);
+            for (mime_defs, 0..) |mime, i| {
+                _ = try arr.set(@intCast(i), mime.type_name, .{});
+            }
+            return arr;
+        }
+
+        fn queryName(self: *const Plugin, key: []const u8) !u32 {
+            if (self.getByName(key) != null) return js.v8.ReadOnly | js.v8.DontEnum;
+            return error.NotHandled;
+        }
+
+        fn queryIndex(_: *const Plugin, index: u32) !u32 {
+            if (index < mime_defs.len) return js.v8.ReadOnly;
+            return error.NotHandled;
+        }
     };
 };
 
-pub const JsApi = struct {
-    pub const bridge = js.Bridge(PluginArray);
+pub const MimeTypeArray = struct {
+    _pad: bool = false,
 
-    pub const Meta = struct {
-        pub const name = "PluginArray";
-        pub const prototype_chain = bridge.prototypeChain();
-        pub var class_id: bridge.ClassId = undefined;
-        pub const empty_with_no_proto = true;
-    };
-
-    pub const length = bridge.property(0, .{ .template = false });
-    pub const refresh = bridge.function(PluginArray.refresh, .{});
-    pub const @"[int]" = bridge.indexed(PluginArray.getAtIndex, null, .{ .null_as_undefined = true });
-    pub const @"[str]" = bridge.namedIndexed(PluginArray.getByName, null, null, null, null, .{ .null_as_undefined = true });
-    pub const item = bridge.function(_item, .{});
-    fn _item(self: *const PluginArray, index: i32) ?*Plugin {
-        if (index < 0) {
-            return null;
-        }
-        return self.getAtIndex(@intCast(index));
+    pub fn getLength(_: *const MimeTypeArray) u32 {
+        return mime_defs.len;
     }
-    pub const namedItem = bridge.function(PluginArray.getByName, .{});
+
+    pub fn getAtIndex(_: *const MimeTypeArray, index: usize) ?*MimeType {
+        const storage = mimesStorage();
+        if (index >= storage.len) return null;
+        return &storage[index];
+    }
+
+    pub fn getByName(_: *const MimeTypeArray, name: []const u8) ?*MimeType {
+        for (mimesStorage()) |*m| {
+            if (std.mem.eql(u8, m._type, name)) return m;
+        }
+        return null;
+    }
+
+    pub fn iterator(self: *MimeTypeArray, exec: *const js.Execution) !*Iterator {
+        return Iterator.init(.{ .index = 0, .list = self }, exec);
+    }
+
+    const GenericIterator = @import("collections/iterator.zig").Entry;
+    pub const Iterator = GenericIterator(struct {
+        index: u32,
+        list: *MimeTypeArray,
+
+        pub fn next(self: *@This(), _: *const js.Execution) ?*MimeType {
+            const mime = self.list.getAtIndex(self.index) orelse return null;
+            self.index += 1;
+            return mime;
+        }
+    }, null);
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(MimeTypeArray);
+        pub const Meta = struct {
+            pub const name = "MimeTypeArray";
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+            pub const empty_with_no_proto = true;
+        };
+
+        pub const length = bridge.accessor(MimeTypeArray.getLength, null, .{});
+        pub const @"[int]" = bridge.indexedReadWrite(MimeTypeArray.getAtIndex, null, null, queryIndex, getIndexes, .{ .null_as_undefined = true });
+        pub const @"[str]" = bridge.namedIndexed(MimeTypeArray.getByName, null, null, getNames, queryName, .{ .null_as_undefined = true });
+        pub const item = bridge.function(_item, .{});
+        fn _item(self: *const MimeTypeArray, index: i32) ?*MimeType {
+            if (index < 0) return null;
+            return self.getAtIndex(@intCast(index));
+        }
+        pub const namedItem = bridge.function(MimeTypeArray.getByName, .{});
+        pub const symbol_iterator = bridge.iterator(MimeTypeArray.iterator, .{});
+
+        fn getIndexes(_: *const MimeTypeArray, exec: *const js.Execution) !js.Array {
+            return indexArray(mime_defs.len, exec);
+        }
+
+        fn getNames(_: *const MimeTypeArray, exec: *const js.Execution) !js.Array {
+            var arr = exec.js.local.?.newArray(mime_defs.len);
+            for (mime_defs, 0..) |mime, i| {
+                _ = try arr.set(@intCast(i), mime.type_name, .{});
+            }
+            return arr;
+        }
+
+        fn queryName(self: *const MimeTypeArray, key: []const u8) !u32 {
+            if (self.getByName(key) != null) return js.v8.ReadOnly | js.v8.DontEnum;
+            return error.NotHandled;
+        }
+
+        fn queryIndex(_: *const MimeTypeArray, index: u32) !u32 {
+            if (index < mime_defs.len) return js.v8.ReadOnly;
+            return error.NotHandled;
+        }
+    };
+};
+
+fn indexArray(len: u32, exec: *const js.Execution) !js.Array {
+    var arr = exec.js.local.?.newArray(len);
+    for (0..len) |i| {
+        _ = try arr.set(@intCast(i), i, .{});
+    }
+    return arr;
+}
+
+pub const MimeType = struct {
+    _index: usize,
+    _plugin_index: usize,
+    _type: []const u8,
+    _suffixes: []const u8,
+    _description: []const u8,
+
+    pub fn getType(self: *const MimeType) []const u8 {
+        return self._type;
+    }
+
+    pub fn getSuffixes(self: *const MimeType) []const u8 {
+        return self._suffixes;
+    }
+
+    pub fn getDescription(self: *const MimeType) []const u8 {
+        return self._description;
+    }
+
+    pub fn getEnabledPlugin(self: *const MimeType) ?*Plugin {
+        const storage = pluginsStorage();
+        return &storage[self._plugin_index];
+    }
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(MimeType);
+        pub const Meta = struct {
+            pub const name = "MimeType";
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+        };
+
+        pub const @"type" = bridge.accessor(MimeType.getType, null, .{});
+        pub const suffixes = bridge.accessor(MimeType.getSuffixes, null, .{});
+        pub const description = bridge.accessor(MimeType.getDescription, null, .{});
+        pub const enabledPlugin = bridge.accessor(MimeType.getEnabledPlugin, null, .{});
+    };
 };

--- a/src/browser/webapi/Screen.zig
+++ b/src/browser/webapi/Screen.zig
@@ -52,7 +52,31 @@ pub fn getWidth(_: *const Screen, frame: *Frame) u32 {
 }
 
 pub fn getHeight(_: *const Screen, frame: *Frame) u32 {
-    return frame._page.getViewport().height;
+    return frame._page.getViewport().screenHeight();
+}
+
+// The area a window may occupy: the screen less the taskbar/dock. A maximized
+// window fills it exactly, so this is also window.outerHeight.
+pub fn getAvailHeight(_: *const Screen, frame: *Frame) u32 {
+    return frame._page.getViewport().outerHeight();
+}
+
+// The maximized window is flush left on every desktop we emulate; only the
+// vertical inset varies. Chrome always exposes availLeft, so a missing property
+// is itself a tell.
+pub fn getAvailLeft(_: *const Screen, _: *Frame) u32 {
+    return 0;
+}
+
+// System chrome above the window: the macOS menu bar or the GNOME top bar.
+// Windows puts its taskbar at the bottom, so availTop stays 0 there. A macOS
+// profile reporting availTop === 0 is the headless shape.
+pub fn getAvailTop(_: *const Screen, frame: *Frame) u32 {
+    return switch (frame._session.browser.app.config.fingerprint_profile.platform) {
+        .macos => 25,
+        .windows => 0,
+        .linux => 27,
+    };
 }
 
 pub const JsApi = struct {
@@ -67,7 +91,9 @@ pub const JsApi = struct {
     pub const width = bridge.accessor(Screen.getWidth, null, .{});
     pub const height = bridge.accessor(Screen.getHeight, null, .{});
     pub const availWidth = bridge.accessor(Screen.getWidth, null, .{});
-    pub const availHeight = bridge.property(1040, .{ .template = false });
+    pub const availHeight = bridge.accessor(Screen.getAvailHeight, null, .{});
+    pub const availLeft = bridge.accessor(Screen.getAvailLeft, null, .{});
+    pub const availTop = bridge.accessor(Screen.getAvailTop, null, .{});
     pub const colorDepth = bridge.property(24, .{ .template = false });
     pub const pixelDepth = bridge.property(24, .{ .template = false });
     pub const orientation = bridge.accessor(Screen.getOrientation, null, .{});

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -30,6 +30,7 @@ const CSS = @import("CSS.zig");
 const Navigator = @import("Navigator.zig");
 const ModelContext = @import("ModelContext.zig");
 const Screen = @import("Screen.zig");
+const Chrome = @import("Chrome.zig");
 const VisualViewport = @import("VisualViewport.zig");
 const Performance = @import("Performance.zig");
 const Document = @import("Document.zig");
@@ -71,6 +72,7 @@ _css: CSS = .init,
 _crypto: Crypto = .init,
 _console: Console = .init,
 _navigator: Navigator = .init,
+_chrome: Chrome = .{},
 _model_context: ModelContext = .init,
 _screen: *Screen,
 _visual_viewport: *VisualViewport,
@@ -240,6 +242,21 @@ pub fn setPageXOffset(self: *Window, value: js.Value) void {
 
 pub fn setPageYOffset(self: *Window, value: js.Value) void {
     self.replaceGlobalProperty(value, "pageYOffset");
+}
+
+// outerWidth tracks the content width for a maximized window.
+pub fn getOuterWidth(self: *const Window, frame: *Frame) u32 {
+    _ = self;
+    return frame._page.getViewport().width;
+}
+
+// outerHeight includes browser chrome above the content viewport.
+pub fn getOuterHeight(_: *const Window, frame: *Frame) u32 {
+    return frame._page.getViewport().outerHeight();
+}
+
+pub fn getChrome(self: *Window) *Chrome {
+    return &self._chrome;
 }
 
 pub fn getNavigator(self: *Window) *Navigator {
@@ -1174,6 +1191,7 @@ pub const JsApi = struct {
     pub const self = bridge.accessor(Window.getWindow, Window.setSelf, .{});
     pub const window = bridge.accessor(Window.getWindow, null, .{});
     pub const parent = bridge.accessor(Window.getParent, Window.setParent, .{});
+    pub const chrome = bridge.accessor(Window.getChrome, null, .{});
     pub const navigator = bridge.accessor(Window.getNavigator, null, .{});
     pub const scheduler = bridge.accessor(Window.getScheduler, null, .{});
     pub const screen = bridge.accessor(Window.getScreen, Window.setScreen, .{});
@@ -1248,6 +1266,8 @@ pub const JsApi = struct {
     // the attribute rather than throwing.
     pub const innerWidth = bridge.accessor(Window.getInnerWidth, Window.setInnerWidth, .{});
     pub const innerHeight = bridge.accessor(Window.getInnerHeight, Window.setInnerHeight, .{});
+    pub const outerWidth = bridge.accessor(Window.getOuterWidth, null, .{});
+    pub const outerHeight = bridge.accessor(Window.getOuterHeight, null, .{});
     pub const devicePixelRatio = bridge.property(1, .{ .template = false, .readonly = false });
 
     pub const opener = bridge.accessor(Window.getOpener, Window.setOpener, .{});

--- a/src/browser/webapi/device.zig
+++ b/src/browser/webapi/device.zig
@@ -1,0 +1,145 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! `navigator.getBattery()` and `navigator.connection`. Chrome exposes both;
+//! their absence is a headless heuristic. Values are derived from the
+//! fingerprint seed so one instance stays self-consistent for a session and
+//! different seeds look like different machines.
+
+const std = @import("std");
+
+const js = @import("../js/js.zig");
+const Execution = js.Execution;
+
+pub fn registerTypes() []const type {
+    return &.{ BatteryManager, NetworkInformation };
+}
+
+fn profileSeed(exec: *const Execution) u64 {
+    return exec.session.browser.app.config.fingerprint_profile.noise_seed;
+}
+
+pub fn networkDownlink(seed: u64) f64 {
+    const step: f64 = @floatFromInt((seed >> 16) % 21);
+    return 5.0 + step * 0.25;
+}
+
+pub fn networkRtt(seed: u64) u32 {
+    return @intCast(((seed >> 24) % 8) * 25 + 25);
+}
+
+pub const BatteryManager = struct {
+    // Padding to avoid zero-size struct pointer collisions.
+    _pad: bool = false,
+
+    pub fn getCharging(_: *const BatteryManager, exec: *const Execution) bool {
+        return profileSeed(exec) % 2 == 0;
+    }
+
+    /// 0.05 steps in [0.35, 1.0] — Chrome quantizes level to 1% and desktops
+    /// spend most of their time in the upper half of the range.
+    pub fn getLevel(_: *const BatteryManager, exec: *const Execution) f64 {
+        const step: f64 = @floatFromInt((profileSeed(exec) >> 8) % 14);
+        return 0.35 + step * 0.05;
+    }
+
+    pub fn getChargingTime(self: *const BatteryManager, exec: *const Execution) f64 {
+        if (!self.getCharging(exec)) return std.math.inf(f64);
+        const level = self.getLevel(exec);
+        if (level >= 1.0) return 0;
+        // Roughly a 2h charge from empty, rounded to Chrome's 15-minute grid.
+        return @round((1.0 - level) * 7200.0 / 900.0) * 900.0;
+    }
+
+    pub fn getDischargingTime(self: *const BatteryManager, exec: *const Execution) f64 {
+        if (self.getCharging(exec)) return std.math.inf(f64);
+        return @round(self.getLevel(exec) * 21600.0 / 900.0) * 900.0;
+    }
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(BatteryManager);
+
+        pub const Meta = struct {
+            pub const name = "BatteryManager";
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+            pub const empty_with_no_proto = true;
+        };
+
+        pub const charging = bridge.accessor(BatteryManager.getCharging, null, .{});
+        pub const chargingTime = bridge.accessor(BatteryManager.getChargingTime, null, .{});
+        pub const dischargingTime = bridge.accessor(BatteryManager.getDischargingTime, null, .{});
+        pub const level = bridge.accessor(BatteryManager.getLevel, null, .{});
+    };
+};
+
+pub const NetworkInformation = struct {
+    // Padding to avoid zero-size struct pointer collisions.
+    _pad: bool = false,
+    _on_change: ?js.Function.Global = null,
+
+    pub fn getOnChange(self: *const NetworkInformation) ?js.Function.Global {
+        return self._on_change;
+    }
+
+    pub fn setOnChange(self: *NetworkInformation, callback: ?js.Function.Global) void {
+        self._on_change = callback;
+    }
+
+    /// Chrome clamps `effectiveType` to "4g" on any decent broadband link, and
+    /// that's what the overwhelming majority of real desktops report.
+    pub fn getEffectiveType(_: *const NetworkInformation) []const u8 {
+        return "4g";
+    }
+
+    /// Chrome caps downlink at 10 Mbps and quantizes it to 0.05 steps.
+    pub fn getDownlink(_: *const NetworkInformation, exec: *const Execution) f64 {
+        return networkDownlink(profileSeed(exec));
+    }
+
+    /// Chrome quantizes rtt to 25ms buckets.
+    pub fn getRtt(_: *const NetworkInformation, exec: *const Execution) u32 {
+        return networkRtt(profileSeed(exec));
+    }
+
+    pub fn getSaveData(_: *const NetworkInformation) bool {
+        return false;
+    }
+
+    /// The connection technology's theoretical ceiling, which Chrome reports
+    /// as Infinity on wifi/ethernet. The value carries almost no information —
+    /// its *absence* is the signal (CreepJS counts `noDownlinkMax` toward
+    /// "like headless"), so what matters is that the property exists.
+    pub fn getDownlinkMax(_: *const NetworkInformation) f64 {
+        return std.math.inf(f64);
+    }
+
+    pub const JsApi = struct {
+        pub const bridge = js.Bridge(NetworkInformation);
+
+        pub const Meta = struct {
+            pub const name = "NetworkInformation";
+            pub const prototype_chain = bridge.prototypeChain();
+            pub var class_id: bridge.ClassId = undefined;
+            pub const empty_with_no_proto = true;
+        };
+
+        pub const onchange = bridge.accessor(NetworkInformation.getOnChange, NetworkInformation.setOnChange, .{});
+        pub const effectiveType = bridge.accessor(NetworkInformation.getEffectiveType, null, .{});
+        pub const rtt = bridge.accessor(NetworkInformation.getRtt, null, .{});
+        pub const downlink = bridge.accessor(NetworkInformation.getDownlink, null, .{});
+        pub const saveData = bridge.accessor(NetworkInformation.getSaveData, null, .{});
+    };
+};

--- a/src/help.zon
+++ b/src/help.zon
@@ -26,7 +26,7 @@
     \\          Defaults to --host value.
     \\  --cdp-max-connections <INT>
     \\          Maximum number of simultaneous CDP connections.
-    \\          Defaults to 16.
+    \\          Defaults to 16, or up to 32 with --resource-profile pi, or 2 with slot.
     \\  --cdp-max-http-message-size <INT>
     \\          Maximum allowed HTTP request size
     \\          Defaults to 4096 (maximum allowed: 16383)
@@ -354,14 +354,14 @@
     \\          Defaults to 0.
     \\  --http-max-concurrent <INT>
     \\          Maximum number of concurrent HTTP requests.
-    \\          Defaults to 40.
+    \\          Defaults to 40, or 8 with the pi/slot resource profiles.
     \\  --http-max-host-open <INT>
     \\          Maximum open connections to a given host:port.
-    \\          Defaults to 6.
+    \\          Defaults to 6, or 2 with the pi/slot resource profiles.
     \\  --http-max-response-size <INT>
     \\          Limits the acceptable response size for any request
     \\          e.g. XHR, fetch, script loading.
-    \\          Defaults to 1 GiB.
+    \\          Defaults to 1 GiB, or 32 MiB with the pi/slot resource profiles.
     \\  --http-proxy <URL>
     \\          HTTP proxy for all HTTP requests.
     \\          username:password may be included for basic auth.
@@ -410,6 +410,29 @@
     \\          Unsupported escape hatch: V8 does not validate flags against the
     \\          prebuilt snapshot, so an incompatible flag can misbehave or
     \\          crash at any point.
+    \\  --no-stealth
+    \\          Opt out of the default Chrome-compatible identity and identify
+    \\          as Lightpanda (UA/client hints/JS surfaces).
+    \\  --fingerprint <SEED>
+    \\          Deterministic fingerprint seed. Same seed reproduces the same
+    \\          GPU/screen/hardware identity.
+    \\  --fingerprint-platform <PLATFORM>
+    \\          Platform reported to JS and client hints: windows|macos|linux.
+    \\  --resource-profile <PROFILE>
+    \\          Runtime resource defaults: "standard" (default) or lean profiles
+    \\          "pi" / "slot". Both lean profiles apply V8 --optimize-for-size
+    \\          --no-concurrent-recompilation, a 64 MiB V8 heap, one V8 background
+    \\          thread and disabled V8 idle tasks. "slot" further tightens process
+    \\          concurrency for one-session processes (2 CDP connections / pending).
+    \\          Prefer one slot process per independently concurrent session.
+    \\          Builds with -Dlow_resource_default=true default to "pi".
+    \\  --stealth
+    \\          Accepted as a no-op; Chrome-compatible identity is already default.
+    \\  --disable-v8-idle-tasks
+    \\          Disable V8 background idle work. Implied by --resource-profile pi or slot.
+    \\  --v8-thread-pool-size <INT>
+    \\          Number of V8 background worker threads. 0 lets V8 use the CPU count.
+    \\          Defaults to 0, or 1 with --resource-profile pi or slot.
     \\  --v8-max-heap-mb <INT>
     \\          Maximum V8 heap size in megabytes, per browser instance. Values
     \\          below ~16 are clamped by V8 and all behave the same.

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -2725,6 +2725,10 @@ pub const Transfer = struct {
         source: HeaderSource = .user_agent,
     };
 
+    pub fn clearRequestHeaders(self: *Transfer) void {
+        self.req_headers.clearRetainingCapacity();
+    }
+
     pub fn addHeader(self: *Transfer, name: []const u8, value: []const u8, opts: HeaderOpts) !void {
         const arena = self.arena.allocator();
         try self.req_headers.append(arena, .{

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -526,6 +526,7 @@ test "tests:beforeAll" {
     const test_allocator = @import("root").tracking_allocator;
 
     test_config = try Config.init(test_allocator, "test", .{ .serve = .{
+        .no_stealth = true,
         .insecure_disable_tls_host_verification = true,
         .user_agent_suffix = "internal-tester",
         .ws_max_concurrent = 50,


### PR DESCRIPTION
## Summary

This PR adds two focused, opt-in/out capabilities that help Lightpanda run as a lean, Chrome-shaped automation browser without pulling in larger fork-only stacks (render, captcha solvers, webdriver MCP).

1. **Chrome-compatible identity (stealth)** — default on, `--no-stealth` to opt out  
2. **Lean resource profiles** — `--resource-profile pi|slot` for lower mem/CPU defaults

### Problem

- Bot-detection / feature probes often key off missing Chrome surfaces (`window.chrome`, PDF `navigator.plugins`, UA-CH brand lists) and inconsistent client hints.
- Shared multi-session servers and one-session agent pools need different concurrency/memory defaults than desktop `standard`.

### Approach

**Stealth / fingerprint**
- Config flags: `--stealth` (no-op retained for compatibility), `--no-stealth`, `--fingerprint <seed>`, `--fingerprint-platform windows|macos|linux`
- New `Fingerprint.zig` seed profiles (GPU/screen/hw identity)
- Minimal Chrome support surfaces stealth needs:
  - `window.chrome` (`Chrome.zig`: `csi` / `loadTimes` / `app`)
  - Chrome PDF `PluginArray` / `mimeTypes`
  - `Navigator` / `NavigatorUAData` / `Screen` fingerprint wiring
  - Stealth-aware navigation `Sec-Ch-Ua*` / UA client hints in `Frame`
- Viewport geometry helpers so `screen` / `outerHeight` stay coherent with fingerprint resolutions
- Unit-test harness stays on `--no-stealth` so existing WebAPI fixtures keep an honest Lightpanda UA

**Resource profiles**
- `ResourceProfile = { standard, pi, slot }` on `serve` / `fetch` / `mcp` / `agent` (no `render` mode dependency)
- `leanProfile()` shared by `pi` and `slot`:
  - V8 flags: `--optimize-for-size --no-concurrent-recompilation`
  - 64 MiB V8 heap default
  - V8 thread pool size 1, idle tasks off
  - Tighter HTTP concurrency / response caps
- `slot` additionally budgets a **one-session process**: 2 CDP connections / 2 pending (and analogous MCP caps where applicable)
- `-Dlow_resource_default` build option defaults unset profile to `pi`
- `App` / `Platform.initWithOptions` / `ArenaPool.Config.pi` honor lean defaults

### Flags (quick ref)

```bash
# Lean one-session process (agent / pool style)
./lightpanda serve --resource-profile slot

# Shared lean multi-session server
./lightpanda serve --resource-profile pi

# Honest Lightpanda identity
./lightpanda fetch --no-stealth https://example.com

# Deterministic Chrome-shaped identity
./lightpanda fetch --fingerprint 42 --fingerprint-platform macos https://example.com
```

### Mem / CPU rationale

- Measured lean V8 flags reduce peak RSS (~7%) with negligible CPU cost versus full desktop defaults.
- 64 MiB heap is intentional: lower growth caps did not reduce RSS after `--optimize-for-size` and OOMed common SPAs.
- `slot` keeps those V8 savings but assumes **many cheap processes** (1 live session each) rather than one fat multi-session server — hence 2 connections of headroom (live session + health/reconnect), not pi’s memory-capped dozens.

## Test plan

- [x] `make test F="Config"` — 9/9 (profiles, stealth flags, CLI parse/reject)
- [x] `make test F="Fingerprint"` — 3/3
- [x] `make test F="Viewport"` — geometry chain
- [x] `make test F="WebApi: stealth"` — plugins / webdriver / `window.chrome`
- [x] `make test F="WebApi: Navigator"` — existing navigator fixtures with `--no-stealth` harness
- [x] `zig build` with prebuilt V8
- [ ] CI on this PR

## Explicit non-goals (follow-ups)

- **Not included:** entire `src/render/` virtual-browser stack
- **Not included:** CaptchaSolver / Turnstile auto-solve / `--solve-captchas` (natural follow-up once stealth lands)
- **Not included:** Webdriver MCP megadiff, curl_h3_compat, broad CORS rewrites
- **Deferred web surfaces:** canvas/WebGL/audio fingerprint noise, `CompatibilityInterfaces` / Snapshot interface-name cloaking, `navigator.share` / `getBattery` / `connection` chrome_surface probes (device helpers are present for header RTT/Downlink only)

Happy to split further or trim any surface the maintainers prefer to land separately.