### PR TITLE
webapi: reject elementFromPoint outside viewport

### DIFF
--- a/src/browser/tests/document/element_from_point.html
+++ b/src/browser/tests/document/element_from_point.html
@@ -68,9 +68,24 @@
 
 <script id="outside_viewport">
 {
-  // Test points outside all elements
-  const element = document.elementFromPoint(-1000, -1000);
-  testing.expectEqual(null, element);
+  // CSSOM View requires viewport-external coordinates to return null.
+  const outsidePoints = [
+    [-1, 0],
+    [0, -1],
+    [window.innerWidth + 1, 10],
+    [0, window.innerHeight + 1],
+    // Coordinates observed on Taobao before the traversal hotspot.
+    [1248, 1932576],
+  ];
+
+  for (const [x, y] of outsidePoints) {
+    testing.expectEqual(null, document.elementFromPoint(x, y));
+  }
+
+  // The CSSOM View bounds are strict: coordinates equal to the dimensions
+  // are not rejected by the viewport guard.
+  testing.expectTrue(document.elementFromPoint(window.innerWidth, 10) !== null);
+  testing.expectTrue(document.elementFromPoint(10, window.innerHeight) !== null);
 }
 </script>
 
@@ -209,11 +224,20 @@
 
 <script id="elementsFromPoint_outside">
 {
-  // Test with point outside all elements
-  const elements = document.elementsFromPoint(-1000, -1000);
+  // elementsFromPoint shares the viewport guard and returns an empty sequence.
+  const outsidePoints = [
+    [-1, 0],
+    [0, -1],
+    [window.innerWidth + 1, 10],
+    [0, window.innerHeight + 1],
+    [1248, 1932576],
+  ];
 
-  testing.expectTrue(Array.isArray(elements));
-  testing.expectEqual(0, elements.length);
+  for (const [x, y] of outsidePoints) {
+    const elements = document.elementsFromPoint(x, y);
+    testing.expectTrue(Array.isArray(elements));
+    testing.expectEqual(0, elements.length);
+  }
 }
 </script>
 

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -875,6 +875,16 @@ pub fn moveBefore(self: *Document, node: js.Value, child: js.Value, frame: *Fram
 }
 
 pub fn elementFromPoint(self: *Document, x: f64, y: f64, frame: *Frame) !?*Element {
+    // CSSOM View requires the public hit-test APIs to reject coordinates
+    // outside the viewport before walking the document. Keep this check here
+    // so elementFromVerticalPoint can continue using document coordinates.
+    const viewport = frame._page.getViewport();
+    const width: f64 = @floatFromInt(viewport.width);
+    const height: f64 = @floatFromInt(viewport.height);
+    if (x < 0 or y < 0 or x > width or y > height) {
+        return null;
+    }
+
     return self.elementFromPointImpl(x, y, false, frame);
 }
 


### PR DESCRIPTION
## Summary
- return early when `elementFromPoint()` receives coordinates outside the viewport
- preserve internal document-coordinate hit testing used by `elementFromVerticalPoint()`
- cover negative, viewport-overflow, exact-boundary, and Taobao reproduction coordinates

## Motivation
CSSOM View requires negative coordinates or coordinates greater than the viewport dimensions to return `null`. For very large y values, the existing traversal shortcut does not fire, so the browser unnecessarily walks the DOM and performs visibility checks.

## Testing
- `git diff --check`
- embedded test-script syntax validation
- CI: `TEST_FILTER="WebApi: Document#element_from_point.html" make test`