### PR TITLE
webapi: don't fire error event when a worker script fetch is aborted

### DIFF
--- a/src/browser/webapi/SharedWorkerGlobalScope.zig
+++ b/src/browser/webapi/SharedWorkerGlobalScope.zig
@@ -252,10 +252,14 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     self._http_transfer = null;
     self.releaseScriptArena();
 
-    log.err(.browser, "shared worker fetch error", .{
-        .url = self._url,
-        .err = err,
-    });
+    // error.Abort means teardown (deinit) cancelled a still-inflight script
+    // fetch — a cancellation, not a load failure.
+    if (err != error.Abort) {
+        log.err(.browser, "shared worker fetch error", .{
+            .url = self._url,
+            .err = err,
+        });
+    }
 
     // The worker will never load and onconnect will never be registered.
     // Drain the buffered connects so they get dispatched (and dropped at the

--- a/src/browser/webapi/Worker.zig
+++ b/src/browser/webapi/Worker.zig
@@ -274,10 +274,17 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     self._http_transfer = null;
     self.releaseScriptArena();
 
-    log.err(.browser, "worker fetch error", .{
-        .url = self._url,
-        .err = err,
-    });
+    // error.Abort is not a load failure: terminate() (or worker teardown)
+    // cancelled a still-inflight script fetch. Per spec a terminated worker
+    // fires no further events, so no error event either — Chrome is silent
+    // here, and challenge scripts do probe this exact sequence.
+    const is_abort = err == error.Abort;
+    if (!is_abort) {
+        log.err(.browser, "worker fetch error", .{
+            .url = self._url,
+            .err = err,
+        });
+    }
 
     // The worker will never load and onmessage will never be registered.
     // Drain any buffered messages so they get dispatched (and silently
@@ -286,7 +293,9 @@ fn httpErrorCallback(ctx: *anyopaque, err: anyerror) void {
     self._script_loaded = true;
     self._worker_scope.drainPendingMessages();
 
-    self.fireErrorEvent(@errorName(err), null);
+    if (!is_abort) {
+        self.fireErrorEvent(@errorName(err), null);
+    }
 }
 
 fn releaseScriptArena(self: *Worker) void {


### PR DESCRIPTION
terminate() can cancel a still-inflight script fetch. That's a cancellation, not a failure: a terminated worker must fire no further events, and Chrome is silent here. We logged an error and fired an ErrorEvent — observable by Cloudflare challenge scripts, which create a blob-URL worker and terminate it in the same tick.

On error.Abort, skip the log and the error event; same log skip in SharedWorkerGlobalScope.

Previously we had
```
$ lightpanda fetch https://bed-vyne.com/
$time=1786629337502 $scope=browser $level=error $msg="worker fetch error" url=blob:https://bed-vyne.com/dafb8b4c-d872-47fe-9c31-5c61a3e96753 err=Abort
```