### PR TITLE
webapi: promise-returning operations reject, don't throw, on bad receiver

### DIFF
--- a/src/browser/js/Snapshot.zig
+++ b/src/browser/js/Snapshot.zig
@@ -796,8 +796,9 @@ fn attachClass(comptime JsApi: type, comptime flatten: bool, isolate: *v8.Isolat
                     continue;
                 }
 
-                // For non-static functions, use the signature to validate the receiver
-                const func_signature = if (value.static) null else signature;
+                // For non-static functions, use the signature to validate the
+                // receiver, unless the operation has to reject rather than throw.
+                const func_signature = if (value.static or value.rejects_bad_receiver) null else signature;
                 const function_template = v8.v8__FunctionTemplate__New__Config(isolate, &.{
                     .callback = value.func,
                     .length = value.arity,

--- a/src/browser/js/bridge.zig
+++ b/src/browser/js/bridge.zig
@@ -170,6 +170,7 @@ pub const Function = struct {
     js_name: ?[:0]const u8 = null,
     exposed: Caller.Function.Opts.Exposed = .both,
     cache: ?Caller.Function.Opts.Caching = null,
+    rejects_bad_receiver: bool,
     func: *const fn (?*const v8.FunctionCallbackInfo) callconv(.c) void,
 
     fn init(comptime T: type, comptime func: anytype, comptime opts: Caller.Function.Opts) Function {
@@ -179,8 +180,7 @@ pub const Function = struct {
             .wpt_only = opts.wpt_only,
             .js_name = opts.js_name,
             .exposed = opts.exposed,
-            // Non-static methods receive `self` as their first param; static
-            // methods don't, so don't skip the first param for them.
+            .rejects_bad_receiver = returnsPromise(@TypeOf(func)),
             .arity = getArity(@TypeOf(func), if (opts.static) 0 else 1),
             .func = if (opts.noop) noopFunction else struct {
                 fn wrap(handle: ?*const v8.FunctionCallbackInfo) callconv(.c) void {
@@ -191,6 +191,14 @@ pub const Function = struct {
     }
 
     pub fn noopFunction(_: ?*const v8.FunctionCallbackInfo) callconv(.c) void {}
+
+    fn returnsPromise(comptime F: type) bool {
+        const R = @typeInfo(F).@"fn".return_type orelse return false;
+        return switch (@typeInfo(R)) {
+            .error_union => |eu| eu.payload,
+            else => R,
+        } == js.Promise;
+    }
 
     fn getArity(comptime T: type, comptime start: usize) usize {
         const Execution = js.Execution;


### PR DESCRIPTION
We currently implement a v8 signature check on the receiver. This throws on failure. However, for a promise-returning function, it should reject the promise instead. This skips the (v8) signature check for promise-returning so that it flows through the normal code which does rejection.

Fixes a few WPT cases (in fetch and FileAPI, but probably others too).

This reject, don't throw, is an ongoing thing that we're fixing, e.g. https://github.com/lightpanda-io/browser/pull/3095