### PR TITLE
tools: add a screenshot tool

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,8 +36,8 @@
             .hash = "sqlite3-3.53.2-DMxLWuAOAAA_Px0arJOIOaP4AKEu5prbsQgPMA35W1zz",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#a745bb1b654e150955f7f4d84ddd1e35ed8beb9e",
-            .hash = "zenai-0.0.0-iOY_VI6EBgAryRPO5dH1uS_knQguW5hqcL8EfpnBKBFK",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#b76da59f1b7c36d367a0914adf60a72ca6d87dd4",
+            .hash = "zenai-0.0.0-iOY_VEm3BgDBXrcf-iedI2lNaTE5oF7vyG0AxB85b-2q",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline?ref=lightpanda#832a9fe25f5f4458fcc47b5acc7c21db669c2f47",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,8 +36,8 @@
             .hash = "sqlite3-3.53.2-DMxLWuAOAAA_Px0arJOIOaP4AKEu5prbsQgPMA35W1zz",
         },
         .zenai = .{
-            .url = "git+https://github.com/lightpanda-io/zenai.git#b76da59f1b7c36d367a0914adf60a72ca6d87dd4",
-            .hash = "zenai-0.0.0-iOY_VEm3BgDBXrcf-iedI2lNaTE5oF7vyG0AxB85b-2q",
+            .url = "git+https://github.com/lightpanda-io/zenai.git#be5d2e70d3dcc9866041dbdbcfa1f18799601a30",
+            .hash = "zenai-0.0.0-iOY_VE23BgCNT-WtrAC6BM1J_G98bSk6kD0v8g09XWYA",
         },
         .isocline = .{
             .url = "git+https://github.com/arrufat/isocline?ref=lightpanda#832a9fe25f5f4458fcc47b5acc7c21db669c2f47",

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -572,7 +572,6 @@ fn runTurn(self: *Agent, input: TurnInput) bool {
         error.UnsupportedAttachment, error.AttachmentReadFailed => return false,
         error.UserCancelled => {
             self.terminal.printInfo("Interrupted.", .{});
-            self.conversation.expireImages();
             self.conversation.prune();
             return false;
         },
@@ -594,7 +593,6 @@ fn runTurn(self: *Agent, input: TurnInput) bool {
         else
             self.terminal.printInfo("(no response from model)", .{});
     }
-    self.conversation.expireImages();
     self.conversation.prune();
     return true;
 }
@@ -1491,7 +1489,7 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         else => return .{ .text = "internal: command has no tool mapping", .is_error = true },
     };
     // The terminal can't show an image, but the conversation can.
-    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{ .inline_image = if (self.ai_client != null) .{} else null }) catch |err| .{
+    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{ .inline_image = self.ai_client != null }) catch |err| .{
         .text = switch (err) {
             error.OutOfMemory => "out of memory",
             error.FrameNotLoaded => "no page loaded — run /goto <url> first",
@@ -1938,7 +1936,7 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
 
 /// The text plus the rendered PNG, for backends that can show the model an image.
 fn toolOutcome(self: *Agent, allocator: std.mem.Allocator, tool_name: []const u8, arguments: ?std.json.Value) browser_tools.ToolError!zenai.provider.Client.ToolHandler.Result {
-    const result = try browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = .{} });
+    const result = try browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = true });
     const content = capToolOutput(allocator, tool_name, result.text);
     return .{
         .content = content,
@@ -2064,6 +2062,7 @@ test {
     _ = save;
     _ = settings;
     _ = picker;
+    _ = Conversation;
 }
 
 test "savePrompt: save instructions followed by the rendered script skill" {
@@ -2117,8 +2116,4 @@ test "capToolOutput: extract is exempt from the default cap" {
 
     try std.testing.expectEqual(extract_output_max_bytes, toolOutputCap("extract"));
     try std.testing.expectEqual(tool_output_max_bytes, toolOutputCap("html"));
-}
-
-test {
-    std.testing.refAllDecls(Conversation);
 }

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -572,6 +572,7 @@ fn runTurn(self: *Agent, input: TurnInput) bool {
         error.UnsupportedAttachment, error.AttachmentReadFailed => return false,
         error.UserCancelled => {
             self.terminal.printInfo("Interrupted.", .{});
+            self.conversation.expireImages();
             self.conversation.prune();
             return false;
         },
@@ -593,6 +594,7 @@ fn runTurn(self: *Agent, input: TurnInput) bool {
         else
             self.terminal.printInfo("(no response from model)", .{});
     }
+    self.conversation.expireImages();
     self.conversation.prune();
     return true;
 }
@@ -1489,7 +1491,7 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         else => return .{ .text = "internal: command has no tool mapping", .is_error = true },
     };
     // The terminal can't show an image, but the conversation can.
-    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{ .inline_image = self.ai_client != null }) catch |err| .{
+    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{ .inline_image = if (self.ai_client != null) .{} else null }) catch |err| .{
         .text = switch (err) {
             error.OutOfMemory => "out of memory",
             error.FrameNotLoaded => "no page loaded — run /goto <url> first",
@@ -1936,7 +1938,7 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
 
 /// The text plus the rendered PNG, for backends that can show the model an image.
 fn toolOutcome(self: *Agent, allocator: std.mem.Allocator, tool_name: []const u8, arguments: ?std.json.Value) browser_tools.ToolError!zenai.provider.Client.ToolHandler.Result {
-    const result = try browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = true });
+    const result = try browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = .{} });
     const content = capToolOutput(allocator, tool_name, result.text);
     return .{
         .content = content,
@@ -2115,4 +2117,8 @@ test "capToolOutput: extract is exempt from the default cap" {
 
     try std.testing.expectEqual(extract_output_max_bytes, toolOutputCap("extract"));
     try std.testing.expectEqual(tool_output_max_bytes, toolOutputCap("html"));
+}
+
+test {
+    std.testing.refAllDecls(Conversation);
 }

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1488,7 +1488,8 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         .tool_call => |t| t,
         else => return .{ .text = "internal: command has no tool mapping", .is_error = true },
     };
-    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{}) catch |err| .{
+    // The terminal can't show an image, but the conversation can.
+    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{ .inline_image = self.ai_client != null }) catch |err| .{
         .text = switch (err) {
             error.OutOfMemory => "out of memory",
             error.FrameNotLoaded => "no page loaded — run /goto <url> first",
@@ -1620,6 +1621,7 @@ fn recordSlashToolCall(
         .id = try ma.dupe(u8, tool_calls[0].id),
         .name = try ma.dupe(u8, tool_calls[0].name),
         .content = content,
+        .parts = if (result.image) |image| try imageParts(ma, content, &image) else null,
         .is_error = result.is_error,
     };
 
@@ -1922,14 +1924,10 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
     self.terminal.spinner.setTool(tool_name, args_str);
     defer self.terminal.spinner.setThinking();
 
-    const outcome: zenai.provider.Client.ToolHandler.Result = if (browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = true })) |result| blk: {
-        const content = capToolOutput(allocator, tool_name, result.text);
-        break :blk .{
-            .content = content,
-            .is_error = result.is_error,
-            .parts = if (result.image) |image| imageParts(allocator, content, &image) catch null else null,
-        };
-    } else |err| .{ .content = std.fmt.allocPrint(allocator, "Error: {s}", .{browser_tools.errorMessage(err)}) catch "Error: tool execution failed", .is_error = true };
+    const outcome = self.toolOutcome(allocator, tool_name, arguments) catch |err| zenai.provider.Client.ToolHandler.Result{
+        .content = std.fmt.allocPrint(allocator, "Error: {s}", .{browser_tools.errorMessage(err)}) catch "Error: tool execution failed",
+        .is_error = true,
+    };
 
     self.terminal.agentToolDone(tool_name, args_str, !outcome.is_error);
     if (self.terminal.verbosity == .high) self.terminal.printToolOutcome(tool_name, outcome.content, outcome.is_error);
@@ -1937,11 +1935,19 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
 }
 
 /// The text plus the rendered PNG, for backends that can show the model an image.
-fn imageParts(allocator: std.mem.Allocator, text: []const u8, image: *const lp.screenshot.Prepared) ![]const zenai.provider.ContentPart {
-    const parts = try allocator.alloc(zenai.provider.ContentPart, 2);
-    parts[0] = .{ .text = text };
-    parts[1] = .{ .image = .{ .data = try image.base64Alloc(allocator), .mime_type = "image/png" } };
-    return parts;
+fn toolOutcome(self: *Agent, allocator: std.mem.Allocator, tool_name: []const u8, arguments: ?std.json.Value) browser_tools.ToolError!zenai.provider.Client.ToolHandler.Result {
+    const result = try browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = true });
+    const content = capToolOutput(allocator, tool_name, result.text);
+    return .{
+        .content = content,
+        .is_error = result.is_error,
+        .parts = if (result.image) |image| try imageParts(allocator, content, &image) else null,
+    };
+}
+
+fn imageParts(arena: std.mem.Allocator, text: []const u8, image: *const lp.screenshot.Prepared) browser_tools.ToolError![]const zenai.provider.ContentPart {
+    const data = image.base64Alloc(arena) catch return error.InternalError;
+    return try arena.dupe(zenai.provider.ContentPart, &.{ .{ .text = text }, .{ .image = .{ .data = data, .mime_type = "image/png" } } });
 }
 
 /// One-shot for `--list-models`: resolve provider+key, fetch chat-capable model

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1488,7 +1488,7 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         .tool_call => |t| t,
         else => return .{ .text = "internal: command has no tool mapping", .is_error = true },
     };
-    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args) catch |err| .{
+    const result = browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args) catch |err| return .{
         .text = switch (err) {
             error.OutOfMemory => "out of memory",
             error.FrameNotLoaded => "no page loaded — run /goto <url> first",
@@ -1496,6 +1496,9 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         },
         .is_error = true,
     };
+    // Tool results reach the model as text; an inline image has nowhere to go.
+    if (result.image != null) return .{ .text = "screenshot needs `path` here; the inline image is MCP-only", .is_error = true };
+    return result;
 }
 
 /// Data output (/extract, /evaluate, /markdown, /tree, …) → plain stdout on

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1488,7 +1488,7 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         .tool_call => |t| t,
         else => return .{ .text = "internal: command has no tool mapping", .is_error = true },
     };
-    const result = browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args) catch |err| return .{
+    return browser_tools.call(arena, self.session, &self.node_registry, tc.name(), tc.args, .{}) catch |err| .{
         .text = switch (err) {
             error.OutOfMemory => "out of memory",
             error.FrameNotLoaded => "no page loaded — run /goto <url> first",
@@ -1496,9 +1496,6 @@ fn runCommand(self: *Agent, arena: std.mem.Allocator, cmd: Command) browser_tool
         },
         .is_error = true,
     };
-    // Tool results reach the model as text; an inline image has nowhere to go.
-    if (result.image != null) return .{ .text = "screenshot needs `path` here; the inline image is MCP-only", .is_error = true };
-    return result;
 }
 
 /// Data output (/extract, /evaluate, /markdown, /tree, …) → plain stdout on
@@ -1925,7 +1922,7 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
     self.terminal.spinner.setTool(tool_name, args_str);
     defer self.terminal.spinner.setThinking();
 
-    const outcome: zenai.provider.Client.ToolHandler.Result = if (browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments)) |result|
+    const outcome: zenai.provider.Client.ToolHandler.Result = if (browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{})) |result|
         .{ .content = capToolOutput(allocator, tool_name, result.text), .is_error = result.is_error }
     else |err|
         .{ .content = std.fmt.allocPrint(allocator, "Error: {s}", .{browser_tools.errorMessage(err)}) catch "Error: tool execution failed", .is_error = true };

--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -1922,14 +1922,26 @@ fn handleToolCall(ctx: *anyopaque, allocator: std.mem.Allocator, tool_name: []co
     self.terminal.spinner.setTool(tool_name, args_str);
     defer self.terminal.spinner.setThinking();
 
-    const outcome: zenai.provider.Client.ToolHandler.Result = if (browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{})) |result|
-        .{ .content = capToolOutput(allocator, tool_name, result.text), .is_error = result.is_error }
-    else |err|
-        .{ .content = std.fmt.allocPrint(allocator, "Error: {s}", .{browser_tools.errorMessage(err)}) catch "Error: tool execution failed", .is_error = true };
+    const outcome: zenai.provider.Client.ToolHandler.Result = if (browser_tools.call(allocator, self.session, &self.node_registry, tool_name, arguments, .{ .inline_image = true })) |result| blk: {
+        const content = capToolOutput(allocator, tool_name, result.text);
+        break :blk .{
+            .content = content,
+            .is_error = result.is_error,
+            .parts = if (result.image) |image| imageParts(allocator, content, &image) catch null else null,
+        };
+    } else |err| .{ .content = std.fmt.allocPrint(allocator, "Error: {s}", .{browser_tools.errorMessage(err)}) catch "Error: tool execution failed", .is_error = true };
 
     self.terminal.agentToolDone(tool_name, args_str, !outcome.is_error);
     if (self.terminal.verbosity == .high) self.terminal.printToolOutcome(tool_name, outcome.content, outcome.is_error);
     return outcome;
+}
+
+/// The text plus the rendered PNG, for backends that can show the model an image.
+fn imageParts(allocator: std.mem.Allocator, text: []const u8, image: *const lp.screenshot.Prepared) ![]const zenai.provider.ContentPart {
+    const parts = try allocator.alloc(zenai.provider.ContentPart, 2);
+    parts[0] = .{ .text = text };
+    parts[1] = .{ .image = .{ .data = try image.base64Alloc(allocator), .mime_type = "image/png" } };
+    return parts;
 }
 
 /// One-shot for `--list-models`: resolve provider+key, fetch chat-capable model

--- a/src/agent/Conversation.zig
+++ b/src/agent/Conversation.zig
@@ -33,6 +33,8 @@ const Message = zenai.provider.Message;
 // system prompt plus the most recent `prune_keep`.
 const prune_high = 30;
 const prune_keep = 20;
+// Every image in history is re-sent on every request; keep only the newest.
+const image_keep = 2;
 
 allocator: std.mem.Allocator,
 /// Seeded as `messages[0]` on the first turn. Lives outside `arena` (static or
@@ -66,6 +68,29 @@ pub fn ensureSystemPrompt(self: *Conversation) !void {
             .content = self.system_prompt,
         });
     }
+}
+
+/// Drop tool-result images older than the newest `image_keep`; their text
+/// stays, with a note so the model knows to look again.
+pub fn expireImages(self: *Conversation) void {
+    var kept: usize = 0;
+    var i = self.messages.items.len;
+    while (i > 0) {
+        i -= 1;
+        for (self.messages.items[i].tool_results orelse continue) |*res| {
+            if (!hasImage(res.parts orelse continue)) continue;
+            kept += 1;
+            if (kept <= image_keep) continue;
+            const result = @constCast(res);
+            result.parts = null;
+            result.content = std.fmt.allocPrint(self.arena.allocator(), "{s} (image dropped from context; call the tool again to look)", .{res.content}) catch res.content;
+        }
+    }
+}
+
+fn hasImage(parts: []const zenai.provider.ContentPart) bool {
+    for (parts) |part| if (part == .image) return true;
+    return false;
 }
 
 /// Cap history growth: once it exceeds `prune_high`, keep the system prompt plus
@@ -108,4 +133,26 @@ fn repackTail(self: *Conversation, tail: []const Message) void {
     self.messages.shrinkRetainingCapacity(1 + duped.len);
     self.arena.deinit();
     self.arena = new_arena;
+}
+
+test "expireImages keeps the newest images and annotates the rest" {
+    var conv: Conversation = .init(std.testing.allocator, "sys");
+    defer conv.deinit();
+    const a = conv.arena.allocator();
+
+    const image = [_]zenai.provider.ContentPart{.{ .image = .{ .data = "AAAA", .mime_type = "image/png" } }};
+    for (0..4) |n| {
+        const results = try a.alloc(zenai.provider.ToolResult, 1);
+        results[0] = .{ .id = "c", .name = "screenshot", .content = try std.fmt.allocPrint(a, "shot {d}", .{n}), .parts = &image };
+        try conv.messages.append(std.testing.allocator, .{ .role = .tool, .tool_results = results });
+    }
+
+    conv.expireImages();
+
+    try std.testing.expect(conv.messages.items[0].tool_results.?[0].parts == null);
+    try std.testing.expectEqualStrings("shot 0 (image dropped from context; call the tool again to look)", conv.messages.items[0].tool_results.?[0].content);
+    try std.testing.expect(conv.messages.items[1].tool_results.?[0].parts == null);
+    try std.testing.expect(conv.messages.items[2].tool_results.?[0].parts != null);
+    try std.testing.expect(conv.messages.items[3].tool_results.?[0].parts != null);
+    try std.testing.expectEqualStrings("shot 3", conv.messages.items[3].tool_results.?[0].content);
 }

--- a/src/agent/Conversation.zig
+++ b/src/agent/Conversation.zig
@@ -85,7 +85,7 @@ fn expireImages(self: *Conversation) void {
         const results = msg.tool_results orelse continue;
         var stripped: ?[]zenai.provider.ToolResult = null;
         for (results, 0..) |res, n| {
-            if (!hasImage(res.parts orelse continue)) continue;
+            if (!zenai.provider.hasImage(res.parts orelse continue)) continue;
             if (budget > 0) {
                 budget -= 1;
                 continue;
@@ -97,11 +97,6 @@ fn expireImages(self: *Conversation) void {
         }
         if (stripped) |s| msg.tool_results = s;
     }
-}
-
-fn hasImage(parts: []const zenai.provider.ContentPart) bool {
-    for (parts) |part| if (part == .image) return true;
-    return false;
 }
 
 /// Cap history growth: expire stale images, then once history exceeds

--- a/src/agent/Conversation.zig
+++ b/src/agent/Conversation.zig
@@ -70,21 +70,32 @@ pub fn ensureSystemPrompt(self: *Conversation) !void {
     }
 }
 
+const image_dropped_note = " (image dropped from context; call the tool again to look)";
+
 /// Drop tool-result images older than the newest `image_keep`; their text
-/// stays, with a note so the model knows to look again.
-pub fn expireImages(self: *Conversation) void {
-    var kept: usize = 0;
+/// stays, with a note so the model knows to look again. Tool results are
+/// immutable, so a message that loses an image gets a re-homed copy.
+fn expireImages(self: *Conversation) void {
+    const arena = self.arena.allocator();
+    var budget: usize = image_keep;
     var i = self.messages.items.len;
     while (i > 0) {
         i -= 1;
-        for (self.messages.items[i].tool_results orelse continue) |*res| {
+        const msg = &self.messages.items[i];
+        const results = msg.tool_results orelse continue;
+        var stripped: ?[]zenai.provider.ToolResult = null;
+        for (results, 0..) |res, n| {
             if (!hasImage(res.parts orelse continue)) continue;
-            kept += 1;
-            if (kept <= image_keep) continue;
-            const result = @constCast(res);
-            result.parts = null;
-            result.content = std.fmt.allocPrint(self.arena.allocator(), "{s} (image dropped from context; call the tool again to look)", .{res.content}) catch res.content;
+            if (budget > 0) {
+                budget -= 1;
+                continue;
+            }
+            const copy = stripped orelse arena.dupe(zenai.provider.ToolResult, results) catch return;
+            stripped = copy;
+            copy[n].parts = null;
+            copy[n].content = std.mem.concat(arena, u8, &.{ res.content, image_dropped_note }) catch res.content;
         }
+        if (stripped) |s| msg.tool_results = s;
     }
 }
 
@@ -93,10 +104,12 @@ fn hasImage(parts: []const zenai.provider.ContentPart) bool {
     return false;
 }
 
-/// Cap history growth: once it exceeds `prune_high`, keep the system prompt plus
-/// the most recent `prune_keep` messages, snapped to a safe boundary so a
-/// tool_call isn't split from its result.
+/// Cap history growth: expire stale images, then once history exceeds
+/// `prune_high`, keep the system prompt plus the most recent `prune_keep`
+/// messages, snapped to a safe boundary so a tool_call isn't split from its
+/// result.
 pub fn prune(self: *Conversation) void {
+    self.expireImages();
     const msgs = self.messages.items;
     if (msgs.len <= prune_high) return;
     const tail_start = zenai.provider.safeTruncationStart(msgs, msgs.len - prune_keep) orelse return;
@@ -150,7 +163,7 @@ test "expireImages keeps the newest images and annotates the rest" {
     conv.expireImages();
 
     try std.testing.expect(conv.messages.items[0].tool_results.?[0].parts == null);
-    try std.testing.expectEqualStrings("shot 0 (image dropped from context; call the tool again to look)", conv.messages.items[0].tool_results.?[0].content);
+    try std.testing.expectEqualStrings("shot 0" ++ image_dropped_note, conv.messages.items[0].tool_results.?[0].content);
     try std.testing.expect(conv.messages.items[1].tool_results.?[0].parts == null);
     try std.testing.expect(conv.messages.items[2].tool_results.?[0].parts != null);
     try std.testing.expect(conv.messages.items[3].tool_results.?[0].parts != null);

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -64,8 +64,7 @@ pub fn png(arena: Allocator, node: *Node, opts: Opts, writer: *std.Io.Writer, fr
 // get the height of the PNG if we were to render it.
 pub fn contentHeight(arena: Allocator, node: *Node, width: u32, frame: *Frame) !u32 {
     const prepared = try prepare(arena, node, .{ .width = width }, frame);
-    var discard: std.Io.Writer.Discarding = .init(&.{});
-    return prepared.render(&discard.writer, RENDER_MEASURE_ONLY);
+    return prepared.measure();
 }
 
 // The DOM walk, done up front so it can fail (allocation) before any output
@@ -90,6 +89,12 @@ pub const Prepared = struct {
 
     pub fn write(self: *const Prepared, writer: *std.Io.Writer) std.Io.Writer.Error!u32 {
         return self.render(writer, 0);
+    }
+
+    /// The content height at `opts.width`, without rasterizing.
+    pub fn measure(self: *const Prepared) std.Io.Writer.Error!u32 {
+        var discard: std.Io.Writer.Discarding = .init(&.{});
+        return self.render(&discard.writer, RENDER_MEASURE_ONLY);
     }
 
     fn render(self: *const Prepared, writer: *std.Io.Writer, flags: u32) std.Io.Writer.Error!u32 {

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -61,7 +61,7 @@ pub fn png(arena: Allocator, node: *Node, opts: Opts, writer: *std.Io.Writer, fr
     return prepared.write(writer);
 }
 
-// get the height of the PNG if we were to render it.
+/// The height a render at `width` would have.
 pub fn contentHeight(arena: Allocator, node: *Node, width: u32, frame: *Frame) !u32 {
     const prepared = try prepare(arena, node, .{ .width = width }, frame);
     return prepared.measure();
@@ -95,6 +95,16 @@ pub const Prepared = struct {
     pub fn measure(self: *const Prepared) std.Io.Writer.Error!u32 {
         var discard: std.Io.Writer.Discarding = .init(&.{});
         return self.render(&discard.writer, RENDER_MEASURE_ONLY);
+    }
+
+    /// Bound the render for a consumer with size limits. Layout reflows to
+    /// the width, so the height is measured after narrowing, and only when it
+    /// isn't already a fixed strip within the limit.
+    pub fn fit(self: *Prepared, max_width: u32, max_height: u32) std.Io.Writer.Error!void {
+        self.opts.width = @min(self.opts.width, max_width);
+        if (self.opts.height == 0 or self.opts.height > max_height) {
+            self.opts.height = @min(try self.measure(), max_height);
+        }
     }
 
     fn render(self: *const Prepared, writer: *std.Io.Writer, flags: u32) std.Io.Writer.Error!u32 {

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -23,6 +23,7 @@ const Base64Writer = @import("../Base64Writer.zig");
 const isAllWhitespace = @import("../string.zig").isAllWhitespace;
 
 const Frame = @import("Frame.zig");
+const Viewport = @import("Viewport.zig");
 const markdown = @import("markdown.zig");
 
 const Node = @import("webapi/Node.zig");
@@ -44,6 +45,15 @@ pub const Opts = struct {
         width: f32,
         height: f32,
     };
+
+    /// Height 0 renders the whole content instead of one viewport.
+    pub fn fromViewport(viewport: Viewport, full_page: bool) Opts {
+        return .{
+            .width = viewport.width,
+            .height = if (full_page) 0 else viewport.height,
+            .scale = viewport.scale,
+        };
+    }
 };
 
 pub fn png(arena: Allocator, node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !u32 {

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -130,11 +130,23 @@ pub const Prepared = struct {
     pub fn jsonStringify(self: *const Prepared, jws: *std.json.Stringify) std.Io.Writer.Error!void {
         try jws.beginWriteRaw();
         try jws.writer.writeByte('"');
-        var b64 = Base64Writer.init(jws.writer, .standard);
-        _ = try self.write(&b64.writer);
-        try b64.finish();
+        try self.writeBase64(jws.writer);
         try jws.writer.writeByte('"');
         jws.endWriteRaw();
+    }
+
+    /// The PNG as base64, for APIs that want it as one string.
+    pub fn base64Alloc(self: *const Prepared, allocator: Allocator) ![]const u8 {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        errdefer aw.deinit();
+        try self.writeBase64(&aw.writer);
+        return aw.toOwnedSlice();
+    }
+
+    fn writeBase64(self: *const Prepared, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        var b64 = Base64Writer.init(writer, .standard);
+        _ = try self.write(&b64.writer);
+        try b64.finish();
     }
 };
 
@@ -662,6 +674,23 @@ test "browser.screenshot: png signature and dimensions" {
     const height = std.mem.readInt(u32, out[20..24], .big);
     // Two blocks plus margins.
     try testing.expectEqual(true, height > 60 and height < 200);
+}
+
+test "browser.screenshot: base64Alloc is the png, base64 encoded" {
+    defer testing.test_session.closeAllPages();
+    const frame = try testing.createFrame();
+    frame.url = "http://localhost/";
+    const div = try frame.window._document.createElement("div", null, frame);
+    try Frame.parse.htmlAsChildren(frame, div.asNode(), "<p>Hello</p>");
+
+    const prepared = try prepare(testing.arena_allocator, div.asNode(), .{ .width = 320 }, frame);
+    const b64 = try prepared.base64Alloc(testing.arena_allocator);
+    try testing.expect(std.mem.startsWith(u8, b64, "iVBORw0KGgo"));
+
+    const decoder = std.base64.standard.Decoder;
+    const bytes = try testing.arena_allocator.alloc(u8, try decoder.calcSizeForSlice(b64));
+    try decoder.decode(bytes, b64);
+    try testing.expectEqual("\x89PNG\r\n\x1a\n", bytes[0..8]);
 }
 
 test "browser.screenshot: fixed height, clip and scale" {

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -136,11 +136,10 @@ pub const Prepared = struct {
     }
 
     /// The PNG as base64, for APIs that want it as one string.
-    pub fn base64Alloc(self: *const Prepared, allocator: Allocator) ![]const u8 {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        errdefer aw.deinit();
+    pub fn base64Alloc(self: *const Prepared, arena: Allocator) ![]const u8 {
+        var aw: std.Io.Writer.Allocating = .init(arena);
         try self.writeBase64(&aw.writer);
-        return aw.toOwnedSlice();
+        return aw.written();
     }
 
     fn writeBase64(self: *const Prepared, writer: *std.Io.Writer) std.Io.Writer.Error!void {
@@ -676,23 +675,6 @@ test "browser.screenshot: png signature and dimensions" {
     try testing.expectEqual(true, height > 60 and height < 200);
 }
 
-test "browser.screenshot: base64Alloc is the png, base64 encoded" {
-    defer testing.test_session.closeAllPages();
-    const frame = try testing.createFrame();
-    frame.url = "http://localhost/";
-    const div = try frame.window._document.createElement("div", null, frame);
-    try Frame.parse.htmlAsChildren(frame, div.asNode(), "<p>Hello</p>");
-
-    const prepared = try prepare(testing.arena_allocator, div.asNode(), .{ .width = 320 }, frame);
-    const b64 = try prepared.base64Alloc(testing.arena_allocator);
-    try testing.expect(std.mem.startsWith(u8, b64, "iVBORw0KGgo"));
-
-    const decoder = std.base64.standard.Decoder;
-    const bytes = try testing.arena_allocator.alloc(u8, try decoder.calcSizeForSlice(b64));
-    try decoder.decode(bytes, b64);
-    try testing.expectEqual("\x89PNG\r\n\x1a\n", bytes[0..8]);
-}
-
 test "browser.screenshot: fixed height, clip and scale" {
     defer testing.test_session.closeAllPages();
     const frame = try testing.createFrame();
@@ -810,6 +792,7 @@ test "browser.screenshot: json streams base64" {
     _ = enc.encode(expected[9 .. expected.len - 2], raw.written());
     @memcpy(expected[expected.len - 2 ..], "\"}");
     try testing.expectString(expected, json.written());
+    try testing.expectString(expected[9 .. expected.len - 2], try prepared.base64Alloc(testing.arena_allocator));
 }
 
 test "browser.screenshot: block extraction" {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -39,8 +39,9 @@ const Selector = @import("webapi/selector/Selector.zig");
 /// recordable as JavaScript agent scripts.
 pub const driver_guidance =
     \\You are driving Lightpanda, a headless browser, through text tools:
-    \\no screenshots, no images, no PDFs — you reason over pages as a
-    \\semantic tree, markdown or HTML.
+    \\you reason over pages as a semantic tree, markdown or HTML. `screenshot`
+    \\renders that text layout as a PNG (no images, fonts or CSS) — use it
+    \\for spatial layout, not as a primary read.
     \\
     \\Reading pages (cheap → expensive — prefer cheaper):
     \\- `tree` → semantic overview (role, name, value, backendNodeId per
@@ -234,6 +235,7 @@ pub const Tool = enum {
     search,
     markdown,
     html,
+    screenshot,
     links,
     evaluate,
     extract,
@@ -263,7 +265,7 @@ pub const Tool = enum {
     /// with noise.
     pub fn isRecorded(self: Tool) bool {
         return switch (self) {
-            .goto, .evaluate, .extract, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked => true,
+            .goto, .screenshot, .evaluate, .extract, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked => true,
             .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
     }
@@ -275,7 +277,7 @@ pub const Tool = enum {
     pub fn isAsync(self: Tool) bool {
         return switch (self) {
             .goto => true,
-            .evaluate, .extract, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked, .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+            .evaluate, .extract, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked, .search, .markdown, .html, .screenshot, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
     }
 
@@ -285,7 +287,7 @@ pub const Tool = enum {
     pub fn waitsForReadiness(self: Tool) bool {
         return switch (self) {
             .waitForSelector, .waitForScript, .waitForState => true,
-            .goto, .evaluate, .extract, .click, .fill, .scroll, .hover, .press, .selectOption, .setChecked, .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+            .goto, .evaluate, .extract, .click, .fill, .scroll, .hover, .press, .selectOption, .setChecked, .search, .markdown, .html, .screenshot, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
     }
 
@@ -295,7 +297,7 @@ pub const Tool = enum {
     /// `getCookies` (`url` filters, not navigates).
     pub fn navigatesToUrl(self: Tool) bool {
         return switch (self) {
-            .markdown, .html, .links, .tree, .interactiveElements, .structuredData, .detectForms => true,
+            .markdown, .html, .screenshot, .links, .tree, .interactiveElements, .structuredData, .detectForms => true,
             .goto, .search, .evaluate, .extract, .nodeDetails, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
     }
@@ -306,7 +308,7 @@ pub const Tool = enum {
     pub fn needsLocator(self: Tool) bool {
         return switch (self) {
             .click, .fill, .hover, .selectOption, .setChecked => true,
-            .goto, .search, .markdown, .html, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .scroll, .waitForSelector, .waitForScript, .waitForState, .press, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+            .goto, .search, .markdown, .html, .screenshot, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .scroll, .waitForSelector, .waitForScript, .waitForState, .press, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
         };
     }
 
@@ -315,7 +317,7 @@ pub const Tool = enum {
     pub fn producesData(self: Tool) bool {
         return switch (self) {
             .search, .markdown, .html, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => true,
-            .goto, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked => false,
+            .goto, .screenshot, .click, .fill, .scroll, .waitForSelector, .waitForScript, .waitForState, .hover, .press, .selectOption, .setChecked => false,
         };
     }
 
@@ -393,6 +395,23 @@ pub const Tool = enum {
                     \\    "maxBytes": { "type": "integer", "description": "Optional soft cap on output size in bytes. Content is truncated at a UTF-8 boundary and a short '[truncated]' marker is appended past the cap." },
                     \\    "strip": { "type": "object", "description": "Optional. Omit element groups from the output: `js` (script, noscript, script preloads), `css` (style, stylesheet links), `ui` (css plus img, picture, video, audio, svg, canvas, iframe), `invisible` (elements an author rule or inline style sets to display:none). {\"js\":true,\"css\":true} keeps a page dump small.", "properties": { "js": { "type": "boolean" }, "css": { "type": "boolean" }, "ui": { "type": "boolean" }, "invisible": { "type": "boolean" } } },
                     \\    "url": { "type": "string", "description": "Optional URL to navigate to before dumping." },
+                    \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." }
+                    \\  }
+                    \\}
+                ),
+            },
+            .screenshot => .{
+                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file and returns its location; without it, returns the image inline (MCP only). Use it to see spatial layout; read content with `markdown`/`tree`.",
+                .summary = "Screenshot of the page or a node",
+                .input_schema = minify(
+                    \\{
+                    \\  "type": "object",
+                    \\  "properties": {
+                    \\    "path": { "type": "string", "description": "Optional relative path (no '..' segments) to write the PNG to. Created or overwritten. Required outside MCP." },
+                    \\    "selector": { "type": "string", "description": "Optional CSS selector. When set, render only that element." },
+                    \\    "backendNodeId": { "type": "integer", "description": "Optional backend node ID. When set, render only that node. 0 is treated as omitted." },
+                    \\    "fullPage": { "type": "boolean", "description": "Render the whole content height instead of one viewport. Defaults to false." },
+                    \\    "url": { "type": "string", "description": "Optional URL to navigate to before rendering." },
                     \\    "timeout": { "type": "integer", "description": "Optional timeout in milliseconds. Defaults to 10000." }
                     \\  }
                     \\}
@@ -703,7 +722,7 @@ pub const Tool = enum {
 };
 
 pub fn minify(comptime json: []const u8) []const u8 {
-    @setEvalBranchQuota(10000);
+    @setEvalBranchQuota(100_000);
     return comptime blk: {
         var buf: [json.len]u8 = undefined;
         var len: usize = 0;
@@ -790,6 +809,8 @@ pub fn errorMessage(err: ToolError) []const u8 {
 pub const ToolResult = struct {
     text: []const u8,
     is_error: bool = false,
+    /// A rendered PNG the caller streams out itself (MCP image content).
+    image: ?lp.screenshot.Prepared = null,
 };
 
 pub const GotoParams = struct {
@@ -862,6 +883,7 @@ fn dispatch(
         .search => execSearch(arena, substituted),
         .markdown => .{ .text = try execMarkdown(arena, session, registry, substituted) },
         .html => .{ .text = try execHtml(arena, session, registry, substituted) },
+        .screenshot => try execScreenshot(arena, session, registry, substituted),
         .links => .{ .text = try execLinks(arena, session, registry, substituted) },
         .tree => .{ .text = try execTree(arena, session, registry, substituted) },
         .nodeDetails => .{ .text = try execNodeDetails(arena, session, registry, substituted) },
@@ -1307,6 +1329,64 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
         lp.dump.root(page.document, opts, &aw.writer, page) catch return ToolError.InternalError;
     }
     return aw.written();
+}
+
+fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError!ToolResult {
+    const Params = struct {
+        path: ?[]const u8 = null,
+        selector: ?[]const u8 = null,
+        backendNodeId: ?CDPNode.Id = null,
+        fullPage: bool = false,
+        url: ?[:0]const u8 = null,
+        timeout: ?u32 = null,
+    };
+    const args = try parseArgsOrDefault(Params, arena, arguments);
+    if (args.path) |path| {
+        if (!isPathSafe(path)) return .{ .text = "path must be relative and must not contain '..' segments", .is_error = true };
+    }
+    const page = try ensurePage(session, registry, args.url, args.timeout);
+
+    var node = page.document.asNode();
+    var frame = page;
+    if (args.selector) |sel| {
+        const resolved = try resolveBySelector(session, sel);
+        node = resolved.node;
+        frame = resolved.page;
+    } else if (args.backendNodeId) |nid| {
+        const resolved = try resolveNodeAndPage(session, registry, nid);
+        node = resolved.node;
+        frame = resolved.page;
+    }
+
+    const viewport = page._page.getViewport();
+    const prepared = lp.screenshot.prepare(arena, node, .{
+        .width = viewport.width,
+        .height = if (args.fullPage) 0 else viewport.height,
+        .scale = viewport.scale,
+    }, frame) catch return ToolError.InternalError;
+
+    const path = args.path orelse return .{
+        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{viewport.width}) catch return ToolError.OutOfMemory,
+        .image = prepared,
+    };
+
+    const height = writePng(&prepared, path) catch |err| return .{
+        .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
+        .is_error = true,
+    };
+    // Absolute path: the cwd is the server's, not one the user picked.
+    const where = std.Io.Dir.cwd().realPathFileAlloc(lp.io, path, arena) catch path;
+    return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ viewport.width, height, where }) catch return ToolError.OutOfMemory };
+}
+
+fn writePng(prepared: *const lp.screenshot.Prepared, path: []const u8) !u32 {
+    const file = try std.Io.Dir.cwd().createFile(lp.io, path, .{ .truncate = true });
+    defer file.close(lp.io);
+    var buf: [8 * 1024]u8 = undefined;
+    var writer = file.writer(lp.io, &buf);
+    const height = try prepared.write(&writer.interface);
+    try writer.interface.flush();
+    return height;
 }
 
 fn execLinks(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -408,7 +408,7 @@ pub const Tool = enum {
                 ),
             },
             .screenshot => .{
-                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file at full size and returns its location; without it, returns the image inline where the client can display one, at most 1280px wide and 4096px tall. Use it to see spatial layout; read content with `markdown`/`tree`.",
+                .description = std.fmt.comptimePrint("Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file at full size and returns its location; without it, returns the image inline where the client can display one, at most {d}px wide and {d}px tall. Use it to see spatial layout; read content with `markdown`/`tree`.", .{ inline_image_max_width, inline_image_max_height }),
                 .summary = "Screenshot of the page or a node",
                 .input_schema = minify(
                     \\{
@@ -848,15 +848,14 @@ const NodeAndPage = struct { node: *DOMNode, page: *lp.Frame, target: ActionTarg
 
 /// What the caller can do with a result beyond its text.
 pub const CallOpts = struct {
-    /// Set when the caller can hand an image to a model; the limits keep a
-    /// screenshot within what models consume (and re-send every turn).
-    inline_image: ?InlineImage = null,
-
-    pub const InlineImage = struct {
-        max_width: u32 = 1280,
-        max_height: u32 = 4096,
-    };
+    /// The caller can hand an image to a model.
+    inline_image: bool = false,
 };
+
+// An inline screenshot is re-sent on every turn; keep it within what models
+// consume. Files written to `path` are full size.
+pub const inline_image_max_width = 1280;
+pub const inline_image_max_height = 4096;
 
 pub fn call(
     arena: std.mem.Allocator,
@@ -1349,7 +1348,7 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
     return aw.written();
 }
 
-fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value, inline_image: ?CallOpts.InlineImage) ToolError!ToolResult {
+fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value, inline_image: bool) ToolError!ToolResult {
     const Params = struct {
         path: ?[]const u8 = null,
         selector: ?[]const u8 = null,
@@ -1361,7 +1360,7 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
     const args = try parseArgsOrDefault(Params, arena, arguments);
     if (args.path) |path| {
         if (!isPathSafe(path)) return .{ .text = unsafe_path_message, .is_error = true };
-    } else if (inline_image == null) {
+    } else if (!inline_image) {
         return .{ .text = "pass `path`: this client cannot display an inline image", .is_error = true };
     }
     const page = try ensurePage(session, registry, args.url, args.timeout);
@@ -1377,13 +1376,7 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
         return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ prepared.opts.width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
     }
 
-    // Layout reflows to the width, so measure after narrowing.
-    const limits = inline_image.?;
-    prepared.opts.width = @min(prepared.opts.width, limits.max_width);
-    const content_height = prepared.measure() catch return ToolError.InternalError;
-    if (prepared.opts.height == 0 or prepared.opts.height > limits.max_height) {
-        prepared.opts.height = @min(content_height, limits.max_height);
-    }
+    prepared.fit(inline_image_max_width, inline_image_max_height) catch return ToolError.InternalError;
     return .{
         .text = std.fmt.allocPrint(arena, "PNG, {d}x{d}", .{ prepared.opts.width, prepared.opts.height }) catch return ToolError.OutOfMemory,
         .image = prepared,

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -408,7 +408,7 @@ pub const Tool = enum {
                 ),
             },
             .screenshot => .{
-                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file and returns its location; without it, returns the image inline where the client can display one. Use it to see spatial layout; read content with `markdown`/`tree`.",
+                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file at full size and returns its location; without it, returns the image inline where the client can display one, at most 1280px wide and 4096px tall. Use it to see spatial layout; read content with `markdown`/`tree`.",
                 .summary = "Screenshot of the page or a node",
                 .input_schema = minify(
                     \\{
@@ -848,7 +848,14 @@ const NodeAndPage = struct { node: *DOMNode, page: *lp.Frame, target: ActionTarg
 
 /// What the caller can do with a result beyond its text.
 pub const CallOpts = struct {
-    inline_image: bool = false,
+    /// Set when the caller can hand an image to a model; the limits keep a
+    /// screenshot within what models consume (and re-send every turn).
+    inline_image: ?InlineImage = null,
+
+    pub const InlineImage = struct {
+        max_width: u32 = 1280,
+        max_height: u32 = 4096,
+    };
 };
 
 pub fn call(
@@ -1342,7 +1349,7 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
     return aw.written();
 }
 
-fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value, inline_image: bool) ToolError!ToolResult {
+fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value, inline_image: ?CallOpts.InlineImage) ToolError!ToolResult {
     const Params = struct {
         path: ?[]const u8 = null,
         selector: ?[]const u8 = null,
@@ -1354,23 +1361,31 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
     const args = try parseArgsOrDefault(Params, arena, arguments);
     if (args.path) |path| {
         if (!isPathSafe(path)) return .{ .text = unsafe_path_message, .is_error = true };
-    } else if (!inline_image) {
+    } else if (inline_image == null) {
         return .{ .text = "pass `path`: this client cannot display an inline image", .is_error = true };
     }
     const page = try ensurePage(session, registry, args.url, args.timeout);
     const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
-    const opts: lp.screenshot.Opts = .fromViewport(page._page.getViewport(), args.fullPage);
-    const prepared = lp.screenshot.prepare(arena, node, opts, page) catch return ToolError.InternalError;
+    var prepared = lp.screenshot.prepare(arena, node, .fromViewport(page._page.getViewport(), args.fullPage), page) catch
+        return ToolError.InternalError;
 
     if (args.path) |path| {
         const height = writePng(&prepared, path) catch |err| return .{
             .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
             .is_error = true,
         };
-        return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ opts.width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
+        return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ prepared.opts.width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
+    }
+
+    // Layout reflows to the width, so measure after narrowing.
+    const limits = inline_image.?;
+    prepared.opts.width = @min(prepared.opts.width, limits.max_width);
+    const content_height = prepared.measure() catch return ToolError.InternalError;
+    if (prepared.opts.height == 0 or prepared.opts.height > limits.max_height) {
+        prepared.opts.height = @min(content_height, limits.max_height);
     }
     return .{
-        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{opts.width}) catch return ToolError.OutOfMemory,
+        .text = std.fmt.allocPrint(arena, "PNG, {d}x{d}", .{ prepared.opts.width, prepared.opts.height }) catch return ToolError.OutOfMemory,
         .image = prepared,
     };
 }

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -40,8 +40,7 @@ const Selector = @import("webapi/selector/Selector.zig");
 pub const driver_guidance =
     \\You are driving Lightpanda, a headless browser, through text tools:
     \\you reason over pages as a semantic tree, markdown or HTML. `screenshot`
-    \\renders that text layout as a PNG (no images, fonts or CSS) — use it
-    \\for spatial layout, not as a primary read.
+    \\renders that text layout as a PNG: for spatial layout, not a primary read.
     \\
     \\Reading pages (cheap → expensive — prefer cheaper):
     \\- `tree` → semantic overview (role, name, value, backendNodeId per
@@ -215,14 +214,6 @@ pub const save_script_rules =
 /// `..` segment. Operator-controlled symlinks already inside CWD are out
 /// of scope — the threat we close here is "client supplies an arbitrary
 /// path string".
-pub const unsafe_path_message = "path must be relative and must not contain '..' segments";
-
-/// The cwd is the server's, not one the user picked, so report where a file
-/// really went.
-pub fn absolutePath(arena: std.mem.Allocator, path: []const u8) []const u8 {
-    return std.Io.Dir.cwd().realPathFileAlloc(lp.io, path, arena) catch path;
-}
-
 pub fn isPathSafe(path: []const u8) bool {
     if (path.len == 0) return false;
     if (std.fs.path.isAbsolute(path)) return false;
@@ -231,6 +222,14 @@ pub fn isPathSafe(path: []const u8) bool {
         if (std.mem.eql(u8, seg, "..")) return false;
     }
     return true;
+}
+
+pub const unsafe_path_message = "path must be relative and must not contain '..' segments";
+
+/// The cwd is the server's, not one the user picked, so report where a file
+/// really went.
+pub fn absolutePath(arena: std.mem.Allocator, path: []const u8) []const u8 {
+    return std.Io.Dir.cwd().realPathFileAlloc(lp.io, path, arena) catch path;
 }
 
 /// Hand-written so per-tool semantics (record/heal/locator/data) and
@@ -318,13 +317,6 @@ pub const Tool = enum {
             .screenshot => &.{"path"},
             .goto, .search, .markdown, .html, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .scroll, .waitForSelector, .waitForScript, .waitForState, .press, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => &.{},
         };
-    }
-
-    pub fn needsLocator(self: Tool) bool {
-        for (self.replayRequires()) |field| {
-            if (std.mem.eql(u8, field, "selector")) return true;
-        }
-        return false;
     }
 
     /// Result is data the caller probably wants on stdout (extracted JSON,
@@ -1322,9 +1314,8 @@ fn execMarkdown(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNo
 /// The node a read tool works on: the selector match, the registry node, or
 /// the whole document. All three live in the current frame.
 fn resolveScope(session: *lp.Session, registry: *CDPNode.Registry, page: *lp.Frame, selector: ?[]const u8, node_id: ?CDPNode.Id) ToolError!*DOMNode {
-    if (selector) |sel| return (try resolveBySelector(session, sel)).node;
-    if (node_id) |nid| return (try resolveNodeAndPage(session, registry, nid)).node;
-    return page.document.asNode();
+    if (selector == null and node_id == null) return page.document.asNode();
+    return (try resolveTarget(session, registry, selector, node_id)).node;
 }
 
 const HtmlParams = struct {
@@ -1345,7 +1336,7 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
     if (args.selector == null and args.backendNodeId == null) {
         lp.dump.root(page.document, opts, &aw.writer, page) catch return ToolError.InternalError;
     } else {
-        const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
+        const node = (try resolveTarget(session, registry, args.selector, args.backendNodeId)).node;
         lp.dump.deep(node, opts, &aw.writer, page) catch return ToolError.InternalError;
     }
     return aw.written();
@@ -1368,19 +1359,18 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
     }
     const page = try ensurePage(session, registry, args.url, args.timeout);
     const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
-    const prepared = lp.screenshot.prepare(arena, node, .fromViewport(page._page.getViewport(), args.fullPage), page) catch
-        return ToolError.InternalError;
-    const width = prepared.opts.width;
+    const opts: lp.screenshot.Opts = .fromViewport(page._page.getViewport(), args.fullPage);
+    const prepared = lp.screenshot.prepare(arena, node, opts, page) catch return ToolError.InternalError;
 
     if (args.path) |path| {
         const height = writePng(&prepared, path) catch |err| return .{
             .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
             .is_error = true,
         };
-        return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
+        return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ opts.width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
     }
     return .{
-        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{width}) catch return ToolError.OutOfMemory,
+        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{opts.width}) catch return ToolError.OutOfMemory,
         .image = prepared,
     };
 }

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -215,6 +215,14 @@ pub const save_script_rules =
 /// `..` segment. Operator-controlled symlinks already inside CWD are out
 /// of scope — the threat we close here is "client supplies an arbitrary
 /// path string".
+pub const unsafe_path_message = "path must be relative and must not contain '..' segments";
+
+/// The cwd is the server's, not one the user picked, so report where a file
+/// really went.
+pub fn absolutePath(arena: std.mem.Allocator, path: []const u8) []const u8 {
+    return std.Io.Dir.cwd().realPathFileAlloc(lp.io, path, arena) catch path;
+}
+
 pub fn isPathSafe(path: []const u8) bool {
     if (path.len == 0) return false;
     if (std.fs.path.isAbsolute(path)) return false;
@@ -302,14 +310,21 @@ pub const Tool = enum {
         };
     }
 
-    /// Tool requires a target element (selector or backendNodeId) at
-    /// runtime even though the JSON schema marks both as optional. Used by
-    /// the recorder to skip lines that can't be replayed.
-    pub fn needsLocator(self: Tool) bool {
+    /// Args a replay needs even though the schema marks them optional; the
+    /// recorder skips a line missing one. Exhaustive so a new tool must choose.
+    pub fn replayRequires(self: Tool) []const []const u8 {
         return switch (self) {
-            .click, .fill, .hover, .selectOption, .setChecked => true,
-            .goto, .search, .markdown, .html, .screenshot, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .scroll, .waitForSelector, .waitForScript, .waitForState, .press, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => false,
+            .click, .fill, .hover, .selectOption, .setChecked => &.{"selector"},
+            .screenshot => &.{"path"},
+            .goto, .search, .markdown, .html, .links, .evaluate, .extract, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .scroll, .waitForSelector, .waitForScript, .waitForState, .press, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => &.{},
         };
+    }
+
+    pub fn needsLocator(self: Tool) bool {
+        for (self.replayRequires()) |field| {
+            if (std.mem.eql(u8, field, "selector")) return true;
+        }
+        return false;
     }
 
     /// Result is data the caller probably wants on stdout (extracted JSON,
@@ -401,13 +416,13 @@ pub const Tool = enum {
                 ),
             },
             .screenshot => .{
-                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file and returns its location; without it, returns the image inline (MCP only). Use it to see spatial layout; read content with `markdown`/`tree`.",
+                .description = "Render the page, or one node, as a PNG: the text layout Lightpanda computes, not a pixel-accurate browser rendering (no images, fonts or CSS colours). With `path`, writes the file and returns its location; without it, returns the image inline where the client can display one. Use it to see spatial layout; read content with `markdown`/`tree`.",
                 .summary = "Screenshot of the page or a node",
                 .input_schema = minify(
                     \\{
                     \\  "type": "object",
                     \\  "properties": {
-                    \\    "path": { "type": "string", "description": "Optional relative path (no '..' segments) to write the PNG to. Created or overwritten. Required outside MCP." },
+                    \\    "path": { "type": "string", "description": "Optional relative path (no '..' segments) to write the PNG to. Created or overwritten. Without it the image is returned inline, which needs a client that can display images." },
                     \\    "selector": { "type": "string", "description": "Optional CSS selector. When set, render only that element." },
                     \\    "backendNodeId": { "type": "integer", "description": "Optional backend node ID. When set, render only that node. 0 is treated as omitted." },
                     \\    "fullPage": { "type": "boolean", "description": "Render the whole content height instead of one viewport. Defaults to false." },
@@ -722,6 +737,7 @@ pub const Tool = enum {
 };
 
 pub fn minify(comptime json: []const u8) []const u8 {
+    // Cumulative: tool_defs evaluates every schema in one comptime scope.
     @setEvalBranchQuota(100_000);
     return comptime blk: {
         var buf: [json.len]u8 = undefined;
@@ -809,7 +825,7 @@ pub fn errorMessage(err: ToolError) []const u8 {
 pub const ToolResult = struct {
     text: []const u8,
     is_error: bool = false,
-    /// A rendered PNG the caller streams out itself (MCP image content).
+    /// Only set when the caller passed `CallOpts.inline_image`.
     image: ?lp.screenshot.Prepared = null,
 };
 
@@ -838,12 +854,18 @@ const ActionTarget = union(enum) {
 
 const NodeAndPage = struct { node: *DOMNode, page: *lp.Frame, target: ActionTarget };
 
+/// What the caller can do with a result beyond its text.
+pub const CallOpts = struct {
+    inline_image: bool = false,
+};
+
 pub fn call(
     arena: std.mem.Allocator,
     session: *lp.Session,
     registry: *CDPNode.Registry,
     tool_name: []const u8,
     arguments: ?std.json.Value,
+    opts: CallOpts,
 ) ToolError!ToolResult {
     // In-band so an LLM that invented a tool name (e.g. OpenAI's internal
     // `multi_tool_use.parallel` wrapper) learns the name is wrong instead of
@@ -862,7 +884,7 @@ pub fn call(
     };
     const substituted = try substituteStringArgs(arena, tool, normalized);
 
-    return dispatch(arena, session, registry, tool, substituted) catch |err| {
+    return dispatch(arena, session, registry, tool, substituted, opts) catch |err| {
         if (err == error.NavigationFailed) {
             if (formatNavigationError(arena, session)) |text|
                 return .{ .text = text, .is_error = true };
@@ -877,13 +899,14 @@ fn dispatch(
     registry: *CDPNode.Registry,
     tool: Tool,
     substituted: ?std.json.Value,
+    opts: CallOpts,
 ) ToolError!ToolResult {
     return switch (tool) {
         .goto => .{ .text = try execGoto(arena, session, registry, substituted) },
         .search => execSearch(arena, substituted),
         .markdown => .{ .text = try execMarkdown(arena, session, registry, substituted) },
         .html => .{ .text = try execHtml(arena, session, registry, substituted) },
-        .screenshot => try execScreenshot(arena, session, registry, substituted),
+        .screenshot => try execScreenshot(arena, session, registry, substituted, opts.inline_image),
         .links => .{ .text = try execLinks(arena, session, registry, substituted) },
         .tree => .{ .text = try execTree(arena, session, registry, substituted) },
         .nodeDetails => .{ .text = try execNodeDetails(arena, session, registry, substituted) },
@@ -1289,19 +1312,19 @@ fn execMarkdown(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNo
     const args = try parseArgsOrDefault(Params, arena, arguments);
     const page = try ensurePage(session, registry, args.url, args.timeout);
 
-    const opts: lp.markdown.Opts = .{ .max_bytes = args.maxBytes };
+    const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
 
     var aw: std.Io.Writer.Allocating = .init(arena);
-    if (args.selector) |sel| {
-        const resolved = try resolveBySelector(session, sel);
-        lp.markdown.dump(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
-    } else if (args.backendNodeId) |nid| {
-        const resolved = try resolveNodeAndPage(session, registry, nid);
-        lp.markdown.dump(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
-    } else {
-        lp.markdown.dump(page.document.asNode(), opts, &aw.writer, page) catch return ToolError.InternalError;
-    }
+    lp.markdown.dump(node, .{ .max_bytes = args.maxBytes }, &aw.writer, page) catch return ToolError.InternalError;
     return aw.written();
+}
+
+/// The node a read tool works on: the selector match, the registry node, or
+/// the whole document. All three live in the current frame.
+fn resolveScope(session: *lp.Session, registry: *CDPNode.Registry, page: *lp.Frame, selector: ?[]const u8, node_id: ?CDPNode.Id) ToolError!*DOMNode {
+    if (selector) |sel| return (try resolveBySelector(session, sel)).node;
+    if (node_id) |nid| return (try resolveNodeAndPage(session, registry, nid)).node;
+    return page.document.asNode();
 }
 
 const HtmlParams = struct {
@@ -1319,19 +1342,16 @@ fn execHtml(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
 
     const opts: lp.dump.Opts = .{ .strip = args.strip, .max_bytes = args.maxBytes };
     var aw: std.Io.Writer.Allocating = .init(arena);
-    if (args.selector) |sel| {
-        const resolved = try resolveBySelector(session, sel);
-        lp.dump.deep(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
-    } else if (args.backendNodeId) |nid| {
-        const resolved = try resolveNodeAndPage(session, registry, nid);
-        lp.dump.deep(resolved.node, opts, &aw.writer, resolved.page) catch return ToolError.InternalError;
-    } else {
+    if (args.selector == null and args.backendNodeId == null) {
         lp.dump.root(page.document, opts, &aw.writer, page) catch return ToolError.InternalError;
+    } else {
+        const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
+        lp.dump.deep(node, opts, &aw.writer, page) catch return ToolError.InternalError;
     }
     return aw.written();
 }
 
-fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError!ToolResult {
+fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value, inline_image: bool) ToolError!ToolResult {
     const Params = struct {
         path: ?[]const u8 = null,
         selector: ?[]const u8 = null,
@@ -1342,41 +1362,27 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
     };
     const args = try parseArgsOrDefault(Params, arena, arguments);
     if (args.path) |path| {
-        if (!isPathSafe(path)) return .{ .text = "path must be relative and must not contain '..' segments", .is_error = true };
+        if (!isPathSafe(path)) return .{ .text = unsafe_path_message, .is_error = true };
+    } else if (!inline_image) {
+        return .{ .text = "pass `path`: this client cannot display an inline image", .is_error = true };
     }
     const page = try ensurePage(session, registry, args.url, args.timeout);
+    const node = try resolveScope(session, registry, page, args.selector, args.backendNodeId);
+    const prepared = lp.screenshot.prepare(arena, node, .fromViewport(page._page.getViewport(), args.fullPage), page) catch
+        return ToolError.InternalError;
+    const width = prepared.opts.width;
 
-    var node = page.document.asNode();
-    var frame = page;
-    if (args.selector) |sel| {
-        const resolved = try resolveBySelector(session, sel);
-        node = resolved.node;
-        frame = resolved.page;
-    } else if (args.backendNodeId) |nid| {
-        const resolved = try resolveNodeAndPage(session, registry, nid);
-        node = resolved.node;
-        frame = resolved.page;
+    if (args.path) |path| {
+        const height = writePng(&prepared, path) catch |err| return .{
+            .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
+            .is_error = true,
+        };
+        return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
     }
-
-    const viewport = page._page.getViewport();
-    const prepared = lp.screenshot.prepare(arena, node, .{
-        .width = viewport.width,
-        .height = if (args.fullPage) 0 else viewport.height,
-        .scale = viewport.scale,
-    }, frame) catch return ToolError.InternalError;
-
-    const path = args.path orelse return .{
-        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{viewport.width}) catch return ToolError.OutOfMemory,
+    return .{
+        .text = std.fmt.allocPrint(arena, "PNG, {d}px wide", .{width}) catch return ToolError.OutOfMemory,
         .image = prepared,
     };
-
-    const height = writePng(&prepared, path) catch |err| return .{
-        .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
-        .is_error = true,
-    };
-    // Absolute path: the cwd is the server's, not one the user picked.
-    const where = std.Io.Dir.cwd().realPathFileAlloc(lp.io, path, arena) catch path;
-    return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ viewport.width, height, where }) catch return ToolError.OutOfMemory };
 }
 
 fn writePng(prepared: *const lp.screenshot.Prepared, path: []const u8) !u32 {
@@ -2455,7 +2461,7 @@ test "call: unknown tool name surfaces in-band" {
 
     // Session/registry are never touched on this branch; the name check is
     // the first thing `call` does.
-    const r = try call(arena.allocator(), undefined, undefined, "multi_tool_use.parallel", null);
+    const r = try call(arena.allocator(), undefined, undefined, "multi_tool_use.parallel", null, .{});
     try std.testing.expect(r.is_error);
     try std.testing.expectEqualStrings("Unknown tool: multi_tool_use.parallel", r.text);
 }

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1369,10 +1369,12 @@ fn execScreenshot(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
         return ToolError.InternalError;
 
     if (args.path) |path| {
-        const height = writePng(&prepared, path) catch |err| return .{
+        const content_height = writePng(&prepared, path) catch |err| return .{
             .text = std.fmt.allocPrint(arena, "could not write {s}: {s}", .{ path, @errorName(err) }) catch return ToolError.OutOfMemory,
             .is_error = true,
         };
+        // The renderer reports the content height; a fixed strip is its own height.
+        const height = if (prepared.opts.height == 0) content_height else prepared.opts.height;
         return .{ .text = std.fmt.allocPrint(arena, "Saved {d}x{d} PNG to {s}", .{ prepared.opts.width, height, absolutePath(arena, path) }) catch return ToolError.OutOfMemory };
     }
 

--- a/src/cdp/domains/page.zig
+++ b/src/cdp/domains/page.zig
@@ -993,11 +993,7 @@ fn captureScreenshot(cmd: *CDP.Command) !void {
     const frame = bc.mainFrame() orelse return error.FrameNotLoaded;
     const viewport = cmd.cdp.browser.getViewport();
 
-    var opts: lp.screenshot.Opts = .{
-        .scale = viewport.scale,
-        .width = viewport.width,
-        .height = if (params.captureBeyondViewport orelse false) 0 else viewport.height,
-    };
+    var opts: lp.screenshot.Opts = .fromViewport(viewport, params.captureBeyondViewport orelse false);
     if (params.clip) |clip| {
         opts.clip = .{
             .x = @floatCast(clip.x),

--- a/src/lightpanda.zig
+++ b/src/lightpanda.zig
@@ -439,9 +439,7 @@ fn writeResults(app: *App, opts: FetchOpts, pages: []const Session.PageHandle, e
 }
 
 fn prepareShot(arena: std.mem.Allocator, frame: *Frame, opts: FetchOpts) !screenshot.Prepared {
-    return screenshot.prepare(arena, try dumpRoot(frame, opts.selector), .{
-        .width = frame._page.getViewport().width,
-    }, frame);
+    return screenshot.prepare(arena, try dumpRoot(frame, opts.selector), .fromViewport(frame._page.getViewport(), true), frame);
 }
 
 fn dumpRoot(frame: *Frame, selector: ?[]const u8) !*Node {
@@ -462,9 +460,7 @@ fn dumpContent(app: *App, mode: Config.DumpFormat, opts: FetchOpts, frame: *Fram
         .png => {
             var arena: std.heap.ArenaAllocator = .init(app.allocator);
             defer arena.deinit();
-            _ = try screenshot.png(arena.allocator(), root, .{
-                .width = frame._page.getViewport().width,
-            }, writer, frame);
+            _ = try screenshot.png(arena.allocator(), root, .fromViewport(frame._page.getViewport(), true), writer, frame);
         },
         .semantic_tree, .semantic_tree_text => {
             var registry = CDPNode.Registry.init(app.allocator);

--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -35,6 +35,7 @@ const App = @import("../App.zig");
 const sys_net = @import("../sys/net.zig");
 
 const Server = @import("Server.zig");
+const Transport = @import("Transport.zig");
 const router = @import("router.zig");
 
 const log = lp.log;
@@ -379,6 +380,10 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
         _ = arena.reset(.retain_capacity);
         out.clearRetainingCapacity();
         self.serve(&out.writer, arena.allocator(), &request) catch return;
+        if (out.writer.buffer.len > Transport.large_response) {
+            out.deinit();
+            out = .init(self.allocator);
+        }
         if (!request.head.keep_alive or http_server.reader.state == .closing) return;
     }
 }

--- a/src/mcp/Transport.zig
+++ b/src/mcp/Transport.zig
@@ -25,7 +25,8 @@ const protocol = @import("protocol.zig");
 
 const Self = @This();
 
-const large_response = 256 * 1024;
+/// A screenshot response is hundreds of KB; don't keep that parked.
+pub const large_response = 256 * 1024;
 
 writer: *std.Io.Writer,
 mutex: std.Io.Mutex = .init,
@@ -56,7 +57,6 @@ pub fn sendResponse(self: *Self, response: anytype) !void {
     try self.writer.writeAll(self.aw.writer.buffered());
     try self.writer.flush();
 
-    // A screenshot response is hundreds of KB; don't keep that parked.
     if (self.aw.writer.buffer.len > large_response) {
         const allocator = self.aw.allocator;
         self.aw.deinit();

--- a/src/mcp/Transport.zig
+++ b/src/mcp/Transport.zig
@@ -53,7 +53,16 @@ pub fn sendResponse(self: *Self, response: anytype) !void {
     try self.aw.writer.writeByte('\n');
     try self.writer.writeAll(self.aw.writer.buffered());
     try self.writer.flush();
+
+    // A screenshot response can be megabytes; don't keep that much parked.
+    if (self.aw.writer.buffer.len > large_response) {
+        const allocator = self.aw.allocator;
+        self.aw.deinit();
+        self.aw = .init(allocator);
+    }
 }
+
+const large_response = 1024 * 1024;
 
 pub fn sendResult(self: *Self, id: std.json.Value, result: anytype) !void {
     const GenericResponse = struct {

--- a/src/mcp/Transport.zig
+++ b/src/mcp/Transport.zig
@@ -25,6 +25,8 @@ const protocol = @import("protocol.zig");
 
 const Self = @This();
 
+const large_response = 256 * 1024;
+
 writer: *std.Io.Writer,
 mutex: std.Io.Mutex = .init,
 aw: std.Io.Writer.Allocating,
@@ -54,15 +56,13 @@ pub fn sendResponse(self: *Self, response: anytype) !void {
     try self.writer.writeAll(self.aw.writer.buffered());
     try self.writer.flush();
 
-    // A screenshot response can be megabytes; don't keep that much parked.
+    // A screenshot response is hundreds of KB; don't keep that parked.
     if (self.aw.writer.buffer.len > large_response) {
         const allocator = self.aw.allocator;
         self.aw.deinit();
         self.aw = .init(allocator);
     }
 }
-
-const large_response = 1024 * 1024;
 
 pub fn sendResult(self: *Self, id: std.json.Value, result: anytype) !void {
     const GenericResponse = struct {

--- a/src/mcp/protocol.zig
+++ b/src/mcp/protocol.zig
@@ -167,12 +167,6 @@ pub const CallParams = struct {
     arguments: ?std.json.Value = null,
 };
 
-pub const ImageContent = struct {
-    type: []const u8 = "image",
-    data: @import("../browser/screenshot.zig").Prepared,
-    mimeType: []const u8 = "image/png",
-};
-
 pub fn TextContent(comptime T: type) type {
     return struct {
         type: []const u8 = "text",
@@ -180,9 +174,19 @@ pub fn TextContent(comptime T: type) type {
     };
 }
 
-pub fn CallToolResult(comptime T: type) type {
+/// `T` serializes as the base64 payload.
+pub fn ImageContent(comptime T: type) type {
     return struct {
-        content: []const TextContent(T),
+        type: []const u8 = "image",
+        data: T,
+        mimeType: []const u8,
+    };
+}
+
+/// `Content` is the content array: a slice or tuple of `TextContent`/`ImageContent`.
+pub fn CallToolResult(comptime Content: type) type {
+    return struct {
+        content: Content,
         isError: bool = false,
     };
 }

--- a/src/mcp/protocol.zig
+++ b/src/mcp/protocol.zig
@@ -167,6 +167,12 @@ pub const CallParams = struct {
     arguments: ?std.json.Value = null,
 };
 
+pub const ImageContent = struct {
+    type: []const u8 = "image",
+    data: @import("../browser/screenshot.zig").Prepared,
+    mimeType: []const u8 = "image/png",
+};
+
 pub fn TextContent(comptime T: type) type {
     return struct {
         type: []const u8 = "text",

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -173,8 +173,9 @@ fn dispatchBrowserTool(
     };
 
     if (result.image) |image| {
-        return server.sendResult(id, .{
-            .content = .{ protocol.ImageContent{ .data = image }, protocol.TextContent([]const u8){ .text = result.text } },
+        const Content = struct { protocol.ImageContent(lp.screenshot.Prepared), protocol.TextContent([]const u8) };
+        return server.sendResult(id, protocol.CallToolResult(Content){
+            .content = .{ .{ .data = image, .mimeType = "image/png" }, .{ .text = result.text } },
             .isError = result.is_error,
         });
     }
@@ -289,7 +290,7 @@ fn writeScript(path: []const u8, content: []const u8) !void {
 
 fn sendToolResultText(server: *Server, id: std.json.Value, msg: []const u8, is_error: bool) !void {
     const content = [_]protocol.TextContent([]const u8){.{ .text = msg }};
-    try server.sendResult(id, protocol.CallToolResult([]const u8){ .content = &content, .isError = is_error });
+    try server.sendResult(id, protocol.CallToolResult([]const protocol.TextContent([]const u8)){ .content = &content, .isError = is_error });
 }
 
 fn sendErrorContent(server: *Server, id: std.json.Value, msg: []const u8) !void {

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -156,7 +156,7 @@ fn dispatchBrowserTool(
     };
 
     const active = server.active_session;
-    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments, .{ .inline_image = true }) catch |err| {
+    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments, .{ .inline_image = .{} }) catch |err| {
         // evaluate/extract surface failures in-band so the LLM can self-correct;
         // other tools' operational failures are protocol-level.
         if (surfacesErrorInBand(tool)) {
@@ -1465,6 +1465,13 @@ test "MCP - screenshot: inline image, file, unsafe path" {
     // base64 of the PNG signature
     try testing.expect(std.mem.indexOf(u8, out.written(), "\"data\":\"iVBORw0KGgo") != null);
     try testing.expect(std.mem.indexOf(u8, out.written(), "\"isError\":false") != null);
+    // Inline images are narrowed to 1280px; IHDR width is big-endian at offset 16.
+    try testing.expect(std.mem.indexOf(u8, out.written(), "PNG, 1280x") != null);
+    const start = std.mem.indexOf(u8, out.written(), "\"data\":\"").? + "\"data\":\"".len;
+    const b64 = out.written()[start .. start + 32];
+    var header: [24]u8 = undefined;
+    try std.base64.standard.Decoder.decode(&header, b64);
+    try testing.expectEqual(1280, std.mem.readInt(u32, header[16..20], .big));
 
     const path = "mcp-screenshot-test.png";
     std.Io.Dir.cwd().deleteFile(lp.io, path) catch {};

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -156,7 +156,7 @@ fn dispatchBrowserTool(
     };
 
     const active = server.active_session;
-    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments) catch |err| {
+    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments, .{ .inline_image = true }) catch |err| {
         // evaluate/extract surface failures in-band so the LLM can self-correct;
         // other tools' operational failures are protocol-level.
         if (surfacesErrorInBand(tool)) {
@@ -173,40 +173,13 @@ fn dispatchBrowserTool(
     };
 
     if (result.image) |image| {
-        return server.sendResult(id, ImageResult{ .image = image, .text = result.text });
+        return server.sendResult(id, .{
+            .content = .{ protocol.ImageContent{ .data = image }, protocol.TextContent([]const u8){ .text = result.text } },
+            .isError = result.is_error,
+        });
     }
     try sendToolResultText(server, id, result.text, result.is_error);
 }
-
-/// MCP image content: the PNG streams straight into the message as base64.
-const ImageResult = struct {
-    image: lp.screenshot.Prepared,
-    text: []const u8,
-
-    pub fn jsonStringify(self: @This(), jw: anytype) !void {
-        try jw.beginObject();
-        try jw.objectField("content");
-        try jw.beginArray();
-        try jw.beginObject();
-        try jw.objectField("type");
-        try jw.write("image");
-        try jw.objectField("data");
-        try jw.write(self.image);
-        try jw.objectField("mimeType");
-        try jw.write("image/png");
-        try jw.endObject();
-        try jw.beginObject();
-        try jw.objectField("type");
-        try jw.write("text");
-        try jw.objectField("text");
-        try jw.write(self.text);
-        try jw.endObject();
-        try jw.endArray();
-        try jw.objectField("isError");
-        try jw.write(false);
-        try jw.endObject();
-    }
-};
 
 fn surfacesErrorInBand(tool: BrowserTool) bool {
     return tool == .evaluate or tool == .extract;
@@ -219,7 +192,7 @@ fn handleSave(server: *Server, arena: std.mem.Allocator, id: std.json.Value, arg
     };
 
     if (!browser_tools.isPathSafe(args.path)) {
-        return sendErrorContent(server, id, "path must be relative and must not contain '..' segments");
+        return sendErrorContent(server, id, browser_tools.unsafe_path_message);
     }
 
     // The client never sees resolved secrets, but scrub any literal LP_* value
@@ -233,8 +206,7 @@ fn handleSave(server: *Server, arena: std.mem.Allocator, id: std.json.Value, arg
         return sendErrorContent(server, id, msg);
     };
 
-    // Absolute path: the cwd is the client-launched server's, not one the user picked.
-    const where = std.Io.Dir.cwd().realPathFileAlloc(lp.io, args.path, arena) catch args.path;
+    const where = browser_tools.absolutePath(arena, args.path);
     const lines = std.mem.count(u8, script, "\n") + 1;
     const msg = std.fmt.allocPrint(arena, "saved {d} line(s) to {s}", .{ lines, where }) catch
         return sendErrorContent(server, id, "out of memory");
@@ -1498,9 +1470,7 @@ test "MCP - screenshot: inline image, file, unsafe path" {
     defer std.Io.Dir.cwd().deleteFile(lp.io, path) catch {};
 
     out.clearRetainingCapacity();
-    const to_file =
-        \\{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"screenshot","arguments":{"path":"mcp-screenshot-test.png","selector":"#hoverTarget"}}}
-    ;
+    const to_file = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"screenshot\",\"arguments\":{\"path\":\"" ++ path ++ "\",\"selector\":\"#hoverTarget\"}}}";
     try router.handleMessage(server, testing.arena_allocator, to_file);
     try testing.expect(std.mem.indexOf(u8, out.written(), "Saved 1920x") != null);
     try testing.expect(std.mem.indexOf(u8, out.written(), "\"type\":\"image\"") == null);

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -38,6 +38,8 @@ fn annotations(tool: BrowserTool) protocol.ToolAnnotations {
         // Drains the buffer: a second call returns something else.
         .consoleLogs => .{ .readOnlyHint = true, .destructiveHint = false, .openWorldHint = false },
         .goto, .search, .markdown, .html, .links, .tree, .interactiveElements, .structuredData, .detectForms => .{ .destructiveHint = false, .idempotentHint = true },
+        // Overwrites `path` when given.
+        .screenshot => .{ .idempotentHint = true },
         .waitForSelector, .waitForScript, .waitForState => .{ .destructiveHint = false, .idempotentHint = true, .openWorldHint = false },
         .evaluate, .click, .press => .{},
         .fill, .selectOption, .setChecked, .hover => .{ .destructiveHint = false, .idempotentHint = true, .openWorldHint = false },
@@ -170,8 +172,41 @@ fn dispatchBrowserTool(
         return server.sendError(id, code, browser_tools.errorMessage(err));
     };
 
+    if (result.image) |image| {
+        return server.sendResult(id, ImageResult{ .image = image, .text = result.text });
+    }
     try sendToolResultText(server, id, result.text, result.is_error);
 }
+
+/// MCP image content: the PNG streams straight into the message as base64.
+const ImageResult = struct {
+    image: lp.screenshot.Prepared,
+    text: []const u8,
+
+    pub fn jsonStringify(self: @This(), jw: anytype) !void {
+        try jw.beginObject();
+        try jw.objectField("content");
+        try jw.beginArray();
+        try jw.beginObject();
+        try jw.objectField("type");
+        try jw.write("image");
+        try jw.objectField("data");
+        try jw.write(self.image);
+        try jw.objectField("mimeType");
+        try jw.write("image/png");
+        try jw.endObject();
+        try jw.beginObject();
+        try jw.objectField("type");
+        try jw.write("text");
+        try jw.objectField("text");
+        try jw.write(self.text);
+        try jw.endObject();
+        try jw.endArray();
+        try jw.objectField("isError");
+        try jw.write(false);
+        try jw.endObject();
+    }
+};
 
 fn surfacesErrorInBand(tool: BrowserTool) bool {
     return tool == .evaluate or tool == .extract;
@@ -1441,6 +1476,43 @@ test "MCP - html: maxBytes truncation and strip" {
     try testing.expect(std.mem.indexOf(u8, out.written(), "<!DOCTYPE html>") != null);
     try testing.expect(std.mem.indexOf(u8, out.written(), "<h1>") == null);
     try testing.expect(std.mem.indexOf(u8, out.written(), "[truncated]") != null);
+}
+
+test "MCP - screenshot: inline image, file, unsafe path" {
+    var out: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_actions.html", &out.writer);
+    defer server.deinit();
+
+    const inline_call =
+        \\{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"screenshot"}}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, inline_call);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"type\":\"image\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"mimeType\":\"image/png\"") != null);
+    // base64 of the PNG signature
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"data\":\"iVBORw0KGgo") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"isError\":false") != null);
+
+    const path = "mcp-screenshot-test.png";
+    std.Io.Dir.cwd().deleteFile(lp.io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(lp.io, path) catch {};
+
+    out.clearRetainingCapacity();
+    const to_file =
+        \\{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"screenshot","arguments":{"path":"mcp-screenshot-test.png","selector":"#hoverTarget"}}}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, to_file);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "Saved 1920x") != null);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"type\":\"image\"") == null);
+    const png = try std.Io.Dir.cwd().readFileAlloc(lp.io, path, testing.arena_allocator, .limited(1024 * 1024));
+    try testing.expect(std.mem.startsWith(u8, png, "\x89PNG\r\n\x1a\n"));
+
+    out.clearRetainingCapacity();
+    const unsafe =
+        \\{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"screenshot","arguments":{"path":"../escape.png"}}}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, unsafe);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"isError\":true") != null);
 }
 
 test "MCP - links: dedup, hidden, text fallback, limit" {

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -156,7 +156,7 @@ fn dispatchBrowserTool(
     };
 
     const active = server.active_session;
-    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments, .{ .inline_image = .{} }) catch |err| {
+    const result = browser_tools.call(arena, active.session, &active.node_registry, name, arguments, .{ .inline_image = true }) catch |err| {
         // evaluate/extract surface failures in-band so the LLM can self-correct;
         // other tools' operational failures are protocol-level.
         if (surfacesErrorInBand(tool)) {
@@ -1465,13 +1465,8 @@ test "MCP - screenshot: inline image, file, unsafe path" {
     // base64 of the PNG signature
     try testing.expect(std.mem.indexOf(u8, out.written(), "\"data\":\"iVBORw0KGgo") != null);
     try testing.expect(std.mem.indexOf(u8, out.written(), "\"isError\":false") != null);
-    // Inline images are narrowed to 1280px; IHDR width is big-endian at offset 16.
+    // Inline images are narrowed to the model-facing limit.
     try testing.expect(std.mem.indexOf(u8, out.written(), "PNG, 1280x") != null);
-    const start = std.mem.indexOf(u8, out.written(), "\"data\":\"").? + "\"data\":\"".len;
-    const b64 = out.written()[start .. start + 32];
-    var header: [24]u8 = undefined;
-    try std.base64.standard.Decoder.decode(&header, b64);
-    try testing.expectEqual(1280, std.mem.readInt(u32, header[16..20], .big));
 
     const path = "mcp-screenshot-test.png";
     std.Io.Dir.cwd().deleteFile(lp.io, path) catch {};

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -714,14 +714,13 @@ fn callTool(
     self.session.browser.env.isolate.enter();
     defer self.session.browser.env.isolate.exit();
 
-    const result = browser_tools.call(arena, self.session, self.registry, @tagName(tool), args) catch |err| switch (err) {
+    const result = browser_tools.call(arena, self.session, self.registry, @tagName(tool), args, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         error.FrameNotLoaded => return .{ .fail = "no page loaded - run page.goto(url) first" },
         else => return .{ .fail = std.fmt.allocPrint(arena, "{s} failed: {s}", .{ @tagName(tool), @errorName(err) }) catch return error.OutOfMemory },
     };
 
     if (result.is_error) return .{ .fail = result.text };
-    if (result.image != null) return .{ .fail = "screenshot needs `path` in a script" };
     return .{ .ok = result.text };
 }
 

--- a/src/script/Runtime.zig
+++ b/src/script/Runtime.zig
@@ -721,6 +721,7 @@ fn callTool(
     };
 
     if (result.is_error) return .{ .fail = result.text };
+    if (result.image != null) return .{ .fail = "screenshot needs `path` in a script" };
     return .{ .ok = result.text };
 }
 

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -104,19 +104,20 @@ pub const Command = union(enum) {
         }
 
         /// Skip the line when the recorded form would not round-trip:
-        /// - no `selector` AND (tool needs one OR only locator is the
-        ///   ephemeral `backendNodeId`);
+        /// - an arg the replay requires (`Tool.replayRequires`) is missing;
+        /// - the only locator is the ephemeral `backendNodeId`;
         /// - a string field can't be quoted unambiguously.
         fn isRecorded(self: ToolCall) bool {
             if (!self.tool.isRecorded()) return false;
             const s = self.schema();
-            const args = self.args orelse return s.required.len == 0 and !self.tool.needsLocator() and self.tool != .screenshot;
-            if (args != .object) return !self.tool.needsLocator();
-            // An inline screenshot (no `path`) only exists as MCP image content.
-            if (self.tool == .screenshot and !args.object.contains("path")) return false;
+            const required = self.tool.replayRequires();
+            const args = self.args orelse return s.required.len == 0 and required.len == 0;
+            if (args != .object) return required.len == 0;
 
-            const has_selector = args.object.contains("selector");
-            if (!has_selector and (self.tool.needsLocator() or args.object.contains("backendNodeId"))) return false;
+            if (!args.object.contains("selector") and args.object.contains("backendNodeId")) return false;
+            for (required) |field| {
+                if (!args.object.contains(field)) return false;
+            }
 
             const positional = s.isBarePositional(args.object);
 

--- a/src/script/command.zig
+++ b/src/script/command.zig
@@ -110,8 +110,10 @@ pub const Command = union(enum) {
         fn isRecorded(self: ToolCall) bool {
             if (!self.tool.isRecorded()) return false;
             const s = self.schema();
-            const args = self.args orelse return s.required.len == 0 and !self.tool.needsLocator();
+            const args = self.args orelse return s.required.len == 0 and !self.tool.needsLocator() and self.tool != .screenshot;
             if (args != .object) return !self.tool.needsLocator();
+            // An inline screenshot (no `path`) only exists as MCP image content.
+            if (self.tool == .screenshot and !args.object.contains("path")) return false;
 
             const has_selector = args.object.contains("selector");
             if (!has_selector and (self.tool.needsLocator() or args.object.contains("backendNodeId"))) return false;
@@ -496,6 +498,22 @@ test "isRecorded / producesData via tool flags" {
 
     const login: Command = .{ .llm = .login };
     try testing.expect(!login.isRecorded());
+}
+
+test "isRecorded: screenshot needs a path to replay" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    try testing.expect(!Command.fromToolCall(.screenshot, null).isRecorded());
+
+    var without: std.json.ObjectMap = .empty;
+    try without.put(aa, "selector", .{ .string = "#main" });
+    try testing.expect(!Command.fromToolCall(.screenshot, .{ .object = without }).isRecorded());
+
+    var with: std.json.ObjectMap = .empty;
+    try with.put(aa, "path", .{ .string = "shot.png" });
+    try testing.expect(Command.fromToolCall(.screenshot, .{ .object = with }).isRecorded());
 }
 
 test "isRecorded: args shape and locator semantics" {

--- a/src/script/skill.zig
+++ b/src/script/skill.zig
@@ -198,6 +198,7 @@ fn note(tool: browser_tools.Tool) []const u8 {
         .waitForSelector => "`waitFor*` default timeout 5000 ms.",
         .waitForScript => "Re-evaluates page JS until truthy.",
         .waitForState => "",
+        .screenshot => "Needs `path`; writes a PNG of the text layout.",
         .press => "Selector first! `page.press(\"Enter\")` binds \"Enter\" to `selector` and fails — use `page.press(null, \"Enter\")` or `page.press({ key: \"Enter\" })`.",
         .click, .fill, .scroll, .hover, .selectOption, .setChecked => "",
         .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => "",

--- a/src/script/skill.zig
+++ b/src/script/skill.zig
@@ -180,7 +180,9 @@ fn positionalOptional(s: *const Schema, p: []const u8) bool {
     if (s.findField(p)) |f| {
         if (f.default_true) return true;
     }
-    if (std.mem.eql(u8, p, "selector") and s.tool.needsLocator()) return false;
+    for (s.tool.replayRequires()) |r| {
+        if (std.mem.eql(u8, r, p)) return false;
+    }
     for (s.required) |r| {
         if (std.mem.eql(u8, r, p)) return false;
     }

--- a/src/script/skill.zig
+++ b/src/script/skill.zig
@@ -198,7 +198,7 @@ fn note(tool: browser_tools.Tool) []const u8 {
         .waitForSelector => "`waitFor*` default timeout 5000 ms.",
         .waitForScript => "Re-evaluates page JS until truthy.",
         .waitForState => "",
-        .screenshot => "Needs `path`; writes a PNG of the text layout.",
+        .screenshot => "`path` is required: writes a PNG of the text layout.",
         .press => "Selector first! `page.press(\"Enter\")` binds \"Enter\" to `selector` and fails — use `page.press(null, \"Enter\")` or `page.press({ key: \"Enter\" })`.",
         .click, .fill, .scroll, .hover, .selectOption, .setChecked => "",
         .search, .markdown, .html, .links, .tree, .nodeDetails, .interactiveElements, .structuredData, .detectForms, .findElement, .consoleLogs, .getUrl, .getCookies, .getEnv => "",


### PR DESCRIPTION
The PNG renderer (#3231) was reachable from CDP `Page.captureScreenshot` and `fetch --dump png` only; MCP clients, the agent and PandaScript had no way to get one.

- `screenshot {path?, selector?, backendNodeId?, fullPage?, url?, timeout?}`. With `path` (relative, no `..`, same rule as `save`) it writes the PNG and returns `Saved WxH PNG to <abs path>`. Without it, MCP returns `{type:"image", data, mimeType:"image/png"}` content plus a text part (`protocol.ImageContent`); the base64 streams straight from the renderer (`Prepared.jsonStringify`), no buffer.
- Callers declare what they can consume: `tools.call(…, .{ .inline_image = … })`. MCP opts in and returns image content; the agent opts in whenever a model is attached (both the model-driven path and a REPL `/screenshot`, whose image goes to the conversation while the terminal shows the status line); the script runtime passes the default, so a path-less call is rejected in-band before any navigation or rendering. zenai carries the image parts (lightpanda-io/zenai#12, #13).
- Bounded for the model: an inline screenshot renders at most 1280 wide and 4096 tall (`Prepared.fit`, measured after the reflow so short pages aren't padded; `path` files keep full size), and the conversation keeps only the newest two images — older tool results keep their text with a "dropped from context" note (`Conversation.prune`). The MCP transport releases its buffer after a large response.
- Recorded, so `page.screenshot({path})` replays. The recorder's `needsLocator` generalizes to `Tool.replayRequires()` (`selector` for the click-like tools, `path` for screenshot), so `isRecorded` has no per-tool clause.
- `screenshot.Opts.fromViewport` replaces three hand-built viewport→Opts mappings (CDP, fetch, tool); markdown/html/screenshot share one node-scope resolver; `save` and `screenshot` share the path-safety message and absolute-path helper.
- Driver guidance no longer claims there are no screenshots and says what the render is (text layout, no images/fonts/CSS). `minify`'s comptime branch quota is cumulative over all schemas and needed raising.

Verified: MCP over stdio (inline 17 KB PNG with valid signature; file with `selector`+`fullPage`), `lightpanda run` writing the file and failing cleanly without `path`. Tests: MCP inline/file/unsafe-path, recorder rule. Full suite passes.



