### PR TITLE
Enforce User-Agent and Sec-Ch-Ua HTTP headers restriction

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -1051,6 +1051,20 @@ test "Config: advertiseHost preserves concrete host when not a wildcard" {
     try std.testing.expectEqualStrings("127.0.0.1", config.advertiseHost());
 }
 
+test "Config: parseArgs refuses a mozilla user-agent" {
+    log.expectLog(&.{.app});
+    const argv = [_][*:0]const u8{ "lightpanda", "fetch", "--user-agent", "mozilla/1.0" };
+    const proc_args: std.process.Args = .{ .vector = &argv };
+    try std.testing.expectError(error.InvalidArgument, parseArgs(std.testing.allocator, proc_args));
+}
+
+test "Config: validateUserAgent" {
+    try validateUserAgent("Lightpanda/1.0");
+    try std.testing.expectError(error.Reserved, validateUserAgent("mozilla/1.0"));
+    try std.testing.expectError(error.Reserved, validateUserAgent("Mozilla/5.0"));
+    try std.testing.expectError(error.NonPrintable, validateUserAgent("bad\x01ua"));
+}
+
 fn userAgentValidator(allocator: Allocator, args: *std.process.Args.Iterator, ua: *?[]const u8) !void {
     const str = args.next() orelse return error.MissingArgument;
     validateUserAgent(str) catch {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -195,7 +195,7 @@ const CommonOptions = .{
     .{ .name = "web_bot_auth_key_file", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_keyid", .type = ?[]const u8 },
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
-    .{ .name = "user_agent", .type = ?[]const u8 },
+    .{ .name = "user_agent", .type = ?[]const u8, .validator = userAgentValidator },
     .{ .name = "block_private_networks", .type = bool },
     .{ .name = "block_cidrs", .type = ?[]const u8 },
     .{ .name = "block_urls", .type = ?[]const u8 },
@@ -1049,6 +1049,16 @@ test "Config: advertiseHost preserves concrete host when not a wildcard" {
     defer config.deinit(std.testing.allocator);
     try std.testing.expect(!config.bindIsWildcard());
     try std.testing.expectEqualStrings("127.0.0.1", config.advertiseHost());
+}
+
+fn userAgentValidator(allocator: Allocator, args: *std.process.Args.Iterator, ua: *?[]const u8) !void {
+    const str = args.next() orelse return error.MissingArgument;
+    validateUserAgent(str) catch {
+        log.fatal(.app, "invalid user-agent", .{ .hint = "User agent can't contain Mozilla" });
+        return error.InvalidArgument;
+    };
+
+    ua.* = try allocator.dupe(u8, str);
 }
 
 pub fn validateUserAgent(ua: []const u8) !void {

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -623,7 +623,7 @@ pub fn httpMetadata(self: *const Frame) HttpMetadata {
 pub fn headersForRequest(self: *Frame, transfer: *HttpClient.Transfer) !void {
     const arena = transfer.arena.allocator();
     if (try referrer.compute(arena, self.referrer_policy, self.referrerSource(), transfer.req.url)) |ref| {
-        try transfer.addHeader("Referer", ref, .{});
+        try transfer.setHeader("Referer", ref, .{});
         transfer.req.referrer_policy = self.referrer_policy;
     }
 }
@@ -851,15 +851,15 @@ pub fn navigate(self: *Frame, request_url: [:0]const u8, opts: NavigateOpts) !vo
     {
         // Ours until submit; clean up if header setup fails.
         errdefer transfer.deinit();
-        try transfer.addHeader("Accept", lp.Config.HttpHeaders.navigation_accept, .{});
+        try transfer.setHeader("Accept", lp.Config.HttpHeaders.navigation_accept, .{});
         if (opts.header) |hdr| {
             // Arrives pre-joined ("Name: Value"), e.g. from the CLI.
             if (HttpClient.Header.parse(hdr)) |parsed| {
-                try transfer.addHeader(parsed.name, parsed.value, .{});
+                try transfer.setHeader(parsed.name, parsed.value, .{});
             }
         }
         if (opts.referer) |ref| {
-            try transfer.addHeader("Referer", ref, .{});
+            try transfer.setHeader("Referer", ref, .{});
             self._referrer = try self.arena.dupe(u8, ref);
             transfer.req.referrer_policy = opts.referrer_policy;
         }
@@ -2315,7 +2315,7 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []co
     };
     {
         errdefer transfer.deinit();
-        try transfer.addHeader("Accept", "text/css,*/*;q=0.1", .{});
+        try transfer.setHeader("Accept", "text/css,*/*;q=0.1", .{});
         try self.headersForRequest(transfer);
     }
 

--- a/src/browser/webapi/net/EventSource.zig
+++ b/src/browser/webapi/net/EventSource.zig
@@ -196,15 +196,15 @@ fn connect(self: *EventSource) !void {
 
     {
         errdefer transfer.deinit();
-        try transfer.addHeader("Accept", "text/event-stream", .{});
-        try transfer.addHeader("Cache-Control", "no-cache", .{});
+        try transfer.setHeader("Accept", "text/event-stream", .{});
+        try transfer.setHeader("Cache-Control", "no-cache", .{});
         if (self._last_event_id.items.len > 0) {
-            try transfer.addHeader("Last-Event-ID", self._last_event_id.items, .{});
+            try transfer.setHeader("Last-Event-ID", self._last_event_id.items, .{});
         }
         if (!same_origin) {
             // EventSource is a CORS request: cross-origin fetches carry the
             // document's origin ("null" for opaque origins, like Chrome).
-            try transfer.addHeader("Origin", exec.origin() orelse "null", .{});
+            try transfer.setHeader("Origin", exec.origin() orelse "null", .{});
         }
         try exec.headersForRequest(transfer);
     }

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -101,7 +101,7 @@ pub fn forEach(self: *Headers, cb_: js.Function, js_this_: ?js.Object) !void {
 const HttpClient = @import("../../../network/HttpClient.zig");
 pub fn populateRequestHeaders(self: *Headers, transfer: *HttpClient.Transfer) !void {
     for (self._list._entries.items) |entry| {
-        try transfer.addHeader(entry.name.str(), entry.value.str(), .{ .source = .author });
+        try transfer.appendHeader(entry.name.str(), entry.value.str(), .{ .source = .author });
     }
 }
 

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -101,6 +101,15 @@ pub fn forEach(self: *Headers, cb_: js.Function, js_this_: ?js.Object) !void {
 const HttpClient = @import("../../../network/HttpClient.zig");
 pub fn populateRequestHeaders(self: *Headers, transfer: *HttpClient.Transfer) !void {
     for (self._list._entries.items) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.name.str(), "user-agent")) {
+            lp.Config.validateUserAgent(entry.value.str()) catch |err| {
+                log.info(.js, "populateRequestHeaders", .{ .info = "user-agent override", .err = err });
+                continue;
+            };
+            try transfer.setHeader(entry.name.str(), entry.value.str(), .{ .source = .author });
+            continue;
+        }
+
         try transfer.appendHeader(entry.name.str(), entry.value.str(), .{ .source = .author });
     }
 }

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -24,7 +24,6 @@ const ArenaPool = @import("../ArenaPool.zig");
 const Notification = @import("../Notification.zig");
 
 const CDP = @import("../cdp/CDP.zig");
-const Config = @import("../Config.zig");
 const Watchdog = @import("../Watchdog.zig");
 const URL = @import("../browser/URL.zig");
 const referrer = @import("../browser/referrer.zig");
@@ -384,10 +383,10 @@ pub fn getUserAgent(self: *const Client) [:0]const u8 {
 }
 
 // Headers _all_ requests include.
-pub fn baselineHeaders(self: *const Client) [3]http.Header {
+pub fn baselineHeaders(self: *const Client) [3]Transfer.RequestHeader {
     return .{
         .{ .name = "User-Agent", .value = self.getUserAgent() },
-        .{ .name = "Sec-Ch-Ua", .value = lp.Config.HttpHeaders.sec_ch_ua },
+        .{ .name = "Sec-Ch-Ua", .value = lp.Config.HttpHeaders.sec_ch_ua, .source = .fixed },
         // Omitting Accept-Language triggers bot-protection on some CDNs
         // (Akamai) when Accept-Encoding is present.
         .{ .name = "Accept-Language", .value = lp.Config.HttpHeaders.accept_language },
@@ -2731,7 +2730,8 @@ pub const Transfer = struct {
 
     // Who put the header on the request. CORS cares: only non-safelisted
     // author (i.e. script-set) headers trigger a preflight.
-    pub const HeaderSource = enum { user_agent, author };
+    // fixed is hardcoded and can't be changed.
+    pub const HeaderSource = enum { user_agent, author, fixed };
 
     pub const HeaderOpts = struct {
         source: HeaderSource = .user_agent,
@@ -2776,6 +2776,13 @@ pub const Transfer = struct {
                 i += 1;
                 continue;
             }
+
+            // Don't override any fixed header.
+            if (hdr.source == .fixed) {
+                log.info(.http, "ignore overriding fixed header", .{ .header = hdr.name });
+                return;
+            }
+
             if (found) {
                 _ = self.req_headers.orderedRemove(i);
                 continue;
@@ -2793,7 +2800,7 @@ pub const Transfer = struct {
     // The client's baseline headers, added to every request at creation.
     fn seedHeaders(self: *Transfer) !void {
         for (self.client.baselineHeaders()) |hdr| {
-            try self.addHeader(hdr.name, hdr.value, .{});
+            try self.addHeader(hdr.name, hdr.value, .{ .source = hdr.source });
         }
     }
 
@@ -2806,7 +2813,7 @@ pub const Transfer = struct {
         try self.seedHeaders();
         for (headers) |hdr| {
             if (std.ascii.eqlIgnoreCase(hdr.name, "user-agent")) {
-                Config.validateUserAgent(hdr.value) catch |err| {
+                lp.Config.validateUserAgent(hdr.value) catch |err| {
                     log.info(.http, "ignored request header", .{ .intercepted = self.client.intercepted, .name = hdr.name, .err = err });
                     continue;
                 };

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -931,10 +931,10 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
                 .last_modified = cached.last_modified,
             });
             if (cached.etag) |etag| {
-                try transfer.addHeader("If-None-Match", etag, .{});
+                try transfer.setHeader("If-None-Match", etag, .{});
             }
             if (cached.last_modified) |lm| {
-                try transfer.addHeader("If-Modified-Since", lm, .{});
+                try transfer.setHeader("If-Modified-Since", lm, .{});
             }
             transfer._cache_intent = .{ .revalidate = cached };
             return false;
@@ -2737,7 +2737,7 @@ pub const Transfer = struct {
         source: HeaderSource = .user_agent,
     };
 
-    pub fn addHeader(self: *Transfer, name: []const u8, value: []const u8, opts: HeaderOpts) !void {
+    fn addHeader(self: *Transfer, name: []const u8, value: []const u8, opts: HeaderOpts) !void {
         const arena = self.arena.allocator();
         try self.req_headers.append(arena, .{
             .name = try arena.dupe(u8, name),
@@ -2795,6 +2795,30 @@ pub const Transfer = struct {
         if (!found) {
             try self.addHeader(name, value, opts);
         }
+    }
+
+    // Adds, appending every existing header with the first same case-insensitive name.
+    // appendHeader doesn't deduplicate any existing headers.
+    pub fn appendHeader(self: *Transfer, name: []const u8, value: []const u8, opts: HeaderOpts) !void {
+        var i: usize = 0;
+        while (i < self.req_headers.items.len) {
+            const hdr = &self.req_headers.items[i];
+            if (std.ascii.eqlIgnoreCase(hdr.name, name) == false) {
+                i += 1;
+                continue;
+            }
+
+            // Don't override any fixed header.
+            if (hdr.source == .fixed) {
+                log.info(.http, "ignore overriding fixed header", .{ .header = hdr.name });
+                return;
+            }
+
+            hdr.value = try std.fmt.allocPrint(self.arena.allocator(), "{s}, {s}", .{ hdr.value, value });
+            hdr.source = opts.source;
+            return;
+        }
+        try self.addHeader(name, value, opts);
     }
 
     // The client's baseline headers, added to every request at creation.
@@ -3470,9 +3494,15 @@ test "HttpClient: Transfer.setHeader replaces by case-insensitive name" {
         .start_time = 0,
     };
 
-    try transfer.addHeader("User-Agent", "Lightpanda/1.0", .{});
-    try transfer.addHeader("X-Twice", "a", .{});
-    try transfer.addHeader("x-twice", "b", .{});
+    try transfer.setHeader("User-Agent", "Lightpanda/1.0", .{});
+    try transfer.setHeader("X-Twice", "a", .{});
+
+    // force a duplicated value manually
+    try transfer.req_headers.append(transfer.arena.allocator(), .{
+        .name = "x-twice",
+        .value = "b",
+        .source = .user_agent,
+    });
 
     // replaces in place, collapsing duplicates
     try transfer.setHeader("user-agent", "Custom/1.0", .{});
@@ -3489,6 +3519,46 @@ test "HttpClient: Transfer.setHeader replaces by case-insensitive name" {
     try testing.expectEqual(.author, headers[1].source);
     try testing.expectEqual("X-New", headers[2].name);
     try testing.expectEqual("yes", headers[2].value);
+}
+
+test "HttpClient: Transfer.appendHeader joins values by case-insensitive name" {
+    var pool = ArenaPool.init(testing.allocator, .{});
+    defer pool.deinit();
+
+    const arena = try pool.acquire(.small, "test");
+    defer arena.release();
+
+    var transfer = Transfer{
+        .arena = arena,
+        .owner = null,
+        .req = .{
+            .frame_id = 0,
+            .loader_id = 0,
+            .method = .GET,
+            .url = "http://example.com/",
+            .cookie_jar = null,
+            .cookie_origin = "",
+            .resource_type = .document,
+            .notification = undefined,
+            .shutdown_callback = noopShutdown,
+        },
+        .client = undefined,
+        .id = 1,
+        .start_time = 0,
+    };
+
+    // no match: appends a new header
+    try transfer.appendHeader("Cookie", "a=1", .{});
+    // match by case-insensitive name: joins onto the existing value
+    try transfer.appendHeader("COOKIE", "b=2", .{ .source = .author });
+
+    {
+        const headers = transfer.req_headers.items;
+        try testing.expectEqual(1, headers.len);
+        try testing.expectEqual("Cookie", headers[0].name);
+        try testing.expectEqual("a=1, b=2", headers[0].value);
+        try testing.expectEqual(.author, headers[0].source);
+    }
 }
 
 test "HttpClient: Fetch header overrides restore after one hop" {

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -24,6 +24,7 @@ const ArenaPool = @import("../ArenaPool.zig");
 const Notification = @import("../Notification.zig");
 
 const CDP = @import("../cdp/CDP.zig");
+const Config = @import("../Config.zig");
 const Watchdog = @import("../Watchdog.zig");
 const URL = @import("../browser/URL.zig");
 const referrer = @import("../browser/referrer.zig");
@@ -2804,6 +2805,12 @@ pub const Transfer = struct {
         self.req_headers.clearRetainingCapacity();
         try self.seedHeaders();
         for (headers) |hdr| {
+            if (std.ascii.eqlIgnoreCase(hdr.name, "user-agent")) {
+                Config.validateUserAgent(hdr.value) catch |err| {
+                    log.info(.http, "ignored request header", .{ .intercepted = self.client.intercepted, .name = hdr.name, .err = err });
+                    continue;
+                };
+            }
             try self.setHeader(hdr.name, hdr.value, .{});
         }
     }

--- a/src/network/WebBotAuth.zig
+++ b/src/network/WebBotAuth.zig
@@ -121,9 +121,9 @@ pub fn signRequest(
     const encoded = try arena.alloc(u8, encoded_len);
     _ = std.base64.standard.Encoder.encode(encoded, &sig);
 
-    try transfer.addHeader("Signature-Agent", try std.fmt.allocPrint(arena, "\"{s}\"", .{self.directory_url}), .{});
-    try transfer.addHeader("Signature-Input", try std.fmt.allocPrint(arena, "sig1={s}", .{sig_input_value}), .{});
-    try transfer.addHeader("Signature", try std.fmt.allocPrint(arena, "sig1=:{s}:", .{encoded}), .{});
+    try transfer.setHeader("Signature-Agent", try std.fmt.allocPrint(arena, "\"{s}\"", .{self.directory_url}), .{});
+    try transfer.setHeader("Signature-Input", try std.fmt.allocPrint(arena, "sig1={s}", .{sig_input_value}), .{});
+    try transfer.setHeader("Signature", try std.fmt.allocPrint(arena, "sig1=:{s}:", .{encoded}), .{});
 }
 
 pub fn deinit(self: WebBotAuth, allocator: std.mem.Allocator) void {


### PR DESCRIPTION
Add missing checks on request interception, set extra headers and webapi.

This PR also makes Transfer.addHeader private and add Transfer.appendHeader used by Headers webapi to append a header value into an existing Header instead of duplicating it.

Relates with https://github.com/lightpanda-io/demo/pull/224