### PR TITLE
network: per-host pressure in the navigation rate limiter

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -309,7 +309,7 @@ jobs:
           fi
 
           mkdir -p $CG_ROOT/$CG
-          cgexec -g memory:$CG ./lightpanda serve --protocol cdp --insecure-disable-tls-host-verification & echo $! > LPD.pid
+          cgexec -g memory:$CG ./lightpanda serve --http-nav-delay 0 --protocol cdp --insecure-disable-tls-host-verification & echo $! > LPD.pid
 
           sleep 2
 

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -642,12 +642,21 @@ pub fn httpMaxHostOpen(self: *const Config) u8 {
     };
 }
 
-pub fn httpNavDelay(self: *const Config) ?u32 {
+pub const HttpNavDelay = union(enum) {
+    // --http-nav-delay 0: no rate limiting
+    off,
+    // no --http-nav-delay: dynamic spacing, grows with the host's load
+    adaptive,
+    // --http-nav-delay N: exact spacing asked by the user
+    fixed: u32,
+};
+
+pub fn httpNavDelay(self: *const Config) HttpNavDelay {
     const ms = switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_nav_delay,
         else => unreachable,
-    } orelse return null;
-    return if (ms == 0) null else ms;
+    } orelse return .adaptive;
+    return if (ms == 0) .off else .{ .fixed = ms };
 }
 
 pub fn httpNavBurst(self: *const Config) u32 {
@@ -1226,6 +1235,31 @@ test "Config: adblockLists splits comma-separated paths" {
     try std.testing.expectEqualStrings("easylist.txt", paths.next().?);
     try std.testing.expectEqualStrings("easyprivacy.txt", paths.next().?);
     try std.testing.expectEqual(null, paths.next());
+}
+
+test "Config: httpNavDelay modes" {
+    // unset: adaptive rate limit by default
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{} });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(.adaptive, config.httpNavDelay());
+    }
+    // 0: no rate limit
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .http_nav_delay = 0,
+        } });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(.off, config.httpNavDelay());
+    }
+    // explicit value: fixed rate limit
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .http_nav_delay = 250,
+        } });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(HttpNavDelay{ .fixed = 250 }, config.httpNavDelay());
+    }
 }
 
 test "Config: blockedUrlPatterns splits comma-separated patterns" {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -659,11 +659,15 @@ pub fn httpNavDelay(self: *const Config) HttpNavDelay {
     return if (ms == 0) .off else .{ .fixed = ms };
 }
 
+// Navigations an idle host absorbs before the rate limiter spaces them. A
+// short job never reaches it, so the limiter stays invisible to it.
+pub const DEFAULT_NAV_BURST: u32 = 10;
+
 pub fn httpNavBurst(self: *const Config) u32 {
     const burst = switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.http_nav_burst,
         else => unreachable,
-    } orelse 1;
+    } orelse DEFAULT_NAV_BURST;
     return @max(burst, 1);
 }
 
@@ -1259,6 +1263,23 @@ test "Config: httpNavDelay modes" {
         } });
         defer config.deinit(std.testing.allocator);
         try std.testing.expectEqual(HttpNavDelay{ .fixed = 250 }, config.httpNavDelay());
+    }
+}
+
+test "Config: httpNavBurst" {
+    // unset: an idle host absorbs DEFAULT_NAV_BURST navigations at once
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{} });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(DEFAULT_NAV_BURST, config.httpNavBurst());
+    }
+    // 0 is treated as 1: strict spacing, no burst
+    {
+        var config = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+            .http_nav_burst = 0,
+        } });
+        defer config.deinit(std.testing.allocator);
+        try std.testing.expectEqual(1, config.httpNavBurst());
     }
 }
 

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -591,7 +591,9 @@ test "Runner: waits out a throttled navigation" {
     // Enable the per-host navigation throttle for this test only, and spend
     // 127.0.0.1's slot so the navigation below has to wait ~300ms.
     const network = http_client.network;
-    network.rate_limiter = @import("../network/RateLimiter.zig").init(testing.allocator, 300, 1);
+    network.rate_limiter = @import("../network/RateLimiter.zig").init(testing.allocator, 300, 1, .fixed);
+    // the test server is local, and loopback is normally never throttled
+    network.rate_limiter.?.exempt_loopback = false;
     defer {
         network.rate_limiter.?.deinit();
         network.rate_limiter = null;

--- a/src/help.zon
+++ b/src/help.zon
@@ -425,9 +425,13 @@
     \\          navigations are spaced by --http-nav-delay again.
     \\          Defaults to 1.
     \\  --http-nav-delay <INT>
-    \\          Minimum time in ms between two top-level navigations to the same
-    \\          host (see --http-nav-burst). Disable by setting to 0.
-    \\          Defaults to 0.
+    \\          Fixed time in ms between two top-level navigations to the same
+    \\          host (see --http-nav-burst). Set to 0 to disable rate limiting.
+    \\          By default the delay is dynamic: it starts at 20ms, grows with
+    \\          the number of navigations sent to the host and with its errors
+    \\          (429, 503, Retry-After, other 5xx, no answer), and comes back
+    \\          down when the host is left alone.
+    \\          localhost, 127.0.0.1 and [::1] are never rate limited.
     \\  --http-proxy <URL>
     \\          HTTP proxy for all HTTP requests.
     \\          username:password may be included for basic auth.

--- a/src/help.zon
+++ b/src/help.zon
@@ -421,9 +421,10 @@
     \\          Defaults to 1 GiB.
     \\  --http-nav-burst <INT>
     \\          Number of top-level navigations to an idle host allowed to
-    \\          start without waiting for --http-nav-delay. After a burst,
-    \\          navigations are spaced by --http-nav-delay again.
-    \\          Defaults to 1.
+    \\          start without waiting. The allowance refills as the host goes
+    \\          idle again. It buys a head start only: it does not change how
+    \\          fast the delay grows once the host is busy.
+    \\          Defaults to 10.
     \\  --http-nav-delay <INT>
     \\          Fixed time in ms between two top-level navigations to the same
     \\          host (see --http-nav-burst). Set to 0 to disable rate limiting.

--- a/src/help.zon
+++ b/src/help.zon
@@ -430,7 +430,8 @@
     \\          By default the delay is dynamic: it starts at 20ms, grows with
     \\          the number of navigations sent to the host and with its errors
     \\          (429, 503, Retry-After, other 5xx, no answer), and comes back
-    \\          down when the host is left alone.
+    \\          down over time. Under sustained load it settles around 100ms,
+    \\          about 10 navigations per second to the same host.
     \\          localhost, 127.0.0.1 and [::1] are never rate limited.
     \\  --http-proxy <URL>
     \\          HTTP proxy for all HTTP requests.

--- a/src/log.zig
+++ b/src/log.zig
@@ -36,6 +36,7 @@ pub const Scope = enum {
     mcp,
     note,
     not_implemented,
+    rate_limit,
     scheduler,
     serve,
     storage,

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -1808,14 +1808,18 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     // navigations to it.
     if (transfer.req.throttle) {
         if (self.network.rate_limiter) |*rl| {
-            const status = try msg.conn.getResponseCode();
-            rl.observe(URL.getHostname(transfer.req.url), .{
-                .status = status,
-                .retry_after_ms = getRetryAfterMs(msg.conn, status),
-            }, lp.datetime.milliTimestamp(.boot)) catch |err| {
-                // rate limit is best effort.
-                log.warn(.http, "rate limit observe", .{ .err = err });
-            };
+            // rate limit is best effort: a status we can't read is not worth
+            // failing an otherwise good response over.
+            if (msg.conn.getResponseCode()) |status| {
+                rl.observe(URL.getHostname(transfer.req.url), .{
+                    .status = status,
+                    .retry_after_ms = getRetryAfterMs(msg.conn, status),
+                }, lp.datetime.milliTimestamp(.boot)) catch |err| {
+                    log.warn(.http, "rate limit observe", .{ .err = err });
+                };
+            } else |err| {
+                log.warn(.http, "rate limit status", .{ .err = err });
+            }
         }
     }
 

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -1106,7 +1106,6 @@ fn pipeline(self: *Client, transfer: *Transfer, from: SubmitFrom) !void {
                     if (run_at > now) {
                         const d = run_at - now;
                         lp.metrics.http_navigation_delay_ms.observe(@intCast(d));
-                        log.debug(.http, "navigation delayed", .{ .url = transfer.req.url, .ms = d });
                         return self.delay(transfer, run_at);
                     }
                 }
@@ -1584,6 +1583,17 @@ pub fn isRedirectStatus(status: u16) bool {
     };
 }
 
+// Read the Retry-After header of a 429/503 response and convert it to ms.
+// Only the delay-seconds form is supported; the HTTP-date form is ignored.
+fn getRetryAfterMs(conn: *const http.Connection, status: u16) ?u64 {
+    if (status != 429 and status != 503) {
+        return null;
+    }
+    const hdr = conn.getResponseHeader("retry-after", 0) orelse return null;
+    const seconds = std.fmt.parseInt(u64, std.mem.trim(u8, hdr.value, " "), 10) catch return null;
+    return seconds *| std.time.ms_per_s;
+}
+
 fn processMessages(self: *Client) !bool {
     var processed = false;
     while (try self.handles.readMessage()) |msg| {
@@ -1774,6 +1784,16 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
     // callbacks run later, from dispatch(), never from here.
 
     if (effective_err != null and !is_conn_close_recv) {
+        // A host that does not answer gets more spacing. Our own callback
+        // failing (callback_error) is not the host's fault.
+        if (transfer.req.throttle and transfer.res.callback_error == null) {
+            if (self.network.rate_limiter) |*rl| {
+                rl.observe(URL.getHostname(transfer.req.url), .{}, lp.datetime.milliTimestamp(.boot)) catch |err| {
+                    // rate limit is best effort.
+                    log.warn(.http, "rate limit observe", .{ .err = err });
+                };
+            }
+        }
         self.removeConn(msg.conn);
         transfer._conn = null;
         transfer.failAsync(transfer.res.callback_error orelse effective_err.?);
@@ -1782,6 +1802,22 @@ fn processOneMessage(self: *Client, msg: http.Handles.MultiMessage, transfer: *T
 
     try transfer.materializeResponse(msg.conn, .{});
     if (self.enforceCorsResponse(msg, transfer)) return true;
+
+    // Tell the rate limiter how the host answered: an overloaded host
+    // (429, 503, Retry-After, 5xx) gets more spacing before the next
+    // navigations to it.
+    if (transfer.req.throttle) {
+        if (self.network.rate_limiter) |*rl| {
+            const status = try msg.conn.getResponseCode();
+            rl.observe(URL.getHostname(transfer.req.url), .{
+                .status = status,
+                .retry_after_ms = getRetryAfterMs(msg.conn, status),
+            }, lp.datetime.milliTimestamp(.boot)) catch |err| {
+                // rate limit is best effort.
+                log.warn(.http, "rate limit observe", .{ .err = err });
+            };
+        }
+    }
 
     // Latency is only meaningful for responses that hit the network (cache
     // and synthetic responses never reach processOneMessage).
@@ -5349,7 +5385,7 @@ test "HttpClient: throttled navigations wait for their per-host slot" {
     // of putting it on the wire — .queued IS "entered the pipeline".
     net.available = .{};
     net.conn_mutex = .init;
-    net.rate_limiter = @import("RateLimiter.zig").init(testing.allocator, 60_000, 1);
+    net.rate_limiter = @import("RateLimiter.zig").init(testing.allocator, 60_000, 1, .fixed);
     defer net.rate_limiter.?.deinit();
 
     var client: Client = undefined;

--- a/src/network/Network.zig
+++ b/src/network/Network.zig
@@ -123,7 +123,11 @@ pub fn init(app: *App) !Network {
         .cache = cache,
         .robot_store = RobotStore.init(allocator),
         .web_bot_auth = web_bot_auth,
-        .rate_limiter = if (config.httpNavDelay()) |ms| RateLimiter.init(allocator, ms, config.httpNavBurst()) else null,
+        .rate_limiter = switch (config.httpNavDelay()) {
+            .off => null,
+            .adaptive => RateLimiter.init(allocator, RateLimiter.ADAPTIVE_INTERVAL_MS, config.httpNavBurst(), .adaptive),
+            .fixed => |ms| RateLimiter.init(allocator, ms, config.httpNavBurst(), .fixed),
+        },
         .adblocker = adblocker,
 
         .ws_pool = .empty,

--- a/src/network/RateLimiter.zig
+++ b/src/network/RateLimiter.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const lp = @import("lightpanda");
+const log = lp.log;
 
 const Network = @import("Network.zig");
 
@@ -25,82 +26,295 @@ const Allocator = std.mem.Allocator;
 
 const RateLimiter = @This();
 
+// In adaptive mode the interval grows with the host's pressure and comes
+// back down when the host is left alone. In fixed mode the interval never
+// changes: the user asked for an exact spacing with --http-nav-delay.
+pub const Mode = enum { fixed, adaptive };
+
+// Base interval used in adaptive mode, when no --http-nav-delay is given.
+pub const ADAPTIVE_INTERVAL_MS: u64 = 20;
+
+// In adaptive mode, the interval grows by one base interval every
+// `burst * RAMP_BURSTS` navigations: the more we ask a host, the more we
+// space our requests.
+pub const RAMP_BURSTS: u64 = 10;
+
+// Each `COOLDOWN_INTERVALS` base intervals a host is left alone forgives one
+// navigation of pressure.
+pub const COOLDOWN_INTERVALS: u64 = 10;
+
+// The interval never grows beyond `MAX_INTERVALS` base intervals.
+pub const MAX_INTERVALS: u64 = 60;
+
+// Pressure added, in base intervals, when a host answers 429 or 503: the
+// server asked us to back off.
+pub const OVERLOAD_INTERVALS: u64 = 5;
+
+// Pressure added, in base intervals, when a host answers another 5xx or
+// does not answer at all (timeout, connection error).
+pub const FAILURE_INTERVALS: u64 = 1;
+
+// A Retry-After header is honored up to this delay.
+pub const RETRY_AFTER_MAX_MS: u64 = 60_000;
+
 allocator: Allocator,
 
-// Sustained minimum gap between two navigations to the same host.
+// Minimum gap between two navigations to the same host.
 interval_ms: u64,
 
 // Burst tolerance (GCRA tau): how far ahead of "now" a host's theoretical
 // arrival time may run before a navigation has to wait. (burst - 1) *
-// interval_ms, so burst = 1 means strict spacing.
+// interval_ms, so burst = 1 means strict spacing. Always in units of the
+// base interval: a busy host's burst is spent faster.
 tau: u64,
 
-// hostname (no port) -> theoretical arrival time (TAT): the time the host's
-// reservations would have reached if every one had been spaced by
-// interval_ms. A host is idle once its TAT is in the past.
-next: Network.HostHashMap(u64) = .empty,
+// The four fields below are not constants: they are derived in init from
+// the --http-nav-delay and --http-nav-burst flags and the constants above.
+
+// Pressure units per extra base interval (see RAMP_BURSTS).
+ramp_step: u64,
+
+// Idle time forgiving one unit of pressure (see COOLDOWN_INTERVALS).
+cooldown_ms: u64,
+
+// Cap on the effective interval (see MAX_INTERVALS).
+max_ms: u64,
+
+mode: Mode,
+
+// Pressure at which the cap is reached; pressure never grows past it, so a
+// host hammered for hours still recovers in bounded time. 0 in fixed mode:
+// pressure never accumulates and the interval stays at interval_ms.
+pressure_max: u64,
+
+// hostname (no port) -> per-host state
+hosts: Network.HostHashMap(Host) = .empty,
 
 mutex: std.Io.Mutex = .init,
 
 // Idle entries are swept once the map reaches this size
 sweep_at: usize = 256,
 
-pub fn init(allocator: Allocator, interval_ms: u64, burst: u32) RateLimiter {
+// Loopback hosts (localhost, 127.0.0.1, [::1]) are exempt: the limiter
+// protects remote hosts, not local servers. Tests turn this off to
+// throttle a local test server.
+exempt_loopback: bool = true,
+
+const Host = struct {
+    // Theoretical arrival time (TAT): the time the host's reservations would
+    // have reached if every one had been spaced by its interval. A host is
+    // idle once its TAT is in the past.
+    tat: u64,
+
+    // Leaky bucket of recent navigations. Each one adds 1, each `cooldown_ms` of
+    // idle time removes 1.
+    pressure: u64,
+
+    // Cooldown clock: the time up to which idle time has already been credited
+    // to `pressure`. Advanced by whole `cooldown_ms` steps so no idle time is
+    // lost to rounding.
+    clock: u64,
+
+    // log_msg indicates if a rate limited host has already been notified to
+    // the user via a log message.
+    log_msg: bool = false,
+};
+
+pub fn init(allocator: Allocator, interval_ms: u64, burst: u32, mode: Mode) RateLimiter {
+    lp.assert(interval_ms > 0, "RateLimiter.init", .{ .interval_ms = interval_ms, .mode = mode });
+
+    const b: u64 = @max(burst, 1);
+    const ramp_step = b * RAMP_BURSTS;
     return .{
         .allocator = allocator,
+        .mode = mode,
         .interval_ms = interval_ms,
-        .tau = interval_ms * (@max(burst, 1) - 1),
+        .tau = interval_ms * (b - 1),
+        .ramp_step = ramp_step,
+        .cooldown_ms = interval_ms * COOLDOWN_INTERVALS,
+        .max_ms = interval_ms * MAX_INTERVALS,
+        .pressure_max = switch (mode) {
+            .adaptive => (MAX_INTERVALS - 1) * ramp_step,
+            .fixed => 0,
+        },
     };
 }
 
 pub fn deinit(self: *RateLimiter) void {
-    var it = self.next.keyIterator();
+    var it = self.hosts.keyIterator();
     while (it.next()) |key| {
         self.allocator.free(key.*);
     }
-    self.next.deinit(self.allocator);
+    self.hosts.deinit(self.allocator);
 }
 
 // Reserve the next navigation slot for the given host. Returns the time the
 // request can run at (can be 0, for now).
 pub fn reserve(self: *RateLimiter, host: []const u8, now: u64) !u64 {
+    if (self.exempt_loopback and isLoopback(host)) {
+        return now;
+    }
+
     self.mutex.lockUncancelable(lp.io);
     defer self.mutex.unlock(lp.io);
 
-    const gop = try self.next.getOrPut(self.allocator, host);
+    const gop = try self.hosts.getOrPut(self.allocator, host);
     if (gop.found_existing) {
-        const tat = gop.value_ptr.*;
-        const start = @max(now, tat -| self.tau);
-        gop.value_ptr.* = @max(tat, start) + self.interval_ms;
+        const h = gop.value_ptr;
+        self.cooldown(h, now);
+
+        const interval = self.intervalFor(h.pressure);
+        const start = @max(now, h.tat -| self.tau);
+        h.tat = @max(h.tat, start) + interval;
+        h.pressure = @min(h.pressure + 1, self.pressure_max);
+
+        const wait = start - now;
+
+        // log.debug(.rate_limit, "navigation reserved", .{
+        //     .host = host,
+        //     .pressure = h.pressure,
+        //     .interval_ms = interval,
+        //     .wait_ms = wait,
+        // });
+
+        if (h.log_msg == false and wait > 0) {
+            const level: log.Level = if (self.mode == .adaptive) .warn else .debug;
+            log.log(.rate_limit, level, "navigation delayed", .{
+                .host = host,
+                .hint = "use `--http-nav-delay 0` to disable the rate limiter",
+            });
+            h.log_msg = true;
+        }
         return start;
     }
 
     gop.key_ptr.* = self.allocator.dupe(u8, host) catch |err| {
-        self.next.removeByPtr(gop.key_ptr);
+        self.hosts.removeByPtr(gop.key_ptr);
         return err;
     };
-    gop.value_ptr.* = now + self.interval_ms;
+    gop.value_ptr.* = .{
+        .tat = now + self.interval_ms,
+        .pressure = @min(1, self.pressure_max),
+        .clock = now,
+    };
 
-    if (self.next.count() >= self.sweep_at) {
+    if (self.hosts.count() >= self.sweep_at) {
         self.sweep(now);
     }
     return now;
 }
 
-// Drop every host whose TAT is already in the past.
+pub const Feedback = struct {
+    // HTTP status of the response; 0 when no response arrived (timeout,
+    // connection error).
+    status: u16 = 0,
+
+    // Retry-After header of the response, when present.
+    retry_after_ms: ?u64 = null,
+};
+
+// Record the outcome of a throttled navigation. An overloaded or failing
+// host gets extra pressure, so the next navigations to it are spaced more.
+// Fixed mode ignores feedback: the user asked for an exact spacing.
+pub fn observe(self: *RateLimiter, host: []const u8, feedback: Feedback, now: u64) !void {
+    if (self.pressure_max == 0) {
+        return;
+    }
+    if (self.exempt_loopback and isLoopback(host)) {
+        return;
+    }
+
+    const intervals: u64 = switch (feedback.status) {
+        // the server explicitly asked to back off
+        429, 503 => OVERLOAD_INTERVALS,
+        // no response at all, or another server error
+        0, 500...502, 504...599 => FAILURE_INTERVALS,
+        else => 0,
+    };
+    if (intervals == 0 and feedback.retry_after_ms == null) {
+        return;
+    }
+
+    self.mutex.lockUncancelable(lp.io);
+    defer self.mutex.unlock(lp.io);
+
+    // The host can be missing: it was swept, or a redirect landed on a host
+    // that was never reserved. Create it, so its feedback is not lost.
+    const gop = try self.hosts.getOrPut(self.allocator, host);
+    if (!gop.found_existing) {
+        gop.key_ptr.* = self.allocator.dupe(u8, host) catch |err| {
+            self.hosts.removeByPtr(gop.key_ptr);
+            return err;
+        };
+        gop.value_ptr.* = .{ .tat = now, .pressure = 0, .clock = now };
+    }
+
+    const h = gop.value_ptr;
+    self.cooldown(h, now);
+    h.pressure = @min(h.pressure + intervals * self.ramp_step, self.pressure_max);
+    if (feedback.retry_after_ms) |ms| {
+        h.tat = @max(h.tat, now + @min(ms, RETRY_AFTER_MAX_MS));
+    }
+    log.debug(.rate_limit, "response observed", .{
+        .host = host,
+        .status = feedback.status,
+        .pressure = h.pressure,
+        .retry_after_ms = feedback.retry_after_ms,
+    });
+
+    if (!gop.found_existing and self.hosts.count() >= self.sweep_at) {
+        self.sweep(now);
+    }
+}
+
+// True for the loopback names URL.getHostname can produce: an IPv6 host
+// keeps its brackets ("[::1]").
+fn isLoopback(host: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(host, "localhost") or
+        std.mem.eql(u8, host, "127.0.0.1") or
+        std.mem.eql(u8, host, "[::1]");
+}
+
+// Effective interval for a host under the given pressure: one extra base
+// interval per full `ramp_step` of navigations, capped at `max_ms`.
+fn intervalFor(self: *const RateLimiter, pressure: u64) u64 {
+    return @min(self.interval_ms * (1 + pressure / self.ramp_step), self.max_ms);
+}
+
+// Credit the idle time since the host's cooldown clock to its pressure.
+fn cooldown(self: *const RateLimiter, h: *Host, now: u64) void {
+    const steps = (now -| h.clock) / self.cooldown_ms;
+    if (steps == 0) {
+        return;
+    }
+    if (steps >= h.pressure) {
+        h.pressure = 0;
+        h.clock = now;
+        return;
+    }
+    h.pressure -= steps;
+    h.clock += steps * self.cooldown_ms;
+}
+
+// Drop every host whose TAT is already in the past and whose pressure has
+// fully cooled down.
 // Caller holds the mutex.
 fn sweep(self: *RateLimiter, now: u64) void {
-    var it = self.next.iterator();
+    var it = self.hosts.iterator();
     while (it.next()) |entry| {
-        if (entry.value_ptr.* > now) {
+        const h = entry.value_ptr.*;
+        if (h.tat > now) {
+            continue;
+        }
+        if ((now -| h.clock) / self.cooldown_ms < h.pressure) {
             continue;
         }
         const key = entry.key_ptr.*;
-        self.next.removeByPtr(entry.key_ptr);
+        self.hosts.removeByPtr(entry.key_ptr);
         self.allocator.free(key);
     }
 
-    if (self.next.count() >= self.sweep_at) {
+    if (self.hosts.count() >= self.sweep_at) {
         // we don't want reserve() to turn into an O(N), constantly sweeping
         // what it can't clean. So we increase the size of what we'll hold
         self.sweep_at *= 2;
@@ -109,7 +323,8 @@ fn sweep(self: *RateLimiter, now: u64) void {
 
 const testing = @import("../testing.zig");
 test "RateLimiter: reserve" {
-    var rl = RateLimiter.init(testing.allocator, 100, 1);
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
     defer rl.deinit();
 
     // idle host starts now, then serializes at the interval
@@ -123,11 +338,12 @@ test "RateLimiter: reserve" {
 
     // once the interval has elapsed, the host is idle again
     try testing.expectEqual(5000, try rl.reserve("a.test", 5000));
-    try testing.expectEqual(2, rl.next.count());
+    try testing.expectEqual(2, rl.hosts.count());
 }
 
 test "RateLimiter: burst" {
-    var rl = RateLimiter.init(testing.allocator, 100, 3);
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 3, .adaptive);
     defer rl.deinit();
 
     // an idle host absorbs `burst` navigations at once
@@ -152,13 +368,201 @@ test "RateLimiter: burst" {
     try testing.expectEqual(5100, try rl.reserve("a.test", 5000));
 
     // burst = 0 is treated as 1
-    var strict = RateLimiter.init(testing.allocator, 100, 0);
+    var strict = RateLimiter.init(testing.allocator, 100, 0, .adaptive);
     defer strict.deinit();
     try testing.expectEqual(0, strict.tau);
+    try testing.expectEqual(10, strict.ramp_step);
+}
+
+test "RateLimiter: pressure ramp" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    // 10 navigations queued at once: the host is now under 10 units of
+    // pressure (ramp_step for burst = 1), so the 11th is spaced by 2x the
+    // base interval, and the 21st by 3x.
+    var last: u64 = 0;
+    for (0..10) |_| {
+        last = try rl.reserve("a.test", 1000);
+    }
+    try testing.expectEqual(1900, last);
+    try testing.expectEqual(10, rl.hosts.get("a.test").?.pressure);
+
+    try testing.expectEqual(2000, try rl.reserve("a.test", 1000));
+    try testing.expectEqual(2200, try rl.reserve("a.test", 1000));
+
+    for (0..9) |_| {
+        last = try rl.reserve("a.test", 1000);
+    }
+    try testing.expectEqual(4000, last);
+    try testing.expectEqual(4300, try rl.reserve("a.test", 1000));
+}
+
+test "RateLimiter: pressure cooldown" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    for (0..10) |_| {
+        _ = try rl.reserve("a.test", 1000);
+    }
+    // 10 units of pressure cool down in 10 * cooldown_ms (1000ms each)
+    try testing.expectEqual(10, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(1000, rl.hosts.get("a.test").?.clock);
+
+    // half-way: 5 units forgiven, the spacing is back below the ramp step
+    try testing.expectEqual(6000, try rl.reserve("a.test", 6000));
+    try testing.expectEqual(6, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(6000, rl.hosts.get("a.test").?.clock);
+    try testing.expectEqual(6100, try rl.reserve("a.test", 6000));
+
+    // partial idle time is not lost: 999ms short of a step forgives nothing,
+    // 1ms more forgives one and only moves the clock by a whole step
+    try testing.expectEqual(6999, try rl.reserve("a.test", 6999));
+    try testing.expectEqual(8, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(7099, try rl.reserve("a.test", 7000));
+    try testing.expectEqual(8, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(7000, rl.hosts.get("a.test").?.clock);
+
+    // fully idle: pressure is gone and the clock catches up
+    try testing.expectEqual(100_000, try rl.reserve("a.test", 100_000));
+    try testing.expectEqual(1, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(100_000, rl.hosts.get("a.test").?.clock);
+}
+
+test "RateLimiter: pressure cap" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    // hammer the host: the interval grows up to 60x the base and no further
+    var prev: u64 = 0;
+    var max_gap: u64 = 0;
+    for (0..2000) |_| {
+        const t = try rl.reserve("a.test", 1000);
+        if (prev != 0) {
+            max_gap = @max(max_gap, t - prev);
+        }
+        prev = t;
+    }
+    try testing.expectEqual(6000, max_gap);
+    try testing.expectEqual(rl.pressure_max, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(6000, rl.intervalFor(rl.pressure_max));
+    try testing.expectEqual(6000, rl.intervalFor(rl.pressure_max * 2));
+}
+
+test "RateLimiter: observe overload" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    // a 429 adds 5 base intervals of pressure at once
+    try testing.expectEqual(1000, try rl.reserve("a.test", 1000));
+    try rl.observe("a.test", .{ .status = 429 }, 1050);
+    try testing.expectEqual(51, rl.hosts.get("a.test").?.pressure);
+
+    // navigations are now spaced by 100 * (1 + 51/10) = 600
+    try testing.expectEqual(1100, try rl.reserve("a.test", 1100));
+    try testing.expectEqual(1700, try rl.reserve("a.test", 1100));
+
+    // Retry-After pushes the next slot directly
+    try rl.observe("a.test", .{ .status = 503, .retry_after_ms = 5000 }, 2000);
+    try testing.expectEqual(7000, try rl.reserve("a.test", 2100));
+
+    // and is honored up to RETRY_AFTER_MAX_MS only
+    try rl.observe("a.test", .{ .status = 429, .retry_after_ms = 3_600_000 }, 10_000);
+    try testing.expectEqual(70_000, try rl.reserve("a.test", 10_100));
+}
+
+test "RateLimiter: observe failures" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    try testing.expectEqual(1000, try rl.reserve("a.test", 1000));
+
+    // a server error, or no response at all, adds one base interval each
+    try rl.observe("a.test", .{ .status = 500 }, 1010);
+    try rl.observe("a.test", .{}, 1020);
+    try testing.expectEqual(21, rl.hosts.get("a.test").?.pressure);
+
+    // a success adds nothing
+    try rl.observe("a.test", .{ .status = 200 }, 1030);
+    try testing.expectEqual(21, rl.hosts.get("a.test").?.pressure);
+}
+
+test "RateLimiter: observe unknown host" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    // a success on an unknown host records nothing
+    try rl.observe("a.test", .{ .status = 200 }, 1000);
+    try testing.expect(rl.hosts.get("a.test") == null);
+
+    // an error creates the host: a redirect can land on a host that was
+    // never reserved, and its feedback must not be lost
+    try rl.observe("a.test", .{ .status = 429, .retry_after_ms = 2000 }, 1000);
+    try testing.expectEqual(50, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(3000, try rl.reserve("a.test", 1100));
+}
+
+test "RateLimiter: observe fixed mode" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .fixed);
+    defer rl.deinit();
+
+    // fixed mode ignores feedback: the user asked for an exact spacing
+    try testing.expectEqual(1000, try rl.reserve("a.test", 1000));
+    try rl.observe("a.test", .{ .status = 429, .retry_after_ms = 5000 }, 1010);
+    try testing.expectEqual(0, rl.hosts.get("a.test").?.pressure);
+    try testing.expectEqual(1100, try rl.reserve("a.test", 1050));
+}
+
+test "RateLimiter: loopback is exempt" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+
+    // loopback hosts are never delayed and never tracked
+    try testing.expectEqual(1000, try rl.reserve("localhost", 1000));
+    try testing.expectEqual(1000, try rl.reserve("LOCALHOST", 1000));
+    try testing.expectEqual(1000, try rl.reserve("127.0.0.1", 1000));
+    try testing.expectEqual(1000, try rl.reserve("[::1]", 1000));
+    try rl.observe("127.0.0.1", .{ .status = 429, .retry_after_ms = 5000 }, 1000);
+    try testing.expectEqual(0, rl.hosts.count());
+
+    // tests can turn the exemption off to throttle a local server
+    rl.exempt_loopback = false;
+    try testing.expectEqual(1000, try rl.reserve("127.0.0.1", 1000));
+    try testing.expectEqual(1100, try rl.reserve("127.0.0.1", 1000));
+}
+
+test "RateLimiter: fixed mode" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .fixed);
+    defer rl.deinit();
+
+    // pressure never accumulates: the spacing stays at the base interval,
+    // no matter how many navigations the host gets
+    var last: u64 = 0;
+    for (0..50) |_| {
+        last = try rl.reserve("a.test", 1000);
+    }
+    try testing.expectEqual(1000 + 49 * 100, last);
+    try testing.expectEqual(0, rl.hosts.get("a.test").?.pressure);
+
+    // with no pressure to cool down, an idle host is swept as soon as its
+    // TAT is in the past
+    rl.sweep_at = 2;
+    _ = try rl.reserve("b.test", 50_000);
+    try testing.expect(rl.hosts.get("a.test") == null);
 }
 
 test "RateLimiter: sweep" {
-    var rl = RateLimiter.init(testing.allocator, 100, 1);
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
     defer rl.deinit();
     rl.sweep_at = 4;
 
@@ -166,22 +570,46 @@ test "RateLimiter: sweep" {
     for (0..3) |i| {
         _ = try rl.reserve(try std.fmt.bufPrint(&buf, "h{d}.test", .{i}), 1000);
     }
-    try testing.expectEqual(3, rl.next.count());
+    try testing.expectEqual(3, rl.hosts.count());
 
     // 4th insert reaches sweep_at; nothing is idle yet, so the threshold grows
     _ = try rl.reserve("h3.test", 1000);
-    try testing.expectEqual(4, rl.next.count());
+    try testing.expectEqual(4, rl.hosts.count());
     try testing.expectEqual(8, rl.sweep_at);
 
     for (4..7) |i| {
         _ = try rl.reserve(try std.fmt.bufPrint(&buf, "h{d}.test", .{i}), 1000);
     }
-    try testing.expectEqual(7, rl.next.count());
+    try testing.expectEqual(7, rl.hosts.count());
 
     // hits sweep_at again, far in the future: every earlier host is idle
     try testing.expectEqual(9000, try rl.reserve("h7.test", 9000));
-    try testing.expectEqual(1, rl.next.count());
+    try testing.expectEqual(1, rl.hosts.count());
     try testing.expectEqual(8, rl.sweep_at);
     // and the survivor keeps its reservation
     try testing.expectEqual(9100, try rl.reserve("h7.test", 9000));
+}
+
+test "RateLimiter: sweep keeps pressured hosts" {
+    testing.silenceLog(&.{.rate_limit});
+    var rl = RateLimiter.init(testing.allocator, 100, 1, .adaptive);
+    defer rl.deinit();
+    rl.sweep_at = 2;
+
+    // 5 units of pressure on a.test: it needs 5000ms of idle time to be
+    // forgotten, well after its TAT (1500) is in the past
+    var at: u64 = 1000;
+    for (0..5) |_| {
+        at = try rl.reserve("a.test", at);
+    }
+
+    // a sweep at 3000 keeps it (and doubles the threshold)
+    _ = try rl.reserve("b.test", 3000);
+    try testing.expectEqual(2, rl.hosts.count());
+    try testing.expectEqual(4, rl.sweep_at);
+
+    // a sweep once the pressure has cooled down drops it
+    rl.sweep_at = 2;
+    _ = try rl.reserve("c.test", 10_000);
+    try testing.expect(rl.hosts.get("a.test") == null);
 }

--- a/src/network/RateLimiter.zig
+++ b/src/network/RateLimiter.zig
@@ -27,7 +27,7 @@ const Allocator = std.mem.Allocator;
 const RateLimiter = @This();
 
 // In adaptive mode the interval grows with the host's pressure and comes
-// back down when the host is left alone. In fixed mode the interval never
+// back down as that pressure drains. In fixed mode the interval never
 // changes: the user asked for an exact spacing with --http-nav-delay.
 pub const Mode = enum { fixed, adaptive };
 
@@ -39,9 +39,11 @@ pub const ADAPTIVE_INTERVAL_MS: u64 = 20;
 // space our requests.
 pub const RAMP_BURSTS: u64 = 10;
 
-// Each `COOLDOWN_INTERVALS` base intervals a host is left alone forgives one
-// navigation of pressure.
-pub const COOLDOWN_INTERVALS: u64 = 10;
+// One navigation of pressure is forgiven every `COOLDOWN_INTERVALS` base
+// intervals of elapsed time. This constant alone sets the sustained rate: a
+// host stops gaining pressure once its spacing reaches `cooldown_ms`, so it
+// settles at one navigation per `COOLDOWN_INTERVALS` base intervals.
+pub const COOLDOWN_INTERVALS: u64 = 5;
 
 // The interval never grows beyond `MAX_INTERVALS` base intervals.
 pub const MAX_INTERVALS: u64 = 60;
@@ -74,7 +76,7 @@ tau: u64,
 // Pressure units per extra base interval (see RAMP_BURSTS).
 ramp_step: u64,
 
-// Idle time forgiving one unit of pressure (see COOLDOWN_INTERVALS).
+// Elapsed time forgiving one unit of pressure (see COOLDOWN_INTERVALS).
 cooldown_ms: u64,
 
 // Cap on the effective interval (see MAX_INTERVALS).
@@ -106,13 +108,13 @@ const Host = struct {
     // idle once its TAT is in the past.
     tat: u64,
 
-    // Leaky bucket of recent navigations. Each one adds 1, each `cooldown_ms` of
-    // idle time removes 1.
+    // Leaky bucket of recent navigations. Each one adds 1, each `cooldown_ms`
+    // of elapsed time removes 1.
     pressure: u64,
 
-    // Cooldown clock: the time up to which idle time has already been credited
-    // to `pressure`. Advanced by whole `cooldown_ms` steps so no idle time is
-    // lost to rounding.
+    // Cooldown clock: the time up to which elapsed time has already been
+    // credited to `pressure`. Advanced by whole `cooldown_ms` steps so no time
+    // is lost to rounding.
     clock: u64,
 
     // log_msg indicates if a rate limited host has already been notified to
@@ -281,7 +283,10 @@ fn intervalFor(self: *const RateLimiter, pressure: u64) u64 {
     return @min(self.interval_ms * (1 + pressure / self.ramp_step), self.max_ms);
 }
 
-// Credit the idle time since the host's cooldown clock to its pressure.
+// Credit the time elapsed since the host's cooldown clock to its pressure.
+// This is wall clock, not idle time: a host under constant load drains too.
+// That is what makes the spacing settle at `cooldown_ms` instead of climbing
+// to the cap.
 fn cooldown(self: *const RateLimiter, h: *Host, now: u64) void {
     const steps = (now -| h.clock) / self.cooldown_ms;
     if (steps == 0) {
@@ -297,7 +302,7 @@ fn cooldown(self: *const RateLimiter, h: *Host, now: u64) void {
 }
 
 // Drop every host whose TAT is already in the past and whose pressure has
-// fully cooled down.
+// fully drained.
 // Caller holds the mutex.
 fn sweep(self: *RateLimiter, now: u64) void {
     var it = self.hosts.iterator();
@@ -407,25 +412,26 @@ test "RateLimiter: pressure cooldown" {
     for (0..10) |_| {
         _ = try rl.reserve("a.test", 1000);
     }
-    // 10 units of pressure cool down in 10 * cooldown_ms (1000ms each)
+    // 10 units of pressure drain in 10 * cooldown_ms (500ms each)
     try testing.expectEqual(10, rl.hosts.get("a.test").?.pressure);
     try testing.expectEqual(1000, rl.hosts.get("a.test").?.clock);
 
-    // half-way: 5 units forgiven, the spacing is back below the ramp step
-    try testing.expectEqual(6000, try rl.reserve("a.test", 6000));
+    // half-way (2500ms later): 5 units forgiven, the spacing is back below
+    // the ramp step
+    try testing.expectEqual(3500, try rl.reserve("a.test", 3500));
     try testing.expectEqual(6, rl.hosts.get("a.test").?.pressure);
-    try testing.expectEqual(6000, rl.hosts.get("a.test").?.clock);
-    try testing.expectEqual(6100, try rl.reserve("a.test", 6000));
+    try testing.expectEqual(3500, rl.hosts.get("a.test").?.clock);
+    try testing.expectEqual(3600, try rl.reserve("a.test", 3500));
 
-    // partial idle time is not lost: 999ms short of a step forgives nothing,
+    // a partial step is not lost: 499ms short of a step forgives nothing,
     // 1ms more forgives one and only moves the clock by a whole step
-    try testing.expectEqual(6999, try rl.reserve("a.test", 6999));
+    try testing.expectEqual(3999, try rl.reserve("a.test", 3999));
     try testing.expectEqual(8, rl.hosts.get("a.test").?.pressure);
-    try testing.expectEqual(7099, try rl.reserve("a.test", 7000));
+    try testing.expectEqual(4099, try rl.reserve("a.test", 4000));
     try testing.expectEqual(8, rl.hosts.get("a.test").?.pressure);
-    try testing.expectEqual(7000, rl.hosts.get("a.test").?.clock);
+    try testing.expectEqual(4000, rl.hosts.get("a.test").?.clock);
 
-    // fully idle: pressure is gone and the clock catches up
+    // long enough with no traffic: pressure is gone and the clock catches up
     try testing.expectEqual(100_000, try rl.reserve("a.test", 100_000));
     try testing.expectEqual(1, rl.hosts.get("a.test").?.pressure);
     try testing.expectEqual(100_000, rl.hosts.get("a.test").?.clock);
@@ -596,7 +602,7 @@ test "RateLimiter: sweep keeps pressured hosts" {
     defer rl.deinit();
     rl.sweep_at = 2;
 
-    // 5 units of pressure on a.test: it needs 5000ms of idle time to be
+    // 5 units of pressure on a.test: it needs 2500ms of elapsed time to be
     // forgotten, well after its TAT (1500) is in the past
     var at: u64 = 1000;
     for (0..5) |_| {
@@ -608,7 +614,7 @@ test "RateLimiter: sweep keeps pressured hosts" {
     try testing.expectEqual(2, rl.hosts.count());
     try testing.expectEqual(4, rl.sweep_at);
 
-    // a sweep once the pressure has cooled down drops it
+    // a sweep once the pressure has drained drops it
     rl.sweep_at = 2;
     _ = try rl.reserve("c.test", 10_000);
     try testing.expect(rl.hosts.get("a.test") == null);

--- a/src/network/RateLimiter.zig
+++ b/src/network/RateLimiter.zig
@@ -35,8 +35,9 @@ pub const Mode = enum { fixed, adaptive };
 pub const ADAPTIVE_INTERVAL_MS: u64 = 20;
 
 // In adaptive mode, the interval grows by one base interval every
-// `burst * RAMP_BURSTS` navigations: the more we ask a host, the more we
-// space our requests.
+// `RAMP_BURSTS` navigations: the more we ask a host, the more we space our
+// requests. Independent of --http-nav-burst: the burst buys a head start on
+// an idle host, it does not change how fast the spacing ramps up.
 pub const RAMP_BURSTS: u64 = 10;
 
 // One navigation of pressure is forgiven every `COOLDOWN_INTERVALS` base
@@ -70,11 +71,8 @@ interval_ms: u64,
 // base interval: a busy host's burst is spent faster.
 tau: u64,
 
-// The four fields below are not constants: they are derived in init from
-// the --http-nav-delay and --http-nav-burst flags and the constants above.
-
-// Pressure units per extra base interval (see RAMP_BURSTS).
-ramp_step: u64,
+// The three fields below are not constants: they are derived in init from
+// the --http-nav-delay flag and the constants above.
 
 // Elapsed time forgiving one unit of pressure (see COOLDOWN_INTERVALS).
 cooldown_ms: u64,
@@ -126,17 +124,15 @@ pub fn init(allocator: Allocator, interval_ms: u64, burst: u32, mode: Mode) Rate
     lp.assert(interval_ms > 0, "RateLimiter.init", .{ .interval_ms = interval_ms, .mode = mode });
 
     const b: u64 = @max(burst, 1);
-    const ramp_step = b * RAMP_BURSTS;
     return .{
         .allocator = allocator,
         .mode = mode,
         .interval_ms = interval_ms,
         .tau = interval_ms * (b - 1),
-        .ramp_step = ramp_step,
         .cooldown_ms = interval_ms * COOLDOWN_INTERVALS,
         .max_ms = interval_ms * MAX_INTERVALS,
         .pressure_max = switch (mode) {
-            .adaptive => (MAX_INTERVALS - 1) * ramp_step,
+            .adaptive => (MAX_INTERVALS - 1) * RAMP_BURSTS,
             .fixed => 0,
         },
     };
@@ -253,7 +249,7 @@ pub fn observe(self: *RateLimiter, host: []const u8, feedback: Feedback, now: u6
 
     const h = gop.value_ptr;
     self.cooldown(h, now);
-    h.pressure = @min(h.pressure + intervals * self.ramp_step, self.pressure_max);
+    h.pressure = @min(h.pressure + intervals * RAMP_BURSTS, self.pressure_max);
     if (feedback.retry_after_ms) |ms| {
         h.tat = @max(h.tat, now + @min(ms, RETRY_AFTER_MAX_MS));
     }
@@ -278,9 +274,9 @@ fn isLoopback(host: []const u8) bool {
 }
 
 // Effective interval for a host under the given pressure: one extra base
-// interval per full `ramp_step` of navigations, capped at `max_ms`.
+// interval per full `RAMP_BURSTS` of navigations, capped at `max_ms`.
 fn intervalFor(self: *const RateLimiter, pressure: u64) u64 {
-    return @min(self.interval_ms * (1 + pressure / self.ramp_step), self.max_ms);
+    return @min(self.interval_ms * (1 + pressure / RAMP_BURSTS), self.max_ms);
 }
 
 // Credit the time elapsed since the host's cooldown clock to its pressure.
@@ -376,7 +372,12 @@ test "RateLimiter: burst" {
     var strict = RateLimiter.init(testing.allocator, 100, 0, .adaptive);
     defer strict.deinit();
     try testing.expectEqual(0, strict.tau);
-    try testing.expectEqual(10, strict.ramp_step);
+
+    // the burst only buys a head start on an idle host. It does not change
+    // how fast the spacing ramps up, nor how far it can go.
+    try testing.expectEqual(rl.pressure_max, strict.pressure_max);
+    try testing.expectEqual(rl.intervalFor(100), strict.intervalFor(100));
+    try testing.expectEqual(rl.intervalFor(595), strict.intervalFor(595));
 }
 
 test "RateLimiter: pressure ramp" {
@@ -385,8 +386,8 @@ test "RateLimiter: pressure ramp" {
     defer rl.deinit();
 
     // 10 navigations queued at once: the host is now under 10 units of
-    // pressure (ramp_step for burst = 1), so the 11th is spaced by 2x the
-    // base interval, and the 21st by 3x.
+    // pressure (one RAMP_BURSTS), so the 11th is spaced by 2x the base
+    // interval, and the 21st by 3x.
     var last: u64 = 0;
     for (0..10) |_| {
         last = try rl.reserve("a.test", 1000);

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -539,6 +539,8 @@ test "tests:beforeAll" {
             .ws_max_concurrent = 50,
             .load_resources = .{ .worker = true, .iframe = true },
             .watchdog_ms = 0,
+            // no navigation rate limit in tests: they hammer 127.0.0.1
+            .http_nav_delay = 0,
         },
     });
 


### PR DESCRIPTION
The goal of the PR is to space out top-level navigations to the same host. The delay starts
near zero, grows while you keep hitting the host, and comes back down over
time. Only top-level navigations are affected. Iframes, scripts, images, XHR
and fetch are never delayed, and `localhost`, `127.0.0.1` and `[::1]` are
exempt.

The bucket is keyed by hostname, ignoring port and scheme.

## The rule

Each host carries a `pressure` counter. Pressure sets the spacing:

```
spacing = min(20ms * (1 + pressure / 10), 1200ms)
```

Each navigation books the next free slot:

```
start = max(now, tat - tau)
tat   = max(tat, start) + spacing
```

`tat` is the time the host's booked slots run out. `tau` is the burst
allowance, `(--http-nav-burst - 1) * 20ms`, which is 180ms by default. It lets
an idle host run ahead before anything waits.

## What you actually see

The first 10 navigations to an idle host go out back to back. After that the
spacing appears and grows:

| enforced gap | first at navigation | after |
|---|---|---|
| 0ms | 1 to 10 | 0s |
| 20ms | 11 | 0.02s |
| 40ms | 12 | 0.06s |
| 60ms | 27 | 0.68s |
| 80ms | 52 | 2.20s |
| 100ms | 100 | 6.06s |

It stops at 100ms and stays there. That is not the cap, it is where the two
sides balance: one navigation adds a unit, 100ms of elapsed time removes one.
So a sustained crawl of one host runs at **10 navigations per second**, the
same rate `--http-nav-delay 100` gives you.

The burst allowance is not a one time budget. A host left alone long enough
gets its 10 free navigations again.

## What raises the delay

| event | pressure added | effect |
|---|---|---|
| one navigation | +1 | +20ms every 10 navigations |
| 429 or 503 | +50 | +100ms at once |
| other 5xx, or no answer | +10 | +20ms at once |

A `Retry-After` header on a 429 or 503 pushes the next slot directly, honoured
up to 60s. Only the delay-seconds form is read; an HTTP-date is ignored.

Pressure stops at 590, so the spacing never exceeds 1200ms. You reach that
with twelve consecutive 429s, or by submitting hundreds of navigations at once.

## What lowers it

One unit of pressure is forgiven every 100ms. This counts wall clock, not idle
time: a host under constant load drains too, which is why the spacing settles
instead of climbing to the cap.

Draining is computed lazily, when the host is next touched, and the clock moves
in whole 100ms steps so nothing is lost to rounding.

```
from the 100ms plateau (pressure 41)  ->  drained after ~4s
from the cap           (pressure 590) ->  drained after ~59s
```

## Measured

400 navigations per phase against one host, with `demo/rate-limit`:

```
  mode      phase  reqs  span (s)  req/s  gap p50  gap p95  gap max
  off           1   400      2.29  174.5      5.5      7.7     10.5
  fixed100      1   400     39.00   10.2    100.0    100.8    101.2
  adaptive      1   400     36.06   11.1     99.8    100.7    101.3
                2   400     36.06   11.1     99.8    100.8    101.2
```

Phase 2 runs after 8s of no traffic and repeats phase 1 exactly. The spacing
falls back to zero and climbs the same curve again.

The gaps the server saw at the start of a phase, in ms:

```
 nav          2    3    4    5    6    7    8    9   10   11    12    13    14
 gap (ms)   4.5  4.4  4.6  4.6  4.7  5.0  4.7  4.4  4.5  4.6  14.8  40.4  39.1
```

Eleven go at page load speed rather than the ten the arithmetic predicts,
because the allowance refills while you spend it.

## Flags

`--http-nav-delay 0` turns the limiter off. `--http-nav-delay N` gives a fixed
N ms spacing with no ramp and no response feedback. Leaving it unset gives the
adaptive behaviour above.

`--http-nav-burst` sets how many navigations an idle host absorbs at once,
default 10. It buys a head start and nothing else: the ramp and the sustained
rate are the same at any burst setting.

## Constants

In `src/network/RateLimiter.zig`:

| constant | value | role |
|---|---|---|
| `ADAPTIVE_INTERVAL_MS` | 20 | base interval |
| `RAMP_BURSTS` | 10 | navigations per extra base interval |
| `COOLDOWN_INTERVALS` | 5 | base intervals draining one unit; sets the sustained rate |
| `MAX_INTERVALS` | 60 | spacing cap, in base intervals |
| `OVERLOAD_INTERVALS` | 5 | base intervals added on 429 or 503 |
| `FAILURE_INTERVALS` | 1 | base intervals added on other 5xx or no answer |
| `RETRY_AFTER_MAX_MS` | 60000 | longest `Retry-After` honoured |
