### PR TITLE
webapi: improve hover events

### DIFF
--- a/src/browser/Page.zig
+++ b/src/browser/Page.zig
@@ -27,6 +27,7 @@ const Factory = @import("Factory.zig");
 const Viewport = @import("Viewport.zig");
 
 const Blob = @import("webapi/Blob.zig");
+const Element = @import("webapi/Element.zig");
 const WebDriver = @import("webapi/WebDriver.zig");
 const SharedWorkerGlobalScope = @import("webapi/SharedWorkerGlobalScope.zig");
 
@@ -113,6 +114,9 @@ queued_queued_navigation: std.ArrayList(*Frame) = .empty,
 frame: Frame,
 
 input_modifiers: if (lp.build_config.wpt_extensions) WebDriver.Modifiers else struct {} = .{},
+
+// The element the synthetic pointer is currently over
+input_hover_target: ?*Element = null,
 
 // Popup Frames opened by window.open. They are top-level browsing contexts
 // (parent == null, no iframe element) but share this Page's factory, arena,

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -49,6 +49,135 @@ pub const mouse_button = struct {
     pub const fifth: i32 = 4; // forward
 };
 
+pub const HoverContext = struct {
+    x: f64 = 0,
+    y: f64 = 0,
+    buttons: u16 = 0,
+    modifiers: Modifiers = .{},
+    // WebDriver's pointer source also fires the pointerover/out/enter/leave
+    // twins; the CDP mouse path only synthesizes mouse events.
+    with_pointer: bool = false,
+};
+
+// Update the element being hovered. The page always tracks the currently
+// hovered item so that trasitions can fire the correct events. e.g. mouseout
+// bubbles up normally, but mouseleave will only fire on parents where the new
+// target isn't part of.
+pub fn updateHoverTarget(frame: *Frame, to: ?*Element, ctx: HoverContext) void {
+    const page = frame._page;
+    const from = page.input_hover_target;
+    if (from == to) {
+        return;
+    }
+    page.input_hover_target = to;
+
+    const pivot: ?*Node = blk: {
+        const a = from orelse break :blk null;
+        const b = to orelse break :blk null;
+        var current: ?*Node = a.asNode();
+        while (current) |node| : (current = node.parentNode()) {
+            if (node.contains(b.asNode())) {
+                break :blk node;
+            }
+        }
+        break :blk null;
+    };
+
+    if (from) |old| {
+        dispatchBoundaryEvent(frame, old, "mouseout", "pointerout", to, true, ctx);
+        var current: ?*Node = old.asNode();
+        while (current) |node| : (current = node.parentNode()) {
+            if (node == pivot) {
+                break;
+            }
+            if (node.is(Element)) |element| {
+                dispatchBoundaryEvent(frame, element, "mouseleave", "pointerleave", to, false, ctx);
+            }
+        }
+    }
+
+    if (to) |new| {
+        dispatchBoundaryEvent(frame, new, "mouseover", "pointerover", from, true, ctx);
+
+        // Enter fires outermost-first. The chain is walked without allocating:
+        // count the elements between the target and the pivot, then re-walk to
+        // reach each one from the deepest ancestor down.
+        var count: usize = 0;
+        var current: ?*Node = new.asNode();
+        while (current) |node| : (current = node.parentNode()) {
+            if (node == pivot) {
+                break;
+            }
+            if (node.is(Element) != null) {
+                count += 1;
+            }
+        }
+        while (count > 0) : (count -= 1) {
+            var remaining = count;
+            current = new.asNode();
+            while (current) |node| : (current = node.parentNode()) {
+                const element = node.is(Element) orelse continue;
+                remaining -= 1;
+                if (remaining == 0) {
+                    dispatchBoundaryEvent(frame, element, "mouseenter", "pointerenter", from, false, ctx);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// Fire a pointer/mouse event pair, e.g. pointerout + mouseout
+fn dispatchBoundaryEvent(frame: *Frame, target: *Element, comptime mouse_typ: []const u8, comptime pointer_typ: []const u8, related: ?*Element, bubbling: bool, ctx: HoverContext) void {
+    const modifiers = ctx.modifiers;
+    const related_target = if (related) |r| r.asEventTarget() else null;
+
+    if (ctx.with_pointer) {
+        const pointer_event = PointerEvent.initTrusted(pointer_typ, .{
+            .bubbles = bubbling,
+            .cancelable = bubbling,
+            .composed = bubbling,
+            .clientX = ctx.x,
+            .clientY = ctx.y,
+            .buttons = ctx.buttons,
+            .pointerId = 1,
+            .pointerType = "mouse",
+            .isPrimary = true,
+            .relatedTarget = related_target,
+            .ctrlKey = modifiers.ctrl,
+            .shiftKey = modifiers.shift,
+            .altKey = modifiers.alt,
+            .metaKey = modifiers.meta,
+        }, frame) catch |err| {
+            log.warn(.frame, "boundary pointer event", .{ .err = err, .type = pointer_typ });
+            return;
+        };
+        frame._event_manager.dispatch(target.asEventTarget(), pointer_event.asEvent()) catch |err| {
+            log.warn(.frame, "boundary pointer dispatch", .{ .err = err, .type = pointer_typ });
+        };
+    }
+
+    const mouse_event = MouseEvent.initTrusted(comptime .wrap(mouse_typ), .{
+        .bubbles = bubbling,
+        .cancelable = bubbling,
+        .composed = bubbling,
+        .clientX = ctx.x,
+        .clientY = ctx.y,
+        .buttons = ctx.buttons,
+        .relatedTarget = related_target,
+        .ctrlKey = modifiers.ctrl,
+        .shiftKey = modifiers.shift,
+        .altKey = modifiers.alt,
+        .metaKey = modifiers.meta,
+    }, frame) catch |err| {
+        log.warn(.frame, "boundary mouse event", .{ .err = err, .type = mouse_typ });
+        return;
+    };
+    frame._event_manager.dispatch(target.asEventTarget(), mouse_event.asEvent()) catch |err| {
+        log.warn(.frame, "boundary mouse dispatch", .{ .err = err, .type = mouse_typ });
+    };
+}
+
 // Dispatch a single trusted mouse event of the given type on `target`, carrying
 // the pressed button and pointer position. `detail` is the click count (used for
 // click/dblclick); 0 for events where it does not apply.
@@ -93,6 +222,8 @@ pub fn triggerMouseMove(frame: *Frame, x: f64, y: f64) !void {
         });
     }
 
+    updateHoverTarget(frame, target, .{ .x = x, .y = y });
+
     const move_event: *MouseEvent = try .initTrusted(comptime .wrap("mousemove"), .{
         .bubbles = true,
         .cancelable = true,
@@ -101,22 +232,6 @@ pub fn triggerMouseMove(frame: *Frame, x: f64, y: f64) !void {
         .clientY = y,
     }, frame);
     try frame._event_manager.dispatch(target.asEventTarget(), move_event.asEvent());
-
-    const over_event: *MouseEvent = try .initTrusted(comptime .wrap("mouseover"), .{
-        .bubbles = true,
-        .cancelable = true,
-        .composed = true,
-        .clientX = x,
-        .clientY = y,
-    }, frame);
-    try frame._event_manager.dispatch(target.asEventTarget(), over_event.asEvent());
-
-    const enter_event: *MouseEvent = try .initTrusted(comptime .wrap("mouseenter"), .{
-        .composed = true,
-        .clientX = x,
-        .clientY = y,
-    }, frame);
-    try frame._event_manager.dispatch(target.asEventTarget(), enter_event.asEvent());
 }
 
 pub fn triggerMouseRelease(frame: *Frame, x: f64, y: f64, button: i32, click_count: i32) !void {
@@ -742,3 +857,10 @@ pub fn insertText(frame: *Frame, v: []const u8) !void {
         return textarea.innerInsert(v, frame);
     }
 }
+
+pub const Modifiers = struct {
+    ctrl: bool = false,
+    shift: bool = false,
+    alt: bool = false,
+    meta: bool = false,
+};

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -22,17 +22,19 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 const Page = @import("../Page.zig");
 const Frame = @import("../Frame.zig");
+const EventManagerBase = @import("../EventManagerBase.zig");
+const Modifiers = @import("../frame/user_input.zig").Modifiers;
+
+const Event = @import("Event.zig");
+const Element = @import("Element.zig");
+const EventTarget = @import("EventTarget.zig");
 
 const Cookie = @import("storage/Cookie.zig");
-const Element = @import("Element.zig");
-const Event = @import("Event.zig");
-const EventTarget = @import("EventTarget.zig");
 const MouseEvent = @import("event/MouseEvent.zig");
+const TouchEvent = @import("event/TouchEvent.zig");
+const WheelEvent = @import("event/WheelEvent.zig");
 const PointerEvent = @import("event/PointerEvent.zig");
 const KeyboardEvent = @import("event/KeyboardEvent.zig");
-const WheelEvent = @import("event/WheelEvent.zig");
-const TouchEvent = @import("event/TouchEvent.zig");
-const EventManagerBase = @import("../EventManagerBase.zig");
 
 const log = lp.log;
 
@@ -234,6 +236,9 @@ fn performPointerSource(source: js.Object, frame: *Frame) !void {
     // whose origin resolved to an element.
     var target: ?*Element = null;
     var pressed = false;
+    // The buttons bitmask of the currently depressed button, carried on move
+    // and boundary events while dragging.
+    var pressed_mask: u16 = 0;
     // Where the last pointerDown landed: the click fires at the nearest common
     // inclusive ancestor of the down and up targets when they differ.
     var down_target: ?*Element = null;
@@ -253,20 +258,34 @@ fn performPointerSource(source: js.Object, frame: *Frame) !void {
             const origin = try action.get("origin");
             if (origin.isObject()) {
                 target = origin.local.jsValueToZig(*Element, origin) catch null;
+            } else {
+                const y = readI32(action, "y", 0);
+                if (frame.document.elementFromVerticalPoint(@floatFromInt(y), frame) catch null) |el| {
+                    target = el;
+                } else if (frame.document.getDocumentElement()) |root| {
+                    target = root;
+                }
             }
             const el = target orelse continue;
-            dispatchPointer(el, "pointermove", 0, 0, frame);
             if (is_touch) {
+                dispatchPointer(el, "pointermove", 0, pressed_mask, frame);
                 if (pressed) {
                     dispatchTouch(el, "touchmove", frame);
                 }
             } else {
-                dispatchMouse(el, "mousemove", 0, 0, 0, frame);
+                Frame.user_input.updateHoverTarget(frame, el, .{
+                    .buttons = pressed_mask,
+                    .modifiers = frame._page.input_modifiers,
+                    .with_pointer = true,
+                });
+                dispatchPointer(el, "pointermove", 0, pressed_mask, frame);
+                dispatchMouse(el, "mousemove", 0, pressed_mask, 0, frame);
             }
         } else if (action_type.eql(comptime .wrap("pointerDown"))) {
             const el = target orelse continue;
             const button = readI32(action, "button", 0);
             pressed = true;
+            pressed_mask = buttonsMask(button);
             down_target = el;
             if (last_click_target == el and last_click_button == button) {
                 click_count += 1;
@@ -286,6 +305,7 @@ fn performPointerSource(source: js.Object, frame: *Frame) !void {
             const el = target orelse continue;
             const button = readI32(action, "button", 0);
             pressed = false;
+            pressed_mask = 0;
             dispatchPointer(el, "pointerup", button, 0, frame);
             if (is_touch) {
                 dispatchTouch(el, "touchend", frame);
@@ -483,13 +503,6 @@ fn webdriverKey(value: []const u8) []const u8 {
         else => value,
     };
 }
-
-pub const Modifiers = struct {
-    ctrl: bool = false,
-    shift: bool = false,
-    alt: bool = false,
-    meta: bool = false,
-};
 
 fn setModifier(modifiers: *Modifiers, key: []const u8, pressed: bool) void {
     if (std.mem.eql(u8, key, "Shift")) {


### PR DESCRIPTION
The Page now tracks the element currently being hovered. We need to track this so that subsequent mouse events can fire the correct events. This is largely a WebDriver (WPT) change, but it's also triggered from CDP's `input.dispatchMouseEvent`.

So, for example, if CDP `dispatchMouseEvent` with a mouseMoved to element1 we'll fire a mouseenter. If the same command is issue for the same element, we should NOT trigger a mouseout and mouseenter.