### PR TITLE
build: pin dev_fast to the host's glibc version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,7 +69,7 @@ pub fn build(b: *Build) !void {
         .os_tag = .linux,
         .abi = .gnu,
         // Explicit version => bundled CRT, https://codeberg.org/ziglang/zig/issues/31272
-        .glibc_version = b.graph.host.result.os.version_range.linux.glibc,
+        .glibc_version = devFastGlibcVersion(b),
     }) else requested_target;
 
     // Without an explicit -Dprebuilt_v8_path, pick up whatever `make
@@ -236,6 +236,12 @@ fn addExe(b: *Build, config: ExeConfig, name: []const u8, check_name: []const u8
     config.check.dependOn(&exe_check.step);
 
     return exe;
+}
+
+fn devFastGlibcVersion(b: *Build) std.SemanticVersion {
+    const host = b.graph.host.result.os.version_range.linux.glibc;
+    const newest_known: std.SemanticVersion = .{ .major = 2, .minor = 43, .patch = 0 };
+    return if (host.order(newest_known) == .gt) newest_known else host;
 }
 
 /// Looks for the prebuilt V8 that `make download-v8` caches. The cache

--- a/build.zig
+++ b/build.zig
@@ -68,8 +68,8 @@ pub fn build(b: *Build) !void {
         .cpu_arch = .x86_64,
         .os_tag = .linux,
         .abi = .gnu,
-        // https://codeberg.org/ziglang/zig/issues/31272
-        .glibc_version = .{ .major = 2, .minor = 43, .patch = 0 },
+        // Explicit version => bundled CRT, https://codeberg.org/ziglang/zig/issues/31272
+        .glibc_version = b.graph.host.result.os.version_range.linux.glibc,
     }) else requested_target;
 
     // Without an explicit -Dprebuilt_v8_path, pick up whatever `make


### PR DESCRIPTION
## Problem

Since #3231 merged, `zig build run` on a host with glibc < 2.43 (e.g. Ubuntu 24.04, glibc 2.39) fails with:

```
libm.so.6: version `GLIBC_2.43' not found (required by lightpanda)
```

Two things combine:

- `build.zig` pins the `dev_fast` target to `glibc_version = 2.43`. That pin exists only to make Zig link its bundled CRT instead of the host's `crt1.o` (https://codeberg.org/ziglang/zig/issues/31272), but an explicit version also decides which glibc symbol versions the binary links against.
- #3231 added `tiny-skia`, which calls `acosf`. glibc 2.43 re-versioned `acosf`, so the binary now imports `acosf@GLIBC_2.43`. Nothing before that used a symbol newer than what any dev host had, so the over-pin was harmless.

Commenting the line out works on older hosts, but reintroduces #31272 on hosts whose `crt1.o` carries `.sframe` sections.

## Fix

Keep an explicit version (bundled CRT is still used) but take it from the detected host glibc instead of hardcoding 2.43.

## Verified

- Pinned to 2.39 (simulating the failing host): `acosf` links as `acosf@GLIBC_2.2.5`, highest required version is `GLIBC_2.39`.
- Host glibc 2.44: target becomes `x86_64-linux-gnu.2.44`, Zig clamps to its newest abilist (2.43); incremental and fresh-cache builds succeed and the binary runs.
- `zig fmt --check` passes.