### PR TITLE
stability: clear V8 terminating state after a terminated microtask checkpoint

### DIFF
--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -427,7 +427,22 @@ pub fn runMicrotasks(self: *Env) void {
         while (i < self.contexts.items.len) : (i += 1) {
             const ctx = self.contexts.items[i];
             v8.v8__MicrotaskQueue__PerformCheckpoint(ctx.microtask_queue, v8_isolate);
+            if (self.terminatePending()) {
+                // A terminate landed inside this checkpoint. Unlike a JS entry,
+                // the checkpoint exit does not clear V8's terminating state, and
+                // leaving it set makes later V8 calls (teardown, inspector) fail
+                // in ways their callers don't expect. Clear the V8 state; the
+                // sticky terminate_requested keeps blocking new JS entries.
+                clearTerminationState(v8_isolate);
+                return;
+            }
         }
+    }
+}
+
+fn clearTerminationState(v8_isolate: *v8.Isolate) void {
+    if (v8.v8__Isolate__IsExecutionTerminating(v8_isolate)) {
+        v8.v8__Isolate__CancelTerminateExecution(v8_isolate);
     }
 }
 
@@ -633,6 +648,11 @@ pub fn performIsolateMicrotasks(self: *Env) void {
     defer self.terminate_mutex.unlock(lp.io);
     if (self.terminatePending()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
+    if (self.terminatePending()) {
+        // See runMicrotasks: a checkpoint exit doesn't clear V8's terminating
+        // state the way a JS entry unwind does.
+        clearTerminationState(self.isolate.handle);
+    }
 }
 
 fn promiseRejectCallback(message_handle: v8.PromiseRejectMessage) callconv(.c) void {

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -427,22 +427,21 @@ pub fn runMicrotasks(self: *Env) void {
         while (i < self.contexts.items.len) : (i += 1) {
             const ctx = self.contexts.items[i];
             v8.v8__MicrotaskQueue__PerformCheckpoint(ctx.microtask_queue, v8_isolate);
+
             if (self.terminatePending()) {
-                // A terminate landed inside this checkpoint. Unlike a JS entry,
-                // the checkpoint exit does not clear V8's terminating state, and
-                // leaving it set makes later V8 calls (teardown, inspector) fail
-                // in ways their callers don't expect. Clear the V8 state; the
-                // sticky terminate_requested keeps blocking new JS entries.
-                clearTerminationState(v8_isolate);
+                if (v8.v8__Isolate__IsExecutionTerminating(v8_isolate)) {
+                    for (self.contexts.items) |c| {
+                        if (c.call_depth > 0) {
+                            return;
+                        }
+                    }
+                    // None of the contexts are "entered", it's safe to
+                    // clear the termination flag.
+                    v8.v8__Isolate__CancelTerminateExecution(v8_isolate);
+                }
                 return;
             }
         }
-    }
-}
-
-fn clearTerminationState(v8_isolate: *v8.Isolate) void {
-    if (v8.v8__Isolate__IsExecutionTerminating(v8_isolate)) {
-        v8.v8__Isolate__CancelTerminateExecution(v8_isolate);
     }
 }
 
@@ -648,11 +647,6 @@ pub fn performIsolateMicrotasks(self: *Env) void {
     defer self.terminate_mutex.unlock(lp.io);
     if (self.terminatePending()) return;
     v8.v8__Isolate__PerformMicrotaskCheckpoint(self.isolate.handle);
-    if (self.terminatePending()) {
-        // See runMicrotasks: a checkpoint exit doesn't clear V8's terminating
-        // state the way a JS entry unwind does.
-        clearTerminationState(self.isolate.handle);
-    }
 }
 
 fn promiseRejectCallback(message_handle: v8.PromiseRejectMessage) callconv(.c) void {

--- a/src/browser/js/Function.zig
+++ b/src/browser/js/Function.zig
@@ -347,6 +347,130 @@ test "Function: requested termination is classified and blocks re-entry" {
     try testing.expectEqual(3, try (try local.exec("1 + 2", null)).toI32());
 }
 
+test "Function: nested microtask checkpoint keeps the caller's termination" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const env = frame.js.env;
+    defer env.cancelTerminate();
+
+    const State = struct {
+        env: *js.Env,
+        local: *const js.Local,
+        resumed: bool = false,
+
+        fn kill(self: *@This()) void {
+            self.env.requestTerminate();
+        }
+
+        // Draining the queue from a native call runs at call depth >= 1, with
+        // the caller's JS still on the stack. A terminate landing in here is
+        // aimed at that caller too, so the checkpoint must not clear it.
+        fn pump(self: *@This()) void {
+            self.local.runMicrotasks();
+        }
+
+        fn markResumed(self: *@This()) void {
+            self.resumed = true;
+        }
+    };
+    var state = State{ .env = env, .local = local };
+
+    const driver = try local.exec(
+        \\(function(kill, pump, resumed) {
+        \\  Promise.resolve().then(function(){ kill(); for(;;){} });
+        \\  pump();
+        \\  resumed();
+        \\})
+    , null);
+    const driver_fn = Function{ .local = local, .handle = @ptrCast(driver.handle) };
+
+    var caught: js.TryCatch.Caught = .{};
+    const args = .{
+        local.newCallback(State.kill, &state),
+        local.newCallback(State.pump, &state),
+        local.newCallback(State.markResumed, &state),
+    };
+    try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, args, &caught));
+    try testing.expectEqual(false, state.resumed);
+    try testing.expectEqual(true, env.terminatePending());
+}
+
+test "Function: a terminated checkpoint stops the context loop" {
+    const frame = try testing.createFrame();
+    const other = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const env = frame.js.env;
+    defer env.cancelTerminate();
+
+    // The second context's queue is the one the loop must not go on to reach:
+    // entering a checkpoint on a terminating isolate consumes the termination,
+    // which would let the wedged caller below resume.
+    {
+        var other_ls: js.Local.Scope = undefined;
+        other.js.localScope(&other_ls);
+        defer other_ls.deinit();
+        try other_ls.local.eval(
+            \\window.__ran = false;
+            \\Promise.resolve().then(function(){ window.__ran = true; });
+        , null);
+    }
+
+    const State = struct {
+        env: *js.Env,
+        local: *const js.Local,
+        resumed: bool = false,
+
+        fn kill(self: *@This()) void {
+            self.env.requestTerminate();
+        }
+
+        fn pump(self: *@This()) void {
+            self.local.runMicrotasks();
+        }
+
+        fn markResumed(self: *@This()) void {
+            self.resumed = true;
+        }
+    };
+    var state = State{ .env = env, .local = local };
+
+    const driver = try local.exec(
+        \\(function(kill, pump, resumed) {
+        \\  Promise.resolve().then(function(){ kill(); for(;;){} });
+        \\  pump();
+        \\  resumed();
+        \\})
+    , null);
+    const driver_fn = Function{ .local = local, .handle = @ptrCast(driver.handle) };
+
+    var caught: js.TryCatch.Caught = .{};
+    const args = .{
+        local.newCallback(State.kill, &state),
+        local.newCallback(State.pump, &state),
+        local.newCallback(State.markResumed, &state),
+    };
+    try testing.expectError(error.ExecutionTerminated, driver_fn.tryCall(void, args, &caught));
+    try testing.expectEqual(false, state.resumed);
+
+    env.cancelTerminate();
+    var other_ls: js.Local.Scope = undefined;
+    other.js.localScope(&other_ls);
+    defer other_ls.deinit();
+    try testing.expectEqual(false, (try other_ls.local.exec("window.__ran", null)).toBool());
+}
+
 // A cheap, copyable handle to a persisted function. See js.GlobalSlot.
 pub const Global = struct {
     slot: *js.GlobalSlot,

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -469,3 +469,69 @@ const testing = @import("../../testing.zig");
 test "WebApi: MutationObserver" {
     try testing.htmlRunner("mutation_observer", .{});
 }
+
+// Production watchdog path (lightpanda-io/browser#3130 follow-up): the
+// terminate lands inside a MutationObserver callback, so ExecutionTerminated
+// must unwind out of deliverRecords, stay sticky against further V8 entries,
+// and leave the observer machinery usable after a top-level cancel.
+test "WebApi: MutationObserver requested termination unwinds delivery" {
+    const v8 = js.v8;
+    testing.expectLog(&.{ .frame, .frame });
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const env = frame.js.env;
+    defer env.cancelTerminate();
+
+    const State = struct {
+        env: *js.Env,
+
+        fn kill(self: *@This()) void {
+            self.env.requestTerminate();
+        }
+    };
+    var state = State{ .env = env };
+    const kill_cb = local.newCallback(State.kill, &state);
+
+    // An observer whose callback wedges until the requested termination
+    // lands, like a storefront spinning inside its MutationObserver callback
+    // when the watchdog fires.
+    const setup = try local.exec(
+        \\(function(kill) {
+        \\  const target = document.createElement('div');
+        \\  window.__delivered = 0;
+        \\  window.__wedge = true;
+        \\  window.__target = target;
+        \\  new MutationObserver(() => {
+        \\    window.__delivered++;
+        \\    if (window.__wedge) { kill(); for(;;){} }
+        \\  }).observe(target, { attributes: true });
+        \\  target.setAttribute('x', '1');
+        \\})
+    , null);
+    const setup_fn = js.Function{ .local = local, .handle = @ptrCast(setup.handle) };
+    try setup_fn.call(void, .{kill_cb});
+
+    // The queued delivery microtask wedges; the terminate unwinds it and the
+    // unwind must stop at deliverRecords without another V8 entry.
+    env.runMicrotasks();
+
+    try testing.expectEqual(true, env.terminatePending());
+    try testing.expectEqual(false, v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
+
+    // Sticky: no fresh eval may enter V8 while the termination is pending.
+    try testing.expectError(error.ExecutionTerminated, local.exec("1 + 1", null));
+
+    // A top-level cancel restores execution AND mutation delivery.
+    env.cancelTerminate();
+    try testing.expectEqual(1, try (try local.exec("window.__delivered", null)).toI32());
+    try local.eval("window.__wedge = false; window.__target.setAttribute('x', '2');", null);
+    env.runMicrotasks();
+    try testing.expectEqual(2, try (try local.exec("window.__delivered", null)).toI32());
+}


### PR DESCRIPTION
## Summary

When a requested termination (watchdog / CDP-disconnect kill) lands inside a **microtask checkpoint** — e.g. a wedged MutationObserver callback — `PerformCheckpoint` returns with `v8::Isolate::IsExecutionTerminating()` still set, and nothing ever clears it. A JS entry (`JSEntry`) clears the terminating state when the termination unwinds past it, which is what `tryCall`/`exec` rely on (and what #3130's model assumes); the checkpoint path has no such boundary.

The isolate is then permanently "terminating": every later V8 call — connection teardown, inspector `resetContextGroup`, value conversions — runs against a terminating isolate and can return empty where callers don't expect it, ending in SIGSEGV.

This is the remaining production watchdog crash signature after #3130 (observed on `1.0.0-nightly.8578` through `8589`):

```
$msg="watchdog stall" stalled_ms=30533
$msg="MutObserver.deliverRecords" err=ExecutionTerminated
$msg="frame.deliverMutations" err=ExecutionTerminated
$msg="document is loaded2" err=ExecutionTerminated
$msg="closing connection" reason="pending terminate"
→ SIGSEGV/139 within ~500ms, during teardown
```

## Fix

After a checkpoint in which a terminate landed, cancel the V8-level termination while keeping the sticky `terminate_requested`, and skip the remaining context queues. The existing entry gates (function/constructor/script/isolate-microtask) keep refusing new JS exactly as before — this only restores the same post-unwind V8 state the `JSEntry` path already produces. Same handling in `performIsolateMicrotasks`.

## Reproduction

Deterministic: a page whose MutationObserver callback wedges (`for(;;){}`) until the watchdog fires. On current `main`, after `runMicrotasks()` delivers and the terminate unwinds, `IsExecutionTerminating()` remains `true` (the new unit test fails without the fix); with the fix it is cleared and the env behaves like the #3130 Function-path test: sticky flag set, no V8 re-entry, `cancelTerminate` restores execution *and* mutation delivery.

Also verified live against a `serve` build with `--watchdog-ms 1500` and a fixture page wedging inside the observer callback across 100+ terminate cycles (macOS aarch64 + Linux aarch64), including concurrent CDP connections and in-flight transfers: the terminated connection closes with `pending terminate`, the process stays alive, and subsequent contexts work.

## Checks

- `make test` (1152 tests; includes the new regression test, which fails without the fix)
- `zig fmt --check ./*.zig ./**/*.zig`
