### PR TITLE
webapi: edit key support in input/textarea

### DIFF
--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -32,6 +32,8 @@ const Node = @import("../webapi/Node.zig");
 const Event = @import("../webapi/Event.zig");
 const Element = @import("../webapi/Element.zig");
 const TreeWalker = @import("../webapi/TreeWalker.zig");
+const TextEvent = @import("../webapi/event/TextEvent.zig");
+const InputEvent = @import("../webapi/event/InputEvent.zig");
 const MouseEvent = @import("../webapi/event/MouseEvent.zig");
 const WheelEvent = @import("../webapi/event/WheelEvent.zig");
 const PointerEvent = @import("../webapi/event/PointerEvent.zig");
@@ -628,22 +630,79 @@ pub fn handleKeydown(frame: *Frame, target: *Node, event: *Event) !void {
             return;
         }
 
-        // Handle printable characters
-        if (key.isPrintable()) {
-            try input.innerInsert(key.asString(), frame);
+        return editKey(frame, event, input, key);
+    }
+
+    if (target.is(Element.Html.TextArea)) |textarea| {
+        if (key == .Enter) {
+            if (try allowEdit(frame, event, textarea.asElement(), null, "\n", "insertLineBreak")) {
+                try textarea.innerInsert("\n", frame);
+            }
+            return;
+        }
+
+        return editKey(frame, event, textarea, key);
+    }
+}
+
+// edit keys are handled by Input and TextArea the same
+fn editKey(frame: *Frame, event: *Event, ctl: anytype, key: KeyboardEvent.Key) !void {
+    if (key == .Backspace or key == .Delete) {
+        const forward = key == .Delete;
+        if (try allowEdit(frame, event, ctl.asElement(), null, null, deleteInputType(forward))) {
+            try ctl.innerDelete(forward, frame);
         }
         return;
     }
 
-    if (target.is(Element.Html.TextArea)) |textarea| {
-        // zig fmt: off
-        const append =
-            if (key == .Enter) "\n"
-            else if (key.isPrintable()) key.asString()
-            else return
-        ;
-        // zig fmt: on
-        return textarea.innerInsert(append, frame);
+    if (key.isPrintable()) {
+        if (try allowEdit(frame, event, ctl.asElement(), key.asString(), key.asString(), "insertText")) {
+            try ctl.innerInsert(key.asString(), frame);
+        }
+    }
+}
+
+fn deleteInputType(forward: bool) []const u8 {
+    return if (forward) "deleteContentForward" else "deleteContentBackward";
+}
+
+// pre-edit events for a key's default action, can cancel the edit (i.e. by
+// returning false)
+fn allowEdit(frame: *Frame, keydown: *Event, target: *Element, before_data: ?[]const u8, text_data: ?[]const u8, input_type: []const u8) !bool {
+    if (keydown.getIsTrusted() == false) {
+        // only trusted events fire these events, so for a untrusted event, the
+        // edit isn't cancelled.
+        return true;
+    }
+
+    {
+        const before = (try InputEvent.initTrusted(comptime .wrap("beforeinput"), .{
+            .bubbles = true,
+            .cancelable = true,
+            .composed = true,
+            .data = before_data,
+            .inputType = input_type,
+        }, frame)).asEvent();
+        before.acquireRef(); // need to check its _prevent_default
+        defer _ = before.releaseRef(frame._page);
+        try frame._event_manager.dispatch(target.asEventTarget(), before);
+        if (before._prevent_default) {
+            return false;
+        }
+    }
+
+    {
+        const data = text_data orelse return true;
+        const text_event = (try TextEvent.initTrusted("textInput", .{
+            .bubbles = true,
+            .cancelable = true,
+            .view = frame.window,
+            .data = data,
+        }, frame)).asEvent();
+        text_event.acquireRef(); // need to check its _prevent_default
+        defer _ = text_event.releaseRef(frame._page);
+        try frame._event_manager.dispatch(target.asEventTarget(), text_event);
+        return text_event._prevent_default == false;
     }
 }
 

--- a/src/browser/tests/event/text.html
+++ b/src/browser/tests/event/text.html
@@ -25,7 +25,8 @@
     let evt = document.createEvent('TextEvent');
     evt.initTextEvent('foo');
     testing.expectEqual('foo', evt.type);
-    testing.expectEqual('', evt.data);
+    // legacy IDL default: optional DOMString dataArg = "undefined"
+    testing.expectEqual('undefined', evt.data);
     testing.expectEqual(false, evt.bubbles);
     testing.expectEqual(false, evt.cancelable);
   }

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -29,12 +29,12 @@ const HtmlElement = @import("../Html.zig");
 const Form = @import("Form.zig");
 const Selection = @import("../../Selection.zig");
 const Event = @import("../../Event.zig");
-const InputEvent = @import("../../event/InputEvent.zig");
 const ValidityState = @import("ValidityState.zig");
 const popover = @import("../popover.zig");
 const File = @import("../../File.zig");
 const FileList = @import("../../FileList.zig");
 const reflection = @import("../reflection.zig");
+const text_entry = @import("../text_entry.zig");
 
 const String = lp.String;
 
@@ -111,16 +111,6 @@ pub fn setOnSelectionChange(self: *Input, listener: ?js.Function) !void {
     } else {
         self._on_selectionchange = null;
     }
-}
-
-fn dispatchSelectionChangeEvent(self: *Input, frame: *Frame) !void {
-    const event = try Event.init("selectionchange", .{ .bubbles = true }, frame._page);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
-}
-
-fn dispatchInputEvent(self: *Input, data: ?[]const u8, input_type: []const u8, frame: *Frame) !void {
-    const event = try InputEvent.initTrusted(comptime .wrap("input"), .{ .data = data, .inputType = input_type }, frame);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event.asEvent());
 }
 
 pub fn asElement(self: *Input) *Element {
@@ -623,135 +613,32 @@ pub fn setSrc(self: *Input, src: []const u8, frame: *Frame) !void {
     try self.asElement().setAttributeSafe(comptime .wrap("src"), .wrap(trimmed), frame);
 }
 
-pub fn select(self: *Input, frame: *Frame) !void {
-    const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
-    try self.setSelectionRange(0, len, null, frame);
-    const event = try Event.init("select", .{ .bubbles = true }, frame._page);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
-}
+const entry = text_entry.TextEntry(Input);
 
-fn selectionAvailable(self: *const Input) bool {
+pub const select = entry.select;
+pub const innerInsert = entry.innerInsert;
+pub const innerDelete = entry.innerDelete;
+pub const getSelectionDirection = entry.getSelectionDirection;
+pub const setSelectionStart = entry.setSelectionStart;
+pub const setSelectionEnd = entry.setSelectionEnd;
+pub const setSelectionRange = entry.setSelectionRange;
+
+pub fn selectionAvailable(self: *const Input) bool {
     switch (self._input_type) {
         .text, .search, .url, .tel, .password => return true,
         else => return false,
     }
 }
 
-const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };
-
-fn howSelected(self: *const Input) HowSelected {
-    if (!self.selectionAvailable()) return .none;
-    const value = self._value orelse return .none;
-
-    if (self._selection_start == self._selection_end) return .none;
-    if (self._selection_start == 0 and self._selection_end == value.len) return .full;
-    return .{ .partial = .{ self._selection_start, self._selection_end } };
-}
-
-pub fn innerInsert(self: *Input, str: []const u8, frame: *Frame) !void {
-    const arena = frame.arena;
-
-    switch (self.howSelected()) {
-        .full => {
-            // if the input is fully selected, replace the content.
-            const new_value = try arena.dupe(u8, str);
-            try self.setValue(new_value, frame);
-            self._selection_start = @intCast(new_value.len);
-            self._selection_end = @intCast(new_value.len);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .partial => |range| {
-            // if the input is partially selected, replace the selected content.
-            const current_value = self.getValue();
-            const before = current_value[0..range[0]];
-            const remaining = current_value[range[1]..];
-
-            const new_value = try std.mem.concat(
-                arena,
-                u8,
-                &.{ before, str, remaining },
-            );
-            try self.setValue(new_value, frame);
-
-            const new_pos = range[0] + str.len;
-            self._selection_start = @intCast(new_pos);
-            self._selection_end = @intCast(new_pos);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .none => {
-            // if the input is not selected, just insert at cursor.
-            const current_value = self.getValue();
-            const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
-            try self.setValue(new_value, frame);
-        },
-    }
-    try self.dispatchInputEvent(str, "insertText", frame);
-}
-
-pub fn getSelectionDirection(self: *const Input) []const u8 {
-    return @tagName(self._selection_direction);
-}
-
+// Nullable here, unlike <textarea>'s, which is why these two aren't shared.
 pub fn getSelectionStart(self: *const Input) !?u32 {
     if (!self.selectionAvailable()) return null;
     return self._selection_start;
 }
 
-pub fn setSelectionStart(self: *Input, value: u32, frame: *Frame) !void {
-    if (!self.selectionAvailable()) return error.InvalidStateError;
-    self._selection_start = value;
-    try self.dispatchSelectionChangeEvent(frame);
-}
-
 pub fn getSelectionEnd(self: *const Input) !?u32 {
     if (!self.selectionAvailable()) return null;
     return self._selection_end;
-}
-
-pub fn setSelectionEnd(self: *Input, value: u32, frame: *Frame) !void {
-    if (!self.selectionAvailable()) return error.InvalidStateError;
-    self._selection_end = value;
-    try self.dispatchSelectionChangeEvent(frame);
-}
-
-pub fn setSelectionRange(
-    self: *Input,
-    selection_start: u32,
-    selection_end: u32,
-    selection_dir: ?[]const u8,
-    frame: *Frame,
-) !void {
-    if (!self.selectionAvailable()) return error.InvalidStateError;
-
-    const direction = blk: {
-        if (selection_dir) |sd| {
-            break :blk std.meta.stringToEnum(Selection.SelectionDirection, sd) orelse .none;
-        } else break :blk .none;
-    };
-
-    const value = self._value orelse {
-        self._selection_start = 0;
-        self._selection_end = 0;
-        self._selection_direction = .none;
-        return;
-    };
-
-    const len_u32: u32 = @intCast(value.len);
-    var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
-    const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
-
-    // If end is less than start, both are equal to end.
-    if (end < start) {
-        start = end;
-    }
-
-    self._selection_direction = direction;
-    self._selection_start = start;
-    self._selection_end = end;
-
-    try self.dispatchSelectionChangeEvent(frame);
 }
 
 pub fn getLabels(self: *Input, frame: *Frame) !js.Array {

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -28,9 +28,9 @@ const HtmlElement = @import("../Html.zig");
 const Form = @import("Form.zig");
 const Selection = @import("../../Selection.zig");
 const Event = @import("../../Event.zig");
-const InputEvent = @import("../../event/InputEvent.zig");
 const ValidityState = @import("ValidityState.zig");
 const reflection = @import("../reflection.zig");
+const text_entry = @import("../text_entry.zig");
 
 const TextArea = @This();
 
@@ -57,16 +57,6 @@ pub fn setOnSelectionChange(self: *TextArea, listener: ?js.Function) !void {
     } else {
         self._on_selectionchange = null;
     }
-}
-
-fn dispatchSelectionChangeEvent(self: *TextArea, frame: *Frame) !void {
-    const event = try Event.init("selectionchange", .{ .bubbles = true }, frame._page);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
-}
-
-fn dispatchInputEvent(self: *TextArea, data: ?[]const u8, input_type: []const u8, frame: *Frame) !void {
-    const event = try InputEvent.initTrusted(comptime .wrap("input"), .{ .data = data, .inputType = input_type }, frame);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event.asEvent());
 }
 
 pub fn asElement(self: *TextArea) *Element {
@@ -123,121 +113,28 @@ pub fn getMinLength(self: *const TextArea) i32 {
     return reflection.getLimitedLong(self.asConstElement(), comptime .wrap("minlength"));
 }
 
-pub fn select(self: *TextArea, frame: *Frame) !void {
-    const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
-    try self.setSelectionRange(0, len, null, frame);
-    const event = try Event.init("select", .{ .bubbles = true }, frame._page);
-    try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+const entry = text_entry.TextEntry(TextArea);
+
+pub const select = entry.select;
+pub const innerInsert = entry.innerInsert;
+pub const innerDelete = entry.innerDelete;
+pub const getSelectionDirection = entry.getSelectionDirection;
+pub const setSelectionStart = entry.setSelectionStart;
+pub const setSelectionEnd = entry.setSelectionEnd;
+pub const setSelectionRange = entry.setSelectionRange;
+
+// <textarea> always supports selection; <input> only does for some types.
+pub fn selectionAvailable(_: *const TextArea) bool {
+    return true;
 }
 
-const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };
-
-fn howSelected(self: *const TextArea) HowSelected {
-    const value = self._value orelse return .none;
-
-    if (self._selection_start == self._selection_end) return .none;
-    if (self._selection_start == 0 and self._selection_end == value.len) return .full;
-    return .{ .partial = .{ self._selection_start, self._selection_end } };
-}
-
-pub fn innerInsert(self: *TextArea, str: []const u8, frame: *Frame) !void {
-    const arena = frame.arena;
-
-    switch (self.howSelected()) {
-        .full => {
-            // if the text area is fully selected, replace the content.
-            const new_value = try arena.dupe(u8, str);
-            try self.setValue(new_value, frame);
-            self._selection_start = @intCast(new_value.len);
-            self._selection_end = @intCast(new_value.len);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .partial => |range| {
-            // if the text area is partially selected, replace the selected content.
-            const current_value = self.getValue();
-            const before = current_value[0..range[0]];
-            const remaining = current_value[range[1]..];
-
-            const new_value = try std.mem.concat(
-                arena,
-                u8,
-                &.{ before, str, remaining },
-            );
-            try self.setValue(new_value, frame);
-
-            const new_pos = range[0] + str.len;
-            self._selection_start = @intCast(new_pos);
-            self._selection_end = @intCast(new_pos);
-            self._selection_direction = .none;
-            try self.dispatchSelectionChangeEvent(frame);
-        },
-        .none => {
-            // if the text area is not selected, just insert at cursor.
-            const current_value = self.getValue();
-            const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
-            try self.setValue(new_value, frame);
-        },
-    }
-    try self.dispatchInputEvent(str, "insertText", frame);
-}
-
-pub fn getSelectionDirection(self: *const TextArea) []const u8 {
-    return @tagName(self._selection_direction);
-}
-
+// Non-null unlike input
 pub fn getSelectionStart(self: *const TextArea) u32 {
     return self._selection_start;
 }
 
-pub fn setSelectionStart(self: *TextArea, value: u32, frame: *Frame) !void {
-    self._selection_start = value;
-    try self.dispatchSelectionChangeEvent(frame);
-}
-
 pub fn getSelectionEnd(self: *const TextArea) u32 {
     return self._selection_end;
-}
-
-pub fn setSelectionEnd(self: *TextArea, value: u32, frame: *Frame) !void {
-    self._selection_end = value;
-    try self.dispatchSelectionChangeEvent(frame);
-}
-
-pub fn setSelectionRange(
-    self: *TextArea,
-    selection_start: u32,
-    selection_end: u32,
-    selection_dir: ?[]const u8,
-    frame: *Frame,
-) !void {
-    const direction = blk: {
-        if (selection_dir) |sd| {
-            break :blk std.meta.stringToEnum(Selection.SelectionDirection, sd) orelse .none;
-        } else break :blk .none;
-    };
-
-    const value = self._value orelse {
-        self._selection_start = 0;
-        self._selection_end = 0;
-        self._selection_direction = .none;
-        return;
-    };
-
-    const len_u32: u32 = @intCast(value.len);
-    var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
-    const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
-
-    // If end is less than start, both are equal to end.
-    if (end < start) {
-        start = end;
-    }
-
-    self._selection_direction = direction;
-    self._selection_start = start;
-    self._selection_end = end;
-
-    try self.dispatchSelectionChangeEvent(frame);
 }
 
 pub fn getForm(self: *TextArea, frame: *Frame) ?*Form {

--- a/src/browser/webapi/element/text_entry.zig
+++ b/src/browser/webapi/element/text_entry.zig
@@ -1,0 +1,218 @@
+// Copyright (C) 2023-2026  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Input and TextArea share much in common. All shared logic between Input and
+// TextArea sits here.
+
+const std = @import("std");
+
+const Frame = @import("../../Frame.zig");
+
+const Event = @import("../Event.zig");
+const Selection = @import("../Selection.zig");
+const InputEvent = @import("../event/InputEvent.zig");
+
+pub fn TextEntry(comptime T: type) type {
+    return struct {
+        pub fn select(self: *T, frame: *Frame) !void {
+            const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
+            try setSelectionRange(self, 0, len, null, frame);
+            const event = try Event.init("select", .{ .bubbles = true }, frame._page);
+            try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+        }
+
+        pub fn innerInsert(self: *T, str: []const u8, frame: *Frame) !void {
+            const arena = frame.arena;
+
+            switch (howSelected(self)) {
+                .full => {
+                    // fully selected, replace the content.
+                    const new_value = try arena.dupe(u8, str);
+                    try self.setValue(new_value, frame);
+                    self._selection_start = @intCast(new_value.len);
+                    self._selection_end = @intCast(new_value.len);
+                    self._selection_direction = .none;
+                    try dispatchSelectionChangeEvent(self, frame);
+                },
+                .partial => |range| {
+                    // partially selected, replace the selected content.
+                    const current_value = self.getValue();
+                    const before = current_value[0..range[0]];
+                    const remaining = current_value[range[1]..];
+
+                    const new_value = try std.mem.concat(
+                        arena,
+                        u8,
+                        &.{ before, str, remaining },
+                    );
+                    try self.setValue(new_value, frame);
+
+                    const new_pos = range[0] + str.len;
+                    self._selection_start = @intCast(new_pos);
+                    self._selection_end = @intCast(new_pos);
+                    self._selection_direction = .none;
+                    try dispatchSelectionChangeEvent(self, frame);
+                },
+                .none => {
+                    // nothing selected, just insert at cursor.
+                    const current_value = self.getValue();
+                    const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
+                    try self.setValue(new_value, frame);
+                },
+            }
+            try dispatchInputEvent(self, str, "insertText", frame);
+        }
+
+        // forward == delete
+        // !forward == backspace
+        pub fn innerDelete(self: *T, forward: bool, frame: *Frame) !void {
+            const current_value = self.getValue();
+            const value_len: u32 = @intCast(current_value.len);
+
+            var start: u32 = undefined;
+            var end: u32 = undefined;
+            switch (howSelected(self)) {
+                .full => {
+                    start = 0;
+                    end = value_len;
+                },
+                .partial => |range| {
+                    start, end = range;
+                },
+                .none => {
+                    // Controls without selection support keep no caret; edit at the end.
+                    const caret = if (self.selectionAvailable()) @min(self._selection_start, value_len) else value_len;
+                    if (forward) {
+                        if (caret >= value_len) {
+                            return;
+                        }
+                        start = caret;
+                        end = caret + (std.unicode.utf8ByteSequenceLength(current_value[caret]) catch 1);
+                    } else {
+                        if (caret == 0) {
+                            return;
+                        }
+                        end = caret;
+                        start = caret - 1;
+                        while (start > 0 and (current_value[start] & 0xC0) == 0x80) {
+                            start -= 1;
+                        }
+                    }
+                },
+            }
+
+            const new_value = try std.mem.concat(frame.arena, u8, &.{
+                current_value[0..start],
+                current_value[@min(end, value_len)..],
+            });
+            try self.setValue(new_value, frame);
+            self._selection_start = start;
+            self._selection_end = start;
+            self._selection_direction = .none;
+            try dispatchSelectionChangeEvent(self, frame);
+            try dispatchInputEvent(self, null, if (forward) "deleteContentForward" else "deleteContentBackward", frame);
+        }
+
+        pub fn getSelectionDirection(self: *const T) []const u8 {
+            return @tagName(self._selection_direction);
+        }
+
+        pub fn setSelectionStart(self: *T, value: u32, frame: *Frame) !void {
+            if (self.selectionAvailable() == false) {
+                return error.InvalidStateError;
+            }
+            self._selection_start = value;
+            try dispatchSelectionChangeEvent(self, frame);
+        }
+
+        pub fn setSelectionEnd(self: *T, value: u32, frame: *Frame) !void {
+            if (self.selectionAvailable() == false) {
+                return error.InvalidStateError;
+            }
+            self._selection_end = value;
+            try dispatchSelectionChangeEvent(self, frame);
+        }
+
+        pub fn setSelectionRange(
+            self: *T,
+            selection_start: u32,
+            selection_end: u32,
+            selection_dir: ?[]const u8,
+            frame: *Frame,
+        ) !void {
+            if (self.selectionAvailable() == false) {
+                return error.InvalidStateError;
+            }
+
+            const direction = blk: {
+                if (selection_dir) |sd| {
+                    break :blk std.meta.stringToEnum(Selection.SelectionDirection, sd) orelse .none;
+                } else break :blk .none;
+            };
+
+            const value = self._value orelse {
+                self._selection_start = 0;
+                self._selection_end = 0;
+                self._selection_direction = .none;
+                return;
+            };
+
+            const len_u32: u32 = @intCast(value.len);
+            var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
+            const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
+
+            // If end is less than start, both are equal to end.
+            if (end < start) {
+                start = end;
+            }
+
+            self._selection_direction = direction;
+            self._selection_start = start;
+            self._selection_end = end;
+
+            try dispatchSelectionChangeEvent(self, frame);
+        }
+
+        const HowSelected = union(enum) { partial: struct { u32, u32 }, full, none };
+
+        fn howSelected(self: *const T) HowSelected {
+            if (self.selectionAvailable() == false) {
+                return .none;
+            }
+            const value = self._value orelse return .none;
+
+            if (self._selection_start == self._selection_end) {
+                return .none;
+            }
+            if (self._selection_start == 0 and self._selection_end == value.len) {
+                return .full;
+            }
+            return .{ .partial = .{ self._selection_start, self._selection_end } };
+        }
+
+        fn dispatchSelectionChangeEvent(self: *T, frame: *Frame) !void {
+            const event = try Event.init("selectionchange", .{ .bubbles = true }, frame._page);
+            try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
+        }
+
+        fn dispatchInputEvent(self: *T, data: ?[]const u8, input_type: []const u8, frame: *Frame) !void {
+            const event = try InputEvent.initTrusted(comptime .wrap("input"), .{ .data = data, .inputType = input_type }, frame);
+            try frame._event_manager.dispatch(self.asElement().asEventTarget(), event.asEvent());
+        }
+    };
+}

--- a/src/browser/webapi/event/TextEvent.zig
+++ b/src/browser/webapi/event/TextEvent.zig
@@ -43,6 +43,14 @@ pub const Options = Event.inheritOptions(
 );
 
 pub fn init(typ: []const u8, _opts: ?Options, frame: *Frame) !*TextEvent {
+    return initWithTrusted(typ, _opts, false, frame);
+}
+
+pub fn initTrusted(typ: []const u8, _opts: ?Options, frame: *Frame) !*TextEvent {
+    return initWithTrusted(typ, _opts, true, frame);
+}
+
+fn initWithTrusted(typ: []const u8, _opts: ?Options, trusted: bool, frame: *Frame) !*TextEvent {
     const arena = try frame.getArena(.tiny, "TextEvent");
     errdefer arena.release();
     const type_string = try String.init(arena.allocator(), typ, .{});
@@ -58,7 +66,7 @@ pub fn init(typ: []const u8, _opts: ?Options, frame: *Frame) !*TextEvent {
         },
     );
 
-    Event.populatePrototypes(event, opts, false);
+    Event.populatePrototypes(event, opts, trusted);
     return event;
 }
 
@@ -90,7 +98,8 @@ pub fn initTextEvent(
     event._bubbles = bubbles orelse false;
     event._cancelable = cancelable orelse false;
     ui._view = view;
-    self._data = if (data) |d| try arena.dupe(u8, d) else "";
+    // yup, the literal string "undefined" (not undefined) is the default
+    self._data = if (data) |d| try arena.dupe(u8, d) else "undefined";
 }
 
 pub const JsApi = struct {


### PR DESCRIPTION
A trusted backspace/delete or printable character now: 1 - fires beforeinput and textInput (which can cancel the edit) 2 - change the input's value

Input and TextArea share enough in common and this change has enough selection logic that a new text_entry.zig helper is added to implement the shared logic.