### PR TITLE
chore: Remove Server component from Network

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -81,10 +81,6 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
     return app;
 }
 
-pub fn shutdown(self: *const App) bool {
-    return self.network.shutdown.load(.acquire);
-}
-
 pub fn deinit(self: *App) void {
     const allocator = self.allocator;
     // All browsers are gone by now, so the entry list is empty; this just

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -24,13 +24,46 @@ const App = @import("App.zig");
 const Config = @import("Config.zig");
 
 const CDP = @import("cdp/CDP.zig");
+const http = @import("network/http.zig");
 const sys_net = @import("sys/net.zig");
 
 const log = lp.log;
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
+const DoublyLinkedList = std.DoublyLinkedList;
 
 const Server = @This();
+
+// Read side of a CDP WebSocket, registered with the server's run loop so
+// bytes are read off the socket there and dispatched into the CDP layer
+// via direct method calls on `cdp`. The loop never sends on the socket —
+// the worker is the sole writer. After registerLink returns, the worker
+// must not call posix.read on this socket directly. unregisterLink is
+// synchronous: it blocks until the loop confirms the link has been
+// dropped from its poll set and won't touch it again.
+pub const Link = struct {
+    cdp: *CDP,
+    state: State,
+    socket: posix.socket_t,
+    // The worker's HttpClient.Handles (by value — it's one pointer wide).
+    // The loop calls handles.wakeup() to unblock the worker from
+    // curl_multi_poll whenever it pushes to the worker's inbox.
+    handles: http.Handles,
+    node: DoublyLinkedList.Node = .{},
+
+    pub const State = enum {
+        live,
+        // Worker called unregisterLink; the loop will drop the link on
+        // its next iteration and signal link_removed.
+        unregistering,
+        // The loop has dropped the link from its poll set. The worker
+        // can safely free anything the link's callbacks closed over.
+        removed,
+    };
+};
+
+// Number of fixed pollfds entries (wakeup pipe + listener).
+const PSEUDO_POLLFDS = 2;
 
 app: *App,
 max_connections: usize,
@@ -46,32 +79,115 @@ cdps: std.ArrayList(*CDP) = .empty,
 cdp_mutex: std.Io.Mutex = .init,
 cdp_pool: std.heap.MemoryPool(CDP),
 
+listener: posix.socket_t,
+
+// pollfds layout:
+//   [0]                                  wakeup pipe
+//   [1]                                  listener
+//   [PSEUDO_POLLFDS .. + max_connections] link sockets
+pollfds: []posix.pollfd,
+
+// Wakeup pipe: other threads write to [1], the run loop polls [0]
+wakeup_pipe: [2]posix.fd_t,
+
+shutting_down: std.atomic.Value(bool) = .init(false),
+
+// Registered CDP read endpoints. Producer-side (the worker doing
+// register/unregister) and consumer-side (the run loop) are serialized
+// by link_mutex. link_removed signals when a link transitions to
+// .removed so unregisterLink can return.
+links: DoublyLinkedList = .{},
+link_mutex: std.Io.Mutex = .init,
+link_removed: std.Io.Condition = .init,
+// Per-iteration snapshot of Links whose sockets are in pollfds. Sized at
+// max_connections at init time so we never allocate inside run().
+// Parallel to pollfds[PSEUDO_POLLFDS..][0..poll_count]. Persists across
+// iterations; only rebuilt when `links_dirty` is set.
+poll_snapshot: []?*Link,
+poll_count: usize = 0,
+
+// Set whenever the links list changes (register / unregister / natural
+// drop). preparePollFds rebuilds the snapshot only when this is true;
+// idle iterations skip the rebuild. run() ticks hundreds of times per
+// second, and the link set is stable between connection lifecycle
+// events, so the steady-state cost of the poll prep is one mutex
+// acquire + one bool read.
+links_dirty: bool = false,
+
 pub fn init(app: *App, address: sys_net.IpAddress) !*Server {
-    const self = try app.allocator.create(Server);
-    errdefer app.allocator.destroy(self);
+    const allocator = app.allocator;
+    const self = try allocator.create(Server);
+    errdefer allocator.destroy(self);
+
+    const pipe = try sys_net.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
+    errdefer for (pipe) |fd| {
+        _ = std.c.close(fd);
+    };
+
+    const max_connections = app.config.maxConnections();
+    const pollfds = try allocator.alloc(posix.pollfd, PSEUDO_POLLFDS + max_connections);
+    errdefer allocator.free(pollfds);
+    @memset(pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
+    pollfds[0] = .{ .fd = pipe[0], .events = posix.POLL.IN, .revents = 0 };
+
+    const poll_snapshot = try allocator.alloc(?*Link, max_connections);
+    errdefer allocator.free(poll_snapshot);
+    @memset(poll_snapshot, null);
+
+    // Bind first so /json/version can advertise the OS-assigned port (--port 0).
+    var bound_address = address;
+    const listener = try bindListener(app.config, &bound_address);
+    errdefer _ = std.c.close(listener);
+    pollfds[1] = .{ .fd = listener, .events = posix.POLL.IN, .revents = 0 };
+    log.note(.app, "server running", .{ .address = bound_address });
+
+    const json_version_response = try buildJSONVersionResponse(app, bound_address.getPort());
 
     self.* = .{
         .app = app,
         .cdp_pool = .empty,
-        .json_version_response = "",
-        .max_connections = app.config.maxConnections(),
+        .json_version_response = json_version_response,
+        .max_connections = max_connections,
+        .listener = listener,
+        .pollfds = pollfds,
+        .wakeup_pipe = pipe,
+        .poll_snapshot = poll_snapshot,
     };
-    errdefer self.cdp_pool.deinit(app.allocator);
-
-    // Bind first so /json/version can advertise the OS-assigned port (--port 0).
-    var bound_address = address;
-    try app.network.bind(&bound_address, self, onAccept);
-    log.note(.app, "server running", .{ .address = bound_address });
-
-    self.json_version_response = try buildJSONVersionResponse(app, bound_address.getPort());
     return self;
 }
 
+fn bindListener(config: *const Config, address: *sys_net.IpAddress) !posix.socket_t {
+    const flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
+    const listener = try sys_net.socket(sys_net.family(address), flags, posix.IPPROTO.TCP);
+    errdefer _ = std.c.close(listener);
+
+    try posix.setsockopt(listener, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+    if (@hasDecl(posix.TCP, "NODELAY")) {
+        try posix.setsockopt(listener, posix.IPPROTO.TCP, posix.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
+    }
+
+    const sa = sys_net.sockaddrFromAddress(address);
+    try sys_net.bind(listener, sa.ptr(), sa.len);
+    try sys_net.listen(listener, config.maxPendingConnections());
+
+    // When the caller requests port 0, the OS assigns an ephemeral port; read
+    // the actual bound address back so callers (e.g. logging) see the real port.
+    var bound: posix.sockaddr.storage = undefined;
+    var bound_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+    try sys_net.getsockname(listener, @ptrCast(&bound), &bound_len);
+    address.* = sys_net.addressFromSockaddr(@ptrCast(&bound));
+
+    return listener;
+}
+
+// Stop accepting, make run() return, and terminate every live CDP worker.
+// Idempotent: the signal handler calls it, and so does deinit.
 pub fn shutdown(self: *Server) void {
+    self.shutting_down.store(true, .release);
+    self.wakeup();
+
     self.cdp_mutex.lockUncancelable(lp.io);
     defer self.cdp_mutex.unlock(lp.io);
-
-    self.app.network.unbind();
 
     for (self.cdps.items) |cdp| {
         if (cdp.conn.state == .live) {
@@ -94,22 +210,341 @@ pub fn deinit(self: *Server) void {
     const allocator = self.app.allocator;
     self.cdps.deinit(allocator);
     self.cdp_pool.deinit(allocator);
-    self.app.allocator.free(self.json_version_response);
-    self.app.allocator.destroy(self);
+    allocator.free(self.json_version_response);
+    allocator.free(self.pollfds);
+    allocator.free(self.poll_snapshot);
+    for (self.wakeup_pipe) |fd| {
+        _ = std.c.close(fd);
+    }
+    if (self.listener >= 0) {
+        // run() never ran (or never returned through its exit path).
+        _ = std.c.close(self.listener);
+    }
+    allocator.destroy(self);
 }
 
-fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
-    const self: *Server = @ptrCast(@alignCast(ctx));
+// Blocks the calling thread servicing the listener and the registered CDP
+// read sockets until shutdown(). Page fetches run on per-worker HttpClient
+// multis and telemetry on its own thread, so nothing here drives libcurl.
+pub fn run(self: *Server) void {
+    var drain_buf: [64]u8 = undefined;
 
-    configureSocket(socket) catch {
-        _ = std.c.close(socket);
+    const wakeup_fd = &self.pollfds[0];
+    const listen_fd = &self.pollfds[1];
+
+    while (true) {
+        self.preparePollFds();
+
+        // wait until we get a CDP message or a signal on the wakeup pipe
+        _ = posix.poll(self.pollfds, -1) catch |err| {
+            log.err(.app, "poll", .{ .err = err });
+            continue;
+        };
+
+        // check wakeup pipe
+        if (wakeup_fd.revents != 0) {
+            wakeup_fd.revents = 0;
+            while (true)
+                _ = posix.read(self.wakeup_pipe[0], &drain_buf) catch break;
+        }
+
+        // accept new connections
+        if (listen_fd.revents != 0) {
+            listen_fd.revents = 0;
+            self.acceptConnections();
+        }
+
+        self.processLinks();
+
+        if (self.shutting_down.load(.acquire)) {
+            // Drain any live links so their workers can exit (issue #2510),
+            // then stop. Existing connections are torn down by shutdown();
+            // there is nothing else to flush here.
+            self.shutdownLinks();
+            break;
+        }
+    }
+
+    if (self.listener >= 0) {
+        sys_net.shutdown(self.listener, .both) catch |err| blk: {
+            if (err == error.SocketNotConnected and builtin.os.tag != .linux) {
+                // This error is normal/expected on BSD/MacOS. We probably
+                // shouldn't bother calling shutdown at all, but I guess this
+                // is safer.
+                break :blk;
+            }
+            log.warn(.app, "listener shutdown", .{ .err = err });
+        };
+        _ = std.c.close(self.listener);
+        self.listener = -1;
+    }
+}
+
+fn wakeup(self: *Server) void {
+    _ = sys_net.write(self.wakeup_pipe[1], &.{1}) catch {};
+}
+
+fn acceptConnections(self: *Server) void {
+    if (self.shutting_down.load(.acquire)) {
         return;
-    };
+    }
+    if (self.listener < 0) {
+        return;
+    }
 
-    self.spawnWorker(socket) catch |err| {
-        log.err(.app, "CDP spawn", .{ .err = err });
-        _ = std.c.close(socket);
-    };
+    while (true) {
+        const socket = sys_net.accept(self.listener, null, null, posix.SOCK.NONBLOCK) catch |err| {
+            switch (err) {
+                error.WouldBlock => break,
+                error.SocketNotListening => {
+                    self.pollfds[1] = .{ .fd = -1, .events = 0, .revents = 0 };
+                    _ = std.c.close(self.listener);
+                    self.listener = -1;
+                    return;
+                },
+                error.ConnectionAborted => {
+                    log.warn(.app, "accept connection aborted", .{});
+                    continue;
+                },
+                else => {
+                    log.err(.app, "accept error", .{ .err = err });
+                    continue;
+                },
+            }
+        };
+
+        configureSocket(socket) catch {
+            _ = std.c.close(socket);
+            continue;
+        };
+
+        self.spawnWorker(socket) catch |err| {
+            log.err(.app, "CDP spawn", .{ .err = err });
+            _ = std.c.close(socket);
+        };
+    }
+}
+
+// Hand a CDP WebSocket's read side over to the run loop. The caller owns
+// the link and must keep it alive until unregisterLink is called. The
+// caller must not read from the socket.
+pub fn registerLink(self: *Server, link: *Link) void {
+    self.link_mutex.lockUncancelable(lp.io);
+    self.links.append(&link.node);
+    self.links_dirty = true;
+    self.link_mutex.unlock(lp.io);
+    self.wakeup();
+}
+
+// Synchronous teardown. Blocks the caller until the run loop has dropped
+// the link from its poll set and won't invoke any of the link's
+// callbacks. Safe to call after the loop has already dropped the link
+// unsolicited (state == .removed) — returns immediately in that case.
+pub fn unregisterLink(self: *Server, link: *Link) void {
+    self.link_mutex.lockUncancelable(lp.io);
+    defer self.link_mutex.unlock(lp.io);
+    if (link.state == .live) {
+        link.state = .unregistering;
+        self.links_dirty = true;
+        self.wakeup();
+    }
+
+    while (link.state != .removed) {
+        // condition variable, waiting for a signal
+        self.link_removed.waitUncancelable(lp.io, &self.link_mutex);
+    }
+}
+
+const DropLinkOpts = struct {
+    // on_disconnect is fired iff `notify` is true. false when the worker already
+    // knows the link is dead.
+    notify: bool,
+
+    // Set when we know the peer is dead. Can help unblock a blocked worker's send()
+    shutdown_socket: bool = false,
+};
+
+// Drop a link from the poll set. Caller must hold link_mutex.
+fn dropLink(self: *Server, link: *Link, err: ?anyerror, opts: DropLinkOpts) void {
+    self.links.remove(&link.node);
+    link.state = .removed;
+    self.links_dirty = true;
+
+    if (opts.shutdown_socket) {
+        sys_net.shutdown(link.socket, .both) catch {};
+    }
+
+    if (opts.notify) {
+        link.cdp.terminateFromServer();
+
+        // notify=true means the worker hasn't been told yet — push the
+        // disconnect into the inbox and break it out of curl_multi_poll.
+        // notify=false paths have already woken the worker (close frame
+        // case) or are about to be unblocked via link_removed.broadcast
+        // (unregister case); no extra wakeup needed.
+        link.cdp.onLinkDisconnect(err);
+        link.handles.wakeup() catch |e| {
+            log.warn(.cdp, "CDP link wakeup", .{ .err = e });
+        };
+    }
+}
+
+// Build the link portion of pollfds and snapshot the matching *Link
+// pointers so we can correlate revents after poll() returns. Called
+// before poll, under link_mutex.
+fn preparePollFds(self: *Server) void {
+    self.link_mutex.lockUncancelable(lp.io);
+    defer self.link_mutex.unlock(lp.io);
+
+    // Idle fast-path: link set unchanged since last rebuild, so the
+    // snapshot + pollfds entries from the previous iteration are still
+    // correct. Kernel will overwrite `revents` in the next poll() call.
+    if (!self.links_dirty) {
+        return;
+    }
+    self.links_dirty = false;
+
+    const link_pollfds = self.pollfds[PSEUDO_POLLFDS..];
+    @memset(link_pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
+
+    var i: usize = 0;
+    var it = self.links.first;
+    while (it) |node| : (it = node.next) {
+        lp.assert(i < self.poll_snapshot.len, "poll snapshot overflow", .{ .i = i, .len = self.poll_snapshot.len });
+        const link: *Link = @fieldParentPtr("node", node);
+        if (link.state != .live) {
+            // Will be handled in processLinks; don't poll its fd.
+            continue;
+        }
+
+        link_pollfds[i] = .{
+            .fd = link.socket,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        };
+        self.poll_snapshot[i] = link;
+        i += 1;
+    }
+    self.poll_count = i;
+}
+
+// Per-iteration link handling: process pending unregistrations, then
+// process revents on each polled link. Called after poll().
+fn processLinks(self: *Server) void {
+    var any_removed = false;
+
+    self.link_mutex.lockUncancelable(lp.io);
+    defer self.link_mutex.unlock(lp.io);
+
+    // First pass: pending unregister requests.
+    var it = self.links.first;
+    while (it) |node| {
+        const next = node.next;
+        const link: *Link = @fieldParentPtr("node", node);
+        if (link.state == .unregistering) {
+            self.dropLink(link, null, .{ .notify = false });
+            any_removed = true;
+        }
+        it = next;
+    }
+
+    // Second pass: revents on the snapshot. Skip links the first pass
+    // (or a prior natural drop) has already removed.
+    const link_pollfds = self.pollfds[PSEUDO_POLLFDS..];
+    for (self.poll_snapshot[0..self.poll_count], 0..) |link_opt, i| {
+        const link = link_opt orelse continue;
+        if (link.state != .live) {
+            continue;
+        }
+        const pfd = link_pollfds[i];
+        if (pfd.revents == 0) {
+            continue;
+        }
+
+        const fatal_events: i16 = comptime @intCast(posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
+        if (pfd.revents & fatal_events != 0) {
+            self.dropLink(link, null, .{ .notify = true, .shutdown_socket = true });
+            any_removed = true;
+            continue;
+        }
+
+        if (pfd.revents & posix.POLL.IN == 0) {
+            continue;
+        }
+
+        var buf: [16 * 1024]u8 = undefined;
+        const n = posix.read(link.socket, &buf) catch |err| switch (err) {
+            error.WouldBlock => continue,
+            else => {
+                log.warn(.cdp, "CDP read", .{ .err = err });
+                self.dropLink(link, err, .{ .notify = true, .shutdown_socket = true });
+                any_removed = true;
+                continue;
+            },
+        };
+
+        if (n == 0) {
+            // peer EOF
+            self.dropLink(link, null, .{ .notify = true, .shutdown_socket = true });
+            any_removed = true;
+            continue;
+        }
+
+        const keep = link.cdp.onData(buf[0..n]) catch |err| {
+            // Fatal frame/feed error. Whatever messages on_bytes
+            // managed to push are still in the inbox; the failing
+            // frame was NOT pushed, and the worker has no way to
+            // know it should exit. Drop with notify=true so
+            // on_disconnect surfaces a .disconnect into the inbox.
+            // dropLink wakes the worker.
+            log.info(.cdp, "CDP onData", .{ .err = err });
+            self.dropLink(link, err, .{ .notify = true });
+            any_removed = true;
+            continue;
+        };
+
+        // on_bytes succeeded — wake the worker so it observes anything
+        // new in the inbox (data / ping / close).
+        link.handles.wakeup() catch |err| {
+            log.warn(.cdp, "CDP link wakeup", .{ .err = err });
+        };
+
+        if (!keep) {
+            // Close frame: the handler already pushed .close. Worker's
+            // drainInbox will call on_disconnect itself after replying,
+            // so we drop without re-notifying.
+            self.dropLink(link, null, .{ .notify = false });
+            any_removed = true;
+        }
+    }
+
+    if (any_removed) {
+        self.link_removed.broadcast(lp.io);
+    }
+}
+
+// On shutdown, force-disconnect every still-live link. Each link's
+// worker thread blocks in curl_multi_poll and is woken ONLY by this
+// thread via dropLink -> handles.wakeup(). If the run loop exits with
+// links still live, those workers never wake and deinit() spins on
+// active_threads forever (issue #2510). Mirrors the peer-EOF path in
+// processLinks: dropLink(notify=true) pushes a .disconnect into the
+// worker's inbox and wakes it, so cdp.tick() returns false and the
+// worker exits.
+fn shutdownLinks(self: *Server) void {
+    self.link_mutex.lockUncancelable(lp.io);
+    defer self.link_mutex.unlock(lp.io);
+
+    var it = self.links.first;
+    while (it) |node| {
+        it = node.next;
+        const link: *Link = @fieldParentPtr("node", node);
+        if (link.state == .live) {
+            self.dropLink(link, null, .{ .notify = true });
+        }
+    }
+
+    self.link_removed.broadcast(lp.io);
 }
 
 // Liveness is enforced at the TCP layer via keepalive probes sent by the
@@ -147,7 +582,7 @@ fn configureSocket(socket: posix.socket_t) !void {
 }
 
 fn spawnWorker(self: *Server, socket: posix.socket_t) !void {
-    if (self.app.shutdown()) {
+    if (self.shutting_down.load(.acquire)) {
         return error.ShuttingDown;
     }
 
@@ -256,31 +691,31 @@ fn handleConnection(self: *Server, socket: posix.socket_t) void {
         cdp.conn.state = .live;
     }
 
-    // Hand the read side of the CDP socket over to the Network thread.
-    // From here until the matching unregisterCdp, the worker must NOT
+    // Hand the read side of the CDP socket over to the run loop.
+    // From here until the matching unregisterLink, the worker must NOT
     // read from the socket directly — bytes arrive via the inbox.
-    // unregisterCdp is synchronous, so by the time it returns Network
+    // unregisterLink is synchronous, so by the time it returns the loop
     // is guaranteed to be done with this link.
     //
     // cdp_link_active gates HttpClient.perform's block in
     // curl_multi_poll: with it false (tests, pre-handshake), perform
     // skips the poll when there's no in-flight curl work — sleeping
     // would just eat the timeout waiting for a wakeup that won't
-    // come. We set it true *after* registerCdp so Network is already
+    // come. We set it true *after* registerLink so the loop is already
     // accepting wakeups by the time the worker might poll, and clear
-    // it *after* unregisterCdp returns (Network is guaranteed done
+    // it *after* unregisterLink returns (the loop is guaranteed done
     // with us by then).
-    self.app.network.registerCdp(&cdp.link);
+    self.registerLink(&cdp.link);
     cdp.browser.http_client.cdp_link_active = true;
     defer {
-        self.app.network.unregisterCdp(&cdp.link);
+        self.unregisterLink(&cdp.link);
         cdp.browser.http_client.cdp_link_active = false;
     }
 
     // Check shutdown after markLive so that a concurrent shutdown either
     // sees us as .live and terminates us, or we observe the stop signal
     // here. Otherwise we could miss it and block deinit() indefinitely.
-    if (self.app.shutdown()) {
+    if (self.shutting_down.load(.acquire)) {
         return;
     }
 

--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -25,7 +25,7 @@ const Notification = @import("../Notification.zig");
 
 const WS = @import("../network/WS.zig");
 const http = @import("../network/http.zig");
-const Network = @import("../network/Network.zig");
+const Server = @import("../Server.zig");
 const Transfer = @import("../network/HttpClient.zig").Transfer;
 
 const js = @import("../browser/js/js.zig");
@@ -62,11 +62,10 @@ conn: Connection,
 browser: Browser,
 allocator: Allocator,
 
-// Network-thread read-side handle for the CDP socket. Populated in
-// init; Server.handleConnection calls network.registerCdp(&cdp.link)
-// after the worker-side handshake completes, and unregisterCdp before
-// teardown.
-link: Network.CdpLink,
+// Server run-loop read-side handle for the CDP socket. Populated in
+// init; Server.handleConnection calls registerLink(&cdp.link) after the
+// worker-side handshake completes, and unregisterLink before teardown.
+link: Server.Link,
 
 // when true, any target creation must be attached.
 target_auto_attach: bool = false,
@@ -143,10 +142,10 @@ pub fn deinit(self: *CDP) void {
     self.browser_context_arena.deinit();
     self.conn.deinit();
 }
-// Called by Network when readable bytes arrive on the CDP socket.
-// Feeds them through the WS framer and pushes each parsed frame into
-// the worker's inbox. Returns false if a close frame was seen (or a
-// fatal frame error) so Network drops the link from its poll set.
+// Called by the Server run loop when readable bytes arrive on the CDP
+// socket. Feeds them through the WS framer and pushes each parsed frame
+// into the worker's inbox. Returns false if a close frame was seen (or a
+// fatal frame error) so the loop drops the link from its poll set.
 //
 // One network read can carry more bytes than the reader's current
 // free space — large CDP messages (Page.addScriptToEvaluateOnNewDocument,
@@ -167,8 +166,8 @@ pub fn onData(self: *CDP, data: []const u8) anyerror!bool {
     return true;
 }
 
-// Called by Network when it drops the link unsolicited (peer EOF, read
-// error, poll HUP/ERR). Push a disconnect into the inbox so the
+// Called by the Server run loop when it drops the link unsolicited (peer
+// EOF, read error, poll HUP/ERR). Push a disconnect into the inbox so the
 // worker's drainInbox surfaces error.ClientDisconnected.
 pub fn onLinkDisconnect(self: *CDP, err: ?anyerror) void {
     const arena = self.browser.arena_pool.acquire(.tiny, "cdp disconnect") catch |e| switch (e) {
@@ -178,14 +177,14 @@ pub fn onLinkDisconnect(self: *CDP, err: ?anyerror) void {
     self.browser.http_client.inbox.push(arena, .{ .disconnect = err });
 }
 
-// Called by Network to try to force the Worker to shutdown. Protects against a
-// stuck worker.
-pub fn terminateFromNetwork(self: *CDP) void {
+// Called by the Server run loop to try to force the Worker to shutdown.
+// Protects against a stuck worker.
+pub fn terminateFromServer(self: *CDP) void {
     self.browser.env.requestTerminate();
 }
 
 // Called in the Worker to dispatch a single CDP message bubbled up by
-// HttpClient.drainInbox. The Network thread already parsed the JSON
+// HttpClient.drainInbox. The Server run loop already parsed the JSON
 // when it pushed the message to the inbox, so we skip straight to
 // dispatchParsed without re-parsing. `c.raw` and `c.arena` outlive
 // this call (they're owned by the inbox Message which drainInbox
@@ -1493,9 +1492,9 @@ test "cdp: disconnect latches so the worker keeps exiting" {
 
     const client = &ctx.cdp().browser.http_client;
 
-    // Simulate the Network thread delivering a peer disconnect into the
-    // worker's inbox — the dropCdp(notify=true) path used on peer EOF and,
-    // since #2510, on shutdown via shutdownCdpLinks.
+    // Simulate the Server run loop delivering a peer disconnect into the
+    // worker's inbox — the dropLink(notify=true) path used on peer EOF and,
+    // since #2510, on shutdown via shutdownLinks.
     {
         const arena = try client.arena_pool.acquire(.tiny, "test disconnect");
         client.inbox.push(arena, .{ .disconnect = null });

--- a/src/main.zig
+++ b/src/main.zig
@@ -99,8 +99,6 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
     var app = try App.init(allocator, &args);
     defer app.deinit();
 
-    try sighandler.on(lp.Network.stop, .{&app.network});
-
     app.telemetry.record(.{ .run = {} });
 
     defer if (app.config.dumpMetricsOnExit()) {
@@ -133,7 +131,7 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
 
             try sighandler.on(lp.Server.shutdown, .{server});
 
-            app.network.run();
+            server.run();
         },
         .fetch => |opts| {
             const urls = opts.url.items;
@@ -207,10 +205,10 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
             log.opts.format = .logfmt;
 
             // --port serves MCP over HTTP instead of stdio. It and --cdp-port
-            // both need app.network's single listener, so they can't combine.
+            // each run their accept loop on this thread, so they can't combine.
             if (opts.port) |port| {
                 if (opts.cdp_port != null) {
-                    log.fatal(.mcp, "port conflicts with cdp-port", .{ .hint = "both need the single network listener" });
+                    log.fatal(.mcp, "port conflicts with cdp-port", .{ .hint = "both need the main thread for their accept loop" });
                     return error.InvalidArgument;
                 }
                 const address = std.Io.net.IpAddress.parse(opts.host, port) catch |err| {
@@ -219,8 +217,8 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 };
                 const http_server = try lp.mcp.HttpServer.init(allocator, app);
                 defer http_server.deinit();
-                // Shutdown rides the already-registered Network.stop handler:
-                // a signal stops the accept loop, run() returns, deinit joins.
+                // A signal stops the accept loop, run() returns, deinit joins.
+                try sighandler.on(lp.mcp.HttpServer.stop, .{http_server});
                 http_server.run(address) catch |err| {
                     log.fatal(.mcp, "mcp http error", .{ .err = err });
                     return err;
@@ -241,14 +239,14 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
 
             var mcp_err: ?anyerror = null;
             {
-                var worker_thread = try std.Thread.spawn(.{}, mcpThread, .{ allocator, app, &mcp_err });
+                var worker_thread = try std.Thread.spawn(.{}, mcpThread, .{ allocator, app, cdp_server, &mcp_err });
                 defer worker_thread.join();
 
                 // mcp talks over stdio on mcpThread. Only run the CDP accept/read
                 // loop when an optional CDP server was started; otherwise the main
                 // thread just waits for the worker.
-                if (cdp_server != null) {
-                    app.network.run();
+                if (cdp_server) |s| {
+                    s.run();
                 }
             }
             if (mcp_err) |err| return err;
@@ -292,8 +290,6 @@ fn agentThread(
     cancelled: *bool,
     sig_bridge: *lp.Agent.SigBridge,
 ) void {
-    defer app.network.stop();
-
     var agent_instance = lp.Agent.init(allocator, app, opts) catch |err| {
         if (err == error.UserCancelled) {
             cancelled.* = true;
@@ -351,8 +347,6 @@ const FetchTerminator = struct {
 };
 
 fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetch_opts: lp.FetchOpts, err_out: *?anyerror) void {
-    defer app.network.stop();
-
     var browser: lp.Browser = undefined;
     browser.init(app, .{}, null) catch |err| {
         err_out.* = err;
@@ -373,8 +367,10 @@ fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetc
     };
 }
 
-fn mcpThread(allocator: std.mem.Allocator, app: *App, err_out: *?anyerror) void {
-    defer app.network.stop();
+fn mcpThread(allocator: std.mem.Allocator, app: *App, cdp_server: ?*lp.Server, err_out: *?anyerror) void {
+    defer if (cdp_server) |s| {
+        s.shutdown();
+    };
 
     var stdout = std.Io.File.stdout().writerStreaming(lp.io, &.{});
     var mcp_server: *lp.mcp.Server = lp.mcp.Server.init(allocator, app, &stdout.interface) catch |err| {

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -29,6 +29,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const builtin = @import("builtin");
 
 const App = @import("../App.zig");
 const sys_net = @import("../sys/net.zig");
@@ -126,7 +127,12 @@ app: *App,
 
 queue: Queue = .{},
 
-// Registration happens in onAccept — the same (network) thread deinit runs
+// Blocking listener owned by run(); -1 until bound. stop() unblocks the
+// accept from another thread.
+listener: posix.socket_t = -1,
+shutting_down: std.atomic.Value(bool) = .init(false),
+
+// Registration happens in onAccept — the same (accept) thread deinit runs
 // on — so a connection is always counted and its socket registered before
 // deinit can observe either.
 active_conns: std.atomic.Value(u32) = .init(0),
@@ -180,30 +186,60 @@ pub fn deinit(self: *HttpServer) void {
     self.allocator.destroy(self);
 }
 
-/// Accept MCP-over-HTTP connections until the network loop is stopped
-/// (e.g. by the signal handler). Reuses the shared accept infrastructure;
-/// blocks the calling thread in `Network.run`.
+/// Accept MCP-over-HTTP connections until stop() (e.g. from the signal
+/// handler). Blocks the calling thread; each accepted connection is served
+/// by its own thread doing blocking IO.
 pub fn run(self: *HttpServer, address: sys_net.IpAddress) !void {
-    var bound = address;
-    try self.app.network.bind(&bound, self, onAccept);
-    log.note(.mcp, "mcp http server running", .{ .address = bound });
-    self.app.network.run();
+    const listener = try sys_net.socket(sys_net.family(&address), posix.SOCK.STREAM | posix.SOCK.CLOEXEC, posix.IPPROTO.TCP);
+    errdefer _ = std.c.close(listener);
+
+    try posix.setsockopt(listener, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+    if (@hasDecl(posix.TCP, "NODELAY")) {
+        try posix.setsockopt(listener, posix.IPPROTO.TCP, posix.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
+    }
+
+    const sa = sys_net.sockaddrFromAddress(&address);
+    try sys_net.bind(listener, sa.ptr(), sa.len);
+    try sys_net.listen(listener, self.app.config.maxPendingConnections());
+
+    // --port 0 asks the OS for an ephemeral port; log the one we actually got.
+    var bound: posix.sockaddr.storage = undefined;
+    var bound_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+    try sys_net.getsockname(listener, @ptrCast(&bound), &bound_len);
+    log.note(.mcp, "mcp http server running", .{ .address = sys_net.addressFromSockaddr(@ptrCast(&bound)) });
+
+    self.listener = listener;
+    // On non-Linux stop() closes the listener itself to unblock accept.
+    defer if (builtin.os.tag == .linux) {
+        _ = std.c.close(listener);
+    };
+
+    while (!self.shutting_down.load(.acquire)) {
+        const socket = sys_net.accept(listener, null, null, 0) catch |err| {
+            if (self.shutting_down.load(.acquire)) {
+                return;
+            }
+            switch (err) {
+                error.ConnectionAborted => log.warn(.mcp, "accept connection aborted", .{}),
+                else => log.err(.mcp, "accept error", .{ .err = err }),
+            }
+            continue;
+        };
+        self.onAccept(socket);
+    }
 }
 
-/// Network hands us a nonblocking accepted socket; each connection is served
-/// by its own thread doing blocking IO, so we clear O_NONBLOCK first.
-fn onAccept(ctx: *anyopaque, socket: posix.socket_t) void {
-    const self: *HttpServer = @ptrCast(@alignCast(ctx));
+/// Make run() return. Linux wakes a blocked accept() on shutdown(); BSD/macOS
+/// only on close(), in which case run() must not close it again.
+pub fn stop(self: *HttpServer) void {
+    self.shutting_down.store(true, .release);
+    switch (builtin.os.tag) {
+        .linux => sys_net.shutdown(self.listener, .recv) catch {},
+        else => _ = std.c.close(self.listener),
+    }
+}
 
-    const flags = sys_net.fcntl(socket, posix.F.GETFL, 0) catch {
-        _ = std.c.close(socket);
-        return;
-    };
-    _ = sys_net.fcntl(socket, posix.F.SETFL, flags & ~@as(u32, @bitCast(posix.O{ .NONBLOCK = true }))) catch {
-        _ = std.c.close(socket);
-        return;
-    };
-
+fn onAccept(self: *HttpServer, socket: posix.socket_t) void {
     {
         self.conn_mutex.lockUncancelable(lp.io);
         defer self.conn_mutex.unlock(lp.io);

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -731,3 +731,4 @@ const HostContext = struct {
         return std.ascii.eqlIgnoreCase(a, b);
     }
 };
+

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -18,13 +18,10 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
-const builtin = @import("builtin");
 
 const App = @import("../App.zig");
 const Config = @import("../Config.zig");
 
-const CDP = @import("../cdp/CDP.zig");
-const sys_net = @import("../sys/net.zig");
 const libcurl = @import("../sys/libcurl.zig");
 
 const http = @import("http.zig");
@@ -37,49 +34,10 @@ const Certificates = @import("Certificates.zig");
 const Cache = @import("cache/Cache.zig");
 const AdBlocker = @import("adblock/AdBlocker.zig");
 
-const log = lp.log;
-const posix = std.posix;
 const Allocator = std.mem.Allocator;
 const DoublyLinkedList = std.DoublyLinkedList;
 
 const Network = @This();
-
-const Listener = struct {
-    socket: posix.socket_t,
-    ctx: *anyopaque,
-    onAccept: *const fn (ctx: *anyopaque, socket: posix.socket_t) void,
-};
-
-// Read side of a CDP WebSocket, registered with the Network thread so
-// bytes are read off the socket from here and dispatched into the CDP
-// layer via direct method calls on `cdp`. Network never sends on the
-// socket — the worker is the sole writer. After registerCdp returns,
-// the worker must not call posix.read on this socket directly.
-// unregisterCdp is synchronous: it blocks until Network confirms the
-// link has been dropped from its poll set and won't touch it again.
-pub const CdpLink = struct {
-    cdp: *CDP,
-    state: State,
-    socket: posix.socket_t,
-    // The worker's HttpClient.Handles (by value — it's one pointer
-    // wide). Network calls handles.wakeup() to unblock the worker
-    // from curl_multi_poll whenever it pushes to the worker's inbox.
-    handles: http.Handles,
-    node: DoublyLinkedList.Node = .{},
-
-    pub const State = enum {
-        live,
-        // Worker called unregisterCdp; Network will drop the link on
-        // its next loop iteration and signal cdp_unregister.
-        unregistering,
-        // Network has dropped the link from its poll set. The worker
-        // can safely free anything the link's callbacks closed over.
-        removed,
-    };
-};
-
-// Number of fixed pollfds entries (wakeup pipe + listener).
-const PSEUDO_POLLFDS = 2;
 
 cache: Cache,
 allocator: Allocator,
@@ -88,8 +46,6 @@ robot_store: RobotStore,
 web_bot_auth: ?WebBotAuth,
 rate_limiter: ?RateLimiter,
 certificates: Certificates,
-/// Hostname dictionaries built from `--adblock-lists`. Parsed once here and
-/// never mutated afterwards, so every HttpClient can share this one copy.
 adblocker: ?AdBlocker,
 
 connections: []http.Connection,
@@ -100,40 +56,6 @@ ws_pool: std.heap.MemoryPool(http.Connection),
 ws_count: usize = 0,
 ws_max: u8,
 ws_mutex: std.Io.Mutex = .init,
-
-pollfds: []posix.pollfd,
-listener: ?Listener = null,
-accept: std.atomic.Value(bool) = .init(true),
-
-// Wakeup pipe: workers write to [1], main thread polls [0]
-wakeup_pipe: [2]posix.fd_t = .{ -1, -1 },
-
-shutdown: std.atomic.Value(bool) = .init(false),
-
-// Registered CDP read endpoints. Producer-side (the worker doing
-// register/unregister) and consumer-side (this thread's run loop) are
-// serialized by cdp_mutex. cdp_unregister signals when a link
-// transitions to .removed so unregisterCdp can return.
-cdp_links: DoublyLinkedList = .{},
-cdp_mutex: std.Io.Mutex = .init,
-cdp_unregister: std.Io.Condition = .init,
-// Per-iteration snapshot of CdpLinks whose sockets are in pollfds.
-// Sized at maxConnections at init time so we never allocate inside
-// run(). Parallel to pollfds[cdp_start..cdp_start + cdp_poll_count].
-// Persists across iterations; only rebuilt when `cdp_dirty` is set.
-cdp_poll_snapshot: []?*CdpLink,
-cdp_poll_count: usize = 0,
-
-// Set whenever the cdp_links list changes (register / unregister /
-// natural drop). prepareCdpPollFds rebuilds the snapshot only when
-// this is true; idle iterations skip the rebuild. Network run() ticks
-// hundreds of times per second, and the link set is stable between
-// connection lifecycle events, so the steady-state cost of the CDP
-// poll prep is one mutex acquire + one bool read.
-cdp_dirty: bool = false,
-
-// Location in pollfds where cdp sockets start
-cdp_start: usize,
 
 /// Optional IP filter for blocking requests to private/internal networks (--block-private-networks).
 ip_filter: ?*IpFilter = null,
@@ -146,23 +68,6 @@ pub fn init(app: *App) !Network {
 
     const config = app.config;
     const allocator = app.allocator;
-
-    const pipe = try sys_net.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
-
-    // pollfds layout:
-    //   [0]                                  wakeup pipe
-    //   [1]                                  listener
-    //   [PSEUDO_POLLFDS .. + max_cdp]        CDP socket fds
-    const max_cdp = config.maxConnections();
-    const pollfds = try allocator.alloc(posix.pollfd, PSEUDO_POLLFDS + max_cdp);
-    errdefer allocator.free(pollfds);
-
-    const cdp_poll_snapshot = try allocator.alloc(?*CdpLink, max_cdp);
-    errdefer allocator.free(cdp_poll_snapshot);
-    @memset(cdp_poll_snapshot, null);
-
-    @memset(pollfds, .{ .fd = -1, .events = 0, .revents = 0 });
-    pollfds[0] = .{ .fd = pipe[0], .events = posix.POLL.IN, .revents = 0 };
 
     const certificates = try Certificates.init(allocator, config);
     errdefer certificates.deinit();
@@ -212,11 +117,6 @@ pub fn init(app: *App) !Network {
         .allocator = allocator,
         .certificates = certificates,
 
-        .pollfds = pollfds,
-        .wakeup_pipe = pipe,
-        .cdp_poll_snapshot = cdp_poll_snapshot,
-        .cdp_start = PSEUDO_POLLFDS,
-
         .available = available,
         .connections = connections,
 
@@ -234,16 +134,6 @@ pub fn init(app: *App) !Network {
 }
 
 pub fn deinit(self: *Network) void {
-    for (&self.wakeup_pipe) |*fd| {
-        if (fd.* >= 0) {
-            _ = std.c.close(fd.*);
-            fd.* = -1;
-        }
-    }
-
-    self.allocator.free(self.pollfds);
-    self.allocator.free(self.cdp_poll_snapshot);
-
     self.certificates.deinit();
 
     for (self.connections) |*conn| {
@@ -271,380 +161,6 @@ pub fn deinit(self: *Network) void {
     }
 
     libcurl.curl_global_cleanup();
-}
-
-pub fn bind(
-    self: *Network,
-    address: *sys_net.IpAddress,
-    ctx: *anyopaque,
-    on_accept: *const fn (ctx: *anyopaque, socket: posix.socket_t) void,
-) !void {
-    if (self.listener != null) return error.TooManyListeners;
-
-    self.accept.store(true, .release);
-
-    const flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
-    const listener = try sys_net.socket(sys_net.family(address), flags, posix.IPPROTO.TCP);
-    errdefer _ = std.c.close(listener);
-
-    try posix.setsockopt(listener, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
-    if (@hasDecl(posix.TCP, "NODELAY")) {
-        try posix.setsockopt(listener, posix.IPPROTO.TCP, posix.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
-    }
-
-    const sa = sys_net.sockaddrFromAddress(address);
-    try sys_net.bind(listener, sa.ptr(), sa.len);
-    try sys_net.listen(listener, self.config.maxPendingConnections());
-
-    // When the caller requests port 0, the OS assigns an ephemeral port; read
-    // the actual bound address back so callers (e.g. logging) see the real port.
-    var bound: posix.sockaddr.storage = undefined;
-    var bound_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
-    try sys_net.getsockname(listener, @ptrCast(&bound), &bound_len);
-    address.* = sys_net.addressFromSockaddr(@ptrCast(&bound));
-
-    self.listener = .{
-        .socket = listener,
-        .ctx = ctx,
-        .onAccept = on_accept,
-    };
-    self.pollfds[1] = .{
-        .fd = listener,
-        .events = posix.POLL.IN,
-        .revents = 0,
-    };
-}
-
-pub fn unbind(self: *Network) void {
-    self.accept.store(false, .release);
-    self.wakeupPoll();
-}
-
-// Hand a CDP WebSocket's read side over to the main network thread. The caller
-// owns the link and must keep it alive until unregisterCdp is called.
-// The caller must not read from the socket.
-pub fn registerCdp(self: *Network, link: *CdpLink) void {
-    self.cdp_mutex.lockUncancelable(lp.io);
-    self.cdp_links.append(&link.node);
-    self.cdp_dirty = true;
-    self.cdp_mutex.unlock(lp.io);
-    self.wakeupPoll();
-}
-
-// Synchronous teardown. Blocks the caller until this thread has
-// dropped the link from its poll set and won't invoke any of the
-// link's callbacks. Safe to call after Network has already dropped
-// the link unsolicited (state == .removed) — returns immediately in
-// that case.
-pub fn unregisterCdp(self: *Network, link: *CdpLink) void {
-    self.cdp_mutex.lockUncancelable(lp.io);
-    defer self.cdp_mutex.unlock(lp.io);
-    if (link.state == .live) {
-        link.state = .unregistering;
-        self.cdp_dirty = true;
-        self.wakeupPoll();
-    }
-
-    while (link.state != .removed) {
-        // condition variable, waiting for a signal
-        self.cdp_unregister.waitUncancelable(lp.io, &self.cdp_mutex);
-    }
-}
-
-const DropCdpOpts = struct {
-    // on_disconnect is fired iff `notify` is true. false when the worker already
-    // knows the link is dead.
-    notify: bool,
-
-    // Set when we know the peer is dead. Can help unblock a blocked worker's send()
-    shutdown_socket: bool = false,
-};
-
-// Drop a link from the poll set. Caller must hold cdp_mutex.
-fn dropCdp(self: *Network, link: *CdpLink, err: ?anyerror, opts: DropCdpOpts) void {
-    self.cdp_links.remove(&link.node);
-    link.state = .removed;
-    self.cdp_dirty = true;
-
-    if (opts.shutdown_socket) {
-        sys_net.shutdown(link.socket, .both) catch {};
-    }
-
-    if (opts.notify) {
-        link.cdp.terminateFromNetwork();
-
-        // notify=true means the worker hasn't been told yet — push the
-        // disconnect into the inbox and break it out of curl_multi_poll.
-        // notify=false paths have already woken the worker (close frame
-        // case) or are about to be unblocked via cdp_unregister.broadcast
-        // (unregister case); no extra wakeup needed.
-        link.cdp.onLinkDisconnect(err);
-        link.handles.wakeup() catch |e| {
-            lp.log.warn(.cdp, "CDP link wakeup", .{ .err = e });
-        };
-    }
-}
-
-// Build the CDP portion of pollfds and snapshot the matching *CdpLink
-// pointers so we can correlate revents after poll() returns. Called
-// before poll, under cdp_mutex.
-fn prepareCdpPollFds(self: *Network) void {
-    const cdp_start = self.cdp_start;
-
-    self.cdp_mutex.lockUncancelable(lp.io);
-    defer self.cdp_mutex.unlock(lp.io);
-
-    // Idle fast-path: link set unchanged since last rebuild, so the
-    // snapshot + pollfds entries from the previous iteration are still
-    // correct. Kernel will overwrite `revents` in the next poll() call.
-    if (!self.cdp_dirty) {
-        return;
-    }
-    self.cdp_dirty = false;
-
-    @memset(self.pollfds[cdp_start..], .{ .fd = -1, .events = 0, .revents = 0 });
-
-    var i: usize = 0;
-    var it = self.cdp_links.first;
-    while (it) |node| : (it = node.next) {
-        lp.assert(i < self.cdp_poll_snapshot.len, "CDP poll snapshot overflow", .{ .i = i, .len = self.cdp_poll_snapshot.len });
-        const link: *CdpLink = @fieldParentPtr("node", node);
-        if (link.state != .live) {
-            // Will be handled in processCdpEvents; don't poll its fd.
-            continue;
-        }
-
-        self.pollfds[cdp_start + i] = .{
-            .fd = link.socket,
-            .events = posix.POLL.IN,
-            .revents = 0,
-        };
-        self.cdp_poll_snapshot[i] = link;
-        i += 1;
-    }
-    self.cdp_poll_count = i;
-}
-
-// Per-iteration CDP handling: process pending unregistrations, then
-// process revents on each polled link. Called after poll().
-fn processCdpEvents(self: *Network) void {
-    var any_removed = false;
-    const cdp_start = self.cdp_start;
-
-    self.cdp_mutex.lockUncancelable(lp.io);
-    defer self.cdp_mutex.unlock(lp.io);
-
-    // First pass: pending unregister requests.
-    var it = self.cdp_links.first;
-    while (it) |node| {
-        const next = node.next;
-        const link: *CdpLink = @fieldParentPtr("node", node);
-        if (link.state == .unregistering) {
-            self.dropCdp(link, null, .{ .notify = false });
-            any_removed = true;
-        }
-        it = next;
-    }
-
-    // Second pass: revents on the snapshot. Skip links the first pass
-    // (or a prior natural drop) has already removed.
-    for (self.cdp_poll_snapshot[0..self.cdp_poll_count], 0..) |link_opt, i| {
-        const link = link_opt orelse continue;
-        if (link.state != .live) {
-            continue;
-        }
-        const pfd = self.pollfds[cdp_start + i];
-        if (pfd.revents == 0) {
-            continue;
-        }
-
-        const fatal_events: i16 = comptime @intCast(posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
-        if (pfd.revents & fatal_events != 0) {
-            self.dropCdp(link, null, .{ .notify = true, .shutdown_socket = true });
-            any_removed = true;
-            continue;
-        }
-
-        if (pfd.revents & posix.POLL.IN == 0) {
-            continue;
-        }
-
-        var buf: [16 * 1024]u8 = undefined;
-        const n = posix.read(link.socket, &buf) catch |err| switch (err) {
-            error.WouldBlock => continue,
-            else => {
-                lp.log.warn(.cdp, "CDP read", .{ .err = err });
-                self.dropCdp(link, err, .{ .notify = true, .shutdown_socket = true });
-                any_removed = true;
-                continue;
-            },
-        };
-
-        if (n == 0) {
-            // peer EOF
-            self.dropCdp(link, null, .{ .notify = true, .shutdown_socket = true });
-            any_removed = true;
-            continue;
-        }
-
-        const keep = link.cdp.onData(buf[0..n]) catch |err| {
-            // Fatal frame/feed error. Whatever messages on_bytes
-            // managed to push are still in the inbox; the failing
-            // frame was NOT pushed, and the worker has no way to
-            // know it should exit. Drop with notify=true so
-            // on_disconnect surfaces a .disconnect into the inbox.
-            // dropCdp wakes the worker.
-            lp.log.info(.cdp, "CDP onData", .{ .err = err });
-            self.dropCdp(link, err, .{ .notify = true });
-            any_removed = true;
-            continue;
-        };
-
-        // on_bytes succeeded — wake the worker so it observes anything
-        // new in the inbox (data / ping / close).
-        link.handles.wakeup() catch |err| {
-            lp.log.warn(.cdp, "CDP link wakeup", .{ .err = err });
-        };
-
-        if (!keep) {
-            // Close frame: the handler already pushed .close. Worker's
-            // drainInbox will call on_disconnect itself after replying,
-            // so we drop without re-notifying.
-            self.dropCdp(link, null, .{ .notify = false });
-            any_removed = true;
-        }
-    }
-
-    if (any_removed) {
-        self.cdp_unregister.broadcast(lp.io);
-    }
-}
-
-// On shutdown, force-disconnect every still-live CDP link. Each link's
-// worker thread blocks in curl_multi_poll and is woken ONLY by this
-// (Network) thread via dropCdp -> handles.wakeup(). If the run loop
-// exits with links still live, those workers never wake and
-// Server.deinit() spins on active_threads forever (issue #2510).
-// Mirrors the peer-EOF path in processCdpEvents: dropCdp(notify=true)
-// pushes a .disconnect into the worker's inbox and wakes it, so
-// cdp.tick() returns false and the worker exits.
-fn shutdownCdpLinks(self: *Network) void {
-    self.cdp_mutex.lockUncancelable(lp.io);
-    defer self.cdp_mutex.unlock(lp.io);
-
-    var it = self.cdp_links.first;
-    while (it) |node| {
-        it = node.next;
-        const link: *CdpLink = @fieldParentPtr("node", node);
-        if (link.state == .live) {
-            self.dropCdp(link, null, .{ .notify = true });
-        }
-    }
-
-    self.cdp_unregister.broadcast(lp.io);
-}
-
-pub fn run(self: *Network) void {
-    var drain_buf: [64]u8 = undefined;
-
-    const poll_fd = &self.pollfds[0];
-    const listen_fd = &self.pollfds[1];
-
-    // Receiving a shutdown command does not terminate existing connections: we
-    // stop accepting new ones but leave in-flight requests to external code to
-    // terminate. This loop only services the listener and the CDP read sockets;
-    // page fetches run on per-worker HttpClient multis and telemetry on its own
-    // thread, so nothing here drives libcurl.
-    while (true) {
-        if (self.listener != null and !self.accept.load(.acquire)) {
-            _ = std.c.close(self.listener.?.socket);
-            self.listener = null;
-            self.pollfds[1] = .{ .fd = -1, .events = 0, .revents = 0 };
-        }
-
-        self.prepareCdpPollFds();
-
-        // wait until we get a CDP message or a signal on the wakeup pipe
-        _ = posix.poll(self.pollfds, -1) catch |err| {
-            lp.log.err(.app, "poll", .{ .err = err });
-            continue;
-        };
-
-        // check wakeup pipe
-        if (poll_fd.revents != 0) {
-            poll_fd.revents = 0;
-            while (true)
-                _ = posix.read(self.wakeup_pipe[0], &drain_buf) catch break;
-        }
-
-        // accept new connections
-        if (listen_fd.revents != 0) {
-            listen_fd.revents = 0;
-            self.acceptConnections();
-        }
-
-        self.processCdpEvents();
-
-        if (self.shutdown.load(.acquire)) {
-            // Drain any live CDP links so their workers can exit (issue #2510),
-            // then stop. Page fetches and telemetry don't run on this loop, so
-            // there is nothing else to flush here.
-            self.shutdownCdpLinks();
-            break;
-        }
-    }
-
-    if (self.listener) |listener| {
-        sys_net.shutdown(listener.socket, .both) catch |err| blk: {
-            if (err == error.SocketNotConnected and builtin.os.tag != .linux) {
-                // This error is normal/expected on BSD/MacOS. We probably
-                // shouldn't bother calling shutdown at all, but I guess this
-                // is safer.
-                break :blk;
-            }
-            lp.log.warn(.app, "listener shutdown", .{ .err = err });
-        };
-        _ = std.c.close(listener.socket);
-    }
-}
-
-fn wakeupPoll(self: *Network) void {
-    _ = sys_net.write(self.wakeup_pipe[1], &.{1}) catch {};
-}
-
-pub fn stop(self: *Network) void {
-    self.shutdown.store(true, .release);
-    self.wakeupPoll();
-}
-
-fn acceptConnections(self: *Network) void {
-    if (self.shutdown.load(.acquire)) {
-        return;
-    }
-    const listener = self.listener orelse return;
-
-    while (true) {
-        const socket = sys_net.accept(listener.socket, null, null, posix.SOCK.NONBLOCK) catch |err| {
-            switch (err) {
-                error.WouldBlock => break,
-                error.SocketNotListening => {
-                    self.pollfds[1] = .{ .fd = -1, .events = 0, .revents = 0 };
-                    self.listener = null;
-                    return;
-                },
-                error.ConnectionAborted => {
-                    lp.log.warn(.app, "accept connection aborted", .{});
-                    continue;
-                },
-                else => {
-                    lp.log.err(.app, "accept error", .{ .err = err });
-                    continue;
-                },
-            }
-        };
-
-        listener.onAccept(listener.ctx, socket);
-    }
 }
 
 pub fn getConnection(self: *Network) ?*http.Connection {
@@ -731,4 +247,3 @@ const HostContext = struct {
         return std.ascii.eqlIgnoreCase(a, b);
     }
 };
-

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -560,7 +560,9 @@ test "tests:beforeAll" {
 }
 
 test "tests:afterAll" {
-    test_app.network.stop();
+    if (test_cdp_server) |server| {
+        server.shutdown();
+    }
     if (test_cdp_server_thread) |thread| {
         thread.join();
     }
@@ -605,7 +607,7 @@ fn serveCDP(wg: *lp.WaitGroup) !void {
     };
     wg.finish();
 
-    test_app.network.run();
+    test_cdp_server.?.run();
 }
 
 // /serve-count/ counters; only ever touched from the test HTTP server thread.


### PR DESCRIPTION
Network is less cohesive than https://github.com/lightpanda-io/browser/pull/3242 would indicate. It has two distinct and _completely_ separate responsibilities.

1 - It acts as the base for each HttpClient, providing a shared connection pool
    (for http and ws) and access to the process wide Cache, RobotStore,
    WebBothAuth, certificates, ...

2 - It accepts, polls and reads from CDP connection

There is zero relationship between these, and it's a particularly bad place for this duality to exist because both parts are, in their own way, the main multi-threaded junction in the system.

This commit is purely mechanical it:

1 - Keeps network as the base for each HttpClient. 
2 - Extract the CDP interaction into the existing Server.zig 3 - Gives mcp's HttpServer its own accept loop