### PR TITLE
zig: replace the deprecated @intFromFloat with @trunc

### DIFF
--- a/src/browser/color.zig
+++ b/src/browser/color.zig
@@ -201,7 +201,7 @@ pub const RGBA = packed struct(u32) {
 
     pub fn init(r: u8, g: u8, b: u8, a: f32) RGBA {
         const clamped = std.math.clamp(a, 0, 1);
-        return .{ .r = r, .g = g, .b = b, .a = @intFromFloat(clamped * 255) };
+        return .{ .r = r, .g = g, .b = b, .a = @trunc(clamped * 255) };
     }
 
     /// Finds a color by its name.

--- a/src/browser/css/Tokenizer.zig
+++ b/src/browser/css/Tokenizer.zig
@@ -612,7 +612,7 @@ fn consumeNumeric(self: *Tokenizer) Token {
             break :blk std.math.minInt(i32);
         }
 
-        break :blk @as(i32, @intFromFloat(value));
+        break :blk @as(i32, @trunc(value));
     } else null;
 
     if (!self.isEof() and self.nextByteUnchecked() == '%') {

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -312,7 +312,7 @@ pub fn triggerMouseWheel(frame: *Frame, x: f64, y: f64, delta_x: f64, delta_y: f
 
 fn deltaToScroll(d: f64) i32 {
     if (std.math.isNan(d)) return 0;
-    return @intFromFloat(std.math.clamp(d, std.math.minInt(i32), std.math.maxInt(i32)));
+    return @trunc(std.math.clamp(d, std.math.minInt(i32), std.math.maxInt(i32)));
 }
 
 // callback when the "click" event reaches the frame.

--- a/src/browser/webapi/Blob.zig
+++ b/src/browser/webapi/Blob.zig
@@ -405,7 +405,7 @@ fn clampLongLong(value: f64) i64 {
     if (@abs(value - @trunc(value)) == 0.5 and @mod(rounded, 2) != 0) {
         rounded -= std.math.sign(value);
     }
-    return @intFromFloat(rounded);
+    return @trunc(rounded);
 }
 
 /// Returns the size of the Blob in bytes.

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1839,7 +1839,7 @@ pub fn scrollIntoView(self: *Element, opts: ?ScrollIntoViewOpts, frame: *Frame) 
     // Positions come from the faux-layout document position (top = preorder
     // depth-scaled y), the same source getBoundingClientRect uses.
     const y = calculateDocumentPosition(self.asNode());
-    frame.window.scrollTo(.{ .x = 0 }, @intFromFloat(@max(0, y)), frame) catch {};
+    frame.window.scrollTo(.{ .x = 0 }, @trunc(@max(0, y)), frame) catch {};
 }
 
 const ScrollToOpts = union(enum) {

--- a/src/browser/webapi/storage/idb/Engine.zig
+++ b/src/browser/webapi/storage/idb/Engine.zig
@@ -261,7 +261,7 @@ pub fn maybeBumpGenerator(self: *Engine, store_id: i64, key: f64) !void {
 
     // Cap at 2^53, the largest integer the generator tracks per spec.
     const capped = @min(@floor(key), 9007199254740992);
-    const want: i64 = @intFromFloat(capped + 1);
+    const want: i64 = @trunc(capped + 1);
     try self.conn.exec(
         "update idb_object_stores set key_generator = ?2 where id = ?1 and key_generator < ?2",
         .{ store_id, want },

--- a/src/browser/xpath/functions.zig
+++ b/src/browser/xpath/functions.zig
@@ -231,19 +231,19 @@ fn substringFn(arena: Allocator, args: []const result.Result) Error![]const u8 {
         if (std.math.isNan(len_raw)) return "";
         const len = roundHalfToPosInf(len_raw);
         const sum = start - 1 + len;
-        // -inf + inf is NaN; @intFromFloat(NaN) is illegal behavior.
+        // -inf + inf is NaN, and NaN to integer is illegal behavior.
         if (std.math.isNan(sum)) return "";
         const si_f = @max(start - 1, 0);
         const ei_f = @min(sum, s_len);
         if (si_f >= ei_f) return "";
-        const si: usize = @intFromFloat(si_f);
-        const ei: usize = @intFromFloat(ei_f);
+        const si: usize = @trunc(si_f);
+        const ei: usize = @trunc(ei_f);
         return s[si..ei];
     }
 
     const si_f = @max(start - 1, 0);
     if (si_f >= s_len) return "";
-    const si: usize = @intFromFloat(si_f);
+    const si: usize = @trunc(si_f);
     return s[si..];
 }
 

--- a/src/browser/xpath/result.zig
+++ b/src/browser/xpath/result.zig
@@ -115,7 +115,7 @@ pub fn numberToString(arena: Allocator, n: f64) error{OutOfMemory}![]const u8 {
     if (std.math.isNegativeInf(n)) return "-Infinity";
     if (n == 0) return "0"; // covers +0 and -0
     if (@trunc(n) == n and n >= -9.007199254740992e15 and n <= 9.007199254740992e15) {
-        return std.fmt.allocPrint(arena, "{d}", .{@as(i64, @intFromFloat(n))});
+        return std.fmt.allocPrint(arena, "{d}", .{@as(i64, @trunc(n))});
     }
     return std.fmt.allocPrint(arena, "{d}", .{n});
 }

--- a/src/cdp/domains/dom.zig
+++ b/src/cdp/domains/dom.zig
@@ -537,8 +537,8 @@ fn getBoxModel(cmd: *CDP.Command) !void {
         .padding = zero,
         .border = zero,
         .margin = zero,
-        .width = @intFromFloat(rect.width),
-        .height = @intFromFloat(rect.height),
+        .width = @trunc(rect.width),
+        .height = @trunc(rect.height),
     } }, .{});
 }
 


### PR DESCRIPTION
Zig 0.16 [forwards the result type through the unary float builtins](https://ziglang.org/download/0.16.0/release-notes.html#Unary-Float-Builtins-Forward-Result-Type), so `@trunc` yields the integer directly and the release notes deprecate `@intFromFloat` as redundant with it.

All 13 sites were plain truncating casts (or values already rounded/floored before the cast), so `@trunc` with the inferred result type is a like-for-like replacement; no behaviour changes. `grep @intFromFloat src` is now empty.

Tests: 1311/1311.
