### PR TITLE
tweak: improve screenshot code

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -67,6 +67,9 @@ permissions: std.StringHashMapUnmanaged(PermissionState) = .empty,
 // Runtime viewport override
 viewport_override: ?Viewport = null,
 
+// Screenshot renderer (fonts, glyph cache); created on the first screenshot.
+renderer: ?*lp.screenshot.Renderer = null,
+
 // Runtime geolocation override
 geolocation_override: ?Geolocation.Override = null,
 
@@ -154,6 +157,7 @@ pub fn deinit(self: *Browser) void {
     self.fc_identity_pool.deinit(allocator);
     self.page_pool.deinit(allocator);
     self.http_client.deinit();
+    if (self.renderer) |r| r.deinit();
     self.clearPermissions();
     self.permissions.deinit(allocator);
     self.selector_cache.deinit();

--- a/src/browser/screenshot.zig
+++ b/src/browser/screenshot.zig
@@ -46,6 +46,24 @@ pub const Opts = struct {
     };
 };
 
+// Parsed fonts, shaping scratch and the glyph cache, on the Rust side. One
+// per Browser, created on the first screenshot.
+pub const Renderer = opaque {
+    pub fn deinit(self: *Renderer) void {
+        lp_render_free(self);
+    }
+};
+
+fn rendererFor(frame: *Frame) !*Renderer {
+    const browser = frame._session.browser;
+    if (browser.renderer) |r| {
+        return r;
+    }
+    const r = lp_render_new() orelse return error.RendererInit;
+    browser.renderer = r;
+    return r;
+}
+
 pub fn png(arena: Allocator, node: *Node, opts: Opts, writer: *std.Io.Writer, frame: *Frame) !u32 {
     const prepared = try prepare(arena, node, opts, frame);
     return prepared.write(writer);
@@ -71,12 +89,17 @@ pub fn prepare(arena: Allocator, node: *Node, opts: Opts, frame: *Frame) !Prepar
     };
     try builder.render(node);
     try builder.closeBlock();
-    return .{ .blocks = builder.blocks.items, .opts = opts };
+    return .{
+        .opts = opts,
+        .blocks = builder.blocks.items,
+        .renderer = try rendererFor(frame),
+    };
 }
 
 pub const Prepared = struct {
     opts: Opts,
     blocks: []const LpBlock,
+    renderer: *Renderer,
 
     pub fn write(self: *const Prepared, writer: *std.Io.Writer) std.Io.Writer.Error!u32 {
         return self.render(writer, 0);
@@ -87,7 +110,7 @@ pub const Prepared = struct {
         const clip = opts.clip orelse Opts.Clip{ .x = 0, .y = 0, .width = 0, .height = 0 };
         var content_height: u32 = 0;
         var sink: Sink = .{ .writer = writer };
-        const rc = lp_render_png(self.blocks.ptr, self.blocks.len, .{
+        const rc = lp_render_png(self.renderer, self.blocks.ptr, self.blocks.len, .{
             .width = opts.width,
             .height = opts.height,
             .clip_x = clip.x,
@@ -194,10 +217,69 @@ const RC_NO_RASTER: i32 = 3;
 const RC_ENCODE_FAILED: i32 = 4;
 const RC_PANIC: i32 = 5;
 
+// What the Rust side reports about the mirror above; see the "rust abi" test.
+const LpAbi = extern struct {
+    size: u32,
+
+    span_size: u32,
+    span_align: u32,
+    span_text: u32,
+    span_len: u32,
+    span_flags: u32,
+    span_color: u32,
+
+    block_size: u32,
+    block_align: u32,
+    block_spans: u32,
+    block_spans_len: u32,
+    block_marker: u32,
+    block_marker_len: u32,
+    block_kind: u32,
+    block_level: u32,
+    block_list_depth: u32,
+    block_quote_depth: u32,
+    block_flags: u32,
+
+    opts_size: u32,
+    opts_align: u32,
+    opts_width: u32,
+    opts_height: u32,
+    opts_clip_x: u32,
+    opts_clip_y: u32,
+    opts_clip_w: u32,
+    opts_clip_h: u32,
+    opts_scale: u32,
+    opts_flags: u32,
+
+    span_bold: u32,
+    span_italic: u32,
+    span_underline: u32,
+    span_mono: u32,
+    span_strike: u32,
+    span_has_color: u32,
+
+    block_heading: u32,
+    block_pre: u32,
+    block_rule: u32,
+    block_tight: u32,
+
+    render_measure_only: u32,
+
+    rc_ok: u32,
+    rc_write_refused: u32,
+    rc_invalid: u32,
+    rc_no_raster: u32,
+    rc_encode_failed: u32,
+    rc_panic: u32,
+};
+
 const LINK_COLOR: u32 = 0x1a0dab;
 const MUTED_COLOR: u32 = 0x6b6b6b;
 
+extern "c" fn lp_render_new() ?*Renderer;
+extern "c" fn lp_render_free(r: *Renderer) void;
 extern "c" fn lp_render_png(
+    r: *Renderer,
     blocks: [*]const LpBlock,
     blocks_len: usize,
     opts: LpRenderOpts,
@@ -205,6 +287,7 @@ extern "c" fn lp_render_png(
     ctx: *anyopaque,
     write: *const fn (ctx: *anyopaque, data: [*]const u8, len: usize) callconv(.c) bool,
 ) i32;
+extern "c" fn lp_render_abi(out: *LpAbi) void;
 
 const Builder = struct {
     frame: *Frame,
@@ -641,6 +724,76 @@ const Builder = struct {
 };
 
 const testing = @import("../testing.zig");
+test "browser.screenshot: rust abi matches" {
+    var got: LpAbi = undefined;
+    lp_render_abi(&got);
+
+    const expected: LpAbi = .{
+        .size = @sizeOf(LpAbi),
+
+        .span_size = @sizeOf(LpSpan),
+        .span_align = @alignOf(LpSpan),
+        .span_text = @offsetOf(LpSpan, "text"),
+        .span_len = @offsetOf(LpSpan, "len"),
+        .span_flags = @offsetOf(LpSpan, "flags"),
+        .span_color = @offsetOf(LpSpan, "color"),
+
+        .block_size = @sizeOf(LpBlock),
+        .block_align = @alignOf(LpBlock),
+        .block_spans = @offsetOf(LpBlock, "spans"),
+        .block_spans_len = @offsetOf(LpBlock, "spans_len"),
+        .block_marker = @offsetOf(LpBlock, "marker"),
+        .block_marker_len = @offsetOf(LpBlock, "marker_len"),
+        .block_kind = @offsetOf(LpBlock, "kind"),
+        .block_level = @offsetOf(LpBlock, "level"),
+        .block_list_depth = @offsetOf(LpBlock, "list_depth"),
+        .block_quote_depth = @offsetOf(LpBlock, "quote_depth"),
+        .block_flags = @offsetOf(LpBlock, "flags"),
+
+        .opts_size = @sizeOf(LpRenderOpts),
+        .opts_align = @alignOf(LpRenderOpts),
+        .opts_width = @offsetOf(LpRenderOpts, "width"),
+        .opts_height = @offsetOf(LpRenderOpts, "height"),
+        .opts_clip_x = @offsetOf(LpRenderOpts, "clip_x"),
+        .opts_clip_y = @offsetOf(LpRenderOpts, "clip_y"),
+        .opts_clip_w = @offsetOf(LpRenderOpts, "clip_w"),
+        .opts_clip_h = @offsetOf(LpRenderOpts, "clip_h"),
+        .opts_scale = @offsetOf(LpRenderOpts, "scale"),
+        .opts_flags = @offsetOf(LpRenderOpts, "flags"),
+
+        .span_bold = SPAN_BOLD,
+        .span_italic = SPAN_ITALIC,
+        .span_underline = SPAN_UNDERLINE,
+        .span_mono = SPAN_MONO,
+        .span_strike = SPAN_STRIKE,
+        .span_has_color = SPAN_HAS_COLOR,
+
+        .block_heading = @intFromEnum(LpBlock.Kind.heading),
+        .block_pre = @intFromEnum(LpBlock.Kind.pre),
+        .block_rule = @intFromEnum(LpBlock.Kind.rule),
+        .block_tight = BLOCK_TIGHT,
+
+        .render_measure_only = RENDER_MEASURE_ONLY,
+
+        .rc_ok = @intCast(RC_OK),
+        .rc_write_refused = @intCast(RC_WRITE_REFUSED),
+        .rc_invalid = @intCast(RC_INVALID),
+        .rc_no_raster = @intCast(RC_NO_RASTER),
+        .rc_encode_failed = @intCast(RC_ENCODE_FAILED),
+        .rc_panic = @intCast(RC_PANIC),
+    };
+
+    // Size first: a field present on only one side of LpAbi itself shifts
+    // everything after it, and the per-field loop would just report noise.
+    try testing.expectEqual(expected.size, got.size);
+    inline for (@typeInfo(LpAbi).@"struct".fields) |f| {
+        testing.expectEqual(@field(expected, f.name), @field(got, f.name)) catch |err| {
+            std.debug.print("rust/zig abi mismatch on {s}\n", .{f.name});
+            return err;
+        };
+    }
+}
+
 test "browser.screenshot: png signature and dimensions" {
     defer testing.test_session.closeAllPages();
     const out = try testPng("<h1>Title</h1><p>Hello <b>world</b> <a href='/x'>link</a></p>", 640);

--- a/src/rust/render/lib.rs
+++ b/src/rust/render/lib.rs
@@ -26,7 +26,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::os::raw::c_void;
-use std::sync::{Mutex, OnceLock};
 
 use fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
 use parley::{
@@ -114,11 +113,148 @@ pub const RC_NO_RASTER: i32 = 3;
 pub const RC_ENCODE_FAILED: i32 = 4;
 pub const RC_PANIC: i32 = 5;
 
+/// Self-description of the ABI above, so screenshot.zig can check its
+/// hand-written mirror. `size` is `size_of::<LpAbi>()` and is compared first:
+/// it catches a field added to only one side of this struct itself.
+#[repr(C)]
+pub struct LpAbi {
+    pub size: u32,
+
+    pub span_size: u32,
+    pub span_align: u32,
+    pub span_text: u32,
+    pub span_len: u32,
+    pub span_flags: u32,
+    pub span_color: u32,
+
+    pub block_size: u32,
+    pub block_align: u32,
+    pub block_spans: u32,
+    pub block_spans_len: u32,
+    pub block_marker: u32,
+    pub block_marker_len: u32,
+    pub block_kind: u32,
+    pub block_level: u32,
+    pub block_list_depth: u32,
+    pub block_quote_depth: u32,
+    pub block_flags: u32,
+
+    pub opts_size: u32,
+    pub opts_align: u32,
+    pub opts_width: u32,
+    pub opts_height: u32,
+    pub opts_clip_x: u32,
+    pub opts_clip_y: u32,
+    pub opts_clip_w: u32,
+    pub opts_clip_h: u32,
+    pub opts_scale: u32,
+    pub opts_flags: u32,
+
+    pub span_bold: u32,
+    pub span_italic: u32,
+    pub span_underline: u32,
+    pub span_mono: u32,
+    pub span_strike: u32,
+    pub span_has_color: u32,
+
+    pub block_heading: u32,
+    pub block_pre: u32,
+    pub block_rule: u32,
+    pub block_tight: u32,
+
+    pub render_measure_only: u32,
+
+    pub rc_ok: u32,
+    pub rc_write_refused: u32,
+    pub rc_invalid: u32,
+    pub rc_no_raster: u32,
+    pub rc_encode_failed: u32,
+    pub rc_panic: u32,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn lp_render_abi(out: *mut LpAbi) {
+    use std::mem::{align_of, offset_of, size_of};
+    *out = LpAbi {
+        size: size_of::<LpAbi>() as u32,
+
+        span_size: size_of::<LpSpan>() as u32,
+        span_align: align_of::<LpSpan>() as u32,
+        span_text: offset_of!(LpSpan, text) as u32,
+        span_len: offset_of!(LpSpan, len) as u32,
+        span_flags: offset_of!(LpSpan, flags) as u32,
+        span_color: offset_of!(LpSpan, color) as u32,
+
+        block_size: size_of::<LpBlock>() as u32,
+        block_align: align_of::<LpBlock>() as u32,
+        block_spans: offset_of!(LpBlock, spans) as u32,
+        block_spans_len: offset_of!(LpBlock, spans_len) as u32,
+        block_marker: offset_of!(LpBlock, marker) as u32,
+        block_marker_len: offset_of!(LpBlock, marker_len) as u32,
+        block_kind: offset_of!(LpBlock, kind) as u32,
+        block_level: offset_of!(LpBlock, level) as u32,
+        block_list_depth: offset_of!(LpBlock, list_depth) as u32,
+        block_quote_depth: offset_of!(LpBlock, quote_depth) as u32,
+        block_flags: offset_of!(LpBlock, flags) as u32,
+
+        opts_size: size_of::<LpRenderOpts>() as u32,
+        opts_align: align_of::<LpRenderOpts>() as u32,
+        opts_width: offset_of!(LpRenderOpts, width) as u32,
+        opts_height: offset_of!(LpRenderOpts, height) as u32,
+        opts_clip_x: offset_of!(LpRenderOpts, clip_x) as u32,
+        opts_clip_y: offset_of!(LpRenderOpts, clip_y) as u32,
+        opts_clip_w: offset_of!(LpRenderOpts, clip_w) as u32,
+        opts_clip_h: offset_of!(LpRenderOpts, clip_h) as u32,
+        opts_scale: offset_of!(LpRenderOpts, scale) as u32,
+        opts_flags: offset_of!(LpRenderOpts, flags) as u32,
+
+        span_bold: SPAN_BOLD,
+        span_italic: SPAN_ITALIC,
+        span_underline: SPAN_UNDERLINE,
+        span_mono: SPAN_MONO,
+        span_strike: SPAN_STRIKE,
+        span_has_color: SPAN_HAS_COLOR,
+
+        block_heading: BLOCK_HEADING as u32,
+        block_pre: BLOCK_PRE as u32,
+        block_rule: BLOCK_RULE as u32,
+        block_tight: BLOCK_TIGHT as u32,
+
+        render_measure_only: RENDER_MEASURE_ONLY,
+
+        rc_ok: RC_OK as u32,
+        rc_write_refused: RC_WRITE_REFUSED as u32,
+        rc_invalid: RC_INVALID as u32,
+        rc_no_raster: RC_NO_RASTER as u32,
+        rc_encode_failed: RC_ENCODE_FAILED as u32,
+        rc_panic: RC_PANIC as u32,
+    };
+}
+
+/// A renderer: parsed fonts, shaping scratch and the glyph cache. Not
+/// thread-safe; the caller drives each handle from one thread at a time.
+/// Null on panic (font registration is the only thing in there that could).
+#[no_mangle]
+pub extern "C" fn lp_render_new() -> *mut Renderer {
+    match std::panic::catch_unwind(Renderer::new) {
+        Ok(r) => Box::into_raw(Box::new(r)),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn lp_render_free(r: *mut Renderer) {
+    drop(Box::from_raw(r));
+}
+
 /// Renders `blocks` to PNG, streaming the encoded bytes to `write`.
 /// `content_height` receives the full-page height in CSS px, and is filled in
-/// even when rendering fails. Returns one of the RC_* codes above.
+/// even when rendering fails. Returns one of the RC_* codes above. The
+/// renderer stays usable after RC_PANIC: layout state is scratch that the
+/// next call resets.
 #[no_mangle]
 pub unsafe extern "C" fn lp_render_png(
+    r: *mut Renderer,
     blocks: *const LpBlock,
     blocks_len: usize,
     opts: LpRenderOpts,
@@ -127,12 +263,21 @@ pub unsafe extern "C" fn lp_render_png(
     write: LpWriteFn,
 ) -> i32 {
     let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        render_png(blocks, blocks_len, opts, content_height, ctx, write)
+        render_png(
+            &mut *r,
+            blocks,
+            blocks_len,
+            opts,
+            content_height,
+            ctx,
+            write,
+        )
     }));
     caught.unwrap_or(RC_PANIC)
 }
 
 unsafe fn render_png(
+    r: &mut Renderer,
     blocks: *const LpBlock,
     blocks_len: usize,
     opts: LpRenderOpts,
@@ -179,12 +324,6 @@ unsafe fn render_png(
             spans: out_spans,
         });
     }
-
-    static RENDERER: OnceLock<Mutex<Renderer>> = OnceLock::new();
-    let mut r = RENDERER
-        .get_or_init(|| Mutex::new(Renderer::new()))
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
 
     let mut sink = Sink {
         ctx,
@@ -260,7 +399,7 @@ const MAX_RASTER_PIXELS: u64 = 64 << 20;
 /// (font, glyph id). Deliberately not the size — see draw_glyph_run.
 type GlyphKey = (usize, u32);
 
-struct Renderer {
+pub struct Renderer {
     fcx: FontContext,
     lcx: LayoutContext<Rgb>,
     glyph_cache: HashMap<GlyphKey, Option<tiny_skia::Path>>,


### PR DESCRIPTION
Remove singleton and give each Browser a screenshot.Renderer.

Also, add tests to make sure the Rust and Zig structures/constants match (this has proven useful with zig-v8-fork).