### PR TITLE
mcp: close the connection after a keep_alive=false response

### DIFF
--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -379,7 +379,7 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
         _ = arena.reset(.retain_capacity);
         out.clearRetainingCapacity();
         self.serve(&out.writer, arena.allocator(), &request) catch return;
-        if (!request.head.keep_alive) return;
+        if (!request.head.keep_alive or http_server.reader.state == .closing) return;
     }
 }
 


### PR DESCRIPTION
## Summary

`std.http.Server`'s `respond()` only drains the request body when the server keeps the connection alive. With `.keep_alive = false` it leaves the body unread, sets `reader.state = .closing`, and expects the caller to sever the connection (per the std comment: "the connection will be severed after the response is sent").

`handleConn` looped on the *client's* keep-alive flag instead, which is `true` for any HTTP/1.1 request, so after a 405/413/417 (and 403/415 once #3256 lands) it called `receiveHead()` again and fed the unread POST body to the head parser. The server advertised `connection: close` but held the socket open until the peer gave up.

This honours the reader's closing state so the socket is closed right after the rejection response. Predates #3256, but that PR makes the rejection path routine (wrong `Content-Type`, non-IP `Host`), which is how it surfaced — see https://github.com/lightpanda-io/browser/pull/3256#discussion_r3850932145.

## Verification

Raw-socket client sending `GET /mcp` with a JSON body (→ 405, `connection: close`), then waiting for EOF:

- before: `server still holding the connection open after 3.00s`
- after: `server closed the connection after 0.00s`

Two POSTs (`initialize`, `tools/list`) over one keep-alive connection still both return 200, so the normal path is unchanged. `make test F="HttpServer"` passes.

Clients that honour `connection: close` (curl) close their side first and were never visibly affected; the hang only showed for clients that keep the socket open after being told to close.