### PR TITLE
dev: support for pre-build shared library

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.5.2'
+    default: 'v0.5.3'
   v8:
     description: 'v8 version to install'
     required: false

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig-v8 release tag the prebuilt lib came from'
     required: false
-    default: 'v0.5.2'
+    default: 'v0.5.3'
 
 runs:
   using: "composite"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ By default the build compiles V8 from source, which takes several minutes. Run
 [`zig-v8-fork`](https://github.com/lightpanda-io/zig-v8-fork/releases) releases
 instead; later `make build` / `make test` pick it up automatically.
 
+On Linux x86_64, `make download-v8-shared` additionally fetches the shared
+flavor (`libc_v8.so`) that `zig build -Ddev_fast=true` picks up automatically
+for much faster debug rebuilds.
+
 ## Before opening a PR
 
 - [ ] Tests pass (`make test`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.9.207.35
-ARG ZIG_V8=v0.5.2
+ARG ZIG_V8=v0.5.3
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ ZIG_V8_TAG := $(shell awk -F\' '/^  zig-v8:/{f=1} f&&/default:/{print $$2; exit}
 V8_ARCHIVE := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).a
 V8_CACHE   := .lp-cache/prebuilt-v8/$(ZIG_V8_TAG)/$(V8_ARCHIVE)
 
+# The shared flavor serves -Ddev_fast (Linux x86_64 Debug only). It is cached
+# under the name the exe's DT_NEEDED records, libc_v8.so; the tag directory
+# already keys freshness.
+V8_SO_ASSET := libc_v8_$(V8_VERSION)_$(OS)_$(ARCH).so
+V8_SO_CACHE := .lp-cache/prebuilt-v8/$(ZIG_V8_TAG)/libc_v8.so
+
 # If the prebuilt archive is in place and the caller hasn't set ZIGFLAGS, point
 # the build at it rather than building V8 from source.
 ifeq ($(strip $(ZIGFLAGS)),)
@@ -79,7 +85,7 @@ help:
 
 # $(ZIG) commands
 # ------------
-.PHONY: build build-v8-snapshot build-dev download-v8 run run-release test bench data end2end clean
+.PHONY: build build-v8-snapshot build-dev download-v8 download-v8-shared run run-release test bench data end2end clean
 
 ## Download the prebuilt V8 archive (skips the 10+ min source build)
 download-v8:
@@ -90,6 +96,16 @@ download-v8:
 			https://github.com/lightpanda-io/zig-v8-fork/releases/download/$(ZIG_V8_TAG)/$(V8_ARCHIVE) \
 		|| (rm -f $(V8_CACHE); printf "\033[33mDownload ERROR\033[0m\n"; exit 1) )
 	@printf "\033[33mV8 ready: %s\033[0m\n" "$(V8_CACHE)"
+
+## Download the prebuilt shared V8 used by -Ddev_fast builds (Linux x86_64)
+download-v8-shared:
+	@mkdir -p $(dir $(V8_SO_CACHE))
+	@test -f $(V8_SO_CACHE) || ( \
+		printf "\033[36mDownloading prebuilt shared V8 $(V8_VERSION) ($(ZIG_V8_TAG))...\033[0m\n"; \
+		curl -fL --progress-bar -o $(V8_SO_CACHE) \
+			https://github.com/lightpanda-io/zig-v8-fork/releases/download/$(ZIG_V8_TAG)/$(V8_SO_ASSET) \
+		|| (rm -f $(V8_SO_CACHE); printf "\033[33mDownload ERROR\033[0m\n"; exit 1) )
+	@printf "\033[33mShared V8 ready: %s\033[0m\n" "$(V8_SO_CACHE)"
 
 ## Build v8 snapshot
 build-v8-snapshot:

--- a/build.zig
+++ b/build.zig
@@ -64,7 +64,11 @@ pub fn build(b: *Build) !void {
         }
     }
 
-    const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
+    // dev_fast links V8 shared, so it defaults to the libc_v8.so that
+    // `make download-v8-shared` caches (when present) rather than a
+    // multi-minute from-source build.
+    const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to a prebuilt libc_v8.a or libc_v8.so") orelse
+        if (dev_fast) findSharedV8Cache(b) else null;
     const snapshot_path = b.option([]const u8, "snapshot_path", "Path to v8 snapshot");
     const wpt_extensions = b.option(bool, "wpt_extensions", "Extend WebAPI with WPT driver behavior") orelse false;
     const shared_v8 = b.option(bool, "shared_v8", "Link V8 as a shared library") orelse dev_fast;
@@ -245,6 +249,44 @@ pub fn build(b: *Build) !void {
         const test_step = b.step("test", "Run unit tests");
         test_step.dependOn(&run_tests.step);
     }
+}
+
+/// Looks for the shared V8 that `make download-v8-shared` caches. The cache
+/// path is keyed on the zig-v8 release tag, read from the install action so
+/// it cannot drift from CI (the Makefile reads the same source of truth).
+fn findSharedV8Cache(b: *Build) ?[]const u8 {
+    const io = b.graph.io;
+    const action = std.Io.Dir.cwd().readFileAlloc(
+        io,
+        b.pathFromRoot(".github/actions/install/action.yml"),
+        b.allocator,
+        .limited(64 * 1024),
+    ) catch return null;
+
+    const tag = blk: {
+        var in_zig_v8 = false;
+        var lines = std.mem.splitScalar(u8, action, '\n');
+        while (lines.next()) |line| {
+            if (std.mem.startsWith(u8, line, "  ") and !std.mem.startsWith(u8, line, "   ")) {
+                in_zig_v8 = std.mem.eql(u8, std.mem.trimEnd(u8, line, " \r"), "  zig-v8:");
+                continue;
+            }
+            if (!in_zig_v8) continue;
+            const trimmed = std.mem.trim(u8, line, " \r");
+            if (std.mem.startsWith(u8, trimmed, "default:")) {
+                var it = std.mem.splitScalar(u8, trimmed, '\'');
+                _ = it.next();
+                break :blk it.next() orelse return null;
+            }
+        }
+        return null;
+    };
+    if (tag.len == 0) return null;
+
+    const path = b.fmt("{s}/prebuilt-v8/{s}/libc_v8.so", .{ b.pathFromRoot(".lp-cache"), tag });
+    std.Io.Dir.cwd().access(io, path, .{}) catch return null;
+    std.debug.print("Using prebuilt shared V8: {s}\n", .{path});
+    return path;
 }
 
 fn linkV8(

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/db264d2c4d70c09e102167799e99cebb8a74713f.tar.gz",
-            .hash = "v8-0.0.0-xddH6wsDAwA_VE-G-JbVC9XnMTGzeuYmzGPmxHpj0KIF",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/47e8be3edae7a28071192556f1a5ffbf31774344.tar.gz",
+            .hash = "v8-0.0.0-xddH6x4GAwB6psyI4sllqMbK7cLkz-Bo3xC9WDheGksn",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/47e8be3edae7a28071192556f1a5ffbf31774344.tar.gz",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/57747955a59f09147b4dc1142152f0d960b2c7e1.tar.gz",
             .hash = "v8-0.0.0-xddH6x4GAwB6psyI4sllqMbK7cLkz-Bo3xC9WDheGksn",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },


### PR DESCRIPTION
Supports prebuild-v8 shared library and adds a `download-v8-shared` make target. Depends on: https://github.com/lightpanda-io/zig-v8-fork/pull/198

The auto-discovery of the .so is done in the build.zig, which is different than the auto-discovery of the .a which is done in the Makefile. This is intentional and if we inverse -Ddev_fast so that it's on by default, the .a's auto discovery will be moved to build.zig for consistency and explicitness. As-is, we have no way to tell whether -Dprebuilt_v8_path=v8.a is being injected by Makefile or is explicit (which isn't a problem so long as we're not doing dev_fast by default).