### PR TITLE
cdp: answer unknown methods with -32601 like Chrome

### DIFF
--- a/src/cdp/CDP.zig
+++ b/src/cdp/CDP.zig
@@ -343,10 +343,14 @@ fn dispatchParsed(self: *CDP, arena: Allocator, sender: Command.Sender, str: []c
     } else {
         dispatchCommand(&command, input.method) catch |err| {
             switch (err) {
-                error.UnknownDomain, error.UnknownMethod => lp.metrics.cdp_unknown_commands.incr(),
-                else => {},
+                error.InvalidMethod, error.UnknownDomain, error.UnknownMethod => {
+                    lp.metrics.cdp_unknown_commands.incr();
+                    // Chrome's code and wording; drivers feature-detect on it.
+                    const message = std.fmt.allocPrint(command.arena, "'{s}' wasn't found", .{input.method}) catch return err;
+                    command.sendError(-32601, message, .{}) catch return err;
+                },
+                else => command.sendError(-31998, @errorName(err), .{}) catch return err,
             }
-            command.sendError(-31998, @errorName(err), .{}) catch return err;
         };
     }
 }
@@ -1423,17 +1427,17 @@ test "cdp: invalid json" {
     try ctx.processMessage(.{
         .method = "Target",
     });
-    try ctx.expectSentError(-31998, "InvalidMethod", .{});
+    try ctx.expectSentError(-32601, "'Target' wasn't found", .{});
 
     try ctx.processMessage(.{
         .method = "Unknown.domain",
     });
-    try ctx.expectSentError(-31998, "UnknownDomain", .{});
+    try ctx.expectSentError(-32601, "'Unknown.domain' wasn't found", .{});
 
     try ctx.processMessage(.{
         .method = "Target.over9000",
     });
-    try ctx.expectSentError(-31998, "UnknownMethod", .{});
+    try ctx.expectSentError(-32601, "'Target.over9000' wasn't found", .{});
 }
 
 test "cdp: invalid sessionId" {


### PR DESCRIPTION
Unknown domains/methods returned our private `-31998` with the Zig error name (`UnknownMethod`, `UnknownDomain`, `InvalidMethod`). Chrome answers `-32601` `"'X' wasn't found"` and drivers feature-detect on that code. Other dispatch errors keep `-31998`.

```
{"id":1,"error":{"code":-32601,"message":"'Runtime.releaseObjectGroup' wasn't found"}}
```