### PR TITLE
tools: drop the 'no rendering' claim from the driver guidance

### DIFF
--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -38,8 +38,9 @@ const Selector = @import("webapi/selector/Selector.zig");
 /// correctly" — most importantly the selector rule that keeps sessions
 /// recordable as JavaScript agent scripts.
 pub const driver_guidance =
-    \\You are driving Lightpanda — a text-only headless browser. You reason
-    \\over pages through tools; there is no rendering, no images, no PDFs.
+    \\You are driving Lightpanda, a headless browser, through text tools:
+    \\no screenshots, no images, no PDFs — you reason over pages as a
+    \\semantic tree, markdown or HTML.
     \\
     \\Reading pages (cheap → expensive — prefer cheaper):
     \\- `tree` → semantic overview (role, name, value, backendNodeId per


### PR DESCRIPTION
The driver guidance (MCP `instructions`, agent system prompt) opened with "a text-only headless browser … there is no rendering, no images, no PDFs". Stale since #3231 shipped the PNG renderer. What is still true for the model is that no tool exposes pixels, so the line now says that: no screenshots, no images, no PDFs; reason over the semantic tree, markdown or HTML.

Text only; `mcp`/`tools` tests pass.