### PR TITLE
webapi: Add (and rework) many element getter/setters

### DIFF
--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -53,7 +53,7 @@
     testing.expectEqual(5, input.size);
     input.size = -449;
     testing.expectEqual(20, input.size);
-    testing.expectError('Error: ZeroNotAllowed', () => { input.size = 0; });
+    testing.expectError('IndexSizeError', () => { input.size = 0; });
 
     testing.expectEqual('', input.src);
     input.src = 'foo'

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -22,7 +22,6 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 const dump = @import("../dump.zig");
 const Frame = @import("../Frame.zig");
-const reflect = @import("../reflect.zig");
 const Factory = @import("../Factory.zig");
 const StyleManager = @import("../StyleManager.zig");
 
@@ -31,17 +30,19 @@ const Node = @import("Node.zig");
 const ShadowRoot = @import("ShadowRoot.zig");
 const EventTarget = @import("EventTarget.zig");
 const collections = @import("collections.zig");
-pub const DOMRect = @import("DOMRect.zig");
 
 const Selector = @import("selector/Selector.zig");
 const Animation = @import("animation/Animation.zig");
 const CSSStyleProperties = @import("css/CSSStyleProperties.zig");
 
+const slotting = @import("element/slotting.zig");
+const DOMStringMap = @import("element/DOMStringMap.zig");
+
+pub const DOMRect = @import("DOMRect.zig");
 pub const Svg = @import("element/Svg.zig");
 pub const Html = @import("element/Html.zig");
-const slotting = @import("element/slotting.zig");
 pub const Attribute = @import("element/Attribute.zig");
-const DOMStringMap = @import("element/DOMStringMap.zig");
+pub const Reflect = @import("element/reflection.zig").Reflect;
 
 const log = lp.log;
 const String = lp.String;

--- a/src/browser/webapi/HTMLDocument.zig
+++ b/src/browser/webapi/HTMLDocument.zig
@@ -210,7 +210,7 @@ pub fn getDir(self: *HTMLDocument) []const u8 {
 pub fn setDir(self: *HTMLDocument, value: []const u8, frame: *Frame) !void {
     const el = self._proto.getDocumentElement() orelse return;
     const html = el.is(Element.Html) orelse return;
-    try html.setDir(value, frame);
+    try html.asElement().setAttributeSafe(comptime .wrap("dir"), .wrap(value), frame);
 }
 
 pub fn getLang(self: *HTMLDocument) []const u8 {
@@ -268,6 +268,28 @@ pub const JsApi = struct {
     }
 
     pub const dir = bridge.accessor(HTMLDocument.getDir, HTMLDocument.setDir, .{ .ce_reactions = true });
+    pub const fgColor = bodyColor("text");
+    pub const linkColor = bodyColor("link");
+    pub const vlinkColor = bodyColor("vlink");
+    pub const alinkColor = bodyColor("alink");
+    pub const bgColor = bodyColor("bgcolor");
+
+    // Legacy [LegacyNullToEmptyString] attributes that reflect an attribute of
+    // the body element ("" without one).
+    fn bodyColor(comptime attr: []const u8) js.bridge.Accessor {
+        const R = struct {
+            fn get(self: *HTMLDocument) []const u8 {
+                const b = self.getBody() orelse return "";
+                return b.asElement().getAttributeSafe(comptime .wrap(attr)) orelse "";
+            }
+            fn set(self: *HTMLDocument, value: js.Value, frame: *Frame) !void {
+                const b = self.getBody() orelse return;
+                const str = if (value.isNull()) "" else try value.toStringSlice();
+                try b.asElement().setAttributeSafe(comptime .wrap(attr), .wrap(str), frame);
+            }
+        };
+        return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+    }
     pub const head = bridge.accessor(HTMLDocument.getHead, null, .{});
     pub const body = bridge.accessor(HTMLDocument.getBody, HTMLDocument.setBody, .{ .ce_reactions = true });
     pub const lang = bridge.accessor(HTMLDocument.getLang, HTMLDocument.setLang, .{});

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -20,10 +20,10 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../../js/js.zig");
-const reflect = @import("../../reflect.zig");
 const Factory = @import("../../Factory.zig");
 
 const Frame = @import("../../Frame.zig");
+const reflection = @import("reflection.zig");
 const Node = @import("../Node.zig");
 const Element = @import("../Element.zig");
 const global_event_handlers = @import("../global_event_handlers.zig");
@@ -521,11 +521,7 @@ pub fn setTabIndex(self: *HtmlElement, value: i32, frame: *Frame) !void {
 }
 
 pub fn getDir(self: *HtmlElement) []const u8 {
-    return reflectEnumerated(self.asElement().getAttributeSafe(comptime .wrap("dir")), &.{ "ltr", "rtl", "auto" }, "", "").?;
-}
-
-pub fn setDir(self: *HtmlElement, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("dir"), .wrap(value), frame);
+    return reflection.enumeratedValue(self.asElement().getAttributeSafe(comptime .wrap("dir")), &.{ "ltr", "rtl", "auto" }, "", "").?;
 }
 
 pub fn getAccessKey(self: *HtmlElement) []const u8 {
@@ -1445,55 +1441,14 @@ pub fn getOnWheel(self: *HtmlElement, frame: *Frame) !?js.Function.Global {
     return self.getAttributeFunction(.onwheel, frame);
 }
 
-// HTML integer parsing is lax
+// HTML "rules for parsing integers", for callers that want an i32 (tabindex);
+// out-of-range values parse as failure.
 pub fn parseInteger(input: []const u8) ?i32 {
-    var normalized = std.mem.trimStart(u8, input, "\t\n\r\x0c ");
-    if (normalized.len == 0) {
-        return null;
-    }
-
-    var negative = false;
-    if (normalized[0] == '-') {
-        negative = true;
-        normalized = normalized[1..];
-    } else if (normalized[0] == '+') {
-        normalized = normalized[1..];
-    }
-
-    if (normalized.len == 0 or std.ascii.isDigit(normalized[0]) == false) {
-        return null;
-    }
-
-    var i: usize = 0;
-    var value: i64 = 0;
-    while (i < normalized.len and std.ascii.isDigit(normalized[i])) : (i += 1) {
-        value = value * 10 + (normalized[i] - '0');
-        if (value > 2147483648) {
-            return null;
-        }
-    }
-
-    if (negative) {
-        value = -value;
-    }
-
-    if (value < -2147483648 or value > 2147483647) {
+    const value = reflection.parseInteger(input) orelse return null;
+    if (value < std.math.minInt(i32) or value > std.math.maxInt(i32)) {
         return null;
     }
     return @intCast(value);
-}
-
-pub fn reflectEnumerated(
-    value: ?[]const u8,
-    keywords: []const []const u8,
-    missing: ?[]const u8,
-    invalid: ?[]const u8,
-) ?[]const u8 {
-    const v = value orelse return missing;
-    for (keywords) |keyword| {
-        if (std.ascii.eqlIgnoreCase(v, keyword)) return keyword;
-    }
-    return invalid;
 }
 
 const InnerTextState = struct {
@@ -1819,6 +1774,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(HtmlElement);
+    pub const inputMode = reflect.enumerated("inputmode", &.{ "none", "text", "tel", "url", "email", "numeric", "decimal", "search" }, .{});
+    pub const enterKeyHint = reflect.enumerated("enterkeyhint", &.{ "enter", "done", "go", "next", "previous", "search", "send" }, .{});
+
     pub const constructor = bridge.constructor(HtmlElement.construct, .{ .new_target = true });
     pub const upgrade_constructor = bridge.constructor(HtmlElement.upgradeConstruct, .{});
 
@@ -1841,7 +1800,7 @@ pub const JsApi = struct {
 
     pub const accessKey = bridge.accessor(HtmlElement.getAccessKey, HtmlElement.setAccessKey, .{ .ce_reactions = true });
     pub const autofocus = bridge.accessor(HtmlElement.getAutofocus, HtmlElement.setAutofocus, .{ .ce_reactions = true });
-    pub const dir = bridge.accessor(HtmlElement.getDir, HtmlElement.setDir, .{ .ce_reactions = true });
+    pub const dir = reflect.enumerated("dir", &.{ "ltr", "rtl", "auto" }, .{});
     pub const hidden = bridge.accessor(HtmlElement.getHidden, HtmlElement.setHidden, .{ .ce_reactions = true });
     pub const translate = bridge.accessor(HtmlElement.getTranslate, HtmlElement.setTranslate, .{ .ce_reactions = true });
     pub const accessKeyLabel = bridge.accessor(HtmlElement.getAccessKeyLabel, null, .{});

--- a/src/browser/webapi/element/html/Anchor.zig
+++ b/src/browser/webapi/element/html/Anchor.zig
@@ -59,14 +59,6 @@ pub fn setHref(self: *Anchor, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("href"), .wrap(value), frame);
 }
 
-pub fn getTarget(self: *Anchor) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("target")) orelse "";
-}
-
-pub fn setTarget(self: *Anchor, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
-}
-
 pub fn getOrigin(self: *Anchor, frame: *Frame) ![]const u8 {
     const href = try getResolvedHref(self, frame) orelse return "";
     return (try URL.getOrigin(frame.local_arena, href)) orelse "null";
@@ -196,30 +188,6 @@ pub fn setPassword(self: *Anchor, value: []const u8, frame: *Frame) !void {
     try setHref(self, new_href, frame);
 }
 
-pub fn getType(self: *Anchor) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Anchor, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getRel(self: *Anchor) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("rel")) orelse "";
-}
-
-pub fn setRel(self: *Anchor, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("rel"), .wrap(value), frame);
-}
-
-pub fn getName(self: *const Anchor) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Anchor, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
-}
-
 pub fn getText(self: *Anchor, frame: *Frame) ![:0]const u8 {
     return self.asNode().getTextContentAlloc(frame.local_arena);
 }
@@ -241,6 +209,10 @@ fn getResolvedHref(self: *Anchor, frame: *Frame) !?[:0]const u8 {
     };
 }
 
+pub fn getTarget(self: *Anchor) []const u8 {
+    return self.asElement().getAttributeSafe(comptime .wrap("target")) orelse "";
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Anchor);
 
@@ -250,9 +222,19 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Anchor);
+    pub const referrerPolicy = reflect.referrerPolicy();
+    pub const shape = reflect.string("shape");
+    pub const rev = reflect.string("rev");
+    pub const ping = reflect.string("ping");
+    pub const hreflang = reflect.string("hreflang");
+    pub const download = reflect.string("download");
+    pub const coords = reflect.string("coords");
+    pub const charset = reflect.string("charset");
+
     pub const href = bridge.accessor(Anchor.getHref, Anchor.setHref, .{ .ce_reactions = true });
-    pub const target = bridge.accessor(Anchor.getTarget, Anchor.setTarget, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Anchor.getName, Anchor.setName, .{ .ce_reactions = true });
+    pub const target = reflect.string("target");
+    pub const name = reflect.string("name");
     pub const origin = bridge.accessor(Anchor.getOrigin, null, .{});
     pub const protocol = bridge.accessor(Anchor.getProtocol, Anchor.setProtocol, .{ .ce_reactions = true });
     pub const host = bridge.accessor(Anchor.getHost, Anchor.setHost, .{ .ce_reactions = true });
@@ -263,8 +245,8 @@ pub const JsApi = struct {
     pub const pathname = bridge.accessor(Anchor.getPathname, Anchor.setPathname, .{ .ce_reactions = true });
     pub const search = bridge.accessor(Anchor.getSearch, Anchor.setSearch, .{ .ce_reactions = true });
     pub const hash = bridge.accessor(Anchor.getHash, Anchor.setHash, .{ .ce_reactions = true });
-    pub const rel = bridge.accessor(Anchor.getRel, Anchor.setRel, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Anchor.getType, Anchor.setType, .{ .ce_reactions = true });
+    pub const rel = reflect.string("rel");
+    pub const @"type" = reflect.string("type");
     pub const text = bridge.accessor(Anchor.getText, Anchor.setText, .{ .ce_reactions = true });
     pub const relList = bridge.accessor(_getRelList, null, .{ .null_as_undefined = true });
     pub const toString = bridge.function(Anchor.getHref, .{});

--- a/src/browser/webapi/element/html/Area.zig
+++ b/src/browser/webapi/element/html/Area.zig
@@ -43,73 +43,6 @@ pub fn asNode(self: *Area) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getAlt(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("alt")) orelse "";
-}
-
-pub fn setAlt(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("alt"), .wrap(value), frame);
-}
-
-pub fn getCoords(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("coords")) orelse "";
-}
-
-pub fn setCoords(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("coords"), .wrap(value), frame);
-}
-
-pub fn getShape(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("shape")) orelse "";
-}
-
-pub fn setShape(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("shape"), .wrap(value), frame);
-}
-
-pub fn getTarget(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("target")) orelse "";
-}
-
-pub fn setTarget(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
-}
-
-pub fn getDownload(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("download")) orelse "";
-}
-
-pub fn setDownload(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("download"), .wrap(value), frame);
-}
-
-pub fn getRel(self: *const Area) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("rel")) orelse "";
-}
-
-pub fn setRel(self: *Area, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("rel"), .wrap(value), frame);
-}
-
-pub fn getReferrerPolicy(self: *const Area) []const u8 {
-    const valid_referrer_policy = [_][]const u8{
-        "",
-        "no-referrer",
-        "no-referrer-when-downgrade",
-        "same-origin",
-        "origin",
-        "strict-origin",
-        "origin-when-cross-origin",
-        "strict-origin-when-cross-origin",
-        "unsafe-url",
-    };
-    return HtmlElement.reflectEnumerated(self.asConstElement().getAttributeSafe(.wrap("referrerpolicy")), &valid_referrer_policy, "", "").?;
-}
-
-pub fn setReferrerPolicy(self: *Area, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(.wrap("referrerpolicy"), .wrap(value), frame);
-}
-
 pub fn getHref(self: *Area, frame: *Frame) ![]const u8 {
     const href = self.asElement().getAttributeSafe(comptime .wrap("href")) orelse return "";
     if (href.len == 0) {
@@ -286,6 +219,12 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Area);
+    pub const noHref = reflect.boolean("nohref");
+    pub const @"type" = reflect.string("type");
+    pub const ping = reflect.string("ping");
+    pub const hreflang = reflect.string("hreflang");
+
     pub const href = bridge.accessor(Area.getHref, Area.setHref, .{ .ce_reactions = true });
     pub const origin = bridge.accessor(Area.getOrigin, null, .{});
     pub const protocol = bridge.accessor(Area.getProtocol, Area.setProtocol, .{ .ce_reactions = true });
@@ -297,13 +236,13 @@ pub const JsApi = struct {
     pub const pathname = bridge.accessor(Area.getPathname, Area.setPathname, .{ .ce_reactions = true });
     pub const search = bridge.accessor(Area.getSearch, Area.setSearch, .{ .ce_reactions = true });
     pub const hash = bridge.accessor(Area.getHash, Area.setHash, .{ .ce_reactions = true });
-    pub const alt = bridge.accessor(Area.getAlt, Area.setAlt, .{ .ce_reactions = true });
-    pub const coords = bridge.accessor(Area.getCoords, Area.setCoords, .{ .ce_reactions = true });
-    pub const shape = bridge.accessor(Area.getShape, Area.setShape, .{ .ce_reactions = true });
-    pub const target = bridge.accessor(Area.getTarget, Area.setTarget, .{ .ce_reactions = true });
-    pub const download = bridge.accessor(Area.getDownload, Area.setDownload, .{ .ce_reactions = true });
-    pub const rel = bridge.accessor(Area.getRel, Area.setRel, .{ .ce_reactions = true });
-    pub const referrerPolicy = bridge.accessor(Area.getReferrerPolicy, Area.setReferrerPolicy, .{ .ce_reactions = true });
+    pub const alt = reflect.string("alt");
+    pub const coords = reflect.string("coords");
+    pub const shape = reflect.string("shape");
+    pub const target = reflect.string("target");
+    pub const download = reflect.string("download");
+    pub const rel = reflect.string("rel");
+    pub const referrerPolicy = reflect.referrerPolicy();
     pub const toString = bridge.function(Area.getHref, .{});
     pub const relList = bridge.accessor(Area.getRelList, null, .{ .null_as_undefined = true });
 };

--- a/src/browser/webapi/element/html/BR.zig
+++ b/src/browser/webapi/element/html/BR.zig
@@ -27,4 +27,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(BR);
+    pub const clear = reflect.string("clear");
 };

--- a/src/browser/webapi/element/html/Base.zig
+++ b/src/browser/webapi/element/html/Base.zig
@@ -22,14 +22,6 @@ pub fn asNode(self: *Base) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getTarget(self: *Base) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("target")) orelse "";
-}
-
-pub fn setTarget(self: *Base, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
-}
-
 pub fn getHref(self: *Base, frame: *Frame) ![]const u8 {
     const element = self.asElement();
     const href = element.getAttributeSafe(comptime .wrap("href")) orelse return "";
@@ -78,8 +70,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Base);
+
     pub const href = bridge.accessor(Base.getHref, Base.setHref, .{ .ce_reactions = true });
-    pub const target = bridge.accessor(Base.getTarget, Base.setTarget, .{ .ce_reactions = true });
+    pub const target = reflect.string("target");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -104,6 +104,14 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Body);
+    pub const vLink = reflect.stringNullToEmpty("vlink");
+    pub const text = reflect.stringNullToEmpty("text");
+    pub const link = reflect.stringNullToEmpty("link");
+    pub const bgColor = reflect.stringNullToEmpty("bgcolor");
+    pub const background = reflect.string("background");
+    pub const aLink = reflect.stringNullToEmpty("alink");
+
     pub const onblur = bridge.accessor(getOnBlur, setOnBlur, .{ .null_as_undefined = false });
     pub const onerror = bridge.accessor(getOnError, setOnError, .{ .null_as_undefined = false });
     pub const onfocus = bridge.accessor(getOnFocus, setOnFocus, .{ .null_as_undefined = false });

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -51,52 +51,8 @@ pub fn asNode(self: *Button) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getDisabled(self: *const Button) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *Button, disabled: bool, frame: *Frame) !void {
-    if (disabled) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
-pub fn getName(self: *const Button) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Button, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
 pub fn getType(self: *const Button) []const u8 {
     return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "submit";
-}
-
-pub fn setType(self: *Button, typ: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(typ), frame);
-}
-
-pub fn getValue(self: *const Button) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("value")) orelse "";
-}
-
-pub fn setValue(self: *Button, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("value"), .wrap(value), frame);
-}
-
-pub fn getRequired(self: *const Button) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
-}
-
-pub fn setRequired(self: *Button, required: bool, frame: *Frame) !void {
-    if (required) {
-        try self.asElement().setAttributeSafe(comptime .wrap("required"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("required"), frame);
-    }
 }
 
 pub fn getForm(self: *Button, frame: *Frame) ?*Form {
@@ -167,14 +123,6 @@ pub fn getFormMethod(self: *const Button) []const u8 {
 
 pub fn setFormMethod(self: *Button, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("formmethod"), .wrap(value), frame);
-}
-
-pub fn getFormTarget(self: *const Button) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("formtarget")) orelse "";
-}
-
-pub fn setFormTarget(self: *Button, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("formtarget"), .wrap(value), frame);
 }
 
 pub fn getFormNoValidate(self: *const Button) bool {
@@ -259,6 +207,14 @@ pub fn setPopoverTargetAction(self: *Button, value: []const u8, frame: *Frame) !
     try self.asElement().setAttribute(.wrap("popovertargetaction"), .wrap(value), frame);
 }
 
+pub fn getDisabled(self: *const Button) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
+}
+
+pub fn getValue(self: *const Button) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("value")) orelse "";
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Button);
 
@@ -268,17 +224,19 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const disabled = bridge.accessor(Button.getDisabled, Button.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Button.getName, Button.setName, .{ .ce_reactions = true });
-    pub const required = bridge.accessor(Button.getRequired, Button.setRequired, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Button);
+
+    pub const disabled = reflect.boolean("disabled");
+    pub const name = reflect.string("name");
+    pub const required = reflect.boolean("required");
     pub const form = bridge.accessor(Button.getForm, null, .{});
     pub const formAction = bridge.accessor(Button.getFormAction, Button.setFormAction, .{ .ce_reactions = true });
     pub const formEnctype = bridge.accessor(Button.getFormEnctype, Button.setFormEnctype, .{ .ce_reactions = true });
     pub const formMethod = bridge.accessor(Button.getFormMethod, Button.setFormMethod, .{ .ce_reactions = true });
     pub const formNoValidate = bridge.accessor(Button.getFormNoValidate, Button.setFormNoValidate, .{ .ce_reactions = true });
-    pub const formTarget = bridge.accessor(Button.getFormTarget, Button.setFormTarget, .{ .ce_reactions = true });
-    pub const value = bridge.accessor(Button.getValue, Button.setValue, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Button.getType, Button.setType, .{ .ce_reactions = true });
+    pub const formTarget = reflect.string("formtarget");
+    pub const value = reflect.string("value");
+    pub const @"type" = reflect.enumerated("type", &.{ "submit", "reset", "button" }, .{ .missing = "submit" });
     pub const labels = bridge.accessor(Button.getLabels, null, .{});
     pub const popoverTargetElement = bridge.accessor(Button.getPopoverTargetElement, Button.setPopoverTargetElement, .{ .ce_reactions = true });
     pub const popoverTargetAction = bridge.accessor(Button.getPopoverTargetAction, Button.setPopoverTargetAction, .{ .ce_reactions = true });

--- a/src/browser/webapi/element/html/Canvas.zig
+++ b/src/browser/webapi/element/html/Canvas.zig
@@ -52,19 +52,9 @@ pub fn getWidth(self: *const Canvas) u32 {
     return std.fmt.parseUnsigned(u32, attr, 10) catch 300;
 }
 
-pub fn setWidth(self: *Canvas, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.local_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(str), frame);
-}
-
 pub fn getHeight(self: *const Canvas) u32 {
     const attr = self.asConstElement().getAttributeSafe(comptime .wrap("height")) orelse return 150;
     return std.fmt.parseUnsigned(u32, attr, 10) catch 150;
-}
-
-pub fn setHeight(self: *Canvas, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.local_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(str), frame);
 }
 
 /// Since there's no base class rendering contexts inherit from,
@@ -124,8 +114,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const width = bridge.accessor(Canvas.getWidth, Canvas.setWidth, .{ .ce_reactions = true });
-    pub const height = bridge.accessor(Canvas.getHeight, Canvas.setHeight, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Canvas);
+
+    pub const width = reflect.unsignedLong("width", .{ .default = 300 });
+    pub const height = reflect.unsignedLong("height", .{ .default = 150 });
     pub const getContext = bridge.function(Canvas.getContext, .{});
     pub const transferControlToOffscreen = bridge.function(Canvas.transferControlToOffscreen, .{});
 };

--- a/src/browser/webapi/element/html/DList.zig
+++ b/src/browser/webapi/element/html/DList.zig
@@ -44,4 +44,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(DList);
+    pub const compact = reflect.boolean("compact");
 };

--- a/src/browser/webapi/element/html/Data.zig
+++ b/src/browser/webapi/element/html/Data.zig
@@ -40,14 +40,6 @@ pub fn asNode(self: *Data) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getValue(self: *Data) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("value")) orelse "";
-}
-
-pub fn setValue(self: *Data, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("value"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Data);
 
@@ -57,5 +49,7 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const value = bridge.accessor(Data.getValue, Data.setValue, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Data);
+
+    pub const value = reflect.string("value");
 };

--- a/src/browser/webapi/element/html/Details.zig
+++ b/src/browser/webapi/element/html/Details.zig
@@ -24,10 +24,6 @@ pub fn asNode(self: *Details) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getOpen(self: *const Details) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("open")) != null;
-}
-
 pub fn setOpen(self: *Details, open: bool, frame: *Frame) !void {
     if (open) {
         try self.asElement().setAttributeSafe(comptime .wrap("open"), .wrap(""), frame);
@@ -36,12 +32,8 @@ pub fn setOpen(self: *Details, open: bool, frame: *Frame) !void {
     }
 }
 
-pub fn getName(self: *const Details) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Details, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
+pub fn getOpen(self: *const Details) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("open")) != null;
 }
 
 pub const JsApi = struct {
@@ -53,8 +45,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const open = bridge.accessor(Details.getOpen, Details.setOpen, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Details.getName, Details.setName, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Details);
+
+    pub const open = reflect.boolean("open");
+    pub const name = reflect.string("name");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Dialog.zig
+++ b/src/browser/webapi/element/html/Dialog.zig
@@ -25,26 +25,6 @@ pub fn asNode(self: *Dialog) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getOpen(self: *const Dialog) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("open")) != null;
-}
-
-pub fn setOpen(self: *Dialog, open: bool, frame: *Frame) !void {
-    if (open) {
-        try self.asElement().setAttributeSafe(comptime .wrap("open"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("open"), frame);
-    }
-}
-
-pub fn getReturnValue(self: *const Dialog) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("returnvalue")) orelse "";
-}
-
-pub fn setReturnValue(self: *Dialog, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("returnvalue"), .wrap(value), frame);
-}
-
 /// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show
 /// If the open attribute is set, return; otherwise set it to the empty string.
 /// Focus / inert / top-layer steps are no-ops here — no rendering pipeline.
@@ -76,6 +56,10 @@ pub fn close(self: *Dialog, return_value: ?[]const u8, frame: *Frame) !void {
     try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
 }
 
+pub fn getOpen(self: *const Dialog) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("open")) != null;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Dialog);
 
@@ -85,8 +69,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const open = bridge.accessor(Dialog.getOpen, Dialog.setOpen, .{ .ce_reactions = true });
-    pub const returnValue = bridge.accessor(Dialog.getReturnValue, Dialog.setReturnValue, .{});
+    const reflect = Element.Reflect(Dialog);
+
+    pub const open = reflect.boolean("open");
+    pub const returnValue = reflect.string("returnvalue");
 
     pub const show = bridge.function(Dialog.show, .{});
     pub const showModal = bridge.function(Dialog.showModal, .{});

--- a/src/browser/webapi/element/html/Directory.zig
+++ b/src/browser/webapi/element/html/Directory.zig
@@ -20,18 +20,6 @@ pub fn asNode(self: *Directory) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getCompact(self: *Directory) bool {
-    return self.asElement().getAttributeSafe(comptime .wrap("compact")) != null;
-}
-
-pub fn setCompact(self: *Directory, compact: bool, frame: *Frame) !void {
-    if (compact) {
-        try self.asElement().setAttributeSafe(comptime .wrap("compact"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("compact"), frame);
-    }
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Directory);
 
@@ -41,5 +29,7 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const compact = bridge.accessor(Directory.getCompact, Directory.setCompact, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Directory);
+
+    pub const compact = reflect.boolean("compact");
 };

--- a/src/browser/webapi/element/html/Div.zig
+++ b/src/browser/webapi/element/html/Div.zig
@@ -44,4 +44,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Div);
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/Embed.zig
+++ b/src/browser/webapi/element/html/Embed.zig
@@ -53,30 +53,6 @@ pub fn setSrc(self: *Embed, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
 }
 
-pub fn getType(self: *const Embed) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Embed, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getWidth(self: *const Embed) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("width")) orelse "";
-}
-
-pub fn setWidth(self: *Embed, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(value), frame);
-}
-
-pub fn getHeight(self: *const Embed) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("height")) orelse "";
-}
-
-pub fn setHeight(self: *Embed, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Embed);
 
@@ -86,10 +62,14 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const height = bridge.accessor(Embed.getHeight, Embed.setHeight, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Embed);
+    pub const @"align" = reflect.string("align");
+    pub const name = reflect.string("name");
+
+    pub const height = reflect.string("height");
     pub const src = bridge.accessor(Embed.getSrc, Embed.setSrc, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Embed.getType, Embed.setType, .{ .ce_reactions = true });
-    pub const width = bridge.accessor(Embed.getWidth, Embed.setWidth, .{ .ce_reactions = true });
+    pub const @"type" = reflect.string("type");
+    pub const width = reflect.string("width");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/FieldSet.zig
+++ b/src/browser/webapi/element/html/FieldSet.zig
@@ -20,26 +20,6 @@ pub fn asNode(self: *FieldSet) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getDisabled(self: *FieldSet) bool {
-    return self.asElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *FieldSet, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
-pub fn getName(self: *FieldSet) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *FieldSet, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(FieldSet);
 
@@ -49,8 +29,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const disabled = bridge.accessor(FieldSet.getDisabled, FieldSet.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(FieldSet.getName, FieldSet.setName, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(FieldSet);
+
+    pub const disabled = reflect.boolean("disabled");
+    pub const name = reflect.string("name");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Font.zig
+++ b/src/browser/webapi/element/html/Font.zig
@@ -31,22 +31,6 @@ pub fn setColor(self: *Font, value: js.Value, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("color"), .wrap(str), frame);
 }
 
-pub fn getFace(self: *Font) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("face")) orelse "";
-}
-
-pub fn setFace(self: *Font, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("face"), .wrap(value), frame);
-}
-
-pub fn getSize(self: *Font) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("size")) orelse "";
-}
-
-pub fn setSize(self: *Font, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("size"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Font);
 
@@ -56,9 +40,11 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Font);
+
     pub const color = bridge.accessor(Font.getColor, Font.setColor, .{ .ce_reactions = true });
-    pub const face = bridge.accessor(Font.getFace, Font.setFace, .{ .ce_reactions = true });
-    pub const size = bridge.accessor(Font.getSize, Font.setSize, .{ .ce_reactions = true });
+    pub const face = reflect.string("face");
+    pub const size = reflect.string("size");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -58,14 +58,6 @@ pub fn asNode(self: *Form) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getName(self: *const Form) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Form, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
 /// Canonicalize the `method` content attribute (or its `formmethod` submitter
 /// override) per WHATWG HTML "limited to only known values":
 ///   - missing → returns `missing_default`
@@ -132,32 +124,12 @@ pub fn setAction(self: *Form, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("action"), .wrap(value), frame);
 }
 
-pub fn getTarget(self: *Form) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("target")) orelse "";
-}
-
-pub fn setTarget(self: *Form, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
-}
-
 pub fn getAcceptCharset(self: *Form) []const u8 {
     return self.asElement().getAttributeSafe(.wrap("accept-charset")) orelse "";
 }
 
 pub fn setAcceptCharset(self: *Form, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(.wrap("accept-charset"), .wrap(value), frame);
-}
-
-pub fn getNoValidate(self: *const Form) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("novalidate")) != null;
-}
-
-pub fn setNoValidate(self: *Form, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("novalidate"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("novalidate"), frame);
-    }
 }
 
 pub fn getEnctype(self: *const Form) []const u8 {
@@ -245,6 +217,10 @@ fn checkElementValidity(element: *Element, frame: *Frame) !bool {
     return true;
 }
 
+pub fn getNoValidate(self: *const Form) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("novalidate")) != null;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Form);
     pub const Meta = struct {
@@ -253,13 +229,17 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const name = bridge.accessor(Form.getName, Form.setName, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Form);
+    pub const encoding = reflect.enumerated("enctype", &.{ "application/x-www-form-urlencoded", "multipart/form-data", "text/plain" }, .{ .missing = "application/x-www-form-urlencoded" });
+    pub const autocomplete = reflect.enumerated("autocomplete", &.{ "on", "off" }, .{ .missing = "on" });
+
+    pub const name = reflect.string("name");
     pub const method = bridge.accessor(Form.getMethod, Form.setMethod, .{ .ce_reactions = true });
     pub const action = bridge.accessor(Form.getAction, Form.setAction, .{ .ce_reactions = true });
-    pub const target = bridge.accessor(Form.getTarget, Form.setTarget, .{ .ce_reactions = true });
+    pub const target = reflect.string("target");
     pub const acceptCharset = bridge.accessor(Form.getAcceptCharset, Form.setAcceptCharset, .{ .ce_reactions = true });
     pub const enctype = bridge.accessor(Form.getEnctype, Form.setEnctype, .{ .ce_reactions = true });
-    pub const noValidate = bridge.accessor(Form.getNoValidate, Form.setNoValidate, .{ .ce_reactions = true });
+    pub const noValidate = reflect.boolean("novalidate");
     pub const elements = bridge.accessor(Form.getElements, null, .{});
     pub const length = bridge.accessor(Form.getLength, null, .{});
     pub const submit = bridge.function(Form.submit, .{});

--- a/src/browser/webapi/element/html/FrameSet.zig
+++ b/src/browser/webapi/element/html/FrameSet.zig
@@ -77,22 +77,6 @@ pub fn setOnScroll(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Fram
     self.reflectedWindow(frame)._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
-pub fn getCols(self: *FrameSet) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("cols")) orelse "";
-}
-
-pub fn setCols(self: *FrameSet, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("cols"), .wrap(value), frame);
-}
-
-pub fn getRows(self: *FrameSet) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("rows")) orelse "";
-}
-
-pub fn setRows(self: *FrameSet, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("rows"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(FrameSet);
 
@@ -102,8 +86,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const cols = bridge.accessor(FrameSet.getCols, FrameSet.setCols, .{ .ce_reactions = true });
-    pub const rows = bridge.accessor(FrameSet.getRows, FrameSet.setRows, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(FrameSet);
+
+    pub const cols = reflect.string("cols");
+    pub const rows = reflect.string("rows");
 
     pub const onblur = bridge.accessor(getOnBlur, setOnBlur, .{ .null_as_undefined = false });
     pub const onerror = bridge.accessor(getOnError, setOnError, .{ .null_as_undefined = false });

--- a/src/browser/webapi/element/html/HR.zig
+++ b/src/browser/webapi/element/html/HR.zig
@@ -44,4 +44,11 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(HR);
+    pub const noShade = reflect.boolean("noshade");
+    pub const width = reflect.string("width");
+    pub const size = reflect.string("size");
+    pub const color = reflect.string("color");
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/Heading.zig
+++ b/src/browser/webapi/element/html/Heading.zig
@@ -49,4 +49,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Heading);
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/Html.zig
+++ b/src/browser/webapi/element/html/Html.zig
@@ -44,4 +44,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Html);
+    pub const version = reflect.string("version");
 };

--- a/src/browser/webapi/element/html/IFrame.zig
+++ b/src/browser/webapi/element/html/IFrame.zig
@@ -93,14 +93,6 @@ pub fn setSrcdoc(self: *IFrame, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("srcdoc"), .wrap(value), frame);
 }
 
-pub fn getName(self: *IFrame) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *IFrame, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
-}
-
 pub fn getSandbox(self: *IFrame, frame: *Frame) !?*DOMTokenList {
     const element = self.asElement();
     if (element._namespace != .html) {
@@ -118,9 +110,21 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(IFrame);
+    pub const referrerPolicy = reflect.referrerPolicy();
+    pub const longDesc = reflect.url("longdesc");
+    pub const allowFullscreen = reflect.boolean("allowfullscreen");
+    pub const width = reflect.string("width");
+    pub const scrolling = reflect.string("scrolling");
+    pub const marginWidth = reflect.stringNullToEmpty("marginwidth");
+    pub const marginHeight = reflect.stringNullToEmpty("marginheight");
+    pub const height = reflect.string("height");
+    pub const frameBorder = reflect.string("frameborder");
+    pub const @"align" = reflect.string("align");
+
     pub const src = bridge.accessor(IFrame.getSrc, IFrame.setSrc, .{ .ce_reactions = true });
     pub const srcdoc = bridge.accessor(IFrame.getSrcdoc, IFrame.setSrcdoc, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(IFrame.getName, IFrame.setName, .{ .ce_reactions = true });
+    pub const name = reflect.string("name");
     pub const contentWindow = bridge.accessor(IFrame.getContentWindow, null, .{});
     pub const contentDocument = bridge.accessor(IFrame.getContentDocument, null, .{});
     pub const sandbox = bridge.accessor(IFrame.getSandbox, null, .{ .null_as_undefined = true });

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -54,45 +54,6 @@ pub fn setSrc(self: *Image, value: []const u8, frame: *Frame) !void {
     return self.imageAddedCallback(frame);
 }
 
-pub fn getAlt(self: *const Image) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("alt")) orelse "";
-}
-
-pub fn setAlt(self: *Image, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("alt"), .wrap(value), frame);
-}
-
-pub fn getWidth(self: *const Image) u32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("width")) orelse return 0;
-    return std.fmt.parseUnsigned(u32, attr, 10) catch 0;
-}
-
-pub fn setWidth(self: *Image, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(str), frame);
-}
-
-pub fn getHeight(self: *const Image) u32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("height")) orelse return 0;
-    return std.fmt.parseUnsigned(u32, attr, 10) catch 0;
-}
-
-pub fn setHeight(self: *Image, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(str), frame);
-}
-
-pub fn getCrossOrigin(self: *const Image) ?[]const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("crossorigin"));
-}
-
-pub fn setCrossOrigin(self: *Image, value: ?[]const u8, frame: *Frame) !void {
-    if (value) |v| {
-        return self.asElement().setAttributeSafe(comptime .wrap("crossorigin"), .wrap(v), frame);
-    }
-    return self.asElement().removeAttribute(comptime .wrap("crossorigin"), frame);
-}
-
 pub fn getLoading(self: *const Image) []const u8 {
     return self.asConstElement().getAttributeSafe(comptime .wrap("loading")) orelse "eager";
 }
@@ -149,11 +110,26 @@ pub const JsApi = struct {
     pub const constructor = bridge.constructor(Image.constructor, .{});
     pub const src = bridge.accessor(Image.getSrc, Image.setSrc, .{ .ce_reactions = true });
     pub const currentSrc = bridge.accessor(Image.getSrc, null, .{});
-    pub const alt = bridge.accessor(Image.getAlt, Image.setAlt, .{ .ce_reactions = true });
-    pub const width = bridge.accessor(Image.getWidth, Image.setWidth, .{ .ce_reactions = true });
-    pub const height = bridge.accessor(Image.getHeight, Image.setHeight, .{ .ce_reactions = true });
-    pub const crossOrigin = bridge.accessor(Image.getCrossOrigin, Image.setCrossOrigin, .{ .ce_reactions = true });
+    pub const alt = reflect.string("alt");
+    pub const width = reflect.unsignedLong("width", .{});
+    pub const height = reflect.unsignedLong("height", .{});
+    pub const crossOrigin = reflect.enumerated("crossorigin", &.{ "anonymous", "use-credentials" }, .{ .missing = null, .nullable = true, .invalid = "anonymous" });
     pub const loading = bridge.accessor(Image.getLoading, Image.setLoading, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Image);
+    pub const srcset = reflect.string("srcset");
+    pub const useMap = reflect.string("usemap");
+    pub const isMap = reflect.boolean("ismap");
+    pub const referrerPolicy = reflect.referrerPolicy();
+    pub const decoding = reflect.enumerated("decoding", &.{ "async", "sync", "auto" }, .{ .missing = "auto" });
+    // Obsolete
+    pub const name = reflect.string("name");
+    pub const lowsrc = reflect.url("lowsrc");
+    pub const @"align" = reflect.string("align");
+    pub const hspace = reflect.unsignedLong("hspace", .{});
+    pub const vspace = reflect.unsignedLong("vspace", .{});
+    pub const longDesc = reflect.url("longdesc");
+    pub const border = reflect.stringNullToEmpty("border");
+
     pub const naturalWidth = bridge.accessor(Image.getNaturalWidth, null, .{});
     pub const naturalHeight = bridge.accessor(Image.getNaturalHeight, null, .{});
     pub const complete = bridge.accessor(Image.getComplete, null, .{});

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -34,6 +34,7 @@ const ValidityState = @import("ValidityState.zig");
 const popover = @import("../popover.zig");
 const File = @import("../../File.zig");
 const FileList = @import("../../FileList.zig");
+const reflection = @import("../reflection.zig");
 
 const String = lp.String;
 
@@ -137,9 +138,8 @@ pub fn getType(self: *const Input) []const u8 {
 }
 
 pub fn setType(self: *Input, typ: []const u8, frame: *Frame) !void {
-    // Setting the type property should update the attribute, which will trigger attributeChange
-    const type_enum = Type.fromString(typ);
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(type_enum.toString()), frame);
+    // Reflected verbatim; attributeChange derives the state from it
+    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(typ), frame);
 }
 
 pub fn getValue(self: *const Input) []const u8 {
@@ -589,75 +589,12 @@ pub fn setDisabled(self: *Input, disabled: bool, frame: *Frame) !void {
     }
 }
 
-pub fn getName(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Input, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
-pub fn getAccept(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("accept")) orelse "";
-}
-
-pub fn setAccept(self: *Input, accept: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("accept"), .wrap(accept), frame);
-}
-
-pub fn getAlt(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("alt")) orelse "";
-}
-
-pub fn setAlt(self: *Input, alt: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("alt"), .wrap(alt), frame);
-}
-
 pub fn getMaxLength(self: *const Input) i32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("maxlength")) orelse return -1;
-    return std.fmt.parseInt(i32, attr, 10) catch -1;
-}
-
-pub fn setMaxLength(self: *Input, max_length: i32, frame: *Frame) !void {
-    if (max_length < 0) {
-        return error.IndexSizeError;
-    }
-    var buf: [32]u8 = undefined;
-    const value = std.fmt.bufPrint(&buf, "{d}", .{max_length}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap("maxlength"), .wrap(value), frame);
+    return reflection.getLimitedLong(self.asConstElement(), comptime .wrap("maxlength"));
 }
 
 pub fn getMinLength(self: *const Input) i32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("minlength")) orelse return -1;
-    return std.fmt.parseInt(i32, attr, 10) catch -1;
-}
-
-pub fn setMinLength(self: *Input, min_length: i32, frame: *Frame) !void {
-    if (min_length < 0) {
-        return error.IndexSizeError;
-    }
-    var buf: [32]u8 = undefined;
-    const value = std.fmt.bufPrint(&buf, "{d}", .{min_length}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap("minlength"), .wrap(value), frame);
-}
-
-pub fn getSize(self: *const Input) i32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("size")) orelse return 20;
-    const parsed = std.fmt.parseInt(i32, attr, 10) catch return 20;
-    return if (parsed == 0) 20 else parsed;
-}
-
-pub fn setSize(self: *Input, size: i32, frame: *Frame) !void {
-    if (size == 0) {
-        return error.ZeroNotAllowed;
-    }
-    if (size < 0) {
-        return self.asElement().setAttributeSafe(comptime .wrap("size"), .wrap("20"), frame);
-    }
-
-    var buf: [32]u8 = undefined;
-    const value = std.fmt.bufPrint(&buf, "{d}", .{size}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap("size"), .wrap(value), frame);
+    return reflection.getLimitedLong(self.asConstElement(), comptime .wrap("minlength"));
 }
 
 pub fn getSrc(self: *const Input, frame: *Frame) ![]const u8 {
@@ -668,90 +605,6 @@ pub fn getSrc(self: *const Input, frame: *Frame) ![]const u8 {
 pub fn setSrc(self: *Input, src: []const u8, frame: *Frame) !void {
     const trimmed = std.mem.trim(u8, src, &std.ascii.whitespace);
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(trimmed), frame);
-}
-
-pub fn getReadonly(self: *const Input) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("readonly")) != null;
-}
-
-pub fn setReadonly(self: *Input, readonly: bool, frame: *Frame) !void {
-    if (readonly) {
-        try self.asElement().setAttributeSafe(comptime .wrap("readonly"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("readonly"), frame);
-    }
-}
-
-pub fn getRequired(self: *const Input) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
-}
-
-pub fn setRequired(self: *Input, required: bool, frame: *Frame) !void {
-    if (required) {
-        try self.asElement().setAttributeSafe(comptime .wrap("required"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("required"), frame);
-    }
-}
-
-pub fn getPlaceholder(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("placeholder")) orelse "";
-}
-
-pub fn setPlaceholder(self: *Input, placeholder: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("placeholder"), .wrap(placeholder), frame);
-}
-
-pub fn getPattern(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("pattern")) orelse "";
-}
-
-pub fn setPattern(self: *Input, pattern: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("pattern"), .wrap(pattern), frame);
-}
-
-pub fn getMin(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("min")) orelse "";
-}
-
-pub fn setMin(self: *Input, min: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("min"), .wrap(min), frame);
-}
-
-pub fn getMax(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("max")) orelse "";
-}
-
-pub fn setMax(self: *Input, max: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("max"), .wrap(max), frame);
-}
-
-pub fn getStep(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("step")) orelse "";
-}
-
-pub fn setStep(self: *Input, step: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("step"), .wrap(step), frame);
-}
-
-pub fn getMultiple(self: *const Input) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("multiple")) != null;
-}
-
-pub fn setMultiple(self: *Input, multiple: bool, frame: *Frame) !void {
-    if (multiple) {
-        try self.asElement().setAttributeSafe(comptime .wrap("multiple"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("multiple"), frame);
-    }
-}
-
-pub fn getAutocomplete(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("autocomplete")) orelse "";
-}
-
-pub fn setAutocomplete(self: *Input, autocomplete: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("autocomplete"), .wrap(autocomplete), frame);
 }
 
 pub fn select(self: *Input, frame: *Frame) !void {
@@ -966,14 +819,6 @@ pub fn getFormMethod(self: *const Input) []const u8 {
 
 pub fn setFormMethod(self: *Input, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("formmethod"), .wrap(value), frame);
-}
-
-pub fn getFormTarget(self: *const Input) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("formtarget")) orelse "";
-}
-
-pub fn setFormTarget(self: *Input, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("formtarget"), .wrap(value), frame);
 }
 
 pub fn getFormNoValidate(self: *const Input) bool {
@@ -1406,6 +1251,22 @@ pub fn setPopoverTargetAction(self: *Input, value: []const u8, frame: *Frame) !v
     try self.asElement().setAttribute(.wrap("popovertargetaction"), .wrap(value), frame);
 }
 
+pub fn getMax(self: *const Input) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("max")) orelse "";
+}
+
+pub fn getMin(self: *const Input) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("min")) orelse "";
+}
+
+pub fn getRequired(self: *const Input) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
+}
+
+pub fn getStep(self: *const Input) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("step")) orelse "";
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Input);
 
@@ -1414,6 +1275,11 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Input);
+    pub const useMap = reflect.string("usemap");
+    pub const dirName = reflect.string("dirname");
+    pub const @"align" = reflect.string("align");
 
     /// Handles [LegacyNullToEmptyString]: null → "" per HTML spec.
     fn setValueFromJS(self: *Input, js_value: js.Value, frame: *Frame) !void {
@@ -1431,14 +1297,14 @@ pub const JsApi = struct {
     pub const checked = bridge.accessor(Input.getChecked, Input.setChecked, .{});
     pub const defaultChecked = bridge.accessor(Input.getDefaultChecked, Input.setDefaultChecked, .{ .ce_reactions = true });
     pub const disabled = bridge.accessor(Input.getDisabled, Input.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Input.getName, Input.setName, .{ .ce_reactions = true });
-    pub const required = bridge.accessor(Input.getRequired, Input.setRequired, .{ .ce_reactions = true });
-    pub const accept = bridge.accessor(Input.getAccept, Input.setAccept, .{ .ce_reactions = true });
-    pub const readOnly = bridge.accessor(Input.getReadonly, Input.setReadonly, .{ .ce_reactions = true });
-    pub const alt = bridge.accessor(Input.getAlt, Input.setAlt, .{ .ce_reactions = true });
-    pub const maxLength = bridge.accessor(Input.getMaxLength, Input.setMaxLength, .{ .ce_reactions = true });
-    pub const minLength = bridge.accessor(Input.getMinLength, Input.setMinLength, .{ .ce_reactions = true });
-    pub const size = bridge.accessor(Input.getSize, Input.setSize, .{ .ce_reactions = true });
+    pub const name = reflect.string("name");
+    pub const required = reflect.boolean("required");
+    pub const accept = reflect.string("accept");
+    pub const readOnly = reflect.boolean("readonly");
+    pub const alt = reflect.string("alt");
+    pub const maxLength = reflect.limitedLong("maxlength");
+    pub const minLength = reflect.limitedLong("minlength");
+    pub const size = reflect.unsignedLong("size", .{ .default = 20, .positive = true });
     pub const src = bridge.accessor(Input.getSrc, Input.setSrc, .{ .ce_reactions = true });
     pub const form = bridge.accessor(Input.getForm, null, .{});
     pub const list = bridge.accessor(Input.getList, null, .{});
@@ -1446,18 +1312,18 @@ pub const JsApi = struct {
     pub const formEnctype = bridge.accessor(Input.getFormEnctype, Input.setFormEnctype, .{});
     pub const formMethod = bridge.accessor(Input.getFormMethod, Input.setFormMethod, .{});
     pub const formNoValidate = bridge.accessor(Input.getFormNoValidate, Input.setFormNoValidate, .{});
-    pub const formTarget = bridge.accessor(Input.getFormTarget, Input.setFormTarget, .{});
+    pub const formTarget = reflect.string("formtarget");
     pub const labels = bridge.accessor(Input.getLabels, null, .{});
     pub const popoverTargetElement = bridge.accessor(Input.getPopoverTargetElement, Input.setPopoverTargetElement, .{ .ce_reactions = true });
     pub const popoverTargetAction = bridge.accessor(Input.getPopoverTargetAction, Input.setPopoverTargetAction, .{ .ce_reactions = true });
     pub const indeterminate = bridge.accessor(Input.getIndeterminate, Input.setIndeterminate, .{});
-    pub const placeholder = bridge.accessor(Input.getPlaceholder, Input.setPlaceholder, .{ .ce_reactions = true });
-    pub const pattern = bridge.accessor(Input.getPattern, Input.setPattern, .{ .ce_reactions = true });
-    pub const min = bridge.accessor(Input.getMin, Input.setMin, .{ .ce_reactions = true });
-    pub const max = bridge.accessor(Input.getMax, Input.setMax, .{ .ce_reactions = true });
-    pub const step = bridge.accessor(Input.getStep, Input.setStep, .{ .ce_reactions = true });
-    pub const multiple = bridge.accessor(Input.getMultiple, Input.setMultiple, .{ .ce_reactions = true });
-    pub const autocomplete = bridge.accessor(Input.getAutocomplete, Input.setAutocomplete, .{ .ce_reactions = true });
+    pub const placeholder = reflect.string("placeholder");
+    pub const pattern = reflect.string("pattern");
+    pub const min = reflect.string("min");
+    pub const max = reflect.string("max");
+    pub const step = reflect.string("step");
+    pub const multiple = reflect.boolean("multiple");
+    pub const autocomplete = reflect.string("autocomplete");
     pub const willValidate = bridge.accessor(Input.getWillValidate, null, .{});
     pub const validity = bridge.accessor(Input.getValidity, null, .{});
     pub const validationMessage = bridge.accessor(Input.getValidationMessage, null, .{});

--- a/src/browser/webapi/element/html/LI.zig
+++ b/src/browser/webapi/element/html/LI.zig
@@ -17,7 +17,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const lp = @import("lightpanda");
-const std = @import("std");
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
@@ -38,16 +37,6 @@ pub fn asNode(self: *LI) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getValue(self: *LI) i32 {
-    const attr = self.asElement().getAttributeSafe(comptime .wrap("value")) orelse return 0;
-    return std.fmt.parseInt(i32, attr, 10) catch 0;
-}
-
-pub fn setValue(self: *LI, value: i32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("value"), .wrap(str), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(LI);
 
@@ -57,7 +46,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const value = bridge.accessor(LI.getValue, LI.setValue, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(LI);
+    pub const @"type" = reflect.string("type");
+
+    pub const value = reflect.long("value", 0);
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Label.zig
+++ b/src/browser/webapi/element/html/Label.zig
@@ -22,14 +22,6 @@ pub fn asNode(self: *Label) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getHtmlFor(self: *Label) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("for")) orelse "";
-}
-
-pub fn setHtmlFor(self: *Label, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("for"), .wrap(value), frame);
-}
-
 pub fn getControl(self: *Label, frame: *Frame) ?*Element {
     if (self.asElement().getAttributeSafe(comptime .wrap("for"))) |id| {
         const el = frame.getElementByIdFromNode(self.asElement().asNode(), id) orelse return null;
@@ -143,7 +135,9 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const htmlFor = bridge.accessor(Label.getHtmlFor, Label.setHtmlFor, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Label);
+
+    pub const htmlFor = reflect.string("for");
     pub const control = bridge.accessor(Label.getControl, null, .{});
 };
 

--- a/src/browser/webapi/element/html/Legend.zig
+++ b/src/browser/webapi/element/html/Legend.zig
@@ -27,4 +27,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Legend);
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/Link.zig
+++ b/src/browser/webapi/element/html/Link.zig
@@ -75,122 +75,12 @@ pub fn setRel(self: *Link, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("rel"), .wrap(value), frame);
 }
 
-pub fn getAs(self: *const Link) []const u8 {
-    const valid_as = [_][]const u8{
-        "fetch",
-        "audio",
-        "document",
-        "embed",
-        "font",
-        "image",
-        "manifest",
-        "object",
-        "report",
-        "script",
-        "sharedworker",
-        "style",
-        "track",
-        "video",
-        "worker",
-        "xslt",
-    };
-    return HtmlElement.reflectEnumerated(self.asConstElement().getAttributeSafe(comptime .wrap("as")), &valid_as, "", "").?;
-}
-
-pub fn setAs(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("as"), .wrap(value), frame);
-}
-
-pub fn getReferrerPolicy(self: *const Link) []const u8 {
-    const valid_referrer_policy = [_][]const u8{
-        "",
-        "no-referrer",
-        "no-referrer-when-downgrade",
-        "same-origin",
-        "origin",
-        "strict-origin",
-        "origin-when-cross-origin",
-        "strict-origin-when-cross-origin",
-        "unsafe-url",
-    };
-    return HtmlElement.reflectEnumerated(self.asConstElement().getAttributeSafe(.wrap("referrerpolicy")), &valid_referrer_policy, "", "").?;
-}
-
-pub fn setReferrerPolicy(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(.wrap("referrerpolicy"), .wrap(value), frame);
-}
-
 pub fn getMedia(self: *Link) []const u8 {
     return self.asElement().getAttributeSafe(comptime .wrap("media")) orelse return "";
 }
 
 pub fn setMedia(self: *Link, value: []const u8, frame: *Frame) !void {
     return self.asElement().setAttributeSafe(comptime .wrap("media"), .wrap(value), frame);
-}
-
-pub fn getCrossOrigin(self: *const Link) ?[]const u8 {
-    const valid_cross_origin = [_][]const u8{
-        "anonymous", "use-credentials",
-    };
-    return HtmlElement.reflectEnumerated(self.asConstElement().getAttributeSafe(comptime .wrap("crossorigin")), &valid_cross_origin, null, "anonymous");
-}
-
-pub fn setCrossOrigin(self: *Link, value: ?[]const u8, frame: *Frame) !void {
-    // Nullable reflection: a null (or undefined) value removes the attribute;
-    // otherwise the content attribute mirrors the value verbatim and the
-    // getter canonicalizes it.
-    if (value) |v| {
-        return self.asElement().setAttributeSafe(comptime .wrap("crossorigin"), .wrap(v), frame);
-    }
-    return self.asElement().removeAttribute(comptime .wrap("crossorigin"), frame);
-}
-
-pub fn getCharset(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("charset")) orelse "";
-}
-
-pub fn setCharset(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("charset"), .wrap(value), frame);
-}
-
-pub fn getHreflang(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("hreflang")) orelse "";
-}
-
-pub fn setHreflang(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("hreflang"), .wrap(value), frame);
-}
-
-pub fn getIntegrity(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("integrity")) orelse "";
-}
-
-pub fn setIntegrity(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("integrity"), .wrap(value), frame);
-}
-
-pub fn getType(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getRev(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("rev")) orelse "";
-}
-
-pub fn setRev(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("rev"), .wrap(value), frame);
-}
-
-pub fn getTarget(self: *const Link) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("target")) orelse "";
-}
-
-pub fn setTarget(self: *Link, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("target"), .wrap(value), frame);
 }
 
 pub fn getSizes(self: *Link, frame: *Frame) !?*DOMTokenList {
@@ -266,18 +156,21 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const as = bridge.accessor(Link.getAs, Link.setAs, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Link);
+    pub const nonce = reflect.string("nonce");
+
+    pub const as = reflect.enumerated("as", &.{ "fetch", "audio", "document", "embed", "font", "image", "manifest", "object", "report", "script", "sharedworker", "style", "track", "video", "worker", "xslt" }, .{});
     pub const rel = bridge.accessor(Link.getRel, Link.setRel, .{ .ce_reactions = true });
     pub const media = bridge.accessor(Link.getMedia, Link.setMedia, .{ .ce_reactions = true });
     pub const href = bridge.accessor(Link.getHref, Link.setHref, .{ .ce_reactions = true });
-    pub const crossOrigin = bridge.accessor(Link.getCrossOrigin, Link.setCrossOrigin, .{ .ce_reactions = true });
-    pub const referrerPolicy = bridge.accessor(Link.getReferrerPolicy, Link.setReferrerPolicy, .{ .ce_reactions = true });
-    pub const charset = bridge.accessor(Link.getCharset, Link.setCharset, .{ .ce_reactions = true });
-    pub const hreflang = bridge.accessor(Link.getHreflang, Link.setHreflang, .{ .ce_reactions = true });
-    pub const integrity = bridge.accessor(Link.getIntegrity, Link.setIntegrity, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Link.getType, Link.setType, .{ .ce_reactions = true });
-    pub const rev = bridge.accessor(Link.getRev, Link.setRev, .{ .ce_reactions = true });
-    pub const target = bridge.accessor(Link.getTarget, Link.setTarget, .{ .ce_reactions = true });
+    pub const crossOrigin = reflect.enumerated("crossorigin", &.{ "anonymous", "use-credentials" }, .{ .missing = null, .nullable = true, .invalid = "anonymous" });
+    pub const referrerPolicy = reflect.referrerPolicy();
+    pub const charset = reflect.string("charset");
+    pub const hreflang = reflect.string("hreflang");
+    pub const integrity = reflect.string("integrity");
+    pub const @"type" = reflect.string("type");
+    pub const rev = reflect.string("rev");
+    pub const target = reflect.string("target");
     pub const relList = bridge.accessor(Link.getRelList, null, .{ .null_as_undefined = true });
     pub const sizes = bridge.accessor(Link.getSizes, null, .{ .null_as_undefined = true });
 };

--- a/src/browser/webapi/element/html/Map.zig
+++ b/src/browser/webapi/element/html/Map.zig
@@ -27,4 +27,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Map);
+    pub const name = reflect.string("name");
 };

--- a/src/browser/webapi/element/html/Marquee.zig
+++ b/src/browser/webapi/element/html/Marquee.zig
@@ -1,5 +1,4 @@
 const lp = @import("lightpanda");
-const std = @import("std");
 
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
@@ -22,116 +21,6 @@ pub fn asNode(self: *Marquee) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getBehavior(self: *Marquee) []const u8 {
-    const valid_behavior = [_][]const u8{
-        "scroll", "slide", "alternate",
-    };
-    return HtmlElement.reflectEnumerated(self.asElement().getAttributeSafe(comptime .wrap("behavior")), &valid_behavior, "scroll", "scroll").?;
-}
-
-pub fn setBehavior(self: *Marquee, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("behavior"), .wrap(value), frame);
-}
-
-pub fn getDirection(self: *Marquee) []const u8 {
-    const valid_direction = [_][]const u8{
-        "up", "right", "down", "left",
-    };
-    return HtmlElement.reflectEnumerated(self.asElement().getAttributeSafe(comptime .wrap("direction")), &valid_direction, "left", "left").?;
-}
-
-pub fn setDirection(self: *Marquee, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("direction"), .wrap(value), frame);
-}
-
-pub fn getBgColor(self: *Marquee) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("bgcolor")) orelse "";
-}
-
-pub fn setBgColor(self: *Marquee, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("bgcolor"), .wrap(value), frame);
-}
-
-pub fn getHeight(self: *Marquee) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("height")) orelse "";
-}
-
-pub fn setHeight(self: *Marquee, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(value), frame);
-}
-
-pub fn getWidth(self: *Marquee) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("width")) orelse "";
-}
-
-pub fn setWidth(self: *Marquee, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(value), frame);
-}
-
-pub fn getHspace(self: *Marquee) u32 {
-    return getU32(self, "hspace", 0);
-}
-
-pub fn setHspace(self: *Marquee, value: u32, frame: *Frame) !void {
-    try setU32(self, "hspace", value, 0, frame);
-}
-
-pub fn getVspace(self: *Marquee) u32 {
-    return getU32(self, "vspace", 0);
-}
-
-pub fn setVspace(self: *Marquee, value: u32, frame: *Frame) !void {
-    try setU32(self, "vspace", value, 0, frame);
-}
-
-pub fn getScrollAmount(self: *Marquee) u32 {
-    return getU32(self, "scrollamount", 6);
-}
-
-pub fn setScrollAmount(self: *Marquee, value: u32, frame: *Frame) !void {
-    try setU32(self, "scrollamount", value, 6, frame);
-}
-
-pub fn getScrollDelay(self: *Marquee) u32 {
-    return getU32(self, "scrolldelay", 85);
-}
-
-pub fn setScrollDelay(self: *Marquee, value: u32, frame: *Frame) !void {
-    try setU32(self, "scrolldelay", value, 85, frame);
-}
-
-pub fn getTrueSpeed(self: *Marquee) bool {
-    return self.asElement().getAttributeSafe(comptime .wrap("truespeed")) != null;
-}
-
-pub fn setTrueSpeed(self: *Marquee, truespeed: bool, frame: *Frame) !void {
-    if (truespeed) {
-        try self.asElement().setAttributeSafe(comptime .wrap("truespeed"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("truespeed"), frame);
-    }
-}
-
-// Reflects an `unsigned long` content attribute: parses with the "rules for
-// parsing non-negative integers" (the lax integer parser, then rejecting a
-// negative result), so a valid value lands in [0, 2147483647].
-fn getU32(self: *Marquee, comptime attr: []const u8, default: u32) u32 {
-    const value = self.asElement().getAttributeSafe(comptime .wrap(attr)) orelse return default;
-    const parsed = HtmlElement.parseInteger(value) orelse return default;
-
-    if (parsed < 0) {
-        return default;
-    }
-    return @intCast(parsed);
-}
-
-fn setU32(self: *Marquee, comptime attr: []const u8, value: u32, default: u32, frame: *Frame) !void {
-    const written = if (value > 2147483647) default else value;
-    var buf: [10]u8 = undefined;
-    const str = std.fmt.bufPrint(&buf, "{d}", .{written}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap(attr), .wrap(str), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Marquee);
 
@@ -141,16 +30,18 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const behavior = bridge.accessor(Marquee.getBehavior, Marquee.setBehavior, .{ .ce_reactions = true });
-    pub const bgColor = bridge.accessor(Marquee.getBgColor, Marquee.setBgColor, .{ .ce_reactions = true });
-    pub const direction = bridge.accessor(Marquee.getDirection, Marquee.setDirection, .{ .ce_reactions = true });
-    pub const height = bridge.accessor(Marquee.getHeight, Marquee.setHeight, .{ .ce_reactions = true });
-    pub const hspace = bridge.accessor(Marquee.getHspace, Marquee.setHspace, .{ .ce_reactions = true });
-    pub const scrollAmount = bridge.accessor(Marquee.getScrollAmount, Marquee.setScrollAmount, .{ .ce_reactions = true });
-    pub const scrollDelay = bridge.accessor(Marquee.getScrollDelay, Marquee.setScrollDelay, .{ .ce_reactions = true });
-    pub const trueSpeed = bridge.accessor(Marquee.getTrueSpeed, Marquee.setTrueSpeed, .{ .ce_reactions = true });
-    pub const vspace = bridge.accessor(Marquee.getVspace, Marquee.setVspace, .{ .ce_reactions = true });
-    pub const width = bridge.accessor(Marquee.getWidth, Marquee.setWidth, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Marquee);
+
+    pub const behavior = reflect.enumerated("behavior", &.{ "scroll", "slide", "alternate" }, .{ .missing = "scroll" });
+    pub const bgColor = reflect.string("bgcolor");
+    pub const direction = reflect.enumerated("direction", &.{ "up", "right", "down", "left" }, .{ .missing = "left" });
+    pub const height = reflect.string("height");
+    pub const hspace = reflect.unsignedLong("hspace", .{});
+    pub const scrollAmount = reflect.unsignedLong("scrollamount", .{ .default = 6 });
+    pub const scrollDelay = reflect.unsignedLong("scrolldelay", .{ .default = 85 });
+    pub const trueSpeed = reflect.boolean("truespeed");
+    pub const vspace = reflect.unsignedLong("vspace", .{});
+    pub const width = reflect.string("width");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Media.zig
+++ b/src/browser/webapi/element/html/Media.zig
@@ -261,50 +261,6 @@ pub fn setSrc(self: *Media, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
 }
 
-pub fn getAutoplay(self: *const Media) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("autoplay")) != null;
-}
-
-pub fn setAutoplay(self: *Media, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("autoplay"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("autoplay"), frame);
-    }
-}
-
-pub fn getControls(self: *const Media) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("controls")) != null;
-}
-
-pub fn setControls(self: *Media, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("controls"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("controls"), frame);
-    }
-}
-
-pub fn getLoop(self: *const Media) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("loop")) != null;
-}
-
-pub fn setLoop(self: *Media, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("loop"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("loop"), frame);
-    }
-}
-
-pub fn getPreload(self: *const Media) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("preload")) orelse "auto";
-}
-
-pub fn setPreload(self: *Media, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("preload"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Media);
 
@@ -313,6 +269,10 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Media);
+    pub const crossOrigin = reflect.enumerated("crossorigin", &.{ "anonymous", "use-credentials" }, .{ .missing = null, .nullable = true, .invalid = "anonymous" });
+    pub const defaultMuted = reflect.boolean("muted");
 
     pub const NETWORK_EMPTY = bridge.property(@intFromEnum(NetworkState.NETWORK_EMPTY), .{ .template = true });
     pub const NETWORK_IDLE = bridge.property(@intFromEnum(NetworkState.NETWORK_IDLE), .{ .template = true });
@@ -327,11 +287,11 @@ pub const JsApi = struct {
 
     pub const src = bridge.accessor(Media.getSrc, Media.setSrc, .{ .ce_reactions = true });
     pub const currentSrc = bridge.accessor(Media.getSrc, null, .{});
-    pub const autoplay = bridge.accessor(Media.getAutoplay, Media.setAutoplay, .{ .ce_reactions = true });
-    pub const controls = bridge.accessor(Media.getControls, Media.setControls, .{ .ce_reactions = true });
-    pub const loop = bridge.accessor(Media.getLoop, Media.setLoop, .{ .ce_reactions = true });
+    pub const autoplay = reflect.boolean("autoplay");
+    pub const controls = reflect.boolean("controls");
+    pub const loop = reflect.boolean("loop");
     pub const muted = bridge.accessor(Media.getMuted, Media.setMuted, .{});
-    pub const preload = bridge.accessor(Media.getPreload, Media.setPreload, .{ .ce_reactions = true });
+    pub const preload = reflect.enumerated("preload", &.{ "none", "metadata", "auto" }, .{ .missing = "auto" });
     pub const volume = bridge.accessor(Media.getVolume, Media.setVolume, .{});
     pub const playbackRate = bridge.accessor(Media.getPlaybackRate, Media.setPlaybackRate, .{});
     pub const currentTime = bridge.accessor(Media.getCurrentTime, Media.setCurrentTime, .{});

--- a/src/browser/webapi/element/html/Mod.zig
+++ b/src/browser/webapi/element/html/Mod.zig
@@ -31,4 +31,8 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Mod);
+    pub const cite = reflect.url("cite");
+    pub const dateTime = reflect.string("datetime");
 };

--- a/src/browser/webapi/element/html/OL.zig
+++ b/src/browser/webapi/element/html/OL.zig
@@ -17,7 +17,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const lp = @import("lightpanda");
-const std = @import("std");
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
@@ -38,28 +37,6 @@ pub fn asNode(self: *OL) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getStart(self: *OL) i32 {
-    const attr = self.asElement().getAttributeSafe(comptime .wrap("start")) orelse return 1;
-    return std.fmt.parseInt(i32, attr, 10) catch 1;
-}
-
-pub fn setStart(self: *OL, value: i32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("start"), .wrap(str), frame);
-}
-
-pub fn getReversed(self: *OL) bool {
-    return self.asElement().getAttributeSafe(comptime .wrap("reversed")) != null;
-}
-
-pub fn setReversed(self: *OL, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("reversed"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("reversed"), frame);
-    }
-}
-
 pub fn getType(self: *OL) []const u8 {
     return self.asElement().getAttributeSafe(comptime .wrap("type")) orelse "1";
 }
@@ -77,8 +54,11 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const start = bridge.accessor(OL.getStart, OL.setStart, .{ .ce_reactions = true });
-    pub const reversed = bridge.accessor(OL.getReversed, OL.setReversed, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(OL);
+    pub const compact = reflect.boolean("compact");
+
+    pub const start = reflect.long("start", 1);
+    pub const reversed = reflect.boolean("reversed");
     pub const @"type" = bridge.accessor(OL.getType, OL.setType, .{ .ce_reactions = true });
 };
 

--- a/src/browser/webapi/element/html/Object.zig
+++ b/src/browser/webapi/element/html/Object.zig
@@ -27,4 +27,22 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Object);
+    pub const vspace = reflect.unsignedLong("vspace", .{});
+    pub const hspace = reflect.unsignedLong("hspace", .{});
+    pub const data = reflect.url("data");
+    pub const codeBase = reflect.url("codebase");
+    pub const declare = reflect.boolean("declare");
+    pub const width = reflect.string("width");
+    pub const useMap = reflect.string("usemap");
+    pub const @"type" = reflect.string("type");
+    pub const standby = reflect.string("standby");
+    pub const height = reflect.string("height");
+    pub const codeType = reflect.string("codetype");
+    pub const code = reflect.string("code");
+    pub const border = reflect.stringNullToEmpty("border");
+    pub const archive = reflect.string("archive");
+    pub const @"align" = reflect.string("align");
+    pub const name = reflect.string("name");
 };

--- a/src/browser/webapi/element/html/OptGroup.zig
+++ b/src/browser/webapi/element/html/OptGroup.zig
@@ -20,26 +20,6 @@ pub fn asNode(self: *OptGroup) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getDisabled(self: *OptGroup) bool {
-    return self.asElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *OptGroup, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
-pub fn getLabel(self: *OptGroup) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("label")) orelse "";
-}
-
-pub fn setLabel(self: *OptGroup, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("label"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(OptGroup);
 
@@ -49,8 +29,10 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const disabled = bridge.accessor(OptGroup.getDisabled, OptGroup.setDisabled, .{ .ce_reactions = true });
-    pub const label = bridge.accessor(OptGroup.getLabel, OptGroup.setLabel, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(OptGroup);
+
+    pub const disabled = reflect.boolean("disabled");
+    pub const label = reflect.string("label");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -37,7 +37,6 @@ _proto_canary: if (lp.IS_DEBUG) *HtmlElement else void = undefined,
 _value: ?[]const u8 = null,
 _selected: bool = false,
 _default_selected: bool = false,
-_disabled: bool = false,
 
 pub fn asElement(self: *Option) *Element {
     return Factory.protoOf(self).asElement();
@@ -87,28 +86,16 @@ pub fn setSelected(self: *Option, selected: bool, frame: *Frame) !void {
 }
 
 pub fn getDefaultSelected(self: *const Option) bool {
-    return self._default_selected;
+    return self.asConstElement().hasAttributeSafe(comptime .wrap("selected"));
 }
 
-pub fn getDisabled(self: *const Option) bool {
-    return self._disabled;
-}
-
-pub fn setDisabled(self: *Option, disabled: bool, frame: *Frame) !void {
-    self._disabled = disabled;
-    if (disabled) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
+pub fn setDefaultSelected(self: *Option, value: bool, frame: *Frame) !void {
+    self._default_selected = value;
+    if (value) {
+        try self.asElement().setAttributeSafe(comptime .wrap("selected"), .wrap(""), frame);
     } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
+        try self.asElement().removeAttribute(comptime .wrap("selected"), frame);
     }
-}
-
-pub fn getName(self: *const Option) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Option, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-label
@@ -135,13 +122,15 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Option);
+
     pub const value = bridge.accessor(Option.getValue, Option.setValue, .{ .ce_reactions = true });
     pub const text = bridge.accessor(Option.getText, Option.setText, .{ .ce_reactions = true });
     pub const label = bridge.accessor(Option.getLabel, Option.setLabel, .{ .ce_reactions = true });
     pub const selected = bridge.accessor(Option.getSelected, Option.setSelected, .{});
-    pub const defaultSelected = bridge.accessor(Option.getDefaultSelected, null, .{});
-    pub const disabled = bridge.accessor(Option.getDisabled, Option.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Option.getName, Option.setName, .{ .ce_reactions = true });
+    pub const defaultSelected = bridge.accessor(Option.getDefaultSelected, Option.setDefaultSelected, .{ .ce_reactions = true });
+    pub const disabled = reflect.boolean("disabled");
+    pub const name = reflect.string("name");
 };
 
 pub const Build = struct {
@@ -155,9 +144,6 @@ pub const Build = struct {
         // Check for selected attribute
         self._default_selected = element.getAttributeSafe(comptime .wrap("selected")) != null;
         self._selected = self._default_selected;
-
-        // Check for disabled attribute
-        self._disabled = element.getAttributeSafe(comptime .wrap("disabled")) != null;
     }
 
     pub fn attributeChange(element: *Element, name: String, _: String, _: *Frame) !void {

--- a/src/browser/webapi/element/html/Output.zig
+++ b/src/browser/webapi/element/html/Output.zig
@@ -62,6 +62,9 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Output);
+    pub const name = reflect.string("name");
+
     pub const labels = bridge.accessor(Output.getLabels, null, .{});
     pub const htmlFor = bridge.accessor(Output.getHtmlFor, null, .{ .null_as_undefined = true });
 };

--- a/src/browser/webapi/element/html/Paragraph.zig
+++ b/src/browser/webapi/element/html/Paragraph.zig
@@ -44,4 +44,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Paragraph);
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/Param.zig
+++ b/src/browser/webapi/element/html/Param.zig
@@ -20,22 +20,6 @@ pub fn asNode(self: *Param) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getName(self: *Param) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Param, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(value), frame);
-}
-
-pub fn getValue(self: *Param) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("value")) orelse "";
-}
-
-pub fn setValue(self: *Param, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("value"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Param);
 
@@ -45,8 +29,12 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const name = bridge.accessor(Param.getName, Param.setName, .{ .ce_reactions = true });
-    pub const value = bridge.accessor(Param.getValue, Param.setValue, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Param);
+    pub const valueType = reflect.string("valuetype");
+    pub const @"type" = reflect.string("type");
+
+    pub const name = reflect.string("name");
+    pub const value = reflect.string("value");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Pre.zig
+++ b/src/browser/webapi/element/html/Pre.zig
@@ -27,4 +27,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(Pre);
+    pub const width = reflect.long("width", 0);
 };

--- a/src/browser/webapi/element/html/Progress.zig
+++ b/src/browser/webapi/element/html/Progress.zig
@@ -33,5 +33,8 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Progress);
+    pub const max = reflect.double("max", 1.0, true);
+
     pub const labels = bridge.accessor(Progress.getLabels, null, .{});
 };

--- a/src/browser/webapi/element/html/Script.zig
+++ b/src/browser/webapi/element/html/Script.zig
@@ -58,30 +58,6 @@ pub fn setSrc(self: *Script, src: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(src), frame);
 }
 
-pub fn getType(self: *const Script) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Script, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getNonce(self: *const Script) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("nonce")) orelse "";
-}
-
-pub fn setNonce(self: *Script, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("nonce"), .wrap(value), frame);
-}
-
-pub fn getCharset(self: *const Script) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("charset")) orelse "";
-}
-
-pub fn setCharset(self: *Script, value: []const u8, frame: *Frame) !void {
-    return self.asElement().setAttributeSafe(comptime .wrap("charset"), .wrap(value), frame);
-}
-
 pub fn getAsync(self: *const Script) bool {
     return self._force_async or self.asConstElement().getAttributeSafe(comptime .wrap("async")) != null;
 }
@@ -93,22 +69,6 @@ pub fn setAsync(self: *Script, value: bool, frame: *Frame) !void {
     } else {
         try self.asElement().removeAttribute(comptime .wrap("async"), frame);
     }
-}
-
-pub fn getDefer(self: *const Script) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("defer")) != null;
-}
-
-pub fn setDefer(self: *Script, value: bool, frame: *Frame) !void {
-    if (value) {
-        try self.asElement().setAttributeSafe(comptime .wrap("defer"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("defer"), frame);
-    }
-}
-
-pub fn getNoModule(self: *const Script) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("nomodule")) != null;
 }
 
 pub fn setInnerText(self: *Script, text: []const u8, frame: *Frame) !void {
@@ -135,13 +95,19 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Script);
+    pub const crossOrigin = reflect.enumerated("crossorigin", &.{ "anonymous", "use-credentials" }, .{ .missing = null, .nullable = true, .invalid = "anonymous" });
+    pub const integrity = reflect.string("integrity");
+    pub const htmlFor = reflect.string("for");
+    pub const event = reflect.string("event");
+
     pub const src = bridge.accessor(Script.getSrc, Script.setSrc, .{ .ce_reactions = true });
-    pub const @"defer" = bridge.accessor(Script.getDefer, Script.setDefer, .{ .ce_reactions = true });
+    pub const @"defer" = reflect.boolean("defer");
     pub const async = bridge.accessor(Script.getAsync, Script.setAsync, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Script.getType, Script.setType, .{ .ce_reactions = true });
-    pub const nonce = bridge.accessor(Script.getNonce, Script.setNonce, .{ .ce_reactions = true });
-    pub const charset = bridge.accessor(Script.getCharset, Script.setCharset, .{ .ce_reactions = true });
-    pub const noModule = bridge.accessor(Script.getNoModule, null, .{});
+    pub const @"type" = reflect.string("type");
+    pub const nonce = reflect.string("nonce");
+    pub const charset = reflect.string("charset");
+    pub const noModule = reflect.boolean("nomodule");
     pub const supports = bridge.function(Script.supports, .{ .static = true });
     pub const innerText = bridge.accessor(_innerText, Script.setInnerText, .{ .ce_reactions = true });
     fn _innerText(self: *Script, frame: *const Frame) ![]const u8 {

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -171,78 +171,11 @@ pub fn setSelectedIndex(self: *Select, index: i32) !void {
     }
 }
 
-pub fn getMultiple(self: *const Select) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("multiple")) != null;
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-type
 // The `type` IDL attribute reflects the element's mode: "select-multiple" when
 // the `multiple` attribute is present, "select-one" otherwise.
 pub fn getType(self: *const Select) []const u8 {
     return if (self.getMultiple()) "select-multiple" else "select-one";
-}
-
-pub fn setMultiple(self: *Select, multiple: bool, frame: *Frame) !void {
-    if (multiple) {
-        try self.asElement().setAttributeSafe(comptime .wrap("multiple"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("multiple"), frame);
-    }
-}
-
-pub fn getDisabled(self: *const Select) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *Select, disabled: bool, frame: *Frame) !void {
-    if (disabled) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
-pub fn getName(self: *const Select) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Select, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
-pub fn getSize(self: *const Select) u32 {
-    const s = self.asConstElement().getAttributeSafe(comptime .wrap("size")) orelse return 0;
-
-    const trimmed = std.mem.trimStart(u8, s, &std.ascii.whitespace);
-
-    var end: usize = 0;
-    for (trimmed) |b| {
-        if (!std.ascii.isDigit(b)) {
-            break;
-        }
-        end += 1;
-    }
-    if (end == 0) {
-        return 0;
-    }
-    return std.fmt.parseInt(u32, trimmed[0..end], 10) catch 0;
-}
-
-pub fn setSize(self: *Select, size: u32, frame: *Frame) !void {
-    const size_string = try std.fmt.allocPrint(frame.call_arena, "{d}", .{size});
-    try self.asElement().setAttributeSafe(comptime .wrap("size"), .wrap(size_string), frame);
-}
-
-pub fn getRequired(self: *const Select) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
-}
-
-pub fn setRequired(self: *Select, required: bool, frame: *Frame) !void {
-    if (required) {
-        try self.asElement().setAttributeSafe(comptime .wrap("required"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("required"), frame);
-    }
 }
 
 pub fn getOptions(self: *Select, frame: *Frame) !*collections.HTMLOptionsCollection {
@@ -393,6 +326,18 @@ pub fn suffersValueMissing(self: *const Select) bool {
     return false;
 }
 
+pub fn getDisabled(self: *const Select) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
+}
+
+pub fn getMultiple(self: *const Select) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("multiple")) != null;
+}
+
+pub fn getRequired(self: *const Select) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Select);
 
@@ -402,17 +347,19 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Select);
+
     pub const value = bridge.accessor(Select.getValue, Select.setValue, .{});
     pub const @"type" = bridge.accessor(Select.getType, null, .{});
     pub const selectedIndex = bridge.accessor(Select.getSelectedIndex, Select.setSelectedIndex, .{});
-    pub const multiple = bridge.accessor(Select.getMultiple, Select.setMultiple, .{ .ce_reactions = true });
-    pub const disabled = bridge.accessor(Select.getDisabled, Select.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(Select.getName, Select.setName, .{ .ce_reactions = true });
-    pub const required = bridge.accessor(Select.getRequired, Select.setRequired, .{ .ce_reactions = true });
+    pub const multiple = reflect.boolean("multiple");
+    pub const disabled = reflect.boolean("disabled");
+    pub const name = reflect.string("name");
+    pub const required = reflect.boolean("required");
     pub const options = bridge.accessor(Select.getOptions, null, .{});
     pub const selectedOptions = bridge.accessor(Select.getSelectedOptions, null, .{});
     pub const form = bridge.accessor(Select.getForm, null, .{});
-    pub const size = bridge.accessor(Select.getSize, Select.setSize, .{ .ce_reactions = true });
+    pub const size = reflect.unsignedLong("size", .{});
     pub const length = bridge.accessor(Select.getLength, null, .{});
     pub const labels = bridge.accessor(Select.getLabels, null, .{});
     pub const willValidate = bridge.accessor(Select.getWillValidate, null, .{});

--- a/src/browser/webapi/element/html/Slot.zig
+++ b/src/browser/webapi/element/html/Slot.zig
@@ -32,14 +32,6 @@ pub fn asNode(self: *Slot) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getName(self: *const Slot) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *Slot, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
 const AssignedNodesOptions = struct {
     flatten: bool = false,
 };
@@ -157,6 +149,10 @@ pub fn assign(self: *Slot, values: []const js.Value, frame: *Frame) !void {
     }
 }
 
+pub fn getName(self: *const Slot) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Slot);
 
@@ -166,7 +162,9 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const name = bridge.accessor(Slot.getName, Slot.setName, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Slot);
+
+    pub const name = reflect.string("name");
     pub const assignedNodes = bridge.function(Slot.assignedNodes, .{});
     pub const assignedElements = bridge.function(Slot.assignedElements, .{});
     pub const assign = bridge.function(Slot.assign, .{});

--- a/src/browser/webapi/element/html/Source.zig
+++ b/src/browser/webapi/element/html/Source.zig
@@ -1,5 +1,4 @@
 const lp = @import("lightpanda");
-const std = @import("std");
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
@@ -37,58 +36,6 @@ pub fn setSrc(self: *Source, value: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
 }
 
-pub fn getSrcset(self: *const Source) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("srcset")) orelse "";
-}
-
-pub fn setSrcset(self: *Source, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("srcset"), .wrap(value), frame);
-}
-
-pub fn getSizes(self: *const Source) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("sizes")) orelse "";
-}
-
-pub fn setSizes(self: *Source, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("sizes"), .wrap(value), frame);
-}
-
-pub fn getMedia(self: *const Source) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("media")) orelse "";
-}
-
-pub fn setMedia(self: *Source, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("media"), .wrap(value), frame);
-}
-
-pub fn getType(self: *const Source) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Source, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getWidth(self: *const Source) u32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("width")) orelse return 0;
-    return std.fmt.parseUnsigned(u32, attr, 10) catch 0;
-}
-
-pub fn setWidth(self: *Source, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("width"), .wrap(str), frame);
-}
-
-pub fn getHeight(self: *const Source) u32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("height")) orelse return 0;
-    return std.fmt.parseUnsigned(u32, attr, 10) catch 0;
-}
-
-pub fn setHeight(self: *Source, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("height"), .wrap(str), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Source);
 
@@ -98,13 +45,15 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const height = bridge.accessor(Source.getHeight, Source.setHeight, .{ .ce_reactions = true });
-    pub const media = bridge.accessor(Source.getMedia, Source.setMedia, .{ .ce_reactions = true });
-    pub const sizes = bridge.accessor(Source.getSizes, Source.setSizes, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Source);
+
+    pub const height = reflect.unsignedLong("height", .{});
+    pub const media = reflect.string("media");
+    pub const sizes = reflect.string("sizes");
     pub const src = bridge.accessor(Source.getSrc, Source.setSrc, .{ .ce_reactions = true });
-    pub const srcset = bridge.accessor(Source.getSrcset, Source.setSrcset, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Source.getType, Source.setType, .{ .ce_reactions = true });
-    pub const width = bridge.accessor(Source.getWidth, Source.setWidth, .{ .ce_reactions = true });
+    pub const srcset = reflect.string("srcset");
+    pub const @"type" = reflect.string("type");
+    pub const width = reflect.unsignedLong("width", .{});
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Style.zig
+++ b/src/browser/webapi/element/html/Style.zig
@@ -44,42 +44,6 @@ pub fn asNode(self: *Style) *Node {
 
 // Attribute-backed properties
 
-pub fn getBlocking(self: *const Style) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("blocking")) orelse "";
-}
-
-pub fn setBlocking(self: *Style, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("blocking"), .wrap(value), frame);
-}
-
-pub fn getMedia(self: *const Style) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("media")) orelse "";
-}
-
-pub fn setMedia(self: *Style, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("media"), .wrap(value), frame);
-}
-
-pub fn getType(self: *const Style) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
-}
-
-pub fn setType(self: *Style, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("type"), .wrap(value), frame);
-}
-
-pub fn getDisabled(self: *const Style) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *Style, disabled: bool, frame: *Frame) !void {
-    if (disabled) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
 const CSSStyleSheet = @import("../../css/CSSStyleSheet.zig");
 pub fn getSheet(self: *Style, frame: *Frame) !?*CSSStyleSheet {
     // Per spec, sheet is null for disconnected elements or non-CSS types.
@@ -121,6 +85,10 @@ pub fn styleAddedCallback(self: *Style, frame: *Frame) !void {
     try frame.queueLoad(Factory.protoOf(self));
 }
 
+pub fn getType(self: *const Style) []const u8 {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("type")) orelse "";
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Style);
 
@@ -130,10 +98,13 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const blocking = bridge.accessor(Style.getBlocking, Style.setBlocking, .{ .ce_reactions = true });
-    pub const media = bridge.accessor(Style.getMedia, Style.setMedia, .{ .ce_reactions = true });
-    pub const @"type" = bridge.accessor(Style.getType, Style.setType, .{ .ce_reactions = true });
-    pub const disabled = bridge.accessor(Style.getDisabled, Style.setDisabled, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Style);
+    pub const nonce = reflect.string("nonce");
+
+    pub const blocking = reflect.string("blocking");
+    pub const media = reflect.string("media");
+    pub const @"type" = reflect.string("type");
+    pub const disabled = reflect.boolean("disabled");
     pub const sheet = bridge.accessor(Style.getSheet, null, .{});
 };
 

--- a/src/browser/webapi/element/html/Table.zig
+++ b/src/browser/webapi/element/html/Table.zig
@@ -122,6 +122,17 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Table);
+    pub const width = reflect.string("width");
+    pub const summary = reflect.string("summary");
+    pub const rules = reflect.string("rules");
+    pub const frame = reflect.string("frame");
+    pub const cellSpacing = reflect.stringNullToEmpty("cellspacing");
+    pub const cellPadding = reflect.stringNullToEmpty("cellpadding");
+    pub const border = reflect.string("border");
+    pub const bgColor = reflect.stringNullToEmpty("bgcolor");
+    pub const @"align" = reflect.string("align");
+
     pub const tBodies = bridge.accessor(Table.getTBodies, null, .{});
     pub const deleteRow = bridge.function(Table.deleteRow, .{ .ce_reactions = true });
 };

--- a/src/browser/webapi/element/html/TableCaption.zig
+++ b/src/browser/webapi/element/html/TableCaption.zig
@@ -27,4 +27,7 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(TableCaption);
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/TableCell.zig
+++ b/src/browser/webapi/element/html/TableCell.zig
@@ -1,4 +1,3 @@
-const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
@@ -25,29 +24,6 @@ pub fn asNode(self: *TableCell) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getColSpan(self: *TableCell) u32 {
-    const attr = self.asElement().getAttributeSafe(comptime .wrap("colspan")) orelse return 1;
-    const v = std.fmt.parseUnsigned(u32, attr, 10) catch return 1;
-    if (v == 0) return 1;
-    return @min(v, 1000);
-}
-
-pub fn setColSpan(self: *TableCell, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("colspan"), .wrap(str), frame);
-}
-
-pub fn getRowSpan(self: *TableCell) u32 {
-    const attr = self.asElement().getAttributeSafe(comptime .wrap("rowspan")) orelse return 1;
-    const v = std.fmt.parseUnsigned(u32, attr, 10) catch return 1;
-    return @min(v, 65534);
-}
-
-pub fn setRowSpan(self: *TableCell, value: u32, frame: *Frame) !void {
-    const str = try std.fmt.allocPrint(frame.call_arena, "{d}", .{value});
-    try self.asElement().setAttributeSafe(comptime .wrap("rowspan"), .wrap(str), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(TableCell);
 
@@ -57,8 +33,22 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const colSpan = bridge.accessor(TableCell.getColSpan, TableCell.setColSpan, .{ .ce_reactions = true });
-    pub const rowSpan = bridge.accessor(TableCell.getRowSpan, TableCell.setRowSpan, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(TableCell);
+    pub const scope = reflect.enumerated("scope", &.{ "row", "col", "rowgroup", "colgroup" }, .{});
+    pub const noWrap = reflect.boolean("nowrap");
+    pub const width = reflect.string("width");
+    pub const vAlign = reflect.string("valign");
+    pub const height = reflect.string("height");
+    pub const headers = reflect.string("headers");
+    pub const chOff = reflect.string("charoff");
+    pub const ch = reflect.string("char");
+    pub const bgColor = reflect.stringNullToEmpty("bgcolor");
+    pub const axis = reflect.string("axis");
+    pub const @"align" = reflect.string("align");
+    pub const abbr = reflect.string("abbr");
+
+    pub const colSpan = reflect.unsignedLong("colspan", .{ .default = 1, .clamp = .{ .min = 1, .max = 1000 } });
+    pub const rowSpan = reflect.unsignedLong("rowspan", .{ .default = 1, .clamp = .{ .min = 0, .max = 65534 } });
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/TableCol.zig
+++ b/src/browser/webapi/element/html/TableCol.zig
@@ -31,4 +31,12 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(TableCol);
+    pub const span = reflect.unsignedLong("span", .{ .default = 1, .clamp = .{ .min = 1, .max = 1000 } });
+    pub const width = reflect.string("width");
+    pub const vAlign = reflect.string("valign");
+    pub const chOff = reflect.string("charoff");
+    pub const ch = reflect.string("char");
+    pub const @"align" = reflect.string("align");
 };

--- a/src/browser/webapi/element/html/TableRow.zig
+++ b/src/browser/webapi/element/html/TableRow.zig
@@ -34,5 +34,12 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(TableRow);
+    pub const vAlign = reflect.string("valign");
+    pub const chOff = reflect.string("charoff");
+    pub const ch = reflect.string("char");
+    pub const bgColor = reflect.stringNullToEmpty("bgcolor");
+    pub const @"align" = reflect.string("align");
+
     pub const cells = bridge.accessor(TableRow.getCells, null, .{});
 };

--- a/src/browser/webapi/element/html/TableSection.zig
+++ b/src/browser/webapi/element/html/TableSection.zig
@@ -38,5 +38,11 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(TableSection);
+    pub const vAlign = reflect.string("valign");
+    pub const chOff = reflect.string("charoff");
+    pub const ch = reflect.string("char");
+    pub const @"align" = reflect.string("align");
+
     pub const rows = bridge.accessor(TableSection.getRows, null, .{});
 };

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -30,6 +30,7 @@ const Selection = @import("../../Selection.zig");
 const Event = @import("../../Event.zig");
 const InputEvent = @import("../../event/InputEvent.zig");
 const ValidityState = @import("ValidityState.zig");
+const reflection = @import("../reflection.zig");
 
 const TextArea = @This();
 
@@ -114,64 +115,12 @@ pub fn setDefaultValue(self: *TextArea, value: []const u8, frame: *Frame) !void 
     _ = try node.appendChild(text_node, frame);
 }
 
-pub fn getDisabled(self: *const TextArea) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
-}
-
-pub fn setDisabled(self: *TextArea, disabled: bool, frame: *Frame) !void {
-    if (disabled) {
-        try self.asElement().setAttributeSafe(comptime .wrap("disabled"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("disabled"), frame);
-    }
-}
-
-pub fn getName(self: *const TextArea) []const u8 {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("name")) orelse "";
-}
-
-pub fn setName(self: *TextArea, name: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("name"), .wrap(name), frame);
-}
-
-pub fn getRequired(self: *const TextArea) bool {
-    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
-}
-
-pub fn setRequired(self: *TextArea, required: bool, frame: *Frame) !void {
-    if (required) {
-        try self.asElement().setAttributeSafe(comptime .wrap("required"), .wrap(""), frame);
-    } else {
-        try self.asElement().removeAttribute(comptime .wrap("required"), frame);
-    }
-}
-
 pub fn getMaxLength(self: *const TextArea) i32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("maxlength")) orelse return -1;
-    return std.fmt.parseInt(i32, attr, 10) catch -1;
-}
-
-pub fn setMaxLength(self: *TextArea, max_length: i32, frame: *Frame) !void {
-    if (max_length < 0) {
-        return error.IndexSizeError;
-    }
-    var buf: [32]u8 = undefined;
-    const value = std.fmt.bufPrint(&buf, "{d}", .{max_length}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap("maxlength"), .wrap(value), frame);
+    return reflection.getLimitedLong(self.asConstElement(), comptime .wrap("maxlength"));
 }
 
 pub fn getMinLength(self: *const TextArea) i32 {
-    const attr = self.asConstElement().getAttributeSafe(comptime .wrap("minlength")) orelse return -1;
-    return std.fmt.parseInt(i32, attr, 10) catch -1;
-}
-
-pub fn setMinLength(self: *TextArea, min_length: i32, frame: *Frame) !void {
-    if (min_length < 0) {
-        return error.IndexSizeError;
-    }
-    var buf: [32]u8 = undefined;
-    const value = std.fmt.bufPrint(&buf, "{d}", .{min_length}) catch unreachable;
-    try self.asElement().setAttributeSafe(comptime .wrap("minlength"), .wrap(value), frame);
+    return reflection.getLimitedLong(self.asConstElement(), comptime .wrap("minlength"));
 }
 
 pub fn select(self: *TextArea, frame: *Frame) !void {
@@ -391,6 +340,14 @@ pub fn suffersTooShort(self: *const TextArea) bool {
     return count < @as(usize, @intCast(min));
 }
 
+pub fn getDisabled(self: *const TextArea) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
+}
+
+pub fn getRequired(self: *const TextArea) bool {
+    return self.asConstElement().getAttributeSafe(comptime .wrap("required")) != null;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(TextArea);
 
@@ -399,6 +356,14 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(TextArea);
+    pub const rows = reflect.unsignedLong("rows", .{ .default = 2, .positive = true, .fallback = true });
+    pub const cols = reflect.unsignedLong("cols", .{ .default = 20, .positive = true, .fallback = true });
+    pub const readOnly = reflect.boolean("readonly");
+    pub const wrap = reflect.string("wrap");
+    pub const placeholder = reflect.string("placeholder");
+    pub const dirName = reflect.string("dirname");
 
     pub const labels = bridge.accessor(TextArea.getLabels, null, .{});
     pub const willValidate = bridge.accessor(TextArea.getWillValidate, null, .{});
@@ -410,11 +375,11 @@ pub const JsApi = struct {
     pub const onselectionchange = bridge.accessor(TextArea.getOnSelectionChange, TextArea.setOnSelectionChange, .{});
     pub const value = bridge.accessor(TextArea.getValue, TextArea.setValue, .{});
     pub const defaultValue = bridge.accessor(TextArea.getDefaultValue, TextArea.setDefaultValue, .{ .ce_reactions = true });
-    pub const disabled = bridge.accessor(TextArea.getDisabled, TextArea.setDisabled, .{ .ce_reactions = true });
-    pub const name = bridge.accessor(TextArea.getName, TextArea.setName, .{ .ce_reactions = true });
-    pub const required = bridge.accessor(TextArea.getRequired, TextArea.setRequired, .{ .ce_reactions = true });
-    pub const maxLength = bridge.accessor(TextArea.getMaxLength, TextArea.setMaxLength, .{ .ce_reactions = true });
-    pub const minLength = bridge.accessor(TextArea.getMinLength, TextArea.setMinLength, .{ .ce_reactions = true });
+    pub const disabled = reflect.boolean("disabled");
+    pub const name = reflect.string("name");
+    pub const required = reflect.boolean("required");
+    pub const maxLength = reflect.limitedLong("maxlength");
+    pub const minLength = reflect.limitedLong("minlength");
     pub const form = bridge.accessor(TextArea.getForm, null, .{});
     pub const select = bridge.function(TextArea.select, .{});
 

--- a/src/browser/webapi/element/html/Time.zig
+++ b/src/browser/webapi/element/html/Time.zig
@@ -20,14 +20,6 @@ pub fn asNode(self: *Time) *Node {
     return self.asElement().asNode();
 }
 
-pub fn getDateTime(self: *Time) []const u8 {
-    return self.asElement().getAttributeSafe(comptime .wrap("datetime")) orelse "";
-}
-
-pub fn setDateTime(self: *Time, value: []const u8, frame: *Frame) !void {
-    try self.asElement().setAttributeSafe(comptime .wrap("datetime"), .wrap(value), frame);
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Time);
 
@@ -37,7 +29,9 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const dateTime = bridge.accessor(Time.getDateTime, Time.setDateTime, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Time);
+
+    pub const dateTime = reflect.string("datetime");
 };
 
 const testing = @import("../../../../testing.zig");

--- a/src/browser/webapi/element/html/Track.zig
+++ b/src/browser/webapi/element/html/Track.zig
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const std = @import("std");
 const lp = @import("lightpanda");
 
 const js = @import("../../../js/js.zig");
@@ -45,38 +44,6 @@ pub fn asNode(self: *Track) *Node {
     return self.asElement().asNode();
 }
 
-pub fn setKind(self: *Track, maybe_kind: ?String) void {
-    const kind = maybe_kind orelse {
-        self._kind = comptime .wrap("metadata");
-        return;
-    };
-
-    // Special case, for some reason, FF does this case-insensitive.
-    if (std.ascii.eqlIgnoreCase(kind.str(), "subtitles")) {
-        self._kind = comptime .wrap("subtitles");
-        return;
-    }
-    if (kind.eql(comptime .wrap("captions"))) {
-        self._kind = comptime .wrap("captions");
-        return;
-    }
-    if (kind.eql(comptime .wrap("descriptions"))) {
-        self._kind = comptime .wrap("descriptions");
-        return;
-    }
-    if (kind.eql(comptime .wrap("chapters"))) {
-        self._kind = comptime .wrap("chapters");
-        return;
-    }
-
-    // Anything else must be considered as `metadata`.
-    self._kind = comptime .wrap("metadata");
-}
-
-pub fn getKind(self: *const Track) String {
-    return self._kind;
-}
-
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Track);
 
@@ -86,7 +53,13 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const kind = bridge.accessor(Track.getKind, Track.setKind, .{ .ce_reactions = true });
+    const reflect = Element.Reflect(Track);
+    pub const src = reflect.url("src");
+    pub const default = reflect.boolean("default");
+    pub const srclang = reflect.string("srclang");
+    pub const label = reflect.string("label");
+
+    pub const kind = reflect.enumerated("kind", &.{ "subtitles", "captions", "descriptions", "chapters", "metadata" }, .{ .missing = "subtitles", .invalid = "metadata" });
 
     pub const NONE = bridge.property(@as(u16, @intFromEnum(ReadyState.none)), .{ .template = true });
     pub const LOADING = bridge.property(@as(u16, @intFromEnum(ReadyState.loading)), .{ .template = true });

--- a/src/browser/webapi/element/html/UL.zig
+++ b/src/browser/webapi/element/html/UL.zig
@@ -44,4 +44,8 @@ pub const JsApi = struct {
         pub const prototype_chain = bridge.prototypeChain();
         pub var class_id: bridge.ClassId = undefined;
     };
+
+    const reflect = Element.Reflect(UL);
+    pub const compact = reflect.boolean("compact");
+    pub const @"type" = reflect.string("type");
 };

--- a/src/browser/webapi/element/html/Video.zig
+++ b/src/browser/webapi/element/html/Video.zig
@@ -78,6 +78,11 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    const reflect = Element.Reflect(Video);
+    pub const width = reflect.unsignedLong("width", .{});
+    pub const height = reflect.unsignedLong("height", .{});
+    pub const playsInline = reflect.boolean("playsinline");
+
     pub const poster = bridge.accessor(Video.getPoster, Video.setPoster, .{ .ce_reactions = true });
     pub const videoWidth = bridge.accessor(Video.getVideoWidth, null, .{});
     pub const videoHeight = bridge.accessor(Video.getVideoHeight, null, .{});

--- a/src/browser/webapi/element/reflection.zig
+++ b/src/browser/webapi/element/reflection.zig
@@ -1,0 +1,396 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+const js = @import("../../js/js.zig");
+const Frame = @import("../../Frame.zig");
+const Factory = @import("../../Factory.zig");
+
+const Element = @import("../Element.zig");
+
+const String = lp.String;
+
+const max_long: i64 = 2147483647;
+
+pub const UnsignedLongOpts = struct {
+    default: u32 = 0,
+    // limited to only non-negative numbers greater than zero: 0 is
+    // IndexSizeError on setting; with `fallback`, 0 becomes the default.
+    positive: bool = false,
+    fallback: bool = false,
+    // clamped to the range [min, max]
+    clamp: ?struct { min: u32, max: u32 } = null,
+};
+
+pub const EnumOpts = struct {
+    // missing value default; null means the attribute reflects as null
+    missing: ?[]const u8 = "",
+    // invalid value default; defaults to `missing`
+    invalid: ?[]const u8 = null,
+    // IDL attribute is nullable (setting null removes the attribute)
+    nullable: bool = false,
+};
+
+pub fn Reflect(comptime T: type) type {
+    return struct {
+        const bridge = js.Bridge(T);
+
+        pub fn string(comptime attr: []const u8) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) []const u8 {
+                    return element(self).getAttributeSafe(.wrap(attr)) orelse "";
+                }
+                fn set(self: *T, value: []const u8, frame: *Frame) !void {
+                    try element(self).setAttributeSafe(.wrap(attr), .wrap(value), frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn stringNullToEmpty(comptime attr: []const u8) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) []const u8 {
+                    return element(self).getAttributeSafe(.wrap(attr)) orelse "";
+                }
+                fn set(self: *T, value: js.Value, frame: *Frame) !void {
+                    const str = if (value.isNull()) "" else try value.toStringSlice();
+                    try element(self).setAttributeSafe(.wrap(attr), .wrap(str), frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn url(comptime attr: []const u8) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T, frame: *Frame) ![]const u8 {
+                    const el = element(self);
+                    const value = el.getAttributeSafe(.wrap(attr)) orelse return "";
+                    return el.asConstNode().resolveURLReflect(value, frame, .{});
+                }
+                fn set(self: *T, value: []const u8, frame: *Frame) !void {
+                    try element(self).setAttributeSafe(.wrap(attr), .wrap(value), frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn boolean(comptime attr: []const u8) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) bool {
+                    return element(self).hasAttributeSafe(.wrap(attr));
+                }
+                fn set(self: *T, value: bool, frame: *Frame) !void {
+                    const el = element(self);
+                    if (value) {
+                        try el.setAttributeSafe(.wrap(attr), String.empty, frame);
+                    } else {
+                        try el.removeAttribute(.wrap(attr), frame);
+                    }
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn enumerated(comptime attr: []const u8, comptime keywords: []const []const u8, comptime opts: EnumOpts) js.bridge.Accessor {
+            const invalid = opts.invalid orelse opts.missing;
+            const R = struct {
+                fn get(self: *const T) ?[]const u8 {
+                    return enumeratedValue(element(self).getAttributeSafe(.wrap(attr)), keywords, opts.missing, invalid);
+                }
+                fn set(self: *T, value: []const u8, frame: *Frame) !void {
+                    try element(self).setAttributeSafe(.wrap(attr), .wrap(value), frame);
+                }
+                fn setNullable(self: *T, value: ?[]const u8, frame: *Frame) !void {
+                    const el = element(self);
+                    if (value) |v| {
+                        try el.setAttributeSafe(.wrap(attr), .wrap(v), frame);
+                    } else {
+                        try el.removeAttribute(.wrap(attr), frame);
+                    }
+                }
+            };
+            if (opts.nullable) {
+                return bridge.accessor(R.get, R.setNullable, .{ .ce_reactions = true });
+            }
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn referrerPolicy() js.bridge.Accessor {
+            const referrer_policies = [_][]const u8{
+                "",
+                "no-referrer",
+                "no-referrer-when-downgrade",
+                "same-origin",
+                "origin",
+                "strict-origin",
+                "origin-when-cross-origin",
+                "strict-origin-when-cross-origin",
+                "unsafe-url",
+            };
+            return enumerated("referrerpolicy", &referrer_policies, .{});
+        }
+
+        pub fn long(comptime attr: []const u8, comptime default: i32) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) i32 {
+                    const value = element(self).getAttributeSafe(.wrap(attr)) orelse return default;
+                    const parsed = parseInteger(value) orelse return default;
+                    if (parsed < -max_long - 1 or parsed > max_long) {
+                        return default;
+                    }
+                    return @intCast(parsed);
+                }
+                fn set(self: *T, value: i32, frame: *Frame) !void {
+                    try setInteger(element(self), attr, value, frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        // unsigned, but -1 is used to signal no limit
+        pub fn limitedLong(comptime attr: []const u8) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) i32 {
+                    return getLimitedLong(element(self), .wrap(attr));
+                }
+                fn set(self: *T, value: i32, frame: *Frame) !void {
+                    if (value < 0) {
+                        return error.IndexSizeError;
+                    }
+                    try setInteger(element(self), attr, value, frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn unsignedLong(comptime attr: []const u8, comptime opts: UnsignedLongOpts) js.bridge.Accessor {
+            const min: i64 = if (opts.clamp) |c| c.min else if (opts.positive) 1 else 0;
+            const max: i64 = if (opts.clamp) |c| c.max else max_long;
+            const R = struct {
+                fn get(self: *const T) u32 {
+                    const value = element(self).getAttributeSafe(.wrap(attr)) orelse return opts.default;
+                    const parsed = parseInteger(value) orelse return opts.default;
+                    if (parsed < 0) {
+                        return opts.default;
+                    }
+                    if (opts.clamp != null) {
+                        return @intCast(std.math.clamp(parsed, min, max));
+                    }
+                    if (parsed < min or parsed > max) {
+                        return opts.default;
+                    }
+                    return @intCast(parsed);
+                }
+                fn set(self: *T, value: u32, frame: *Frame) !void {
+                    if (opts.positive and !opts.fallback and value == 0) {
+                        return error.IndexSizeError;
+                    }
+                    // clamping is a getter rule; setting is a plain unsigned long
+                    const set_min: i64 = if (opts.positive) 1 else 0;
+                    var n: i64 = value;
+                    if (n < set_min or n > max_long) {
+                        n = if (opts.fallback or opts.default != 0) opts.default else 0;
+                    }
+                    try setInteger(element(self), attr, n, frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        pub fn double(comptime attr: []const u8, comptime default: f64, comptime positive: bool) js.bridge.Accessor {
+            const R = struct {
+                fn get(self: *const T) f64 {
+                    const value = element(self).getAttributeSafe(.wrap(attr)) orelse return default;
+                    const parsed = parseFloat(value) orelse return default;
+                    if (positive and parsed <= 0) {
+                        return default;
+                    }
+                    return parsed;
+                }
+                fn set(self: *T, value: f64, frame: *Frame) !void {
+                    if (!std.math.isFinite(value)) {
+                        return error.TypeError;
+                    }
+                    if (positive and value <= 0) {
+                        return;
+                    }
+                    // JS's Number-to-string is the "best representation"
+                    const str = try (try frame.js.local.?.newNumber(value)).toStringSlice();
+                    try element(self).setAttributeSafe(.wrap(attr), .wrap(str), frame);
+                }
+            };
+            return bridge.accessor(R.get, R.set, .{ .ce_reactions = true });
+        }
+
+        fn element(self: anytype) *Element {
+            const proto = Factory.protoOf(self);
+            if (@TypeOf(proto) == *Element) {
+                return proto;
+            }
+            return proto.asElement();
+        }
+
+        // comptime SSO when the name fits (fast compare), a plain slice String otherwise
+        fn name(comptime attr: []const u8) String {
+            if (comptime attr.len <= 12) {
+                return comptime .wrap(attr);
+            }
+            return .wrap(attr);
+        }
+    };
+}
+
+// Enumerated attribute limited to only known values: the canonical keyword,
+// or the missing/invalid default. Shared with elements that read one internally.
+pub fn enumeratedValue(
+    value: ?[]const u8,
+    keywords: []const []const u8,
+    missing: ?[]const u8,
+    invalid: ?[]const u8,
+) ?[]const u8 {
+    const v = value orelse return missing;
+    for (keywords) |keyword| {
+        if (std.ascii.eqlIgnoreCase(v, keyword)) return keyword;
+    }
+    return invalid;
+}
+
+// unsigned, but returns -1 for no limit.
+pub fn getLimitedLong(el: *const Element, attr: String) i32 {
+    const value = el.getAttributeSafe(attr) orelse return -1;
+    const parsed = parseInteger(value) orelse return -1;
+    if (parsed < 0 or parsed > max_long) {
+        return -1;
+    }
+    return @intCast(parsed);
+}
+
+fn setInteger(el: *Element, comptime attr: []const u8, value: i64, frame: *Frame) !void {
+    var buf: [24]u8 = undefined;
+    const str = std.fmt.bufPrint(&buf, "{d}", .{value}) catch unreachable;
+    try el.setAttributeSafe(.wrap(attr), .wrap(str), frame);
+}
+
+// HTML "rules for parsing integers". Saturates instead of failing on
+// absurdly long digit runs so the clamped reflections still see "too big".
+pub fn parseInteger(input: []const u8) ?i64 {
+    var s = std.mem.trimStart(u8, input, "\t\n\x0c\r ");
+    if (s.len == 0) {
+        return null;
+    }
+
+    var negative = false;
+    if (s[0] == '-') {
+        negative = true;
+        s = s[1..];
+    } else if (s[0] == '+') {
+        s = s[1..];
+    }
+    if (s.len == 0 or !std.ascii.isDigit(s[0])) {
+        return null;
+    }
+
+    var value: i64 = 0;
+    for (s) |c| {
+        if (std.ascii.isDigit(c) == false) {
+            break;
+        }
+        if (value < (1 << 53)) {
+            value = value * 10 + (c - '0');
+        }
+    }
+    return if (negative) -value else value;
+}
+
+// HTML "rules for parsing floating-point number values". The grammar isn't
+// the same as Zig's, so we need to validate by hand, but can let std do some
+// of the work
+fn parseFloat(input: []const u8) ?f64 {
+    const s = std.mem.trimStart(u8, input, "\t\n\x0c\r ");
+    var i: usize = 0;
+    if (i < s.len and (s[i] == '-' or s[i] == '+')) {
+        i += 1;
+    }
+
+    var digits = false;
+    while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) {
+        digits = true;
+    }
+
+    if (i < s.len and s[i] == '.' and i + 1 < s.len and std.ascii.isDigit(s[i + 1])) {
+        i += 1;
+        while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) {
+            digits = true;
+        }
+    }
+    if (digits == false) {
+        return null;
+    }
+
+    var end = i;
+    if (i < s.len and (s[i] == 'e' or s[i] == 'E')) {
+        var j = i + 1;
+        if (j < s.len and (s[j] == '-' or s[j] == '+')) {
+            j += 1;
+        }
+        if (j < s.len and std.ascii.isDigit(s[j])) {
+            while (j < s.len and std.ascii.isDigit(s[j])) {
+                j += 1;
+            }
+            end = j;
+        }
+    }
+    const value = std.fmt.parseFloat(f64, s[0..end]) catch return null;
+    if (std.math.isFinite(value) == false) {
+        return null;
+    }
+    return value;
+}
+
+const testing = @import("../../../testing.zig");
+test "reflect: parseInteger" {
+    try testing.expectEqual(7, parseInteger(" \t7"));
+    try testing.expectEqual(-36, parseInteger("-36abc"));
+    try testing.expectEqual(0, parseInteger("-0"));
+    try testing.expectEqual(100, parseInteger("+100"));
+    try testing.expectEqual(null, parseInteger(""));
+    try testing.expectEqual(null, parseInteger("-"));
+    try testing.expectEqual(null, parseInteger(".5"));
+    try testing.expectEqual(null, parseInteger("\u{a0}7"));
+    try testing.expect(parseInteger("99999999999999999999999999").? > max_long);
+}
+
+test "reflect: parseFloat" {
+    try testing.expectEqual(1.5, parseFloat(" 1.5"));
+    try testing.expectEqual(0.5, parseFloat(".5"));
+    try testing.expectEqual(1, parseFloat("1."));
+    try testing.expectEqual(100, parseFloat("1e2"));
+    try testing.expectEqual(100, parseFloat("1E+2"));
+    try testing.expectEqual(0.01, parseFloat("1e-2"));
+    try testing.expectEqual(1, parseFloat("1.e2"));
+    try testing.expectEqual(1, parseFloat("1e 2"));
+    try testing.expectEqual(1, parseFloat("1 e2"));
+    try testing.expectEqual(-1, parseFloat("-1"));
+    try testing.expectEqual(null, parseFloat(""));
+    try testing.expectEqual(null, parseFloat("-"));
+    try testing.expectEqual(null, parseFloat("."));
+    try testing.expectEqual(null, parseFloat("e5"));
+    try testing.expectEqual(null, parseFloat("1.8e308"));
+}


### PR DESCRIPTION
This adds a bunch of missing attributes to various HTML Elements, e.g. div.align.

These attributes all end up calling getAttribute and setAttribute, but with a fairly fixed set of transformation, e.g. fieldset.disabled has to be a boolean. So, a new helper has been added to generate bridge accessors. Existing accessor which are not used in Zig now use this helper.

**The only interesting change here is the addition of:** src/browser/webapi/element/reflection.zig

Should pass ~9400 WPT cases.