### PR TITLE
CI: bump timeout from 20 to 30 for e2e-test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
     name: zig build release
 
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     # Don't run the CI with draft PR.
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Mimic https://github.com/lightpanda-io/browser/pull/3294

I looked into this a little bit, and the main issue is that we build the binary in releasefast twice: once for the snapshot and once for the browser itself. Each build takes ~10 minutes.

The snapshot cache almost always misses (since any change to webapi/* invalidates it). I don't see a great solution.