### PR TITLE
css: compare visibility keyword values case-insensitively

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -689,7 +689,7 @@ fn isElementHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOp
     // Check inline styles FIRST - they use INLINE_PRIORITY so no stylesheet can beat them
     if (options.check_display) {
         if (getInlineStyleProperty(el, comptime .wrap("display"), self.frame)) |property| {
-            if (property._value.eql(comptime .wrap("none"))) {
+            if (property._value.eqlSliceIgnoreCase("none")) {
                 return true; // Early exit for hiding value
             }
             display_none = false;
@@ -702,7 +702,7 @@ fn isElementHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOp
 
     if (options.check_visibility) {
         if (getInlineStyleProperty(el, comptime .wrap("visibility"), self.frame)) |property| {
-            if (property._value.eql(comptime .wrap("hidden")) or property._value.eql(comptime .wrap("collapse"))) {
+            if (property._value.eqlSliceIgnoreCase("hidden") or property._value.eqlSliceIgnoreCase("collapse")) {
                 return true;
             }
             visibility_hidden = false;
@@ -717,7 +717,7 @@ fn isElementHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOp
 
     if (options.check_opacity) {
         if (getInlineStyleProperty(el, comptime .wrap("opacity"), self.frame)) |property| {
-            if (property._value.eql(comptime .wrap("0"))) {
+            if (property._value.eqlSliceIgnoreCase("0")) {
                 return true;
             }
             opacity_zero = false;
@@ -872,7 +872,7 @@ fn elementHasPointerEventsNone(self: *StyleManager, el: *Element) bool {
 
     // Check inline style first
     if (getInlineStyleProperty(el, .wrap("pointer-events"), frame)) |property| {
-        if (property._value.eql(comptime .wrap("none"))) {
+        if (property._value.eqlSliceIgnoreCase("none")) {
             return true;
         }
         return false;
@@ -1046,19 +1046,19 @@ fn extractVisibilityProperties(style: *CSSStyleProperties) VisibilityProperties 
     const decl = style.asCSSStyleDeclaration();
 
     if (decl.findProperty(comptime .wrap("display"))) |property| {
-        props.display_none = property._value.eql(comptime .wrap("none"));
+        props.display_none = property._value.eqlSliceIgnoreCase("none");
     }
 
     if (decl.findProperty(comptime .wrap("visibility"))) |property| {
-        props.visibility_hidden = property._value.eql(comptime .wrap("hidden")) or property._value.eql(comptime .wrap("collapse"));
+        props.visibility_hidden = property._value.eqlSliceIgnoreCase("hidden") or property._value.eqlSliceIgnoreCase("collapse");
     }
 
     if (decl.findProperty(comptime .wrap("opacity"))) |property| {
-        props.opacity_zero = property._value.eql(comptime .wrap("0"));
+        props.opacity_zero = property._value.eqlSliceIgnoreCase("0");
     }
 
     if (decl.findProperty(.wrap("pointer-events"))) |property| {
-        props.pointer_events_none = property._value.eql(comptime .wrap("none"));
+        props.pointer_events_none = property._value.eqlSliceIgnoreCase("none");
     }
 
     return props;

--- a/src/browser/interactive.zig
+++ b/src/browser/interactive.zig
@@ -606,6 +606,12 @@ test "browser.interactive: pointer-events none" {
     try testing.expectEqual(0, elements.len);
 }
 
+test "browser.interactive: pointer-events none is case-insensitive" {
+    const elements = try testInteractive("<button style=\"pointer-events: NONE;\">Click me</button>");
+    defer testing.test_session.closeAllPages();
+    try testing.expectEqual(0, elements.len);
+}
+
 test "browser.interactive: non-interactive div" {
     const elements = try testInteractive("<div>Just text</div>");
     defer testing.test_session.closeAllPages();

--- a/src/browser/tests/element/check_visibility.html
+++ b/src/browser/tests/element/check_visibility.html
@@ -443,3 +443,32 @@
     elements[0].remove();
   }
 </script>
+
+<style id="style-keyword-case">
+  .hidden-upper { DISPLAY: NONE; }
+  .invisible-upper { Visibility: Hidden; }
+</style>
+<script id="keyword_values_are_case_insensitive">
+  {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    el.setAttribute("style", "display: NONE");
+    testing.expectEqual(false, el.checkVisibility());
+    testing.expectEqual('none', window.getComputedStyle(el).display);
+
+    el.setAttribute("style", "visibility: HIDDEN");
+    testing.expectEqual(true, el.checkVisibility());
+    testing.expectEqual(false, el.checkVisibility({ visibilityProperty: true }));
+
+    el.removeAttribute("style");
+    el.className = "hidden-upper";
+    testing.expectEqual(false, el.checkVisibility());
+
+    el.className = "invisible-upper";
+    testing.expectEqual(true, el.checkVisibility());
+    testing.expectEqual(false, el.checkVisibility({ visibilityProperty: true }));
+
+    el.remove();
+  }
+</script>

--- a/src/string.zig
+++ b/src/string.zig
@@ -224,6 +224,10 @@ pub const String = extern struct {
         };
     }
 
+    pub fn eqlSliceIgnoreCase(a: String, b: []const u8) bool {
+        return std.ascii.eqlIgnoreCase(a.str(), b);
+    }
+
     const EqualOrDeleted = union(enum) {
         deleted,
         equal: bool,


### PR DESCRIPTION
## Summary

CSS keywords are ASCII case-insensitive, but `StyleManager` compared `display: none`, `visibility: hidden|collapse`, `opacity: 0` and `pointer-events: none` with exact `String.eql`. `style="DISPLAY: NONE"` or `.x { Visibility: Hidden }` left the element visible to `checkVisibility`, `getComputedStyle`, `tree`, `interactiveElements` and `markdown`.

The 10 comparison sites now use a new `String.eqlSliceIgnoreCase`. Property *names* were already lowercased at parse time; values are deliberately compared rather than normalized, since lowercasing declared values would break `content`, `url()` and custom properties that `el.style` must reflect verbatim.

Found while doing #3269; independent of it.

## Verification

New `check_visibility.html` case (uppercase inline + stylesheet, `display` and `visibility`) and an uppercase `pointer-events` case in `interactive.zig`. Full suite passes.
