### PR TITLE
crash: Fix potential crash on label click.

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -222,7 +222,7 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
             // activation behavior (ancestors only for bubbling events).
             if (event.is(@import("webapi/event/MouseEvent.zig")) != null) {
                 if (Frame.user_input.findClickActivationTarget(target, event._bubbles)) |activation_target| {
-                    Frame.user_input.handleClick(frame, activation_target) catch |err| {
+                    Frame.user_input.handleClick(frame, activation_target, target) catch |err| {
                         log.warn(.event, "frame.click", .{ .err = err });
                     };
                 }

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -334,7 +334,11 @@ const JavascriptUrlTask = struct {
     }
 };
 
-pub fn handleClick(frame: *Frame, target: *Node) !void {
+// event_target is the element that was actually clicked
+// target is the element that's being activated. Imagine a span inside an anchor
+// the span is clicked (event_target), but it's the anchor that we're activating
+// (target).
+pub fn handleClick(frame: *Frame, target: *Node, event_target: *Node) !void {
     // TODO: Also support <area> elements when implement
     const element = target.is(Element) orelse return;
 
@@ -377,6 +381,12 @@ pub fn handleClick(frame: *Frame, target: *Node) !void {
             // behavior is to run the synthetic click activation steps on the
             // labeled control. Mirrors Chrome's HTMLLabelElement::DefaultEventHandler.
             const control = label.getControl(frame) orelse return;
+            if (control.asNode().contains(event_target)) {
+                // label is the only control that synthesizes another click, so
+                // we need to guard against that activation re-triggering the
+                // label (into an infinite loop)
+                return;
+            }
             const control_html = control.is(Element.Html) orelse return;
             try control_html.click(frame);
         },

--- a/src/browser/tests/element/html/label_click.html
+++ b/src/browser/tests/element/html/label_click.html
@@ -156,3 +156,35 @@
     document.body.removeChild(cb);
   }
 </script>
+
+<label id="lab_meter"><meter id="meter_in_label"></meter></label>
+<label id="lab_div"><div id="div_in_label"><output id="output_in_label"></output></div></label>
+
+<script id="click_inside_control_is_not_forwarded">
+  {
+    // A click that starts on the labeled control (or inside it) already is
+    // the control's click; forwarding it must not bounce through the label
+    // forever. Browsers differ on whether it is forwarded once (Firefox: 2,
+    // Chrome and us: 1), so only boundedness is asserted, like the WPT.
+    const meter = $('#meter_in_label');
+    let clicks = 0;
+    meter.addEventListener('click', () => { clicks++; if (clicks > 10) throw new Error('label click loop'); });
+    meter.click();
+    testing.expectEqual(true, clicks >= 1 && clicks <= 2);
+
+    clicks = 0;
+    const span = document.createElement('span');
+    meter.appendChild(span);
+    span.click();
+    testing.expectEqual(true, clicks >= 1 && clicks <= 2);
+
+    // A click elsewhere inside the label still forwards once.
+    const output = $('#output_in_label');
+    clicks = 0;
+    output.addEventListener('click', () => { clicks++; });
+    $('#div_in_label').click();
+    testing.expectEqual(1, clicks);
+    $('#lab_div').click();
+    testing.expectEqual(2, clicks);
+  }
+</script>


### PR DESCRIPTION
This fixes a WPT crash on /html/semantics/forms/the-label-element/clicking-noninteractive-labelable-content.html

The short of it is that a label activates a click on a different element (it's the only element that does this), and if that element is inside the label and has its own activation behavior, you end up in an infinite loop.