### PR TITLE
stability: disconnect runaway mutation observers

### DIFF
--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -44,6 +44,12 @@ pub const Mutation = struct {
     observers: std.DoublyLinkedList = .{},
     delivery_scheduled: bool = false,
     delivery_depth: u32 = 0,
+
+    // Consecutive delivery sessions that hit delivery_depth's cap instead of
+    // draining. delivery_depth only bounds one session's recursion; a
+    // callback that reschedules itself can restart a fresh session forever.
+    consecutive_full_depth: u32 = 0,
+    hit_limit_this_session: bool = false,
 };
 
 // IntersectionObserver bookkeeping for a frame.
@@ -316,6 +322,22 @@ pub fn deliverIntersections(frame: *Frame) void {
     }
 }
 
+// No observer on the frame can make progress once this path is reached.
+fn disconnectRunawayMutationObservers(frame: *Frame) void {
+    log.err(.frame, "frame.MutationRunaway", .{ .type = frame._type, .url = frame.url });
+
+    var node: ?*std.DoublyLinkedList.Node = frame._mutation.observers.first;
+    while (node) |n| {
+        node = n.next;
+        const observer: *MutationObserver = @fieldParentPtr("node", n);
+        observer.disconnect(frame);
+    }
+}
+
+// ~1600 observer callbacks (100 cascades x 16 depth) with zero progress is
+// well past any legitimate coalescing burst.
+const MUTATION_RUNAWAY_LIMIT = 100;
+
 pub fn deliverMutations(frame: *Frame) void {
     if (!frame._mutation.delivery_scheduled) {
         return;
@@ -323,14 +345,26 @@ pub fn deliverMutations(frame: *Frame) void {
     frame._mutation.delivery_scheduled = false;
 
     frame._mutation.delivery_depth += 1;
+    // A session (this call plus every nested/rescheduled call until nothing
+    // is left scheduled) only counts toward consecutive_full_depth once, at
+    // the point where it's known whether it hit the cap.
     defer if (!frame._mutation.delivery_scheduled) {
-        // reset the depth once nothing is left to be scheduled
         frame._mutation.delivery_depth = 0;
+        if (frame._mutation.hit_limit_this_session) {
+            frame._mutation.hit_limit_this_session = false;
+            frame._mutation.consecutive_full_depth += 1;
+            if (frame._mutation.consecutive_full_depth >= MUTATION_RUNAWAY_LIMIT) {
+                disconnectRunawayMutationObservers(frame);
+            }
+        } else {
+            frame._mutation.consecutive_full_depth = 0;
+        }
     };
 
     if (frame._mutation.delivery_depth > 16) {
         log.err(.frame, "frame.MutationLimit", .{ .type = frame._type, .url = frame.url });
         frame._mutation.delivery_depth = 0;
+        frame._mutation.hit_limit_this_session = true;
         return;
     }
 

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -49,7 +49,6 @@ pub const Mutation = struct {
     // draining. delivery_depth only bounds one session's recursion; a
     // callback that reschedules itself can restart a fresh session forever.
     consecutive_full_depth: u32 = 0,
-    hit_limit_this_session: bool = false,
 };
 
 // IntersectionObserver bookkeeping for a frame.
@@ -345,13 +344,10 @@ pub fn deliverMutations(frame: *Frame) void {
     frame._mutation.delivery_scheduled = false;
 
     frame._mutation.delivery_depth += 1;
-    // A session (this call plus every nested/rescheduled call until nothing
-    // is left scheduled) only counts toward consecutive_full_depth once, at
-    // the point where it's known whether it hit the cap.
+    var capped = false;
     defer if (!frame._mutation.delivery_scheduled) {
         frame._mutation.delivery_depth = 0;
-        if (frame._mutation.hit_limit_this_session) {
-            frame._mutation.hit_limit_this_session = false;
+        if (capped) {
             frame._mutation.consecutive_full_depth += 1;
             if (frame._mutation.consecutive_full_depth >= MUTATION_RUNAWAY_LIMIT) {
                 disconnectRunawayMutationObservers(frame);
@@ -364,7 +360,7 @@ pub fn deliverMutations(frame: *Frame) void {
     if (frame._mutation.delivery_depth > 16) {
         log.err(.frame, "frame.MutationLimit", .{ .type = frame._type, .url = frame.url });
         frame._mutation.delivery_depth = 0;
-        frame._mutation.hit_limit_this_session = true;
+        capped = true;
         return;
     }
 

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -470,6 +470,42 @@ test "WebApi: MutationObserver" {
     try testing.htmlRunner("mutation_observer", .{});
 }
 
+test "WebApi: runaway MutationObserver delivery is disconnected" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    try ls.local.eval(
+        \\(function() {
+        \\  const target = document.createElement('div');
+        \\  const children = [target.appendChild(document.createElement('div'))];
+        \\  let n = 0;
+        \\  const mutate = () => {
+        \\    n++;
+        \\    for (const child of children) child.style.transform = `translate3d(${n}px,0,0)`;
+        \\  };
+        \\  new MutationObserver(() => {
+        \\    setTimeout(mutate, 0);
+        \\    mutate();
+        \\  }).observe(target, {attributes: true, subtree: true, attributeFilter: ['style']});
+        \\  mutate();
+        \\})()
+    , null);
+
+    for (0..200) |_| {
+        frame.js.env.runMicrotasks();
+        try frame.js.env.runMacrotasks();
+        if (!Frame.observers.hasMutationObservers(frame)) break;
+    }
+
+    try testing.expectEqual(false, Frame.observers.hasMutationObservers(frame));
+}
+
 // Production watchdog path (lightpanda-io/browser#3130 follow-up): the
 // terminate lands inside a MutationObserver callback, so ExecutionTerminated
 // must unwind out of deliverRecords, stay sticky against further V8 entries,


### PR DESCRIPTION
## Summary

Disconnect a frame's MutationObservers after 100 consecutive delivery sessions hit the existing recursion cap without draining.

The existing `delivery_depth` limit bounds recursion within one delivery session. A callback can still mutate synchronously and schedule another mutation via a timer, starting a fresh capped session indefinitely. The new session-level streak detects that no observer is making progress and cuts off the loop.

## Production context

This was found while investigating watchdog-associated browser-process exits in a production rendering workload. The original production incident involved mutation delivery during termination, but direct replay of those pages was not deterministic.

A production-like concurrent replay then exposed a separate concrete fatal path: a real carousel callback repeatedly updated inline styles and rearmed itself with a timer. Each delivery session returned to the event loop, so the watchdog did not consider it stalled; the process remained CPU-bound while native memory grew until a fatal process exit. A network-independent fixture reduced that behavior to one element, one MutationObserver, and `setTimeout(0)`.

This PR fixes the reproduced runaway-delivery path. It does not claim that every watchdog-associated production exit has the same cause.

## Reproduction

The fixture observes an element's inline style. Its callback updates that style synchronously and schedules the same update with `setTimeout(0)`.

Before this change it emits `frame.MutationLimit` indefinitely while process memory grows. With this change it emits `frame.MutationRunaway`, disconnects the observer, and remains usable.

The committed regression test covers the same timer-rearmed mutation cascade.

## Test

- `make test` — 1312/1312
- Release build fixture — `frame.MutationRunaway`, clean process exit
- Production-like stress replay completed 439 contexts over seven minutes; the pre-fix run exited fatally after 240 contexts
- `zig fmt --check ./*.zig ./**/*.zig`
