### PR TITLE
webapi: URLSearchParams improvements

### DIFF
--- a/src/browser/tests/net/url_search_params.html
+++ b/src/browser/tests/net/url_search_params.html
@@ -571,3 +571,67 @@
   testing.expectEqual(original, usp2.get('test'));
 }
 </script>
+
+<script id=deletePreservesOrder>
+{
+  const usp = new URLSearchParams('a=b&c=d');
+  usp.delete('a');
+  testing.expectEqual('c=d', usp.toString());
+
+  const usp2 = new URLSearchParams('a=a&b=b&a=a&c=c');
+  usp2.delete('a');
+  testing.expectEqual('b=b&c=c', usp2.toString());
+}
+</script>
+
+<script id=setPreservesPosition>
+{
+  const usp = new URLSearchParams('a=1&b=2&a=3&c=4');
+  usp.set('a', 'B');
+  testing.expectEqual('a=B&b=2&c=4', usp.toString());
+
+  // no existing entry appends
+  usp.set('d', '5');
+  testing.expectEqual('a=B&b=2&c=4&d=5', usp.toString());
+}
+</script>
+
+<script id=hasWithValue>
+{
+  const usp = new URLSearchParams('a=b&a=d&c&e&');
+  testing.expectEqual(true, usp.has('a', 'b'));
+  testing.expectEqual(false, usp.has('a', 'c'));
+  testing.expectEqual(true, usp.has('a', 'd'));
+  testing.expectEqual(true, usp.has('e', ''));
+  // undefined second arg behaves like the one-argument form
+  testing.expectEqual(true, usp.has('a', undefined));
+  usp.delete('a', 'b');
+  testing.expectEqual(false, usp.has('a', 'b'));
+  testing.expectEqual(true, usp.has('a', 'd'));
+}
+</script>
+
+<script id=sortUtf16CodeUnits>
+{
+  // 🌈 (U+1F308) is a higher code *point* than ﬃ (U+FB03), but sorts first
+  // by UTF-16 code units (lead surrogate 0xD83C < 0xFB03).
+  const usp = new URLSearchParams('ﬃ&\u{1F308}');
+  usp.sort();
+  testing.expectEqual(['\u{1F308}', 'ﬃ'], Array.from(usp.keys()));
+}
+</script>
+
+<script id=deleteDuringIteration>
+{
+  const usp = new URLSearchParams('param0=0&param1=1&param2=2');
+  const seen = [];
+  for (const param of usp) {
+    seen.push(param[0]);
+    usp.delete(param[0]);
+  }
+  // deleting the current entry shifts the next one into its slot, so the
+  // live iterator skips param1 - matching WPT urlsearchparams-foreach
+  testing.expectEqual(['param0', 'param2'], seen);
+  testing.expectEqual('param1=1', usp.toString());
+}
+</script>

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -122,10 +122,12 @@ pub fn getAll(self: *const KeyValueList, allocator: Allocator, name: []const u8)
     return arr.items;
 }
 
-pub fn has(self: *const KeyValueList, name: []const u8) bool {
+pub fn has(self: *const KeyValueList, name: []const u8, value: ?[]const u8) bool {
     for (self._entries.items) |*entry| {
         if (entry.name.eqlSlice(name)) {
-            return true;
+            if (value == null or entry.value.eqlSlice(value.?)) {
+                return true;
+            }
         }
     }
     return false;
@@ -145,22 +147,47 @@ pub fn appendAssumeCapacity(self: *KeyValueList, allocator: Allocator, name: []c
     });
 }
 
+// Preserve the relative order
 pub fn delete(self: *KeyValueList, name: []const u8, value: ?[]const u8) void {
+    const entries = self._entries.items;
     var i: usize = 0;
-    while (i < self._entries.items.len) {
-        const entry = self._entries.items[i];
+    for (entries) |entry| {
         if (entry.name.eqlSlice(name)) {
             if (value == null or entry.value.eqlSlice(value.?)) {
-                _ = self._entries.swapRemove(i);
                 continue;
             }
         }
+        entries[i] = entry;
         i += 1;
     }
+    self._entries.items.len = i;
 }
 
+// Update the first match, remove all the others
 pub fn set(self: *KeyValueList, allocator: Allocator, name: []const u8, value: []const u8) !void {
-    self.delete(name, null);
+    const entries = self._entries.items;
+    for (entries, 0..) |*entry, i| {
+        if (entry.name.eqlSlice(name) == false) {
+            continue;
+        }
+
+        // this is our first matching entry, update its value
+        entry.value = try String.init(allocator, value, .{});
+
+        // and now delete all other matching entreis
+        var w: usize = i + 1;
+        for (entries[i + 1 ..]) |later| {
+            if (later.name.eqlSlice(name)) {
+                continue;
+            }
+            entries[w] = later;
+            w += 1;
+        }
+        self._entries.items.len = w;
+        return;
+    }
+
+    // wasn't found, append
     try self.append(allocator, name, value);
 }
 

--- a/src/browser/webapi/net/Headers.zig
+++ b/src/browser/webapi/net/Headers.zig
@@ -67,7 +67,7 @@ pub fn get(self: *const Headers, name: []const u8, exec: *const Execution) !?[]c
 
 pub fn has(self: *const Headers, name: []const u8, exec: *const Execution) bool {
     const normalized_name = normalizeHeaderName(name, exec.buf);
-    return self._list.has(normalized_name);
+    return self._list.has(normalized_name, null);
 }
 
 pub fn set(self: *Headers, name: []const u8, value: []const u8, exec: *const Execution) !void {

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -122,8 +122,8 @@ pub fn getAll(self: *const URLSearchParams, name: []const u8, exec: *const Execu
     return self._params.getAll(exec.local_arena, name);
 }
 
-pub fn has(self: *const URLSearchParams, name: []const u8) bool {
-    return self._params.has(name);
+pub fn has(self: *const URLSearchParams, name: []const u8, value: ?[]const u8) bool {
+    return self._params.has(name, value);
 }
 
 pub fn set(self: *URLSearchParams, name: []const u8, value: []const u8) !void {
@@ -162,7 +162,10 @@ pub fn format(self: *const URLSearchParams, writer: *std.Io.Writer) !void {
 pub fn forEach(self: *URLSearchParams, cb_: js.Function, js_this_: ?js.Object) !void {
     const cb = if (js_this_) |js_this| try cb_.withThis(js_this) else cb_;
 
-    for (self._params._entries.items) |entry| {
+    // the callback can mutate the list
+    var i: usize = 0;
+    while (i < self._params._entries.items.len) : (i += 1) {
+        const entry = self._params._entries.items[i];
         cb.call(void, .{ entry.value.str(), entry.name.str(), self }) catch |err| {
             // this is a non-JS error
             log.warn(.js, "URLSearchParams.forEach", .{ .err = err });
@@ -171,11 +174,59 @@ pub fn forEach(self: *URLSearchParams, cb_: js.Function, js_this_: ?js.Object) !
 }
 
 pub fn sort(self: *URLSearchParams) void {
+    // std.mem.sort is stable (as required by the spec)
     std.mem.sort(KeyValueList.Entry, self._params._entries.items, {}, struct {
         fn cmp(_: void, a: KeyValueList.Entry, b: KeyValueList.Entry) bool {
-            return std.mem.order(u8, a.name.str(), b.name.str()) == .lt;
+            return utf16Order(a.name.str(), b.name.str()) == .lt;
         }
     }.cmp);
+}
+
+fn utf16Order(a: []const u8, b: []const u8) std.math.Order {
+    var ia: usize = 0;
+    var ib: usize = 0;
+    var pending_a: ?u16 = null;
+    var pending_b: ?u16 = null;
+    while (true) {
+        const ua = nextUtf16Unit(a, &ia, &pending_a) orelse {
+            return if (ib < b.len or pending_b != null) .lt else .eq;
+        };
+        const ub = nextUtf16Unit(b, &ib, &pending_b) orelse return .gt;
+        if (ua != ub) {
+            return if (ua < ub) .lt else .gt;
+        }
+    }
+}
+
+fn nextUtf16Unit(s: []const u8, i: *usize, pending: *?u16) ?u16 {
+    if (pending.*) |unit| {
+        pending.* = null;
+        return unit;
+    }
+    if (i.* >= s.len) {
+        return null;
+    }
+    // Invalid UTF-8 (e.g. raw bytes from an unpaired percent-escape) compares
+    // as U+FFFD, matching how the bytes surface to JS.
+    const seq_len = std.unicode.utf8ByteSequenceLength(s[i.*]) catch {
+        i.* += 1;
+        return 0xFFFD;
+    };
+    if (i.* + seq_len > s.len) {
+        i.* = s.len;
+        return 0xFFFD;
+    }
+    const cp = std.unicode.utf8Decode(s[i.* .. i.* + seq_len]) catch {
+        i.* += 1;
+        return 0xFFFD;
+    };
+    i.* += seq_len;
+    if (cp < 0x10000) {
+        return @intCast(cp);
+    }
+    const c = cp - 0x10000;
+    pending.* = @intCast(0xDC00 + (c & 0x3FF));
+    return @intCast(0xD800 + (c >> 10));
 }
 
 fn paramsFromArray(allocator: Allocator, array: js.Array) !KeyValueList {


### PR DESCRIPTION
`has` add support for optional value (matches name AND value)

`delete` preserve entry order

`sort` compares by UTF-16

`forEach` iterates by index since the callback can mutate the list

Minor improvement to a handful of WPT tests, e.g.
/url/urlsearchparams-delete.any.html  (first of a handful of /url/ WPT improvements)