### PR TITLE
Introduce `--load-resources`, supporting `image` parameter

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -211,6 +211,26 @@ fn caPathValidator(
     }
 }
 
+// Sub-resources the browser actually requests. A comma-separated list so
+// more can be opted into individually as they land; only `image` fetches
+// today.
+pub const LoadResources = packed struct(u1) {
+    image: bool = false,
+};
+
+fn loadResourcesValidator(_: Allocator, args: *std.process.Args.Iterator, target: *LoadResources) !void {
+    const resources = args.next() orelse return error.MissingArgument;
+
+    var it = std.mem.splitScalar(u8, resources, ',');
+    while (it.next()) |resource| {
+        inline for (@typeInfo(LoadResources).@"struct".fields) |field| {
+            if (std.mem.eql(u8, field.name, resource)) {
+                @field(target, field.name) = true;
+            }
+        }
+    }
+}
+
 /// Common CLI args.
 const CommonOptions = .{
     .{ .name = "obey_robots", .type = bool },
@@ -245,6 +265,12 @@ const CommonOptions = .{
     .{ .name = "disable_subframes", .type = bool },
     .{ .name = "disable_workers", .type = bool },
     .{ .name = "enable_external_stylesheets", .type = bool },
+    .{
+        .name = "load_resources",
+        .type = LoadResources,
+        .default = LoadResources{},
+        .validator = loadResourcesValidator,
+    },
     .{ .name = "v8_flags_unsafe", .type = ?[]const u8 },
     .{ .name = "v8_max_heap_mb", .type = ?u32 },
     .{ .name = "watchdog_ms", .type = ?u32 },
@@ -522,6 +548,13 @@ pub fn watchdogMs(self: *const Config) ?u32 {
 pub fn enableExternalStylesheets(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.enable_external_stylesheets,
+        else => unreachable,
+    };
+}
+
+pub fn loadResources(self: *const Config) LoadResources {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.load_resources,
         else => unreachable,
     };
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -211,25 +211,9 @@ fn caPathValidator(
     }
 }
 
-// Sub-resources the browser actually requests. A comma-separated list so
-// more can be opted into individually as they land; only `image` fetches
-// today.
 pub const LoadResources = packed struct(u1) {
     image: bool = false,
 };
-
-fn loadResourcesValidator(_: Allocator, args: *std.process.Args.Iterator, target: *LoadResources) !void {
-    const resources = args.next() orelse return error.MissingArgument;
-
-    var it = std.mem.splitScalar(u8, resources, ',');
-    while (it.next()) |resource| {
-        inline for (@typeInfo(LoadResources).@"struct".fields) |field| {
-            if (std.mem.eql(u8, field.name, resource)) {
-                @field(target, field.name) = true;
-            }
-        }
-    }
-}
 
 /// Common CLI args.
 const CommonOptions = .{
@@ -265,12 +249,7 @@ const CommonOptions = .{
     .{ .name = "disable_subframes", .type = bool },
     .{ .name = "disable_workers", .type = bool },
     .{ .name = "enable_external_stylesheets", .type = bool },
-    .{
-        .name = "load_resources",
-        .type = LoadResources,
-        .default = LoadResources{},
-        .validator = loadResourcesValidator,
-    },
+    .{ .name = "load_resources", .type = LoadResources, .default = LoadResources{} },
     .{ .name = "v8_flags_unsafe", .type = ?[]const u8 },
     .{ .name = "v8_max_heap_mb", .type = ?u32 },
     .{ .name = "watchdog_ms", .type = ?u32 },

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2384,6 +2384,155 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []co
     try self.fireElementEvent(element, comptime .wrap("load"));
 }
 
+// Asynchronous, unlike `loadExternalStylesheet`: nothing in the document
+// depends on the result, so there's no reason to block the parser on it.
+// The request does take a `_pending_loads` slot, so the window load event
+// waits for it the way the HTML spec says it should.
+pub fn loadImage(self: *Frame, image: *Element.Html.Image, src: []const u8) !void {
+    const session = self._session;
+    // Fragment-parsed images (innerHTML, DOMParser, ...) may never be
+    // attached, and may belong to another Document. Same call as
+    // `loadExternalStylesheet` makes. They still get the synthetic load the
+    // no-fetch path would have given them, so the two modes agree.
+    if (self._parse_mode == .fragment) {
+        return self.queueLoad(Factory.protoOf(image));
+    }
+
+    const arena = try session.getArena(.small, "Frame.loadImage");
+    defer arena.release();
+
+    const resolved = URL.resolve(arena.allocator(), self.base(), src, .{ .encoding = self.charset }) catch |err| {
+        // An unresolvable src is a load failure the same way a 404 is, and
+        // unlike a real fetch we can settle it without a request. No pending
+        // load was taken out yet, so queue rather than decrementing.
+        log.info(.http, "image resolve", .{ .err = err, .src = src });
+        image._complete = true;
+        return self.queueElementEvent(Factory.protoOf(image), .@"error");
+    };
+
+    // an in-flight image is a fixed-size record we can hand back the moment it
+    // settles, and a page can create a lot of them.
+    const load = try self._factory.create(ImageLoad{
+        .frame = self,
+        .image = image,
+        .generation = image._generation,
+    });
+    errdefer self._factory.destroy(load);
+
+    // New load event always sets `_complete` back to false.
+    image._complete = false;
+    self._pending_loads += 1;
+    errdefer {
+        image._complete = true;
+        self._pending_loads -= 1;
+    }
+
+    const transfer = try session.browser.http_client.newRequest(.{
+        .ctx = load,
+        .url = resolved,
+        .method = .GET,
+        .frame_id = self._frame_id,
+        .loader_id = self._loader_id,
+        .cookie_jar = &session.cookie_jar,
+        .cookie_origin = self.url,
+        .resource_type = .image,
+        .notification = session.notification,
+        .headers_only = true,
+        .header_callback = ImageLoad.headerCallback,
+        .data_callback = ImageLoad.dataCallback,
+        .done_callback = ImageLoad.doneCallback,
+        .error_callback = ImageLoad.errorCallback,
+        .shutdown_callback = ImageLoad.shutdownCallback,
+    }, &self._http_owner);
+    {
+        // `deinit` fires no callbacks, so the errdefers above are still the
+        // ones responsible for undoing our state on this path.
+        errdefer transfer.deinit();
+        // Part of mimicking the real request: origins that content-negotiate
+        // (or that turn away clients which don't look like browsers) key off
+        // exactly this header.
+        try transfer.addHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8", .{});
+        try self.headersForRequest(transfer);
+    }
+
+    // From here the transfer owns `load`. `submit` either succeeds or has
+    // already routed the failure through error_callback, which settles the
+    // ImageLoad and gives the pending-load slot back.
+    transfer.submit() catch |err| {
+        log.warn(.http, "image fetch", .{ .err = err, .url = resolved });
+    };
+}
+
+// One in-flight image fetch. Exactly one of done/error/shutdown runs, and
+// each releases the `_pending_loads` slot taken in `loadImage`.
+const ImageLoad = struct {
+    frame: *Frame,
+    image: *Element.Html.Image,
+    generation: u32,
+    status: u16 = 0,
+
+    fn headerCallback(transfer: *HttpClient.Transfer) !HttpClient.Transfer.HeaderResult {
+        const self: *ImageLoad = @ptrCast(@alignCast(transfer.req.ctx));
+        self.status = transfer.responseStatus() orelse 0;
+        return .proceed;
+    }
+
+    fn dataCallback(_: *HttpClient.Transfer, _: []const u8) !void {
+        // Nothing should ever reach here.
+        unreachable;
+    }
+
+    fn doneCallback(ctx: *anyopaque) !void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        const ok = self.status >= 200 and self.status < 300;
+        self.settle(if (ok) .load else .@"error");
+    }
+
+    fn errorCallback(ctx: *anyopaque, err: anyerror) void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        log.info(.http, "image fetch", .{ .err = err, .status = self.status });
+        self.settle(.@"error");
+    }
+
+    fn shutdownCallback(ctx: *anyopaque) void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        const frame = self.frame;
+        self.image._complete = true;
+        frame._factory.destroy(self);
+
+        // Teardown or a superseding navigation. Release the slot directly:
+        // `pendingLoadCompleted` could reach `documentIsComplete`, and
+        // running the load event on a frame that's being dismantled is
+        // exactly what we're being told to stop doing.
+        frame._pending_loads -|= 1;
+    }
+
+    fn settle(self: *ImageLoad, kind: QueuedEvent.Kind) void {
+        const frame = self.frame;
+        const image = self.image;
+        defer frame._factory.destroy(self);
+
+        // A later src assignment owns the element's events now; this
+        // response is only still here to give its pending-load slot back.
+        const superseded = self.generation != image._generation;
+        if (!superseded) {
+            image._complete = true;
+        }
+
+        if (!superseded and !frame.isGoingAway()) {
+            const name: String = switch (kind) {
+                .load => comptime .wrap("load"),
+                .@"error" => comptime .wrap("error"),
+            };
+            frame.fireElementEvent(image.asElement(), name) catch |err| {
+                log.warn(.js, "image event", .{ .err = err, .kind = kind });
+            };
+        }
+
+        frame.pendingLoadCompleted();
+    }
+};
+
 fn fireElementEvent(self: *Frame, el: *Element, name: String) !void {
     const event = try Event.initTrusted(name, .{}, self._page);
     try self._event_manager.dispatch(el.asEventTarget(), event);

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2451,7 +2451,7 @@ pub fn loadImage(self: *Frame, image: *Element.Html.Image, src: []const u8) !voi
         // Part of mimicking the real request: origins that content-negotiate
         // (or that turn away clients which don't look like browsers) key off
         // exactly this header.
-        try transfer.addHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8", .{});
+        try transfer.setHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8", .{});
         try self.headersForRequest(transfer);
     }
 

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -79,6 +79,7 @@ const GlobalEventHandlersLookup = @import("webapi/global_event_handlers.zig").Lo
 
 pub const parse = @import("frame/parse.zig");
 pub const preload = @import("frame/preload.zig");
+pub const resource_load = @import("frame/resource_load.zig");
 pub const observers = @import("frame/observers.zig");
 pub const user_input = @import("frame/user_input.zig");
 pub const node_factory = @import("frame/node_factory.zig");
@@ -1198,7 +1199,7 @@ pub fn iframeCompletedLoading(self: *Frame, iframe: *IFrame, delays_load: bool) 
     }
 }
 
-fn pendingLoadCompleted(self: *Frame) void {
+pub fn pendingLoadCompleted(self: *Frame) void {
     const pending_loads = self._pending_loads;
     if (pending_loads == 1) {
         self._pending_loads = 0;
@@ -2383,154 +2384,6 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []co
 
     try self.fireElementEvent(element, comptime .wrap("load"));
 }
-
-// Asynchronous, unlike `loadExternalStylesheet`: nothing in the document
-// depends on the result, so there's no reason to block the parser on it.
-// The request does take a `_pending_loads` slot, so the window load event
-// waits for it the way the HTML spec says it should.
-pub fn loadImage(self: *Frame, image: *Element.Html.Image, src: []const u8) !void {
-    const session = self._session;
-    // Fragment-parsed images (innerHTML, DOMParser, ...) may never be
-    // attached, and may belong to another Document. Same call as
-    // `loadExternalStylesheet` makes. They still get the synthetic load the
-    // no-fetch path would have given them, so the two modes agree.
-    if (self._parse_mode == .fragment) {
-        return self.queueLoad(Factory.protoOf(image));
-    }
-
-    const arena = try session.getArena(.small, "Frame.loadImage");
-    defer arena.release();
-
-    const resolved = URL.resolve(arena.allocator(), self.base(), src, .{ .encoding = self.charset }) catch |err| {
-        // An unresolvable src is a load failure the same way a 404 is, and
-        // unlike a real fetch we can settle it without a request. No pending
-        // load was taken out yet, so queue rather than decrementing.
-        log.info(.http, "image resolve", .{ .err = err, .src = src });
-        image._complete = true;
-        return self.queueElementEvent(Factory.protoOf(image), .@"error");
-    };
-
-    // an in-flight image is a fixed-size record we can hand back the moment it
-    // settles, and a page can create a lot of them.
-    const load = try self._factory.create(ImageLoad{
-        .frame = self,
-        .image = image,
-        .generation = image._generation,
-    });
-    errdefer self._factory.destroy(load);
-
-    // New load event always sets `_complete` back to false.
-    image._complete = false;
-    self._pending_loads += 1;
-    errdefer {
-        image._complete = true;
-        self._pending_loads -= 1;
-    }
-
-    const transfer = try session.browser.http_client.newRequest(.{
-        .ctx = load,
-        .url = resolved,
-        .method = .GET,
-        .frame_id = self._frame_id,
-        .loader_id = self._loader_id,
-        .cookie_jar = &session.cookie_jar,
-        .cookie_origin = self.url,
-        .resource_type = .image,
-        .notification = session.notification,
-        .headers_only = true,
-        .header_callback = ImageLoad.headerCallback,
-        .data_callback = ImageLoad.dataCallback,
-        .done_callback = ImageLoad.doneCallback,
-        .error_callback = ImageLoad.errorCallback,
-        .shutdown_callback = ImageLoad.shutdownCallback,
-    }, &self._http_owner);
-    {
-        // `deinit` fires no callbacks, so the errdefers above are still the
-        // ones responsible for undoing our state on this path.
-        errdefer transfer.deinit();
-        // Part of mimicking the real request: origins that content-negotiate
-        // (or that turn away clients which don't look like browsers) key off
-        // exactly this header.
-        try transfer.setHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8", .{});
-        try self.headersForRequest(transfer);
-    }
-
-    // From here the transfer owns `load`. `submit` either succeeds or has
-    // already routed the failure through error_callback, which settles the
-    // ImageLoad and gives the pending-load slot back.
-    transfer.submit() catch |err| {
-        log.warn(.http, "image fetch", .{ .err = err, .url = resolved });
-    };
-}
-
-// One in-flight image fetch. Exactly one of done/error/shutdown runs, and
-// each releases the `_pending_loads` slot taken in `loadImage`.
-const ImageLoad = struct {
-    frame: *Frame,
-    image: *Element.Html.Image,
-    generation: u32,
-    status: u16 = 0,
-
-    fn headerCallback(transfer: *HttpClient.Transfer) !HttpClient.Transfer.HeaderResult {
-        const self: *ImageLoad = @ptrCast(@alignCast(transfer.req.ctx));
-        self.status = transfer.responseStatus() orelse 0;
-        return .proceed;
-    }
-
-    fn dataCallback(_: *HttpClient.Transfer, _: []const u8) !void {
-        // Nothing should ever reach here.
-    }
-
-    fn doneCallback(ctx: *anyopaque) !void {
-        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
-        const ok = self.status >= 200 and self.status < 300;
-        self.settle(if (ok) .load else .@"error");
-    }
-
-    fn errorCallback(ctx: *anyopaque, err: anyerror) void {
-        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
-        log.info(.http, "image fetch", .{ .err = err, .status = self.status });
-        self.settle(.@"error");
-    }
-
-    fn shutdownCallback(ctx: *anyopaque) void {
-        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
-        const frame = self.frame;
-        self.image._complete = true;
-        frame._factory.destroy(self);
-
-        // Teardown or a superseding navigation. Release the slot directly:
-        // `pendingLoadCompleted` could reach `documentIsComplete`, and
-        // running the load event on a frame that's being dismantled is
-        // exactly what we're being told to stop doing.
-        frame._pending_loads -|= 1;
-    }
-
-    fn settle(self: *ImageLoad, kind: QueuedEvent.Kind) void {
-        const frame = self.frame;
-        const image = self.image;
-        defer frame._factory.destroy(self);
-
-        // A later src assignment owns the element's events now; this
-        // response is only still here to give its pending-load slot back.
-        const superseded = self.generation != image._generation;
-        if (!superseded) {
-            image._complete = true;
-        }
-
-        if (!superseded and !frame.isGoingAway()) {
-            const name: String = switch (kind) {
-                .load => comptime .wrap("load"),
-                .@"error" => comptime .wrap("error"),
-            };
-            frame.fireElementEvent(image.asElement(), name) catch |err| {
-                log.warn(.js, "image event", .{ .err = err, .kind = kind });
-            };
-        }
-
-        frame.pendingLoadCompleted();
-    }
-};
 
 fn fireElementEvent(self: *Frame, el: *Element, name: String) !void {
     const event = try Event.initTrusted(name, .{}, self._page);

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2479,7 +2479,6 @@ const ImageLoad = struct {
 
     fn dataCallback(_: *HttpClient.Transfer, _: []const u8) !void {
         // Nothing should ever reach here.
-        unreachable;
     }
 
     fn doneCallback(ctx: *anyopaque) !void {

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -117,12 +117,7 @@ _console_capture: bool = false,
 load_external_stylesheets: bool = false,
 
 // Sub-resources to actually request. Off by default: a driver that only
-// reads the DOM shouldn't pay for bytes it never looks at. Set from the
-// `--load-resources` CLI flag at session init; the LP.configureLoading CDP
-// method can flip it per-session. When `image` is set,
-// `Image.imageAddedCallback` routes to `Frame.loadImage` and an <img>'s
-// load/error event reflects the real HTTP status instead of always being
-// a synthetic load.
+// reads the DOM shouldn't pay for bytes it never looks at.
 load_resources: Config.LoadResources = .{},
 
 /// Caller-supplied cancellation probe. `Runner._wait` polls it between

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const App = @import("../App.zig");
+const Config = @import("../Config.zig");
 
 const History = @import("webapi/History.zig");
 const storage = @import("webapi/storage/storage.zig");
@@ -115,6 +116,15 @@ _console_capture: bool = false,
 // (synchronous fetch + parse + register on `document.styleSheets`).
 load_external_stylesheets: bool = false,
 
+// Sub-resources to actually request. Off by default: a driver that only
+// reads the DOM shouldn't pay for bytes it never looks at. Set from the
+// `--load-resources` CLI flag at session init; the LP.configureLoading CDP
+// method can flip it per-session. When `image` is set,
+// `Image.imageAddedCallback` routes to `Frame.loadImage` and an <img>'s
+// load/error event reflects the real HTTP status instead of always being
+// a synthetic load.
+load_resources: Config.LoadResources = .{},
+
 /// Caller-supplied cancellation probe. `Runner._wait` polls it between
 /// ticks; once `check` returns true the wait returns `error.Cancelled`.
 /// The agent installs this so SIGINT can abort an in-flight tool call
@@ -180,6 +190,7 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         .worker_loading_enabled = !browser.app.config.disableWorkers(),
         ._console_messages = .init(allocator),
         .load_external_stylesheets = browser.app.config.enableExternalStylesheets(),
+        .load_resources = browser.app.config.loadResources(),
     };
     errdefer self._console_messages.deinit();
 }

--- a/src/browser/frame/resource_load.zig
+++ b/src/browser/frame/resource_load.zig
@@ -1,0 +1,190 @@
+// Copyright (C) 2023 - 2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Sub-resources fetched only for their outcome, gated on `--load-resources`:
+// nothing in the document consumes the body, we fetch so that the element's
+// load/error event reflects the real HTTP status.
+
+const lp = @import("lightpanda");
+
+const URL = @import("../URL.zig");
+const Frame = @import("../Frame.zig");
+const Factory = @import("../Factory.zig");
+const Element = @import("../webapi/Element.zig");
+const HttpClient = @import("../../network/HttpClient.zig");
+
+const log = lp.log;
+
+// Asynchronous, unlike `Frame.loadExternalStylesheet`: nothing in the document
+// depends on the result, so there's no reason to block the parser on it. The
+// request does take a `_pending_loads` slot, so the window load event waits
+// for it the way the HTML spec says it should.
+pub fn image(frame: *Frame, img: *Element.Html.Image, src: []const u8) !void {
+    const session = frame._session;
+
+    // Fragment-parsed images (innerHTML, DOMParser, ...) may never be attached,
+    // and may belong to another Document. Same call `loadExternalStylesheet`
+    // makes. They still get the synthetic load the no-fetch path would have
+    // given them, so the two modes agree.
+    if (frame._parse_mode == .fragment) {
+        return frame.queueLoad(Factory.protoOf(img));
+    }
+
+    const arena = try session.getArena(.small, "resource_load.image");
+    defer arena.release();
+
+    const load = try frame._factory.create(ImageLoad{
+        .frame = frame,
+        .image = img,
+        .generation = img._generation,
+    });
+    errdefer frame._factory.destroy(load);
+
+    img._complete = false;
+    frame._pending_loads += 1;
+    errdefer {
+        frame._pending_loads -= 1;
+        img._complete = true;
+    }
+
+    const resolved = URL.resolve(arena.allocator(), frame.base(), src, .{ .encoding = frame.charset }) catch |err| {
+        // An unresolvable src fails the same way a 404 does, but without a
+        // request to carry the outcome. Settle on a task rather than inline:
+        // we're on a DOM mutation path and must not dispatch events from
+        // inside it.
+        log.info(.http, "image resolve", .{ .err = err, .src = src });
+        try frame.js.scheduler.add(load, ImageLoad.failed, 0, .{
+            .name = "resource_load.image.failed",
+            .finalizer = ImageLoad.finalizer,
+        });
+        return;
+    };
+
+    const transfer = try session.browser.http_client.newRequest(.{
+        .ctx = load,
+        .url = resolved,
+        .method = .GET,
+        .frame_id = frame._frame_id,
+        .loader_id = frame._loader_id,
+        .cookie_jar = &session.cookie_jar,
+        .cookie_origin = frame.url,
+        .resource_type = .image,
+        .notification = session.notification,
+        .headers_only = true,
+        .header_callback = ImageLoad.headerCallback,
+        .data_callback = ImageLoad.dataCallback,
+        .done_callback = ImageLoad.doneCallback,
+        .error_callback = ImageLoad.errorCallback,
+        .shutdown_callback = ImageLoad.shutdownCallback,
+    }, &frame._http_owner);
+    {
+        // `deinit` fires no callbacks, so the errdefers above are still the
+        // ones responsible for undoing our state on this path.
+        errdefer transfer.deinit();
+        // Part of mimicking the real request: origins that content-negotiate
+        // (or that turn away clients which don't look like browsers) key off
+        // exactly this header.
+        try transfer.setHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8", .{});
+        try frame.headersForRequest(transfer);
+    }
+
+    // From here the transfer owns `load`. `submit` either succeeds or has
+    // already routed the failure through error_callback, which settles the
+    // ImageLoad and gives the pending-load slot back.
+    transfer.submit() catch |err| {
+        log.warn(.http, "image fetch", .{ .err = err, .url = resolved });
+    };
+}
+
+// One in-flight image fetch. Exactly one of done/error/shutdown runs, and each
+// releases the `_pending_loads` slot taken above.
+const ImageLoad = struct {
+    frame: *Frame,
+    image: *Element.Html.Image,
+    generation: u32,
+    status: u16 = 0,
+
+    fn headerCallback(transfer: *HttpClient.Transfer) !HttpClient.Transfer.HeaderResult {
+        const self: *ImageLoad = @ptrCast(@alignCast(transfer.req.ctx));
+        self.status = transfer.responseStatus() orelse 0;
+        return .proceed;
+    }
+
+    fn dataCallback(_: *HttpClient.Transfer, _: []const u8) !void {
+        // headers_only tears the transfer down at the first body byte.
+    }
+
+    fn doneCallback(ctx: *anyopaque) !void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        const ok = self.status >= 200 and self.status < 300;
+        self.settle(if (ok) .load else .@"error");
+    }
+
+    fn errorCallback(ctx: *anyopaque, err: anyerror) void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        log.info(.http, "image fetch", .{ .err = err, .status = self.status });
+        self.settle(.@"error");
+    }
+
+    fn shutdownCallback(ctx: *anyopaque) void {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        const frame = self.frame;
+        self.image._complete = true;
+        frame._factory.destroy(self);
+
+        // Teardown or a superseding navigation. Release the slot directly:
+        // `pendingLoadCompleted` could reach `documentIsComplete`, and running
+        // the load event on a frame that's being dismantled is exactly what
+        // we're being told to stop doing.
+        frame._pending_loads -|= 1;
+    }
+
+    // Scheduler task for a failure we knew about before making a request.
+    fn failed(ctx: *anyopaque) !?u32 {
+        const self: *ImageLoad = @ptrCast(@alignCast(ctx));
+        self.settle(.@"error");
+        return null;
+    }
+
+    // Runs instead of `failed` when the task is dropped (page teardown).
+    fn finalizer(ctx: *anyopaque) void {
+        shutdownCallback(ctx);
+    }
+
+    fn settle(self: *ImageLoad, kind: Frame.QueuedEvent.Kind) void {
+        const frame = self.frame;
+        const img = self.image;
+        defer frame._factory.destroy(self);
+
+        // A later src assignment owns the element's events now; this response
+        // is only still here to give its pending-load slot back.
+        if (self.generation == img._generation) {
+            img._complete = true;
+
+            // Queued, not dispatched: `submit` can fail synchronously, which
+            // puts us inside html5ever parsing, and an event handler is free
+            // to navigate. Queueing also puts these events ahead of window
+            // load, which is where the spec wants them.
+            frame.queueElementEvent(Factory.protoOf(img), kind) catch |err| {
+                log.warn(.frame, "image queue event", .{ .err = err, .kind = kind });
+            };
+        }
+
+        frame.pendingLoadCompleted();
+    }
+};

--- a/src/browser/frame/resource_load.zig
+++ b/src/browser/frame/resource_load.zig
@@ -169,13 +169,24 @@ const ImageLoad = struct {
     fn settle(self: *ImageLoad, kind: Frame.QueuedEvent.Kind) void {
         const frame = self.frame;
         const img = self.image;
-        defer frame._factory.destroy(self);
 
         // A later src assignment owns the element's events now; this response
         // is only still here to give its pending-load slot back.
-        if (self.generation == img._generation) {
+        const current = self.generation == img._generation;
+        if (current) {
             img._complete = true;
+        }
 
+        // Released before anything below, because everything below can run JS
+        // and none of it reads `self` again.
+        frame._factory.destroy(self);
+
+        if (frame.isGoingAway()) {
+            frame._pending_loads -|= 1;
+            return;
+        }
+
+        if (current) {
             // Queued, not dispatched: `submit` can fail synchronously, which
             // puts us inside html5ever parsing, and an event handler is free
             // to navigate. Queueing also puts these events ahead of window

--- a/src/browser/tests/element/html/image_fetch.html
+++ b/src/browser/tests/element/html/image_fetch.html
@@ -9,7 +9,7 @@
   complete successfully — that's what makes these a test of the fetch path
   and not just of the event plumbing.
 
-  /images/ok.png is over Request.HEADERS_ONLY_DRAIN_MAX (abort branch),
+  /images/ok.png is over the headers-only drain threshold (abort branch),
   /images/small.png is under it (drain branch).
 -->
 
@@ -69,9 +69,8 @@
 </script>
 
 <script id="img-many-share-one-connection" type=module>
-  // A page's worth of small images. They queue at low priority behind
-  // anything else, and each drained body returns its connection to the
-  // pool, so this must settle without starving or stalling.
+  // A page's worth of small images. Each drained body returns its
+  // connection to the pool, so this must settle without stalling.
   const state = await testing.async();
   const results = await Promise.all(
     Array.from({ length: 12 }, (_, i) => new Promise(resolve => {
@@ -86,6 +85,24 @@
   await state.done(() => {
     testing.expectEqual(12, results.length);
     testing.expectEqual(true, results.every(r => r === "load"));
+  });
+</script>
+
+<script id="img-chunked-body-loads" type=module>
+  // No Content-Length, so the drain/abort decision can't be made up front.
+  // Small enough to drain; either way it must report the real status.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/chunked.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("load", evt);
   });
 </script>
 
@@ -202,6 +219,28 @@
     // The superseded 404 is dropped; only the winning fetch reports.
     testing.expectEqual(1, events.length);
     testing.expectEqual("load", events[0]);
+  });
+</script>
+
+<script id="img-removing-src-supersedes" type=module>
+  // removeAttribute has to invalidate the in-flight fetch the same way a
+  // reassignment does, and leave the element complete.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const events = [];
+  img.addEventListener("load", () => events.push("load"));
+  img.addEventListener("error", () => events.push("error"));
+
+  img.src = "/images/ok.png";
+  img.removeAttribute("src");
+
+  await new Promise(resolve => setTimeout(resolve, 300));
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(0, events.length);
+    testing.expectEqual(true, img.complete);
   });
 </script>
 

--- a/src/browser/tests/element/html/image_fetch.html
+++ b/src/browser/tests/element/html/image_fetch.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+<body></body>
+
+<!--
+  These run with load_resources = .{ .image = true } (see Image.zig's test
+  decl). Every route here has a real body, so a `load` event is only
+  reachable if the transfer really did stop after the headers and still
+  complete successfully — that's what makes these a test of the fetch path
+  and not just of the event plumbing.
+
+  /images/ok.png is over Request.HEADERS_ONLY_DRAIN_MAX (abort branch),
+  /images/small.png is under it (drain branch).
+-->
+
+<script id="img-200-fires-load" type=module>
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/ok.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("load", evt);
+  });
+</script>
+
+<script id="img-404-fires-error" type=module>
+  // The whole point of the flag: without a request there is no status to
+  // branch on, and this fired `load` like everything else.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/404.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("error", evt);
+  });
+</script>
+
+<script id="img-small-body-drains-and-loads" type=module>
+  // Under the drain threshold: the body is read and discarded rather than
+  // aborted, so the connection stays poolable. Observably identical to the
+  // abort branch above.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/small.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("load", evt);
+    // Drained, not decoded: still no dimensions.
+    testing.expectEqual(0, img.naturalWidth);
+  });
+</script>
+
+<script id="img-many-share-one-connection" type=module>
+  // A page's worth of small images. They queue at low priority behind
+  // anything else, and each drained body returns its connection to the
+  // pool, so this must settle without starving or stalling.
+  const state = await testing.async();
+  const results = await Promise.all(
+    Array.from({ length: 12 }, (_, i) => new Promise(resolve => {
+      const img = document.createElement("img");
+      img.addEventListener("load", () => resolve("load"));
+      img.addEventListener("error", () => resolve("error"));
+      img.src = "/images/small.png?n=" + i;
+    }))
+  );
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(12, results.length);
+    testing.expectEqual(true, results.every(r => r === "load"));
+  });
+</script>
+
+<script id="img-500-fires-error" type=module>
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/500.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("error", evt);
+  });
+</script>
+
+<script id="img-redirect-fires-load" type=module>
+  // Redirect hops never reach the header callback, so the status the
+  // load/error decision is made from is the final 200, not the 302.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "/images/redirect.png";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("load", evt);
+  });
+</script>
+
+<script id="img-complete-tracks-the-fetch" type=module>
+  // complete is false only while a request is in flight. naturalWidth stays
+  // 0 either way: we fetch images, we don't decode them.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  testing.expectEqual(true, img.complete);
+  img.src = "/images/ok.png";
+  const during = img.complete;
+
+  await new Promise(resolve => {
+    img.addEventListener("load", resolve);
+    img.addEventListener("error", resolve);
+  });
+  const after = img.complete;
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(false, during);
+    testing.expectEqual(true, after);
+    testing.expectEqual(0, img.naturalWidth);
+    testing.expectEqual(0, img.naturalHeight);
+  });
+</script>
+
+<script id="img-unresolvable-src-fires-error" type=module>
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const evt = await new Promise(resolve => {
+    img.addEventListener("load", () => resolve("load"));
+    img.addEventListener("error", () => resolve("error"));
+    img.src = "http://";
+  });
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual("error", evt);
+  });
+</script>
+
+<script id="img-empty-src-does-nothing" type=module>
+  // No src, no request, no event — in any mode.
+  const state = await testing.async();
+  const img = document.createElement("img");
+  let fired = null;
+  img.addEventListener("load", () => fired = "load");
+  img.addEventListener("error", () => fired = "error");
+  img.src = "";
+  document.body.appendChild(img);
+
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectEqual(null, fired);
+  });
+</script>
+
+<script id="img-src-reassignment-supersedes" type=module>
+  // Reassigning src while a fetch is in flight: the element must end up
+  // reflecting the LAST src, not whichever response happens to land first.
+  const state = await testing.async();
+  const img = document.createElement("img");
+
+  const events = [];
+  img.addEventListener("load", () => events.push("load"));
+  img.addEventListener("error", () => events.push("error"));
+
+  img.src = "/images/404.png";
+  img.src = "/images/ok.png";
+
+  await new Promise(resolve => setTimeout(resolve, 300));
+
+  state.resolve();
+  await state.done(() => {
+    // The superseded 404 is dropped; only the winning fetch reports.
+    testing.expectEqual(1, events.length);
+    testing.expectEqual("load", events[0]);
+  });
+</script>
+
+<script id="img-fragment-parse-does-not-fetch">
+{
+  // Images parsed via innerHTML / DOMParser must not hit the network, for
+  // the same reason stylesheet links in a fragment don't: the subtree may
+  // never be attached, or belongs to another Document.
+  const div = document.createElement('div');
+  div.innerHTML = '<img src="/images/404.png">';
+  const img = div.querySelector('img');
+  // No fetch was issued, so it never entered the in-flight state.
+  testing.expectEqual(true, img.complete);
+}
+</script>

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -179,9 +179,16 @@ pub const Build = struct {
         return self.imageAddedCallback(frame);
     }
 
-    // `img.src = ...` routes through `setSrc`, but `setAttribute("src", ...)`
-    // only reaches us here, and both have to (re)do fetch.
     pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+        return element.as(Image).imageAddedCallback(frame);
+    }
+
+    // Removing the src leaves no request to make, but any in-flight one still
+    // has to be invalidated.
+    pub fn attributeRemove(element: *Element, name: String, frame: *Frame) !void {
         if (!name.eql(comptime .wrap("src"))) {
             return;
         }

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -1,5 +1,6 @@
 const lp = @import("lightpanda");
 const std = @import("std");
+const log = lp.log;
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
@@ -7,10 +8,20 @@ const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
+const String = lp.String;
+
 const Image = @This();
 
 pub const Proto = HtmlElement;
-_pad: bool = false,
+
+// Bumped on every src assignment. An in-flight fetch carries the value it
+// was issued under; when they no longer match, a newer src has taken over
+// and the older response must not fire events on this element.
+_generation: u32 = 0,
+// Per spec, false only while a fetch is in flight. Without
+// `--load-resources image` there is never a fetch, so it never leaves true.
+_complete: bool = true,
+
 _proto_canary: if (lp.IS_DEBUG) *HtmlElement else void = undefined,
 
 pub fn constructor(w_: ?u32, h_: ?u32, frame: *Frame) !*Image {
@@ -48,10 +59,12 @@ pub fn getSrc(self: *const Image, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *Image, value: []const u8, frame: *Frame) !void {
-    const element = self.asElement();
-    try element.setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
-    // No need to check if `Image` is connected to DOM; this is a special case.
-    return self.imageAddedCallback(frame);
+    // Setting the attribute is enough: `_put` dispatches to
+    // `Build.attributeChange`, which starts the load. Calling
+    // `imageAddedCallback` here too would issue the request twice (the first
+    // one immediately superseded, so it costs a request and shows nothing).
+    // Connectivity still isn't checked — a detached `new Image()` loads.
+    return self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
 }
 
 pub fn getLoading(self: *const Image) []const u8 {
@@ -74,17 +87,21 @@ pub fn getNaturalHeight(_: *const Image) u32 {
     return 0;
 }
 
-pub fn getComplete(_: *const Image) bool {
-    // Per spec, complete is true when: no src/srcset, src is empty,
-    // image is fully available, or image is broken (with no pending request).
-    // Since we never fetch images, they are in the "broken" state, which has
-    // complete=true. This is consistent with naturalWidth/naturalHeight=0.
-    return true;
+pub fn getComplete(self: *const Image) bool {
+    // Per spec, complete is true when: no src/srcset, src is empty, the
+    // image is fully available, or the image is broken with no pending
+    // request. Every one of those is "no fetch in flight", which is exactly
+    // what `_complete` tracks. Without `--load-resources image` nothing ever
+    // clears it.
+    return self._complete;
 }
 
-/// Used in `Page.nodeIsReady`.
+/// The one funnel for "this element's src became current": parser-created
+/// images (`Build.created`), `img.src = ...` (`setSrc`) and
+/// `setAttribute("src", ...)` (`Build.attributeChange`) all land here.
 pub fn imageAddedCallback(self: *Image, frame: *Frame) !void {
-    // if we're planning on navigating to another frame, don't trigger load event.
+    // if we're planning on navigating to another frame, don't trigger a load event
+    // or start fetching a resource.
     if (frame.isGoingAway()) {
         return;
     }
@@ -94,7 +111,28 @@ pub fn imageAddedCallback(self: *Image, frame: *Frame) !void {
     const src = element.getAttributeSafe(comptime .wrap("src")) orelse return;
     if (src.len == 0) return;
 
-    try frame.queueLoad(Factory.protoOf(self));
+    // If image loading not desired, we just do fake "load" event.
+    if (frame._session.load_resources.image == false) {
+        return frame.queueLoad(Factory.protoOf(self));
+    }
+
+    // A fetch still in flight for the previous src is stale as of right now,
+    // and this is the only place that knows it. Wrapping is fine: colliding
+    // needs a request to still be in flight 2^32 src assignments later, which
+    // outlives any transfer timeout by several orders of magnitude.
+    self._generation +%= 1;
+
+    // Deliberately not propagated. `newRequest` is declared `anyerror`, and
+    // this runs on DOM mutation paths with narrow declared error sets
+    // (`Node.cloneNode`'s `CloneError`, for one). Failing to even issue the
+    // request is the same observable outcome as the request failing, so
+    // report it the same way — `loadImage` has already unwound `_complete`
+    // and the pending-load slot by the time it returns an error.
+    frame.loadImage(self, src) catch |err| {
+        log.warn(.http, "image fetch", .{ .err = err, .src = src });
+        // On failure, queue "error" event.
+        return frame.queueElementEvent(Factory.protoOf(self), .@"error");
+    };
 }
 
 pub const JsApi = struct {
@@ -139,6 +177,15 @@ pub const Build = struct {
     pub fn created(node: *Node, frame: *Frame) !void {
         const self = node.as(Image);
         return self.imageAddedCallback(frame);
+    }
+
+    // `img.src = ...` routes through `setSrc`, but `setAttribute("src", ...)`
+    // only reaches us here, and both have to (re)do fetch.
+    pub fn attributeChange(element: *Element, name: String, _: String, frame: *Frame) !void {
+        if (!name.eql(comptime .wrap("src"))) {
+            return;
+        }
+        return element.as(Image).imageAddedCallback(frame);
     }
 };
 

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -1,6 +1,5 @@
 const lp = @import("lightpanda");
 const std = @import("std");
-const log = lp.log;
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
@@ -8,18 +7,15 @@ const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
 
+const log = lp.log;
 const String = lp.String;
 
 const Image = @This();
 
 pub const Proto = HtmlElement;
 
-// Bumped on every src assignment. An in-flight fetch carries the value it
-// was issued under; when they no longer match, a newer src has taken over
-// and the older response must not fire events on this element.
 _generation: u32 = 0,
-// Per spec, false only while a fetch is in flight. Without
-// `--load-resources image` there is never a fetch, so it never leaves true.
+// Per spec, false only while a fetch is in flight.
 _complete: bool = true,
 
 _proto_canary: if (lp.IS_DEBUG) *HtmlElement else void = undefined,
@@ -59,11 +55,6 @@ pub fn getSrc(self: *const Image, frame: *Frame) ![]const u8 {
 }
 
 pub fn setSrc(self: *Image, value: []const u8, frame: *Frame) !void {
-    // Setting the attribute is enough: `_put` dispatches to
-    // `Build.attributeChange`, which starts the load. Calling
-    // `imageAddedCallback` here too would issue the request twice (the first
-    // one immediately superseded, so it costs a request and shows nothing).
-    // Connectivity still isn't checked — a detached `new Image()` loads.
     return self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(value), frame);
 }
 
@@ -88,23 +79,21 @@ pub fn getNaturalHeight(_: *const Image) u32 {
 }
 
 pub fn getComplete(self: *const Image) bool {
-    // Per spec, complete is true when: no src/srcset, src is empty, the
-    // image is fully available, or the image is broken with no pending
-    // request. Every one of those is "no fetch in flight", which is exactly
-    // what `_complete` tracks. Without `--load-resources image` nothing ever
-    // clears it.
     return self._complete;
 }
 
 /// The one funnel for "this element's src became current": parser-created
-/// images (`Build.created`), `img.src = ...` (`setSrc`) and
-/// `setAttribute("src", ...)` (`Build.attributeChange`) all land here.
+/// images, `img.src = ...` and `setAttribute`/`removeAttribute("src")` all
+/// land here.
 pub fn imageAddedCallback(self: *Image, frame: *Frame) !void {
     // if we're planning on navigating to another frame, don't trigger a load event
     // or start fetching a resource.
     if (frame.isGoingAway()) {
         return;
     }
+
+    self._generation +%= 1;
+    self._complete = true;
 
     const element = self.asElement();
     // Exit if src not set.
@@ -116,21 +105,8 @@ pub fn imageAddedCallback(self: *Image, frame: *Frame) !void {
         return frame.queueLoad(Factory.protoOf(self));
     }
 
-    // A fetch still in flight for the previous src is stale as of right now,
-    // and this is the only place that knows it. Wrapping is fine: colliding
-    // needs a request to still be in flight 2^32 src assignments later, which
-    // outlives any transfer timeout by several orders of magnitude.
-    self._generation +%= 1;
-
-    // Deliberately not propagated. `newRequest` is declared `anyerror`, and
-    // this runs on DOM mutation paths with narrow declared error sets
-    // (`Node.cloneNode`'s `CloneError`, for one). Failing to even issue the
-    // request is the same observable outcome as the request failing, so
-    // report it the same way — `loadImage` has already unwound `_complete`
-    // and the pending-load slot by the time it returns an error.
-    frame.loadImage(self, src) catch |err| {
+    Frame.resource_load.image(frame, self, src) catch |err| {
         log.warn(.http, "image fetch", .{ .err = err, .src = src });
-        // On failure, queue "error" event.
         return frame.queueElementEvent(Factory.protoOf(self), .@"error");
     };
 }

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -193,3 +193,7 @@ const testing = @import("../../../../testing.zig");
 test "WebApi: HTML.Image" {
     try testing.htmlRunner("element/html/image.html", .{});
 }
+
+test "WebApi: HTML.Image fetch" {
+    try testing.htmlRunner("element/html/image_fetch.html", .{ .load_resources = .{ .image = true } });
+}

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const CDP = @import("../CDP.zig");
-const Config = @import("../../Config.zig");
 
 const Node = @import("../Node.zig");
 const DOMNode = @import("../../browser/webapi/Node.zig");

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -20,6 +20,7 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const CDP = @import("../CDP.zig");
+const Config = @import("../../Config.zig");
 
 const Node = @import("../Node.zig");
 const DOMNode = @import("../../browser/webapi/Node.zig");
@@ -98,12 +99,14 @@ fn configureLoading(cmd: *CDP.Command) !void {
         subFrame: ?bool = null,
         worker: ?bool = null,
         externalStylesheets: ?bool = null,
+        images: ?bool = null,
     })) orelse return error.InvalidParams;
 
     const bc = cmd.browser_context orelse return error.NoBrowserContext;
     if (params.subFrame) |v| bc.session.subframe_loading_enabled = v;
     if (params.worker) |v| bc.session.worker_loading_enabled = v;
     if (params.externalStylesheets) |v| bc.session.load_external_stylesheets = v;
+    if (params.images) |v| bc.session.load_resources.image = v;
     return cmd.sendResult(null, .{});
 }
 

--- a/src/cdp/domains/network.zig
+++ b/src/cdp/domains/network.zig
@@ -650,6 +650,7 @@ fn initialPriority(resource_type: HttpClient.Request.ResourceType) []const u8 {
     return switch (resource_type) {
         .document, .stylesheet => "VeryHigh",
         .script, .xhr, .fetch, .eventsource => "High",
+        .image => "Low",
     };
 }
 

--- a/src/help.zon
+++ b/src/help.zon
@@ -348,19 +348,14 @@
     \\          contribute to computed styles (and therefore to visibility checks like
     \\          display, visibility, opacity, pointer-events).
     \\          Defaults to false, except in agent mode with an LLM, where it is on.
-    \\  --load-resources <LIST>
-    \\          Comma-separated list of sub-resources to actually request.
-    \\          Defaults to empty, i.e. none of them.
-    \\          Allowed values: "image".
-    \\          "image" requests <img> sources so that load/error events reflect the
-    \\          real HTTP status, instead of load firing for any non-empty src. The
-    \\          request stops at the end of the response headers, so only a small
-    \\          image's body is ever transferred, and images are never decoded:
-    \\          naturalWidth/naturalHeight stay 0 either way.
-    \\          Requested images delay the window load event, and therefore
-    \\          --wait-until load. They are fetched at a lower priority than
-    \\          scripts, stylesheets and XHR, and never take a connection one of
-    \\          those is waiting for.
+    \\  --load-resources <RESOURCE>
+    \\          Sub-resource to actually request. Can be passed multiple times.
+    \\          Defaults to requesting none of them.
+    \\          Allowed values:
+    \\              image     <img> sources, so that load/error reflects the real
+    \\                        HTTP status. Only the response headers are read;
+    \\                        images are never decoded, so naturalWidth and
+    \\                        naturalHeight stay 0. Delays the window load event.
     \\  --http-cache-dir <PATH>
     \\          Directory used as a filesystem cache for network resources. Omitting
     \\          this disables caching.

--- a/src/help.zon
+++ b/src/help.zon
@@ -348,6 +348,19 @@
     \\          contribute to computed styles (and therefore to visibility checks like
     \\          display, visibility, opacity, pointer-events).
     \\          Defaults to false, except in agent mode with an LLM, where it is on.
+    \\  --load-resources <LIST>
+    \\          Comma-separated list of sub-resources to actually request.
+    \\          Defaults to empty, i.e. none of them.
+    \\          Allowed values: "image".
+    \\          "image" requests <img> sources so that load/error events reflect the
+    \\          real HTTP status, instead of load firing for any non-empty src. The
+    \\          request stops at the end of the response headers, so only a small
+    \\          image's body is ever transferred, and images are never decoded:
+    \\          naturalWidth/naturalHeight stay 0 either way.
+    \\          Requested images delay the window load event, and therefore
+    \\          --wait-until load. They are fetched at a lower priority than
+    \\          scripts, stylesheets and XHR, and never take a connection one of
+    \\          those is waiting for.
     \\  --http-cache-dir <PATH>
     \\          Directory used as a filesystem cache for network resources. Omitting
     \\          this disables caching.

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -539,7 +539,7 @@ pub fn activity(self: *const Client) Activity {
         .http = self.http_active + self.dispatch_count + self.intercepted + self.delayed_count,
         .ws_events = self.ws_dispatch_count,
         .ws_conns = self.ws_active,
-        .pending = self.pending_queue.first != null or self.pending_low_queue.first != null,
+        .pending = self.pending_queue.first != null,
     };
 }
 
@@ -831,24 +831,13 @@ fn isGated(self: *const Client, transfer: *const Transfer) bool {
     return transfer.id != blocking_id;
 }
 
-// Resources the page's progress doesn't depend on. Images are fetched for
-// their status (so load/error is honest) and, with `--fetch-images headers`,
-// a page can queue dozens of them in one parse — none of which should come
-// ahead of the script that's blocking the parser.
-fn isLowPriority(resource_type: Request.ResourceType) bool {
-    return switch (resource_type) {
-        .image => true,
-        .document, .xhr, .script, .fetch, .stylesheet, .eventsource => false,
-    };
-}
-
 fn startPending(self: *Client) !void {
     try self.startDelayed();
     while (self.pending_queue.popFirst()) |queue_node| {
         const transfer: *Transfer = @fieldParentPtr("_node", queue_node);
         const conn = self.network.getConnection() orelse {
-            queue.prepend(queue_node);
-            return false;
+            self.pending_queue.prepend(queue_node);
+            return;
         };
         // Bridge state to .created so a failure inside makeRequest before
         // any commit cleans up via the failAsync below. makeRequest flips to
@@ -864,7 +853,6 @@ fn startPending(self: *Client) !void {
             return err;
         };
     }
-    return true;
 }
 
 // Enter the pipeline for every delayed transfer whose time has come.
@@ -1018,19 +1006,24 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
         return false;
     }
 
+    const arena = transfer.arena;
+
     // Redirects rewrite req.url; the entry must be stored/renewed under the
     // URL this lookup ran against, not the final hop. req.url is arena-owned,
     // so the captured slice outlives any redirect rewrite.
-    transfer._cache_key = req.url;
+    const key: [:0]const u8 = if (req.headers_only)
+        try std.fmt.allocPrintSentinel(arena.allocator(), "headers-only:{s}", .{req.url}, 0)
+    else
+        req.url;
+    transfer._cache_key = key;
 
-    const arena = transfer.arena;
     const req_headers = try arena.alloc(http.Header, transfer.req_headers.items.len);
     for (transfer.req_headers.items, req_headers) |hdr, *out| {
         out.* = .{ .name = hdr.name, .value = hdr.value };
     }
 
     const cache_result = cache.get(arena.allocator(), .{
-        .url = req.url,
+        .url = key,
         .timestamp = lp.datetime.timestamp(.real),
         .request_headers = req_headers,
     }) catch |e| blk: {
@@ -1046,7 +1039,7 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
         },
         .revalidate => |cached| {
             log.debug(.cache, "revalidate cache entry", .{
-                .url = req.url,
+                .url = key,
                 .etag = cached.etag,
                 .last_modified = cached.last_modified,
             });
@@ -1066,7 +1059,7 @@ fn cacheLookup(self: *Client, transfer: *Transfer) !bool {
         },
         .stale => {
             lp.metrics.http_cache.incr(.miss);
-            cache.evict(req.url);
+            cache.evict(key);
             transfer._cache_intent = .store;
             return false;
         },
@@ -1118,13 +1111,6 @@ fn cacheStore(self: *Client, transfer: *Transfer) void {
     // Cleared with the release above: deinit must not release the stale
     // entry a second time on any early return below.
     transfer._cache_intent = .none;
-
-    // A headers_only transfer never read the body. Storing it would put an
-    // empty entry under the real cache key and every later full fetch of
-    // that URL (an XHR, a `full` image fetch) would hit it and get nothing.
-    if (transfer.req.headers_only) {
-        return;
-    }
 
     // could have been disabled while waiting of the response
     const cache = self.cache.active() orelse return;
@@ -1304,19 +1290,11 @@ pub fn syncRequest(self: *Client, transfer: *Transfer) !SyncResponse {
 }
 
 fn processTransfer(self: *Client, transfer: *Transfer) !void {
-    const low = isLowPriority(transfer.req.resource_type);
-    if (!low or self.pending_queue.first == null) {
-        if (self.network.getConnection()) |conn| {
-            return self.makeRequest(conn, transfer);
-        }
+    if (self.network.getConnection()) |conn| {
+        return self.makeRequest(conn, transfer);
     }
 
-    transfer._queued_low = low;
-    if (low) {
-        self.pending_low_queue.append(&transfer._node);
-    } else {
-        self.pending_queue.append(&transfer._node);
-    }
+    self.pending_queue.append(&transfer._node);
     transfer.state = .queued;
 }
 
@@ -1532,13 +1510,13 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     // we match that behavior: when CURLE_WRITE_ERROR arrives but our callback
     // never errored and bytes were received, treat it as success.
     const effective_err: ?anyerror = if (msg.err) |err| blk: {
-        if (err == error.WriteError and transfer.res.callback_error == null and transfer.res.bytes_received > 0) {
-            log.debug(.http, "WriteError downgraded", .{ .url = transfer.req.url, .bytes = transfer.res.bytes_received });
-            break :blk null;
-        }
         // Our own headers_only abort, not a failure: fall through so the
         // response is materialized and delivered with an empty body.
         if (err == error.WriteError and transfer.res.headers_only_abort) {
+            break :blk null;
+        }
+        if (err == error.WriteError and transfer.res.callback_error == null and transfer.res.bytes_received > 0) {
+            log.debug(.http, "WriteError downgraded", .{ .url = transfer.req.url, .bytes = transfer.res.bytes_received });
             break :blk null;
         }
         break :blk err;
@@ -1806,11 +1784,11 @@ pub const Request = struct {
     // internal requests transparently following redirects.
     pub const RedirectMode = enum { follow, manual, @"error" };
 
-    // Largest body a headers_only transfer will read to the end rather than
-    // abort. Draining costs bandwidth but keeps the connection poolable;
-    // aborting saves bandwidth but forces a reconnect. 16 KiB is the rough
-    // break-even: about ten segments, versus a TCP handshake plus a TLS one.
-    pub const HEADERS_ONLY_DRAIN_MAX: usize = 16 * 1024;
+    // How much of a headers_only body we'll read rather than abort. Draining
+    // costs bandwidth but keeps the connection poolable; aborting saves
+    // bandwidth but forces a reconnect. 16 KiB is the rough break-even: about
+    // ten segments, versus a TCP handshake plus a TLS one.
+    const HEADERS_ONLY_DRAIN_MAX: usize = 16 * 1024;
 
     frame_id: u32,
     loader_id: u32,
@@ -1827,14 +1805,13 @@ pub const Request = struct {
     timeout_ms: u32 = 0,
     skip_cache: bool = false,
 
-    // Tear the transfer off the wire as soon as the first body byte arrives:
-    // the caller wants the status and the response headers, not the body.
+    // The caller wants the status and the response headers, not the body.
     // Unlike a HEAD, the request itself is byte-for-byte a normal GET, so
-    // origins and CDNs see (and answer) exactly what a real browser sends.
-    // The consumer still gets the usual start/header/done sequence with an
-    // empty body; `data_callback` never fires. Note the cost: aborting
-    // mid-response means the connection can't be drained, so libcurl closes
-    // it instead of returning it to the pool.
+    // origins and CDNs see (and answer) exactly what a real browser sends;
+    // the body is then discarded, and torn off the wire if it doesn't fit in
+    // HEADERS_ONLY_DRAIN_MAX. The consumer still gets the usual
+    // start/header/done sequence, with an empty body; `data_callback` never
+    // fires.
     headers_only: bool = false,
 
     // The document frame this request belongs to, for CDP attribution.
@@ -2129,11 +2106,6 @@ pub const Transfer = struct {
     // client.graveyard (deinit unlinks it from those queues first, so the
     // node is always free by then).
     _node: std.DoublyLinkedList.Node = .{},
-
-    // Which of the two pending queues _node is linked into. Only meaningful
-    // while state == .queued; set at enqueue, read when unlinking, because
-    // removing from the wrong list would corrupt both.
-    _queued_low: bool = false,
 
     // Buffered response ordered events awaiting dispatch.
     _events: std.ArrayList(Event) = .empty,
@@ -3115,36 +3087,14 @@ pub const Transfer = struct {
                 return @intCast(chunk_len);
             }
 
-            if (transfer.req.headers_only) {
-                const drainable = if (transfer.getContentLength()) |cl|
-                    cl <= Request.HEADERS_ONLY_DRAIN_MAX
-                else
-                    // No Content-Length (chunked): we can't tell how much is
-                    // coming, so don't gamble on it being small.
-                    false;
-
-                if (drainable) {
-                    // Reuses the redirect machinery: consumed, never buffered,
-                    // so the response still completes with an empty body.
-                    res.skip_body = true;
-                    return @intCast(chunk_len);
+            if (transfer.req.headers_only == false) {
+                if (transfer.getContentLength()) |cl| {
+                    if (cl > transfer.client.max_response_size) {
+                        res.callback_error = error.ResponseTooLarge;
+                        return http.writefunc_error;
+                    }
+                    res.buffer.ensureTotalCapacityPrecise(transfer.arena.allocator(), cl) catch {};
                 }
-
-                // Returning writefunc_error is the only way to end a transfer
-                // early from a write callback; processOneMessage recognises
-                // the flag and treats the resulting CURLE_WRITE_ERROR as a
-                // completed response with an empty body.
-                res.headers_only_abort = true;
-                return http.writefunc_error;
-            }
-
-            // Pre-size buffer from Content-Length.
-            if (transfer.getContentLength()) |cl| {
-                if (cl > transfer.client.max_response_size) {
-                    res.callback_error = error.ResponseTooLarge;
-                    return http.writefunc_error;
-                }
-                res.buffer.ensureTotalCapacityPrecise(transfer.arena.allocator(), cl) catch {};
             }
         }
 
@@ -3153,6 +3103,21 @@ pub const Transfer = struct {
         }
 
         res.bytes_received += chunk_len;
+
+        if (transfer.req.headers_only) {
+            // Plenty of images have no Content-Length to decide this up front, so
+            // decide it as the body arrives.
+            if (res.bytes_received <= Request.HEADERS_ONLY_DRAIN_MAX) {
+                return @intCast(chunk_len);
+            }
+
+            // Returning writefunc_error is the only way to end a transfer
+            // early from a write callback; processOneMessage recognises the
+            // flag and treats the resulting CURLE_WRITE_ERROR as a completed
+            // response with an empty body.
+            res.headers_only_abort = true;
+            return http.writefunc_error;
+        }
 
         const chunk = buffer[0..chunk_len];
 

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -837,7 +837,7 @@ fn isGated(self: *const Client, transfer: *const Transfer) bool {
 // ahead of the script that's blocking the parser.
 fn isLowPriority(resource_type: Request.ResourceType) bool {
     return switch (resource_type) {
-        .image => false, // EXPERIMENT
+        .image => true,
         .document, .xhr, .script, .fetch, .stylesheet, .eventsource => false,
     };
 }

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -539,7 +539,7 @@ pub fn activity(self: *const Client) Activity {
         .http = self.http_active + self.dispatch_count + self.intercepted + self.delayed_count,
         .ws_events = self.ws_dispatch_count,
         .ws_conns = self.ws_active,
-        .pending = self.pending_queue.first != null,
+        .pending = self.pending_queue.first != null or self.pending_low_queue.first != null,
     };
 }
 
@@ -831,13 +831,24 @@ fn isGated(self: *const Client, transfer: *const Transfer) bool {
     return transfer.id != blocking_id;
 }
 
+// Resources the page's progress doesn't depend on. Images are fetched for
+// their status (so load/error is honest) and, with `--fetch-images headers`,
+// a page can queue dozens of them in one parse — none of which should come
+// ahead of the script that's blocking the parser.
+fn isLowPriority(resource_type: Request.ResourceType) bool {
+    return switch (resource_type) {
+        .image => false, // EXPERIMENT
+        .document, .xhr, .script, .fetch, .stylesheet, .eventsource => false,
+    };
+}
+
 fn startPending(self: *Client) !void {
     try self.startDelayed();
     while (self.pending_queue.popFirst()) |queue_node| {
         const transfer: *Transfer = @fieldParentPtr("_node", queue_node);
         const conn = self.network.getConnection() orelse {
-            self.pending_queue.prepend(queue_node);
-            return;
+            queue.prepend(queue_node);
+            return false;
         };
         // Bridge state to .created so a failure inside makeRequest before
         // any commit cleans up via the failAsync below. makeRequest flips to
@@ -853,6 +864,7 @@ fn startPending(self: *Client) !void {
             return err;
         };
     }
+    return true;
 }
 
 // Enter the pipeline for every delayed transfer whose time has come.
@@ -1107,6 +1119,13 @@ fn cacheStore(self: *Client, transfer: *Transfer) void {
     // entry a second time on any early return below.
     transfer._cache_intent = .none;
 
+    // A headers_only transfer never read the body. Storing it would put an
+    // empty entry under the real cache key and every later full fetch of
+    // that URL (an XHR, a `full` image fetch) would hit it and get nothing.
+    if (transfer.req.headers_only) {
+        return;
+    }
+
     // could have been disabled while waiting of the response
     const cache = self.cache.active() orelse return;
 
@@ -1285,11 +1304,19 @@ pub fn syncRequest(self: *Client, transfer: *Transfer) !SyncResponse {
 }
 
 fn processTransfer(self: *Client, transfer: *Transfer) !void {
-    if (self.network.getConnection()) |conn| {
-        return self.makeRequest(conn, transfer);
+    const low = isLowPriority(transfer.req.resource_type);
+    if (!low or self.pending_queue.first == null) {
+        if (self.network.getConnection()) |conn| {
+            return self.makeRequest(conn, transfer);
+        }
     }
 
-    self.pending_queue.append(&transfer._node);
+    transfer._queued_low = low;
+    if (low) {
+        self.pending_low_queue.append(&transfer._node);
+    } else {
+        self.pending_queue.append(&transfer._node);
+    }
     transfer.state = .queued;
 }
 
@@ -1507,6 +1534,11 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     const effective_err: ?anyerror = if (msg.err) |err| blk: {
         if (err == error.WriteError and transfer.res.callback_error == null and transfer.res.bytes_received > 0) {
             log.debug(.http, "WriteError downgraded", .{ .url = transfer.req.url, .bytes = transfer.res.bytes_received });
+            break :blk null;
+        }
+        // Our own headers_only abort, not a failure: fall through so the
+        // response is materialized and delivered with an empty body.
+        if (err == error.WriteError and transfer.res.headers_only_abort) {
             break :blk null;
         }
         break :blk err;
@@ -1751,6 +1783,7 @@ pub const Request = struct {
         fetch,
         stylesheet,
         eventsource,
+        image,
 
         // Allowed Values: Document, Stylesheet, Image, Media, Font, Script,
         // TextTrack, XHR, Fetch, Prefetch, EventSource, WebSocket, Manifest,
@@ -1764,6 +1797,7 @@ pub const Request = struct {
                 .fetch => "Fetch",
                 .stylesheet => "Stylesheet",
                 .eventsource => "EventSource",
+                .image => "Image",
             };
         }
     };
@@ -1771,6 +1805,12 @@ pub const Request = struct {
     // Fetch request redirect mode. `.follow` keeps navigations, XHR and
     // internal requests transparently following redirects.
     pub const RedirectMode = enum { follow, manual, @"error" };
+
+    // Largest body a headers_only transfer will read to the end rather than
+    // abort. Draining costs bandwidth but keeps the connection poolable;
+    // aborting saves bandwidth but forces a reconnect. 16 KiB is the rough
+    // break-even: about ten segments, versus a TCP handshake plus a TLS one.
+    pub const HEADERS_ONLY_DRAIN_MAX: usize = 16 * 1024;
 
     frame_id: u32,
     loader_id: u32,
@@ -1786,6 +1826,16 @@ pub const Request = struct {
     notification: *Notification,
     timeout_ms: u32 = 0,
     skip_cache: bool = false,
+
+    // Tear the transfer off the wire as soon as the first body byte arrives:
+    // the caller wants the status and the response headers, not the body.
+    // Unlike a HEAD, the request itself is byte-for-byte a normal GET, so
+    // origins and CDNs see (and answer) exactly what a real browser sends.
+    // The consumer still gets the usual start/header/done sequence with an
+    // empty body; `data_callback` never fires. Note the cost: aborting
+    // mid-response means the connection can't be drained, so libcurl closes
+    // it instead of returning it to the pool.
+    headers_only: bool = false,
 
     // The document frame this request belongs to, for CDP attribution.
     // This will be different than frame_id for Workers.
@@ -2079,6 +2129,11 @@ pub const Transfer = struct {
     // client.graveyard (deinit unlinks it from those queues first, so the
     // node is always free by then).
     _node: std.DoublyLinkedList.Node = .{},
+
+    // Which of the two pending queues _node is linked into. Only meaningful
+    // while state == .queued; set at enqueue, read when unlinking, because
+    // removing from the wrong list would corrupt both.
+    _queued_low: bool = false,
 
     // Buffered response ordered events awaiting dispatch.
     _events: std.ArrayList(Event) = .empty,
@@ -2643,7 +2698,11 @@ pub const Transfer = struct {
             }
         }
 
-        if (opts.check_content_length) {
+        // headers_only is exempt: the cap exists to bound how much body we
+        // buffer, and this transfer buffers none of it. Failing a 4 MB image
+        // we were never going to read would turn the size limit into a
+        // spurious `error` event on a perfectly good response.
+        if (opts.check_content_length and !self.req.headers_only) {
             if (self.getContentLength()) |cl| {
                 if (cl > self.client.max_response_size) {
                     return error.ResponseTooLarge;
@@ -3056,6 +3115,29 @@ pub const Transfer = struct {
                 return @intCast(chunk_len);
             }
 
+            if (transfer.req.headers_only) {
+                const drainable = if (transfer.getContentLength()) |cl|
+                    cl <= Request.HEADERS_ONLY_DRAIN_MAX
+                else
+                    // No Content-Length (chunked): we can't tell how much is
+                    // coming, so don't gamble on it being small.
+                    false;
+
+                if (drainable) {
+                    // Reuses the redirect machinery: consumed, never buffered,
+                    // so the response still completes with an empty body.
+                    res.skip_body = true;
+                    return @intCast(chunk_len);
+                }
+
+                // Returning writefunc_error is the only way to end a transfer
+                // early from a write callback; processOneMessage recognises
+                // the flag and treats the resulting CURLE_WRITE_ERROR as a
+                // completed response with an empty body.
+                res.headers_only_abort = true;
+                return http.writefunc_error;
+            }
+
             // Pre-size buffer from Content-Length.
             if (transfer.getContentLength()) |cl| {
                 if (cl > transfer.client.max_response_size) {
@@ -3337,6 +3419,12 @@ const Response = struct {
 
     skip_body: bool = false,
     first_data_received: bool = false,
+
+    // Set when dataCallback deliberately killed the transfer to satisfy
+    // `Request.headers_only`. processOneMessage uses it to tell our own
+    // abort apart from a real CURLE_WRITE_ERROR and deliver the response
+    // (headers, status, empty body) as a success.
+    headers_only_abort: bool = false,
 
     // Response body. Filled by dataCallback, consumed in processMessages.
     // See Stream.spare to see how this works in streaming mode

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -342,6 +342,7 @@ const HtmlRunnerOpts = struct {
     timeout_ms: u32 = 2000,
     inject_script: ?[]const u8 = null,
     load_external_stylesheets: bool = false,
+    load_resources: Config.LoadResources = .{},
 };
 
 // Create a fresh page on `test_session` and return its root frame — for tests
@@ -369,6 +370,9 @@ pub fn htmlRunner(comptime path: []const u8, opts: HtmlRunnerOpts) !void {
 
     test_session.load_external_stylesheets = opts.load_external_stylesheets;
     defer test_session.load_external_stylesheets = false;
+
+    test_session.load_resources = opts.load_resources;
+    defer test_session.load_resources = .{};
 
     const root = try std.fs.path.joinZ(arena_allocator, &.{ WEB_API_TEST_ROOT, path });
     const stat = std.Io.Dir.cwd().statFile(io, root, .{}) catch |err| {
@@ -965,6 +969,64 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         return req.respond(body.items, .{
             .extra_headers = &.{
                 .{ .name = "Content-Type", .value = "text/css" },
+            },
+        });
+    }
+
+    // Image routes for element/html/image_fetch.html. Every body here is
+    // non-empty, so libcurl always reaches the write callback — which is
+    // where `--fetch-images headers` decides what to do. A `load` event off
+    // any of these proves that decision ended in a successful response.
+    //
+    // ok.png is deliberately larger than Request.HEADERS_ONLY_DRAIN_MAX so
+    // it takes the abort branch; small.png is deliberately under it so it
+    // takes the drain-and-keep-the-connection branch. Both must behave
+    // identically as far as the DOM is concerned.
+    if (std.mem.eql(u8, path, "/images/ok.png")) {
+        const body = try arena_allocator.alloc(u8, 64 * 1024);
+        @memset(body, 'x');
+        return req.respond(body, .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "image/png" },
+            },
+        });
+    }
+
+    // startsWith, not eql: the concurrency test appends ?n= to get distinct
+    // URLs (and so distinct transfers) off one route.
+    if (std.mem.startsWith(u8, path, "/images/small.png")) {
+        const body = try arena_allocator.alloc(u8, 1024);
+        @memset(body, 'x');
+        return req.respond(body, .{
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "image/png" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/images/404.png")) {
+        return req.respond("not here", .{
+            .status = .not_found,
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/plain" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/images/500.png")) {
+        return req.respond("boom", .{
+            .status = .internal_server_error,
+            .extra_headers = &.{
+                .{ .name = "Content-Type", .value = "text/plain" },
+            },
+        });
+    }
+
+    if (std.mem.eql(u8, path, "/images/redirect.png")) {
+        return req.respond("", .{
+            .status = .found,
+            .extra_headers = &.{
+                .{ .name = "Location", .value = "/images/ok.png" },
             },
         });
     }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -973,17 +973,13 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
-    // Image routes for element/html/image_fetch.html. Every body here is
-    // non-empty, so libcurl always reaches the write callback — which is
-    // where `--fetch-images headers` decides what to do. A `load` event off
-    // any of these proves that decision ended in a successful response.
-    //
-    // ok.png is deliberately larger than Request.HEADERS_ONLY_DRAIN_MAX so
-    // it takes the abort branch; small.png is deliberately under it so it
-    // takes the drain-and-keep-the-connection branch. Both must behave
-    // identically as far as the DOM is concerned.
+    // Bodies are non-empty so that libcurl always reaches the write callback,
+    // which is where a headers_only request decides whether to drain or abort.
+    // ok.png takes the abort branch, small.png the drain branch; both must
+    // behave identically as far as the DOM is concerned.
     if (std.mem.eql(u8, path, "/images/ok.png")) {
-        const body = try arena_allocator.alloc(u8, 64 * 1024);
+        // > HttpClient.Request.HEADERS_ONLY_DRAIN_MAX
+        const body = try arena_allocator.alloc(u8, 16 * 1024 + 1);
         @memset(body, 'x');
         return req.respond(body, .{
             .extra_headers = &.{
@@ -992,8 +988,8 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
-    // startsWith, not eql: the concurrency test appends ?n= to get distinct
-    // URLs (and so distinct transfers) off one route.
+    // startsWith, not eql: a caller can append a query string to get distinct
+    // URLs (and so distinct transfers) off this one route.
     if (std.mem.startsWith(u8, path, "/images/small.png")) {
         const body = try arena_allocator.alloc(u8, 1024);
         @memset(body, 'x');
@@ -1002,6 +998,22 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
                 .{ .name = "Content-Type", .value = "image/png" },
             },
         });
+    }
+
+    // No Content-Length: whether the body is small enough to drain can only
+    // be decided as it arrives.
+    if (std.mem.eql(u8, path, "/images/chunked.png")) {
+        var send_buffer: [1024]u8 = undefined;
+        var res = try req.respondStreaming(&send_buffer, .{
+            .respond_options = .{
+                .extra_headers = &.{
+                    .{ .name = "Content-Type", .value = "image/svg+xml" },
+                },
+            },
+        });
+        try res.writer.writeAll("<svg xmlns=\"http://www.w3.org/2000/svg\"/>");
+        try res.writer.flush();
+        return res.end();
     }
 
     if (std.mem.eql(u8, path, "/images/404.png")) {


### PR DESCRIPTION
This PR adds `--load-resources` CLI argument. It can take `image` parameter to actually request images over network for their existence, verified by HTTP response. In order to reuse connections on HTTP/1.1, we read the response body if it includes `Content-Length` header with value that's <= `HEADERS_ONLY_DRAIN_MAX` (16 KiB), which consumes more bandwidth but performs better than opening a socket, doing TLS handshake etc. steps.