### PR TITLE
mcp: negotiate the protocol version on initialize

### DIFF
--- a/src/mcp/Server.zig
+++ b/src/mcp/Server.zig
@@ -214,7 +214,7 @@ pub fn sendResult(self: *Self, id: std.json.Value, result: anytype) !void {
 pub fn handleInitialize(self: *Self, req: protocol.Request) !void {
     const id = req.id orelse return;
     try self.sendResult(id, protocol.InitializeResult{
-        .protocolVersion = @tagName(protocol.Version.default),
+        .protocolVersion = @tagName(protocol.Version.negotiate(req.params)),
         .capabilities = .{
             .resources = .{},
             .tools = .{},
@@ -265,4 +265,34 @@ test "MCP.Server - Integration: synchronous smoke test" {
     try router.processRequests(server, &in_reader, null);
 
     try testing.expectJson(.{ .jsonrpc = "2.0", .id = 1, .result = .{ .protocolVersion = "2024-11-05" } }, out_alloc.writer.buffered());
+}
+
+test "MCP.Server - initialize negotiates the protocol version" {
+    var out_alloc: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    defer out_alloc.deinit();
+
+    var server = try Self.init(testing.allocator, testing.test_app, &out_alloc.writer);
+    defer server.deinit();
+
+    const aa = testing.arena_allocator;
+
+    // A supported version is echoed back.
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}
+    );
+    try testing.expectJson(.{ .jsonrpc = "2.0", .id = 1, .result = .{ .protocolVersion = "2025-06-18" } }, out_alloc.writer.buffered());
+    out_alloc.writer.end = 0;
+
+    // An unknown one gets the latest supported.
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2099-01-01","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}
+    );
+    try testing.expectJson(.{ .jsonrpc = "2.0", .id = 2, .result = .{ .protocolVersion = "2025-11-25" } }, out_alloc.writer.buffered());
+    out_alloc.writer.end = 0;
+
+    // So does a request with no version at all.
+    try router.handleMessage(server, aa,
+        \\{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"c","version":"1"}}}
+    );
+    try testing.expectJson(.{ .jsonrpc = "2.0", .id = 3, .result = .{ .protocolVersion = "2025-11-25" } }, out_alloc.writer.buffered());
 }

--- a/src/mcp/protocol.zig
+++ b/src/mcp/protocol.zig
@@ -6,7 +6,20 @@ pub const Version = enum {
     @"2025-06-18",
     @"2025-11-25",
 
-    pub const default: Version = .@"2024-11-05";
+    pub const latest: Version = .@"2025-11-25";
+
+    /// The client's version when we support it, else the newest we do.
+    pub fn negotiate(params: ?std.json.Value) Version {
+        const obj = switch (params orelse return .latest) {
+            .object => |o| o,
+            else => return .latest,
+        };
+        const requested = switch (obj.get("protocolVersion") orelse return .latest) {
+            .string => |s| s,
+            else => return .latest,
+        };
+        return std.meta.stringToEnum(Version, requested) orelse .latest;
+    }
 };
 
 pub const Request = struct {


### PR DESCRIPTION
`initialize` replied with `2024-11-05` unconditionally, ignoring the client's `protocolVersion`. The spec says to echo the requested version when supported and otherwise answer with the newest the server supports. `Version.negotiate` does that (the four listed revisions are supported; unknown or missing → `2025-11-25`); `Version.default` is gone.

Clients gate features on the negotiated version, so a 2025-06-18 client no longer gets downgraded to the 2024 revision.

Tests: echo of a supported version, unknown version → latest, missing version → latest. `mcp` tests pass.