### PR TITLE
`application/octet-stream` in Mime for Blob

### DIFF
--- a/src/browser/Mime.zig
+++ b/src/browser/Mime.zig
@@ -47,6 +47,7 @@ pub const ContentTypeEnum = enum {
     image_png,
     image_webp,
     application_json,
+    application_octet_stream,
     unknown,
     other,
     other_xml,
@@ -65,6 +66,7 @@ pub const ContentType = union(ContentTypeEnum) {
     image_png: void,
     image_webp: void,
     application_json: void,
+    application_octet_stream: void,
     unknown: void,
     // A valid but unrecognized type/subtype. Keeping it would require some
     // memory management of the input. Nothing needs it right now, so why bother.
@@ -86,6 +88,7 @@ pub fn contentTypeString(mime: *const Mime) []const u8 {
         .image_gif => "image/gif",
         .image_webp => "image/webp",
         .application_json => "application/json",
+        .application_octet_stream => "application/octet-stream",
         else => "",
     };
 }
@@ -451,6 +454,7 @@ fn parseContentType(value: []const u8) !struct { ContentType, usize } {
         @"image/webp",
 
         @"application/json",
+        @"application/octet-stream",
         @"application/xml",
     }, type_name)) |known_type| {
         const ct: ContentType = switch (known_type) {
@@ -467,6 +471,7 @@ fn parseContentType(value: []const u8) !struct { ContentType, usize } {
             .@"image/gif" => .{ .image_gif = {} },
             .@"image/webp" => .{ .image_webp = {} },
             .@"application/json" => .{ .application_json = {} },
+            .@"application/octet-stream" => .{ .application_octet_stream = {} },
         };
         return .{ ct, attribute_start };
     }
@@ -898,6 +903,8 @@ test "Mime: parse common" {
     try expect(.{ .content_type = .{ .image_png = {} } }, "image/png");
     try expect(.{ .content_type = .{ .image_gif = {} } }, "image/gif");
     try expect(.{ .content_type = .{ .image_webp = {} } }, "image/webp");
+
+    try expect(.{ .content_type = .{ .application_octet_stream = {} } }, "application/octet-stream");
 }
 
 test "Mime: parse uncommon" {

--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -660,10 +660,7 @@ handler runs, abort() cancels the re-send and no load is delivered.
       // Per spec the blob response entity body is cached: the same object comes
       // back on every access.
       testing.expectEqual(req.response, req.response);
-      // TODO: should be 'application/octet-stream'. Mime keeps a content-type
-      // enum, not the header text, and Mime.contentTypeString() has no entry
-      // for it, so the type is lost on the way to the Blob.
-      testing.expectEqual('', req.response.type);
+      testing.expectEqual('application/octet-stream', req.response.type);
     });
 
     testing.expectEqual([0, 0, 1, 2, 0, 0, 9], new Int8Array(await req.response.arrayBuffer()));


### PR DESCRIPTION
This adds the `application/octet-stream` to the Mime.zig, allowing us to get rid of the TODO in `xhr.html` for Blob response type.