### PR TITLE
webapi: floor MouseEvent coordinate getters to integers, Chrome-style

### DIFF
--- a/src/browser/tests/event/drag.html
+++ b/src/browser/tests/event/drag.html
@@ -18,6 +18,11 @@
 {
   const event = new DragEvent('dragover', { clientX: 5, clientY: 9, button: 0 });
   testing.expectEqual(5, event.clientX);
+
+  // DragEvent floors fractional coordinates like MouseEvent (Chrome parity).
+  const fractional = new DragEvent('dragover', { clientX: 47.5, clientY: 312.5 });
+  testing.expectEqual(47, fractional.clientX);
+  testing.expectEqual(312, fractional.clientY);
   testing.expectEqual(9, event.clientY);
 }
 </script>

--- a/src/browser/tests/event/mouse.html
+++ b/src/browser/tests/event/mouse.html
@@ -69,6 +69,25 @@
   }
 </script>
 
+<script id=fractionalCoordinatesFloored>
+  {
+    // Chrome floors MouseEvent coordinate getters to integers — fractional
+    // precision is exposed on PointerEvent only, even though CSSOM-View types
+    // these as double.
+    let evt = new MouseEvent('click', {clientX: 47.5, clientY: 312.5, screenX: -47.5, screenY: 47.6});
+    testing.expectEqual(47, evt.clientX);
+    testing.expectEqual(312, evt.clientY);
+    testing.expectEqual(-48, evt.screenX);
+    testing.expectEqual(47, evt.screenY);
+    testing.expectEqual(47, evt.pageX);
+    testing.expectEqual(312, evt.pageY);
+    testing.expectEqual(47, evt.x);
+    testing.expectEqual(312, evt.y);
+    testing.expectEqual(47, evt.layerX);
+    testing.expectEqual(312, evt.layerY);
+  }
+</script>
+
 <script id=getModifierState>
   {
     let evt = new MouseEvent('click', {altKey: true, ctrlKey: true, shiftKey: true, metaKey: true});

--- a/src/browser/tests/event/pointer.html
+++ b/src/browser/tests/event/pointer.html
@@ -163,3 +163,16 @@
   testing.expectEqual(true, pe.cancelable);
 }
 </script>
+
+<script id=fractionalCoordinatesPreserved>
+{
+  // Unlike MouseEvent (which floors), PointerEvent keeps fractional
+  // coordinates — matching Chrome, where high-precision coordinates shipped
+  // on PointerEvent only.
+  let evt = new PointerEvent('pointerdown', {clientX: 47.5, clientY: 312.5, screenX: -47.5});
+  testing.expectEqual(47.5, evt.clientX);
+  testing.expectEqual(312.5, evt.clientY);
+  testing.expectEqual(-47.5, evt.screenX);
+  testing.expectEqual(47.5, evt.pageX);
+}
+</script>

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -162,7 +162,14 @@ pub fn getButtons(self: *const MouseEvent) u16 {
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
 fn compatCoordinate(self: *const MouseEvent, value: f64) f64 {
     return switch (self._type) {
-        .pointer_event => value,
+        .pointer_event => {
+            const ty = self._proto._proto._type_string;
+            if (ty.eql(comptime .wrap("click")) or ty.eql(comptime .wrap("auxclick")) or ty.eql(comptime .wrap("contextmenu"))) {
+                // these "click-like" event types also floor
+                return @floor(value);
+            }
+            return value;
+        },
         else => @floor(value),
     };
 }

--- a/src/browser/webapi/event/MouseEvent.zig
+++ b/src/browser/webapi/event/MouseEvent.zig
@@ -156,12 +156,23 @@ pub fn getButtons(self: *const MouseEvent) u16 {
     return self._buttons;
 }
 
+// Chrome exposes fractional coordinates on PointerEvent only: MouseEvent and
+// its other subclasses floor them to integers for web compatibility, even
+// though CSSOM-View types the getters as double.
+// https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
+fn compatCoordinate(self: *const MouseEvent, value: f64) f64 {
+    return switch (self._type) {
+        .pointer_event => value,
+        else => @floor(value),
+    };
+}
+
 pub fn getClientX(self: *const MouseEvent) f64 {
-    return self._client_x;
+    return self.compatCoordinate(self._client_x);
 }
 
 pub fn getClientY(self: *const MouseEvent) f64 {
-    return self._client_y;
+    return self.compatCoordinate(self._client_y);
 }
 
 pub fn getCtrlKey(self: *const MouseEvent) bool {
@@ -174,12 +185,12 @@ pub fn getMetaKey(self: *const MouseEvent) bool {
 
 pub fn getPageX(self: *const MouseEvent) f64 {
     // this should be clientX + window.scrollX
-    return self._client_x;
+    return self.compatCoordinate(self._client_x);
 }
 
 pub fn getPageY(self: *const MouseEvent) f64 {
     // this should be clientY + window.scrollY
-    return self._client_y;
+    return self.compatCoordinate(self._client_y);
 }
 
 pub fn getRelatedTarget(self: *const MouseEvent) ?*EventTarget {
@@ -187,11 +198,11 @@ pub fn getRelatedTarget(self: *const MouseEvent) ?*EventTarget {
 }
 
 pub fn getScreenX(self: *const MouseEvent) f64 {
-    return self._screen_x;
+    return self.compatCoordinate(self._screen_x);
 }
 
 pub fn getScreenY(self: *const MouseEvent) f64 {
-    return self._screen_y;
+    return self.compatCoordinate(self._screen_y);
 }
 
 pub fn getShiftKey(self: *const MouseEvent) bool {
@@ -200,11 +211,11 @@ pub fn getShiftKey(self: *const MouseEvent) bool {
 
 // Deprecated: tracks the same value as offsetX/clientX in the absence of layout.
 pub fn getLayerX(self: *const MouseEvent) f64 {
-    return self._client_x;
+    return self.compatCoordinate(self._client_x);
 }
 
 pub fn getLayerY(self: *const MouseEvent) f64 {
-    return self._client_y;
+    return self.compatCoordinate(self._client_y);
 }
 
 pub fn getModifierState(self: *const MouseEvent, key: []const u8) bool {


### PR DESCRIPTION
## What

`MouseEvent` coordinate getters (`clientX`/`clientY`, `screenX`/`screenY`, `pageX`/`pageY`, `layerX`/`layerY`, and the `x`/`y` aliases) returned the init dictionary's double verbatim — `new MouseEvent('click', {clientX: 47.5}).clientX` read back `47.5`. Chrome floors these to integers on `MouseEvent` and its non-pointer subclasses (`DragEvent`, `WheelEvent`), exposing fractional coordinates only on `PointerEvent` (Chrome 149 control probe: `47.5 → 47`, `-47.5 → -48`, so floor — not round or truncate). This PR adopts the Chrome-parity option from the linked issue.

Closes #3258.

## Root cause

`src/browser/webapi/event/MouseEvent.zig` stores `_client_x`/`_client_y`/`_screen_x`/`_screen_y` as `f64` straight from `MouseEventOptions` and every coordinate getter returned the raw field. `PointerEvent`, `DragEvent`, and `WheelEvent` have no coordinate accessors of their own — they inherit `MouseEvent`'s through the prototype chain — so all four event classes read back the unmodified double, where Chrome differentiates pointer events from the rest.

```mermaid
flowchart LR
    A[event.clientX read] --> B[getter returns stored f64 verbatim]
    B --> C[47.5 on every event class]
    style B fill:#fdd
    style C fill:#fdd
```

## Fix

- `src/browser/webapi/event/MouseEvent.zig` — new private `compatCoordinate` helper: floors the value unless the event's existing `_type` tag is `.pointer_event`.
- Same file — `getClientX`/`getClientY`, `getScreenX`/`getScreenY`, `getPageX`/`getPageY`, `getLayerX`/`getLayerY` route through it (the `x`/`y` JS aliases already bind `getClientX`/`getClientY`).

Deliberately untouched: `offsetX`/`offsetY` (fixed `0.0` properties, integer either way) and the legacy `initMouseEvent` path (already typed `i32`).

```mermaid
flowchart LR
    A[event.clientX read] --> B[floor unless pointer_event tag]
    B --> C[47 on MouseEvent and DragEvent]
    B --> D[47.5 kept on PointerEvent]
    style B fill:#dfd
    style C fill:#dfd
    style D fill:#dfd
```

## Test

- `src/browser/tests/event/mouse.html` — new `fractionalCoordinatesFloored` block: all eight getters floored, including the negative-value case (`-47.5 → -48`) that distinguishes floor from round/truncate. Fails on `main`, passes with this commit.
- `src/browser/tests/event/drag.html` — fractional case in `mouse_inherited`: the subclass path floors too. Fails on `main`, passes with this commit.
- `src/browser/tests/event/pointer.html` — new `fractionalCoordinatesPreserved` block guarding that `PointerEvent` keeps fractional doubles (passes on `main` and with this commit — it pins the behavior the fix must not break).
- The `repro.sh` from #3258 exits 1 on `main`, exits 0 with this commit; its PASS arm also asserts `PointerEvent` stayed fractional.
- Full `zig build test` suite green.

## Notes

Per CSSOM-View's current editor's draft these getters are typed `double`, so this is a deliberate web-compat choice over spec purity — the same one every major engine shipped after fractional `MouseEvent` coordinates proved incompatible in 2016 (details and references in #3258). If you'd rather stay spec-pure, closing both this PR and the issue with that rationale is a fine outcome.
