### PR TITLE
agent: run the Terminal tests

### DIFF
--- a/src/agent/Agent.zig
+++ b/src/agent/Agent.zig
@@ -2044,6 +2044,7 @@ test {
     _ = save;
     _ = settings;
     _ = picker;
+    _ = Terminal;
 }
 
 test "savePrompt: save instructions followed by the rendered script skill" {

--- a/src/agent/js_highlight.zig
+++ b/src/agent/js_highlight.zig
@@ -190,25 +190,25 @@ const testing = std.testing;
 /// Records spans as `kind:text` so tests read as the tokenization, not offsets.
 const TestSink = struct {
     text: []const u8,
-    buf: std.ArrayListUnmanaged(u8) = .empty,
+    buf: std.Io.Writer.Allocating,
     last_end: usize = 0,
     overlapped: bool = false,
 
     fn emit(self: *TestSink, start: usize, len: usize, kind: Kind) void {
         if (start < self.last_end) self.overlapped = true;
         self.last_end = start + len;
-        self.buf.writer(testing.allocator).print("{s}:{s} ", .{
+        self.buf.writer.print("{s}:{s} ", .{
             @tagName(kind), self.text[start..][0..len],
         }) catch unreachable;
     }
 };
 
 fn expectTokens(expected: []const u8, src: []const u8) !void {
-    var sink: TestSink = .{ .text = src };
-    defer sink.buf.deinit(testing.allocator);
+    var sink: TestSink = .{ .text = src, .buf = .init(testing.allocator) };
+    defer sink.buf.deinit();
     _ = tokenize(src, .normal, &sink);
     try testing.expect(!sink.overlapped);
-    try testing.expectEqualStrings(expected, std.mem.trimEnd(u8, sink.buf.items, " "));
+    try testing.expectEqualStrings(expected, std.mem.trimEnd(u8, sink.buf.written(), " "));
 }
 
 test "js_highlight: keywords, globals, numbers" {
@@ -247,23 +247,23 @@ test "js_highlight: template interpolations split string spans" {
 }
 
 test "js_highlight: block comment spans lines" {
-    var sink: TestSink = .{ .text = "/* open" };
-    defer sink.buf.deinit(testing.allocator);
+    var sink: TestSink = .{ .text = "/* open", .buf = .init(testing.allocator) };
+    defer sink.buf.deinit();
     try testing.expectEqual(State.block_comment, tokenize("/* open", .normal, &sink));
 
-    var sink2: TestSink = .{ .text = "still */ const" };
-    defer sink2.buf.deinit(testing.allocator);
+    var sink2: TestSink = .{ .text = "still */ const", .buf = .init(testing.allocator) };
+    defer sink2.buf.deinit();
     try testing.expectEqual(State.normal, tokenize("still */ const", .block_comment, &sink2));
-    try testing.expectEqualStrings("comment:still */ keyword:const", std.mem.trimEnd(u8, sink2.buf.items, " "));
+    try testing.expectEqualStrings("comment:still */ keyword:const", std.mem.trimEnd(u8, sink2.buf.written(), " "));
 }
 
 test "js_highlight: template literal spans lines" {
-    var sink: TestSink = .{ .text = "`<div>" };
-    defer sink.buf.deinit(testing.allocator);
+    var sink: TestSink = .{ .text = "`<div>", .buf = .init(testing.allocator) };
+    defer sink.buf.deinit();
     try testing.expectEqual(State.template, tokenize("`<div>", .normal, &sink));
 
-    var sink2: TestSink = .{ .text = "</div>` + x" };
-    defer sink2.buf.deinit(testing.allocator);
+    var sink2: TestSink = .{ .text = "</div>` + x", .buf = .init(testing.allocator) };
+    defer sink2.buf.deinit();
     try testing.expectEqual(State.normal, tokenize("</div>` + x", .template, &sink2));
-    try testing.expectEqualStrings("string:</div>`", std.mem.trimEnd(u8, sink2.buf.items, " "));
+    try testing.expectEqualStrings("string:</div>`", std.mem.trimEnd(u8, sink2.buf.written(), " "));
 }


### PR DESCRIPTION
`Terminal.zig` pulls in `md_term` and `prompt_assist` from a test block, but nothing referenced `Terminal` itself, so those tests were dormant (`TEST_FILTER=md_term` ran 0 of 0). Adding `_ = Terminal;` to `Agent.zig`'s discovery block runs them.

That surfaced one rotted test helper in `js_highlight.zig` still calling `ArrayList.writer(allocator)`, which went away with `std.Io.Writer`; its `TestSink` now writes through `Io.Writer.Allocating`. No non-test code changes. Full suite passes.