### PR TITLE
AGENTS.md: mention make download-v8 before building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to open a pull request (CLA, dev setup, pre-PR checks).
 
-## Tests
+## Build and tests
+
+Run `make download-v8` once first: it fetches the prebuilt V8 archive into `.lp-cache/`, which `build.zig` picks up automatically. Without it every build compiles V8 from source (10+ minutes).
 
 ```bash
 make test                                       # Run all tests


### PR DESCRIPTION
`AGENTS.md` lists the test commands but never mentions `make download-v8`, so an agent that follows it verbatim compiles V8 from source (10+ minutes) on its first `make test`. This adds the one-liner already in `CONTRIBUTING.md`, next to the commands it applies to; `build.zig` picks the cached archive up on its own once it's there.
