### PR TITLE
mcp: release a large HTTP response buffer after the reply

### DIFF
--- a/src/mcp/HttpServer.zig
+++ b/src/mcp/HttpServer.zig
@@ -35,6 +35,7 @@ const App = @import("../App.zig");
 const sys_net = @import("../sys/net.zig");
 
 const Server = @import("Server.zig");
+const Transport = @import("Transport.zig");
 const router = @import("router.zig");
 
 const log = lp.log;
@@ -379,6 +380,10 @@ fn handleConn(self: *HttpServer, socket: posix.socket_t) void {
         _ = arena.reset(.retain_capacity);
         out.clearRetainingCapacity();
         self.serve(&out.writer, arena.allocator(), &request) catch return;
+        if (out.writer.buffer.len > Transport.large_response) {
+            out.deinit();
+            out = .init(self.allocator);
+        }
         if (!request.head.keep_alive or http_server.reader.state == .closing) return;
     }
 }

--- a/src/mcp/Transport.zig
+++ b/src/mcp/Transport.zig
@@ -25,7 +25,8 @@ const protocol = @import("protocol.zig");
 
 const Self = @This();
 
-const large_response = 256 * 1024;
+/// A screenshot response is hundreds of KB; don't keep that parked.
+pub const large_response = 256 * 1024;
 
 writer: *std.Io.Writer,
 mutex: std.Io.Mutex = .init,
@@ -56,7 +57,6 @@ pub fn sendResponse(self: *Self, response: anytype) !void {
     try self.writer.writeAll(self.aw.writer.buffered());
     try self.writer.flush();
 
-    // A screenshot response is hundreds of KB; don't keep that parked.
     if (self.aw.writer.buffer.len > large_response) {
         const allocator = self.aw.allocator;
         self.aw.deinit();


### PR DESCRIPTION
Stacked on #3301.

`Transport` already drops its staging buffer once it grows past 256 KB, but the HTTP connection buffer that receives the copy lives for the whole keep-alive connection and was only ever `clearRetainingCapacity`'d. One inline screenshot pinned its capacity per open connection until the client disconnected.

`handleConn` now applies the same threshold after each reply: past `Transport.large_response` the buffer is freed and re-created. `large_response` is exported so both sites share one number.

An earlier revision of this PR also rewrote `Transport` to stringify straight into the request buffer. That removed only a transient second copy on a single-threaded worker, at the cost of a sink union and a new rollback invariant; dropped in favour of the four-line fix.

Verified over HTTP: initialize (200 + session id), notification (202), an inline screenshot as valid JSON, and a normal call right after. `make test F="MCP"` passes.
