### PR TITLE
Make subframe defaults explicit by mode

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -241,6 +241,7 @@ const CommonOptions = .{
     .{ .name = "cookie", .type = ?[]const u8 },
     .{ .name = "cookie_jar", .type = ?[]const u8 },
     .{ .name = "disable_subframes", .type = bool },
+    .{ .name = "enable_subframes", .type = bool },
     .{ .name = "disable_workers", .type = bool },
     .{ .name = "enable_external_stylesheets", .type = bool },
     .{ .name = "v8_flags_unsafe", .type = ?[]const u8 },
@@ -495,7 +496,8 @@ pub fn obeyRobots(self: *const Config) bool {
 
 pub fn disableSubframes(self: *const Config) bool {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.disable_subframes,
+        .serve => |opts| opts.disable_subframes,
+        inline .fetch, .mcp, .agent => |opts| !opts.enable_subframes,
         else => unreachable,
     };
 }
@@ -1188,6 +1190,36 @@ test "Config: parseArgs collects --http-header" {
     // Name and value are trimmed; an empty value is legal.
     try std.testing.expectEqualStrings("X-Empty", headers[1].name);
     try std.testing.expectEqualStrings("", headers[1].value);
+}
+
+test "Config: subframe loading defaults are mode-aware" {
+    var serve = try Config.init(std.testing.allocator, "test", .{ .serve = .{} });
+    defer serve.deinit(std.testing.allocator);
+    try std.testing.expect(!serve.disableSubframes());
+
+    var serve_disabled = try Config.init(std.testing.allocator, "test", .{ .serve = .{
+        .disable_subframes = true,
+    } });
+    defer serve_disabled.deinit(std.testing.allocator);
+    try std.testing.expect(serve_disabled.disableSubframes());
+
+    var fetch = try Config.init(std.testing.allocator, "test", .{ .fetch = .{} });
+    defer fetch.deinit(std.testing.allocator);
+    try std.testing.expect(fetch.disableSubframes());
+
+    var fetch_enabled = try Config.init(std.testing.allocator, "test", .{ .fetch = .{
+        .enable_subframes = true,
+    } });
+    defer fetch_enabled.deinit(std.testing.allocator);
+    try std.testing.expect(!fetch_enabled.disableSubframes());
+
+    var agent = try Config.init(std.testing.allocator, "test", .{ .agent = .{} });
+    defer agent.deinit(std.testing.allocator);
+    try std.testing.expect(agent.disableSubframes());
+
+    var mcp = try Config.init(std.testing.allocator, "test", .{ .mcp = .{} });
+    defer mcp.deinit(std.testing.allocator);
+    try std.testing.expect(mcp.disableSubframes());
 }
 
 test "Config: httpHeaders accessor" {

--- a/src/help.zon
+++ b/src/help.zon
@@ -335,7 +335,10 @@
     \\  --disable-subframes
     \\          Skip loading <iframe> elements. The parser still registers them in the
     \\          DOM, but no child frame or Page.frameAttached events are produced.
-    \\          Defaults to false.
+    \\          Kept for compatibility; fetch, agent, and mcp already default to off.
+    \\  --enable-subframes
+    \\          Enable loading <iframe> elements in fetch, agent, and mcp modes.
+    \\          Serve mode loads subframes by default.
     \\  --disable-workers
     \\          Skip loading dedicated Web Workers. The Worker constructor still
     \\          returns a Worker object, but no script fetch is initiated and its scope

--- a/src/main.zig
+++ b/src/main.zig
@@ -103,6 +103,11 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
 
     app.telemetry.record(.{ .run = {} });
 
+    log.info(.app, "fidelity", .{
+        .mode = @tagName(std.meta.activeTag(app.config.mode)),
+        .subframes = if (app.config.disableSubframes()) "off" else "on",
+    });
+
     defer if (app.config.dumpMetricsOnExit()) {
         var writer = std.Io.File.stdout().writerStreaming(lp.io, &.{});
         lp.metrics.write(&writer.interface);


### PR DESCRIPTION
## Summary

- Make subframe loading defaults explicit by mode: serve keeps subframes enabled, while fetch, agent, and mcp default to disabled.
- Add a compatibility `--enable-subframes` flag for data-oriented modes and document the transition.
- Emit the effective mode and subframe state in the startup fidelity log.

Fixes #3139

## Tests

- `zig fmt --check src/Config.zig src/main.zig` passed.
- `zig ast-check src/Config.zig` passed.
- `zig ast-check src/main.zig` passed.
- `make test F='Config: subframe'` could not reach compilation because dependency downloads from `build.zig.zon` failed with `HttpConnectionClosing`.

The focused regression test is included in `src/Config.zig`, but could not execute until the dependency fetch succeeds.

## Real Behavior Proof

- Behavior or issue addressed: Mode-specific subframe defaults and an explicit startup fidelity signal for issue #3139.
- Real environment tested: Local macOS checkout at commit `d52229b8e263bda75bb6fb66183e024ea2a95d17`.
- Exact steps or command run after this patch: `zig fmt --check src/Config.zig src/main.zig`; `zig ast-check src/Config.zig`; `zig ast-check src/main.zig`.
- Evidence after fix: Formatting and AST checks passed; the focused Config regression test is present but the build did not reach compilation because dependency fetching failed.
- Observed result after fix: The committed configuration maps serve to subframes-on and fetch/agent/mcp to subframes-off, with `--enable-subframes` restoring data-mode loading; startup logs expose the effective mode and state.
- What was not tested: Full `make test` and runtime startup execution remain unverified because the dependency fetch failed with `HttpConnectionClosing`.