### PR TITLE
chore: Silence the sporadic WriteFailed HTTP Error from the test server

### DIFF
--- a/src/TestHTTPServer.zig
+++ b/src/TestHTTPServer.zig
@@ -98,7 +98,7 @@ fn handleConnection(self: *TestHTTPServer, conn: std.Io.net.Stream) !void {
 
         self.handler(&req) catch |err| {
             switch (err) {
-                error.BrokenPipe => {},
+                error.BrokenPipe, error.WriteFailed => {},
                 else => {
                     std.debug.print("test http error '{s}': {}\n", .{ req.head.target, err });
                     req.respond("server error", .{ .status = .internal_server_error }) catch {};


### PR DESCRIPTION
No clue why this happens, but if the error mattered, a test would fail. A lot of tests can be "harsh" on the server (e.g. a frame that navigates its parent away while some resource load), so a WriteFailed error isn't exactly surprising