### PR TITLE
fix: replace bootstrap about:blank global on first navigation (#3215)

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -578,6 +578,11 @@ pub const BrowserContext = struct {
     inspector_session: *js.Inspector.Session,
     isolated_worlds: std.ArrayList(*IsolatedWorld),
 
+    // True when Runtime.evaluate has been run in the main world. Optimization
+    // so that, if it has _not_ and the page is on its initial about:blank, we
+    // can use the existing Frame/js.Context as-is.
+    main_world_touched: bool = false,
+
     // Scripts registered via Page.addScriptToEvaluateOnNewDocument.
     // Evaluated in each new document after navigation completes.
     scripts_on_new_document: std.ArrayList(ScriptOnNewDocument) = .empty,

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -300,13 +300,8 @@ fn navigate(cmd: *CDP.Command) !void {
 
     const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
 
-    // A cross-document navigation replaces the JS global object. Even a
-    // freshly-created about:blank target must not reuse its bootstrap
-    // context in place: a client can run JS on the blank page (Runtime.evaluate)
-    // before the first Page.navigate, and those globals would leak into the
-    // navigated document (issue #3215). Route every root navigation through
-    // initiateRootNavigation so a fresh page/window/global is committed and
-    // the blank one is discarded.
+    // Always do a full navigate to clear any state (e.g. vs Runtime.evaluate)
+    // that might have been built-up in a dummy about:blank page
     try session.initiateRootNavigation(frame._frame_id, encoded_url, .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
@@ -1631,12 +1626,8 @@ test "cdp.frame: navigate to about:blank replaces a non-blank document" {
     try testing.expect(v.toBool());
 }
 
-test "cdp.frame: first navigation replaces the bootstrap about:blank global (#3215)" {
-    // Regression test for #3215. A JS global set on a freshly-created target's
-    // initial about:blank page must not survive the first Page.navigate: a
-    // cross-document navigation replaces the JS global object. The second
-    // navigation already reset globals correctly; the leak was scoped to the
-    // bootstrap about:blank context being reused as the first navigated page.
+// https://github.com/lightpanda-io/browser/issues/3215
+test "cdp.frame: first navigation replaces the bootstrap about:blank global" {
     var ctx = try testing.context();
     defer ctx.deinit();
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -300,13 +300,23 @@ fn navigate(cmd: *CDP.Command) !void {
 
     const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
 
-    // Always do a full navigate to clear any state (e.g. vs Runtime.evaluate)
-    // that might have been built-up in a dummy about:blank page
-    try session.initiateRootNavigation(frame._frame_id, encoded_url, .{
+    const opts: Frame.NavigateOpts = .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
         .kind = .{ .push = null },
-    });
+    };
+
+    if (canNavigateInPlace(bc, frame)) {
+        return frame.navigate(encoded_url, opts);
+    }
+    try session.initiateRootNavigation(frame._frame_id, encoded_url, opts);
+}
+
+// Fast path that allows using the initial about:blank Frame as-is. Only safe
+// when the frame is still waiting for a navigate AND no JS has been run in the
+// instance (for about:blank, that's only possible via an Runtime.* call)
+fn canNavigateInPlace(bc: *const CDP.BrowserContext, frame: *const Frame) bool {
+    return frame._load_state == .waiting and !bc.main_world_touched;
 }
 
 fn doReload(cmd: *CDP.Command) !void {
@@ -422,7 +432,7 @@ fn navigateToHistoryEntry(cmd: *CDP.Command) !void {
         .kind = .{ .traverse = idx },
     };
 
-    if (frame._load_state == .waiting) {
+    if (canNavigateInPlace(bc, frame)) {
         return frame.navigate(url, opts);
     }
 
@@ -525,6 +535,7 @@ pub fn frameCreated(bc: *CDP.BrowserContext, frame: *Frame) !void {
 
     if (!in_commit) {
         _ = bc.cdp.frame_arena.reset(.{ .retain_with_limit = 1024 * 512 });
+        bc.main_world_touched = false;
     }
 
     for (bc.isolated_worlds.items) |isolated_world| {
@@ -1631,33 +1642,40 @@ test "cdp.frame: first navigation replaces the bootstrap about:blank global" {
     var ctx = try testing.context();
     defer ctx.deinit();
 
-    var bc = try ctx.loadBrowserContext(.{ .id = "BID-GLB", .target_id = "TID-GLB-000000".* });
-    bc.session_id = "SID-GLB";
-
-    // Create a fresh target whose root frame is the bootstrap about:blank
-    // document (this is what Target.createTarget {url: "about:blank"} does).
-    _ = try bc.session.createPage();
+    // A fresh, attached target sitting on its bootstrap about:blank document.
+    try ctx.processMessage(.{ .id = 69, .method = "Target.setAutoAttach", .params = .{ .autoAttach = true, .waitForDebuggerOnStart = false } });
+    try ctx.processMessage(.{ .id = 70, .method = "Target.createTarget", .params = .{ .url = "about:blank" } });
+    const bc = &ctx.cdp().browser_context.?;
     {
         const frame = bc.mainFrame() orelse unreachable;
         try testing.expectEqualSlices(u8, "about:blank", frame.url);
     }
 
-    // Simulate a client running JS on the blank page before navigating
-    // (Runtime.evaluate "window.leak = 'set-on-about-blank'").
+    // A client runs JS on the blank page before navigating. This must go
+    // through the CDP Runtime domain: that is what marks the bootstrap main
+    // world as touched and disables the in-place navigation fast path.
+    try ctx.processMessage(.{
+        .id = 71,
+        .method = "Runtime.evaluate",
+        .params = .{ .expression = "window.leak = 'set-on-about-blank'; window.leak" },
+        .sessionId = bc.session_id.?,
+    });
+    try ctx.expectSentResult(.{ .result = .{ .type = "string", .value = "set-on-about-blank" } }, .{ .id = 71 });
     {
         const frame = bc.mainFrame() orelse unreachable;
         var ls: js.Local.Scope = undefined;
         frame.js.localScope(&ls);
         defer ls.deinit();
-        const v = try ls.local.exec("window.leak = 'set-on-about-blank'; window.leak", null);
+        const v = try ls.local.exec("window.leak === 'set-on-about-blank'", null);
         try testing.expect(v.toBool());
     }
 
     // First real navigation. It must NOT inherit the about:blank global.
     try ctx.processMessage(.{
-        .id = 71,
+        .id = 72,
         .method = "Page.navigate",
         .params = .{ .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html" },
+        .sessionId = bc.session_id.?,
     });
     try testing.waitForPage(bc);
 
@@ -1670,6 +1688,30 @@ test "cdp.frame: first navigation replaces the bootstrap about:blank global" {
     defer ls2.deinit();
     const v2 = try ls2.local.exec("window.leak === undefined", null);
     try testing.expect(v2.toBool());
+}
+
+test "cdp.frame: first navigation of a pristine bootstrap about:blank navigates in place" {
+    // Counterpart of the #3215 test: with no client JS on the bootstrap page,
+    // the first Page.navigate keeps the in-place fast path (no pending Page).
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-PRS", .target_id = "TID-PRS-000000".* });
+    bc.session_id = "SID-PRS";
+    _ = try bc.session.createPage();
+    const before = bc.mainFrame() orelse unreachable;
+    try testing.expectEqualSlices(u8, "about:blank", before.url);
+
+    try ctx.processMessage(.{
+        .id = 73,
+        .method = "Page.navigate",
+        .params = .{ .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html" },
+    });
+    try testing.waitForPage(bc);
+
+    const after = bc.mainFrame() orelse unreachable;
+    try testing.expect(before == after);
+    try testing.expect(std.mem.endsWith(u8, after.url, "/cdp/dom1.html"));
 }
 
 test "cdp.frame: anchor click sends Referer matching the originating page" {

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -300,19 +300,13 @@ fn navigate(cmd: *CDP.Command) !void {
 
     const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
 
-    // Fast path: a freshly-created target whose root frame hasn't navigated
-    // yet has nothing to preserve across the HTTP round-trip. Skip the
-    // pending-Page allocation (which would create a V8 context just to
-    // throw the OLD blank one away at commit) and navigate the active
-    // frame in place.
-    if (frame._load_state == .waiting) {
-        return frame.navigate(encoded_url, .{
-            .reason = .address_bar,
-            .cdp_id = cmd.input.id,
-            .kind = .{ .push = null },
-        });
-    }
-
+    // A cross-document navigation replaces the JS global object. Even a
+    // freshly-created about:blank target must not reuse its bootstrap
+    // context in place: a client can run JS on the blank page (Runtime.evaluate)
+    // before the first Page.navigate, and those globals would leak into the
+    // navigated document (issue #3215). Route every root navigation through
+    // initiateRootNavigation so a fresh page/window/global is committed and
+    // the blank one is discarded.
     try session.initiateRootNavigation(frame._frame_id, encoded_url, .{
         .reason = .address_bar,
         .cdp_id = cmd.input.id,
@@ -1635,6 +1629,56 @@ test "cdp.frame: navigate to about:blank replaces a non-blank document" {
     defer ls.deinit();
     const v = try ls.local.exec("window.location.href === 'about:blank'", null);
     try testing.expect(v.toBool());
+}
+
+test "cdp.frame: first navigation replaces the bootstrap about:blank global (#3215)" {
+    // Regression test for #3215. A JS global set on a freshly-created target's
+    // initial about:blank page must not survive the first Page.navigate: a
+    // cross-document navigation replaces the JS global object. The second
+    // navigation already reset globals correctly; the leak was scoped to the
+    // bootstrap about:blank context being reused as the first navigated page.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    var bc = try ctx.loadBrowserContext(.{ .id = "BID-GLB", .target_id = "TID-GLB-000000".* });
+    bc.session_id = "SID-GLB";
+
+    // Create a fresh target whose root frame is the bootstrap about:blank
+    // document (this is what Target.createTarget {url: "about:blank"} does).
+    _ = try bc.session.createPage();
+    {
+        const frame = bc.mainFrame() orelse unreachable;
+        try testing.expectEqualSlices(u8, "about:blank", frame.url);
+    }
+
+    // Simulate a client running JS on the blank page before navigating
+    // (Runtime.evaluate "window.leak = 'set-on-about-blank'").
+    {
+        const frame = bc.mainFrame() orelse unreachable;
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const v = try ls.local.exec("window.leak = 'set-on-about-blank'; window.leak", null);
+        try testing.expect(v.toBool());
+    }
+
+    // First real navigation. It must NOT inherit the about:blank global.
+    try ctx.processMessage(.{
+        .id = 71,
+        .method = "Page.navigate",
+        .params = .{ .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html" },
+    });
+    try testing.waitForPage(bc);
+
+    const frame = bc.mainFrame() orelse unreachable;
+    try testing.expect(std.mem.endsWith(u8, frame.url, "/cdp/dom1.html"));
+
+    // The leaked global must be gone: the navigation created a fresh global.
+    var ls2: js.Local.Scope = undefined;
+    frame.js.localScope(&ls2);
+    defer ls2.deinit();
+    const v2 = try ls2.local.exec("window.leak === undefined", null);
+    try testing.expect(v2.toBool());
 }
 
 test "cdp.frame: anchor click sends Referer matching the originating page" {

--- a/src/cdp/domains/runtime.zig
+++ b/src/cdp/domains/runtime.zig
@@ -41,7 +41,11 @@ pub fn processMessage(cmd: *CDP.Command) !void {
         .runIfWaitingForDebugger => return cmd.sendResult(null, .{}),
         .enable => return enable(cmd),
         .disable => return disable(cmd),
-        else => return sendInspector(cmd, action),
+        else => {
+            const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+            bc.main_world_touched = true;
+            return sendInspector(cmd, action);
+        },
     }
 }
 


### PR DESCRIPTION
Fixes #3215: a JS global set on a CDP target's initial `about:blank` page survived the first `Page.navigate`, so `Runtime.evaluate`-driven automation (browser-use goto fences, etc.) could read stale state from the bootstrap document. A cross-document navigation must replace the JS global object.

## Root cause

The CDP `Page.navigate` handler had a fast path (added in #2371) that, for a freshly-created target whose root frame is still in `_waiting` state, navigated the active blank frame in place and reused its V8 context/global. That optimization assumed the bootstrap about:blank context was bare — but a client can run JS on it via `Runtime.evaluate` before the first navigation, and those globals then leaked into the first real document. The second navigation already reset globals correctly because it goes through `Session.initiateRootNavigation`, which allocates a fresh page/window/global and discards the old blank one at commit.

## Change

- `src/cdp/domains/page.zig`: removed the `_load_state == .waiting` fast path so every root navigation routes through `initiateRootNavigation`. The first real navigation now commits a fresh page/window/global and discards the bootstrap about:blank context, matching Chrome and the already-correct second-navigation behavior.
- Added a regression test (`cdp.frame: first navigation replaces the bootstrap about:blank global`) that creates a fresh about:blank target, sets `window.leak` on it, navigates to a real document, and asserts the global is gone.

## Verification

- `zig fmt --check src/cdp/domains/page.zig`: clean.
- `zig ast-check src/cdp/domains/page.zig`: clean.
- Full `zig build test` could not run in this sandbox: the build fetches V8 and dependencies from GitHub, which the sandbox proxy/DNS rejects (`HttpConnectionClosing` / `TemporaryNameServerFailure`). The change is confined to the CDP navigate handler plus a test modeled on the existing `#2363` regression test.