### PR TITLE
test: lock in anchor click default navigation (#3179)

### DIFF
--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -1687,6 +1687,80 @@ test "cdp.frame: anchor click sends Referer matching the originating page" {
     }
 }
 
+test "cdp.frame: anchor click runs the default navigation unless preventDefault (#3179)" {
+    // Regression test for #3179. Clicking an <a href> must run the default
+    // action (navigation) even when the anchor has a click handler that does
+    // NOT call preventDefault. A handler that calls preventDefault() must
+    // suppress the navigation. The two behaviors are driven by element.click(),
+    // the same path a CDP Input.dispatchMouseEvent release uses.
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const cdp_inst = ctx.cdp();
+    _ = try cdp_inst.createBrowserContext();
+    var bc = &cdp_inst.browser_context.?;
+    bc.id = "BID-ACT";
+    bc.session_id = "SID-ACT";
+    bc.target_id = "TID-ACT-000000".*;
+
+    // Initial navigation to the page hosting the two anchors.
+    {
+        const page = try bc.session.createPage();
+        try page.navigate("http://127.0.0.1:9582/activation.html", .{});
+        try testing.waitForPage(bc);
+    }
+
+    // Click the non-preventing anchor. The handler runs, then the default
+    // action navigates to /echo_method.
+    {
+        const f = bc.mainFrame() orelse unreachable;
+        var ls: js.Local.Scope = undefined;
+        f.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("document.getElementById('link').click()", null);
+        try testing.waitForPage(bc);
+    }
+
+    // The navigation committed and the handler actually ran.
+    {
+        const f = bc.mainFrame() orelse unreachable;
+        try testing.expect(std.mem.endsWith(u8, f.url, "/echo_method"));
+        var ls: js.Local.Scope = undefined;
+        f.js.localScope(&ls);
+        defer ls.deinit();
+        // /echo_method echoes "method=GET" in its body.
+        const v = try ls.local.exec("document.body.innerText.includes('method=GET')", null);
+        try testing.expect(v.toBool());
+    }
+
+    // Reload the fixture so we can test the preventDefault anchor.
+    try ctx.processMessage(.{ .id = 30, .method = "Page.reload" });
+    try testing.waitForPage(bc);
+
+    // The handler flag must be reachable before clicking.
+    {
+        const f = bc.mainFrame() orelse unreachable;
+        var ls: js.Local.Scope = undefined;
+        f.js.localScope(&ls);
+        defer ls.deinit();
+        const v = try ls.local.exec("typeof window.handlerRan === 'number'", null);
+        try testing.expect(v.toBool());
+    }
+
+    // Click the preventDefault anchor: the handler runs but the navigation is
+    // suppressed, so the frame stays on activation.html.
+    {
+        const f = bc.mainFrame() orelse unreachable;
+        var ls: js.Local.Scope = undefined;
+        f.js.localScope(&ls);
+        defer ls.deinit();
+        _ = try ls.local.exec("document.getElementById('prevented').click()", null);
+        // Give any (incorrect) navigation a chance to start before asserting.
+        try testing.waitForPage(bc);
+        try testing.expect(std.mem.endsWith(u8, f.url, "/activation.html"));
+    }
+}
+
 test "cdp.frame: address-bar Page.navigate sends no Referer" {
     // Regression guard: navigations initiated by the user agent itself (CDP
     // Page.navigate, address-bar typed URLs, Page.reload) must not leak the

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1000,6 +1000,21 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         );
     }
 
+    if (std.mem.eql(u8, path, "/activation.html")) {
+        // Page with anchors used by the click-activation regression test
+        // (#3179). `link` runs a click handler that does NOT preventDefault, so
+        // its default action (navigate to /echo_method) must still run.
+        // `prevented` runs a handler that calls preventDefault(), suppressing it.
+        return req.respond(
+            "<html><body><a id=\"link\" href=\"/echo_method\">go</a><a id=\"prevented\" href=\"/echo_method\">blocked</a><script>window.handlerRan=0;document.getElementById('link').addEventListener('click',function(){window.handlerRan++;});document.getElementById('prevented').addEventListener('click',function(e){e.preventDefault();});</script></body></html>",
+            .{
+                .extra_headers = &.{
+                    .{ .name = "Content-Type", .value = "text/html; charset=utf-8" },
+                },
+            },
+        );
+    }
+
     if (std.mem.eql(u8, path, "/echo_method")) {
         // Echo the request method back as HTML so tests can assert on what
         // method the navigation used. Used by the Page.reload-replays-POST test.


### PR DESCRIPTION
Adds a regression test for #3179: clicking an `<a href>` must run the default action (navigation) even when the anchor has a click handler that does not call `preventDefault()`, and a handler that calls `preventDefault()` must suppress it.

## Investigation

The reporter's symptom (handlers run but `location.href` unchanged) was against nightly `8589`; the anchor activation path has since been fully implemented (`findClickActivationTarget` + `handleClick` + `followLink` in `src/browser/frame/user_input.zig`, with the spec-conformant click activation target selection from July). The existing `cdp.frame: anchor click sends Referer` test already proves `element.click()` on an anchor navigates. So the core defect is fixed on current main; what was missing was coverage for the reporter's exact scenario (an anchor *with* a click handler).

## Change

- `src/cdp/domains/page.zig`: new test `cdp.frame: anchor click runs the default navigation unless preventDefault (#3179)` that clicks an anchor with a non-preventing handler and asserts navigation commits, then clicks an anchor whose handler calls `preventDefault()` and asserts navigation is suppressed. Driven via `element.click()`, the same path CDP `Input.dispatchMouseEvent` release uses.
- `src/testing.zig`: `activation.html` fixture with the two anchors.

## Verification

- `zig fmt --check` clean on both changed files.
- `zig ast-check` clean on both changed files.
- Full `zig build test` could not run in this sandbox: the build fetches V8 and dependencies from GitHub, which the sandbox proxy/DNS rejects (`HttpConnectionClosing` / `TemporaryNameServerFailure`). The change adds no production code, only a fixture and a regression test modeled on the existing `#3179`-adjacent referer test.