### PR TITLE
perf: Introduce Node.flags for lookup shortcircuit

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -634,7 +634,7 @@ fn eventPathParent(node: *Node, event: *Event, target_root: *Node, frame: ?*Fram
     }
 
     if (frame) |f| {
-        if (f._assigned_slots.get(node)) |slot| {
+        if (node.assignedSlot(f)) |slot| {
             return slot.asNode();
         }
     }

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -45,6 +45,7 @@ const Node = @This();
 pub const Proto = EventTarget;
 
 _type: Type,
+_flags: Flags = .{}, // Fits in existing struct padding.
 _parent: ?*Node = null,
 // The first child's `_prev` points at the LAST child (keeping lastChild
 // O(1)); the last child's `_next` is null. A detached node has null links.
@@ -66,6 +67,11 @@ pub const Type = enum(u8) {
     document_type,
     attribute,
     document_fragment,
+};
+
+pub const Flags = packed struct(u8) {
+    assigned_slot: bool = false,
+    _unused: u7 = 0,
 };
 
 pub fn Subtype(comptime tag: Type) type {
@@ -1694,6 +1700,14 @@ pub fn unlink(self: *Node, child: *Node) void {
     child._prev = null;
 }
 
+pub fn assignedSlot(self: *Node, frame: *const Frame) ?*Element.Html.Slot {
+    // optimized with a flag because this is probed for every hop of every event path
+    if (!self._flags.assigned_slot) {
+        return null;
+    }
+    return frame._assigned_slots.get(self);
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(Node);
 
@@ -1866,4 +1880,12 @@ pub const NodeOrText = union(enum) {
 const testing = @import("../../testing.zig");
 test "WebApi: Node" {
     try testing.htmlRunner("node", .{});
+}
+
+test "Node: text chain slot size" {
+    // Guard against accidental growth: new Node fields (e.g. _flags) must fit
+    // in existing padding. Debug is larger from the _proto_canary fields.
+    const Text = @import("cdata/Text.zig");
+    const slot = comptime Factory.chainOffsetOf(Text, Text) + @sizeOf(Text);
+    try testing.expectEqual(if (comptime lp.IS_DEBUG) 104 else 73, slot);
 }

--- a/src/browser/webapi/element/slotting.zig
+++ b/src/browser/webapi/element/slotting.zig
@@ -133,12 +133,14 @@ fn _assignSlottables(slot: *Slot, frame: *Frame) !void {
     for (old) |node| {
         if (frame._assigned_slots.get(node) == slot) {
             _ = frame._assigned_slots.remove(node);
+            node._flags.assigned_slot = false;
         }
     }
     slot._assigned.clearRetainingCapacity();
     try slot._assigned.appendSlice(frame.arena, slottables.items);
     for (slottables.items) |node| {
         try frame._assigned_slots.put(frame.arena, node, slot);
+        node._flags.assigned_slot = true;
     }
 }
 
@@ -205,7 +207,7 @@ pub fn removalSteps(parent: *Node, child: *Node, frame: *Frame) void {
         return;
     }
 
-    if (frame._assigned_slots.get(child)) |slot| {
+    if (child.assignedSlot(frame)) |slot| {
         assignSlottables(slot, frame);
     }
 
@@ -234,7 +236,7 @@ pub fn slotAttributeChanged(slottable: *Node, old_value: []const u8, value: []co
     if (frame._element_shadow_roots.count() == 0) {
         return;
     }
-    if (frame._assigned_slots.get(slottable)) |old_slot| {
+    if (slottable.assignedSlot(frame)) |old_slot| {
         assignSlottables(old_slot, frame);
     }
     assignASlot(slottable, frame);


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/3195 introduced a Flags within the padding of Element to avoid map lookups on the shadow dom piercing hot path.

This does the same thing for Node for Frame._assigned_slots. Node also has spare padding,and this lookup happens on every hot of every event path.