### PR TITLE
`AdBlocker`: request engine

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -276,9 +276,9 @@ const CommonOptions = .{
     .{ .name = "web_bot_auth_domain", .type = ?[]const u8 },
     .{ .name = "user_agent", .type = ?[]const u8, .validator = userAgentValidator },
     .{ .name = "block_private_networks", .type = bool },
-    .{ .name = "block_cidrs", .type = ?[]const u8 },
-    .{ .name = "block_urls", .type = ?[]const u8 },
-    .{ .name = "adblock_lists", .type = ?[]const u8 },
+    .{ .name = "block_cidrs", .type = ?[]const u8, .validator = accumulateValidator },
+    .{ .name = "block_urls", .type = ?[]const u8, .validator = accumulateValidator },
+    .{ .name = "adblock_lists", .type = ?[]const u8, .validator = accumulateValidator },
     .{ .name = "cookie", .type = ?[]const u8 },
     .{ .name = "cookie_jar", .type = ?[]const u8 },
     .{ .name = "disable_subframes", .type = bool, .deprecated = "subframes are now disabled by default, use \"--load-resources iframe\" to enable" },
@@ -1264,6 +1264,30 @@ test "Config: parseArgs refuses an invalid --http-header" {
     }
 }
 
+test "Config: parseArgs accumulates repeated list flags" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const argv = [_][*:0]const u8{
+        "lightpanda",         "fetch",
+        "--adblock-lists",    "easylist.txt",
+        "--adblock-lists",    "easyprivacy.txt,annoyances.txt",
+        "--block-cidrs",      "10.0.0.0/8",
+        "--block-cidrs",      "-10.0.0.42/32",
+        "http://example.com",
+    };
+    const proc_args: std.process.Args = .{ .vector = &argv };
+    const config = try parseArgs(arena.allocator(), proc_args);
+
+    var paths = config.adblockLists().?;
+    try std.testing.expectEqualStrings("easylist.txt", paths.next().?);
+    try std.testing.expectEqualStrings("easyprivacy.txt", paths.next().?);
+    try std.testing.expectEqualStrings("annoyances.txt", paths.next().?);
+    try std.testing.expectEqual(null, paths.next());
+
+    try std.testing.expectEqualStrings("10.0.0.0/8,-10.0.0.42/32", config.blockCidrs().?);
+}
+
 test "Config: parseArgs collects --http-header" {
     // The parsed headers are owned by the allocator for the process lifetime;
     // an arena stands in for main's.
@@ -1309,6 +1333,18 @@ test "Config: httpHeaders accessor" {
         try std.testing.expectEqualStrings("X-Extra", headers[0].name);
         try std.testing.expectEqualStrings("1", headers[0].value);
     }
+}
+
+/// For comma-separated flags the help documents as repeatable: each
+/// occurrence appends to what earlier ones left, so "--x a --x b" equals
+/// "--x a,b" instead of the last flag silently winning.
+fn accumulateValidator(allocator: Allocator, args: *std.process.Args.Iterator, field: *?[]const u8) !void {
+    const str = args.next() orelse return error.MissingArgument;
+    const existing = field.* orelse {
+        field.* = try allocator.dupe(u8, str);
+        return;
+    };
+    field.* = try std.mem.join(allocator, ",", &.{ existing, str });
 }
 
 fn userAgentValidator(allocator: Allocator, args: *std.process.Args.Iterator, ua: *?[]const u8) !void {

--- a/src/Metrics.zig
+++ b/src/Metrics.zig
@@ -94,6 +94,8 @@ robots_access: CounterEnum("result", enum { allow, deny }) = .{},
 cors_check: CounterEnum("result", enum { same_origin, no_cors, simple, preflight }) = .{},
 cors_preflight: CounterEnum("result", enum { allowed, blocked }) = .{},
 cors_response: CounterEnum("result", enum { allowed, blocked }) = .{},
+adblock_verdicts: CounterEnum("verdict", @import("network/adblock/AdBlocker.zig").Verdict) = .{},
+adblock_rules: GaugeEnum("state", enum { loaded, skipped }) = .{},
 
 // Emitted as each metric's "# HELP" line. A field without an entry is a
 // compile error.
@@ -129,6 +131,8 @@ const help = .{
     .cors_check = "CORS initial classification: same_origin/no_cors need no CORS handling, simple needs response validation only, preflight needs an OPTIONS round-trip first",
     .cors_preflight = "CORS preflight (OPTIONS) results, one per request that required one",
     .cors_response = "CORS actual-response validation results",
+    .adblock_verdicts = "Adblocker decisions for evaluated requests, by verdict (none = no filter matched)",
+    .adblock_rules = "Filter-list rules by fate: loaded into the matcher, or skipped as unsupported",
 };
 
 pub fn write(self: *const Metrics, writer: *std.Io.Writer) void {
@@ -216,6 +220,10 @@ fn GaugeEnum(comptime label: []const u8, comptime T: type) type {
 
         pub fn decr(self: *Self, tag: T) void {
             self.values.getPtr(tag).decr();
+        }
+
+        pub fn add(self: *Self, tag: T, n: i64) void {
+            self.values.getPtr(tag).add(n);
         }
 
         fn write(self: *const Self, comptime name: []const u8, comptime help_text: []const u8, writer: *std.Io.Writer) !void {

--- a/src/Metrics.zig
+++ b/src/Metrics.zig
@@ -95,7 +95,7 @@ cors_check: CounterEnum("result", enum { same_origin, no_cors, simple, preflight
 cors_preflight: CounterEnum("result", enum { allowed, blocked }) = .{},
 cors_response: CounterEnum("result", enum { allowed, blocked }) = .{},
 adblock_verdicts: CounterEnum("verdict", @import("network/adblock/AdBlocker.zig").Verdict) = .{},
-adblock_rules: GaugeEnum("state", enum { loaded, skipped }) = .{},
+adblock_rules: GaugeEnum("state", enum { loaded, skipped, cosmetic }) = .{},
 
 // Emitted as each metric's "# HELP" line. A field without an entry is a
 // compile error.
@@ -131,8 +131,8 @@ const help = .{
     .cors_check = "CORS initial classification: same_origin/no_cors need no CORS handling, simple needs response validation only, preflight needs an OPTIONS round-trip first",
     .cors_preflight = "CORS preflight (OPTIONS) results, one per request that required one",
     .cors_response = "CORS actual-response validation results",
-    .adblock_verdicts = "Adblocker decisions for evaluated requests, by verdict (none = no filter matched)",
-    .adblock_rules = "Filter-list rules by fate: loaded into the matcher, or skipped as unsupported",
+    .adblock_verdicts = "Adblocker decisions for evaluated requests, by verdict (none = not blocked, allowed = an exception overrode a block)",
+    .adblock_rules = "Filter-list rules by fate: loaded into the matcher, skipped as unsupported, or cosmetic (domain-scoped element hiding, outside the network realm)",
 };
 
 pub fn write(self: *const Metrics, writer: *std.Io.Writer) void {

--- a/src/help.zon
+++ b/src/help.zon
@@ -328,7 +328,8 @@
     \\common options:
     \\  --adblock-lists <LIST>
     \\          EasyList-syntax filter files to load. Can be passed multiple times.
-    \\          Requests to a hostname blocked by any list are failed before they leave.
+    \\          Requests a list blocks are failed before they leave; the URL,
+    \\          resource type, party and $domain= of each one decide.
     \\          e.g. --adblock-lists easylist.txt --adblock-lists easyprivacy.txt
     \\  --block-cidrs <CIDR>
     \\          Additional CIDR ranges to block. Can be passed multiple times.

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -4264,6 +4264,9 @@ fn testIsUrlBlocked(client: *const Client, opts: TestRequest) bool {
         .req = .{
             .method = .GET,
             .url = opts.url,
+            .origin = null,
+            .credentials_mode = .omit,
+            .request_mode = .no_cors,
             .resource_type = opts.resource_type,
             .internal = opts.internal,
             .shutdown_callback = noopShutdown,

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -404,16 +404,7 @@ fn isUrlBlocked(self: *const Client, transfer: *const Transfer) bool {
     if (self.url_blocklist) |*blocklist| {
         if (blocklist.isBlocked(req.url)) return true;
     }
-    return self.isAdblocked(transfer);
-}
-
-fn isAdblocked(self: *const Client, transfer: *const Transfer) bool {
-    const blocker = if (self.network.adblocker) |*b| b else return false;
-    var buffers: AdBlocker.Request.Buffers = undefined;
-    const target = AdBlocker.Request.fromHttp(transfer, &buffers) orelse return false;
-    const verdict = blocker.match(target);
-    lp.metrics.adblock_verdicts.incr(verdict);
-    return verdict == .blocked;
+    return if (self.network.adblocker) |*blocker| blocker.isBlocked(transfer) else false;
 }
 
 fn adblockSourceUrl(transfer: *const Transfer) ?[]const u8 {

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -410,11 +410,7 @@ fn isUrlBlocked(self: *const Client, transfer: *const Transfer) bool {
 fn isAdblocked(self: *const Client, transfer: *const Transfer) bool {
     const blocker = if (self.network.adblocker) |*b| b else return false;
     var buffers: AdBlocker.Request.Buffers = undefined;
-    const target = AdBlocker.Request.fromHttp(
-        &transfer.req,
-        adblockSourceUrl(transfer),
-        &buffers,
-    ) orelse return false;
+    const target = AdBlocker.Request.fromHttp(transfer, &buffers) orelse return false;
     const verdict = blocker.match(target);
     lp.metrics.adblock_verdicts.incr(verdict);
     return verdict == .blocked;
@@ -1904,11 +1900,6 @@ pub const Request = struct {
     // Whether this request should (possibly) be throttled based on the RateLimiter
     throttle: bool = false,
 
-    // Whether a `.document` request is loading a nested frame rather than the
-    // top-level page. The reason why is filter lists separate the two ($document vs
-    // $subdocument), and only ever block the latter.
-    is_subframe: bool = false,
-
     // Set by syncRequest; only used to label the http_requests metric.
     sync: bool = false,
 
@@ -2109,7 +2100,9 @@ pub const Owner = struct {
 
     // The parent frame's Owner; for a worker, its creating frame's. Outlives
     // this Owner: child frames are torn down before their parent, a worker
-    // before its frame.
+    // before its frame. A `.document` request's owner is the frame it
+    // navigates, so a parent here is what makes that load a nested frame's;
+    // the adblocker tells $document from $subdocument by it.
     parent: ?*const Owner,
 
     // Copied onto every request made through this owner, see Request.
@@ -4251,7 +4244,6 @@ const TestRequest = struct {
     /// The page embedding `document`, when the test wants a deeper chain.
     parent_document: [:0]const u8 = "",
     resource_type: Request.ResourceType = .document,
-    is_subframe: bool = false,
     internal: bool = false,
 };
 
@@ -4282,7 +4274,6 @@ fn testIsUrlBlocked(client: *const Client, opts: TestRequest) bool {
             .method = .GET,
             .url = opts.url,
             .resource_type = opts.resource_type,
-            .is_subframe = opts.is_subframe,
             .internal = opts.internal,
             .shutdown_callback = noopShutdown,
         },
@@ -4331,10 +4322,11 @@ test "HttpClient: adblock verdicts apply per request" {
         .resource_type = .xhr,
     }));
 
-    // A `.document` request is $subdocument only inside a nested frame.
+    // A `.document` request is $subdocument only inside a nested frame,
+    // which its owner chain tells: the navigated frame has a parent.
     try testing.expect(testIsUrlBlocked(&client, .{
         .url = "https://framed.example.com/",
-        .is_subframe = true,
+        .document = "https://news.com/",
     }));
     try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://framed.example.com/" }));
 
@@ -4352,16 +4344,13 @@ test "HttpClient: adblock verdicts apply per request" {
     }));
 
     // A top-level navigation is its own context: the page it was clicked on
-    // does not make it third-party...
-    try testing.expect(!testIsUrlBlocked(&client, .{
-        .url = "https://partied.example.com/",
-        .document = "https://news.com/",
-    }));
+    // is not in its owner chain (it only travels as cookie_origin, which the
+    // adblocker never reads), so nothing makes it third-party...
+    try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://partied.example.com/" }));
     // ...but a subframe loading the same URL keeps its document's context.
     try testing.expect(testIsUrlBlocked(&client, .{
         .url = "https://partied.example.com/",
         .document = "https://news.com/",
-        .is_subframe = true,
     }));
 
     // The context is the issuing frame's document even under a cross-site

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -448,6 +448,7 @@ fn adblockResourceType(req: *const Request) AdBlocker.ResourceTypes {
         .script => .{ .script = true },
         .stylesheet => .{ .stylesheet = true },
         .xhr, .fetch => .{ .xmlhttprequest = true },
+        .image => .{ .image = true },
         .eventsource => .{ .other = true },
     };
 }

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -415,7 +415,9 @@ fn isAdblocked(self: *const Client, transfer: *const Transfer) bool {
         adblockSourceUrl(transfer),
         &buffers,
     ) orelse return false;
-    return blocker.match(target) == .blocked;
+    const verdict = blocker.match(target);
+    lp.metrics.adblock_verdicts.incr(verdict);
+    return verdict == .blocked;
 }
 
 fn adblockSourceUrl(transfer: *const Transfer) ?[]const u8 {

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -398,59 +398,32 @@ fn clearUrlBlocklist(self: *Client) void {
 /// Every reason a request is refused before it reaches the network:
 /// `--block-urls` patterns and the `--adblock-lists` filters both land here
 /// so that no call site can apply one without the other.
-fn isUrlBlocked(self: *const Client, req: *const Request) bool {
+fn isUrlBlocked(self: *const Client, transfer: *const Transfer) bool {
+    const req = &transfer.req;
     if (req.internal) return false;
     if (self.url_blocklist) |*blocklist| {
         if (blocklist.isBlocked(req.url)) return true;
     }
-    return self.isAdblocked(req);
+    return self.isAdblocked(transfer);
 }
 
-/// Longest URL we will match filters against.
-/// Anything past this is not a resource a filter list has an opinion about.
-const ADBLOCK_URL_MAX = 8 * 1024;
-
-fn isAdblocked(self: *const Client, req: *const Request) bool {
+fn isAdblocked(self: *const Client, transfer: *const Transfer) bool {
     const blocker = if (self.network.adblocker) |*b| b else return false;
-
-    var url_buf: [ADBLOCK_URL_MAX]u8 = undefined;
-    const url = normalizeForAdblock(req.url, &url_buf) orelse return false;
-
-    var source_buf: [253]u8 = undefined;
-    const top_level = req.resource_type == .document and !req.is_subframe;
-    const source_host = if (top_level) "" else URL.getOriginHostname(req.cookie_origin);
-    const source = if (source_host.len == 0 or source_host.len > source_buf.len)
-        ""
-    else
-        std.ascii.lowerString(&source_buf, source_host);
-
-    return blocker.match(.init(url, source, adblockResourceType(req))) == .blocked;
+    var buffers: AdBlocker.Request.Buffers = undefined;
+    const target = AdBlocker.Request.fromHttp(
+        &transfer.req,
+        adblockSourceUrl(transfer),
+        &buffers,
+    ) orelse return false;
+    return blocker.match(target) == .blocked;
 }
 
-fn normalizeForAdblock(url: [:0]const u8, buf: []u8) ?[]const u8 {
-    const end = std.mem.indexOfScalar(u8, url, '#') orelse url.len;
-    const trimmed = url[0..end];
-
-    const upper = for (trimmed, 0..) |c, i| {
-        if (std.ascii.isUpper(c)) break i;
-    } else return trimmed;
-
-    if (trimmed.len > buf.len) return null;
-    const out = buf[0..trimmed.len];
-    @memcpy(out[0..upper], trimmed[0..upper]);
-    _ = std.ascii.lowerString(out[upper..], trimmed[upper..]);
-    return out;
-}
-
-fn adblockResourceType(req: *const Request) AdBlocker.ResourceTypes {
-    return switch (req.resource_type) {
-        .document => if (req.is_subframe) .{ .subdocument = true } else .{ .document = true },
-        .script => .{ .script = true },
-        .stylesheet => .{ .stylesheet = true },
-        .xhr, .fetch => .{ .xmlhttprequest = true },
-        .image => .{ .image = true },
-        .eventsource => .{ .other = true },
-    };
+fn adblockSourceUrl(transfer: *const Transfer) ?[]const u8 {
+    var owner: *const Owner = transfer.owner orelse return null;
+    if (transfer.req.resource_type == .document) {
+        owner = owner.parent orelse return null;
+    }
+    return owner.documentUrl();
 }
 
 fn isCrossOriginModeAllowed(transfer: *const Transfer) bool {
@@ -1063,7 +1036,7 @@ fn pipeline(self: *Client, transfer: *Transfer, from: SubmitFrom) !void {
             continue :sw SubmitFrom.after_intercept;
         },
         .after_intercept => {
-            if (self.isUrlBlocked(&transfer.req)) {
+            if (self.isUrlBlocked(transfer)) {
                 log.info(.http, "blocked url", .{ .url = transfer.req.url });
                 return transfer.failAsync(error.UrlBlocked);
             }
@@ -2146,6 +2119,18 @@ pub const Owner = struct {
     notification: *Notification,
 
     const Blob = @import("../browser/webapi/Blob.zig");
+
+    /// The URL of the document this owner's requests belong to.
+    /// Handles `about:` case also.
+    pub fn documentUrl(self: *const Owner) ?[:0]const u8 {
+        var source = self;
+        while (true) {
+            if (source.url) |url| {
+                if (!std.mem.startsWith(u8, url.*, "about:")) return url.*;
+            }
+            source = source.parent orelse return null;
+        }
+    }
 
     // RFC 6265bis "site for cookies"
     pub fn siteForCookies(self: *const Owner) Cookie.SiteForCookies {
@@ -4031,14 +4016,14 @@ const Synthetic = struct {
 
 const testing = @import("../testing.zig");
 
-// Only the transfer list matters to the tests using it: they build their
-// transfers by hand and never go through newRequest.
-fn testOwner() Owner {
+// Only the transfer list, the url and the parent matter to the tests using
+// it: they build their transfers by hand and never go through newRequest.
+fn testOwner(url: ?*const [:0]const u8, parent: ?*const Owner) Owner {
     return .{
         .blob_urls = undefined,
         .origin = undefined,
-        .url = null,
-        .parent = null,
+        .url = url,
+        .parent = parent,
         .frame_id = 0,
         .document_frame_id = 0,
         .loader_id = 0,
@@ -4261,26 +4246,48 @@ test "HttpClient: setBlockedUrls owns, replaces, and clears patterns" {
 const TestRequest = struct {
     url: [:0]const u8,
     document: [:0]const u8 = "",
+    /// The page embedding `document`, when the test wants a deeper chain.
+    parent_document: [:0]const u8 = "",
     resource_type: Request.ResourceType = .document,
     is_subframe: bool = false,
     internal: bool = false,
 };
 
 fn testIsUrlBlocked(client: *const Client, opts: TestRequest) bool {
-    const req: Request = .{
-        .frame_id = 0,
-        .loader_id = 0,
-        .method = .GET,
-        .url = opts.url,
-        .cookie_jar = null,
-        .cookie_origin = opts.document,
-        .resource_type = opts.resource_type,
-        .is_subframe = opts.is_subframe,
-        .internal = opts.internal,
-        .notification = undefined,
-        .shutdown_callback = noopShutdown,
+    // The owner chain a real request carries: [0] the embedding page,
+    // [1] the request's document, [2] the frame being navigated — whose url
+    // slot already holds the target, so its context is its parent's.
+    var chain: [3]Owner = undefined;
+    chain[0] = testOwner(
+        if (opts.parent_document.len == 0) null else &opts.parent_document,
+        null,
+    );
+    chain[1] = testOwner(
+        if (opts.document.len == 0) null else &opts.document,
+        if (opts.parent_document.len == 0) null else &chain[0],
+    );
+    chain[2] = testOwner(&opts.url, if (opts.document.len == 0) null else &chain[1]);
+
+    var transfer: Transfer = .{
+        .arena = undefined,
+        .owner = if (opts.resource_type == .document)
+            &chain[2]
+        else if (opts.document.len == 0)
+            null
+        else
+            &chain[1],
+        .req = .{
+            .method = .GET,
+            .url = opts.url,
+            .resource_type = opts.resource_type,
+            .is_subframe = opts.is_subframe,
+            .internal = opts.internal,
+            .shutdown_callback = noopShutdown,
+        },
+        .client = undefined,
+        .start_time = 0,
     };
-    return client.isUrlBlocked(&req);
+    return client.isUrlBlocked(&transfer);
 }
 
 test "HttpClient: adblock verdicts apply per request" {
@@ -4353,6 +4360,35 @@ test "HttpClient: adblock verdicts apply per request" {
         .url = "https://partied.example.com/",
         .document = "https://news.com/",
         .is_subframe = true,
+    }));
+
+    // The context is the issuing frame's document even under a cross-site
+    // ancestor (the canonical ad iframe) — site-for-cookies semantics would
+    // collapse this chain to nothing and lose the party.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://partied.example.com/x.js",
+        .document = "https://adprovider.com/frame.html",
+        .parent_document = "https://news.com/",
+        .resource_type = .script,
+    }));
+
+    // A document hostname DNS could not carry is nothing a filter list has
+    // an opinion about: the request is let through, not matched sourceless.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://ads.example.com/pixel.gif",
+        .document = "https://news.com/",
+        .resource_type = .image,
+    }));
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://ads.example.com/pixel.gif",
+        .document = "https://" ++ "a" ** 254 ++ ".com/",
+        .resource_type = .image,
+    }));
+    // Same for a URL too long to normalize (uppercase forces the copy).
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://ads.example.com/" ++ "A" ** (8 * 1024),
+        .document = "https://news.com/",
+        .resource_type = .image,
     }));
 }
 
@@ -4518,21 +4554,21 @@ test "HttpClient: Fetch header overrides restore after one hop" {
 
 test "HttpClient: Owner.siteForCookies" {
     var top_url: [:0]const u8 = "http://attacker.example/attacker-nested";
-    var top = testOwner();
+    var top = testOwner(null, null);
     top.url = &top_url;
 
     var middle_url: [:0]const u8 = "http://victim.example/nested-middle";
-    var middle = testOwner();
+    var middle = testOwner(null, null);
     middle.url = &middle_url;
     middle.parent = &top;
 
     var inner_url: [:0]const u8 = "http://victim.example/inner";
-    var inner = testOwner();
+    var inner = testOwner(null, null);
     inner.url = &inner_url;
     inner.parent = &middle;
 
     // A worker has no site of its own; it takes its creating document's.
-    var worker = testOwner();
+    var worker = testOwner(null, null);
     worker.parent = &inner;
 
     // A top-level document is its own site.
@@ -4585,7 +4621,7 @@ test "HttpClient: fulfillIntercepted survives a done_callback that tears down th
     defer client.processGraveyard();
     defer client.transfers.deinit(testing.allocator);
 
-    var owner = testOwner();
+    var owner = testOwner(null, null);
 
     const Ctx = struct {
         client: *Client,
@@ -4658,7 +4694,7 @@ test "HttpClient: kill during done_callback does not also fire shutdown_callback
     defer client.processGraveyard();
     defer client.transfers.deinit(testing.allocator);
 
-    var owner = testOwner();
+    var owner = testOwner(null, null);
 
     const Ctx = struct {
         client: *Client,
@@ -4738,7 +4774,7 @@ test "HttpClient: kill during a non-terminal callback defers shutdown_callback" 
     defer client.processGraveyard();
     defer client.transfers.deinit(testing.allocator);
 
-    var owner = testOwner();
+    var owner = testOwner(null, null);
 
     const Ctx = struct {
         client: *Client,
@@ -5053,7 +5089,7 @@ test "HttpClient: abortParked survives an error_callback that tears down the own
     defer client.processGraveyard();
     defer client.transfers.deinit(testing.allocator);
 
-    var owner = testOwner();
+    var owner = testOwner(null, null);
 
     const Ctx = struct {
         client: *Client,
@@ -5127,7 +5163,7 @@ test "HttpClient: abort survives an error_callback that tears down the owner" {
     defer client.processGraveyard();
     defer client.transfers.deinit(testing.allocator);
 
-    var owner = testOwner();
+    var owner = testOwner(null, null);
 
     const Ctx = struct {
         client: *Client,

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -398,23 +398,58 @@ fn clearUrlBlocklist(self: *Client) void {
 /// Every reason a request is refused before it reaches the network:
 /// `--block-urls` patterns and the `--adblock-lists` filters both land here
 /// so that no call site can apply one without the other.
-fn isUrlBlocked(self: *const Client, url: [:0]const u8, internal: bool) bool {
-    if (internal) return false;
+fn isUrlBlocked(self: *const Client, req: *const Request) bool {
+    if (req.internal) return false;
     if (self.url_blocklist) |*blocklist| {
-        if (blocklist.isBlocked(url)) return true;
+        if (blocklist.isBlocked(req.url)) return true;
     }
-    return self.isHostAdblocked(url);
+    return self.isAdblocked(req);
 }
 
-fn isHostAdblocked(self: *const Client, url: [:0]const u8) bool {
+/// Longest URL we will match filters against.
+/// Anything past this is not a resource a filter list has an opinion about.
+const ADBLOCK_URL_MAX = 8 * 1024;
+
+fn isAdblocked(self: *const Client, req: *const Request) bool {
     const blocker = if (self.network.adblocker) |*b| b else return false;
-    const host = URL.getHostname(url);
-    if (host.len == 0 or host.len > 253) return false;
-    // The trie expects normalized (lowercase) hostnames; URLs aren't
-    // guaranteed to arrive that way.
-    var buf: [253]u8 = undefined;
-    const hostname = std.ascii.lowerString(&buf, host);
-    return blocker.matchHostname(hostname) == .blocked;
+
+    var url_buf: [ADBLOCK_URL_MAX]u8 = undefined;
+    const url = normalizeForAdblock(req.url, &url_buf) orelse return false;
+
+    var source_buf: [253]u8 = undefined;
+    const top_level = req.resource_type == .document and !req.is_subframe;
+    const source_host = if (top_level) "" else URL.getOriginHostname(req.cookie_origin);
+    const source = if (source_host.len == 0 or source_host.len > source_buf.len)
+        ""
+    else
+        std.ascii.lowerString(&source_buf, source_host);
+
+    return blocker.match(.init(url, source, adblockResourceType(req))) == .blocked;
+}
+
+fn normalizeForAdblock(url: [:0]const u8, buf: []u8) ?[]const u8 {
+    const end = std.mem.indexOfScalar(u8, url, '#') orelse url.len;
+    const trimmed = url[0..end];
+
+    const upper = for (trimmed, 0..) |c, i| {
+        if (std.ascii.isUpper(c)) break i;
+    } else return trimmed;
+
+    if (trimmed.len > buf.len) return null;
+    const out = buf[0..trimmed.len];
+    @memcpy(out[0..upper], trimmed[0..upper]);
+    _ = std.ascii.lowerString(out[upper..], trimmed[upper..]);
+    return out;
+}
+
+fn adblockResourceType(req: *const Request) AdBlocker.ResourceTypes {
+    return switch (req.resource_type) {
+        .document => if (req.is_subframe) .{ .subdocument = true } else .{ .document = true },
+        .script => .{ .script = true },
+        .stylesheet => .{ .stylesheet = true },
+        .xhr, .fetch => .{ .xmlhttprequest = true },
+        .eventsource => .{ .other = true },
+    };
 }
 
 fn isCrossOriginModeAllowed(transfer: *const Transfer) bool {
@@ -1027,7 +1062,7 @@ fn pipeline(self: *Client, transfer: *Transfer, from: SubmitFrom) !void {
             continue :sw SubmitFrom.after_intercept;
         },
         .after_intercept => {
-            if (self.isUrlBlocked(transfer.req.url, transfer.req.internal)) {
+            if (self.isUrlBlocked(&transfer.req)) {
                 log.info(.http, "blocked url", .{ .url = transfer.req.url });
                 return transfer.failAsync(error.UrlBlocked);
             }
@@ -1892,6 +1927,11 @@ pub const Request = struct {
 
     // Whether this request should (possibly) be throttled based on the RateLimiter
     throttle: bool = false,
+
+    // Whether a `.document` request is loading a nested frame rather than the
+    // top-level page. The reason why is filter lists separate the two ($document vs
+    // $subdocument), and only ever block the latter.
+    is_subframe: bool = false,
 
     // Set by syncRequest; only used to label the http_requests metric.
     sync: bool = false,
@@ -4217,7 +4257,32 @@ test "HttpClient: setBlockedUrls owns, replaces, and clears patterns" {
     try testing.expectEqual(null, client.url_blocklist);
 }
 
-test "HttpClient: adblock verdicts apply per request hostname" {
+const TestRequest = struct {
+    url: [:0]const u8,
+    document: [:0]const u8 = "",
+    resource_type: Request.ResourceType = .document,
+    is_subframe: bool = false,
+    internal: bool = false,
+};
+
+fn testIsUrlBlocked(client: *const Client, opts: TestRequest) bool {
+    const req: Request = .{
+        .frame_id = 0,
+        .loader_id = 0,
+        .method = .GET,
+        .url = opts.url,
+        .cookie_jar = null,
+        .cookie_origin = opts.document,
+        .resource_type = opts.resource_type,
+        .is_subframe = opts.is_subframe,
+        .internal = opts.internal,
+        .notification = undefined,
+        .shutdown_callback = noopShutdown,
+    };
+    return client.isUrlBlocked(&req);
+}
+
+test "HttpClient: adblock verdicts apply per request" {
     var pool = ArenaPool.init(testing.allocator, .{});
     defer pool.deinit();
 
@@ -4229,18 +4294,65 @@ test "HttpClient: adblock verdicts apply per request hostname" {
     var list: std.Io.Reader = .fixed(
         \\||ads.example.com^
         \\@@||good.ads.example.com^
+        \\||typed.example.com^$script
+        \\||partied.example.com^$third-party
+        \\||framed.example.com^$subdocument
     );
     try blocker.parse(&list);
+    try blocker.build();
     client.network.adblocker = blocker;
     defer client.network.adblocker = null;
 
-    try testing.expect(client.isUrlBlocked("https://ads.example.com/pixel.gif", false));
+    try testing.expect(testIsUrlBlocked(&client, .{ .url = "https://ads.example.com/pixel.gif" }));
     // Hostnames are matched case-insensitively and without the port.
-    try testing.expect(client.isUrlBlocked("https://SUB.ADS.EXAMPLE.COM:8443/x", false));
-    try testing.expect(!client.isUrlBlocked("https://good.ads.example.com/app.js", false));
-    try testing.expect(!client.isUrlBlocked("https://example.com/", false));
+    try testing.expect(testIsUrlBlocked(&client, .{ .url = "https://SUB.ADS.EXAMPLE.COM:8443/x" }));
+    try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://good.ads.example.com/app.js" }));
+    try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://example.com/" }));
     // Internal transfers (robots.txt, ...) are never adblocked.
-    try testing.expect(!client.isUrlBlocked("https://ads.example.com/", true));
+    try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://ads.example.com/", .internal = true }));
+
+    // The request's own type decides, not just its hostname.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://typed.example.com/a.js",
+        .resource_type = .script,
+    }));
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://typed.example.com/a.json",
+        .resource_type = .xhr,
+    }));
+
+    // A `.document` request is $subdocument only inside a nested frame.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://framed.example.com/",
+        .is_subframe = true,
+    }));
+    try testing.expect(!testIsUrlBlocked(&client, .{ .url = "https://framed.example.com/" }));
+
+    // The document URL decides the party; without one the request is first
+    // party to itself.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://partied.example.com/x.js",
+        .document = "https://news.com/",
+        .resource_type = .script,
+    }));
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://partied.example.com/x.js",
+        .document = "https://www.partied.example.com/",
+        .resource_type = .script,
+    }));
+
+    // A top-level navigation is its own context: the page it was clicked on
+    // does not make it third-party...
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://partied.example.com/",
+        .document = "https://news.com/",
+    }));
+    // ...but a subframe loading the same URL keeps its document's context.
+    try testing.expect(testIsUrlBlocked(&client, .{
+        .url = "https://partied.example.com/",
+        .document = "https://news.com/",
+        .is_subframe = true,
+    }));
 }
 
 test "HttpClient: URL blocking exempts internal transfers" {
@@ -4252,8 +4364,11 @@ test "HttpClient: URL blocking exempts internal transfers" {
     defer client.clearUrlBlocklist();
 
     try client.setBlockedUrls(&.{"*example.test*"});
-    try testing.expect(client.isUrlBlocked("https://example.test/script.js", false));
-    try testing.expect(!client.isUrlBlocked("https://example.test/robots.txt", true));
+    try testing.expect(testIsUrlBlocked(&client, .{ .url = "https://example.test/script.js" }));
+    try testing.expect(!testIsUrlBlocked(&client, .{
+        .url = "https://example.test/robots.txt",
+        .internal = true,
+    }));
 }
 
 fn testTransfer(arena: *lp.Arena) Transfer {

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -59,10 +59,6 @@ suppressed: u32,
 blocking: Engine,
 blocking_important: Engine,
 exceptions: Engine,
-/// `@@…$important` exceptions, indexed apart because they outrank the
-/// `$important` blocks while plain exceptions do not — one engine returning
-/// its first match could not tell the two apart.
-exceptions_important: Engine,
 
 /// Rules that reached a trie or an index, across every list parsed so far.
 rules_loaded: usize,
@@ -96,7 +92,6 @@ pub fn init(allocator: Allocator) Allocator.Error!AdBlocker {
         .blocking = .empty,
         .blocking_important = .empty,
         .exceptions = .empty,
-        .exceptions_important = .empty,
         .rules_loaded = 0,
         .rules_skipped = 0,
     };
@@ -106,7 +101,6 @@ pub fn deinit(self: *AdBlocker) void {
     self.blocking.deinit(self.allocator);
     self.blocking_important.deinit(self.allocator);
     self.exceptions.deinit(self.allocator);
-    self.exceptions_important.deinit(self.allocator);
     self.badfilters.deinit(self.allocator);
     self.filters.deinit(self.allocator);
     self.trie.deinit(self.allocator);
@@ -251,8 +245,6 @@ pub fn build(self: *AdBlocker) !void {
     defer important.deinit(self.allocator);
     var exceptions: std.ArrayList(u32) = .empty;
     defer exceptions.deinit(self.allocator);
-    var exceptions_important: std.ArrayList(u32) = .empty;
-    defer exceptions_important.deinit(self.allocator);
 
     var kept: usize = 0;
     for (self.filters.items) |filter| {
@@ -278,7 +270,7 @@ pub fn build(self: *AdBlocker) !void {
         kept += 1;
 
         const list = if (filter.exception)
-            (if (filter.important) &exceptions_important else &exceptions)
+            &exceptions
         else if (filter.important)
             &important
         else
@@ -299,7 +291,6 @@ pub fn build(self: *AdBlocker) !void {
     self.blocking = try .build(self.allocator, arena, filters, blocking.items, &histogram);
     self.blocking_important = try .build(self.allocator, arena, filters, important.items, &histogram);
     self.exceptions = try .build(self.allocator, arena, filters, exceptions.items, &histogram);
-    self.exceptions_important = try .build(self.allocator, arena, filters, exceptions_important.items, &histogram);
 }
 
 fn addToTrie(self: *AdBlocker, root: u32, hostname: []const u8) !void {
@@ -313,8 +304,8 @@ fn addToTrie(self: *AdBlocker, root: u32, hostname: []const u8) !void {
 
 pub const Verdict = enum { none, allowed, blocked };
 
-/// The verdict for one request. uBO's order: `@@…$important` outranks
-/// `$important` blocks, which outrank exceptions, which outrank plain blocks...
+/// The verdict for one request.
+/// `$important` blocks outrank exceptions, which outrank plain blocks; same as uBO.
 pub fn match(self: *const AdBlocker, request: Request) Verdict {
     std.debug.assert(self.built);
 
@@ -322,10 +313,6 @@ pub fn match(self: *const AdBlocker, request: Request) Verdict {
     // A hostname something might unblock stays undecided, whatever else
     // matches it.
     if (self.trie.matches(self.suppressed, hostname) != null) return .none;
-
-    // `@@…$important` is what a list writes to beat a `$important` block, so
-    // it has to be looked at before one.
-    if (self.exceptions_important.match(request) != null) return .allowed;
 
     if (self.trie.matches(self.blocked_important, hostname) != null) return .blocked;
     if (self.blocking_important.match(request) != null) return .blocked;
@@ -352,14 +339,11 @@ fn isSupported(filter: *const NetworkFilter) bool {
 /// its subdomains", which is all a trie can express.
 fn isWholeHostname(filter: *const NetworkFilter) bool {
     if (filter.kind != .hostname) return false;
-    // `||host` without '^' also matches hostnames merely *starting* with
-    // host ("example.com.evil.org"): broader than a suffix match.
+    // A prefix like `||adform.` also matches hostnames merely *starting*
+    // with it, broader than a suffix match.
     if (!filter.require_separator) return false;
     // `||host^|` pins the URL end to the separator: narrower.
     if (filter.left_anchor or filter.right_anchor) return false;
-    // `@@…$important` has to be consulted before the `$important` blocks,
-    // which is an order the fixed trie sequence cannot express.
-    if (filter.exception and filter.important) return false;
     if (!filter.domains.isEmpty()) return false;
     if (!filter.first_party or !filter.third_party) return false;
     return filter.types.bits() == ResourceTypes.all.bits();
@@ -570,11 +554,6 @@ test "adblock.AdBlocker: verdict precedence" {
         \\@@||evil.com^
         \\||strict.example.com^$important,script
         \\@@||strict.example.com^$script
-        \\||both.example.com^$important,script
-        \\@@||both.example.com^$important,script
-        // Both sides pure hostnames, so both would otherwise be tries.
-        \\||pure.example.com^$important
-        \\@@||pure.example.com^$important
     );
 
     try expectVerdict(&blocker, .blocked, "https://ads.example.com/x", "a.com", script);
@@ -585,9 +564,6 @@ test "adblock.AdBlocker: verdict precedence" {
     // ...but $important beats the exception, whichever side is indexed.
     try expectVerdict(&blocker, .blocked, "https://evil.com/x", "a.com", script);
     try expectVerdict(&blocker, .blocked, "https://strict.example.com/x.js", "a.com", script);
-    // ...and $important on the exception takes it back.
-    try expectVerdict(&blocker, .allowed, "https://both.example.com/x.js", "a.com", script);
-    try expectVerdict(&blocker, .allowed, "https://pure.example.com/x.js", "a.com", script);
 
     try expectVerdict(&blocker, .none, "https://example.com/x", "a.com", script);
 }
@@ -650,32 +626,41 @@ test "adblock.AdBlocker: trie absorbs every pure-hostname form" {
 
     try testLoad(&blocker,
         \\||anchored.example.com^
+        \\||caretless.example.com
+        \\||pinned.example.com|
         \\bare-hostname.example.com
         \\0.0.0.0 hosts-style.example.io
     );
 
     try expectVerdict(&blocker, .blocked, "https://anchored.example.com/x", "a.com", script);
+    // `||host` and `||host|` are the same filter as `||host^`.
+    try expectVerdict(&blocker, .blocked, "https://sub.caretless.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .none, "https://caretless.example.com.evil.org/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://pinned.example.com/x?q=1", "a.com", script);
     try expectVerdict(&blocker, .blocked, "https://bare-hostname.example.com/x", "a.com", script);
     try expectVerdict(&blocker, .blocked, "https://hosts-style.example.io/x", "a.com", script);
     // Pure-hostname filters block top-level documents too.
     try expectVerdict(&blocker, .blocked, "https://anchored.example.com/", "a.com", document);
+
+    // Absorbs: every rule above went to a trie, none stayed indexed.
+    try testing.expectEqual(0, blocker.filters.items.len);
 }
 
-test "adblock.AdBlocker: an important exception is found whatever matches first" {
+test "adblock.AdBlocker: $important on an exception is invalid" {
     var blocker: AdBlocker = try .init(testing.allocator);
     defer blocker.deinit();
 
-    // The plain exception is written first, so a single first-match engine
-    // would return it and never see the important one behind it.
+    // uBO rejects `@@…$important`, so nothing outranks a `$important`
+    // block — and being a rule uBO drops too, the invalid exception does
+    // not suppress its hostname either.
     try testLoad(&blocker,
         \\||tracker.com^$important,script
-        \\@@||tracker.com^$script
         \\@@||tracker.com/x.js$important,script
     );
 
-    try expectVerdict(&blocker, .allowed, "https://tracker.com/x.js", "a.com", script);
-    // Off the important exception's path, the $important block still wins.
-    try expectVerdict(&blocker, .blocked, "https://tracker.com/other.js", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://tracker.com/x.js", "a.com", script);
+    try testing.expectEqual(1, blocker.rules_loaded);
+    try testing.expectEqual(1, blocker.rules_skipped);
 }
 
 test "adblock.AdBlocker: an empty blocker decides nothing" {

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -34,8 +34,8 @@ const log = lp.log;
 
 const AdBlocker = @This();
 
-pub const Request = Engine.Request;
-pub const ResourceTypes = NetworkFilter.ResourceTypes;
+const Request = Engine.Request;
+const ResourceTypes = NetworkFilter.ResourceTypes;
 
 allocator: Allocator,
 /// Owns everything the filters point at.
@@ -66,6 +66,11 @@ rules_loaded: usize,
 /// Rules the lists carry and we do not apply, across those same lists: the
 /// ones the parser could not read, plus the ones no matcher can express.
 rules_skipped: usize,
+/// Domain-scoped element-hiding rules and cosmetic-realm exceptions, across
+/// those same lists. Not ours to apply, but not rules we failed at either, so
+/// they stay out of `rules_skipped`. Generic "##" rules read as comments and
+/// are counted nowhere.
+rules_cosmetic: usize,
 
 /// Read buffer for filter lists, and therefore the longest line we can see.
 /// Real-world rules are well under 1KB; the parser skips anything longer.
@@ -95,6 +100,7 @@ pub fn init(allocator: Allocator) Allocator.Error!AdBlocker {
         .exceptions = .empty,
         .rules_loaded = 0,
         .rules_skipped = 0,
+        .rules_cosmetic = 0,
     };
 }
 
@@ -132,9 +138,11 @@ pub fn fromConfig(allocator: Allocator, config: *const Config) !?AdBlocker {
         try blocker.build();
         lp.metrics.adblock_rules.add(.loaded, @intCast(blocker.rules_loaded));
         lp.metrics.adblock_rules.add(.skipped, @intCast(blocker.rules_skipped));
+        lp.metrics.adblock_rules.add(.cosmetic, @intCast(blocker.rules_cosmetic));
         log.info(.app, "adblock lists loaded", .{
             .loaded = blocker.rules_loaded,
             .skipped = blocker.rules_skipped,
+            .cosmetic = blocker.rules_cosmetic,
             .indexed = blocker.filters.items.len,
         });
     }
@@ -161,7 +169,10 @@ pub fn parse(self: *AdBlocker, reader: *Io.Reader) !void {
     var parser: Parser = .init(reader);
     // Lines the parser dropped are rules we did not load just as much as the
     // ones we drop below, and on a real list they are the bulk of them.
-    defer self.rules_skipped += parser.skipped;
+    defer {
+        self.rules_skipped += parser.skipped;
+        self.rules_cosmetic += parser.cosmetic;
+    }
 
     const arena = self.arena.allocator();
     while (try parser.next(scratch)) |item| {
@@ -183,6 +194,13 @@ pub fn parse(self: *AdBlocker, reader: *Io.Reader) !void {
             .filter => |filter| filter,
         };
 
+        // Cosmetic-realm exceptions ($generichide and friends) modify element
+        // hiding, which no network matcher applies: another realm's rule, not
+        // one we failed at.
+        if (filter.generichide or filter.specifichide or filter.elemhide) {
+            self.rules_cosmetic += 1;
+            continue;
+        }
         if (!isSupported(&filter)) {
             self.rules_skipped += 1;
             continue;
@@ -310,14 +328,14 @@ pub const Verdict = enum { none, allowed, blocked };
 pub fn isBlocked(self: *const AdBlocker, transfer: *const HttpClient.Transfer) bool {
     var buffers: Request.Buffers = undefined;
     const request = Request.fromHttp(transfer, &buffers) orelse return false;
-    const verdict = self.match(request);
+    const verdict = self.match(&request);
     lp.metrics.adblock_verdicts.incr(verdict);
     return verdict == .blocked;
 }
 
 /// The verdict for one request.
 /// `$important` blocks outrank exceptions, which outrank plain blocks; same as uBO.
-pub fn match(self: *const AdBlocker, request: Request) Verdict {
+pub fn match(self: *const AdBlocker, request: *const Request) Verdict {
     std.debug.assert(self.built);
 
     const hostname = request.url.hostname();
@@ -340,10 +358,7 @@ pub fn match(self: *const AdBlocker, request: Request) Verdict {
 /// Whether we can evaluate this filter at all.
 fn isSupported(filter: *const NetworkFilter) bool {
     // No regex engine to run them with.
-    if (filter.kind == .regex) return false;
-    // Cosmetic-realm exceptions never say anything about network requests.
-    if (filter.generichide or filter.specifichide or filter.elemhide) return false;
-    return true;
+    return filter.kind != .regex;
 }
 
 /// Whether the filter's whole effect is "every request to this hostname and
@@ -434,7 +449,8 @@ fn expectVerdict(
     // are lowercased too, so a rule spelled "/embed/C-iDzdvIg1Y" still lands.
     var buf: [512]u8 = undefined;
     const lowered = std.ascii.lowerString(buf[0..url.len], url);
-    try testing.expectEqual(expected, blocker.match(.init(lowered, source, kind)));
+    const request: Request = .init(lowered, source, kind);
+    try testing.expectEqual(expected, blocker.match(&request));
 }
 
 const script: ResourceTypes = .{ .script = true };
@@ -548,10 +564,28 @@ test "adblock.AdBlocker: parse accumulates across lists" {
     try expectVerdict(&blocker, .none, "https://tracker.net/x", "sports.news.com", script);
     try expectVerdict(&blocker, .none, "https://tracker.net/x", "other.com", script);
 
-    // Three rules loaded across the two lists; the cosmetic line is a rule
-    // the list carries and we do not apply, so it counts as skipped.
+    // Three rules loaded across the two lists; the cosmetic line is a rule of
+    // another realm, counted as such rather than as one we failed to apply.
     try testing.expectEqual(3, blocker.rules_loaded);
+    try testing.expectEqual(0, blocker.rules_skipped);
+    try testing.expectEqual(1, blocker.rules_cosmetic);
+}
+
+test "adblock.AdBlocker: cosmetic-realm rules are not skipped rules" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        \\||ads.example.com^
+        \\@@||example.com^$generichide
+        \\@@||example.com^$elemhide
+        \\example.com##.ad-banner
+        \\/regex-we-cannot-run/
+    );
+
+    try testing.expectEqual(1, blocker.rules_loaded);
     try testing.expectEqual(1, blocker.rules_skipped);
+    try testing.expectEqual(3, blocker.rules_cosmetic);
 }
 
 test "adblock.AdBlocker: verdict precedence" {

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -23,6 +23,7 @@ const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
 const Config = @import("../../Config.zig");
+const HttpClient = @import("../HttpClient.zig");
 
 const Parser = @import("Parser.zig");
 const Engine = @import("Engine.zig");
@@ -305,6 +306,14 @@ fn addToTrie(self: *AdBlocker, root: u32, hostname: []const u8) !void {
 }
 
 pub const Verdict = enum { none, allowed, blocked };
+
+pub fn isBlocked(self: *const AdBlocker, transfer: *const HttpClient.Transfer) bool {
+    var buffers: Request.Buffers = undefined;
+    const request = Request.fromHttp(transfer, &buffers) orelse return false;
+    const verdict = self.match(request);
+    lp.metrics.adblock_verdicts.incr(verdict);
+    return verdict == .blocked;
+}
 
 /// The verdict for one request.
 /// `$important` blocks outrank exceptions, which outrank plain blocks; same as uBO.

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -25,6 +25,7 @@ const Allocator = std.mem.Allocator;
 const Config = @import("../../Config.zig");
 
 const Parser = @import("Parser.zig");
+const Engine = @import("Engine.zig");
 const HostnameTrie = @import("HostnameTrie.zig");
 const NetworkFilter = @import("NetworkFilter.zig");
 
@@ -32,18 +33,41 @@ const log = lp.log;
 
 const AdBlocker = @This();
 
+pub const Request = Engine.Request;
+pub const ResourceTypes = NetworkFilter.ResourceTypes;
+
 allocator: Allocator,
+/// Owns everything the filters point at.
+arena: std.heap.ArenaAllocator,
+
+/// Filters kept for per-request matching. Filled by `parse`, pruned and
+/// partitioned by `build`; the `Engine`s index into it, so it must not move
+/// after that.
+filters: std.ArrayList(NetworkFilter),
+/// Filled while parsing, consumed by `build`.
+badfilters: std.AutoHashMapUnmanaged(u64, void),
+built: bool,
 trie: HostnameTrie,
 blocked: u32,
-/// $important hostname blocks: they beat exceptions.
+/// `$important` hostname blocks: they beat exceptions.
 blocked_important: u32,
 /// Pure-hostname `@@` exceptions.
 allowed: u32,
+/// Hostnames named by an `@@` rule we could not read at all.
 suppressed: u32,
-/// Rules that reached a trie, across every list parsed so far.
+
+blocking: Engine,
+blocking_important: Engine,
+exceptions: Engine,
+/// `@@…$important` exceptions, indexed apart because they outrank the
+/// `$important` blocks while plain exceptions do not — one engine returning
+/// its first match could not tell the two apart.
+exceptions_important: Engine,
+
+/// Rules that reached a trie or an index, across every list parsed so far.
 rules_loaded: usize,
 /// Rules the lists carry and we do not apply, across those same lists: the
-/// ones the parser could not read, plus the ones no trie can express.
+/// ones the parser could not read, plus the ones no matcher can express.
 rules_skipped: usize,
 
 /// Read buffer for filter lists, and therefore the longest line we can see.
@@ -60,14 +84,33 @@ pub fn init(allocator: Allocator) Allocator.Error!AdBlocker {
 
     return .{
         .allocator = allocator,
+        .arena = std.heap.ArenaAllocator.init(allocator),
+        .filters = .empty,
+        .badfilters = .empty,
+        .built = false,
         .trie = trie,
         .blocked = blocked,
         .blocked_important = blocked_important,
         .allowed = allowed,
         .suppressed = suppressed,
+        .blocking = .empty,
+        .blocking_important = .empty,
+        .exceptions = .empty,
+        .exceptions_important = .empty,
         .rules_loaded = 0,
         .rules_skipped = 0,
     };
+}
+
+pub fn deinit(self: *AdBlocker) void {
+    self.blocking.deinit(self.allocator);
+    self.blocking_important.deinit(self.allocator);
+    self.exceptions.deinit(self.allocator);
+    self.exceptions_important.deinit(self.allocator);
+    self.badfilters.deinit(self.allocator);
+    self.filters.deinit(self.allocator);
+    self.trie.deinit(self.allocator);
+    self.arena.deinit();
 }
 
 /// Builds the blocker from `--adblock-lists`, or null when the option is
@@ -91,9 +134,11 @@ pub fn fromConfig(allocator: Allocator, config: *const Config) !?AdBlocker {
     }
 
     if (adblocker) |*blocker| {
+        try blocker.build();
         log.info(.app, "adblock lists loaded", .{
             .loaded = blocker.rules_loaded,
             .skipped = blocker.rules_skipped,
+            .indexed = blocker.filters.items.len,
         });
     }
     return adblocker;
@@ -109,11 +154,9 @@ fn loadList(blocker: *AdBlocker, path: []const u8, buf: []u8) !void {
     try blocker.parse(&file_reader.interface);
 }
 
-pub fn deinit(self: *AdBlocker) void {
-    self.trie.deinit(self.allocator);
-}
-
 pub fn parse(self: *AdBlocker, reader: *Io.Reader) !void {
+    std.debug.assert(!self.built);
+
     var scratch_instance = std.heap.ArenaAllocator.init(self.allocator);
     defer scratch_instance.deinit();
     const scratch = scratch_instance.allocator();
@@ -123,75 +166,186 @@ pub fn parse(self: *AdBlocker, reader: *Io.Reader) !void {
     // ones we drop below, and on a real list they are the bulk of them.
     defer self.rules_skipped += parser.skipped;
 
-    while (try parser.next(scratch)) |filter| {
-        // Nothing survives the iteration but the trie entry, so the
-        // scratch arena is recycled rather than grown per filter.
+    const arena = self.arena.allocator();
+    while (try parser.next(scratch)) |item| {
+        // Everything here borrows the reader's buffer and the scratch arena,
+        // both of which the next call reuses, so what we keep is copied out.
         defer _ = scratch_instance.reset(.retain_capacity);
 
-        // Filters the tries cannot express (patterns, type/party/domain
-        // constraints) are dropped: deciding those needs a request engine
-        // we do not have yet, and retaining them costs tens of MB on a
-        // list like EasyList.
-        const root = self.trieRoot(&filter) orelse {
+        const filter = switch (item) {
+            // The parser already counted it; all we want is whether it was an
+            // exception, in which case its hostname stops being blockable.
+            .dropped => |dropped| {
+                if (!mayUnblock(dropped.reason)) continue;
+                var buf: [253]u8 = undefined;
+                if (exceptionHostname(dropped.line, &buf)) |hostname| {
+                    try self.addToTrie(self.suppressed, hostname);
+                }
+                continue;
+            },
+            .filter => |filter| filter,
+        };
+
+        if (!isSupported(&filter)) {
             self.rules_skipped += 1;
             continue;
-        };
-        // Duplicate and subdomain-of-existing entries drop.
-        self.trie.add(self.allocator, root, filter.hostname) catch |err| switch (err) {
-            error.OutOfMemory, error.TrieFull => |e| return e,
-            // trieRoot never routes a filter without one.
-            error.InvalidHostname => unreachable,
-        };
+        }
+
+        if (filter.badfilter) {
+            // It cancels a rule that may not have been read yet, so it can
+            // only be resolved once every list is in. It is not a rule we
+            // apply either way.
+            self.rules_skipped += 1;
+            try self.badfilters.put(self.allocator, identity(&filter), {});
+            continue;
+        }
+
+        try self.filters.append(self.allocator, try dupe(arena, &filter));
         self.rules_loaded += 1;
     }
 }
 
+fn mayUnblock(reason: ?NetworkFilter.ParseError) bool {
+    const err = reason orelse return false;
+    return switch (err) {
+        error.UnsupportedOption, error.UnsupportedPattern, error.NoSupportedDomains => true,
+        else => false,
+    };
+}
+
+/// The hostname an unreadable `@@||host…` rule is about, lowercased into
+/// `buf`. Null for anything else.
+fn exceptionHostname(line: []const u8, buf: []u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, line, "@@||")) return null;
+    const rest = line[4..];
+
+    const end = std.mem.indexOfAny(u8, rest, "/^$*|") orelse rest.len;
+    if (end == 0 or end > buf.len) return null;
+
+    const hostname = std.ascii.lowerString(buf[0..end], rest[0..end]);
+    // A hostname is what the trie can store; "example.*" and friends are not.
+    for (hostname) |c| {
+        const ok = std.ascii.isAlphanumeric(c) or switch (c) {
+            '.', '-', '_' => true,
+            else => false,
+        };
+        if (!ok) return null;
+    }
+    if (std.mem.indexOfScalar(u8, hostname, '.') == null) return null;
+    return hostname;
+}
+
+/// Resolves `$badfilter`, then splits what is left between the tries and the
+/// indexes. Must run once, after every list is parsed, and before any match.
+pub fn build(self: *AdBlocker) !void {
+    std.debug.assert(!self.built);
+    self.built = true;
+
+    const arena = self.arena.allocator();
+
+    // Whole-hostname filters go to a trie; the rest keep their slot in
+    // `filters` so the engines can index them.
+    var blocking: std.ArrayList(u32) = .empty;
+    defer blocking.deinit(self.allocator);
+    var important: std.ArrayList(u32) = .empty;
+    defer important.deinit(self.allocator);
+    var exceptions: std.ArrayList(u32) = .empty;
+    defer exceptions.deinit(self.allocator);
+    var exceptions_important: std.ArrayList(u32) = .empty;
+    defer exceptions_important.deinit(self.allocator);
+
+    var kept: usize = 0;
+    for (self.filters.items) |filter| {
+        if (self.badfilters.count() != 0 and self.badfilters.contains(identity(&filter))) {
+            self.rules_loaded -= 1;
+            self.rules_skipped += 1;
+            continue;
+        }
+
+        if (isWholeHostname(&filter)) {
+            const root = if (filter.exception)
+                self.allowed
+            else if (filter.important)
+                self.blocked_important
+            else
+                self.blocked;
+            try self.addToTrie(root, filter.hostname);
+            continue;
+        }
+
+        const index: u32 = @intCast(kept);
+        self.filters.items[kept] = filter;
+        kept += 1;
+
+        const list = if (filter.exception)
+            (if (filter.important) &exceptions_important else &exceptions)
+        else if (filter.important)
+            &important
+        else
+            &blocking;
+        try list.append(self.allocator, index);
+    }
+    self.filters.shrinkAndFree(self.allocator, kept);
+
+    // Rarest-token selection is only meaningful across the whole corpus, so
+    // the counts are taken once and shared by the three engines.
+    var histogram: Engine.Histogram = .empty;
+    defer histogram.deinit(self.allocator);
+    for (self.filters.items) |*filter| {
+        try Engine.count(&histogram, self.allocator, filter);
+    }
+
+    const filters = self.filters.items;
+    self.blocking = try .build(self.allocator, arena, filters, blocking.items, &histogram);
+    self.blocking_important = try .build(self.allocator, arena, filters, important.items, &histogram);
+    self.exceptions = try .build(self.allocator, arena, filters, exceptions.items, &histogram);
+    self.exceptions_important = try .build(self.allocator, arena, filters, exceptions_important.items, &histogram);
+}
+
+fn addToTrie(self: *AdBlocker, root: u32, hostname: []const u8) !void {
+    // Duplicate and subdomain-of-existing entries drop.
+    self.trie.add(self.allocator, root, hostname) catch |err| switch (err) {
+        error.OutOfMemory, error.TrieFull => |e| return e,
+        // Callers never route a filter without a hostname here.
+        error.InvalidHostname => unreachable,
+    };
+}
+
 pub const Verdict = enum { none, allowed, blocked };
 
-/// `.none` means no hostname-wide verdict applies. Filters that need more
-/// than a hostname match are not represented here at all.
-pub fn matchHostname(self: *const AdBlocker, hostname: []const u8) Verdict {
+/// The verdict for one request. uBO's order: `@@…$important` outranks
+/// `$important` blocks, which outrank exceptions, which outrank plain blocks...
+pub fn match(self: *const AdBlocker, request: Request) Verdict {
+    std.debug.assert(self.built);
+
+    const hostname = request.url.hostname();
     // A hostname something might unblock stays undecided, whatever else
     // matches it.
     if (self.trie.matches(self.suppressed, hostname) != null) return .none;
+
+    // `@@…$important` is what a list writes to beat a `$important` block, so
+    // it has to be looked at before one.
+    if (self.exceptions_important.match(request) != null) return .allowed;
+
     if (self.trie.matches(self.blocked_important, hostname) != null) return .blocked;
+    if (self.blocking_important.match(request) != null) return .blocked;
+
+    if (self.exceptions.match(request) != null) return .allowed;
     if (self.trie.matches(self.allowed, hostname) != null) return .allowed;
+
     if (self.trie.matches(self.blocked, hostname) != null) return .blocked;
+    if (self.blocking.match(request) != null) return .blocked;
+
     return .none;
 }
 
-/// The trie holding this filter, or null when it carries no hostname-wide
-/// meaning we can represent.
-fn trieRoot(self: *const AdBlocker, filter: *const NetworkFilter) ?u32 {
-    // An exception or a $badfilter can only ever *unblock*. Where one is
-    // narrower than a whole hostname we cannot evaluate it here — but
-    // ignoring it is not neutral either, because the rule it cancels may
-    // well be a plain block we did keep:
-    //
-    //   ||adsafeprotected.com^
-    //   @@||adsafeprotected.com/iasPET.$script,domain=reuters.com|...
-    //
-    // uBO blocks that host everywhere but those sites; keeping only the
-    // first line blocks it on those sites too, and breaks them. So the
-    // hostname goes to `suppressed` and stops being blockable at all. We
-    // lose most of the block's value to save the pages it would break,
-    // which is the direction we want to fail in.
-    if (filter.exception or filter.badfilter) {
-        // Cosmetic-realm exceptions never unblock network requests.
-        if (filter.exception and (filter.generichide or filter.specifichide or filter.elemhide)) {
-            return null;
-        }
-        if (filter.exception and !filter.badfilter and isWholeHostname(filter)) {
-            return self.allowed;
-        }
-        // `@@/ads/^$script` and friends name no hostname to key on: there
-        // is nothing we can do with them until there is an engine.
-        if (filter.hostname.len == 0) return null;
-        return self.suppressed;
-    }
-
-    if (!isWholeHostname(filter)) return null;
-    return if (filter.important) self.blocked_important else self.blocked;
+/// Whether we can evaluate this filter at all.
+fn isSupported(filter: *const NetworkFilter) bool {
+    // No regex engine to run them with.
+    if (filter.kind == .regex) return false;
+    // Cosmetic-realm exceptions never say anything about network requests.
+    if (filter.generichide or filter.specifichide or filter.elemhide) return false;
+    return true;
 }
 
 /// Whether the filter's whole effect is "every request to this hostname and
@@ -203,12 +357,172 @@ fn isWholeHostname(filter: *const NetworkFilter) bool {
     if (!filter.require_separator) return false;
     // `||host^|` pins the URL end to the separator: narrower.
     if (filter.left_anchor or filter.right_anchor) return false;
-    if (filter.has_domains) return false;
+    // `@@…$important` has to be consulted before the `$important` blocks,
+    // which is an order the fixed trie sequence cannot express.
+    if (filter.exception and filter.important) return false;
+    if (!filter.domains.isEmpty()) return false;
     if (!filter.first_party or !filter.third_party) return false;
-    return filter.types.bits() == NetworkFilter.ResourceTypes.all.bits();
+    return filter.types.bits() == ResourceTypes.all.bits();
 }
 
+/// Copies a filter out of the parser's scratch memory into the arena.
+fn dupe(arena: Allocator, filter: *const NetworkFilter) !NetworkFilter {
+    var out = filter.*;
+    out.hostname = try arena.dupe(u8, filter.hostname);
+    out.pattern = try arena.dupe(u8, filter.pattern);
+    out.domains = .{
+        .included = try dupeEntries(arena, filter.domains.included),
+        .excluded = try dupeEntries(arena, filter.domains.excluded),
+    };
+    return out;
+}
+
+fn dupeEntries(arena: Allocator, entries: []const domain.Entry) ![]const domain.Entry {
+    if (entries.len == 0) return &.{};
+    const out = try arena.alloc(domain.Entry, entries.len);
+    for (entries, out) |entry, *slot| {
+        slot.* = .{ .name = try arena.dupe(u8, entry.name), .entity = entry.entity };
+    }
+    return out;
+}
+
+/// What `$badfilter` compares two rules by: everything the rule says except
+/// the `$badfilter` option itself.
+fn identity(filter: *const NetworkFilter) u64 {
+    var hasher = std.hash.Wyhash.init(0);
+    hasher.update(filter.hostname);
+    hasher.update(filter.pattern);
+    // Entries are separated (names never contain NUL) and carry their entity
+    // flag: "$domain=amazon.*" and "$domain=amazon" are different rules, as
+    // are entry lists that merely concatenate alike.
+    for (filter.domains.included) |entry| {
+        hasher.update(entry.name);
+        hasher.update(&.{ 0, @intFromBool(entry.entity) });
+    }
+    hasher.update("|");
+    for (filter.domains.excluded) |entry| {
+        hasher.update(entry.name);
+        hasher.update(&.{ 0, @intFromBool(entry.entity) });
+    }
+    hasher.update(&std.mem.toBytes(filter.types.bits()));
+    hasher.update(&.{
+        @intFromEnum(filter.kind),
+        @intFromBool(filter.exception),
+        @intFromBool(filter.important),
+        @intFromBool(filter.first_party),
+        @intFromBool(filter.third_party),
+        @intFromBool(filter.hostname_anchor),
+        @intFromBool(filter.left_anchor),
+        @intFromBool(filter.right_anchor),
+        @intFromBool(filter.require_separator),
+    });
+    return hasher.final();
+}
+
+const domain = @import("domain.zig");
 const testing = @import("../../testing.zig");
+
+fn testLoad(blocker: *AdBlocker, list: []const u8) !void {
+    var reader: Io.Reader = .fixed(list);
+    try blocker.parse(&reader);
+    try blocker.build();
+}
+
+fn expectVerdict(
+    blocker: *const AdBlocker,
+    expected: Verdict,
+    url: []const u8,
+    source: []const u8,
+    kind: ResourceTypes,
+) !void {
+    // `match` takes a lowercased URL, as the real caller hands it; patterns
+    // are lowercased too, so a rule spelled "/embed/C-iDzdvIg1Y" still lands.
+    var buf: [512]u8 = undefined;
+    const lowered = std.ascii.lowerString(buf[0..url.len], url);
+    try testing.expectEqual(expected, blocker.match(.init(lowered, source, kind)));
+}
+
+const script: ResourceTypes = .{ .script = true };
+const xhr: ResourceTypes = .{ .xmlhttprequest = true };
+const image: ResourceTypes = .{ .image = true };
+const document: ResourceTypes = .{ .document = true };
+const frame: ResourceTypes = .{ .subdocument = true };
+
+test "adblock.AdBlocker: the doubleclick rules from EasyList" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        \\||ad.doubleclick.net^
+        \\||g.doubleclick.net^
+        \\||doubleclick.net^$popup
+        \\||ad.doubleclick.net/ddm/clk/$domain=ad.doubleclick.net
+        \\@@||doubleclick.net/ddm/$image,domain=aetv.com|fyi.tv|history.com
+        \\@@||g.doubleclick.net/gampad/ads$xmlhttprequest,domain=bloomberg.com|samsclub.com
+        \\@@||pubads.g.doubleclick.net/ssai/
+        \\@@||static.doubleclick.net/instream/ad_status.js$script,domain=ignboards.com
+    );
+
+    // The exceptions no longer cost the blocks their hostnames: this is the
+    // regression the whole engine exists for.
+    try expectVerdict(&blocker, .blocked, "https://ad.doubleclick.net/x.gif", "news.com", image);
+    try expectVerdict(&blocker, .blocked, "https://g.doubleclick.net/gampad/ads?a=1", "news.com", xhr);
+
+    // ...and each exception applies exactly where it was written to.
+    try expectVerdict(&blocker, .allowed, "https://g.doubleclick.net/gampad/ads?a=1", "bloomberg.com", xhr);
+    // Same site, wrong type.
+    try expectVerdict(&blocker, .blocked, "https://g.doubleclick.net/gampad/ads?a=1", "bloomberg.com", script);
+    // Right type, wrong site.
+    try expectVerdict(&blocker, .blocked, "https://g.doubleclick.net/gampad/ads?a=1", "example.com", xhr);
+    // Right everything, wrong path.
+    try expectVerdict(&blocker, .blocked, "https://g.doubleclick.net/pagead/ads", "bloomberg.com", xhr);
+
+    try expectVerdict(&blocker, .allowed, "https://static.doubleclick.net/instream/ad_status.js", "ignboards.com", script);
+    // The unconditional exception carves one path out of the block covering
+    // the whole subtree, and leaves the rest of it blocked.
+    try expectVerdict(&blocker, .allowed, "https://pubads.g.doubleclick.net/ssai/x", "history.com", xhr);
+    try expectVerdict(&blocker, .blocked, "https://pubads.g.doubleclick.net/other", "history.com", xhr);
+
+    // We issue no popup requests, so $popup filters never fire — but they no
+    // longer take the rest of doubleclick.net down with them either.
+    try expectVerdict(&blocker, .none, "https://doubleclick.net/x", "news.com", xhr);
+}
+
+test "adblock.AdBlocker: the youtube rules from EasyList" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        \\||youtube.com/pagead/
+        \\||youtube.com/youtubei/v1/player/ad_break
+        \\||youtube.com/embed/C-iDzdvIg1Y$domain=biznews.com
+        \\||googlesyndication.com^$domain=blogto.com|youtube.com
+        \\||youtube.com/get_video_info?*adunit$~third-party
+        \\@@||youtube.com/get_video_info?$xmlhttprequest,domain=music.youtube.com|tv.youtube.com
+    );
+
+    try expectVerdict(&blocker, .blocked, "https://www.youtube.com/pagead/lvz?ei=x", "youtube.com", xhr);
+    try expectVerdict(&blocker, .blocked, "https://www.youtube.com/youtubei/v1/player/ad_break?x=1", "youtube.com", xhr);
+    try expectVerdict(&blocker, .none, "https://www.youtube.com/watch?v=x", "youtube.com", document);
+
+    // $domain= scopes an embed block to the one site that needed it. The
+    // embed is an iframe, and a filter with no type option covers every type
+    // but a top-level document — which is why this is `frame`, not
+    // `document`.
+    try expectVerdict(&blocker, .blocked, "https://www.youtube.com/embed/C-iDzdvIg1Y", "biznews.com", frame);
+    try expectVerdict(&blocker, .none, "https://www.youtube.com/embed/C-iDzdvIg1Y", "example.com", frame);
+    try expectVerdict(&blocker, .none, "https://www.youtube.com/embed/C-iDzdvIg1Y", "biznews.com", document);
+
+    // A `$domain=` list matches subdomains of its entries.
+    try expectVerdict(&blocker, .blocked, "https://pagead2.googlesyndication.com/x", "www.blogto.com", script);
+    try expectVerdict(&blocker, .none, "https://pagead2.googlesyndication.com/x", "example.com", script);
+
+    // $~third-party: same site only.
+    try expectVerdict(&blocker, .blocked, "https://www.youtube.com/get_video_info?a=adunit", "youtube.com", xhr);
+    try expectVerdict(&blocker, .none, "https://www.youtube.com/get_video_info?a=adunit", "example.com", xhr);
+    // The exception outranks it where it applies.
+    try expectVerdict(&blocker, .allowed, "https://www.youtube.com/get_video_info?a=adunit", "music.youtube.com", xhr);
+}
 
 test "adblock.AdBlocker: parse accumulates across lists" {
     var blocker: AdBlocker = try .init(testing.allocator);
@@ -222,110 +536,152 @@ test "adblock.AdBlocker: parse accumulates across lists" {
     );
     try blocker.parse(&first);
 
-    try testing.expectEqual(.blocked, blocker.matchHostname("ads.example.com"));
-    try testing.expectEqual(.blocked, blocker.matchHostname("sub.ads.example.com"));
-    // The type-restricted exception cannot be evaluated, so it suppresses
-    // its hostname instead of allowing it.
-    try testing.expectEqual(.none, blocker.matchHostname("cdn.example.com"));
-
-    // The block and the exception loaded; the cosmetic line is a rule the
-    // list carries and we do not apply, so it counts as skipped even though
-    // it never reached a trie.
-    try testing.expectEqual(2, blocker.rules_loaded);
-    try testing.expectEqual(1, blocker.rules_skipped);
-
     var second: Io.Reader = .fixed(
         \\||tracker.net^$third-party,domain=news.com|~sports.news.com
     );
     try blocker.parse(&second);
+    try blocker.build();
 
-    try testing.expectEqual(.none, blocker.matchHostname("tracker.net"));
-    // The counts carry across lists, like the entries do.
-    try testing.expectEqual(2, blocker.rules_loaded);
-    try testing.expectEqual(2, blocker.rules_skipped);
-    // The first list's entries survived the second parse.
-    try testing.expectEqual(.blocked, blocker.matchHostname("ads.example.com"));
+    try expectVerdict(&blocker, .blocked, "https://ads.example.com/x", "news.com", script);
+    try expectVerdict(&blocker, .blocked, "https://sub.ads.example.com/x", "news.com", script);
+    // The type-restricted exception now applies to scripts only.
+    try expectVerdict(&blocker, .allowed, "https://cdn.example.com/x.js", "news.com", script);
+    try expectVerdict(&blocker, .none, "https://cdn.example.com/x.png", "news.com", image);
+
+    // The party and $domain= constrained block, from the second list.
+    try expectVerdict(&blocker, .blocked, "https://tracker.net/x", "news.com", script);
+    try expectVerdict(&blocker, .none, "https://tracker.net/x", "sports.news.com", script);
+    try expectVerdict(&blocker, .none, "https://tracker.net/x", "other.com", script);
+
+    // Three rules loaded across the two lists; the cosmetic line is a rule
+    // the list carries and we do not apply, so it counts as skipped.
+    try testing.expectEqual(3, blocker.rules_loaded);
+    try testing.expectEqual(1, blocker.rules_skipped);
 }
 
-test "adblock.AdBlocker: rules that might unblock suppress their hostname" {
+test "adblock.AdBlocker: verdict precedence" {
     var blocker: AdBlocker = try .init(testing.allocator);
     defer blocker.deinit();
 
-    var list: Io.Reader = .fixed(
-        // The easylist pair: without the exception we would break reuters.com.
-        \\||adsafeprotected.com^
-        \\@@||adsafeprotected.com/iasPET.$script,domain=independent.co.uk|reuters.com
-        // uBO's unbreak.txt shape: a $badfilter cancelling a block we kept.
-        \\||unbreak.example.com^
-        \\||unbreak.example.com^$badfilter
-        // Suppression outranks $important: we cannot tell which of our
-        // entries the exception cancels.
-        \\||strict.example.com^$important
-        \\@@||strict.example.com^$xhr
-    );
-    try blocker.parse(&list);
-
-    try testing.expectEqual(.none, blocker.matchHostname("adsafeprotected.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("sub.adsafeprotected.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("unbreak.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("strict.example.com"));
-}
-
-test "adblock.AdBlocker: hostname verdict precedence" {
-    var blocker: AdBlocker = try .init(testing.allocator);
-    defer blocker.deinit();
-
-    var list: Io.Reader = .fixed(
+    try testLoad(&blocker,
         \\||ads.example.com^
         \\@@||good.ads.example.com^
         \\||evil.com^$important
         \\@@||evil.com^
+        \\||strict.example.com^$important,script
+        \\@@||strict.example.com^$script
+        \\||both.example.com^$important,script
+        \\@@||both.example.com^$important,script
+        // Both sides pure hostnames, so both would otherwise be tries.
+        \\||pure.example.com^$important
+        \\@@||pure.example.com^$important
     );
-    try blocker.parse(&list);
 
-    try testing.expectEqual(.blocked, blocker.matchHostname("ads.example.com"));
+    try expectVerdict(&blocker, .blocked, "https://ads.example.com/x", "a.com", script);
     // The exception wins over the plain block...
-    try testing.expectEqual(.allowed, blocker.matchHostname("good.ads.example.com"));
-    try testing.expectEqual(.allowed, blocker.matchHostname("x.good.ads.example.com"));
-    try testing.expectEqual(.blocked, blocker.matchHostname("other.ads.example.com"));
-    // ...but $important beats the exception.
-    try testing.expectEqual(.blocked, blocker.matchHostname("evil.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("example.com"));
+    try expectVerdict(&blocker, .allowed, "https://good.ads.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .allowed, "https://x.good.ads.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://other.ads.example.com/x", "a.com", script);
+    // ...but $important beats the exception, whichever side is indexed.
+    try expectVerdict(&blocker, .blocked, "https://evil.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://strict.example.com/x.js", "a.com", script);
+    // ...and $important on the exception takes it back.
+    try expectVerdict(&blocker, .allowed, "https://both.example.com/x.js", "a.com", script);
+    try expectVerdict(&blocker, .allowed, "https://pure.example.com/x.js", "a.com", script);
+
+    try expectVerdict(&blocker, .none, "https://example.com/x", "a.com", script);
+}
+
+test "adblock.AdBlocker: $badfilter removes its target" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        // The uBO unbreak.txt shape: a $badfilter cancelling a block, whether
+        // that block lives in a trie...
+        \\||unbreak.example.com^
+        \\||unbreak.example.com^$badfilter
+        // ...or in an index.
+        \\||other.example.com^$script
+        \\||other.example.com^$script,badfilter
+        // A $badfilter only cancels the rule it names exactly.
+        \\||kept.example.com^$script
+        \\||kept.example.com^$image,badfilter
+        // "amazon.*" and "amazon" are different rules, not the same one.
+        \\||entity.example.com^$script,domain=amazon.*
+        \\||entity.example.com^$script,domain=amazon,badfilter
+    );
+
+    try expectVerdict(&blocker, .none, "https://unbreak.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .none, "https://other.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://kept.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://entity.example.com/x", "www.amazon.com", script);
+}
+
+test "adblock.AdBlocker: exceptions we cannot read suppress their hostname" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        \\||unreadable.example.com^
+        \\@@||unreadable.example.com/api/$denyallow=cdn.com
+        // A rewriting option excepts the rewriting, never the block...
+        \\||modified.example.com^
+        \\@@||modified.example.com/x.js$redirect-rule=noopjs,script
+        // ...and neither does a rule uBO rejects as well.
+        \\||malformed.example.com^
+        \\@@||malformed.example.com^$notarealoption
+        \\||plain.example.com^
+    );
+
+    // $denyallow narrows a block in ways we cannot evaluate, so we cannot
+    // tell what the exception excepts — the hostname stops being blockable
+    // rather than break the page the rule was written for.
+    try expectVerdict(&blocker, .none, "https://unreadable.example.com/x", "a.com", script);
+
+    try expectVerdict(&blocker, .blocked, "https://modified.example.com/x.js", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://malformed.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://plain.example.com/x", "a.com", script);
 }
 
 test "adblock.AdBlocker: trie absorbs every pure-hostname form" {
     var blocker: AdBlocker = try .init(testing.allocator);
     defer blocker.deinit();
 
-    var list: Io.Reader = .fixed(
+    try testLoad(&blocker,
         \\||anchored.example.com^
         \\bare-hostname.example.com
         \\0.0.0.0 hosts-style.example.io
     );
-    try blocker.parse(&list);
 
-    try testing.expectEqual(.blocked, blocker.matchHostname("anchored.example.com"));
-    try testing.expectEqual(.blocked, blocker.matchHostname("bare-hostname.example.com"));
-    try testing.expectEqual(.blocked, blocker.matchHostname("hosts-style.example.io"));
+    try expectVerdict(&blocker, .blocked, "https://anchored.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://bare-hostname.example.com/x", "a.com", script);
+    try expectVerdict(&blocker, .blocked, "https://hosts-style.example.io/x", "a.com", script);
+    // Pure-hostname filters block top-level documents too.
+    try expectVerdict(&blocker, .blocked, "https://anchored.example.com/", "a.com", document);
 }
 
-test "adblock.AdBlocker: constrained filters stay out of the trie" {
+test "adblock.AdBlocker: an important exception is found whatever matches first" {
     var blocker: AdBlocker = try .init(testing.allocator);
     defer blocker.deinit();
 
-    var list: Io.Reader = .fixed(
-        \\||no-caret.example.com
-        \\||typed.example.com^$script
-        \\||party.example.com^$third-party
-        \\||sited.example.com^$domain=news.com
-        \\@@||cosmetic.example.com^$generichide
+    // The plain exception is written first, so a single first-match engine
+    // would return it and never see the important one behind it.
+    try testLoad(&blocker,
+        \\||tracker.com^$important,script
+        \\@@||tracker.com^$script
+        \\@@||tracker.com/x.js$important,script
     );
-    try blocker.parse(&list);
 
-    try testing.expectEqual(.none, blocker.matchHostname("no-caret.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("typed.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("party.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("sited.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("bad.example.com"));
-    try testing.expectEqual(.none, blocker.matchHostname("cosmetic.example.com"));
+    try expectVerdict(&blocker, .allowed, "https://tracker.com/x.js", "a.com", script);
+    // Off the important exception's path, the $important block still wins.
+    try expectVerdict(&blocker, .blocked, "https://tracker.com/other.js", "a.com", script);
+}
+
+test "adblock.AdBlocker: an empty blocker decides nothing" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+    try blocker.build();
+
+    try expectVerdict(&blocker, .none, "https://example.com/x", "example.com", script);
 }

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -323,7 +323,14 @@ fn addToTrie(self: *AdBlocker, root: u32, hostname: []const u8) !void {
     };
 }
 
-pub const Verdict = enum { none, allowed, blocked };
+pub const Verdict = enum {
+    /// Nothing blocks the request, whether or not an exception names it.
+    none,
+    /// An exception overrode a block.
+    allowed,
+    /// A block no exception overrides, or a `$important` one.
+    blocked,
+};
 
 pub fn isBlocked(self: *const AdBlocker, transfer: *const HttpClient.Transfer) bool {
     var buffers: Request.Buffers = undefined;
@@ -346,13 +353,12 @@ pub fn match(self: *const AdBlocker, request: *const Request) Verdict {
     if (self.trie.matches(self.blocked_important, hostname) != null) return .blocked;
     if (self.blocking_important.match(request) != null) return .blocked;
 
-    if (self.exceptions.match(request) != null) return .allowed;
+    const blocked = self.trie.matches(self.blocked, hostname) != null or
+        self.blocking.match(request) != null;
+    if (!blocked) return .none;
     if (self.trie.matches(self.allowed, hostname) != null) return .allowed;
-
-    if (self.trie.matches(self.blocked, hostname) != null) return .blocked;
-    if (self.blocking.match(request) != null) return .blocked;
-
-    return .none;
+    if (self.exceptions.match(request) != null) return .allowed;
+    return .blocked;
 }
 
 /// Whether we can evaluate this filter at all.
@@ -488,7 +494,9 @@ test "adblock.AdBlocker: the doubleclick rules from EasyList" {
     // Right everything, wrong path.
     try expectVerdict(&blocker, .blocked, "https://g.doubleclick.net/pagead/ads", "bloomberg.com", xhr);
 
-    try expectVerdict(&blocker, .allowed, "https://static.doubleclick.net/instream/ad_status.js", "ignboards.com", script);
+    // An exception with nothing to override decides nothing: `$popup` never
+    // applies to a script, so no block covers this request.
+    try expectVerdict(&blocker, .none, "https://static.doubleclick.net/instream/ad_status.js", "ignboards.com", script);
     // The unconditional exception carves one path out of the block covering
     // the whole subtree, and leaves the rest of it blocked.
     try expectVerdict(&blocker, .allowed, "https://pubads.g.doubleclick.net/ssai/x", "history.com", xhr);
@@ -542,6 +550,7 @@ test "adblock.AdBlocker: parse accumulates across lists" {
     var first: Io.Reader = .fixed(
         \\! Title: First List
         \\||ads.example.com^
+        \\||cdn.example.com^
         \\@@||cdn.example.com^$script
         \\example.com##.ad-banner
     );
@@ -555,20 +564,39 @@ test "adblock.AdBlocker: parse accumulates across lists" {
 
     try expectVerdict(&blocker, .blocked, "https://ads.example.com/x", "news.com", script);
     try expectVerdict(&blocker, .blocked, "https://sub.ads.example.com/x", "news.com", script);
-    // The type-restricted exception now applies to scripts only.
+    // The type-restricted exception carves scripts out of the block.
     try expectVerdict(&blocker, .allowed, "https://cdn.example.com/x.js", "news.com", script);
-    try expectVerdict(&blocker, .none, "https://cdn.example.com/x.png", "news.com", image);
+    try expectVerdict(&blocker, .blocked, "https://cdn.example.com/x.png", "news.com", image);
 
     // The party and $domain= constrained block, from the second list.
     try expectVerdict(&blocker, .blocked, "https://tracker.net/x", "news.com", script);
     try expectVerdict(&blocker, .none, "https://tracker.net/x", "sports.news.com", script);
     try expectVerdict(&blocker, .none, "https://tracker.net/x", "other.com", script);
 
-    // Three rules loaded across the two lists; the cosmetic line is a rule of
+    // Four rules loaded across the two lists; the cosmetic line is a rule of
     // another realm, counted as such rather than as one we failed to apply.
-    try testing.expectEqual(3, blocker.rules_loaded);
+    try testing.expectEqual(4, blocker.rules_loaded);
     try testing.expectEqual(0, blocker.rules_skipped);
     try testing.expectEqual(1, blocker.rules_cosmetic);
+}
+
+test "adblock.AdBlocker: tokens past the request buffer still match" {
+    var blocker: AdBlocker = try .init(testing.allocator);
+    defer blocker.deinit();
+
+    try testLoad(&blocker,
+        \\&utm_tracker=
+    );
+
+    // 140 tokens of query noise push the filter's token ("utm", its rarest)
+    // past what the request holds; the engine walks the rest of the URL.
+    const noise = "https://example.com/?" ++ "a=1&" ** 70;
+    const overflowing: Request = .init(noise ++ "utm_tracker=1", "a.com", script);
+    try testing.expect(overflowing.tail.len != 0);
+    try testing.expectEqual(.blocked, blocker.match(&overflowing));
+    // A token past the buffer finds its bucket, but the pattern does not fit.
+    try expectVerdict(&blocker, .none, noise ++ "utm_other=1", "a.com", script);
+    try expectVerdict(&blocker, .none, noise ++ "b=2", "a.com", script);
 }
 
 test "adblock.AdBlocker: cosmetic-realm rules are not skipped rules" {

--- a/src/network/adblock/AdBlocker.zig
+++ b/src/network/adblock/AdBlocker.zig
@@ -129,6 +129,8 @@ pub fn fromConfig(allocator: Allocator, config: *const Config) !?AdBlocker {
 
     if (adblocker) |*blocker| {
         try blocker.build();
+        lp.metrics.adblock_rules.add(.loaded, @intCast(blocker.rules_loaded));
+        lp.metrics.adblock_rules.add(.skipped, @intCast(blocker.rules_skipped));
         log.info(.app, "adblock lists loaded", .{
             .loaded = blocker.rules_loaded,
             .skipped = blocker.rules_skipped,

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -176,7 +176,7 @@ pub const Histogram = std.AutoHashMapUnmanaged(u32, u32);
 const TOKENS_MAX = 32;
 
 /// The first filter that matches, or null.
-pub fn match(self: *const Engine, request: Request) ?*const NetworkFilter {
+pub fn match(self: *const Engine, request: *const Request) ?*const NetworkFilter {
     if (self.filters.len != 0) {
         for (request.tokens()) |token| {
             const bucket = self.buckets.get(token) orelse continue;
@@ -186,7 +186,7 @@ pub fn match(self: *const Engine, request: Request) ?*const NetworkFilter {
     return self.matchIn(self.fallback, request);
 }
 
-fn matchIn(self: *const Engine, bucket: []const u32, request: Request) ?*const NetworkFilter {
+fn matchIn(self: *const Engine, bucket: []const u32, request: *const Request) ?*const NetworkFilter {
     for (bucket) |index| {
         const filter = &self.filters[index];
         if (matchesFilter(filter, request)) return filter;
@@ -196,7 +196,7 @@ fn matchIn(self: *const Engine, bucket: []const u32, request: Request) ?*const N
 
 /// Cheapest constraint first: the type and party bits are two comparisons,
 /// the pattern walk is the expensive one.
-fn matchesFilter(filter: *const NetworkFilter, request: Request) bool {
+fn matchesFilter(filter: *const NetworkFilter, request: *const Request) bool {
     if (filter.types.bits() & request.kind.bits() == 0) return false;
     if (request.third_party) {
         if (!filter.third_party) return false;
@@ -277,7 +277,7 @@ pub fn build(
 }
 
 /// Runs of alphanumerics. Everything else ('.', '/', '-', '%', '_', '?') is a boundary.
-pub const Tokens = struct {
+const Tokens = struct {
     text: []const u8,
     i: usize = 0,
 

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -1,0 +1,319 @@
+// Copyright (C) 2023-2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! One indexed set of network filters — the blocking ones, the `$important`
+//! ones or the exceptions — and the lookup that finds which of them a request
+//! matches. A port of adblock-rust's `NetworkFilterList`.
+//!
+//! Checking every filter against every request is not affordable: EasyList
+//! alone carries tens of thousands. Instead each filter is filed under one
+//! token of its pattern — a run of alphanumerics that any URL it matches is
+//! bound to contain — and a request only ever pays for the filters filed
+//! under the tokens its own URL happens to have.
+//!
+//! Which token decides how much that costs, so each filter takes its rarest
+//! one across the whole loaded corpus: "gampad" narrows to a handful of
+//! filters where "com" would narrow to nothing. Filters whose pattern offers
+//! no token that is guaranteed to survive into the URL (see `collectTokens`)
+//! go to `fallback`, which every request pays for.
+
+const std = @import("std");
+
+const domain = @import("domain.zig");
+const pattern = @import("pattern.zig");
+const NetworkFilter = @import("NetworkFilter.zig");
+
+const Allocator = std.mem.Allocator;
+
+const Engine = @This();
+
+/// The shared filter array; `buckets` and `fallback` hold indices into it.
+filters: []const NetworkFilter,
+buckets: std.AutoHashMapUnmanaged(u32, []const u32),
+/// Filters no token can stand for; checked on every request.
+fallback: []const u32,
+
+pub const empty: Engine = .{
+    .filters = &.{},
+    .buckets = .empty,
+    .fallback = &.{},
+};
+
+pub fn deinit(self: *Engine, allocator: Allocator) void {
+    self.buckets.deinit(allocator);
+    self.* = .empty;
+}
+
+/// Everything the filters need to know about a request. Built once per
+/// request and shared by all three engines.
+pub const Request = struct {
+    url: pattern.Url,
+    /// The hostname of the document the request belongs to. Falls back to the
+    /// request's own hostname, which is what uBO does for top-level loads.
+    source_hostname: []const u8,
+    /// Exactly one bit set.
+    kind: NetworkFilter.ResourceTypes,
+    third_party: bool,
+
+    /// `url` must already be lowercased and fragment-free; `source_hostname`
+    /// may be empty when there is no document context.
+    pub fn init(
+        url: []const u8,
+        source_hostname: []const u8,
+        kind: NetworkFilter.ResourceTypes,
+    ) Request {
+        const parsed: pattern.Url = .init(url);
+        const source = if (source_hostname.len == 0) parsed.hostname() else source_hostname;
+        return .{
+            .url = parsed,
+            .source_hostname = source,
+            .kind = kind,
+            .third_party = domain.isThirdParty(parsed.hostname(), source),
+        };
+    }
+};
+
+/// How often each token appears across every indexed filter. Shared by the
+/// engines so that "rarest" means rarest overall, not within one class.
+pub const Histogram = std.AutoHashMapUnmanaged(u32, u32);
+
+/// Tokens considered per filter. Long query-string patterns can exceed this;
+/// taking the first few costs a wider bucket, never a wrong answer.
+const TOKENS_MAX = 32;
+
+/// The first filter that matches, or null.
+pub fn match(self: *const Engine, request: Request) ?*const NetworkFilter {
+    if (self.filters.len != 0) {
+        var it: Tokens = .{ .text = request.url.text };
+        while (it.next()) |token| {
+            const bucket = self.buckets.get(token) orelse continue;
+            if (self.matchIn(bucket, request)) |filter| return filter;
+        }
+    }
+    return self.matchIn(self.fallback, request);
+}
+
+fn matchIn(self: *const Engine, bucket: []const u32, request: Request) ?*const NetworkFilter {
+    for (bucket) |index| {
+        const filter = &self.filters[index];
+        if (matchesFilter(filter, request)) return filter;
+    }
+    return null;
+}
+
+/// Cheapest constraint first: the type and party bits are two comparisons,
+/// the pattern walk is the expensive one.
+pub fn matchesFilter(filter: *const NetworkFilter, request: Request) bool {
+    if (filter.types.bits() & request.kind.bits() == 0) return false;
+    if (request.third_party) {
+        if (!filter.third_party) return false;
+    } else if (!filter.first_party) {
+        return false;
+    }
+    if (!filter.domains.matches(request.source_hostname)) return false;
+    return pattern.matches(filter, request.url);
+}
+
+/// Adds `filter`'s tokens to the corpus counts.
+pub fn count(
+    histogram: *Histogram,
+    allocator: Allocator,
+    filter: *const NetworkFilter,
+) Allocator.Error!void {
+    var buf: [TOKENS_MAX]u32 = undefined;
+    for (collectTokens(filter, &buf)) |token| {
+        const gop = try histogram.getOrPut(allocator, token);
+        gop.value_ptr.* = if (gop.found_existing) gop.value_ptr.* + 1 else 1;
+    }
+}
+
+/// Indexes `members` (indices into `filters`) by their rarest token.
+/// `allocator` backs the bucket map, `arena` the index slices it points at.
+pub fn build(
+    allocator: Allocator,
+    arena: Allocator,
+    filters: []const NetworkFilter,
+    members: []const u32,
+    histogram: *const Histogram,
+) Allocator.Error!Engine {
+    var groups: std.AutoHashMapUnmanaged(u32, std.ArrayList(u32)) = .empty;
+    defer {
+        var it = groups.valueIterator();
+        while (it.next()) |list| list.deinit(allocator);
+        groups.deinit(allocator);
+    }
+
+    var fallback: std.ArrayList(u32) = .empty;
+    defer fallback.deinit(allocator);
+
+    var buf: [TOKENS_MAX]u32 = undefined;
+    for (members) |index| {
+        var rarest: ?u32 = null;
+        var lowest: u32 = std.math.maxInt(u32);
+        for (collectTokens(&filters[index], &buf)) |token| {
+            const seen = histogram.get(token) orelse 0;
+            if (seen < lowest) {
+                lowest = seen;
+                rarest = token;
+            }
+        }
+
+        const token = rarest orelse {
+            try fallback.append(allocator, index);
+            continue;
+        };
+        const gop = try groups.getOrPut(allocator, token);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        try gop.value_ptr.append(allocator, index);
+    }
+
+    var buckets: std.AutoHashMapUnmanaged(u32, []const u32) = .empty;
+    errdefer buckets.deinit(allocator);
+    try buckets.ensureTotalCapacity(allocator, groups.count());
+
+    var it = groups.iterator();
+    while (it.next()) |entry| {
+        buckets.putAssumeCapacity(entry.key_ptr.*, try arena.dupe(u32, entry.value_ptr.items));
+    }
+
+    return .{
+        .filters = filters,
+        .buckets = buckets,
+        .fallback = try arena.dupe(u32, fallback.items),
+    };
+}
+
+/// Runs of alphanumerics. Everything else ('.', '/', '-', '%', '_', '?') is a boundary.
+pub const Tokens = struct {
+    text: []const u8,
+    i: usize = 0,
+
+    pub fn next(self: *Tokens) ?u32 {
+        while (self.i < self.text.len and !isTokenChar(self.text[self.i])) self.i += 1;
+        if (self.i == self.text.len) return null;
+
+        const start = self.i;
+        while (self.i < self.text.len and isTokenChar(self.text[self.i])) self.i += 1;
+        return hash(self.text[start..self.i]);
+    }
+};
+
+fn isTokenChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c);
+}
+
+fn hash(token: []const u8) u32 {
+    return @truncate(std.hash.Wyhash.hash(0, token));
+}
+
+fn collectTokens(filter: *const NetworkFilter, buf: []u32) []u32 {
+    var n: usize = 0;
+
+    if (filter.hostname.len != 0) {
+        var it: Tokens = .{ .text = filter.hostname };
+        while (it.next()) |token| {
+            if (n == buf.len) return buf[0..n];
+            buf[n] = token;
+            n += 1;
+        }
+    }
+
+    // A /regex/ literal is never indexed (nothing can run it), and `.any`
+    // has no pattern at all.
+    if (filter.kind == .regex or filter.pattern.len == 0) return buf[0..n];
+
+    const text = filter.pattern;
+    var i: usize = 0;
+    while (i < text.len) {
+        if (!isTokenChar(text[i])) {
+            i += 1;
+            continue;
+        }
+        const start = i;
+        while (i < text.len and isTokenChar(text[i])) i += 1;
+
+        const left_bounded = if (start == 0)
+            filter.left_anchor or filter.hostname_anchor
+        else
+            text[start - 1] != '*';
+        const right_bounded = if (i == text.len) filter.right_anchor else text[i] != '*';
+
+        if (left_bounded and right_bounded) {
+            if (n == buf.len) return buf[0..n];
+            buf[n] = hash(text[start..i]);
+            n += 1;
+        }
+    }
+
+    return buf[0..n];
+}
+
+const testing = @import("../../testing.zig");
+
+fn tokensOf(arena: Allocator, line: []const u8, buf: []u32) ![]u32 {
+    const filter = try NetworkFilter.parse(arena, line);
+    return collectTokens(&filter, buf);
+}
+
+fn contains(tokens: []const u32, token: []const u8) bool {
+    for (tokens) |t| {
+        if (t == hash(token)) return true;
+    }
+    return false;
+}
+
+test "adblock.Engine: only tokens the URL must reproduce are collected" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var buf: [TOKENS_MAX]u32 = undefined;
+
+    // Every hostname label is bounded, the last one by the matcher's
+    // label-boundary requirement — with or without '^'.
+    var tokens = try tokensOf(arena, "||ads.example.com^", &buf);
+    try testing.expect(contains(tokens, "ads"));
+    try testing.expect(contains(tokens, "example"));
+    try testing.expect(contains(tokens, "com"));
+
+    tokens = try tokensOf(arena, "||ads.example.com", &buf);
+    try testing.expect(contains(tokens, "example"));
+    try testing.expect(contains(tokens, "com"));
+
+    // A path following the hostname bounds it just as well.
+    tokens = try tokensOf(arena, "||youtube.com/pagead/", &buf);
+    try testing.expect(contains(tokens, "com"));
+    try testing.expect(contains(tokens, "pagead"));
+
+    // A trailing token is unbounded unless the pattern is right-anchored:
+    // "/ads" also matches "/adserver".
+    tokens = try tokensOf(arena, "||example.com/ads", &buf);
+    try testing.expect(!contains(tokens, "ads"));
+    tokens = try tokensOf(arena, "||example.com/ads|", &buf);
+    try testing.expect(contains(tokens, "ads"));
+
+    // A '*' on either side disqualifies the token beside it, so this one is
+    // carried entirely by its hostname.
+    tokens = try tokensOf(arena, "||example.com/a*banner*c^", &buf);
+    try testing.expect(!contains(tokens, "banner"));
+    try testing.expect(contains(tokens, "example"));
+
+    // Nothing to index: option-only filters ride the fallback bucket.
+    tokens = try tokensOf(arena, "$script,domain=example.com", &buf);
+    try testing.expectEqual(0, tokens.len);
+}

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -72,10 +72,13 @@ pub const Request = struct {
     /// Exactly one bit set.
     kind: NetworkFilter.ResourceTypes,
     third_party: bool,
-    /// The URL's tokens, hashed once here so no engine retokenizes. A URL
-    /// long enough to overflow loses its last tokens.
+    /// The URL's first tokens, hashed once here so no engine retokenizes.
     tokens_buf: [URL_TOKENS_MAX]u32,
     tokens_len: usize,
+    /// The rest of the URL, past the last token that fit.
+    /// Each engine tokenizes it itself, so no token is ever lost. Token-free for
+    /// all but the longest URLs.
+    tail: []const u8,
 
     const URL_TOKENS_MAX = 128;
 
@@ -108,13 +111,15 @@ pub const Request = struct {
             .third_party = domain.isThirdParty(parsed.hostname(), source),
             .tokens_buf = undefined,
             .tokens_len = 0,
+            .tail = "",
         };
         var it: Tokens = .{ .text = url };
-        while (it.next()) |token| {
-            if (request.tokens_len == request.tokens_buf.len) break;
+        while (request.tokens_len < request.tokens_buf.len) {
+            const token = it.next() orelse break;
             request.tokens_buf[request.tokens_len] = token;
             request.tokens_len += 1;
         }
+        request.tail = url[it.i..];
         return request;
     }
 
@@ -177,13 +182,22 @@ const TOKENS_MAX = 32;
 
 /// The first filter that matches, or null.
 pub fn match(self: *const Engine, request: *const Request) ?*const NetworkFilter {
-    if (self.filters.len != 0) {
+    if (self.buckets.count() != 0) {
         for (request.tokens()) |token| {
-            const bucket = self.buckets.get(token) orelse continue;
-            if (self.matchIn(bucket, request)) |filter| return filter;
+            if (self.matchToken(token, request)) |filter| return filter;
+        }
+        // Whatever the request could not hold is hashed again.
+        var it: Tokens = .{ .text = request.tail };
+        while (it.next()) |token| {
+            if (self.matchToken(token, request)) |filter| return filter;
         }
     }
     return self.matchIn(self.fallback, request);
+}
+
+fn matchToken(self: *const Engine, token: u32, request: *const Request) ?*const NetworkFilter {
+    const bucket = self.buckets.get(token) orelse return null;
+    return self.matchIn(bucket, request);
 }
 
 fn matchIn(self: *const Engine, bucket: []const u32, request: *const Request) ?*const NetworkFilter {
@@ -353,6 +367,30 @@ fn contains(tokens: []const u32, token: []const u8) bool {
         if (t == hash(token)) return true;
     }
     return false;
+}
+
+test "adblock.Engine: a request keeps its first tokens, the rest as tail" {
+    const max = Request.URL_TOKENS_MAX;
+    const kind: NetworkFilter.ResourceTypes = .{ .script = true };
+
+    // Exactly as many tokens as the buffer holds: nothing is left to walk...
+    const full = "x/" ** (max - 1) ++ "x";
+    var request: Request = .init(full, "", kind);
+    try testing.expectEqual(max, request.tokens_len);
+    try testing.expectEqual(0, request.tail.len);
+
+    // ...one more, and only that one is in the tail.
+    request = .init(full ++ "/y", "", kind);
+    try testing.expectEqual(max, request.tokens_len);
+    try testing.expectString("/y", request.tail);
+    var it: Tokens = .{ .text = request.tail };
+    try testing.expectEqual(hash("y"), it.next().?);
+    try testing.expect(it.next() == null);
+
+    // Fewer than the buffer holds: the tail is empty.
+    request = .init("https://example.com/a", "", kind);
+    try testing.expectEqual(4, request.tokens_len);
+    try testing.expectEqual(0, request.tail.len);
 }
 
 test "adblock.Engine: only tokens the URL must reproduce are collected" {

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -34,6 +34,9 @@
 
 const std = @import("std");
 
+const URL = @import("../../browser/URL.zig");
+const HttpClient = @import("../HttpClient.zig");
+
 const domain = @import("domain.zig");
 const pattern = @import("pattern.zig");
 const NetworkFilter = @import("NetworkFilter.zig");
@@ -69,6 +72,25 @@ pub const Request = struct {
     /// Exactly one bit set.
     kind: NetworkFilter.ResourceTypes,
     third_party: bool,
+    /// The URL's tokens, hashed once here so no engine retokenizes. A URL
+    /// long enough to overflow loses its last tokens.
+    tokens_buf: [URL_TOKENS_MAX]u32,
+    tokens_len: usize,
+
+    const URL_TOKENS_MAX = 128;
+
+    /// Longest URL `fromHttp` will normalize. Anything past this is not a
+    /// resource a filter list has an opinion about.
+    const URL_MAX = 8 * 1024;
+    /// DNS's own hostname limit.
+    const SOURCE_MAX = 253;
+
+    /// Backs the normalized text of a `fromHttp` request, which stays valid
+    /// only as long as the buffers do.
+    pub const Buffers = struct {
+        url: [URL_MAX]u8,
+        source: [SOURCE_MAX]u8,
+    };
 
     /// `url` must already be lowercased and fragment-free; `source_hostname`
     /// may be empty when there is no document context.
@@ -79,11 +101,77 @@ pub const Request = struct {
     ) Request {
         const parsed: pattern.Url = .init(url);
         const source = if (source_hostname.len == 0) parsed.hostname() else source_hostname;
-        return .{
+        var request: Request = .{
             .url = parsed,
             .source_hostname = source,
             .kind = kind,
             .third_party = domain.isThirdParty(parsed.hostname(), source),
+            .tokens_buf = undefined,
+            .tokens_len = 0,
+        };
+        var it: Tokens = .{ .text = url };
+        while (it.next()) |token| {
+            if (request.tokens_len == request.tokens_buf.len) break;
+            request.tokens_buf[request.tokens_len] = token;
+            request.tokens_len += 1;
+        }
+        return request;
+    }
+
+    /// Builds the request `req` is matched as, `source` being the URL (or
+    /// origin serialization) of the document it was issued from. null when
+    /// there is none.
+    pub fn fromHttp(
+        req: *const HttpClient.Request,
+        source_url: ?[]const u8,
+        buffers: *Buffers,
+    ) ?Request {
+        const url = normalizeUrl(req.url, &buffers.url) orelse return null;
+
+        // Matching top-level nav against the page it was clicked on would make
+        // every link third party.
+        const top_level = req.resource_type == .document and !req.is_subframe;
+        const source_host = if (top_level)
+            ""
+        else if (source_url) |u|
+            URL.getOriginHostname(u)
+        else
+            "";
+        if (source_host.len > buffers.source.len) return null;
+        const source = std.ascii.lowerString(&buffers.source, source_host);
+
+        return .init(url, source, resourceType(req));
+    }
+
+    inline fn tokens(self: *const Request) []const u32 {
+        return self.tokens_buf[0..self.tokens_len];
+    }
+
+    /// Lowercases `url` into `buf` with its fragment stripped; patterns are
+    /// stored lowercased, and no request URL carries a fragment onto the wire.
+    fn normalizeUrl(url: []const u8, buf: []u8) ?[]const u8 {
+        const end = std.mem.indexOfScalar(u8, url, '#') orelse url.len;
+        const trimmed = url[0..end];
+
+        const upper = for (trimmed, 0..) |c, i| {
+            if (std.ascii.isUpper(c)) break i;
+        } else return trimmed;
+
+        if (trimmed.len > buf.len) return null;
+        const out = buf[0..trimmed.len];
+        @memcpy(out[0..upper], trimmed[0..upper]);
+        _ = std.ascii.lowerString(out[upper..], trimmed[upper..]);
+        return out;
+    }
+
+    fn resourceType(req: *const HttpClient.Request) NetworkFilter.ResourceTypes {
+        return switch (req.resource_type) {
+            .document => if (req.is_subframe) .{ .subdocument = true } else .{ .document = true },
+            .script => .{ .script = true },
+            .stylesheet => .{ .stylesheet = true },
+            .xhr, .fetch => .{ .xmlhttprequest = true },
+            .image => .{ .image = true },
+            .eventsource => .{ .other = true },
         };
     }
 };
@@ -99,8 +187,7 @@ const TOKENS_MAX = 32;
 /// The first filter that matches, or null.
 pub fn match(self: *const Engine, request: Request) ?*const NetworkFilter {
     if (self.filters.len != 0) {
-        var it: Tokens = .{ .text = request.url.text };
-        while (it.next()) |token| {
+        for (request.tokens()) |token| {
             const bucket = self.buckets.get(token) orelse continue;
             if (self.matchIn(bucket, request)) |filter| return filter;
         }

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -118,29 +118,31 @@ pub const Request = struct {
         return request;
     }
 
-    /// Builds the request `req` is matched as, `source` being the URL (or
-    /// origin serialization) of the document it was issued from. null when
-    /// there is none.
-    pub fn fromHttp(
-        req: *const HttpClient.Request,
-        source_url: ?[]const u8,
-        buffers: *Buffers,
-    ) ?Request {
+    pub fn fromHttp(transfer: *const HttpClient.Transfer, buffers: *Buffers) ?Request {
+        const req = &transfer.req;
         const url = normalizeUrl(req.url, &buffers.url) orelse return null;
 
-        // Matching top-level nav against the page it was clicked on would make
-        // every link third party.
-        const top_level = req.resource_type == .document and !req.is_subframe;
-        const source_host = if (top_level)
-            ""
-        else if (source_url) |u|
-            URL.getOriginHostname(u)
-        else
-            "";
+        var owner: ?*const HttpClient.Owner = transfer.owner;
+        var subframe = false;
+        if (req.resource_type == .document) {
+            owner = if (owner) |o| o.parent else null;
+            subframe = owner != null;
+        }
+        const source_url = if (owner) |o| o.documentUrl() else null;
+        const source_host = if (source_url) |u| URL.getOriginHostname(u) else "";
         if (source_host.len > buffers.source.len) return null;
         const source = std.ascii.lowerString(&buffers.source, source_host);
 
-        return .init(url, source, resourceType(req));
+        const resource_type: NetworkFilter.ResourceTypes = switch (req.resource_type) {
+            .document => if (subframe) .{ .subdocument = true } else .{ .document = true },
+            .script => .{ .script = true },
+            .stylesheet => .{ .stylesheet = true },
+            .xhr, .fetch => .{ .xmlhttprequest = true },
+            .image => .{ .image = true },
+            .eventsource => .{ .other = true },
+        };
+
+        return .init(url, source, resource_type);
     }
 
     inline fn tokens(self: *const Request) []const u32 {
@@ -162,17 +164,6 @@ pub const Request = struct {
         @memcpy(out[0..upper], trimmed[0..upper]);
         _ = std.ascii.lowerString(out[upper..], trimmed[upper..]);
         return out;
-    }
-
-    fn resourceType(req: *const HttpClient.Request) NetworkFilter.ResourceTypes {
-        return switch (req.resource_type) {
-            .document => if (req.is_subframe) .{ .subdocument = true } else .{ .document = true },
-            .script => .{ .script = true },
-            .stylesheet => .{ .stylesheet = true },
-            .xhr, .fetch => .{ .xmlhttprequest = true },
-            .image => .{ .image = true },
-            .eventsource => .{ .other = true },
-        };
     }
 };
 

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -145,6 +145,7 @@ pub const Request = struct {
             .xhr, .fetch => .{ .xmlhttprequest = true },
             .image => .{ .image = true },
             .eventsource => .{ .other = true },
+            .worker => .{ .script = true },
         };
 
         return .init(url, source, resource_type);

--- a/src/network/adblock/Engine.zig
+++ b/src/network/adblock/Engine.zig
@@ -118,7 +118,7 @@ fn matchIn(self: *const Engine, bucket: []const u32, request: Request) ?*const N
 
 /// Cheapest constraint first: the type and party bits are two comparisons,
 /// the pattern walk is the expensive one.
-pub fn matchesFilter(filter: *const NetworkFilter, request: Request) bool {
+fn matchesFilter(filter: *const NetworkFilter, request: Request) bool {
     if (filter.types.bits() & request.kind.bits() == 0) return false;
     if (request.third_party) {
         if (!filter.third_party) return false;

--- a/src/network/adblock/NetworkFilter.zig
+++ b/src/network/adblock/NetworkFilter.zig
@@ -119,6 +119,9 @@ pub const ParseError = error{
     UnsupportedPattern,
     NoSupportedDomains,
     UnsupportedModifier,
+    // Element hiding ("example.com##.ad"): a rule for another realm, not a
+    // network rule we failed to read.
+    CosmeticFilter,
     // Hosts-file noise ("127.0.0.1 localhost"), skip silently.
     Ignored,
 } || std.mem.Allocator.Error;
@@ -258,6 +261,10 @@ pub fn parse(arena: std.mem.Allocator, line: []const u8) ParseError!NetworkFilte
     if (rest.len == 0) return error.InvalidPattern;
 
     const split = splitOptions(rest);
+    // Cosmetic filters classify as network.
+    if (!isRegexLiteral(split.pattern) and hasCosmeticSeparator(split.pattern)) {
+        return error.CosmeticFilter;
+    }
     var explicit_types = false;
     if (split.options) |options| {
         try filter.parseOptions(arena, options, &explicit_types);
@@ -285,6 +292,23 @@ pub fn parse(arena: std.mem.Allocator, line: []const u8) ParseError!NetworkFilte
     }
 
     return filter;
+}
+
+inline fn isRegexLiteral(text: []const u8) bool {
+    return text.len > 2 and text[0] == '/' and text[text.len - 1] == '/';
+}
+
+/// Whether `text` carries a cosmetic separator.
+/// "##", "#@#", "#?#", "#$#", "#%#" and their combinations, like "#@$?#".
+fn hasCosmeticSeparator(text: []const u8) bool {
+    var start: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, text, start, '#')) |pos| {
+        var i = pos + 1;
+        while (i < text.len and std.mem.indexOfScalar(u8, "@$?%", text[i]) != null) i += 1;
+        if (i < text.len and text[i] == '#') return true;
+        start = pos + 1;
+    }
+    return false;
 }
 
 /// uBO allows a trailing "  # comment" on lines containing whitespace.
@@ -561,16 +585,12 @@ fn parsePattern(
     }
 
     // Whole-pattern regex literal: /.../ with anything between the slashes.
-    if (raw.len > 2 and raw[0] == '/' and raw[raw.len - 1] == '/') {
+    if (isRegexLiteral(raw)) {
         self.kind = .regex;
         self.pattern = raw;
         return;
     }
 
-    // A literal '#' can never match: request URLs have their fragment
-    // stripped before matching. This is also what drops cosmetic filter
-    // lines (example.com##.ad-banner), which classify as network now that
-    // there is no cosmetic-separator scan.
     if (std.mem.indexOfScalar(u8, raw, '#') != null) return error.UnsupportedPattern;
 
     var pattern = raw;
@@ -1070,10 +1090,15 @@ test "adblock.NetworkFilter: option-only and invalid patterns" {
     try testing.expectError(error.InvalidPattern, testParse(arena, "foo bar$script"));
     try testing.expectError(error.UnsupportedPattern, testParse(arena, "||exämple.com^"));
 
-    // Cosmetic lines reach this parser undetected (no separator scan) and
-    // drop here: a '#' never matches a fragment-stripped request URL.
-    try testing.expectError(error.UnsupportedPattern, testParse(arena, "example.com##.ad-banner"));
-    try testing.expectError(error.UnsupportedPattern, testParse(arena, "example.com#@#.sponsored"));
+    // Cosmetic lines reach this parser as network lines, there being no
+    // separator scan up front, and are told apart by their separator,
+    // whichever flavour...
+    try testing.expectError(error.CosmeticFilter, testParse(arena, "example.com##.ad-banner"));
+    try testing.expectError(error.CosmeticFilter, testParse(arena, "example.com#@#.sponsored"));
+    try testing.expectError(error.CosmeticFilter, testParse(arena, "example.com#?#.ad:has(> a)"));
+    try testing.expectError(error.CosmeticFilter, testParse(arena, "example.com#@$#body { background: none }"));
+    try testing.expectError(error.CosmeticFilter, testParse(arena, "example.com##+js(no-fetch-if, ads)"));
+    // ...while a lone '#' is a fragment, which never matches a request URL.
     try testing.expectError(error.UnsupportedPattern, testParse(arena, "|https://a.com/x#y|"));
     // ... but '#' inside a /regex/ body is untouched.
     const regex = try testParse(arena, "/ads#[0-9]+/");

--- a/src/network/adblock/NetworkFilter.zig
+++ b/src/network/adblock/NetworkFilter.zig
@@ -416,7 +416,8 @@ fn parseOptions(
                 self.domains = try domain.parse(arena, v);
             },
             .important => {
-                if (negated) return error.InvalidOption;
+                // Importance is a property of blocks; uBO rejects `@@…$important`.
+                if (negated or self.exception) return error.InvalidOption;
                 self.important = true;
             },
             .badfilter => {
@@ -588,12 +589,14 @@ fn parsePattern(
         pattern = pattern[0 .. pattern.len - 1];
     }
 
-    // Trim pointless wildcards touching the (now removed) ends.
-    while (std.mem.startsWith(u8, pattern, "*")) {
-        pattern = pattern[1..];
+    // Trim pointless wildcards touching the (now removed) ends. A wildcard bordering
+    // a short word stays; which is what keeps the word a substring rather than a hostname.
+    const stars = std.mem.indexOfNone(u8, pattern, "*") orelse pattern.len;
+    if (stars > 0 and (stars == pattern.len or !isPatternWordChar(pattern[stars]))) {
+        pattern = pattern[stars..];
         self.left_anchor = false;
     }
-    while (std.mem.endsWith(u8, pattern, "*")) {
+    while (pointlessTrailingWildcard(pattern)) {
         pattern = pattern[0 .. pattern.len - 1];
         self.right_anchor = false;
     }
@@ -623,6 +626,10 @@ fn parsePattern(
         const remainder = pattern[host_end..];
         if (remainder.len == 0) {
             self.kind = .hostname;
+            if (isHostnameShaped(self.hostname)) {
+                self.require_separator = true;
+                self.right_anchor = false;
+            }
         } else if (std.mem.eql(u8, remainder, "^")) {
             self.kind = .hostname;
             self.require_separator = true;
@@ -633,14 +640,14 @@ fn parsePattern(
         return;
     }
 
-    // A pattern that reads as a bare hostname is a hostname filter
-    // (`ads.example.com` == `||ads.example.com^`)
-    if (!self.left_anchor and !self.right_anchor and isHostnameShaped(pattern)) {
+    if (isHostnameShaped(pattern)) {
         if (isRedirectHostName(pattern)) return error.Ignored;
         self.kind = .hostname;
         self.hostname = pattern;
         self.hostname_anchor = true;
         self.require_separator = true;
+        self.left_anchor = false;
+        self.right_anchor = false;
         return;
     }
 
@@ -650,6 +657,19 @@ fn parsePattern(
 
     self.kind = if (std.mem.indexOfAny(u8, pattern, "*^") != null) .wildcard else .plain;
     self.pattern = pattern;
+}
+
+/// Ditto uBO's `rePointlessTrailingWildcards`.
+fn pointlessTrailingWildcard(pattern: []const u8) bool {
+    if (pattern.len == 0 or pattern[pattern.len - 1] != '*') return false;
+    const before = std.mem.trimEnd(u8, pattern, "*");
+    var run: usize = 0;
+    while (run < before.len and isPatternWordChar(before[before.len - 1 - run])) run += 1;
+    return run == 0 or run >= 7;
+}
+
+inline fn isPatternWordChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '%';
 }
 
 /// Matches uBO's hostname flavor: dot-separated labels of [a-z0-9_-], each
@@ -705,18 +725,35 @@ test "adblock.NetworkFilter: pure hostname forms" {
     // Implicit "strict" blocking: documents included.
     try testing.expectEqual(ResourceTypes.all.bits(), f.types.bits());
 
-    // Without '^' there is no separator requirement and no implicit
-    // document blocking.
+    // `||host` and `||host|` are, in uBO, the same filter as `||host^`:
+    // the request hostname is `host` or a subdomain of it.
     f = try testParse(arena, "||ads.example.com");
     try testing.expectEqual(.hostname, f.kind);
-    try testing.expect(!f.require_separator);
-    try testing.expectEqual(ResourceTypes.all_network.bits(), f.types.bits());
+    try testing.expect(f.require_separator);
+    try testing.expectEqual(ResourceTypes.all.bits(), f.types.bits());
+
+    f = try testParse(arena, "||ads.example.com|");
+    try testing.expectEqual(.hostname, f.kind);
+    try testing.expect(f.require_separator);
+    try testing.expect(!f.right_anchor);
 
     // Bare hostname line == ||host^ (uBO divergence from ABP).
     f = try testParse(arena, "tracker.example.net");
     try testing.expectEqual(.hostname, f.kind);
     try testing.expectString("tracker.example.net", f.hostname);
     try testing.expect(f.require_separator);
+
+    // An anchor on a bare hostname is part of the same reading.
+    f = try testParse(arena, "tracker.example.net|");
+    try testing.expectEqual(.hostname, f.kind);
+    try testing.expectString("tracker.example.net", f.hostname);
+    try testing.expect(f.require_separator);
+    try testing.expect(!f.right_anchor);
+
+    f = try testParse(arena, "|tracker.example.net");
+    try testing.expectEqual(.hostname, f.kind);
+    try testing.expectString("tracker.example.net", f.hostname);
+    try testing.expect(!f.left_anchor);
 
     // Raw IPv4 lines (URLhaus style).
     f = try testParse(arena, "101.126.11.168");
@@ -778,11 +815,23 @@ test "adblock.NetworkFilter: anchors and pattern kinds" {
     try testing.expectEqual(.plain, f.kind);
     try testing.expect(!f.right_anchor);
 
-    // A pattern that trims down to a bare hostname shape gets promoted
-    // (uBO flavor rules), even a single label.
+    // A '*' bordering a short alphanumeric run is meaningful (uBO's
+    // pointless-wildcard rules), so no trimming and no hostname promotion.
     f = try testParse(arena, "*ads*|");
+    try testing.expectEqual(.wildcard, f.kind);
+    try testing.expectString("*ads*", f.pattern);
+
+    // A trailing '*' after 7+ chars drops, and a pattern that trims down
+    // to a bare hostname shape gets promoted (uBO flavor rules)...
+    f = try testParse(arena, "ads.example*");
     try testing.expectEqual(.hostname, f.kind);
-    try testing.expectString("ads", f.hostname);
+    try testing.expectString("ads.example", f.hostname);
+
+    // ...but a leading '*' before a word survives, and keeps the pattern a
+    // substring match rather than a hostname.
+    f = try testParse(arena, "*ads.example*");
+    try testing.expectEqual(.wildcard, f.kind);
+    try testing.expectString("*ads.example", f.pattern);
 
     // '||' hostname region containing '*' stays a generic pattern.
     f = try testParse(arena, "||example.*/ads");
@@ -963,6 +1012,9 @@ test "adblock.NetworkFilter: important, badfilter, noop" {
 
     var f = try testParse(arena, "||ads.com^$important");
     try testing.expect(f.important);
+
+    // Importance is a property of blocks; uBO rejects it on an exception.
+    try testing.expectError(error.InvalidOption, testParse(arena, "@@||ads.com^$important"));
 
     f = try testParse(arena, "||ads.com^$badfilter");
     try testing.expect(f.badfilter);

--- a/src/network/adblock/NetworkFilter.zig
+++ b/src/network/adblock/NetworkFilter.zig
@@ -26,11 +26,14 @@ kind: PatternKind,
 /// for the bare-hostname and hosts-file forms. Empty when the pattern names
 /// no hostname (`/ads/banner.`, `|https://…`, `/regex/`).
 hostname: []const u8 = "",
+/// Normalized (lowercased) pattern with the anchor markers stripped, and
+/// with `hostname` removed when the filter is `||`-anchored — so
+/// `||ads.com/x*.js` keeps `/x*.js` here. Empty for `.hostname` and `.any`;
+/// the raw literal, slashes included, for `.regex`.
+pattern: []const u8 = "",
 types: ResourceTypes = .none,
-/// Whether a `$domain=` list constrains this filter. The entries themselves
-/// are not kept: any of them already makes the filter narrower than the
-/// whole-hostname verdict we can represent.
-has_domains: bool = false,
+/// The `$domain=` constraint; `.none` when the filter carries none.
+domains: domain.List = .none,
 exception: bool = false,
 important: bool = false,
 badfilter: bool = false,
@@ -71,7 +74,8 @@ pub const ResourceTypes = packed struct(u16) {
     websocket: bool = false,
     ping: bool = false,
     other: bool = false,
-    _padding: u4 = 0,
+    popup: bool = false,
+    _padding: u3 = 0,
 
     pub const none: ResourceTypes = .{};
 
@@ -114,6 +118,7 @@ pub const ParseError = error{
     UnsupportedOption,
     UnsupportedPattern,
     NoSupportedDomains,
+    UnsupportedModifier,
     // Hosts-file noise ("127.0.0.1 localhost"), skip silently.
     Ignored,
 } || std.mem.Allocator.Error;
@@ -132,6 +137,8 @@ const Option = enum {
     websocket,
     ping,
     other,
+    popup,
+    popunder,
     all,
     // Party.
     first_party,
@@ -145,8 +152,6 @@ const Option = enum {
     specifichide,
     elemhide,
     // Recognized but unsupported (rule dropped)...
-    popup,
-    popunder,
     inline_script,
     inline_font,
     genericblock,
@@ -255,7 +260,7 @@ pub fn parse(arena: std.mem.Allocator, line: []const u8) ParseError!NetworkFilte
     const split = splitOptions(rest);
     var explicit_types = false;
     if (split.options) |options| {
-        try filter.parseOptions(options, &explicit_types);
+        try filter.parseOptions(arena, options, &explicit_types);
     }
 
     if (std.mem.indexOfAny(u8, split.pattern, &std.ascii.whitespace) != null) {
@@ -335,6 +340,7 @@ fn isNoop(name: []const u8) bool {
 
 fn parseOptions(
     self: *NetworkFilter,
+    arena: std.mem.Allocator,
     options: []const u8,
     explicit_types: *bool,
 ) ParseError!void {
@@ -383,6 +389,8 @@ fn parseOptions(
             .websocket,
             .ping,
             .other,
+            .popup,
+            .popunder,
             => {
                 if (negated and option == .document) return error.InvalidOption;
                 explicit_types.* = true;
@@ -405,8 +413,7 @@ fn parseOptions(
                 if (negated) return error.InvalidOption;
                 const v = value orelse return error.InvalidOption;
                 if (v.len == 0) return error.InvalidOption;
-                try domain.validate(v);
-                self.has_domains = true;
+                self.domains = try domain.parse(arena, v);
             },
             .important => {
                 if (negated) return error.InvalidOption;
@@ -443,8 +450,8 @@ fn parseOptions(
                 explicit_types.* = true;
                 positive.media = true;
             },
-            .popup,
-            .popunder,
+            // Options that narrow or cancel blocking: an `@@` rule carrying
+            // one can unblock something we do block.
             .inline_script,
             .inline_font,
             .genericblock,
@@ -456,6 +463,9 @@ fn parseOptions(
             .strict1p,
             .strict3p,
             .ipaddress,
+            => return error.UnsupportedOption,
+            // Options that only rewrite a request that was going through
+            // regardless.
             .csp,
             .permissions,
             .removeparam,
@@ -463,7 +473,7 @@ fn parseOptions(
             .urlskip,
             .uritransform,
             .redirect_rule,
-            => return error.UnsupportedOption,
+            => return error.UnsupportedModifier,
             .webrtc => return error.InvalidOption,
         }
     }
@@ -494,6 +504,7 @@ fn setType(set: *ResourceTypes, option: Option) void {
         .websocket => set.websocket = true,
         .ping => set.ping = true,
         .other => set.other = true,
+        .popup, .popunder => set.popup = true,
         else => unreachable,
     }
 }
@@ -551,6 +562,7 @@ fn parsePattern(
     // Whole-pattern regex literal: /.../ with anything between the slashes.
     if (raw.len > 2 and raw[0] == '/' and raw[raw.len - 1] == '/') {
         self.kind = .regex;
+        self.pattern = raw;
         return;
     }
 
@@ -603,6 +615,7 @@ fn parsePattern(
             // Wildcard inside the hostname region (`||example.*/ads`):
             // no hostname split, the whole thing is a generic pattern.
             self.kind = .wildcard;
+            self.pattern = pattern;
             return;
         }
         if (host_end == 0) return error.InvalidPattern;
@@ -615,6 +628,7 @@ fn parsePattern(
             self.require_separator = true;
         } else {
             self.kind = if (std.mem.indexOfAny(u8, remainder, "*^") != null) .wildcard else .plain;
+            self.pattern = remainder;
         }
         return;
     }
@@ -635,6 +649,7 @@ fn parsePattern(
     }
 
     self.kind = if (std.mem.indexOfAny(u8, pattern, "*^") != null) .wildcard else .plain;
+    self.pattern = pattern;
 }
 
 /// Matches uBO's hostname flavor: dot-separated labels of [a-z0-9_-], each
@@ -845,6 +860,63 @@ test "adblock.NetworkFilter: type options, aliases and negation" {
     try testing.expectError(error.InvalidOption, testParse(arena, "||ads.com^$~document"));
 }
 
+test "adblock.NetworkFilter: $popup is a type no request carries" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // We issue no popup requests, so these load and never fire. Dropping them
+    // instead would leave their `@@` counterparts with nothing to except.
+    var f = try testParse(arena, "||doubleclick.net^$popup");
+    try testing.expect(f.types.popup);
+    try testing.expect(!f.types.script);
+    try testing.expect(!f.types.document);
+
+    f = try testParse(arena, "@@||ad.doubleclick.net/ddm/$popup,domain=nytimes.com");
+    try testing.expect(f.exception);
+    try testing.expect(f.types.popup);
+    try testing.expectString("/ddm/", f.pattern);
+
+    // $popunder is the same bit, and the implicit type sets exclude both.
+    f = try testParse(arena, "||ads.com^$popunder");
+    try testing.expect(f.types.popup);
+    f = try testParse(arena, "||ads.com^");
+    try testing.expect(!f.types.popup);
+    try testing.expect(!ResourceTypes.all.popup);
+}
+
+test "adblock.NetworkFilter: the pattern survives parsing" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // A `||`-anchored pattern keeps only what follows the hostname.
+    var f = try testParse(arena, "||youtube.com/pagead/");
+    try testing.expectString("youtube.com", f.hostname);
+    try testing.expectString("/pagead/", f.pattern);
+
+    f = try testParse(arena, "||g.doubleclick.net/gampad/ads*%20Web%20Player$domain=imasdk.googleapis.com");
+    try testing.expectEqual(.wildcard, f.kind);
+    try testing.expectString("g.doubleclick.net", f.hostname);
+    try testing.expectString("/gampad/ads*%20web%20player", f.pattern);
+
+    // Pure hostname filters carry no pattern at all.
+    f = try testParse(arena, "||ads.example.com^");
+    try testing.expectString("", f.pattern);
+
+    // Unanchored patterns keep the whole thing, anchors stripped.
+    f = try testParse(arena, "|https://ads.");
+    try testing.expectString("https://ads.", f.pattern);
+
+    f = try testParse(arena, "-Ad-300x250.gif|");
+    try testing.expectString("-ad-300x250.gif", f.pattern);
+
+    // A '*' in the hostname region leaves the hostname unsplit.
+    f = try testParse(arena, "||example.*/ads");
+    try testing.expectString("", f.hostname);
+    try testing.expectString("example.*/ads", f.pattern);
+}
+
 test "adblock.NetworkFilter: party options" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -871,7 +943,12 @@ test "adblock.NetworkFilter: domain option" {
     const arena = arena_state.allocator();
 
     const f = try testParse(arena, "||ads.com^$script,domain=news.com|~sports.news.com|google.*");
-    try testing.expect(f.has_domains);
+    try testing.expectEqual(2, f.domains.included.len);
+    try testing.expectString("news.com", f.domains.included[0].name);
+    try testing.expectString("google", f.domains.included[1].name);
+    try testing.expect(f.domains.included[1].entity);
+    try testing.expectEqual(1, f.domains.excluded.len);
+    try testing.expectString("sports.news.com", f.domains.excluded[0].name);
 
     try testing.expectError(error.InvalidOption, testParse(arena, "||ads.com^$domain="));
     try testing.expectError(error.NoSupportedDomains, testParse(arena, "||ads.com^$domain=/re/"));
@@ -902,10 +979,15 @@ test "adblock.NetworkFilter: unsupported and modifier options" {
 
     // Modifier/rewrite rules are dropped: keeping them as plain blocks
     // would over-block (a $removeparam rule matches nearly everything).
-    try testing.expectError(error.UnsupportedOption, testParse(arena, "$removeparam=utm_source"));
-    try testing.expectError(error.UnsupportedOption, testParse(arena, "||ads.com^$csp=script-src 'none'"));
-    try testing.expectError(error.UnsupportedOption, testParse(arena, "||ads.com^$popup"));
-    try testing.expectError(error.UnsupportedOption, testParse(arena, "||ads.com^$redirect-rule=noopjs"));
+    // They report a distinct error because they never blocked anything, so
+    // their `@@` form has nothing to unblock either.
+    try testing.expectError(error.UnsupportedModifier, testParse(arena, "$removeparam=utm_source"));
+    try testing.expectError(error.UnsupportedModifier, testParse(arena, "||ads.com^$csp=script-src 'none'"));
+    try testing.expectError(error.UnsupportedModifier, testParse(arena, "||ads.com^$redirect-rule=noopjs"));
+
+    // Options that do narrow blocking keep the blunter error.
+    try testing.expectError(error.UnsupportedOption, testParse(arena, "||ads.com^$denyallow=cdn.com"));
+    try testing.expectError(error.UnsupportedOption, testParse(arena, "||ads.com^$method=get"));
 
     // $redirect keeps its blocking half; the directive itself is ignored.
     var f = try testParse(arena, "||ads.com/ad.js$script,redirect=noopjs");

--- a/src/network/adblock/Parser.zig
+++ b/src/network/adblock/Parser.zig
@@ -37,14 +37,30 @@ skipped: usize = 0,
 
 pub const Error = error{ OutOfMemory, ReadFailed };
 
+/// One rule-shaped line. Dropped lines are surfaced rather than swallowed
+/// because an `@@` rule we cannot read still tells the caller that something
+/// on that hostname is not meant to be blocked.
+pub const Item = union(enum) {
+    filter: NetworkFilter,
+    /// Already counted in `skipped`; the caller only inspects it.
+    dropped: Dropped,
+};
+
+pub const Dropped = struct {
+    line: []const u8,
+    /// Why the filter parser refused it. Null when the line never reached it
+    /// (AdGuard `$$` syntax).
+    reason: ?NetworkFilter.ParseError,
+};
+
 pub fn init(reader: *std.Io.Reader) Parser {
     return .{ .reader = reader };
 }
 
-/// Returns the next network filter, or null at end of list. Allocations come
-/// from `arena`; the returned filter borrows from it and from the reader's
+/// Returns the next rule-shaped line, or null at end of list. Allocations
+/// come from `arena`; the result borrows from it and from the reader's
 /// buffer, so it only stays valid until the following call.
-pub fn next(self: *Parser, arena: Allocator) Error!?NetworkFilter {
+pub fn next(self: *Parser, arena: Allocator) Error!?Item {
     while (try self.takeLine()) |raw_line| {
         var stripped: []const u8 = raw_line;
         if (self.first_line) {
@@ -57,15 +73,21 @@ pub fn next(self: *Parser, arena: Allocator) Error!?NetworkFilter {
 
         switch (LineClass.fromLine(line)) {
             .empty, .comment => {},
-            .unsupported => self.skipped += 1,
+            .unsupported => {
+                self.skipped += 1;
+                return .{ .dropped = .{ .line = line, .reason = null } };
+            },
             .network => {
                 if (NetworkFilter.parse(arena, line)) |filter| {
-                    return filter;
+                    return .{ .filter = filter };
                 } else |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     // Anything else is a line outside the supported subset
                     // or malformed; either way it is not ours to enforce.
-                    else => self.skipped += 1,
+                    else => {
+                        self.skipped += 1;
+                        return .{ .dropped = .{ .line = line, .reason = err } };
+                    },
                 }
             },
         }
@@ -154,7 +176,18 @@ test "adblock.Parser: line classification" {
     try testing.expectEqual(.unsupported, LineClass.fromLine("example.com$$script[data-x]"));
 }
 
-test "adblock.Parser: yields one filter per next() call" {
+/// The next item that is a filter, skipping over dropped lines.
+fn nextFilter(parser: *Parser, arena: Allocator) !?NetworkFilter {
+    while (try parser.next(arena)) |item| {
+        switch (item) {
+            .filter => |filter| return filter,
+            .dropped => {},
+        }
+    }
+    return null;
+}
+
+test "adblock.Parser: yields one item per next() call" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -167,13 +200,19 @@ test "adblock.Parser: yields one filter per next() call" {
     var parser: Parser = .init(&reader);
 
     const first = (try parser.next(arena)).?;
-    try testing.expectString("ads.example.com", first.hostname);
+    try testing.expectString("ads.example.com", first.filter.hostname);
 
+    // The cosmetic line comes back as dropped rather than being swallowed,
+    // with the reason the filter parser gave.
     const second = (try parser.next(arena)).?;
-    try testing.expectString("tracker.net", second.hostname);
+    try testing.expectString("example.com##.ad-banner", second.dropped.line);
+    try testing.expectEqual(error.UnsupportedPattern, second.dropped.reason.?);
 
-    // The header, the cosmetic line and the end of the list all yield
-    // nothing, and next() keeps returning null once drained.
+    const third = (try parser.next(arena)).?;
+    try testing.expectString("tracker.net", third.filter.hostname);
+
+    // The header and the end of the list yield nothing, and next() keeps
+    // returning null once drained.
     try testing.expect(try parser.next(arena) == null);
     try testing.expect(try parser.next(arena) == null);
 }
@@ -195,7 +234,7 @@ test "adblock.Parser: only rule-shaped lines count as skipped" {
     var parser: Parser = .init(&reader);
 
     var count: usize = 0;
-    while (try parser.next(arena)) |_| count += 1;
+    while (try nextFilter(&parser, arena)) |_| count += 1;
 
     // The header, the comment and the blank line are not rules.
     try testing.expectEqual(1, count);
@@ -220,14 +259,14 @@ test "adblock.Parser: a line too long for the buffer is skipped" {
     var reader = text_reader.limited(.unlimited, &buf);
     var parser: Parser = .init(&reader.interface);
 
-    const first = (try parser.next(arena)).?;
+    const first = (try nextFilter(&parser, arena)).?;
     try testing.expectString("ads.example.com", first.hostname);
 
     // The oversized line was stepped over, not treated as end of list.
-    const second = (try parser.next(arena)).?;
+    const second = (try nextFilter(&parser, arena)).?;
     try testing.expectString("tracker.net", second.hostname);
 
-    try testing.expect(try parser.next(arena) == null);
+    try testing.expect(try nextFilter(&parser, arena) == null);
     // It is still a line we could not load, and it says so.
     try testing.expectEqual(1, parser.skipped);
 }
@@ -265,7 +304,7 @@ test "adblock.Parser: full list" {
     // A filter only borrows the reader's buffer until the next call, so
     // assert on each one as it comes out.
     var count: usize = 0;
-    while (try parser.next(arena)) |filter| : (count += 1) {
+    while (try nextFilter(&parser, arena)) |filter| : (count += 1) {
         switch (count) {
             // "-banner-468x60." is not hostname-shaped (leading '-'), so it
             // stays a plain pattern rather than becoming a hostname filter.

--- a/src/network/adblock/Parser.zig
+++ b/src/network/adblock/Parser.zig
@@ -34,6 +34,7 @@ first_line: bool = true,
 /// not rules, so they never count. The caller adds this to whatever it drops
 /// afterwards, so that "skipped" means every rule the list has and we do not.
 skipped: usize = 0,
+cosmetic: usize = 0,
 
 pub const Error = error{ OutOfMemory, ReadFailed };
 
@@ -42,7 +43,7 @@ pub const Error = error{ OutOfMemory, ReadFailed };
 /// on that hostname is not meant to be blocked.
 pub const Item = union(enum) {
     filter: NetworkFilter,
-    /// Already counted in `skipped`; the caller only inspects it.
+    /// Already counted in `skipped` or `cosmetic`; the caller only inspects it.
     dropped: Dropped,
 };
 
@@ -82,6 +83,10 @@ pub fn next(self: *Parser, arena: Allocator) Error!?Item {
                     return .{ .filter = filter };
                 } else |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
+                    error.CosmeticFilter => {
+                        self.cosmetic += 1;
+                        return .{ .dropped = .{ .line = line, .reason = err } };
+                    },
                     // Anything else is a line outside the supported subset
                     // or malformed; either way it is not ours to enforce.
                     else => {
@@ -167,8 +172,8 @@ test "adblock.Parser: line classification" {
     try testing.expectEqual(.network, LineClass.fromLine("||ads.example.com^"));
     try testing.expectEqual(.network, LineClass.fromLine("@@|https://example.com/path#frag|"));
     try testing.expectEqual(.network, LineClass.fromLine("0.0.0.0 tracker.com"));
-    // Domain-prefixed cosmetic lines classify as network; the filter
-    // parser drops them via their '#' (see NetworkFilter tests).
+    // Domain-prefixed cosmetic lines classify as network; the filter parser
+    // tells them apart by their separator (see NetworkFilter tests).
     try testing.expectEqual(.network, LineClass.fromLine("example.com#@#.ad"));
     try testing.expectEqual(.network, LineClass.fromLine("example.com#?#.ad:has-text(x)"));
     try testing.expectEqual(.network, LineClass.fromLine("example.com#$#body { padding: 0 }"));
@@ -206,7 +211,7 @@ test "adblock.Parser: yields one item per next() call" {
     // with the reason the filter parser gave.
     const second = (try parser.next(arena)).?;
     try testing.expectString("example.com##.ad-banner", second.dropped.line);
-    try testing.expectEqual(error.UnsupportedPattern, second.dropped.reason.?);
+    try testing.expectEqual(error.CosmeticFilter, second.dropped.reason.?);
 
     const third = (try parser.next(arena)).?;
     try testing.expectString("tracker.net", third.filter.hostname);
@@ -238,8 +243,10 @@ test "adblock.Parser: only rule-shaped lines count as skipped" {
 
     // The header, the comment and the blank line are not rules.
     try testing.expectEqual(1, count);
-    // The cosmetic filter, the unknown option and the AdGuard line are.
-    try testing.expectEqual(3, parser.skipped);
+    // The unknown option and the AdGuard line are rules we do not apply; the
+    // cosmetic filter is a rule for another realm, counted as such.
+    try testing.expectEqual(2, parser.skipped);
+    try testing.expectEqual(1, parser.cosmetic);
 }
 
 test "adblock.Parser: a line too long for the buffer is skipped" {
@@ -319,7 +326,11 @@ test "adblock.Parser: full list" {
 
     // 5 direct network filters + both branches of the !#if block: the
     // directives are comments, their contents parse unconditionally.
-    // Everything else in the list — cosmetic lines, the scriptlet, the
-    // hosts-file noise, $removeparam and the unknown option — is skipped.
+    // Everything else in the list is either cosmetic (the domain-prefixed
+    // element-hiding lines and the scriptlet; the generic "##.ad-banner" is
+    // a comment) or skipped (the hosts-file noise, $removeparam and the
+    // unknown option).
     try testing.expectEqual(7, count);
+    try testing.expectEqual(3, parser.cosmetic);
+    try testing.expectEqual(3, parser.skipped);
 }

--- a/src/network/adblock/domain.zig
+++ b/src/network/adblock/domain.zig
@@ -18,10 +18,77 @@
 
 const std = @import("std");
 
-/// Checks a `$domain=` value. Nothing keeps the entries: a filter carrying
-/// any of them is narrower than a hostname, which is as much as we can
-/// represent, so only "is it well formed" and "did anything survive" matter.
-pub fn validate(raw: []const u8) error{ InvalidDomainList, NoSupportedDomains }!void {
+const public_suffix_list = @import("../../data/public_suffix_list.zig");
+
+const Allocator = std.mem.Allocator;
+
+/// One `$domain=` entry. `entity` marks the "google.*" form, whose `name` is
+/// the hostname with its public suffix removed.
+pub const Entry = struct {
+    name: []const u8,
+    entity: bool = false,
+};
+
+/// A parsed `$domain=` value. Both lists empty means the filter is
+/// unconstrained; `included` empty with `excluded` set means "everywhere but".
+pub const List = struct {
+    included: []const Entry = &.{},
+    excluded: []const Entry = &.{},
+
+    pub const none: List = .{};
+
+    pub fn isEmpty(self: List) bool {
+        return self.included.len == 0 and self.excluded.len == 0;
+    }
+
+    /// uBO semantics.
+    pub fn matches(self: List, hostname: []const u8) bool {
+        if (self.isEmpty()) return true;
+        // Only computed if an entity entry asks for it.
+        const ent = if (hasEntity(self.excluded) or hasEntity(self.included))
+            entity(hostname)
+        else
+            "";
+
+        for (self.excluded) |e| {
+            if (matchEntry(e, hostname, ent)) return false;
+        }
+        if (self.included.len == 0) return true;
+        for (self.included) |e| {
+            if (matchEntry(e, hostname, ent)) return true;
+        }
+        return false;
+    }
+};
+
+fn hasEntity(entries: []const Entry) bool {
+    for (entries) |e| {
+        if (e.entity) return true;
+    }
+    return false;
+}
+
+fn matchEntry(e: Entry, hostname: []const u8, ent: []const u8) bool {
+    if (e.entity) return std.mem.eql(u8, e.name, ent);
+    return isSubdomainOf(hostname, e.name);
+}
+
+/// Whether `hostname` is `suffix` or one of its subdomains.
+pub fn isSubdomainOf(hostname: []const u8, suffix: []const u8) bool {
+    if (hostname.len == suffix.len) return std.mem.eql(u8, hostname, suffix);
+    if (hostname.len < suffix.len + 1) return false;
+    const at = hostname.len - suffix.len;
+    return hostname[at - 1] == '.' and std.mem.eql(u8, hostname[at..], suffix);
+}
+
+/// Parses a `$domain=` value into its inclusions and exclusions. Entries
+/// alias `raw`; only the two slices come from `arena`.
+pub fn parse(
+    arena: Allocator,
+    raw: []const u8,
+) error{ InvalidDomainList, NoSupportedDomains, OutOfMemory }!List {
+    var included: std.ArrayList(Entry) = .empty;
+    var excluded: std.ArrayList(Entry) = .empty;
     var had_entries = false;
     var any_supported = false;
 
@@ -31,7 +98,9 @@ pub fn validate(raw: []const u8) error{ InvalidDomainList, NoSupportedDomains }!
         if (entry.len == 0) continue;
         had_entries = true;
 
+        var negated = false;
         if (entry[0] == '~') {
+            negated = true;
             entry = entry[1..];
             if (entry.len == 0) return error.InvalidDomainList;
         }
@@ -40,13 +109,19 @@ pub fn validate(raw: []const u8) error{ InvalidDomainList, NoSupportedDomains }!
         if (entry[0] == '/') continue;
 
         // An entity ("google.*") is the hostname without its public suffix.
+        var is_entity = false;
         if (std.mem.endsWith(u8, entry, ".*")) {
+            is_entity = true;
             entry = entry[0 .. entry.len - 2];
             if (entry.len == 0) return error.InvalidDomainList;
         }
 
         if (!isValidHost(entry)) return error.InvalidDomainList;
         any_supported = true;
+
+        const name = try lowered(arena, entry);
+        const list = if (negated) &excluded else &included;
+        try list.append(arena, .{ .name = name, .entity = is_entity });
     }
 
     if (had_entries and !any_supported) {
@@ -54,6 +129,45 @@ pub fn validate(raw: []const u8) error{ InvalidDomainList, NoSupportedDomains }!
         // rule rather than let it apply everywhere.
         return error.NoSupportedDomains;
     }
+
+    return .{
+        .included = included.items,
+        .excluded = excluded.items,
+    };
+}
+
+pub fn registrable(host: []const u8) []const u8 {
+    if (isIpLiteral(host)) return host;
+    var i = std.mem.lastIndexOfScalar(u8, host, '.') orelse return host;
+    while (true) {
+        i = std.mem.lastIndexOfScalar(u8, host[0..i], '.') orelse return host;
+        const start = i + 1;
+        if (public_suffix_list.lookup(host[start..]) == false) {
+            return host[start..];
+        }
+    }
+}
+
+pub fn entity(host: []const u8) []const u8 {
+    if (isIpLiteral(host)) return "";
+    const reg = registrable(host);
+    const dot = std.mem.indexOfScalar(u8, reg, '.') orelse return "";
+    return reg[0..dot];
+}
+
+/// Whether two hostnames belong to different sites.
+pub fn isThirdParty(request_host: []const u8, source_host: []const u8) bool {
+    if (std.mem.eql(u8, request_host, source_host)) return false;
+    return !std.mem.eql(u8, registrable(request_host), registrable(source_host));
+}
+
+fn isIpLiteral(host: []const u8) bool {
+    if (host.len == 0) return false;
+    if (host[0] == '[') return true; // IPv6, already bracketed by the URL parser
+    for (host) |c| {
+        if (!std.ascii.isDigit(c) and c != '.') return false;
+    }
+    return true;
 }
 
 fn isValidHost(host: []const u8) bool {
@@ -85,16 +199,94 @@ pub fn lowered(arena: std.mem.Allocator, s: []const u8) ![]const u8 {
 const testing = @import("../../testing.zig");
 
 test "adblock.domain: plain, negated and entity entries" {
-    try validate("example.com|~sub.Example.com|google.*");
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const list = try parse(arena, "example.com|~sub.Example.com|google.*");
+    try testing.expectEqual(2, list.included.len);
+    try testing.expectString("example.com", list.included[0].name);
+    try testing.expect(!list.included[0].entity);
+    try testing.expectString("google", list.included[1].name);
+    try testing.expect(list.included[1].entity);
+
+    try testing.expectEqual(1, list.excluded.len);
+    try testing.expectString("sub.example.com", list.excluded[0].name);
+}
+
+test "adblock.domain: matching against a source hostname" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // An entry matches itself and its subdomains.
+    var list = try parse(arena, "example.com");
+    try testing.expect(list.matches("example.com"));
+    try testing.expect(list.matches("www.example.com"));
+    try testing.expect(!list.matches("notexample.com"));
+    try testing.expect(!list.matches("example.org"));
+
+    // An exclusion wins over the inclusion that covers it.
+    list = try parse(arena, "example.com|~ads.example.com");
+    try testing.expect(list.matches("www.example.com"));
+    try testing.expect(!list.matches("ads.example.com"));
+    try testing.expect(!list.matches("x.ads.example.com"));
+
+    // Exclusions alone mean "everywhere but".
+    list = try parse(arena, "~example.com");
+    try testing.expect(list.matches("other.com"));
+    try testing.expect(!list.matches("example.com"));
+
+    // An entity ignores the public suffix.
+    list = try parse(arena, "google.*");
+    try testing.expect(list.matches("google.com"));
+    try testing.expect(list.matches("www.google.com"));
+    try testing.expect(!list.matches("google.example.com"));
+
+    // No list at all constrains nothing.
+    try testing.expect(List.none.matches("anything.com"));
 }
 
 test "adblock.domain: regex entries are skipped, all-regex errors" {
-    try validate("/foo/|example.com");
-    try testing.expectError(error.NoSupportedDomains, validate("/foo/"));
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const list = try parse(arena, "/foo/|example.com");
+    try testing.expectEqual(1, list.included.len);
+    try testing.expectError(error.NoSupportedDomains, parse(arena, "/foo/"));
 }
 
 test "adblock.domain: invalid entries" {
-    try testing.expectError(error.InvalidDomainList, validate("exa mple.com"));
-    try testing.expectError(error.InvalidDomainList, validate(".example.com"));
-    try testing.expectError(error.InvalidDomainList, validate("~"));
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try testing.expectError(error.InvalidDomainList, parse(arena, "exa mple.com"));
+    try testing.expectError(error.InvalidDomainList, parse(arena, ".example.com"));
+    try testing.expectError(error.InvalidDomainList, parse(arena, "~"));
+}
+
+// The public suffix list is stubbed to {gov.uk, api.gov.uk} in test builds,
+// so these use .com and gov.uk only.
+test "adblock.domain: registrable domain and entity" {
+    try testing.expectString("example.com", registrable("example.com"));
+    try testing.expectString("example.com", registrable("a.b.example.com"));
+    try testing.expectString("dept.gov.uk", registrable("www.dept.gov.uk"));
+    // No registrable domain to find: single labels and IP literals.
+    try testing.expectString("localhost", registrable("localhost"));
+    try testing.expectString("127.0.0.1", registrable("127.0.0.1"));
+    try testing.expectString("[::1]", registrable("[::1]"));
+
+    try testing.expectString("example", entity("a.example.com"));
+    try testing.expectString("dept", entity("www.dept.gov.uk"));
+    try testing.expectString("", entity("127.0.0.1"));
+}
+
+test "adblock.domain: third party" {
+    try testing.expect(!isThirdParty("example.com", "example.com"));
+    try testing.expect(!isThirdParty("cdn.example.com", "www.example.com"));
+    try testing.expect(isThirdParty("ads.com", "example.com"));
+    // Sharing a public suffix is not sharing a site.
+    try testing.expect(isThirdParty("a.gov.uk", "b.gov.uk"));
 }

--- a/src/network/adblock/domain.zig
+++ b/src/network/adblock/domain.zig
@@ -74,7 +74,7 @@ fn matchEntry(e: Entry, hostname: []const u8, ent: []const u8) bool {
 }
 
 /// Whether `hostname` is `suffix` or one of its subdomains.
-pub fn isSubdomainOf(hostname: []const u8, suffix: []const u8) bool {
+fn isSubdomainOf(hostname: []const u8, suffix: []const u8) bool {
     if (hostname.len == suffix.len) return std.mem.eql(u8, hostname, suffix);
     if (hostname.len < suffix.len + 1) return false;
     const at = hostname.len - suffix.len;
@@ -136,7 +136,7 @@ pub fn parse(
     };
 }
 
-pub fn registrable(host: []const u8) []const u8 {
+fn registrable(host: []const u8) []const u8 {
     if (isIpLiteral(host)) return host;
     var i = std.mem.lastIndexOfScalar(u8, host, '.') orelse return host;
     while (true) {
@@ -148,7 +148,7 @@ pub fn registrable(host: []const u8) []const u8 {
     }
 }
 
-pub fn entity(host: []const u8) []const u8 {
+fn entity(host: []const u8) []const u8 {
     if (isIpLiteral(host)) return "";
     const reg = registrable(host);
     const dot = std.mem.indexOfScalar(u8, reg, '.') orelse return "";

--- a/src/network/adblock/pattern.zig
+++ b/src/network/adblock/pattern.zig
@@ -1,0 +1,402 @@
+// Copyright (C) 2023-2026 Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Matching of a filter's URL pattern, once the type, party and `$domain=`
+//! constraints have already passed. Everything here works on a lowercased,
+//! fragment-stripped URL; `$match-case` only survives on /regex/ filters,
+//! which never reach this file.
+
+const std = @import("std");
+
+const NetworkFilter = @import("NetworkFilter.zig");
+
+/// The URL a request is matched against, with its hostname located once so
+/// every filter can reuse the offsets.
+pub const Url = struct {
+    /// Lowercased, fragment stripped.
+    text: []const u8,
+    host_start: u32,
+    host_end: u32,
+
+    pub fn hostname(self: Url) []const u8 {
+        return self.text[self.host_start..self.host_end];
+    }
+
+    /// Locates the hostname inside `url`: after "scheme://", up to the port,
+    /// path, query or end. Offsets, not a slice, because the matcher needs to
+    /// resume the pattern right where the hostname stops.
+    pub fn init(url: []const u8) Url {
+        var start: usize = 0;
+        if (std.mem.indexOf(u8, url, "://")) |scheme| start = scheme + 3;
+
+        var end = url.len;
+        for (url[start..], start..) |c, i| {
+            switch (c) {
+                '/', '?', '#' => {
+                    end = i;
+                    break;
+                },
+                else => {},
+            }
+        }
+
+        // "user:password@host"
+        if (std.mem.lastIndexOfScalar(u8, url[start..end], '@')) |at| {
+            start += at + 1;
+        }
+
+        // A ':' before the path is a port, unless we are inside an IPv6
+        // literal's brackets.
+        const host = url[start..end];
+        var host_end = end;
+        if (host.len > 0 and host[0] == '[') {
+            if (std.mem.indexOfScalar(u8, host, ']')) |close| {
+                host_end = start + close + 1;
+            }
+        } else if (std.mem.indexOfScalar(u8, host, ':')) |colon| {
+            host_end = start + colon;
+        }
+
+        return .{
+            .text = url,
+            .host_start = @intCast(start),
+            .host_end = @intCast(host_end),
+        };
+    }
+};
+
+/// Whether `filter`'s pattern matches `url`. Only the pattern: the caller has
+/// already decided the filter applies to this request.
+pub fn matches(filter: *const NetworkFilter, url: Url) bool {
+    switch (filter.kind) {
+        // Option-only filters ("$script,domain=x") match any URL.
+        .any => return true,
+        // Never indexed: there is no regex engine to run them with.
+        .regex => return false,
+        .hostname, .plain, .wildcard => {},
+    }
+
+    if (filter.hostname.len != 0) {
+        var from: usize = 0;
+        while (hostAnchor(url, filter.hostname, from)) |at| {
+            if (filter.kind == .hostname) {
+                const boundary = at == url.host_end or url.text[at] == '.' or
+                    filter.hostname[filter.hostname.len - 1] == '.';
+                if (boundary) {
+                    if (!filter.require_separator) return true;
+                    if (at == url.text.len) return true;
+                    // `||host^|` pins the separator to the end of the URL.
+                    if (isSeparator(url.text[at]) and
+                        (!filter.right_anchor or at + 1 == url.text.len))
+                    {
+                        return true;
+                    }
+                }
+            } else if (matchFrom(filter, url.text, at, filter.right_anchor)) {
+                return true;
+            }
+            // The label this attempt started on cannot match again.
+            from = at - filter.hostname.len - url.host_start + 1;
+        }
+        return false;
+    }
+
+    if (filter.hostname_anchor) {
+        var i: usize = url.host_start;
+        while (true) {
+            if (matchFrom(filter, url.text, i, filter.right_anchor)) return true;
+            const dot = std.mem.indexOfScalarPos(u8, url.text[0..url.host_end], i, '.') orelse
+                return false;
+            i = dot + 1;
+        }
+    }
+
+    if (filter.left_anchor) {
+        return matchFrom(filter, url.text, 0, filter.right_anchor);
+    }
+    if (filter.kind == .plain) {
+        if (filter.right_anchor) return std.mem.endsWith(u8, url.text, filter.pattern);
+        return std.mem.indexOf(u8, url.text, filter.pattern) != null;
+    }
+
+    var i: usize = 0;
+    while (i <= url.text.len) : (i += 1) {
+        if (matchFrom(filter, url.text, i, filter.right_anchor)) return true;
+    }
+    return false;
+}
+
+/// Finds `needle` starting on a label boundary of the request hostname at or
+/// after `from` (an offset into the hostname), and returns the offset just
+/// past it in the whole URL.
+fn hostAnchor(url: Url, needle: []const u8, from: usize) ?usize {
+    const host = url.hostname();
+    var p = from;
+    while (p <= host.len) {
+        if (p == 0 or host[p - 1] == '.') {
+            if (std.mem.startsWith(u8, host[p..], needle)) {
+                return url.host_start + p + needle.len;
+            }
+        }
+        const dot = std.mem.indexOfScalarPos(u8, host, p, '.') orelse return null;
+        p = dot + 1;
+    }
+    return null;
+}
+
+/// Matches the pattern starting exactly at `start`. `anchor_end` additionally
+/// requires it to run to the end of the URL.
+fn matchFrom(filter: *const NetworkFilter, url: []const u8, start: usize, anchor_end: bool) bool {
+    if (filter.kind == .plain) {
+        // No '*' and no '^': a byte comparison is the whole job.
+        if (start + filter.pattern.len > url.len) return false;
+        if (!std.mem.startsWith(u8, url[start..], filter.pattern)) return false;
+        return !anchor_end or start + filter.pattern.len == url.len;
+    }
+
+    var it = std.mem.splitScalar(u8, filter.pattern, '*');
+    var pos = matchSegment(it.first(), url, start) orelse return false;
+    var pending = it.next();
+    while (pending) |segment| {
+        const following = it.next();
+        if (following == null and anchor_end) {
+            return matchSegmentAtEnd(segment, url, pos);
+        }
+        pos = findSegment(segment, url, pos) orelse return false;
+        pending = following;
+    }
+    return !anchor_end or pos == url.len;
+}
+
+/// Matches one wildcard-free segment at `pos`, returning where it ends.
+fn matchSegment(segment: []const u8, url: []const u8, pos: usize) ?usize {
+    var i = pos;
+    for (segment, 0..) |c, si| {
+        if (i == url.len) {
+            // A '^' at the very end of the pattern also matches the end of
+            // the URL, consuming nothing.
+            return if (c == '^' and si == segment.len - 1) i else null;
+        }
+        if (c == '^') {
+            if (!isSeparator(url[i])) return null;
+        } else if (url[i] != c) {
+            return null;
+        }
+        i += 1;
+    }
+    return i;
+}
+
+/// Leftmost occurrence of `segment` at or after `from`; no backtracking, the
+/// same simplification uBO and adblock-rust make.
+fn findSegment(segment: []const u8, url: []const u8, from: usize) ?usize {
+    var i = from;
+    while (i <= url.len) : (i += 1) {
+        if (matchSegment(segment, url, i)) |end| return end;
+    }
+    return null;
+}
+
+fn matchSegmentAtEnd(segment: []const u8, url: []const u8, from: usize) bool {
+    var i = from;
+    while (i <= url.len) : (i += 1) {
+        if (matchSegment(segment, url, i)) |end| {
+            if (end == url.len) return true;
+        }
+    }
+    return false;
+}
+
+/// uBO's separator class: everything that cannot appear in a hostname or an unescaped path word.
+pub fn isSeparator(c: u8) bool {
+    if (std.ascii.isAlphanumeric(c)) return false;
+    return switch (c) {
+        '_', '%', '.', '-' => false,
+        else => true,
+    };
+}
+
+const testing = @import("../../testing.zig");
+
+fn testMatch(arena: std.mem.Allocator, line: []const u8, url: []const u8) !bool {
+    const filter = try NetworkFilter.parse(arena, line);
+    return matches(&filter, .init(url));
+}
+
+test "adblock.pattern: hostname location" {
+    var u: Url = .init("https://ads.example.com/x?y=1");
+    try testing.expectString("ads.example.com", u.hostname());
+
+    u = .init("https://ads.example.com:8443/x");
+    try testing.expectString("ads.example.com", u.hostname());
+
+    u = .init("https://example.com");
+    try testing.expectString("example.com", u.hostname());
+
+    u = .init("http://[::1]:9222/json");
+    try testing.expectString("[::1]", u.hostname());
+
+    // Credentials are not part of the host.
+    u = .init("https://user:pass@ads.example.com/x");
+    try testing.expectString("ads.example.com", u.hostname());
+
+    // A pattern is matched against whatever it is given, even a bare path.
+    u = .init("/relative/path");
+    try testing.expectString("", u.hostname());
+}
+
+test "adblock.pattern: hostname filters cover subdomains" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try testing.expect(try testMatch(arena, "||ads.example.com^", "https://ads.example.com/a"));
+    try testing.expect(try testMatch(arena, "||ads.example.com^", "https://x.ads.example.com/a"));
+    try testing.expect(!try testMatch(arena, "||ads.example.com^", "https://notads.example.com/a"));
+    try testing.expect(!try testMatch(arena, "||ads.example.com^", "https://example.com/ads.example.com"));
+}
+
+test "adblock.pattern: caret-less hostname filters end on a label boundary" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // The real EasyPrivacy shape "||coinimp.com$third-party": without a '^'
+    // the next label may continue ("coinimp.com.evil.org") but the last one
+    // may not ("coinimp.community" is someone else's site).
+    try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com/miner.js"));
+    try testing.expect(try testMatch(arena, "||coinimp.com", "https://sub.coinimp.com/x"));
+    try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com.evil.org/x"));
+    try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com:8080/x"));
+    try testing.expect(!try testMatch(arena, "||coinimp.com", "https://coinimp.community/miner.js"));
+
+    // A filter hostname ending in '.' carries its own boundary.
+    try testing.expect(try testMatch(arena, "||adform.", "https://adform.net/banner"));
+    try testing.expect(try testMatch(arena, "||adform.", "https://track.adform.co.uk/x"));
+    try testing.expect(!try testMatch(arena, "||adform", "https://adformat.example/x"));
+}
+
+test "adblock.pattern: right-anchored hostname filters pin the URL end" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // `||host^|`: the separator '^' must also be the end of the URL.
+    try testing.expect(try testMatch(arena, "||ads.com^|", "https://ads.com"));
+    try testing.expect(try testMatch(arena, "||ads.com^|", "https://ads.com/"));
+    try testing.expect(!try testMatch(arena, "||ads.com^|", "https://ads.com/path/x"));
+    try testing.expect(!try testMatch(arena, "||ads.com^|", "https://ads.com/?q=1"));
+}
+
+test "adblock.pattern: hostname-anchored patterns resume after the host" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // The real shape from the report.
+    try testing.expect(try testMatch(
+        arena,
+        "||youtube.com/pagead/",
+        "https://www.youtube.com/pagead/lvz?ei=x",
+    ));
+    try testing.expect(!try testMatch(
+        arena,
+        "||youtube.com/pagead/",
+        "https://www.youtube.com/watch?v=x",
+    ));
+    // The path is anchored to the end of the hostname, not searched for.
+    try testing.expect(!try testMatch(
+        arena,
+        "||youtube.com/pagead/",
+        "https://example.com/www.youtube.com/pagead/x",
+    ));
+
+    try testing.expect(try testMatch(
+        arena,
+        "||g.doubleclick.net/gampad/ads",
+        "https://g.doubleclick.net/gampad/ads?env=vp",
+    ));
+    try testing.expect(!try testMatch(
+        arena,
+        "||g.doubleclick.net/gampad/ads",
+        "https://g.doubleclick.net/pagead/ads",
+    ));
+}
+
+test "adblock.pattern: wildcards" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try testing.expect(try testMatch(
+        arena,
+        "||g.doubleclick.net/gampad/ads*%20web%20player",
+        "https://g.doubleclick.net/gampad/ads?a=1&b=my%20web%20player",
+    ));
+    try testing.expect(!try testMatch(
+        arena,
+        "||g.doubleclick.net/gampad/ads*%20web%20player",
+        "https://g.doubleclick.net/gampad/ads?a=1",
+    ));
+
+    // A '*' in the hostname region anchors to a label boundary.
+    try testing.expect(try testMatch(arena, "||example.*/ads", "https://example.co.uk/ads/x"));
+    try testing.expect(try testMatch(arena, "||example.*/ads", "https://www.example.com/ads/x"));
+    try testing.expect(!try testMatch(arena, "||example.*/ads", "https://notexample.com/ads/x"));
+
+    try testing.expect(try testMatch(arena, "/banner/*/img", "https://a.com/banner/x/img"));
+}
+
+test "adblock.pattern: separators" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // '^' matches one separator...
+    try testing.expect(try testMatch(arena, "||example.com/ads^", "https://example.com/ads?x=1"));
+    try testing.expect(try testMatch(arena, "||example.com/ads^", "https://example.com/ads/x"));
+    // ...or the end of the URL.
+    try testing.expect(try testMatch(arena, "||example.com/ads^", "https://example.com/ads"));
+    // Letters, digits, '_', '%', '.' and '-' are not separators.
+    try testing.expect(!try testMatch(arena, "||example.com/ads^", "https://example.com/adsx"));
+    try testing.expect(!try testMatch(arena, "||example.com/ads^", "https://example.com/ads.js"));
+}
+
+test "adblock.pattern: anchors" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try testing.expect(try testMatch(arena, "|https://ads.", "https://ads.example.com/"));
+    try testing.expect(!try testMatch(arena, "|https://ads.", "http://ads.example.com/"));
+
+    try testing.expect(try testMatch(arena, "-ad-300x250.gif|", "https://a.com/-ad-300x250.gif"));
+    try testing.expect(!try testMatch(arena, "-ad-300x250.gif|", "https://a.com/-ad-300x250.gif?x"));
+
+    // Unanchored patterns are plain substrings.
+    try testing.expect(try testMatch(arena, "/banner/ads.", "https://a.com/x/banner/ads.png"));
+    try testing.expect(!try testMatch(arena, "/banner/ads.", "https://a.com/banner/x.png"));
+}
+
+test "adblock.pattern: option-only filters match every URL" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    try testing.expect(try testMatch(arena, "$script,domain=example.com", "https://anything.test/x"));
+}

--- a/src/network/adblock/pattern.zig
+++ b/src/network/adblock/pattern.zig
@@ -223,7 +223,7 @@ fn matchSegmentAtEnd(segment: []const u8, url: []const u8, from: usize) bool {
 }
 
 /// uBO's separator class: everything that cannot appear in a hostname or an unescaped path word.
-pub fn isSeparator(c: u8) bool {
+fn isSeparator(c: u8) bool {
     if (std.ascii.isAlphanumeric(c)) return false;
     return switch (c) {
         '_', '%', '.', '-' => false,

--- a/src/network/adblock/pattern.zig
+++ b/src/network/adblock/pattern.zig
@@ -271,21 +271,31 @@ test "adblock.pattern: hostname filters cover subdomains" {
     try testing.expect(!try testMatch(arena, "||ads.example.com^", "https://example.com/ads.example.com"));
 }
 
-test "adblock.pattern: caret-less hostname filters end on a label boundary" {
+test "adblock.pattern: caret-less hostname filters match the hostname or a subdomain" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // The real EasyPrivacy shape "||coinimp.com$third-party": without a '^'
-    // the next label may continue ("coinimp.com.evil.org") but the last one
-    // may not ("coinimp.community" is someone else's site).
+    // The real EasyPrivacy shape "||coinimp.com$third-party": uBO reads it
+    // as "||coinimp.com^", so "coinimp.com.evil.org" — evil.org's hostname,
+    // not a subdomain of coinimp.com — is out.
     try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com/miner.js"));
     try testing.expect(try testMatch(arena, "||coinimp.com", "https://sub.coinimp.com/x"));
-    try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com.evil.org/x"));
     try testing.expect(try testMatch(arena, "||coinimp.com", "https://coinimp.com:8080/x"));
+    try testing.expect(!try testMatch(arena, "||coinimp.com", "https://coinimp.com.evil.org/x"));
     try testing.expect(!try testMatch(arena, "||coinimp.com", "https://coinimp.community/miner.js"));
 
-    // A filter hostname ending in '.' carries its own boundary.
+    // `||host|` is that same filter once more.
+    try testing.expect(try testMatch(arena, "||coinimp.com|", "https://sub.coinimp.com/x"));
+    try testing.expect(!try testMatch(arena, "||coinimp.com|", "https://coinimp.com.evil.org/x"));
+
+    // `||host*` is NOT: uBO keeps a trailing '*' after a short run, and the
+    // pattern stays a label-anchored prefix.
+    try testing.expect(try testMatch(arena, "||coinimp.com*", "https://coinimp.com.evil.org/x"));
+    try testing.expect(try testMatch(arena, "||coinimp.com*", "https://coinimp.community/miner.js"));
+
+    // A filter hostname ending in '.' names no hostname; it stays a prefix
+    // and carries its own boundary.
     try testing.expect(try testMatch(arena, "||adform.", "https://adform.net/banner"));
     try testing.expect(try testMatch(arena, "||adform.", "https://track.adform.co.uk/x"));
     try testing.expect(!try testMatch(arena, "||adform", "https://adformat.example/x"));


### PR DESCRIPTION
On-going effort; here's the recent benchmark made against EasyList + EasyPrivacy on this branch:

# Adblock engine: EasyList + EasyPrivacy corpus report

Lists downloaded fresh from easylist.to the same day (135,908 lines total). Measured with
the per-request engine (tries + token-bucket indexes) after the adversarial-review fixes.

## Coverage: what loads

|                              | EasyList           | EasyPrivacy         | Combined            |
| ---------------------------- | ------------------ | ------------------- | ------------------- |
| File lines                   | 79,233             | 56,675              | 135,908             |
| Comments / blank             | 13,920             | 771                 | 14,691              |
| **Rules**                    | **65,313**         | **55,904**          | **121,217**         |
| Cosmetic rules (not network) | 10,852             | 32                  | 10,884              |
| **Network rules**            | **54,461**         | **55,872**          | **110,333**         |
| **Loaded**                   | **54,266 (99.6%)** | **55,858 (99.97%)** | **110,124 (99.8%)** |
| → in hostname tries          | 45,264             | 42,955              | 88,219              |
| → engine-indexed             | 9,002              | 12,903              | 21,905              |

## The 209 network rules we don't apply, by reason

- **31 `/regex/` filters** (24 EL + 7 EP) — the only rules uBO enforces as
  blocks that we genuinely can't: there's still no regex engine. ~0.03% of the
  corpus.
- **168 cosmetic-realm exceptions** (`$generichide`/`$elemhide`/
  `$specifichide`) — they modify cosmetic filtering, which we don't have yet,
  so there's nothing for them to except.
- **6 modifier-only rules** (`$removeparam`-class) — uBO applies these as URL
  rewrites, never blocks; dropping them is the conservative, correct choice.
- **3 malformed rules** (EasyPrivacy) — uBO rejects these too.
- **1 unsupported option** (the `@@…$redirect-rule` google-analytics line —
  correctly treated as excepting nothing, so `google-analytics.com` stays
  blocked).

The ~10,884 "cosmetic" drops are element-hiding rules (`##`, `#@#` — including
944 with spaces in their CSS selectors that take the hosts-file parsing path);
no network engine applies those, so they're out of scope rather than failures.
Notably, **zero hostnames land in the `suppressed` trie** across the whole
corpus — every exception either evaluates per-request or provably unblocks
nothing.

## Correctness on the loaded rules

- A 26-assertion doubleclick battery against uBO ground truth passes with the
  review fixes in: gpt.js blocked except on the listed carve-out sites, the
  `/ssai/` exception honored, wrong-type/wrong-site/wrong-path variants all
  correct, and the apex `doubleclick.net` undecided rather than suppressed.
- End-to-end: `lightpanda fetch` on a page loading the real ad stack blocks
  `gpt.js`, `td.`/`googleads.`/`fls.doubleclick.net` and Google Analytics
  before they reach the network.

## Bottom line

**99.8% of the network rules in EasyList+EasyPrivacy load and enforce; the
only real gap is 31 regex filters.**