### PR TITLE
mcp: enforce HTTP conditions

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -908,8 +908,10 @@ test "Client: http handshake host" {
 
     for ([_][]const u8{
         "rebind.evil.com:9583",
-        // Not even the name that resolves to loopback on every machine.
-        "localhost:9583",
+        // Only the exact `localhost:<port>` form is allowed.
+        "localhost",
+        "LOCALHOST:9583",
+        "localhost.evil.com:9583",
     }) |host| {
         var buf: [256]u8 = undefined;
         try assertHTTPError(
@@ -917,6 +919,16 @@ test "Client: http handshake host" {
             "Host not allowed",
             try std.fmt.bufPrint(&buf, with_host, .{host}),
         );
+    }
+
+    // `localhost:<port>` is hardwired to loopback by browsers, no DNS
+    // lookup involved, so it gets through like an IP literal.
+    {
+        var c = try createTestClient();
+        defer c.deinit();
+        var buf: [256]u8 = undefined;
+        const res = try c.httpRequest(try std.fmt.bufPrint(&buf, with_host, .{"localhost:9583"}));
+        try testing.expect(std.mem.startsWith(u8, res, "HTTP/1.1 101 Switching Protocols\r\n"));
     }
 }
 

--- a/src/cdp/Connection.zig
+++ b/src/cdp/Connection.zig
@@ -495,20 +495,27 @@ pub fn upgrade(self: *Connection, request: []u8) !void {
         } else if (std.ascii.eqlIgnoreCase(key, "host")) {
             const host = value;
             const is_allowed = blk: {
+                // allow literal localhost
+                if (std.mem.startsWith(u8, host, "localhost:")) {
+                    break :blk true;
+                }
+
                 _ = std.Io.net.IpAddress.parseLiteral(host) catch break :blk false;
                 break :blk true;
             };
 
             // Defense in depth against DNS rebinding: an IP literal is the only
             // thing that can legitimately reach us, because no name has to be
-            // resolved to produce one. Any name at all - "localhost" included -
-            // means something answered a DNS lookup with our address, which is
-            // exactly what a rebinding attack looks like. A request without a
-            // Host header isn't from a browser, so it can't be the vector.
+            // resolved to produce one. The one name we accept is
+            // `localhost:<port>`, which browsers hardwire to loopback without
+            // any DNS lookup. Any other name means something answered a DNS
+            // lookup with our address, which is exactly what a rebinding
+            // attack looks like. A request without a Host header isn't from a
+            // browser, so it can't be the vector.
             if (!is_allowed) {
                 log.warn(.cdp, "rejected websocket host", .{
                     .host = host[0..@min(host.len, 64)],
-                    .hint = "connect to the CDP endpoint by IP address",
+                    .hint = "connect to the CDP endpoint by IP address or localhost",
                 });
                 return error.ForbiddenHost;
             }

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -403,7 +403,7 @@ fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, reque
     // the head's string memory.
     const session_id = checkHeaders(arena, request) catch |err| switch (err) {
         error.ForbiddenOrigin => return request.respond("Origin not allowed\n", .{ .status = .forbidden, .keep_alive = false }),
-        error.ForbiddenHost => return request.respond("Host not allowed, connect to the MCP endpoint by IP address\n", .{ .status = .forbidden, .keep_alive = false }),
+        error.ForbiddenHost => return request.respond("Host not allowed, connect to the MCP endpoint by IP address or localhost\n", .{ .status = .forbidden, .keep_alive = false }),
         else => return err,
     };
     const keep_alive = request.head.keep_alive;
@@ -457,6 +457,11 @@ fn checkHeaders(arena: std.mem.Allocator, request: *std.http.Server.Request) !?[
             return error.ForbiddenOrigin;
         } else if (std.ascii.eqlIgnoreCase(key, "host")) {
             const is_allowed = blk: {
+                // allow literal localhost
+                if (std.mem.startsWith(u8, value, "localhost:")) {
+                    break :blk true;
+                }
+
                 _ = std.Io.net.IpAddress.parseLiteral(value) catch break :blk false;
                 break :blk true;
             };
@@ -464,7 +469,7 @@ fn checkHeaders(arena: std.mem.Allocator, request: *std.http.Server.Request) !?[
             if (!is_allowed) {
                 log.warn(.mcp, "rejected request host", .{
                     .host = value[0..@min(value.len, 64)],
-                    .hint = "connect to the MCP endpoint by IP address",
+                    .hint = "connect to the MCP endpoint by IP address or localhost",
                 });
                 return error.ForbiddenHost;
             }

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -395,9 +395,18 @@ fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, reque
         return request.respond("", .{ .status = .expectation_failed, .keep_alive = false });
     }
 
-    // Read the session header and keep_alive before the body reader
-    // invalidates the head's string memory.
-    const session_id = try sessionHeader(arena, request);
+    if (method == .POST and !isJsonContentType(request.head.content_type)) {
+        return request.respond("", .{ .status = .unsupported_media_type, .keep_alive = false });
+    }
+
+    // Read the headers and keep_alive before the body reader invalidates
+    // the head's string memory.
+    const session_id = checkHeaders(arena, request) catch |err| switch (err) {
+        error.ForbiddenOrigin, error.ForbiddenHost => {
+            return request.respond("", .{ .status = .forbidden, .keep_alive = false });
+        },
+        else => return err,
+    };
     const keep_alive = request.head.keep_alive;
 
     var body_buf: [8 * 1024]u8 = undefined;
@@ -431,15 +440,55 @@ fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, reque
     });
 }
 
-/// Duplicate the `Mcp-Session-Id` request header into `arena`, or null.
-fn sessionHeader(arena: std.mem.Allocator, request: *std.http.Server.Request) !?[]const u8 {
+/// One pass over the request headers: duplicate `Mcp-Session-Id` into
+/// `arena` (or null) and enforce the same browser-vector policy as the CDP
+/// handshake (see `cdp.Connection.upgrade`).
+fn checkHeaders(arena: std.mem.Allocator, request: *std.http.Server.Request) !?[]const u8 {
+    var session_id: ?[]const u8 = null;
     var it = request.iterateHeaders();
     while (it.next()) |header| {
-        if (std.ascii.eqlIgnoreCase(header.name, "mcp-session-id")) {
-            return try arena.dupe(u8, header.value);
+        const key = header.name;
+        const value = header.value;
+        if (std.ascii.eqlIgnoreCase(key, "mcp-session-id")) {
+            session_id = try arena.dupe(u8, value);
+        } else if (std.ascii.eqlIgnoreCase(key, "origin")) {
+            log.warn(.mcp, "rejected request origin", .{
+                .origin = value[0..@min(value.len, 64)],
+            });
+            return error.ForbiddenOrigin;
+        } else if (std.ascii.eqlIgnoreCase(key, "host")) {
+            const is_allowed = blk: {
+                _ = std.Io.net.IpAddress.parseLiteral(value) catch break :blk false;
+                break :blk true;
+            };
+
+            if (!is_allowed) {
+                log.warn(.mcp, "rejected request host", .{
+                    .host = value[0..@min(value.len, 64)],
+                    .hint = "connect to the MCP endpoint by IP address",
+                });
+                return error.ForbiddenHost;
+            }
         }
     }
-    return null;
+    return session_id;
+}
+
+/// `application/json`, case-insensitive, ignoring parameters (`; charset=`).
+fn isJsonContentType(content_type: ?[]const u8) bool {
+    const ct = content_type orelse return false;
+    const end = std.mem.indexOfScalar(u8, ct, ';') orelse ct.len;
+    const media_type = std.mem.trim(u8, ct[0..end], " \t");
+    return std.ascii.eqlIgnoreCase(media_type, "application/json");
+}
+
+test "HttpServer - content type must be application/json" {
+    try std.testing.expect(isJsonContentType("application/json"));
+    try std.testing.expect(isJsonContentType("Application/JSON; charset=utf-8"));
+    try std.testing.expect(isJsonContentType("application/json ;charset=utf-8"));
+    try std.testing.expect(!isJsonContentType("text/plain"));
+    try std.testing.expect(!isJsonContentType("application/x-www-form-urlencoded"));
+    try std.testing.expect(!isJsonContentType(null));
 }
 
 test "HttpServer - initialize is detected for session minting" {

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -402,9 +402,8 @@ fn serve(self: *HttpServer, out: *std.Io.Writer, arena: std.mem.Allocator, reque
     // Read the headers and keep_alive before the body reader invalidates
     // the head's string memory.
     const session_id = checkHeaders(arena, request) catch |err| switch (err) {
-        error.ForbiddenOrigin, error.ForbiddenHost => {
-            return request.respond("", .{ .status = .forbidden, .keep_alive = false });
-        },
+        error.ForbiddenOrigin => return request.respond("Origin not allowed\n", .{ .status = .forbidden, .keep_alive = false }),
+        error.ForbiddenHost => return request.respond("Host not allowed, connect to the MCP endpoint by IP address\n", .{ .status = .forbidden, .keep_alive = false }),
         else => return err,
     };
     const keep_alive = request.head.keep_alive;


### PR DESCRIPTION
Apply same conditions than CDP for MCP HTTP conns:
* refuse requests including Origin header
* accept only ip as host
* ensure content-type is json for POST