### PR TITLE
webapi: implement the HTMLElement.draggable IDL attribute

### DIFF
--- a/src/browser/tests/element/html/htmlelement-props.html
+++ b/src/browser/tests/element/html/htmlelement-props.html
@@ -82,3 +82,44 @@
     testing.expectEqual(-1, d3.tabIndex);
   }
 </script>
+
+<script id="draggable">
+  {
+    // Explicit keywords win, matched ASCII case-insensitively.
+    const d = document.createElement('div');
+    d.setAttribute('draggable', 'true');
+    testing.expectEqual(true, d.draggable);
+    d.setAttribute('draggable', 'TRUE');
+    testing.expectEqual(true, d.draggable);
+    d.setAttribute('draggable', 'false');
+    testing.expectEqual(false, d.draggable);
+
+    // Missing or invalid values are the auto state: false for most elements.
+    d.removeAttribute('draggable');
+    testing.expectEqual(false, d.draggable);
+    d.setAttribute('draggable', 'auto');
+    testing.expectEqual(false, d.draggable);
+    d.setAttribute('draggable', '');
+    testing.expectEqual(false, d.draggable);
+
+    // Auto defaults to true for <img> and <a> with an href.
+    const img = document.createElement('img');
+    testing.expectEqual(true, img.draggable);
+    img.setAttribute('draggable', 'false');
+    testing.expectEqual(false, img.draggable);
+
+    const a = document.createElement('a');
+    testing.expectEqual(false, a.draggable);
+    a.setAttribute('href', '/x');
+    testing.expectEqual(true, a.draggable);
+    a.setAttribute('draggable', 'false');
+    testing.expectEqual(false, a.draggable);
+
+    // The setter reflects to the content attribute as "true"/"false".
+    const s = document.createElement('div');
+    s.draggable = true;
+    testing.expectEqual('true', s.getAttribute('draggable'));
+    s.draggable = false;
+    testing.expectEqual('false', s.getAttribute('draggable'));
+  }
+</script>

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -471,6 +471,30 @@ pub fn setTranslate(self: *HtmlElement, translate: bool, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("translate"), .wrap(if (translate) "yes" else "no"), frame);
 }
 
+// The draggable IDL attribute reflects the enumerated content attribute:
+// "true" => true, "false" => false, anything else (or no attribute) is the
+// auto state, which defaults to true only for <img> and <a> with an href.
+// https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute
+pub fn getDraggable(self: *HtmlElement) bool {
+    if (self.asElement().getAttributeSafe(comptime .wrap("draggable"))) |value| {
+        if (std.ascii.eqlIgnoreCase(value, "true")) {
+            return true;
+        }
+        if (std.ascii.eqlIgnoreCase(value, "false")) {
+            return false;
+        }
+    }
+    return switch (self._type) {
+        .img => true,
+        .anchor => self.asElement().getAttributeSafe(comptime .wrap("href")) != null,
+        else => false,
+    };
+}
+
+pub fn setDraggable(self: *HtmlElement, draggable: bool, frame: *Frame) !void {
+    try self.asElement().setAttributeSafe(comptime .wrap("draggable"), .wrap(if (draggable) "true" else "false"), frame);
+}
+
 // accessKeyLabel: the UA-assigned shortcut for a valid (single character)
 // accesskey, or the empty string. We report an Alt+ chord like Chromium.
 pub fn getAccessKeyLabel(self: *HtmlElement, frame: *Frame) ![]const u8 {
@@ -1808,6 +1832,7 @@ pub const JsApi = struct {
     pub const accessKey = bridge.accessor(HtmlElement.getAccessKey, HtmlElement.setAccessKey, .{ .ce_reactions = true });
     pub const autofocus = bridge.accessor(HtmlElement.getAutofocus, HtmlElement.setAutofocus, .{ .ce_reactions = true });
     pub const dir = reflect.enumerated("dir", &.{ "ltr", "rtl", "auto" }, .{});
+    pub const draggable = bridge.accessor(HtmlElement.getDraggable, HtmlElement.setDraggable, .{ .ce_reactions = true });
     pub const hidden = bridge.accessor(HtmlElement.getHidden, HtmlElement.setHidden, .{ .ce_reactions = true });
     pub const translate = bridge.accessor(HtmlElement.getTranslate, HtmlElement.setTranslate, .{ .ce_reactions = true });
     pub const accessKeyLabel = bridge.accessor(HtmlElement.getAccessKeyLabel, null, .{});


### PR DESCRIPTION
## What

Implements the `HTMLElement.draggable` reflected IDL attribute. Before this, `el.draggable` read `undefined` for every element (even with an explicit `draggable="true"` content attribute), and assigning `el.draggable = true` created a plain JS own property without touching the content attribute — which breaks HTML5 drag-and-drop code that gates on the property (WebDriver-style drag-simulation scripts walk `while (source && !source.draggable) source = source.parentElement;` and fall off the tree; SortableJS assigns `dragEl.draggable = true` expecting attribute reflection).

Closes #3255.

## Root cause

`HTMLElement` never bound an accessor for `draggable`: only the attribute name was interned in `src/string.zig`. Property reads fell through to the prototype chain and returned `undefined`; property writes landed as expandos.

```mermaid
flowchart LR
    A[read el.draggable] --> B[no accessor on HTMLElement]
    B --> C[undefined]
    D[write el.draggable] --> B2[plain own property]
    B2 --> C2[attribute never written]
    style B fill:#fdd
    style C fill:#fdd
    style B2 fill:#fdd
    style C2 fill:#fdd
```

## Fix

Follows the existing `hidden`/`translate`/`tabIndex` reflection pattern in the same file, per [HTML Living Standard, the `draggable` attribute](https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute):

- `src/browser/webapi/element/Html.zig` — `getDraggable`: `"true"`/`"false"` keywords matched ASCII case-insensitively; anything else (or no attribute) is the *auto* state, which branches on `_type` like `getTabIndex` — `true` for `.img`, `true` for `.anchor` with an `href`, `false` otherwise.
- `src/browser/webapi/element/Html.zig` — `setDraggable`: writes the literal `"true"`/`"false"` onto the content attribute (the spec setter never removes it).
- `src/browser/webapi/element/Html.zig` — `draggable` bridge accessor registered next to `dir`/`hidden` with `.ce_reactions = true`, matching the sibling reflected attributes.

```mermaid
flowchart LR
    A[read el.draggable] --> B[getDraggable reflects the attribute]
    B --> C[true or false per spec]
    D[write el.draggable] --> B2[setDraggable writes the attribute]
    B2 --> C2[getAttribute returns true or false literal]
    style B fill:#dfd
    style C fill:#dfd
    style B2 fill:#dfd
    style C2 fill:#dfd
```

One deliberate deviation from the spec text: the spec also lists `object` elements *that represent images* under the auto-`true` default. Chrome doesn't implement that case (`HTMLObjectElement` takes the generic `false` default), so this matches Chrome — `img` and `a[href]` only.

## Test

- **Unit test**: new `draggable` block in `src/browser/tests/element/html/htmlelement-props.html` (runs under `WebApi: HTMLElement.props`) — covers both keywords, case-insensitive matching, the auto state on `<div>`/`<img>`/`<a>` with and without `href`, keyword-over-default precedence, and setter reflection in both directions. Fails on `main`, passes with this commit; verified by reverting `Html.zig` alone (0 of 1) and restoring (1 of 1).
- **Full suite**: `zig build test` — 1236/1236.
- **Reproducer**: the `repro.sh` from #3255 exits 1 on nightly 8688 (eight FAIL lines) and exits 0 against this branch's build (eight PASS lines).

## Notes

Scope is the reflected property only — the `DataTransfer`/`DragEvent` machinery from #2671 is untouched, and no drag *behavior* is implied by the property (same as any headless context).
