### PR TITLE
webapi: URLSerachParams @@iterator init

### DIFF
--- a/src/browser/js/Object.zig
+++ b/src/browser/js/Object.zig
@@ -151,17 +151,16 @@ pub fn getPropertyNames(self: Object) js.Array {
     };
 }
 
-pub fn nameIterator(self: Object) !NameIterator {
-    const handle = v8.v8__Object__GetOwnPropertyNames(self.handle, self.local.handle) orelse {
+pub fn iterator(self: Object) !Iterator {
+    const names = v8.v8__Object__GetOwnPropertyNames(self.handle, self.local.handle) orelse {
         // see getOwnPropertyNames above
         return error.TypeError;
     };
-    const count = v8.v8__Array__Length(handle);
 
     return .{
-        .local = self.local,
-        .handle = handle,
-        .count = count,
+        .object = self,
+        .names = names,
+        .count = v8.v8__Array__Length(names),
     };
 }
 
@@ -192,21 +191,35 @@ pub const Global = struct {
     }
 };
 
-pub const NameIterator = struct {
+pub const Iterator = struct {
     count: u32,
     idx: u32 = 0,
-    local: *const js.Local,
-    handle: *const v8.Array,
+    object: Object,
+    names: *const v8.Array,
 
-    pub fn next(self: *NameIterator) !?[]const u8 {
+    pub const Entry = struct {
+        name: []const u8,
+        value: js.Value,
+    };
+
+    pub fn next(self: *Iterator) !?Entry {
         const idx = self.idx;
         if (idx == self.count) {
             return null;
         }
-        self.idx += 1;
+        self.idx = idx + 1;
 
-        const local = self.local;
-        const js_val_handle = v8.v8__Object__GetIndex(@ptrCast(self.handle), local.handle, idx) orelse return error.JsException;
-        return try js.Value.toStringSlice(.{ .local = local, .handle = js_val_handle });
+        const object = self.object;
+        const local = object.local;
+        const name_handle = v8.v8__Object__GetIndex(@ptrCast(self.names), local.handle, idx) orelse return error.JsException;
+        const js_name = try js.Value.toString(.{ .local = local, .handle = name_handle });
+
+        // look this up by the js_name, not the js_name.toSlice() which can do
+        // a lossy UTF-8 conversion.
+        const value = try object.get(js_name.handle);
+        return .{
+            .value = value,
+            .name = try js_name.toSlice(),
+        };
     }
 };

--- a/src/browser/tests/net/url_search_params.html
+++ b/src/browser/tests/net/url_search_params.html
@@ -652,3 +652,43 @@
   testing.expectEqual('b=%25*', new URLSearchParams('b=%%2a').toString());
 }
 </script>
+
+<script id=iterableInit>
+{
+  // Map
+  const m = new Map([['a', '1'], ['b', '2']]);
+  testing.expectEqual('a=1&b=2', new URLSearchParams(m).toString());
+
+  // generator
+  function* gen() {
+    yield ['x', '1'];
+    yield ['y', '2'];
+  }
+  testing.expectEqual('x=1&y=2', new URLSearchParams(gen()).toString());
+
+  // a patched @@iterator must be honored (WPT: Custom [Symbol.iterator])
+  const usp = new URLSearchParams();
+  usp[Symbol.iterator] = function*() { yield ['a', 'b']; };
+  testing.expectEqual('b', new URLSearchParams(usp).get('a'));
+
+  // pairs must have exactly 2 items
+  let caught = null;
+  try { new URLSearchParams([[1]]); } catch (e) { caught = e; }
+  testing.expectEqual(true, caught instanceof TypeError);
+  caught = null;
+  try { new URLSearchParams([[1, 2, 3]]); } catch (e) { caught = e; }
+  testing.expectEqual(true, caught instanceof TypeError);
+}
+</script>
+
+<script id=recordInitDuplicateKeys>
+{
+  // Web IDL record conversion: two JS keys that map to the same USVString
+  // (lone surrogates become U+FFFD) update the entry in place, and the
+  // value lookup must use the original key, not the lossy round-trip.
+  const usp = new URLSearchParams({"\uD835x": "1", "xx": "2", "\uD83Dx": "3"});
+  testing.expectEqual(2, usp.size);
+  testing.expectEqual('3', usp.get('�x'));
+  testing.expectEqual('2', usp.get('xx'));
+}
+</script>

--- a/src/browser/webapi/KeyValueList.zig
+++ b/src/browser/webapi/KeyValueList.zig
@@ -63,21 +63,40 @@ pub fn copy(arena: Allocator, original: KeyValueList) !KeyValueList {
 }
 
 pub fn fromJsObject(arena: Allocator, js_obj: js.Object, comptime normalizer: ?Normalizer, buf: []u8) !KeyValueList {
-    var it = try js_obj.nameIterator();
+    var it = try js_obj.iterator();
+
     var list = KeyValueList.init();
     try list.ensureTotalCapacity(arena, it.count);
 
-    while (try it.next()) |name| {
-        const js_value = try js_obj.get(name);
+    while (try it.next()) |kv| {
+        const name = kv.name;
         const normalized = if (comptime normalizer) |n| n(name, buf) else name;
+
+        // Two JS keys can mape to the same string, and in such cases, it's
+        // an update, not an append.
+        if (comptime normalizer == null) {
+            if (list.getEntryPtr(name)) |entry| {
+                entry.value = try kv.value.toSSOWithAlloc(arena);
+                continue;
+            }
+        }
 
         list._entries.appendAssumeCapacity(.{
             .name = try String.init(arena, normalized, .{}),
-            .value = try js_value.toSSOWithAlloc(arena),
+            .value = try kv.value.toSSOWithAlloc(arena),
         });
     }
 
     return list;
+}
+
+fn getEntryPtr(self: *KeyValueList, name: []const u8) ?*Entry {
+    for (self._entries.items) |*entry| {
+        if (entry.name.eqlSlice(name)) {
+            return entry;
+        }
+    }
+    return null;
 }
 
 pub fn fromArray(arena: Allocator, kvs: []const [2][]const u8, comptime normalizer: ?Normalizer, buf: []u8) !KeyValueList {

--- a/src/browser/webapi/net/URLSearchParams.zig
+++ b/src/browser/webapi/net/URLSearchParams.zig
@@ -61,20 +61,12 @@ pub fn init(opts_: ?InitOpts, exec: *const Execution) !*URLSearchParams {
             .query_string => |qs| break :blk try paramsFromString(arena.allocator(), qs, exec.buf),
             .form_data => |fd| break :blk try fd.toKeyValueList(arena.allocator()),
             .value => |js_val| {
-                // Order matters here; Array is also an Object.
-                if (js_val.isArray()) {
-                    break :blk try paramsFromArray(arena.allocator(), js_val.toArray());
-                }
                 if (js_val.isObject()) {
-                    // Per the URL spec, an iterable init (URLSearchParams,
-                    // Map, ...) should be walked via its @@iterator. We
-                    // don't have a generic iterable path yet; cover the
-                    // common case of `new URLSearchParams(otherUSP)` so
-                    // the prototype-method-leak doesn't just turn into a
-                    // silent empty querystring.
-                    if (js_val.toZig(*URLSearchParams)) |other| {
-                        break :blk try KeyValueList.copy(arena.allocator(), other._params);
-                    } else |_| {}
+                    if (try js_val.iterator()) |it| {
+                        // value satisfies the @@iterator protocol, so we're
+                        // expecting [name, value] tuples
+                        break :blk try paramsFromIterator(arena.allocator(), it);
+                    }
                     // normalizer is null, so frame won't be used
                     break :blk try KeyValueList.fromJsObject(arena.allocator(), js_val.toObject(), null, exec.buf);
                 }
@@ -229,29 +221,34 @@ fn nextUtf16Unit(s: []const u8, i: *usize, pending: *?u16) ?u16 {
     return @intCast(0xD800 + (c >> 10));
 }
 
-fn paramsFromArray(allocator: Allocator, array: js.Array) !KeyValueList {
-    const array_len = array.len();
-    if (array_len == 0) {
-        return .empty;
-    }
-
+fn paramsFromIterator(allocator: Allocator, it: js.Value.Iterator) !KeyValueList {
     var params = KeyValueList.init();
-    try params.ensureTotalCapacity(allocator, array_len);
-    // TODO: Release `params` on error.
 
-    var i: u32 = 0;
-    while (i < array_len) : (i += 1) {
-        const item = try array.get(i);
-        if (!item.isArray()) return error.InvalidArgument;
+    var iter = it;
+    while (try iter.next()) |item| {
+        var name_val: js.Value = undefined;
+        var value_val: js.Value = undefined;
 
-        const as_array = item.toArray();
-        // Need 2 items for KV.
-        if (as_array.len() != 2) return error.InvalidArgument;
+        if (item.isArray()) {
+            const as_array = item.toArray();
+            if (as_array.len() != 2) {
+                // we should be getting [name, value]
+                return error.TypeError;
+            }
+            name_val = try as_array.get(0);
+            value_val = try as_array.get(1);
+        } else {
+            // Not an array, but it could itself be an iterator
+            var pair_it = (try item.iterator()) orelse return error.TypeError;
+            name_val = (try pair_it.next()) orelse return error.TypeError;
+            value_val = (try pair_it.next()) orelse return error.TypeError;
+            if (try pair_it.next() != null) {
+                // should only have a name and a value, anything else is wrong
+                return error.TypeError;
+            }
+        }
 
-        const name_val = try as_array.get(0);
-        const value_val = try as_array.get(1);
-
-        params._entries.appendAssumeCapacity(.{
+        try params._entries.append(allocator, .{
             .name = try name_val.toSSOWithAlloc(allocator),
             .value = try value_val.toSSOWithAlloc(allocator),
         });


### PR DESCRIPTION
This has been on my TODO for a long time. https://github.com/lightpanda-io/browser/pull/3238 added support for the @@iterator protocol and now URLSearchParams' init can use it.

We used to only support a v8::Array, but now any type that implements the @@iterator protocol can be passed into URLSearchParams.

This also fixes and simplifies the js.Object iterator. It now yields name + value (so callers don't need to get the name then lookup the value). But it isn't just about making it easier to use. The name can be a lossy UTF-8 conversion, so the value lookup can fail. By internalizing the value lookup we can use the v8::String directly for the lookup.

Fixes a handful of WPT /url/ cases