### PR TITLE
add --http-header option to send headers on every HTTP requests

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -24,6 +24,7 @@ const cli = @import("cli.zig");
 const dump = @import("browser/dump.zig");
 
 const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
+const HttpHeader = @import("network/http.zig").Header;
 
 const log = lp.log;
 const crypto = @import("sys/libcrypto.zig");
@@ -83,6 +84,29 @@ fn logLevelValidator(_: Allocator, args: *std.process.Args.Iterator, target: *?l
         log.fatal(.app, "invalid option choice", .{ .arg = "--log-level", .value = str });
         return error.InvalidArgument;
     };
+}
+
+fn httpHeaderValidator(allocator: Allocator, args: *std.process.Args.Iterator, list: *std.ArrayList(HttpHeader)) !void {
+    const str = args.next() orelse return error.MissingArgument;
+    const header = HttpHeader.parse(str) orelse {
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "expected \"Name: Value\"" });
+        return error.InvalidArgument;
+    };
+
+    if (std.ascii.eqlIgnoreCase(header.name, "User-Agent")) {
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "Use --user-agent instead" });
+        return error.InvalidArgument;
+    }
+
+    if (std.ascii.eqlIgnoreCase(header.name, "Sec-Ch-Ua")) {
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "Sec-Ch-Ua is not oevrridable" });
+        return error.InvalidArgument;
+    }
+
+    try list.append(allocator, .{
+        .name = try allocator.dupe(u8, header.name),
+        .value = try allocator.dupe(u8, header.value),
+    });
 }
 
 const Cert = struct {
@@ -183,6 +207,7 @@ const CommonOptions = .{
     .{ .name = "http_max_host_open", .type = ?u8 },
     .{ .name = "http_timeout", .type = ?u31 },
     .{ .name = "http_connect_timeout", .type = ?u31 },
+    .{ .name = "http_header", .type = HttpHeader, .multiple = true, .validator = httpHeaderValidator },
     .{ .name = "http_max_response_size", .type = ?usize },
     .{ .name = "ws_max_concurrent", .type = ?u8 },
     .{ .name = "insecure_disable_tls_host_verification", .type = bool },
@@ -504,6 +529,13 @@ pub fn httpProxy(self: *const Config) ?[:0]const u8 {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_proxy,
         .version => null,
         else => unreachable,
+    };
+}
+
+pub fn httpHeaders(self: *const Config) []const HttpHeader {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_header.items,
+        else => &.{},
     };
 }
 
@@ -1063,6 +1095,29 @@ test "Config: validateUserAgent" {
     try std.testing.expectError(error.Reserved, validateUserAgent("mozilla/1.0"));
     try std.testing.expectError(error.Reserved, validateUserAgent("Mozilla/5.0"));
     try std.testing.expectError(error.NonPrintable, validateUserAgent("bad\x01ua"));
+}
+
+test "Config: httpHeaders accessor" {
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{} });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(0, config.httpHeaders().len);
+    }
+    {
+        var list: std.ArrayList(HttpHeader) = .empty;
+        defer list.deinit(std.testing.allocator);
+        try list.append(std.testing.allocator, .{ .name = "X-Extra", .value = "1" });
+
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .http_header = list,
+        } });
+        defer config.deinit(std.testing.allocator);
+
+        const headers = config.httpHeaders();
+        try std.testing.expectEqual(1, headers.len);
+        try std.testing.expectEqualStrings("X-Extra", headers[0].name);
+        try std.testing.expectEqualStrings("1", headers[0].value);
+    }
 }
 
 fn userAgentValidator(allocator: Allocator, args: *std.process.Args.Iterator, ua: *?[]const u8) !void {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -22,6 +22,7 @@ const lp = @import("lightpanda");
 
 const cli = @import("cli.zig");
 const dump = @import("browser/dump.zig");
+const Mime = @import("browser/Mime.zig");
 
 const WebBotAuthConfig = @import("network/WebBotAuth.zig").Config;
 const HttpHeader = @import("network/http.zig").Header;
@@ -93,13 +94,25 @@ fn httpHeaderValidator(allocator: Allocator, args: *std.process.Args.Iterator, l
         return error.InvalidArgument;
     };
 
+    // The same shape script-set headers go through in `Headers`: a name that
+    // is an HTTP token, a value that is a CR/LF-free byte string.
+    if (Mime.isHttpToken(header.name) == false) {
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "name must be a non-empty HTTP token" });
+        return error.InvalidArgument;
+    }
+
+    if (Mime.isHttpHeaderValue(header.value) == false) {
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "value must be Latin-1 text without CR, LF or NUL" });
+        return error.InvalidArgument;
+    }
+
     if (std.ascii.eqlIgnoreCase(header.name, "User-Agent")) {
         log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "Use --user-agent instead" });
         return error.InvalidArgument;
     }
 
     if (std.ascii.eqlIgnoreCase(header.name, "Sec-Ch-Ua")) {
-        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "Sec-Ch-Ua is not oevrridable" });
+        log.fatal(.app, "invalid option value", .{ .arg = "--http-header", .value = str, .hint = "Sec-Ch-Ua is not overridable" });
         return error.InvalidArgument;
     }
 
@@ -1095,6 +1108,55 @@ test "Config: validateUserAgent" {
     try std.testing.expectError(error.Reserved, validateUserAgent("mozilla/1.0"));
     try std.testing.expectError(error.Reserved, validateUserAgent("Mozilla/5.0"));
     try std.testing.expectError(error.NonPrintable, validateUserAgent("bad\x01ua"));
+}
+
+test "Config: parseArgs refuses an invalid --http-header" {
+    const invalid = [_][*:0]const u8{
+        // no colon to split on
+        "not-a-header",
+        // empty name
+        ": value",
+        // names that aren't HTTP tokens
+        "Foo Bar: value",
+        "X(Foo)=a: value",
+        // CR/LF in the value would smuggle a second header onto the wire
+        "X-A: b\r\nX-B: c",
+        "X-A: b\n",
+        // reserved names have their own flag, or none at all
+        "User-Agent: Custom/1.0",
+        "Sec-Ch-Ua: \"Chromium\";v=\"140\"",
+    };
+
+    for (invalid) |header| {
+        log.expectLog(&.{.app});
+        const argv = [_][*:0]const u8{ "lightpanda", "fetch", "--http-header", header };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        try std.testing.expectError(error.InvalidArgument, parseArgs(std.testing.allocator, proc_args));
+    }
+}
+
+test "Config: parseArgs collects --http-header" {
+    // The parsed headers are owned by the allocator for the process lifetime;
+    // an arena stands in for main's.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const argv = [_][*:0]const u8{
+        "lightpanda",         "fetch",
+        "--http-header",      "Accept-Language: fr-FR,fr;q=0.9",
+        "--http-header",      " \tX-Empty \t: \t",
+        "http://example.com",
+    };
+    const proc_args: std.process.Args = .{ .vector = &argv };
+    const config = try parseArgs(arena.allocator(), proc_args);
+
+    const headers = config.httpHeaders();
+    try std.testing.expectEqual(2, headers.len);
+    try std.testing.expectEqualStrings("Accept-Language", headers[0].name);
+    try std.testing.expectEqualStrings("fr-FR,fr;q=0.9", headers[0].value);
+    // Name and value are trimmed; an empty value is legal.
+    try std.testing.expectEqualStrings("X-Empty", headers[1].name);
+    try std.testing.expectEqualStrings("", headers[1].value);
 }
 
 test "Config: httpHeaders accessor" {

--- a/src/browser/Mime.zig
+++ b/src/browser/Mime.zig
@@ -648,6 +648,24 @@ pub fn isHttpToken(s: []const u8) bool {
     return true;
 }
 
+pub fn isHttpHeaderValue(value: []const u8) bool {
+    var i: usize = 0;
+    while (i < value.len) {
+        const n = std.unicode.utf8ByteSequenceLength(value[i]) catch return false;
+        if (i + n > value.len) {
+            return false;
+        }
+
+        const cp = std.unicode.utf8Decode(value[i..][0..n]) catch return false;
+
+        if (cp > 0xFF or cp == 0x00 or cp == 0x0A or cp == 0x0D) {
+            return false;
+        }
+        i += n;
+    }
+    return true;
+}
+
 /// Whether every code point in `value` is an "HTTP quoted-string token code
 /// point" (HT, 0x20-0x7E, or 0x80-0xFF). Decodes UTF-8 so that a code point
 /// above U+00FF (e.g. U+FFFD) is rejected even though its bytes are each >=

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -121,30 +121,12 @@ fn validateAndNormalize(list: *KeyValueList) !void {
         if (Mime.isHttpToken(entry.name.str()) == false) {
             return error.TypeError;
         }
+        // A valid header value is a byte string without NUL, LF or CR.
         const trimmed = entry.value.trim(&Mime.HTTP_WHITESPACE);
-        try validateHeaderValue(trimmed.str());
+        if (Mime.isHttpHeaderValue(trimmed.str()) == false) {
+            return error.TypeError;
+        }
         entry.value = trimmed;
-    }
-}
-
-/// Validate an already-normalized header value. Returns `error.TypeError` —
-/// surfaced to script as a JS TypeError — when it contains a code point above
-/// U+00FF (not a valid byte string) or a 0x00/0x0A/0x0D byte.
-/// https://fetch.spec.whatwg.org/#headers-class
-fn validateHeaderValue(value: []const u8) error{TypeError}!void {
-    var i: usize = 0;
-    while (i < value.len) {
-        const n = std.unicode.utf8ByteSequenceLength(value[i]) catch return error.TypeError;
-        if (i + n > value.len) {
-            return error.TypeError;
-        }
-
-        const cp = std.unicode.utf8Decode(value[i..][0..n]) catch return error.TypeError;
-
-        if (cp > 0xFF or cp == 0x00 or cp == 0x0A or cp == 0x0D) {
-            return error.TypeError;
-        }
-        i += n;
     }
 }
 

--- a/src/browser/webapi/net/WebSocket.zig
+++ b/src/browser/webapi/net/WebSocket.zig
@@ -240,7 +240,6 @@ fn connect(self: *WebSocket, protocols: [][]const u8) !void {
     for (http_client.baselineHeaders()) |hdr| {
         try conn.addHeader(allocator, hdr.name, hdr.value);
     }
-
     if (protocols.len > 0) {
         try conn.addHeader(allocator, "Sec-WebSocket-Protocol", try std.mem.join(allocator, ", ", protocols));
     }

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -132,16 +132,13 @@ fn setExtraHTTPHeaders(cmd: *CDP.Command) !void {
         const key = header.key_ptr.*;
         const value = header.value_ptr.*;
 
-        if (std.mem.indexOfAny(u8, key, "\r\n") != null or std.mem.indexOfAny(u8, value, "\r\n") != null) {
-            log.warn(.cdp, "network.setExtraHTTPHeaders", .{ .param = "header", .value = key, .info = "header name/value must not contain CR or LF" });
+        if (Mime.isHttpToken(key) == false) {
+            log.warn(.cdp, "network.setExtraHTTPHeaders", .{ .param = "header", .value = key, .info = "header name must be a non-empty HTTP token" });
             continue;
         }
 
-        // A colon in the name would smuggle a different header name onto the
-        // wire once the pair is joined ("User-Agent:Mozilla/5.0 (X" + "Y)"),
-        // bypassing the User-Agent validation below.
-        if (std.mem.indexOfScalar(u8, key, ':') != null) {
-            log.warn(.cdp, "network.setExtraHTTPHeaders", .{ .param = "header", .value = key, .info = "header name must not contain a colon" });
+        if (Mime.isHttpHeaderValue(value) == false) {
+            log.warn(.cdp, "network.setExtraHTTPHeaders", .{ .param = "header", .value = key, .info = "header value must be Latin-1 text without CR, LF or NUL" });
             continue;
         }
 
@@ -795,6 +792,30 @@ test "cdp.network setExtraHTTPHeaders rejects a header that smuggles CRLF" {
         .method = "Network.setExtraHTTPHeaders",
         .params = .{ .headers = .{
             .@"x-custom" = "bar\r\nUser-Agent: Mozilla/5.0",
+            .@"x-keep" = "ok",
+        } },
+    });
+
+    try testing.expectEqual(bc.extra_headers.items.len, 1);
+    try testing.expectEqual("x-keep", bc.extra_headers.items[0].name);
+    try testing.expectEqual("ok", bc.extra_headers.items[0].value);
+}
+
+test "cdp.network setExtraHTTPHeaders rejects a name that isn't an HTTP token" {
+    testing.silenceLog(&.{.cdp});
+
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .id = "NID-UA6", .session_id = "NESI-UA6" });
+
+    // A space — or any other non-token byte — in the name would land
+    // malformed on the wire.
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Network.setExtraHTTPHeaders",
+        .params = .{ .headers = .{
+            .@"X Custom" = "bar",
             .@"x-keep" = "ok",
         } },
     });

--- a/src/help.zon
+++ b/src/help.zon
@@ -356,11 +356,12 @@
     \\          Defaults to 0.
     \\  --http-header <HEADER>
     \\          Extra custom header added to every outgoing HTTP request, including redirections,
-    \\          in "Name: Value" form. Can be passed multiple times. The first name is used.
+    \\          in "Name: Value" form. Can be passed multiple times. The last one is used.
     \\          Note that if you add a custom header that has the same name as one of the
-    \\          internal ones Lightpanda would use, your set header is used instead of the
+    \\          internal ones Lightpanda would use, your set header is always used instead of the
     \\          internal one. You should not replace internally set headers without knowing
     \\          perfectly well what you are doing.
+    \\          Script set headers via CDP or JS can't override a CLI set header.
     \\  --http-max-concurrent <INT>
     \\          Maximum number of concurrent HTTP requests.
     \\          Defaults to 40.

--- a/src/help.zon
+++ b/src/help.zon
@@ -354,6 +354,13 @@
     \\          Time in ms to establish an HTTP connection before timing out. 0 means
     \\          never.
     \\          Defaults to 0.
+    \\  --http-header <HEADER>
+    \\          Extra custom header added to every outgoing HTTP request, including redirections,
+    \\          in "Name: Value" form. Can be passed multiple times. The first name is used.
+    \\          Note that if you add a custom header that has the same name as one of the
+    \\          internal ones Lightpanda would use, your set header is used instead of the
+    \\          internal one. You should not replace internally set headers without knowing
+    \\          perfectly well what you are doing.
     \\  --http-max-concurrent <INT>
     \\          Maximum number of concurrent HTTP requests.
     \\          Defaults to 40.

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -2742,7 +2742,7 @@ pub const Transfer = struct {
     // setHeader/appendHeader let a source overwrite headers from its own or
     // a lower layer, never a higher one. .fixed is hardcoded and can't be
     // changed (Sec-Ch-Ua). For CORS, only script-set headers cause a preflight.
-    pub const HeaderSource = enum { user_agent, author, cdp, fixed };
+    pub const HeaderSource = enum { user_agent, author, cdp, cli, fixed };
 
     pub const HeaderOpts = struct {
         source: HeaderSource = .user_agent,
@@ -2842,6 +2842,12 @@ pub const Transfer = struct {
     fn seedHeaders(self: *Transfer) !void {
         for (self.client.baselineHeaders()) |hdr| {
             try self.addHeader(hdr.name, hdr.value, .{ .source = hdr.source });
+        }
+
+        // --http-header extras; setHeader so a same-name header (e.g.
+        // Accept-Language) overrides the baseline instead of duplicating.
+        for (self.client.network.config.httpHeaders()) |hdr| {
+            try self.setHeader(hdr.name, hdr.value, .{ .source = .cli });
         }
     }
 

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -62,10 +62,24 @@ pub const Header = struct {
     };
 
     pub fn parse(header_str: []const u8) ?Header {
+        // ignore headers containing "\r\n".
+        if (std.mem.indexOfAny(u8, header_str, "\r\n") != null) {
+            return null;
+        }
+        // ignore headers w/o colon.
         const colon_pos = std.mem.indexOfScalar(u8, header_str, ':') orelse return null;
 
         const name = std.mem.trim(u8, header_str[0..colon_pos], " \t");
         const value = std.mem.trim(u8, header_str[colon_pos + 1 ..], " \t");
+
+        // no empty name.
+        if (name.len == 0) {
+            return null;
+        }
+        // no name incl. space.
+        if (std.mem.indexOfAny(u8, name, " ") != null) {
+            return null;
+        }
 
         return .{ .name = name, .value = value };
     }
@@ -898,6 +912,50 @@ test "isBadPort" {
     for ([_]u16{ 0, 80, 443, 8000, 8080, 9584, 65535 }) |port| {
         try testing.expect(!isBadPort(port));
     }
+}
+
+test "Header.parse" {
+    {
+        const h = Header.parse("Content-Type: text/html; charset=utf-8").?;
+        try testing.expectEqualSlices(u8, "Content-Type", h.name);
+        try testing.expectEqualSlices(u8, "text/html; charset=utf-8", h.value);
+    }
+    {
+        // no space after the colon
+        const h = Header.parse("X-Custom:value").?;
+        try testing.expectEqualSlices(u8, "X-Custom", h.name);
+        try testing.expectEqualSlices(u8, "value", h.value);
+    }
+    {
+        // name and value are trimmed of spaces and tabs
+        const h = Header.parse(" \tAccept \t: \tapplication/json \t").?;
+        try testing.expectEqualSlices(u8, "Accept", h.name);
+        try testing.expectEqualSlices(u8, "application/json", h.value);
+    }
+    {
+        // only the first colon splits; later colons stay in the value
+        const h = Header.parse("Referer: http://example.com:8080/").?;
+        try testing.expectEqualSlices(u8, "Referer", h.name);
+        try testing.expectEqualSlices(u8, "http://example.com:8080/", h.value);
+    }
+    {
+        // empty value
+        const h = Header.parse("X-Empty:").?;
+        try testing.expectEqualSlices(u8, "X-Empty", h.name);
+        try testing.expectEqualSlices(u8, "", h.value);
+    }
+
+    // empty name
+    try testing.expect(Header.parse(": value") == null);
+    // bad name
+    try testing.expect(Header.parse("Foo Bar: value") == null);
+    // no colon
+    try testing.expect(Header.parse("not-a-header") == null);
+    try testing.expect(Header.parse("") == null);
+    // CR or LF anywhere rejects the header (injection guard)
+    try testing.expect(Header.parse("X-A: b\r\nX-B: c") == null);
+    try testing.expect(Header.parse("X-A: b\n") == null);
+    try testing.expect(Header.parse("\rX-A: b") == null);
 }
 
 test "Header.firstValue" {

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -62,24 +62,10 @@ pub const Header = struct {
     };
 
     pub fn parse(header_str: []const u8) ?Header {
-        // ignore headers containing "\r\n".
-        if (std.mem.indexOfAny(u8, header_str, "\r\n") != null) {
-            return null;
-        }
-        // ignore headers w/o colon.
         const colon_pos = std.mem.indexOfScalar(u8, header_str, ':') orelse return null;
 
         const name = std.mem.trim(u8, header_str[0..colon_pos], " \t");
         const value = std.mem.trim(u8, header_str[colon_pos + 1 ..], " \t");
-
-        // no empty name.
-        if (name.len == 0) {
-            return null;
-        }
-        // no name incl. space.
-        if (std.mem.indexOfAny(u8, name, " ") != null) {
-            return null;
-        }
 
         return .{ .name = name, .value = value };
     }
@@ -945,17 +931,17 @@ test "Header.parse" {
         try testing.expectEqualSlices(u8, "", h.value);
     }
 
-    // empty name
-    try testing.expect(Header.parse(": value") == null);
-    // bad name
-    try testing.expect(Header.parse("Foo Bar: value") == null);
-    // no colon
+    {
+        // Splitting is all `parse` does; a name that isn't an HTTP token still
+        // parses. Callers validate what comes back.
+        const h = Header.parse("Foo Bar: value").?;
+        try testing.expectEqualSlices(u8, "Foo Bar", h.name);
+        try testing.expectEqualSlices(u8, "value", h.value);
+    }
+
+    // no colon, no header
     try testing.expect(Header.parse("not-a-header") == null);
     try testing.expect(Header.parse("") == null);
-    // CR or LF anywhere rejects the header (injection guard)
-    try testing.expect(Header.parse("X-A: b\r\nX-B: c") == null);
-    try testing.expect(Header.parse("X-A: b\n") == null);
-    try testing.expect(Header.parse("\rX-A: b") == null);
 }
 
 test "Header.firstValue" {


### PR DESCRIPTION
Add `--http-header` option to configure default headers for all http requests.
Websocket is not covered.

`User-Agent` and `Sec-Ch-Ua` are refused.

Additional headers added by the browser like `Referer`, `Cache-Control`, `Accept` will replace the configured headers.

```$ ./zig-out/bin/lightpanda fetch --http-header "Accept-Language: fr-FR,fr;q=0.9" --dump markdown https://httpbin.io/headers
INFO  frame : navigate . . . . . . . . . . . . . . . . . . . . [+0ms]
      url = https://httpbin.io/headers
      method = GET
      reason = address_bar
      body = false
      type = root

{
  "headers": {
    "Accept": [
      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
    ],
    "Accept-Encoding": [
      "deflate, gzip, br"
    ],
    "Accept-Language": [
      "fr-FR,fr;q=0.9"
    ],
    "Host": [
      "httpbin.io"
    ],
    "Sec-Ch-Ua": [
      "\"Lightpanda\";v=\"1\""
    ],
    "User-Agent": [
      "Lightpanda/1.0"
    ]
  }
}
```
