### PR TITLE
XHR Sync Request

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2332,7 +2332,7 @@ pub fn loadExternalStylesheet(self: *Frame, link: *Element.Html.Link, href: []co
     sm.is_evaluating = true;
     defer sm.endEvaluationWindow(was_evaluating);
 
-    var response = http_client.syncRequest(transfer) catch |err| {
+    var response = transfer.submitSync() catch |err| {
         log.warn(.http, "external stylesheet fetch", .{ .err = err, .url = resolved });
         return self.fireElementEvent(element, comptime .wrap("error"));
     };

--- a/src/browser/ScriptManager.zig
+++ b/src/browser/ScriptManager.zig
@@ -362,7 +362,8 @@ pub fn addFromElement(self: *ScriptManager, comptime from_parser: bool, script_e
                     errdefer transfer.deinit();
                     try frame.headersForRequest(transfer);
                 }
-                const response = try self.base.client.syncRequest(transfer);
+
+                const response = try transfer.submitSync();
 
                 // Take the body's arena rather than releasing it: `source`
                 // has to outlive this call, up to script.deinit().

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -436,7 +436,7 @@ fn importScript(self: *WorkerGlobalScope, arena: Allocator, url: [:0]const u8) !
         try self.headersForRequest(transfer);
     }
 
-    var response = http_client.syncRequest(transfer) catch |err| {
+    var response = transfer.submitSync() catch |err| {
         log.warn(.http, "importScript", .{ .url = resolved_url, .err = err });
         return error.NetworkError;
     };

--- a/src/browser/webapi/event/ProgressEvent.zig
+++ b/src/browser/webapi/event/ProgressEvent.zig
@@ -62,6 +62,7 @@ fn initWithTrusted(arena: *lp.Arena, typ: String, _opts: ?Options, trusted: bool
             ._proto = undefined,
             ._total = opts.total,
             ._loaded = opts.loaded,
+            ._length_computable = opts.lengthComputable,
         },
     );
 

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -347,6 +347,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
         return error.NetworkError;
     };
     defer resp.deinit();
+    defer self.releaseSelfRef();
 
     self._response_status = resp.status;
     self._response_url = self._url;

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -434,6 +434,11 @@ pub fn getResponseType(self: *const XMLHttpRequest) ResponseType {
 }
 
 pub fn setResponseType(self: *XMLHttpRequest, value: []const u8, exec: *const Execution) !void {
+    const rt: ResponseType = if (value.len == 0)
+        .default
+    else
+        std.meta.stringToEnum(ResponseType, value) orelse return;
+
     if (self._ready_state == .loading or self._ready_state == .done) {
         return error.InvalidStateError;
     }
@@ -447,10 +452,8 @@ pub fn setResponseType(self: *XMLHttpRequest, value: []const u8, exec: *const Ex
         return;
     }
 
-    if (std.meta.stringToEnum(ResponseType, value)) |rt| {
-        if (rt != .default) {
-            self._response_type = rt;
-        }
+    if (rt != .default) {
+        self._response_type = rt;
     }
 }
 

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -187,10 +187,9 @@ pub fn getTimeout(self: *const XMLHttpRequest) u32 {
     return self._timeout;
 }
 
-pub fn setTimeout(self: *XMLHttpRequest, value: u32) !void {
+pub fn setTimeout(self: *XMLHttpRequest, value: u32, exec: *const Execution) !void {
     // https://xhr.spec.whatwg.org/#the-timeout-attribute
-    // Throw if the request is sync OR if it is already sent.
-    if (!self._async and self._ready_state != .unsent) {
+    if (!self._async and exec.js.global == .frame) {
         return error.InvalidAccessError;
     }
 
@@ -254,6 +253,12 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     }
     if (self._ready_state != .opened or self._send_flag) {
         return error.InvalidStateError;
+    }
+
+    if (!self._async and exec_.js.global == .frame and
+        (self._timeout != 0 or self._response_type != .default))
+    {
+        return error.InvalidAccessError;
     }
 
     if (body_) |b| {
@@ -428,9 +433,13 @@ pub fn getResponseType(self: *const XMLHttpRequest) ResponseType {
     return self._response_type;
 }
 
-pub fn setResponseType(self: *XMLHttpRequest, value: []const u8) !void {
+pub fn setResponseType(self: *XMLHttpRequest, value: []const u8, exec: *const Execution) !void {
     if (self._ready_state == .loading or self._ready_state == .done) {
         return error.InvalidStateError;
+    }
+
+    if (!self._async and exec.js.global == .frame) {
+        return error.InvalidAccessError;
     }
 
     if (value.len == 0) {

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -187,7 +187,13 @@ pub fn getTimeout(self: *const XMLHttpRequest) u32 {
     return self._timeout;
 }
 
-pub fn setTimeout(self: *XMLHttpRequest, value: u32) void {
+pub fn setTimeout(self: *XMLHttpRequest, value: u32) !void {
+    // https://xhr.spec.whatwg.org/#the-timeout-attribute
+    // Throw if the request is sync OR if it is already sent.
+    if (!self._async and self._ready_state != .unsent) {
+        return error.InvalidAccessError;
+    }
+
     self._timeout = value;
 }
 
@@ -213,6 +219,12 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8, async
     self._response_headers.clearRetainingCapacity();
     self._request_body = null;
     self._async = async_ orelse true;
+
+    // https://xhr.spec.whatwg.org/#the-timeout-attribute
+    // Throw if the request is sync OR if it is already sent.
+    if (self._timeout != 0 and !self._async) {
+        return error.InvalidAccessError;
+    }
 
     const exec = self._exec;
     self._method = try parseMethod(method_);

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -347,6 +347,7 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
             .url = self._url,
             .err = err,
         });
+        self._ready_state = .done;
         self._send_flag = false;
         self.releaseSelfRef();
         return error.NetworkError;

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -337,10 +337,14 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     }
 
     var resp = transfer.submitSync() catch |err| {
+        log.err(.http, "sync request failed", .{
+            .source = "xhr",
+            .url = self._url,
+            .err = err,
+        });
         self._send_flag = false;
-        self.handleError(err);
         self.releaseSelfRef();
-        return;
+        return error.NetworkError;
     };
     defer resp.deinit();
 

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -60,6 +60,8 @@ _method: http.Method = .GET,
 _request_headers: *Headers,
 _request_body: ?[]const u8 = null,
 
+_async: bool = true,
+
 _response: ?Response = null,
 _response_data: std.ArrayList(u8) = .empty,
 _response_status: u16 = 0,
@@ -191,7 +193,7 @@ pub fn setTimeout(self: *XMLHttpRequest, value: u32) void {
 
 // TODO: this takes an optional 3 more parameters
 // TODO: url should be a union, as it can be multiple things
-pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8) !void {
+pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8, async_: ?bool) !void {
     // Abort any in-progress request
     if (self._http_transfer) |transfer| {
         transfer.abort(error.Abort);
@@ -210,6 +212,7 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8) !void
     self._response_mime = null;
     self._response_headers.clearRetainingCapacity();
     self._request_body = null;
+    self._async = async_ orelse true;
 
     const exec = self._exec;
     self._method = try parseMethod(method_);
@@ -311,12 +314,60 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
         log.debug(.http, "request start", .{ .method = self._method, .url = self._url, .source = "xhr" });
     }
 
-    transfer.submit() catch |err| {
-        // don't releaseSelfRef, submit() has taken ownership and will call
-        // our error callback
+    if (self._async) {
+        transfer.submit() catch |err| {
+            // don't releaseSelfRef, submit() has taken ownership and will call
+            // our error callback
+            self._send_flag = false;
+            return err;
+        };
+        return;
+    }
+
+    var resp = transfer.submitSync() catch |err| {
         self._send_flag = false;
-        return err;
+        self.handleError(err);
+        self.releaseSelfRef();
+        return;
     };
+    defer resp.deinit();
+
+    self._http_transfer = null;
+    self._response_status = resp.status;
+    self._response_url = self._url;
+    self._response_len = resp.body.items.len;
+
+    // TODO: Headers.
+    self._response_headers = .empty;
+    self._response_mime = null;
+
+    try self._response_data.appendSlice(self._arena.allocator(), resp.body.items);
+
+    var ls: js.Local.Scope = undefined;
+    exec.js.localScope(&ls);
+    defer ls.deinit();
+
+    try self.stateChanged(.headers_received, exec);
+    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, exec);
+    try self.stateChanged(.loading, exec);
+    try self._proto.dispatch(.progress, .{
+        .total = self._response_len orelse 0,
+        .loaded = self._response_data.items.len,
+    }, exec);
+
+    try self.stateChanged(.done, exec);
+    const loaded = self._response_data.items.len;
+    try self._proto.dispatch(.load, .{ .total = loaded, .loaded = loaded }, exec);
+    try self._proto.dispatch(.load_end, .{ .total = loaded, .loaded = loaded }, exec);
+
+    log.info(.http, "request complete", .{
+        .source = "xhr",
+        .url = self._url,
+        .status = self._response_status,
+        .len = self._response_data.items.len,
+    });
+
+    self.releaseSelfRef();
 }
 
 // https://xhr.spec.whatwg.org/#the-upload-attribute

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -375,8 +375,6 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
         .status = self._response_status,
         .len = self._response_data.items.len,
     });
-
-    self.releaseSelfRef();
 }
 
 // https://xhr.spec.whatwg.org/#the-upload-attribute

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -353,10 +353,6 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     self._response_url = self._url;
     self._response_len = resp.body.items.len;
 
-    // TODO: Headers.
-    self._response_headers = .empty;
-    self._response_mime = null;
-
     try self._response_data.appendSlice(self._arena.allocator(), resp.body.items);
 
     var ls: js.Local.Scope = undefined;

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -346,14 +346,6 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     exec.js.localScope(&ls);
     defer ls.deinit();
 
-    try self.stateChanged(.headers_received, exec);
-    try self._proto.dispatch(.load_start, .{ .loaded = 0, .total = self._response_len orelse 0 }, exec);
-    try self.stateChanged(.loading, exec);
-    try self._proto.dispatch(.progress, .{
-        .total = self._response_len orelse 0,
-        .loaded = self._response_data.items.len,
-    }, exec);
-
     try self.stateChanged(.done, exec);
     const loaded = self._response_data.items.len;
     try self._proto.dispatch(.load, .{ .total = loaded, .loaded = loaded }, exec);

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -348,8 +348,8 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
 
     try self.stateChanged(.done, exec);
     const loaded = self._response_data.items.len;
-    try self._proto.dispatch(.load, .{ .total = loaded, .loaded = loaded }, exec);
-    try self._proto.dispatch(.load_end, .{ .total = loaded, .loaded = loaded }, exec);
+    try self._proto.dispatch(.load, .{ .total = loaded, .loaded = loaded, .length_computable = true }, exec);
+    try self._proto.dispatch(.load_end, .{ .total = loaded, .loaded = loaded, .length_computable = true }, exec);
 
     log.info(.http, "request complete", .{
         .source = "xhr",

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -306,15 +306,15 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
         }
     }
 
-    // Held for abort() / open() / deinit; the error, shutdown and done
-    // callbacks clear it.
-    self._http_transfer = transfer;
-
     if (comptime lp.IS_DEBUG) {
         log.debug(.http, "request start", .{ .method = self._method, .url = self._url, .source = "xhr" });
     }
 
     if (self._async) {
+        // Held for abort() / open() / deinit; the error, shutdown and done
+        // callbacks clear it.
+        self._http_transfer = transfer;
+
         transfer.submit() catch |err| {
             // don't releaseSelfRef, submit() has taken ownership and will call
             // our error callback
@@ -332,7 +332,6 @@ pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !v
     };
     defer resp.deinit();
 
-    self._http_transfer = null;
     self._response_status = resp.status;
     self._response_url = self._url;
     self._response_len = resp.body.items.len;

--- a/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
+++ b/src/browser/webapi/net/XMLHttpRequestEventTarget.zig
@@ -74,7 +74,11 @@ pub fn dispatch(self: *XMLHttpRequestEventTarget, comptime event_type: DispatchT
     const progress = progress_ orelse Progress{};
     const event = (try ProgressEvent.initTrusted(
         comptime .wrap(typ),
-        .{ .total = progress.total, .loaded = progress.loaded },
+        .{
+            .total = progress.total,
+            .loaded = progress.loaded,
+            .lengthComputable = progress.length_computable,
+        },
         exec.page,
     )).asEvent();
 
@@ -173,6 +177,7 @@ const DispatchType = enum {
 const Progress = struct {
     loaded: usize = 0,
     total: usize = 0,
+    length_computable: bool = false,
 };
 
 pub const JsApi = struct {

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -1560,5 +1560,5 @@ test "cdp: syncRequest short-circuits after disconnect" {
         .notification = undefined,
         .shutdown_callback = @import("../network/HttpClient.zig").noopShutdown,
     }, null);
-    try testing.expectError(error.ClientDisconnected, client.syncRequest(transfer));
+    try testing.expectError(error.ClientDisconnected, transfer.submitSync());
 }

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -1226,69 +1226,6 @@ const SyncContext = struct {
     }
 };
 
-// Synchronous submit for a transfer created with newRequest. Like `submit`,
-// `syncRequest` consuems the transfer unconditionally.
-// Caller must deinit SyncResponse or otherwise take ownership of its optional arena
-pub fn syncRequest(self: *Client, transfer: *Transfer) !SyncResponse {
-    if (self.inbox.terminated) {
-        transfer.deinit();
-        return error.ClientDisconnected;
-    }
-    // A parser can start another blocking script/style fetch while unwinding
-    // a previous interrupted fetch. The first tickSync below would fail
-    // anyway; bail before submitting and notifying CDP.
-    if (self.hasPendingTeardown()) {
-        transfer.deinit();
-        return error.SyncWaitInterrupted;
-    }
-
-    var sync_ctx = SyncContext{ .client = self, .body = .empty };
-    errdefer if (sync_ctx.arena) |arena| arena.release();
-
-    const req = &transfer.req;
-    req.sync = true;
-    req.ctx = &sync_ctx;
-    req.header_callback = SyncContext.headerCallback;
-    req.data_callback = SyncContext.dataCallback;
-    req.done_callback = SyncContext.doneCallback;
-    req.error_callback = SyncContext.errorCallback;
-    req.shutdown_callback = SyncContext.shutdownCallback;
-
-    const frame_id = req.frame_id;
-    self.blocking_requests.putNoClobber(self.allocator, frame_id, transfer.id) catch |err| {
-        transfer.deinit();
-        return err;
-    };
-    defer self.releaseBlocking(frame_id);
-
-    try transfer.submit();
-
-    while (sync_ctx.completion == .in_progress) {
-        self.tickSync(200) catch |err| {
-            if (sync_ctx.completion == .in_progress) {
-                // tick failed for a reason unrelated to our transfer: OOM,
-                // client disconnect, or a queued teardown command (which
-                // sync_wait can't dispatch mid-parse — it would free the
-                // Page/Frame this stack holds). transfer.req.ctx points at
-                // &sync_ctx on this stack — abort to sever that reference
-                // before we return
-                transfer.abort(err);
-            }
-            return err;
-        };
-    }
-
-    switch (sync_ctx.completion) {
-        .in_progress => @panic("Impossible to be in progress here."),
-        .done, .shutdown => return .{
-            .status = sync_ctx.status,
-            .body = sync_ctx.body,
-            .arena = sync_ctx.arena,
-        },
-        .err => |e| return e,
-    }
-}
-
 fn processTransfer(self: *Client, transfer: *Transfer) !void {
     if (self.network.getConnection()) |conn| {
         return self.makeRequest(conn, transfer);
@@ -2281,6 +2218,69 @@ pub const Transfer = struct {
             self.abortPipelineError(err);
             return err;
         };
+    }
+
+    pub fn submitSync(self: *Transfer) !SyncResponse {
+        const client = self.client;
+
+        if (client.inbox.terminated) {
+            self.deinit();
+            return error.ClientDisconnected;
+        }
+
+        // A parser can start another blocking script/style fetch while unwinding
+        // a previous interrupted fetch. The first tickSync below would fail
+        // anyway; bail before submitting and notifying CDP.
+        if (client.hasPendingTeardown()) {
+            self.deinit();
+            return error.SyncWaitInterrupted;
+        }
+
+        var sync_ctx = SyncContext{ .client = client, .body = .empty };
+        errdefer if (sync_ctx.arena) |arena| arena.release();
+
+        const req = &self.req;
+        req.sync = true;
+        req.ctx = &sync_ctx;
+        req.header_callback = SyncContext.headerCallback;
+        req.data_callback = SyncContext.dataCallback;
+        req.done_callback = SyncContext.doneCallback;
+        req.error_callback = SyncContext.errorCallback;
+        req.shutdown_callback = SyncContext.shutdownCallback;
+
+        const frame_id = req.frame_id;
+        client.blocking_requests.putNoClobber(client.allocator, frame_id, self.id) catch |err| {
+            self.deinit();
+            return err;
+        };
+        defer client.releaseBlocking(frame_id);
+
+        try self.submit();
+
+        while (sync_ctx.completion == .in_progress) {
+            client.tickSync(200) catch |err| {
+                if (sync_ctx.completion == .in_progress) {
+                    // tick failed for a reason unrelated to our transfer: OOM,
+                    // client disconnect, or a queued teardown command (which
+                    // sync_wait can't dispatch mid-parse — it would free the
+                    // Page/Frame this stack holds). transfer.req.ctx points at
+                    // &sync_ctx on this stack — abort to sever that reference
+                    // before we return
+                    self.abort(err);
+                }
+                return err;
+            };
+        }
+
+        switch (sync_ctx.completion) {
+            .in_progress => @panic("Impossible to be in progress here."),
+            .done, .shutdown => return .{
+                .status = sync_ctx.status,
+                .body = sync_ctx.body,
+                .arena = sync_ctx.arena,
+            },
+            .err => |e| return e,
+        }
     }
 
     pub fn deinit(self: *Transfer) void {


### PR DESCRIPTION
This adds support for synchronous XHR requests. It also improves coverage on the `/xhr/` tests. This will eventually be needed by certain WPT tests to pass on #3002 