### PR TITLE
fetch: add --selector and --max-bytes, honor --strip-mode for markdown

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -374,8 +374,8 @@ const Commands = cli.Builder(.{
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
             .{ .name = "strip_mode", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
-            .{ .name = "selector", .type = ?[:0]const u8 },
-            .{ .name = "max_bytes", .type = ?u32 },
+            .{ .name = "dump_selector", .type = ?[:0]const u8 },
+            .{ .name = "dump_max_bytes", .type = ?u32 },
             .{ .name = "wait_ms", .type = u32, .default = 5_000 },
             .{ .name = "wait_until", .type = ?WaitUntil },
             .{

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -374,6 +374,8 @@ const Commands = cli.Builder(.{
             .{ .name = "with_base", .type = bool },
             .{ .name = "with_frames", .type = bool },
             .{ .name = "strip_mode", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
+            .{ .name = "selector", .type = ?[:0]const u8 },
+            .{ .name = "max_bytes", .type = ?u32 },
             .{ .name = "wait_ms", .type = u32, .default = 5_000 },
             .{ .name = "wait_until", .type = ?WaitUntil },
             .{

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -376,6 +376,7 @@ const Commands = cli.Builder(.{
             .{ .name = "strip_mode", .type = dump.Opts.Strip, .default = dump.Opts.Strip{} },
             .{ .name = "dump_selector", .type = ?[:0]const u8 },
             .{ .name = "dump_max_bytes", .type = ?u32 },
+            .{ .name = "fail_on_http_error", .type = bool },
             .{ .name = "wait_ms", .type = u32, .default = 5_000 },
             .{ .name = "wait_until", .type = ?WaitUntil },
             .{

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 const Frame = @import("Frame.zig");
+const LimitedWriter = @import("../LimitedWriter.zig");
 const Node = @import("webapi/Node.zig");
 const Slot = @import("webapi/element/html/Slot.zig");
 const IFrame = @import("webapi/element/html/IFrame.zig");
@@ -28,6 +29,9 @@ pub const Opts = struct {
     with_frames: bool = false,
     strip: Opts.Strip = .{},
     shadow: Opts.Shadow = .rendered,
+    /// Soft cap: output is cut at a UTF-8 boundary and a truncation marker
+    /// appended.
+    max_bytes: ?u32 = null,
 
     pub const Strip = packed struct(u4) {
         js: bool = false,
@@ -59,6 +63,16 @@ pub const Opts = struct {
 };
 
 pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !void {
+    if (opts.max_bytes == null) return rootUncapped(doc, opts, writer, frame);
+
+    var lw: LimitedWriter = .init(writer, opts.max_bytes);
+    rootUncapped(doc, opts, &lw.writer, frame) catch |err| {
+        if (!lw.truncated) return err;
+        try writer.writeAll(LimitedWriter.truncation_marker);
+    };
+}
+
+fn rootUncapped(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !void {
     if (doc.is(Node.Document.HTMLDocument)) |html_doc| {
         blk: {
             // Ideally we just render the doctype which is part of the document
@@ -80,11 +94,17 @@ pub fn root(doc: *Node.Document, opts: Opts, writer: *std.Io.Writer, frame: *Fra
         }
     }
 
-    return deep(doc.asNode(), opts, writer, frame);
+    return _deep(doc.asNode(), opts, false, writer, frame);
 }
 
 pub fn deep(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) error{WriteFailed}!void {
-    return _deep(node, opts, false, writer, frame);
+    if (opts.max_bytes == null) return _deep(node, opts, false, writer, frame);
+
+    var lw: LimitedWriter = .init(writer, opts.max_bytes);
+    _deep(node, opts, false, &lw.writer, frame) catch |err| {
+        if (!lw.truncated) return err;
+        try writer.writeAll(LimitedWriter.truncation_marker);
+    };
 }
 
 fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Writer, frame: *Frame) error{WriteFailed}!void {
@@ -497,6 +517,20 @@ test "dump: strip.ui removes css plus visual elements" {
         \\<!DOCTYPE html>
         \\<html><head><script>var a=1;</script></head><body><h1>Title</h1><p class="hidden">secret</p><noscript>nojs</noscript><p>visible &amp; well</p></body></html>
     );
+}
+
+test "dump: max_bytes truncates with a marker" {
+    var page = try testing.pageTest("dump.html", .{});
+    defer page.close();
+    const frame = page.frame().?;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    try root(frame.window._document, .{ .max_bytes = 24 }, &aw.writer, frame);
+    try testing.expectString("<!DOCTYPE html>\n<html><h" ++ LimitedWriter.truncation_marker, aw.written());
+
+    aw.clearRetainingCapacity();
+    try deep(frame.window._document.asNode().lastChild().?, .{ .max_bytes = 6 }, &aw.writer, frame);
+    try testing.expectString("<html>" ++ LimitedWriter.truncation_marker, aw.written());
 }
 
 test "dump: strip.invisible removes author display:none elements" {

--- a/src/browser/dump.zig
+++ b/src/browser/dump.zig
@@ -111,7 +111,7 @@ fn _deep(node: *Node, opts: Opts, comptime force_slot: bool, writer: *std.Io.Wri
         },
         .element => {
             const el = node.subtype(Node.Element);
-            if (shouldStripElement(el, opts, frame)) {
+            if (shouldStripElement(el, opts.strip, frame)) {
                 return;
             }
 
@@ -338,15 +338,15 @@ fn isVoidElement(el: *const Node.Element) bool {
     };
 }
 
-fn shouldStripElement(el: *Node.Element, opts: Opts, frame: *Frame) bool {
+pub fn shouldStripElement(el: *Node.Element, strip: Opts.Strip, frame: *Frame) bool {
     // Fast path: with no strip flags set (every innerHTML/outerHTML call)
-    if (@as(u4, @bitCast(opts.strip)) == 0) {
+    if (@as(u4, @bitCast(strip)) == 0) {
         return false;
     }
 
     const tag_name = el.getTagNameDump();
 
-    if (opts.strip.js) {
+    if (strip.js) {
         if (std.mem.eql(u8, tag_name, "script")) return true;
         if (std.mem.eql(u8, tag_name, "noscript")) return true;
 
@@ -364,7 +364,7 @@ fn shouldStripElement(el: *Node.Element, opts: Opts, frame: *Frame) bool {
         }
     }
 
-    if (opts.strip.css or opts.strip.ui) {
+    if (strip.css or strip.ui) {
         if (std.mem.eql(u8, tag_name, "style")) return true;
 
         if (std.mem.eql(u8, tag_name, "link")) {
@@ -374,7 +374,7 @@ fn shouldStripElement(el: *Node.Element, opts: Opts, frame: *Frame) bool {
         }
     }
 
-    if (opts.strip.ui) {
+    if (strip.ui) {
         if (std.mem.eql(u8, tag_name, "img")) return true;
         if (std.mem.eql(u8, tag_name, "picture")) return true;
         if (std.mem.eql(u8, tag_name, "video")) return true;
@@ -384,7 +384,7 @@ fn shouldStripElement(el: *Node.Element, opts: Opts, frame: *Frame) bool {
         if (std.mem.eql(u8, tag_name, "iframe")) return true;
     }
 
-    if (opts.strip.invisible and frame._style_manager.hasAuthorDisplayNone(el, .scan)) {
+    if (strip.invisible and frame._style_manager.hasAuthorDisplayNone(el, .scan)) {
         return true;
     }
 

--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -28,9 +28,13 @@ const Slot = @import("webapi/element/html/Slot.zig");
 
 const isAllWhitespace = @import("../string.zig").isAllWhitespace;
 const LimitedWriter = @import("../LimitedWriter.zig");
+const Strip = @import("dump.zig").Opts.Strip;
 
 pub const Opts = struct {
     max_bytes: ?u32 = null,
+    // Only `ui` (images) applies: scripts, styles and hidden elements are
+    // never rendered.
+    strip: Strip = .{},
 };
 
 const truncation_marker = LimitedWriter.truncation_marker;
@@ -148,6 +152,7 @@ const Context = struct {
     writer: *std.Io.Writer,
     frame: *Frame,
     root: *Node,
+    strip: Strip,
 
     // When there's a slot-attribute, we skip rendering, unless this flag has
     // bet set to true.
@@ -318,6 +323,7 @@ const Context = struct {
                 return;
             },
             .img => {
+                if (self.strip.ui) return;
                 try self.writer.writeAll("![");
                 if (el.getAttributeSafe(comptime .wrap("alt"))) |alt| {
                     try self.escape(alt);
@@ -524,6 +530,7 @@ pub fn dump(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !voi
             .writer = &lw.writer,
             .frame = frame,
             .root = node,
+            .strip = opts.strip,
         };
         ctx.render(node) catch |err| switch (err) {
             error.WriteFailed => {
@@ -543,6 +550,7 @@ pub fn dump(node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !voi
         .writer = writer,
         .frame = frame,
         .root = node,
+        .strip = opts.strip,
     };
     try ctx.render(node);
     if (!ctx.state.last_char_was_newline) {
@@ -855,6 +863,22 @@ test "browser.markdown: scoped dump of a hidden subtree still renders it" {
     try dump(modal, .{}, &aw.writer, frame);
 
     try testing.expectString("\ndialog text\n", aw.written());
+}
+
+test "browser.markdown: strip.ui drops images" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+    frame.url = "http://localhost/";
+
+    const doc = frame.window._document;
+    const div = try doc.createElement("div", null, frame);
+    try Frame.parse.htmlAsChildren(frame, div.asNode(), "<p>Text <img src=\"a.png\" alt=\"A\"> more</p>");
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try dump(div.asNode(), .{ .strip = .{ .ui = true } }, &aw.writer, frame);
+
+    try testing.expectString("\nText  more\n", aw.written());
 }
 
 test "browser.markdown: max_bytes leaves output untouched when under cap" {

--- a/src/browser/markdown.zig
+++ b/src/browser/markdown.zig
@@ -28,12 +28,11 @@ const Slot = @import("webapi/element/html/Slot.zig");
 
 const isAllWhitespace = @import("../string.zig").isAllWhitespace;
 const LimitedWriter = @import("../LimitedWriter.zig");
-const Strip = @import("dump.zig").Opts.Strip;
+const dump_html = @import("dump.zig");
+const Strip = dump_html.Opts.Strip;
 
 pub const Opts = struct {
     max_bytes: ?u32 = null,
-    // Only `ui` (images) applies: scripts, styles and hidden elements are
-    // never rendered.
     strip: Strip = .{},
 };
 
@@ -217,6 +216,7 @@ const Context = struct {
         const tag = el.getTag();
 
         if (el.asNode() != self.root and !isVisibleElement(el, self.frame)) return;
+        if (dump_html.shouldStripElement(el, self.strip, self.frame)) return;
 
         if (!force_slot) {
             if (el.getAttributeSafe(comptime .wrap("slot")) != null) {
@@ -323,7 +323,6 @@ const Context = struct {
                 return;
             },
             .img => {
-                if (self.strip.ui) return;
                 try self.writer.writeAll("![");
                 if (el.getAttributeSafe(comptime .wrap("alt"))) |alt| {
                     try self.escape(alt);
@@ -865,14 +864,14 @@ test "browser.markdown: scoped dump of a hidden subtree still renders it" {
     try testing.expectString("\ndialog text\n", aw.written());
 }
 
-test "browser.markdown: strip.ui drops images" {
+test "browser.markdown: strip.ui drops images and other visual elements" {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();
     frame.url = "http://localhost/";
 
     const doc = frame.window._document;
     const div = try doc.createElement("div", null, frame);
-    try Frame.parse.htmlAsChildren(frame, div.asNode(), "<p>Text <img src=\"a.png\" alt=\"A\"> more</p>");
+    try Frame.parse.htmlAsChildren(frame, div.asNode(), "<p>Text <img src=\"a.png\" alt=\"A\"> more<canvas>fallback</canvas></p>");
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -28,7 +28,6 @@ const keenable = zenai.search.keenable;
 
 const DOMNode = @import("webapi/Node.zig");
 const CDPNode = @import("../cdp/Node.zig");
-const LimitedWriter = @import("../LimitedWriter.zig");
 const Selector = @import("webapi/selector/Selector.zig");
 
 /// Conventions any LLM driving Lightpanda should follow. The standalone
@@ -1287,32 +1286,18 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
     const args = try parseArgsOrDefault(HtmlParams, arena, arguments);
     const page = try ensurePage(session, registry, args.url, args.timeout);
 
+    const opts: lp.dump.Opts = .{ .strip = args.strip, .max_bytes = args.maxBytes };
     var aw: std.Io.Writer.Allocating = .init(arena);
-    var lw: LimitedWriter = .init(&aw.writer, args.maxBytes);
-    dumpHtml(session, registry, page, args, &lw.writer) catch |err| switch (err) {
-        error.WriteFailed => if (!lw.truncated) return ToolError.InternalError,
-        else => |e| return e,
-    };
-    if (lw.truncated) {
-        aw.writer.writeAll(LimitedWriter.truncation_marker) catch return ToolError.InternalError;
-    }
-    return aw.written();
-}
-
-fn dumpHtml(session: *lp.Session, registry: *CDPNode.Registry, page: *lp.Frame, args: HtmlParams, writer: *std.Io.Writer) (ToolError || error{WriteFailed})!void {
-    const opts: lp.dump.Opts = .{ .strip = args.strip };
     if (args.selector) |sel| {
         const resolved = try resolveBySelector(session, sel);
-        return lp.dump.deep(resolved.node, opts, writer, resolved.page);
-    }
-    if (args.backendNodeId) |nid| {
+        lp.dump.deep(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
+    } else if (args.backendNodeId) |nid| {
         const resolved = try resolveNodeAndPage(session, registry, nid);
-        return lp.dump.deep(resolved.node, opts, writer, resolved.page);
+        lp.dump.deep(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
+    } else {
+        lp.dump.root(page.document, opts, &aw.writer, page) catch return ToolError.InternalError;
     }
-    return lp.dump.root(page.document, opts, writer, page) catch |err| switch (err) {
-        error.WriteFailed => error.WriteFailed,
-        else => ToolError.InternalError,
-    };
+    return aw.written();
 }
 
 fn execLinks(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {

--- a/src/help.zon
+++ b/src/help.zon
@@ -84,12 +84,21 @@
     \\          prints one object; multiple URLs print {{"results": [ ... ]}} with
     \\          one object per URL. When used with --dump <MODE> the dumped
     \\          content is wrapped within each object.
+    \\  --max-bytes <INT>
+    \\          Soft cap on the dumped html or markdown, in bytes. Output is cut
+    \\          at a UTF-8 boundary and a '[truncated]' marker is appended.
+    \\          Defaults to no cap.
     \\  --metrics
     \\          Write metrics (Prometheus text format) to stdout on exit, after
     \\          any --dump output.
     \\          Defaults to false.
+    \\  --selector <QUERY>
+    \\          Dump only the first element matching the CSS selector instead
+    \\          of the whole document. Fails if nothing matches.
     \\  --strip-mode <STRIP>
     \\          Tag group to remove from dump. Can be passed multiple times.
+    \\          Markdown never contains scripts, styles or hidden elements, so
+    \\          only 'ui' (images) applies to it.
     \\          Defaults to no-strip.
     \\          Allowed values:
     \\              js        Script and link[as=script, rel=preload].

--- a/src/help.zon
+++ b/src/help.zon
@@ -84,7 +84,7 @@
     \\          prints one object; multiple URLs print {{"results": [ ... ]}} with
     \\          one object per URL. When used with --dump <MODE> the dumped
     \\          content is wrapped within each object.
-    \\  --max-bytes <INT>
+    \\  --dump-max-bytes <INT>
     \\          Soft cap on the dumped html or markdown, in bytes. Output is cut
     \\          at a UTF-8 boundary and a '[truncated]' marker is appended.
     \\          Defaults to no cap.
@@ -92,7 +92,7 @@
     \\          Write metrics (Prometheus text format) to stdout on exit, after
     \\          any --dump output.
     \\          Defaults to false.
-    \\  --selector <QUERY>
+    \\  --dump-duselector <QUERY>
     \\          Dump only the first element matching the CSS selector instead
     \\          of the whole document. Fails if nothing matches.
     \\  --strip-mode <STRIP>

--- a/src/help.zon
+++ b/src/help.zon
@@ -79,6 +79,11 @@
     \\  --dump-selector <QUERY>
     \\          Dump only the first element matching the CSS selector instead
     \\          of the whole document. Fails if nothing matches.
+    \\  --fail-on-http-error
+    \\          Exit with code 22 when any page's HTTP status is 400 or above.
+    \\          The dump is still written. Navigation and wait failures exit
+    \\          with code 1 regardless of this flag.
+    \\          Defaults to false.
     \\  --inject-script <EXPR>
     \\          JavaScript to execute as the document's <head> is parsed, before any
     \\          other scripts in the page run. Can be passed multiple times; scripts
@@ -90,7 +95,10 @@
     \\          Capture and print the status of the fetch as JSON. A single URL
     \\          prints one object; multiple URLs print {{"results": [ ... ]}} with
     \\          one object per URL. When used with --dump <MODE> the dumped
-    \\          content is wrapped within each object.
+    \\          content is wrapped within each object. Each object carries an
+    \\          "error" field: null, or the name of the navigation, wait or
+    \\          dump failure for that URL. One failed URL does not stop the
+    \\          others; the process exits 1 if any URL failed.
     \\  --metrics
     \\          Write metrics (Prometheus text format) to stdout on exit, after
     \\          any --dump output.

--- a/src/help.zon
+++ b/src/help.zon
@@ -72,6 +72,13 @@
     \\                                 PNG image (base64 with --json).
     \\              semantic_tree      JSON-serialized semantic tree.
     \\              semantic_tree_text Pruned plain-text semantic tree.
+    \\  --dump-max-bytes <INT>
+    \\          Soft cap on the dumped html or markdown, in bytes. Output is cut
+    \\          at a UTF-8 boundary and a '[truncated]' marker is appended.
+    \\          Defaults to no cap.
+    \\  --dump-selector <QUERY>
+    \\          Dump only the first element matching the CSS selector instead
+    \\          of the whole document. Fails if nothing matches.
     \\  --inject-script <EXPR>
     \\          JavaScript to execute as the document's <head> is parsed, before any
     \\          other scripts in the page run. Can be passed multiple times; scripts
@@ -84,17 +91,10 @@
     \\          prints one object; multiple URLs print {{"results": [ ... ]}} with
     \\          one object per URL. When used with --dump <MODE> the dumped
     \\          content is wrapped within each object.
-    \\  --dump-max-bytes <INT>
-    \\          Soft cap on the dumped html or markdown, in bytes. Output is cut
-    \\          at a UTF-8 boundary and a '[truncated]' marker is appended.
-    \\          Defaults to no cap.
     \\  --metrics
     \\          Write metrics (Prometheus text format) to stdout on exit, after
     \\          any --dump output.
     \\          Defaults to false.
-    \\  --dump-duselector <QUERY>
-    \\          Dump only the first element matching the CSS selector instead
-    \\          of the whole document. Fails if nothing matches.
     \\  --strip-mode <STRIP>
     \\          Tag group to remove from dump. Can be passed multiple times.
     \\          In markdown only 'ui' changes the output: scripts, styles and

--- a/src/help.zon
+++ b/src/help.zon
@@ -97,8 +97,8 @@
     \\          of the whole document. Fails if nothing matches.
     \\  --strip-mode <STRIP>
     \\          Tag group to remove from dump. Can be passed multiple times.
-    \\          Markdown never contains scripts, styles or hidden elements, so
-    \\          only 'ui' (images) applies to it.
+    \\          In markdown only 'ui' changes the output: scripts, styles and
+    \\          hidden elements are never rendered.
     \\          Defaults to no-strip.
     \\          Allowed values:
     \\              js        Script and link[as=script, rel=preload].

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -40,7 +40,6 @@ pub const dump = @import("browser/dump.zig");
 pub const markdown = @import("browser/markdown.zig");
 pub const screenshot = @import("browser/screenshot.zig");
 pub const Base64Writer = @import("Base64Writer.zig");
-const LimitedWriter = @import("LimitedWriter.zig");
 const Selector = @import("browser/webapi/selector/Selector.zig");
 const Node = @import("browser/webapi/Node.zig");
 pub const SemanticTree = @import("SemanticTree.zig");
@@ -191,8 +190,6 @@ pub const FetchOpts = struct {
     dump_mode: ?Config.DumpFormat = null,
     /// Dump only the first match instead of the document.
     selector: ?[:0]const u8 = null,
-    /// html and markdown only.
-    max_bytes: ?u32 = null,
     /// Any page with an HTTP status >= 400 fails the fetch with `error.HttpError`.
     fail_on_http_error: bool = false,
     writer: ?*std.Io.Writer = null,
@@ -438,18 +435,11 @@ fn dumpRoot(frame: *Frame, selector: ?[]const u8) !*Node {
 fn dumpContent(app: *App, mode: Config.DumpFormat, opts: FetchOpts, frame: *Frame, writer: *std.Io.Writer) !void {
     const root = try dumpRoot(frame, opts.selector);
     switch (mode) {
-        .html => {
-            var lw: LimitedWriter = .init(writer, opts.max_bytes);
-            const result = if (opts.selector == null)
-                dump.root(frame.window._document, opts.dump, &lw.writer, frame)
-            else
-                dump.deep(root, opts.dump, &lw.writer, frame);
-            result catch |err| {
-                if (!lw.truncated) return err;
-                try writer.writeAll(LimitedWriter.truncation_marker);
-            };
-        },
-        .markdown => try markdown.dump(root, .{ .max_bytes = opts.max_bytes, .strip = opts.dump.strip }, writer, frame),
+        .html => if (opts.selector == null)
+            try dump.root(frame.window._document, opts.dump, writer, frame)
+        else
+            try dump.deep(root, opts.dump, writer, frame),
+        .markdown => try markdown.dump(root, .{ .max_bytes = opts.dump.max_bytes, .strip = opts.dump.strip }, writer, frame),
         .png => {
             var arena: std.heap.ArenaAllocator = .init(app.allocator);
             defer arena.deinit();

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -313,10 +313,6 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
                 continue;
             };
             const remaining = opts.wait_ms -| @as(u32, @intCast(timer.untilNow(io, .boot).toMilliseconds()));
-            if (remaining == 0) {
-                err.* = error.Timeout;
-                continue;
-            }
             _ = runner.waitForSelector(frame._frame_id, selector, remaining) catch |e| {
                 err.* = e;
             };
@@ -331,10 +327,6 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
                 continue;
             };
             const remaining = opts.wait_ms -| @as(u32, @intCast(timer.untilNow(io, .boot).toMilliseconds()));
-            if (remaining == 0) {
-                err.* = error.Timeout;
-                continue;
-            }
             runner.waitForScript(frame._frame_id, wait_script, remaining) catch |e| {
                 err.* = e;
             };
@@ -344,19 +336,41 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
     var http_error = false;
     for (pages.items, errors) |page, *err| {
         const frame = page.frame() orelse {
-            if (err.* == null) err.* = error.FrameClosed;
+            if (err.* == null) {
+                err.* = error.FrameClosed;
+            }
             continue;
         };
-        if (err.* == null) err.* = frame._last_navigate_error;
+        if (err.* == null) {
+            err.* = frame._last_navigate_error;
+        }
         if (frame._http_status) |status| {
-            if (status >= 400) http_error = true;
+            if (status >= 400) {
+                http_error = true;
+            }
         }
     }
 
     try writeResults(app, opts, pages.items, errors);
 
-    for (errors) |err| {
-        if (err) |e| return e;
+    var failed = false;
+    for (urls, pages.items, errors) |url, page, err| {
+        if (err) |e| {
+            failed = true;
+            log.err(.app, "page failed", .{ .url = url, .err = e });
+            continue;
+        }
+        if (!opts.fail_on_http_error) {
+            continue;
+        }
+        const frame = page.frame() orelse continue;
+        const status = frame._http_status orelse continue;
+        if (status >= 400) {
+            log.err(.app, "page http error", .{ .url = url, .status = status });
+        }
+    }
+    if (failed) {
+        return error.PageFailed;
     }
     if (opts.fail_on_http_error and http_error) {
         return error.HttpError;
@@ -386,14 +400,13 @@ fn writeResults(app: *App, opts: FetchOpts, pages: []const Session.PageHandle, e
                 const arena = try app.arena_pool.acquire(.large, "screenshot.dump");
                 defer arena.release();
 
-                if (screenshot.prepare(arena.allocator(), try dumpRoot(frame.?, opts.selector), .{
-                    .width = frame.?._page.getViewport().width,
-                }, frame.?)) |shot| {
+                if (prepareShot(arena.allocator(), frame.?, opts)) |shot| {
                     try writeJsonEnvelope(writer, frame, opts.dump_mode, shot, err.*);
-                    continue;
                 } else |e| {
                     if (err.* == null) err.* = e;
+                    try writeJsonEnvelope(writer, frame, opts.dump_mode, "", err.*);
                 }
+                continue;
             }
 
             var aw: std.Io.Writer.Allocating = .init(app.allocator);
@@ -423,6 +436,12 @@ fn writeResults(app: *App, opts: FetchOpts, pages: []const Session.PageHandle, e
         }
     }
     try writer.flush();
+}
+
+fn prepareShot(arena: std.mem.Allocator, frame: *Frame, opts: FetchOpts) !screenshot.Prepared {
+    return screenshot.prepare(arena, try dumpRoot(frame, opts.selector), .{
+        .width = frame._page.getViewport().width,
+    }, frame);
 }
 
 fn dumpRoot(frame: *Frame, selector: ?[]const u8) !*Node {

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -40,6 +40,9 @@ pub const dump = @import("browser/dump.zig");
 pub const markdown = @import("browser/markdown.zig");
 pub const screenshot = @import("browser/screenshot.zig");
 pub const Base64Writer = @import("Base64Writer.zig");
+const LimitedWriter = @import("LimitedWriter.zig");
+const Selector = @import("browser/webapi/selector/Selector.zig");
+const Node = @import("browser/webapi/Node.zig");
 pub const SemanticTree = @import("SemanticTree.zig");
 pub const CDPNode = @import("cdp/Node.zig");
 pub const interactive = @import("browser/interactive.zig");
@@ -186,6 +189,10 @@ pub const FetchOpts = struct {
     wait_selector: ?[:0]const u8 = null,
     dump: dump.Opts,
     dump_mode: ?Config.DumpFormat = null,
+    /// Dump only the first match instead of the document.
+    selector: ?[:0]const u8 = null,
+    /// html and markdown only.
+    max_bytes: ?u32 = null,
     writer: ?*std.Io.Writer = null,
     json: bool = false,
 };
@@ -345,7 +352,7 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
                 const arena = try app.arena_pool.acquire(.large, "screenshot.dump");
                 defer arena.release();
 
-                const shot = try screenshot.prepare(arena.allocator(), frame.?.window._document.asNode(), .{
+                const shot = try screenshot.prepare(arena.allocator(), try dumpRoot(frame.?, opts.selector), .{
                     .width = frame.?._page.getViewport().width,
                 }, frame.?);
                 try writeJsonEnvelope(writer, frame, opts.dump_mode, shot);
@@ -356,7 +363,7 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
             defer aw.deinit();
 
             if (opts.dump_mode) |mode| {
-                if (frame) |f| try dumpContent(app, mode, opts.dump, f, &aw.writer);
+                if (frame) |f| try dumpContent(app, mode, opts, f, &aw.writer);
             }
             try writeJsonEnvelope(writer, frame, opts.dump_mode, aw.written());
         }
@@ -372,20 +379,38 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
                 try writer.writeAll("Frame closed. Please open a bug report including the URL\n");
                 break :blk;
             };
-            try dumpContent(app, mode, opts.dump, frame, writer);
+            try dumpContent(app, mode, opts, frame, writer);
         }
     }
     try writer.flush();
 }
 
-fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: *Frame, writer: *std.Io.Writer) !void {
+fn dumpRoot(frame: *Frame, selector: ?[]const u8) !*Node {
+    const document = frame.window._document.asNode();
+    const sel = selector orelse return document;
+    const element = try Selector.querySelector(document, sel, frame);
+    return (element orelse return error.SelectorNotFound).asNode();
+}
+
+fn dumpContent(app: *App, mode: Config.DumpFormat, opts: FetchOpts, frame: *Frame, writer: *std.Io.Writer) !void {
+    const root = try dumpRoot(frame, opts.selector);
     switch (mode) {
-        .html => try dump.root(frame.window._document, dump_opts, writer, frame),
-        .markdown => try markdown.dump(frame.window._document.asNode(), .{}, writer, frame),
+        .html => {
+            var lw: LimitedWriter = .init(writer, opts.max_bytes);
+            const result = if (opts.selector == null)
+                dump.root(frame.window._document, opts.dump, &lw.writer, frame)
+            else
+                dump.deep(root, opts.dump, &lw.writer, frame);
+            result catch |err| {
+                if (!lw.truncated) return err;
+                try writer.writeAll(LimitedWriter.truncation_marker);
+            };
+        },
+        .markdown => try markdown.dump(root, .{ .max_bytes = opts.max_bytes, .strip = opts.dump.strip }, writer, frame),
         .png => {
             var arena: std.heap.ArenaAllocator = .init(app.allocator);
             defer arena.deinit();
-            _ = try screenshot.png(arena.allocator(), frame.window._document.asNode(), .{
+            _ = try screenshot.png(arena.allocator(), root, .{
                 .width = frame._page.getViewport().width,
             }, writer, frame);
         },
@@ -394,7 +419,7 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, dump_opts: dump.Opts, frame: 
             defer registry.deinit();
 
             const st: SemanticTree = .{
-                .dom_node = frame.window._document.asNode(),
+                .dom_node = root,
                 .registry = &registry,
                 .frame = frame,
                 .arena = frame.call_arena,

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -193,6 +193,8 @@ pub const FetchOpts = struct {
     selector: ?[:0]const u8 = null,
     /// html and markdown only.
     max_bytes: ?u32 = null,
+    /// Any page with an HTTP status >= 400 fails the fetch with `error.HttpError`.
+    fail_on_http_error: bool = false,
     writer: ?*std.Io.Writer = null,
     json: bool = false,
 };
@@ -208,15 +210,13 @@ fn resolveWaitUntil(opts: FetchOpts) ?Config.WaitUntil {
 }
 /// Loads each url in `urls` in a fresh session and waits per `opts`.
 ///
-/// Errors:
-///   - `error.Timeout` if the deadline expires while a `wait_selector` or
-///     `wait_script` is still unmet. The `wait_until` phase never raises it:
-///     when the budget runs out the page is dumped as-is.
-///   - `error.Cancelled` if the embedder installed a `Session.cancel_hook`
-///     that returned true during the wait. The hook is opt-in via
-///     `session.cancel_hook = .{...}`; without it, this error never fires.
-///   - Other errors from navigation / parsing / I/O surface as their
-///     underlying tag.
+/// A page's navigation, wait or dump failure is recorded for that page and
+/// does not stop the others: every page is still written (JSON carries the
+/// failure under `error`), then the first failure is returned. Wait failures
+/// are `error.Timeout` when the deadline expires while a `wait_selector` or
+/// `wait_script` is still unmet (the `wait_until` phase never raises it: when
+/// the budget runs out the page is dumped as-is), or `error.Cancelled` if the
+/// embedder's opt-in `Session.cancel_hook` returned true.
 pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: FetchOpts) !void {
     const notification = try Notification.init(app.allocator);
     defer notification.deinit();
@@ -304,32 +304,69 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
         try runner.waitForAll(opts.wait_ms, .{ .until = wu });
     }
 
+    // One slot per page; the first failure sticks.
+    const errors = try session.arena.allocator().alloc(?anyerror, pages.items.len);
+    @memset(errors, null);
+
     if (opts.wait_selector) |selector| {
-        const elapsed: u32 = @intCast(timer.untilNow(io, .boot).toMilliseconds());
-        const remaining = opts.wait_ms -| elapsed;
-        if (remaining == 0) {
-            return error.Timeout;
-        }
-        for (session.pages.items) |p| {
-            if (p.replacement == null) {
-                _ = try runner.waitForSelector(p.frame._frame_id, selector, remaining);
+        for (pages.items, errors) |page, *err| {
+            if (err.* != null) continue;
+            const frame = page.frame() orelse {
+                err.* = error.FrameClosed;
+                continue;
+            };
+            const remaining = opts.wait_ms -| @as(u32, @intCast(timer.untilNow(io, .boot).toMilliseconds()));
+            if (remaining == 0) {
+                err.* = error.Timeout;
+                continue;
             }
+            _ = runner.waitForSelector(frame._frame_id, selector, remaining) catch |e| {
+                err.* = e;
+            };
         }
     }
 
     if (opts.wait_script) |wait_script| {
-        const elapsed: u32 = @intCast(timer.untilNow(io, .boot).toMilliseconds());
-        const remaining = opts.wait_ms -| elapsed;
-        if (remaining == 0) {
-            return error.Timeout;
-        }
-        for (session.pages.items) |p| {
-            if (p.replacement == null) {
-                try runner.waitForScript(p.frame._frame_id, wait_script, remaining);
+        for (pages.items, errors) |page, *err| {
+            if (err.* != null) continue;
+            const frame = page.frame() orelse {
+                err.* = error.FrameClosed;
+                continue;
+            };
+            const remaining = opts.wait_ms -| @as(u32, @intCast(timer.untilNow(io, .boot).toMilliseconds()));
+            if (remaining == 0) {
+                err.* = error.Timeout;
+                continue;
             }
+            runner.waitForScript(frame._frame_id, wait_script, remaining) catch |e| {
+                err.* = e;
+            };
         }
     }
 
+    var http_error = false;
+    for (pages.items, errors) |page, *err| {
+        const frame = page.frame() orelse {
+            if (err.* == null) err.* = error.FrameClosed;
+            continue;
+        };
+        if (err.* == null) err.* = frame._last_navigate_error;
+        if (frame._http_status) |status| {
+            if (status >= 400) http_error = true;
+        }
+    }
+
+    try writeResults(app, opts, pages.items, errors);
+
+    for (errors) |err| {
+        if (err) |e| return e;
+    }
+    if (opts.fail_on_http_error and http_error) {
+        return error.HttpError;
+    }
+}
+
+fn writeResults(app: *App, opts: FetchOpts, pages: []const Session.PageHandle, errors: []?anyerror) !void {
     const writer = opts.writer orelse return;
 
     if (opts.json) {
@@ -338,11 +375,11 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
         // top-level array is hard to evolve (consumers index it directly),
         // whereas an object lets us add sibling fields later without breaking
         // anyone reading `results`.
-        const wrap = pages.items.len > 1;
+        const wrap = pages.len > 1;
         if (wrap) {
             try writer.writeAll("{\"results\":[");
         }
-        for (pages.items, 0..) |page, i| {
+        for (pages, errors, 0..) |page, *err, i| {
             if (i != 0) {
                 try writer.writeByte(',');
             }
@@ -352,20 +389,26 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
                 const arena = try app.arena_pool.acquire(.large, "screenshot.dump");
                 defer arena.release();
 
-                const shot = try screenshot.prepare(arena.allocator(), try dumpRoot(frame.?, opts.selector), .{
+                if (screenshot.prepare(arena.allocator(), try dumpRoot(frame.?, opts.selector), .{
                     .width = frame.?._page.getViewport().width,
-                }, frame.?);
-                try writeJsonEnvelope(writer, frame, opts.dump_mode, shot);
-                continue;
+                }, frame.?)) |shot| {
+                    try writeJsonEnvelope(writer, frame, opts.dump_mode, shot, err.*);
+                    continue;
+                } else |e| {
+                    if (err.* == null) err.* = e;
+                }
             }
 
             var aw: std.Io.Writer.Allocating = .init(app.allocator);
             defer aw.deinit();
 
             if (opts.dump_mode) |mode| {
-                if (frame) |f| try dumpContent(app, mode, opts, f, &aw.writer);
+                if (frame) |f| dumpContent(app, mode, opts, f, &aw.writer) catch |e| {
+                    aw.clearRetainingCapacity();
+                    if (err.* == null) err.* = e;
+                };
             }
-            try writeJsonEnvelope(writer, frame, opts.dump_mode, aw.written());
+            try writeJsonEnvelope(writer, frame, opts.dump_mode, aw.written(), err.*);
         }
         if (wrap) {
             try writer.writeAll("]}");
@@ -373,7 +416,7 @@ pub fn fetch(app: *App, browser: *Browser, urls: []const [:0]const u8, opts: Fet
         try writer.writeByte('\n');
     } else {
         // main validates that non-JSON dump is only reached with a single url.
-        const page = pages.items[0];
+        const page = pages[0];
         if (opts.dump_mode) |mode| blk: {
             const frame = page.frame() orelse {
                 try writer.writeAll("Frame closed. Please open a bug report including the URL\n");
@@ -445,7 +488,7 @@ pub fn checkVersion(allocator: std.mem.Allocator, config: *const Config) !void {
 
 // Writes a single page's result object. Framing (the enclosing array and any
 // separators / trailing newline) is the caller's responsibility.
-fn writeJsonEnvelope(writer: *std.Io.Writer, frame: ?*Frame, dump_mode: ?Config.DumpFormat, content: anytype) !void {
+fn writeJsonEnvelope(writer: *std.Io.Writer, frame: ?*Frame, dump_mode: ?Config.DumpFormat, content: anytype, err: ?anyerror) !void {
     const meta: ?Frame.HttpMetadata = if (frame) |f| f.httpMetadata() else null;
     try std.json.Stringify.value(.{
         .url = if (meta) |m| m.url else "",
@@ -453,6 +496,7 @@ fn writeJsonEnvelope(writer: *std.Io.Writer, frame: ?*Frame, dump_mode: ?Config.
         .headers = if (meta) |m| m.headers else &.{},
         .dump = if (dump_mode) |mode| @tagName(mode) else "",
         .content = content,
+        .@"error" = if (err) |e| @errorName(e) else null,
     }, .{}, writer);
 }
 
@@ -575,12 +619,25 @@ test "writeJsonEnvelope: null frame" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
 
-    try writeJsonEnvelope(&aw.writer, null, null, "");
+    try writeJsonEnvelope(&aw.writer, null, null, "", null);
     try testing.expectJson(.{
         .url = "",
         .http_status = 0,
         .dump = "",
         .content = "",
+    }, aw.written());
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\"error\":null") != null);
+}
+
+test "writeJsonEnvelope: page error" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try writeJsonEnvelope(&aw.writer, null, .markdown, "", error.Timeout);
+    try testing.expectJson(.{
+        .dump = "markdown",
+        .content = "",
+        .@"error" = "Timeout",
     }, aw.written());
 }
 
@@ -588,7 +645,7 @@ test "writeJsonEnvelope: null frame with dump mode and content" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
 
-    try writeJsonEnvelope(&aw.writer, null, .html, "<html><body>hello</body></html>");
+    try writeJsonEnvelope(&aw.writer, null, .html, "<html><body>hello</body></html>", null);
     try testing.expectJson(.{
         .dump = "html",
         .content = "<html><body>hello</body></html>",

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,11 +49,13 @@ pub fn main(init: std.process.Init) !void {
     run(gpa, main_arena, init.minimal.args) catch |err| {
         if (err == error.UserCancelled) std.process.exit(130);
         // error.AgentFailed: the agent thread reported the failure in-context.
+        // error.PageFailed: fetch already logged every failing url.
         // lp.Agent.UserError: a user-facing message was already printed.
-        if (err == error.AgentFailed or lp.Agent.isUserError(err)) std.process.exit(1);
+        if (err == error.AgentFailed or err == error.PageFailed or lp.Agent.isUserError(err)) std.process.exit(1);
+        // curl's code for --fail on an HTTP error, also already reported per url.
+        if (err == error.HttpError) std.process.exit(22);
         log.fatal(.app, "exit", .{ .err = err });
-        // curl's code for --fail on an HTTP error.
-        std.process.exit(if (err == error.HttpError) 22 else 1);
+        std.process.exit(1);
     };
 }
 
@@ -378,6 +380,8 @@ fn fetchThread(app: *App, ft: *FetchTerminator, urls: []const [:0]const u8, fetc
 
     lp.fetch(app, &browser, urls, fetch_opts) catch |err| {
         err_out.* = err;
+        // Both are already reported per url by fetch itself.
+        if (err == error.PageFailed or err == error.HttpError) return;
         log.fatal(.app, "fetch error", .{ .err = err, .url_count = urls.len });
     };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -177,12 +177,12 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
                 .selector = opts.dump_selector,
-                .max_bytes = opts.dump_max_bytes,
                 .fail_on_http_error = opts.fail_on_http_error,
                 .dump = .{
                     .strip = opts.strip_mode,
                     .with_base = opts.with_base,
                     .with_frames = opts.with_frames,
+                    .max_bytes = opts.dump_max_bytes,
                 },
                 .json = opts.json,
             };

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,8 +163,8 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 });
             }
 
-            if (opts.max_bytes != null and opts.dump != .html and opts.dump != .markdown) {
-                log.fatal(.app, "--max-bytes needs a text dump", .{ .dump = opts.dump, .allowed = "html, markdown" });
+            if (opts.dump_max_bytes != null and opts.dump != .html and opts.dump != .markdown) {
+                log.fatal(.app, "--dump-max-bytes needs text", .{ .dump = opts.dump, .allowed = "html, markdown" });
                 return error.InvalidArgument;
             }
 
@@ -175,8 +175,8 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 .inject_script = opts.inject_script,
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
-                .selector = opts.selector,
-                .max_bytes = opts.max_bytes,
+                .selector = opts.dump_selector,
+                .max_bytes = opts.dump_max_bytes,
                 .dump = .{
                     .strip = opts.strip_mode,
                     .with_base = opts.with_base,

--- a/src/main.zig
+++ b/src/main.zig
@@ -164,6 +164,14 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 });
             }
 
+            if (opts.dump == null and opts.dump_selector != null) {
+                log.fatal(.app, "--dump-selector needs --dump", .{});
+                return error.InvalidArgument;
+            }
+            if (opts.dump == null and opts.dump_max_bytes != null) {
+                log.fatal(.app, "--dump-max-bytes needs --dump", .{});
+                return error.InvalidArgument;
+            }
             if (opts.dump_max_bytes != null and opts.dump != .html and opts.dump != .markdown) {
                 log.fatal(.app, "--dump-max-bytes needs text", .{ .dump = opts.dump, .allowed = "html, markdown" });
                 return error.InvalidArgument;

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,6 +163,11 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 });
             }
 
+            if (opts.max_bytes != null and opts.dump != .html and opts.dump != .markdown) {
+                log.fatal(.app, "--max-bytes needs a text dump", .{ .dump = opts.dump, .allowed = "html, markdown" });
+                return error.InvalidArgument;
+            }
+
             var fetch_opts = lp.FetchOpts{
                 .wait_ms = opts.wait_ms,
                 .wait_until = opts.wait_until,
@@ -170,6 +175,8 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 .inject_script = opts.inject_script,
                 .wait_selector = opts.wait_selector,
                 .dump_mode = opts.dump,
+                .selector = opts.selector,
+                .max_bytes = opts.max_bytes,
                 .dump = .{
                     .strip = opts.strip_mode,
                     .with_base = opts.with_base,

--- a/src/main.zig
+++ b/src/main.zig
@@ -52,7 +52,8 @@ pub fn main(init: std.process.Init) !void {
         // lp.Agent.UserError: a user-facing message was already printed.
         if (err == error.AgentFailed or lp.Agent.isUserError(err)) std.process.exit(1);
         log.fatal(.app, "exit", .{ .err = err });
-        std.process.exit(1);
+        // curl's code for --fail on an HTTP error.
+        std.process.exit(if (err == error.HttpError) 22 else 1);
     };
 }
 
@@ -177,6 +178,7 @@ fn run(allocator: Allocator, main_arena: Allocator, proc_args: std.process.Args)
                 .dump_mode = opts.dump,
                 .selector = opts.dump_selector,
                 .max_bytes = opts.dump_max_bytes,
+                .fail_on_http_error = opts.fail_on_http_error,
                 .dump = .{
                     .strip = opts.strip_mode,
                     .with_base = opts.with_base,


### PR DESCRIPTION
`--strip-mode` was passed to the html dump only; `--dump markdown` got a literal `.{}`, so the flag silently did nothing. `fetch` also had no way to scope a dump to one element or cap its size, although the `markdown`/`html` tools have both, and one failing URL in a multi-URL run aborted the whole output.

- `--dump-selector <css>`: dump the first matching element instead of the document, in every dump mode (html via `dump.deep`, markdown, png, semantic tree).
- `--dump-max-bytes <n>`: caps html and markdown with the same UTF-8-safe truncation and `[truncated]` marker the tools use. `dump.Opts` now takes `max_bytes` like `markdown.Opts`, so `root`/`deep` cap themselves and the html tool and fetch no longer wrap the writer by hand. Refused up front for png/semantic tree.
- `markdown` honors `--strip-mode` through `dump.shouldStripElement`; only `ui` changes its output since scripts, styles and hidden elements are never rendered.
- Per-page failures: a wait (`Timeout`), navigation (`CouldntConnect`, …) or dump (`SelectorNotFound`) failure is recorded for that URL, every page is still written, and the `--json` envelope carries it under `"error"` (`null` otherwise). The process then exits 1. The `--wait-ms` budget is recomputed per page instead of once before the loop. A non-JSON single-URL timeout now prints the page before exiting 1.
- `--fail-on-http-error`: any status >= 400 exits 22 (curl's code) after the dump is written.

Verified end to end against a local fixture: selector scoping in every mode and with `--json`; `--strip-mode ui`; both caps; two URLs where only one matches the selector (complete JSON, `"error":"SelectorNotFound"` on the second, exit 1); two URLs with an unmet `--wait-selector --wait-ms 800` finishing in ~1 s total; a dead host next to a good URL; 404 with and without the flag. Unit tests for `strip.ui`, `dump` capping, and the envelope. Full suite passes.
