### PR TITLE
mcp: make logfmt a Config default instead of an override

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -663,7 +663,10 @@ fn stderrIsTty() bool {
 
 pub fn logFormat(self: *const Config) ?log.Format {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.log_format,
+        // The MCP host captures stderr into a log file, where pretty's ANSI
+        // escapes and multi-line entries are noise.
+        .mcp => |opts| opts.log_format orelse .logfmt,
+        inline .serve, .fetch, .agent => |opts| opts.log_format,
         else => unreachable,
     };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,8 +202,6 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
         .mcp => |opts| {
             log.info(.mcp, "starting server", .{});
 
-            log.opts.format = .logfmt;
-
             // --port serves MCP over HTTP instead of stdio. It and --cdp-port
             // each run their accept loop on this thread, so they can't combine.
             if (opts.port) |port| {


### PR DESCRIPTION
MCP mode unconditionally set `log.opts.format = .logfmt` in `main.zig` *after* the `--log_format` flag had already been applied, so `--log_format pretty` was silently ignored. It also ran after the `"starting server"` log line, which therefore came out in the pre-override format in debug builds.

This moves it into `Config.logFormat()` as a mode-aware default, mirroring what `logLevel()` already does for agent mode: `null` → `logfmt` for `mcp`, an explicit flag wins. The rationale for the default is unchanged — the MCP host captures stderr into a log file, where `pretty`'s ANSI escapes and multi-line entries are noise. Release builds already default to logfmt, so this only changes debug-build behaviour.

The docs for `lightpanda mcp --log_format` already say "Defaults to logfmt", so no doc change.

Verified: `lightpanda mcp --log_format pretty --port N` now emits pretty output; `lightpanda mcp --port N` still emits logfmt; `make test F="Config"` passes; `zig fmt --check` clean.