### PR TITLE
Makefile: fix test filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 ZIG := zig
 BC := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# tikv-jemalloc-sys's nested make can't parse inherited "-- F=..." overrides
+MAKEOVERRIDES =
 # option test filter make test F="server"
 F=
 
@@ -126,7 +128,7 @@ run-debug: build-dev
 	@./zig-out/bin/lightpanda || (printf "\033[33mRun ERROR\033[0m\n"; exit 1;)
 
 test:
-	TEST_FILTER="${F}" $(ZIG) build $(ZIGFLAGS) test -freference-trace
+	TEST_FILTER="$(or $(F),$(TEST_FILTER))" $(ZIG) build $(ZIGFLAGS) test -freference-trace
 
 ## Run demo/runner end to end tests
 end2end:
@@ -138,7 +140,7 @@ end2end:
 ## without one only the deterministic layer runs. See ../demo/agent/README.md.
 test-agent:
 	@test -d ../demo
-	@test -x zig-out/bin/lightpanda || $(MAKE) build
+	@test -x zig-out/bin/lightpanda || $(MAKE) build ZIGFLAGS="$(ZIGFLAGS)"
 	@cd ../demo && ./agent/run.sh $(LAYER)
 
 ## Remove build artifacts (keeps .lp-cache/ and zig-pkg/ — slow to re-fetch)


### PR DESCRIPTION
Two independent bugs in `make test` filtering:

- **`make <target> VAR=value` broke jemalloc's nested make on a cold cargo cache.** GNU make exports command-line variables as `MAKEFLAGS=" -- F=..."`; tikv-jemalloc-sys's `build.rs` appends its jobserver flags after that, so the `--` turns `-j` into a target: `No rule to make target '-j'`. `MAKEOVERRIDES =` stops the re-export. `test-agent` now passes `ZIGFLAGS` to its recursive `$(MAKE)` explicitly since it no longer inherits it.
- **`TEST_FILTER=... make test` ran the whole suite.** The recipe overwrote it with the (empty) `F`. Now falls back to the environment value when `F` is unset, so the form documented in AGENTS.md/README.md works.

Verified: `TEST_FILTER=Server make test` → 15 tests (was 1257), `make test F=Server` → 15, `TEST_FILTER="WebApi: #selector_all" make test` → 154, unfiltered still 1257/1257; a from-scratch tikv-jemalloc-sys build succeeds with `F=...` set.