### PR TITLE
webdriver: Improve WebDriver keyboard handling

### DIFF
--- a/src/browser/EventManager.zig
+++ b/src/browser/EventManager.zig
@@ -231,6 +231,10 @@ fn dispatchNode(self: *EventManager, target: *Node, event: *Event) !void {
             Frame.user_input.handleKeydown(frame, target, event) catch |err| {
                 log.warn(.event, "frame.keydown", .{ .err = err });
             };
+        } else if (event._type_string.eql(comptime .wrap("keyup"))) {
+            Frame.user_input.handleKeyup(frame, target, event) catch |err| {
+                log.warn(.event, "frame.keyup", .{ .err = err });
+            };
         }
     }
 

--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -27,6 +27,7 @@ const Factory = @import("Factory.zig");
 const Viewport = @import("Viewport.zig");
 
 const Blob = @import("webapi/Blob.zig");
+const WebDriver = @import("webapi/WebDriver.zig");
 const SharedWorkerGlobalScope = @import("webapi/SharedWorkerGlobalScope.zig");
 
 const Allocator = std.mem.Allocator;
@@ -110,6 +111,8 @@ queued_queued_navigation: std.ArrayList(*Frame) = .empty,
 
 // The root Frame of this Page. Non-optional — a Page always has a root frame.
 frame: Frame,
+
+input_modifiers: if (lp.build_config.wpt_extensions) WebDriver.Modifiers else struct {} = .{},
 
 // Popup Frames opened by window.open. They are top-level browsing contexts
 // (parent == null, no iframe element) but share this Page's factory, arena,

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -34,6 +34,7 @@ const Element = @import("../webapi/Element.zig");
 const TreeWalker = @import("../webapi/TreeWalker.zig");
 const MouseEvent = @import("../webapi/event/MouseEvent.zig");
 const WheelEvent = @import("../webapi/event/WheelEvent.zig");
+const PointerEvent = @import("../webapi/event/PointerEvent.zig");
 const KeyboardEvent = @import("../webapi/event/KeyboardEvent.zig");
 
 const log = lp.log;
@@ -482,6 +483,25 @@ pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
         return moveFocus(frame, keyboard_event.getShiftKey() == false);
     }
 
+    if (event.getIsTrusted()) {
+        if ((key.isPrintable() or key == .Enter) and keyboard_event.getCtrlKey() == false and keyboard_event.getMetaKey() == false) {
+            // Fire a keypress for a printable (or Enter) keydown when ctrl/meta
+            // aren't pressed
+            if (try dispatchKeypress(frame, target, keyboard_event)) {
+                return;
+            }
+        }
+
+        if (key == .Enter) {
+            if (target.is(Element)) |element| {
+                if (enterActivates(element)) {
+                    // Enter generates a button-like "click" for  some elements
+                    return dispatchKeyboardClick(frame, element);
+                }
+            }
+        }
+    }
+
     if (target.is(Element.Html.Input)) |input| {
         if (key == .Enter) {
             return frame.submitForm(input.asElement(), input.getForm(frame), .{});
@@ -510,6 +530,91 @@ pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
         // zig fmt: on
         return textarea.innerInsert(append, frame);
     }
+}
+
+pub fn handleKeyup(frame: *Frame, target: *Node, event: *Event) !void {
+    if (event.getIsTrusted() == false) {
+        return;
+    }
+    const keyboard_event = event.is(KeyboardEvent) orelse return;
+    const key = keyboard_event.getKey();
+
+    if (key.isPrintable() == false or std.mem.eql(u8, key.asString(), " ") == false) {
+        return;
+    }
+    const element = target.is(Element) orelse return;
+    if (spaceActivates(element)) {
+        // on keyup, for a trusted event and on specific element types, space
+        // triggers a click-like event
+        return dispatchKeyboardClick(frame, element);
+    }
+}
+
+// Dispatch keypress mirroring `keydown`'s key and modifiers; returns true when
+// a listener canceled it.
+fn dispatchKeypress(frame: *Frame, target: *Node, keydown: *KeyboardEvent) !bool {
+    const event = (try KeyboardEvent.initTrusted(comptime .wrap("keypress"), .{
+        .bubbles = true,
+        .cancelable = true,
+        .composed = true,
+        .key = keydown.getKey().asString(),
+        .ctrlKey = keydown.getCtrlKey(),
+        .shiftKey = keydown.getShiftKey(),
+        .altKey = keydown.getAltKey(),
+        .metaKey = keydown.getMetaKey(),
+    }, frame)).asEvent();
+
+    // Keep the event alive past dispatch so we can read _prevent_default.
+    event.acquireRef();
+    defer _ = event.releaseRef(frame._page);
+
+    try frame._event_manager.dispatch(target.asEventTarget(), event);
+    return event._prevent_default;
+}
+
+// keydown+enter or keyup+space trigger this syntthetic pointer event (under
+// specific conditions, see handleKeydown and handleKeyup).
+fn dispatchKeyboardClick(frame: *Frame, element: *Element) !void {
+    const event = try PointerEvent.initTrusted("click", .{
+        .bubbles = true,
+        .cancelable = true,
+        .composed = true,
+        .pointerId = -1,
+    }, frame);
+    try frame._event_manager.dispatch(element.asEventTarget(), event.asEvent());
+}
+
+// elements where enter on a keydown should dispatch a click-click event
+fn enterActivates(element: *Element) bool {
+    const html_element = element.is(Element.Html) orelse return false;
+    if (html_element._type == .button) {
+        return true;
+    }
+    if (html_element._type == .anchor) {
+        return element.getAttributeSafe(comptime .wrap("href")) != null;
+    }
+    if (element.is(Element.Html.Input)) |input| {
+        return switch (input._input_type) {
+            .button, .submit, .reset, .image => true,
+            else => false,
+        };
+    }
+    return false;
+}
+
+// elements where space on a keyup should dispatch a click-click event
+fn spaceActivates(element: *Element) bool {
+    const html_element = element.is(Element.Html) orelse return false;
+    if (html_element._type == .button) {
+        return true;
+    }
+    if (element.is(Element.Html.Input)) |input| {
+        return switch (input._input_type) {
+            .button, .submit, .reset, .image, .checkbox, .radio => true,
+            else => false,
+        };
+    }
+    return false;
 }
 
 // Sequential focus navigation: move `document.activeElement` to the next (Tab)

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -386,34 +386,134 @@ fn performKeySource(source: js.Object, frame: *Frame) !void {
     if (!actions_val.isArray()) return;
     const actions = actions_val.toArray();
 
-    // Key actions have no explicit target; they go to the focused element, or
-    // the document if nothing is focused.
-    const target = if (frame.document._active_element) |el|
-        el.asEventTarget()
-    else
-        frame.document.asNode().asEventTarget();
-
     for (0..actions.len()) |i| {
         const action_val = try actions.get(@intCast(i));
         if (!action_val.isObject()) continue;
         const action = action_val.toObject();
         const action_type = (try action.get("type")).toSSO(false) catch continue;
 
-        const key = (try action.get("value")).toStringSlice() catch "";
-        if (action_type.eql(comptime .wrap("keyDown"))) {
-            dispatchKey(target, comptime .wrap("keydown"), key, frame);
-        } else if (action_type.eql(comptime .wrap("keyUp"))) {
-            dispatchKey(target, comptime .wrap("keyup"), key, frame);
+        const is_down = action_type.eql(comptime .wrap("keyDown"));
+        if (!is_down and action_type.eql(comptime .wrap("keyUp")) == false) {
+            continue;
         }
+
+        const key = webdriverKey((try action.get("value")).toStringSlice() catch "");
+
+        // A modifier's own keydown already carries its flag; its keyup no
+        // longer does.
+        setModifier(&frame._page.input_modifiers, key, is_down);
+
+        // Key actions have no explicit target; they go to the focused element,
+        // or the document if nothing is focused. Resolved per action since a
+        // key's default action can move focus.
+        const target = if (frame.document._active_element) |el|
+            el.asEventTarget()
+        else
+            frame.document.asNode().asEventTarget();
+
+        dispatchKey(target, if (is_down) comptime .wrap("keydown") else comptime .wrap("keyup"), key, frame);
+    }
+}
+
+// WebDriver's normalized-key PUA codepoints to KeyboardEvent.key values
+// (https://w3c.github.io/webdriver/#keyboard-actions). Any other value is the
+// key itself. The U+E050-U+E053 right-hand variants map to the same key name,
+// only the (untracked) location differs.
+fn webdriverKey(value: []const u8) []const u8 {
+    // The U+E000-U+E05D PUA range always encodes as three UTF-8 bytes.
+    if (value.len != 3) {
+        return value;
+    }
+    const cp = std.unicode.utf8Decode(value) catch return value;
+    return switch (cp) {
+        0xE000 => "Unidentified",
+        0xE001 => "Cancel",
+        0xE002 => "Help",
+        0xE003 => "Backspace",
+        0xE004 => "Tab",
+        0xE005 => "Clear",
+        0xE006, 0xE007 => "Enter",
+        0xE008, 0xE050 => "Shift",
+        0xE009, 0xE051 => "Control",
+        0xE00A, 0xE052 => "Alt",
+        0xE00B => "Pause",
+        0xE00C => "Escape",
+        0xE00D => " ",
+        0xE00E => "PageUp",
+        0xE00F => "PageDown",
+        0xE010 => "End",
+        0xE011 => "Home",
+        0xE012 => "ArrowLeft",
+        0xE013 => "ArrowUp",
+        0xE014 => "ArrowRight",
+        0xE015 => "ArrowDown",
+        0xE016 => "Insert",
+        0xE017 => "Delete",
+        0xE018 => ";",
+        0xE019 => "=",
+        0xE01A => "0",
+        0xE01B => "1",
+        0xE01C => "2",
+        0xE01D => "3",
+        0xE01E => "4",
+        0xE01F => "5",
+        0xE020 => "6",
+        0xE021 => "7",
+        0xE022 => "8",
+        0xE023 => "9",
+        0xE024 => "*",
+        0xE025 => "+",
+        0xE026 => ",",
+        0xE027 => "-",
+        0xE028 => ".",
+        0xE029 => "/",
+        0xE031 => "F1",
+        0xE032 => "F2",
+        0xE033 => "F3",
+        0xE034 => "F4",
+        0xE035 => "F5",
+        0xE036 => "F6",
+        0xE037 => "F7",
+        0xE038 => "F8",
+        0xE039 => "F9",
+        0xE03A => "F10",
+        0xE03B => "F11",
+        0xE03C => "F12",
+        0xE03D, 0xE053 => "Meta",
+        else => value,
+    };
+}
+
+pub const Modifiers = struct {
+    ctrl: bool = false,
+    shift: bool = false,
+    alt: bool = false,
+    meta: bool = false,
+};
+
+fn setModifier(modifiers: *Modifiers, key: []const u8, pressed: bool) void {
+    if (std.mem.eql(u8, key, "Shift")) {
+        modifiers.shift = pressed;
+    } else if (std.mem.eql(u8, key, "Control")) {
+        modifiers.ctrl = pressed;
+    } else if (std.mem.eql(u8, key, "Alt")) {
+        modifiers.alt = pressed;
+    } else if (std.mem.eql(u8, key, "Meta")) {
+        modifiers.meta = pressed;
     }
 }
 
 fn dispatchKey(target: *EventTarget, typ: lp.String, key: []const u8, frame: *Frame) void {
+    const modifiers = frame._page.input_modifiers;
     const event = KeyboardEvent.initTrusted(typ, .{
         .bubbles = true,
         .cancelable = true,
         .composed = true,
         .key = key,
+        .ctrlKey = modifiers.ctrl,
+        .shiftKey = modifiers.shift,
+        .altKey = modifiers.alt,
+        .metaKey = modifiers.meta,
     }, frame) catch |err| {
         log.warn(.app, "webdriver key event", .{ .err = err });
         return;
@@ -430,6 +530,7 @@ fn readI32(obj: js.Object, key: []const u8, default: i32) i32 {
 }
 
 fn dispatchPointer(el: *Element, comptime typ: []const u8, button: i32, buttons: u16, frame: *Frame) void {
+    const modifiers = frame._page.input_modifiers;
     const event = PointerEvent.initTrusted(typ, .{
         .bubbles = true,
         .cancelable = true,
@@ -439,6 +540,10 @@ fn dispatchPointer(el: *Element, comptime typ: []const u8, button: i32, buttons:
         .pointerId = 1,
         .pointerType = "mouse",
         .isPrimary = true,
+        .ctrlKey = modifiers.ctrl,
+        .shiftKey = modifiers.shift,
+        .altKey = modifiers.alt,
+        .metaKey = modifiers.meta,
     }, frame) catch |err| {
         log.warn(.app, "webdriver pointer event", .{ .err = err, .type = typ });
         return;
@@ -447,6 +552,7 @@ fn dispatchPointer(el: *Element, comptime typ: []const u8, button: i32, buttons:
 }
 
 fn dispatchMouse(el: *Element, comptime typ: []const u8, button: i32, buttons: u16, detail: u32, frame: *Frame) void {
+    const modifiers = frame._page.input_modifiers;
     const event = MouseEvent.initTrusted(comptime .wrap(typ), .{
         .bubbles = true,
         .cancelable = true,
@@ -454,6 +560,10 @@ fn dispatchMouse(el: *Element, comptime typ: []const u8, button: i32, buttons: u
         .button = button,
         .buttons = buttons,
         .detail = detail,
+        .ctrlKey = modifiers.ctrl,
+        .shiftKey = modifiers.shift,
+        .altKey = modifiers.alt,
+        .metaKey = modifiers.meta,
     }, frame) catch |err| {
         log.warn(.app, "webdriver mouse event", .{ .err = err, .type = typ });
         return;


### PR DESCRIPTION
Normalize key codepoints for the "Private Use Areas" keyboard.

Page holds a `input_modifiers` map so that multiple action sequence preserve modifier keep states (this is only active with -Dwpt_extensions).

We now generate a keypress and synthentic click on specific keyboard events. E.g. A trusted "enter" on keydown where the target is an anchor.

Improves various /uievents/ WPT cases.