### PR TITLE
stability: drop async module completions after termination

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1809,12 +1809,17 @@ fn frameErrorCallback(ctx: *anyopaque, err: anyerror) void {
         return;
     };
 }
+
 pub fn isGoingAway(self: *const Frame) bool {
+    return self.js.env.terminatePending() or self.hasQueuedNavigation();
+}
+
+fn hasQueuedNavigation(self: *const Frame) bool {
     if (self._queued_navigation != null) {
         return true;
     }
     const parent = self.parent orelse return false;
-    return parent.isGoingAway();
+    return parent.hasQueuedNavigation();
 }
 
 pub fn scriptAddedCallback(self: *Frame, comptime from_parser: bool, script: *Element.Html.Script) !void {
@@ -3754,4 +3759,56 @@ test "Frame: 401" {
     defer buf.deinit();
     try @import("dump.zig").root(frame.document, .{}, &buf.writer, frame);
     try testing.expectEqual("<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head><body><pre>No</pre></body></html>", buf.written());
+}
+
+test "Frame: scriptAddedCallback does not run a module when termination is pending" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    // An inline module: classic scripts are already refused by js.Script.run,
+    // modules go through Module.evaluate which has no gate of its own.
+    const element = try frame.document.createElement("script", null, frame);
+    try element.setAttribute(comptime .wrap("type"), comptime .wrap("module"), frame);
+    try element.asNode().setTextContent("globalThis.__terminated_inline_ran = true", frame);
+
+    // Parsing is over, so the inline module is evaluated on insertion rather
+    // than queued behind the static scripts.
+    frame._script_manager.base.static_scripts_done = true;
+
+    // The sticky terminate is set but V8's own state was consumed by the
+    // JSEntry unwind of whatever the terminate landed in.
+    const env = frame.js.env;
+    env.terminate();
+    JS.v8.v8__Isolate__CancelTerminateExecution(env.isolate.handle);
+
+    try frame.scriptAddedCallback(false, element.as(HtmlElement.Script));
+    env.cancelTerminate();
+
+    var ls: JS.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    try testing.expectEqual(false, (try ls.local.exec("globalThis.__terminated_inline_ran === true", null)).toBool());
+}
+
+test "Frame: iframeAddedCallback does not create a frame when termination is pending" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    const session = frame._session;
+    const subframe_loading_enabled = session.subframe_loading_enabled;
+    session.subframe_loading_enabled = true;
+    defer session.subframe_loading_enabled = subframe_loading_enabled;
+
+    const element = try frame.document.createElement("iframe", null, frame);
+    const iframe = element.as(HtmlElement.IFrame);
+
+    const env = frame.js.env;
+    const contexts_before = env.contexts.items.len;
+    env.terminate();
+    JS.v8.v8__Isolate__CancelTerminateExecution(env.isolate.handle);
+    defer env.cancelTerminate();
+
+    try frame.iframeAddedCallback(iframe);
+    try testing.expectEqual(contexts_before, env.contexts.items.len);
+    try testing.expectEqual(false, iframe._executed);
 }

--- a/src/browser/ScriptManagerBase.zig
+++ b/src/browser/ScriptManagerBase.zig
@@ -1153,3 +1153,48 @@ test "ScriptManagerBase: waitForImport stops when teardown is pending" {
 
     try testing.expectError(error.SyncWaitInterrupted, sm.waitForImport(url));
 }
+
+test "ScriptManagerBase: evaluate drops a ready async module when termination is pending" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    const sm = &frame._script_manager.base;
+    const element = try frame.document.createElement("script", null, frame);
+
+    // A fetched <script type=module async> sitting in ready_scripts:
+    // doneCallback moved it there and this tick's drain is about to evaluate
+    // it. Classic scripts are already refused by js.Script.run; modules go
+    // through Module.evaluate, which has no gate of its own.
+    const arena = try sm.acquireArena(.small, "test.terminated_async");
+    const script = try arena.create(Script);
+    script.* = .{
+        .arena = arena,
+        .url = "http://127.0.0.1:9582/late-async.js",
+        .node = .{},
+        .manager = sm,
+        .complete = true,
+        .status = 200,
+        .source = .{ .@"inline" = "globalThis.__late_async_ran = true" },
+        .extra = .{ .frame = .{
+            .kind = .module,
+            .mode = .async,
+            .frame = frame,
+            .script_element = element.as(Element.Html.Script),
+        } },
+    };
+    sm.ready_scripts.append(&script.node);
+
+    // The sticky terminate is set but V8's own state was consumed by the
+    // JSEntry unwind of whatever the terminate landed in.
+    const env = frame.js.env;
+    env.terminate();
+    js.v8.v8__Isolate__CancelTerminateExecution(env.isolate.handle);
+
+    sm.evaluate();
+    env.cancelTerminate();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    try testing.expectEqual(false, (try ls.local.exec("globalThis.__late_async_ran === true", null)).toBool());
+}

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -912,6 +912,12 @@ fn dynamicModuleSourceCallback(ctx: *anyopaque, module_source_: anyerror!ScriptM
     const state: *DynamicModuleResolveState = @ptrCast(@alignCast(ctx));
     var self = state.context;
 
+    if (self.env.terminatePending()) {
+        var module_source = module_source_ catch return;
+        module_source.deinit();
+        return;
+    }
+
     var ls: js.Local.Scope = undefined;
     self.localScope(&ls);
     defer ls.deinit();
@@ -1022,6 +1028,39 @@ fn resolveDynamicModule(self: *Context, state: *DynamicModuleResolveState, modul
         });
         _ = local.toLocal(state.resolver).reject("module promise", local.newString("Failed to evaluate promise"));
     };
+}
+
+const testing = @import("../../testing.zig");
+test "Context: terminated async module completion does not re-enter V8" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const resolver = local.createPromiseResolver();
+    const promise = resolver.promise();
+    const resolver_global = try resolver.persist();
+    defer resolver_global.deinit();
+
+    var state = DynamicModuleResolveState{
+        .module = null,
+        .context_id = frame.js.id,
+        .context = frame.js,
+        .specifier = "https://example.com/late-module.js",
+        .resolver = resolver_global,
+    };
+
+    const env = frame.js.env;
+    env.terminate();
+    js.v8.v8__Isolate__CancelTerminateExecution(env.isolate.handle);
+    defer env.cancelTerminate();
+
+    dynamicModuleSourceCallback(&state, error.Abort);
+
+    try testing.expectEqual(js.Promise.State.pending, promise.state());
 }
 
 // Used to make temporarily enter and exit a context, updating and restoring


### PR DESCRIPTION
## Summary

Do not let an async `import()` source completion re-enter V8 after the watchdog or another caller has requested termination. A successful late source is released without compilation; an error completion is ignored because the browser is already tearing down.

## Root cause

The sticky `terminate_requested` gate added around JS functions, scripts, and microtask checkpoints does not cover `dynamicModuleSourceCallback`. If an async module fetch completes while the CDP tick is unwinding a terminated page, this callback opens a V8 scope and can compile/evaluate the module or settle its resolver before `CDP.tick` observes the pending termination and closes the connection.

A deterministic fixture demonstrates the ordering on current `main`:

```
watchdog stall
MutObserver.deliverRecords err=ExecutionTerminated
frame.deliverMutations err=ExecutionTerminated
console.log ASYNC_MODULE_EVALUATED
closing connection reason="pending terminate"
```

That violates the termination invariant directly. It also matches a production crash where pending async module transfers completed after the mutation-delivery termination and V8 then failed its module-evaluation status check.

With this patch, the same fixture retains the watchdog/termination/close sequence but never evaluates the late module.

## Test

The regression test leaves the sticky termination request set while clearing only V8's consumed termination state, then delivers a late async-module error. Before the fix, the callback re-enters V8 and rejects the resolver (`expected .pending, found .rejected`). With the fix, it leaves the resolver untouched.

- `zig build ... test -freference-trace` — 1237/1237
- `zig fmt --check ./*.zig ./**/*.zig`
- CDP fixture: 5/5 termination cycles; zero post-termination module evaluations (10/10 before the fix)
