### PR TITLE
browser: open target=_blank links as popups and let tools follow them

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -3395,21 +3395,25 @@ pub const QueuedNavigation = struct {
     navigation_type: NavigationType,
 };
 
+pub const TargetFrame = union(enum) {
+    frame: *Frame,
+    blank,
+};
+
 /// Resolves a target attribute value (e.g., "_self", "_parent", "_top", or frame name)
-/// to the appropriateFrame to navigate.
-/// Returns null if the target is "_blank" (which would open a new window/tab).
+/// to the Frame to navigate.
 /// Note: Callers should handle empty target separately (for owner document resolution).
-pub fn resolveTargetFrame(self: *Frame, target_name: []const u8) ?*Frame {
+pub fn resolveTargetFrame(self: *Frame, target_name: []const u8) TargetFrame {
     if (std.ascii.eqlIgnoreCase(target_name, "_self")) {
-        return self;
+        return .{ .frame = self };
     }
 
     if (std.ascii.eqlIgnoreCase(target_name, "_blank")) {
-        return null;
+        return .blank;
     }
 
     if (std.ascii.eqlIgnoreCase(target_name, "_parent")) {
-        return self.parent orelse self;
+        return .{ .frame = self.parent orelse self };
     }
 
     if (std.ascii.eqlIgnoreCase(target_name, "_top")) {
@@ -3417,13 +3421,13 @@ pub fn resolveTargetFrame(self: *Frame, target_name: []const u8) ?*Frame {
         while (frame.parent) |f| {
             frame = f;
         }
-        return frame;
+        return .{ .frame = frame };
     }
 
     // Named frame lookup: search current frame's descendants first, then from root
     // This follows the HTML spec's "implementation-defined" search order.
     if (findFrameByName(self, target_name)) |f| {
-        return f;
+        return .{ .frame = f };
     }
 
     // If not found in descendants, search from root (catches siblings and ancestors' descendants)
@@ -3433,13 +3437,33 @@ pub fn resolveTargetFrame(self: *Frame, target_name: []const u8) ?*Frame {
     }
     if (root != self) {
         if (findFrameByName(root, target_name)) |f| {
-            return f;
+            return .{ .frame = f };
         }
     }
 
     // If no frame found with that name, navigate in current frame
     // (this matches browser behavior - unknown targets act like _self)
-    return self;
+    return .{ .frame = self };
+}
+
+/// Per spec the opener is withheld unless the element has rel=opener.
+pub fn openBlankTarget(self: *Frame, element: *Element, url: []const u8) !*Frame {
+    return self.openPopup(.{
+        .url = url,
+        .name = "",
+        .opener = if (hasRelToken(element, "opener")) self.window else null,
+    });
+}
+
+fn hasRelToken(element: *Element, token: []const u8) bool {
+    const rel = element.getAttributeSafe(comptime .wrap("rel")) orelse return false;
+    var it = std.mem.tokenizeAny(u8, rel, &std.ascii.whitespace);
+    while (it.next()) |t| {
+        if (std.ascii.eqlIgnoreCase(t, token)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn findFrameByName(frame: *Frame, name: []const u8) ?*Frame {
@@ -3502,14 +3526,11 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
         break :blk form_element.getAttributeSafe(comptime .wrap("target"));
     };
 
-    const target_frame = blk: {
+    const target: TargetFrame = blk: {
         const target_name = target_name_ orelse {
-            break :blk form_element.ownerFrame(self);
+            break :blk .{ .frame = form_element.ownerFrame(self) };
         };
-        break :blk self.resolveTargetFrame(target_name) orelse {
-            log.warn(.not_implemented, "target", .{ .type = self._type, .url = self.url, .target = target_name });
-            return;
-        };
+        break :blk self.resolveTargetFrame(target_name);
     };
 
     if (submit_opts.fire_event) {
@@ -3670,6 +3691,12 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
         action = try URL.concatQueryString(arena.allocator(), action, buf.written());
     }
 
+    // Opened only once the submission goes ahead, so an aborted one leaves
+    // no stray window.
+    const target_frame = switch (target) {
+        .frame => |f| f,
+        .blank => try form_element.ownerFrame(self).openBlankTarget(form_element, ""),
+    };
     return self.scheduleNavigationWithArena(arena, action, opts, .{ .form = target_frame });
 }
 

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -86,6 +86,10 @@ _nav_cursor: usize = 0,
 // `commitPendingPage`).
 _tool_frame_override: ?u32 = null,
 
+// A popup the last tool action opened (target=_blank). Tools act on it, as
+// a user whose click opened a tab would, until it goes away.
+_followed_popup: ?u32 = null,
+
 // Loader IDs are scoped to the Session: each new BrowserContext gets a
 // fresh counter. Frame IDs (`frame_id_gen`) live on `Browser` instead so
 // CDP target IDs stay unique across BrowserContext lifecycle on a single
@@ -457,6 +461,12 @@ pub fn currentFrame(self: *Session) ?*Frame {
         // No pages[0] fallthrough: the override targets one specific page.
         return self.findFrameByFrameId(frame_id);
     }
+    if (self._followed_popup) |frame_id| {
+        if (self.findFrameByFrameId(frame_id)) |frame| {
+            return frame;
+        }
+        self._followed_popup = null;
+    }
     if (self.pages.items.len == 0) {
         return null;
     }
@@ -470,6 +480,11 @@ pub fn currentFrame(self: *Session) ?*Frame {
 /// See `_tool_frame_override`. Pass null to clear.
 pub fn setToolFrameOverride(self: *Session, frame_id: ?u32) void {
     self._tool_frame_override = frame_id;
+}
+
+/// See `_followed_popup`.
+pub fn followPopup(self: *Session, frame_id: u32) void {
+    self._followed_popup = frame_id;
 }
 
 // Multi-page aware: frame ids are globally unique (monotonic on `Browser`).

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -553,7 +553,15 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
             break :blk target.ownerFrame(frame);
         }
         break :blk frame.resolveTargetFrame(target_name) orelse {
-            log.warn(.not_implemented, "target", .{ .type = frame._type, .url = frame.url, .target = target_name });
+            // _blank: a new top-level context, as window.open creates. The
+            // opener is withheld unless rel=opener.
+            const owner = target.ownerFrame(frame);
+            try element.focus(frame);
+            _ = try owner.openPopup(.{
+                .url = href,
+                .name = "",
+                .opener = if (hasRelToken(element, "opener")) owner.window else null,
+            });
             return;
         };
     };
@@ -563,6 +571,17 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
         .reason = .script,
         .kind = .{ .push = null },
     }, .{ .anchor = target_frame });
+}
+
+fn hasRelToken(element: *Element, token: []const u8) bool {
+    const rel = element.getAttributeSafe(comptime .wrap("rel")) orelse return false;
+    var it = std.mem.tokenizeAny(u8, rel, &std.ascii.whitespace);
+    while (it.next()) |t| {
+        if (std.ascii.eqlIgnoreCase(t, token)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 pub fn triggerKeyboard(frame: *Frame, keyboard_event: *KeyboardEvent) !void {

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -552,17 +552,13 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
         if (target_name.len == 0) {
             break :blk target.ownerFrame(frame);
         }
-        break :blk frame.resolveTargetFrame(target_name) orelse {
-            // _blank: a new top-level context, as window.open creates. The
-            // opener is withheld unless rel=opener.
-            const owner = target.ownerFrame(frame);
-            try element.focus(frame);
-            _ = try owner.openPopup(.{
-                .url = href,
-                .name = "",
-                .opener = if (hasRelToken(element, "opener")) owner.window else null,
-            });
-            return;
+        break :blk switch (frame.resolveTargetFrame(target_name)) {
+            .frame => |f| f,
+            .blank => {
+                try element.focus(frame);
+                _ = try target.ownerFrame(frame).openBlankTarget(element, href);
+                return;
+            },
         };
     };
 
@@ -571,17 +567,6 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
         .reason = .script,
         .kind = .{ .push = null },
     }, .{ .anchor = target_frame });
-}
-
-fn hasRelToken(element: *Element, token: []const u8) bool {
-    const rel = element.getAttributeSafe(comptime .wrap("rel")) orelse return false;
-    var it = std.mem.tokenizeAny(u8, rel, &std.ascii.whitespace);
-    while (it.next()) |t| {
-        if (std.ascii.eqlIgnoreCase(t, token)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 pub fn triggerKeyboard(frame: *Frame, keyboard_event: *KeyboardEvent) !void {

--- a/src/browser/tests/frames/target.html
+++ b/src/browser/tests/frames/target.html
@@ -38,6 +38,13 @@
   }
 </script>
 
+<a id=lblank target=_blank href=support/page.html></a>
+<script id=blank>
+  // Opens a new top-level context; the opener stays put.
+  $('#lblank').click();
+  testing.expectEqual(true, location.pathname.endsWith('target.html'));
+</script>
+
 <iframe name=frame3 id=f3></iframe>
 <form target="_top" action="support/page.html">
   <input type=submit id=submit1 formtarget="frame3">

--- a/src/browser/tests/frames/target.html
+++ b/src/browser/tests/frames/target.html
@@ -45,6 +45,14 @@
   testing.expectEqual(true, location.pathname.endsWith('target.html'));
 </script>
 
+<form id=fblank target=_blank action=support/page.html>
+  <input type=submit id=submit_blank>
+</form>
+<script id=form_blank>
+  $('#submit_blank').click();
+  testing.expectEqual(true, location.pathname.endsWith('target.html'));
+</script>
+
 <iframe name=frame3 id=f3></iframe>
 <form target="_top" action="support/page.html">
   <input type=submit id=submit1 formtarget="frame3">

--- a/src/browser/tests/mcp_target_blank.html
+++ b/src/browser/tests/mcp_target_blank.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>opener</title></head>
+<body>
+    <a id="nt" target="_blank" href="mcp_actions.html">new tab</a>
+</body>
+</html>

--- a/src/browser/tests/mcp_target_blank.html
+++ b/src/browser/tests/mcp_target_blank.html
@@ -3,5 +3,9 @@
 <head><title>opener</title></head>
 <body>
     <a id="nt" target="_blank" href="mcp_actions.html">new tab</a>
+    <form id="nf" target="_blank" action="mcp_actions.html">
+        <input name="q" value="1">
+        <button id="fs">submit</button>
+    </form>
 </body>
 </html>

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1778,23 +1778,52 @@ fn formatActionResult(
     return std.fmt.allocPrint(arena, "{s} ({f}){s}", .{ prefix, target, suffix }) catch ToolError.InternalError;
 }
 
+/// What `finalizeAction` compares against; take it before the action runs.
+const ActionScope = struct {
+    frame: ?*lp.Frame,
+    popups: usize,
+};
+
+fn beginAction(session: *lp.Session) ActionScope {
+    const frame = session.currentFrame();
+    return .{ .frame = frame, .popups = if (frame) |f| f._page.popups.items.len else 0 };
+}
+
 /// Finish a state-changing action: drain any queued navigation triggered by
 /// the action, then tag `body` with the resulting page URL and title so the
 /// caller (LLM, MCP client) can see whether the action triggered navigation.
-fn finalizeAction(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, body: []const u8) ToolError![]const u8 {
-    const before = session.currentFrame();
+fn finalizeAction(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, scope: ActionScope, body: []const u8) ToolError![]const u8 {
+    const before = scope.frame;
     if (before) |b| {
         try awaitQueuedNavigation(session, b._frame_id);
     }
-    const page = try requireFrame(session);
+    var page = try requireFrame(session);
     // A queued navigation that swaps the root frame tears down the previous
     // Page (`Session.replaceRootImmediate` / `commitPendingPage`), so every
     // DOMNode pointer in the registry now dangles. Drop the registry so the
     // next action can't dereference freed memory.
     if (before != null and before.? != page) registry.reset();
+
+    var note: []const u8 = "";
+    if (page._page.popups.items.len > scope.popups) {
+        // The action opened a new window (target=_blank or window.open).
+        // Follow it, as a user whose click opened a tab would.
+        var runner = session.runner(.{});
+        runner.waitForFrame(page._page.frame._frame_id, 10000, .{ .until = .done }) catch |err|
+            return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
+        page = try requireFrame(session);
+        const popups = page._page.popups.items;
+        if (popups.len > scope.popups) {
+            page = popups[popups.len - 1];
+            session.followPopup(page._frame_id);
+            registry.reset();
+            note = " Opened a new window; tools now act on it.";
+        }
+    }
+
     const page_title = page.getTitle() catch null;
-    return std.fmt.allocPrint(arena, "{s}. Page url: {s}, title: {s}", .{
-        body, page.url, page_title orelse "(none)",
+    return std.fmt.allocPrint(arena, "{s}.{s} Page url: {s}, title: {s}", .{
+        body, note, page.url, page_title orelse "(none)",
     }) catch ToolError.InternalError;
 }
 
@@ -1806,10 +1835,12 @@ fn execClick(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.
     const args = try parseArgs(Params, arena, arguments);
     const resolved = try resolveTarget(session, registry, args.selector, args.backendNodeId);
 
+    const scope = beginAction(session);
+
     lp.actions.click(resolved.node, resolved.page) catch |err| return mapActionError(err);
 
     const body = try formatActionResult(arena, "Clicked element", resolved.target, "");
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execFill(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
@@ -1823,12 +1854,14 @@ fn execFill(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.R
     const text = try substituteEnvVars(arena, raw_text);
     const resolved = try resolveTarget(session, registry, args.selector, args.backendNodeId);
 
+    const scope = beginAction(session);
+
     lp.actions.fill(resolved.node, text, resolved.page) catch |err| return mapActionError(err);
 
     // Show the original reference (e.g. $LP_PASSWORD) in the result, not the resolved value
     const suffix = std.fmt.allocPrint(arena, " with \"{s}\"", .{raw_text}) catch return ToolError.InternalError;
     const body = try formatActionResult(arena, "Filled element", resolved.target, suffix);
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execScroll(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
@@ -1947,10 +1980,12 @@ fn execHover(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.
     const args = try parseArgs(Params, arena, arguments);
     const resolved = try resolveTarget(session, registry, args.selector, args.backendNodeId);
 
+    const scope = beginAction(session);
+
     lp.actions.hover(resolved.node, resolved.page) catch |err| return mapActionError(err);
 
     const body = try formatActionResult(arena, "Hovered element", resolved.target, "");
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execPress(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
@@ -1972,12 +2007,14 @@ fn execPress(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.
         target_node = try resolveOptionalNode(registry, args.backendNodeId);
     }
 
+    const scope = beginAction(session);
+
     lp.actions.press(target_node, args.key, page) catch |err| return mapActionError(err);
 
     // Pressing Enter on a form input triggers implicit form submission;
     // `finalizeAction` drains the queued navigation before tagging the body.
     const body = std.fmt.allocPrint(arena, "Pressed key '{s}'", .{args.key}) catch return ToolError.InternalError;
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execSelectOption(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
@@ -1989,11 +2026,13 @@ fn execSelectOption(arena: std.mem.Allocator, session: *lp.Session, registry: *C
     const args = try parseArgs(Params, arena, arguments);
     const resolved = try resolveTarget(session, registry, args.selector, args.backendNodeId);
 
+    const scope = beginAction(session);
+
     lp.actions.selectOption(resolved.node, args.value, resolved.page) catch |err| return mapActionError(err);
 
     const prefix = std.fmt.allocPrint(arena, "Selected option '{s}'", .{args.value}) catch return ToolError.InternalError;
     const body = try formatActionResult(arena, prefix, resolved.target, "");
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execSetChecked(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {
@@ -2005,12 +2044,14 @@ fn execSetChecked(arena: std.mem.Allocator, session: *lp.Session, registry: *CDP
     const args = try parseArgs(Params, arena, arguments);
     const resolved = try resolveTarget(session, registry, args.selector, args.backendNodeId);
 
+    const scope = beginAction(session);
+
     lp.actions.setChecked(resolved.node, args.checked, resolved.page) catch |err| return mapActionError(err);
 
     const state_str: []const u8 = if (args.checked) "checked" else "unchecked";
     const suffix = std.fmt.allocPrint(arena, " to {s}", .{state_str}) catch return ToolError.InternalError;
     const body = try formatActionResult(arena, "Set element", resolved.target, suffix);
-    return finalizeAction(arena, session, registry, body);
+    return finalizeAction(arena, session, registry, scope, body);
 }
 
 fn execFindElement(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, arguments: ?std.json.Value) ToolError![]const u8 {

--- a/src/browser/tools.zig
+++ b/src/browser/tools.zig
@@ -1544,7 +1544,7 @@ fn execEvaluate(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNo
     }
 
     // Script may have queued a navigation (e.g. `top.location = …`).
-    try awaitQueuedNavigation(session, page._frame_id);
+    try awaitQueuedNavigation(session, page);
     const after = session.currentFrame() orelse return result;
     if (before == null or before.? == after) return result;
 
@@ -1759,13 +1759,17 @@ fn mapActionError(err: anytype) ToolError {
 
 /// If the previous action queued a navigation (form submit, link click,
 /// Enter on an input), drive the runner until it completes or times out.
-fn awaitQueuedNavigation(session: *lp.Session, frame_id: u32) ToolError!void {
+fn awaitQueuedNavigation(session: *lp.Session, frame: *lp.Frame) ToolError!void {
+    // Runner waits are keyed by Page root (a popup lives on its opener's
+    // Page). Read it before processing: a synthetic root navigation frees
+    // the Page in place.
+    const root_frame_id = frame._page.frame._frame_id;
     const navigated = session.processQueuedNavigation() catch return ToolError.InternalError;
     if (navigated == false) {
         return;
     }
     var runner = session.runner(.{});
-    runner.waitForFrame(frame_id, 10000, .{ .until = .done }) catch |err|
+    runner.waitForFrame(root_frame_id, 10000, .{ .until = .done }) catch |err|
         return if (err == error.Cancelled) ToolError.Cancelled else ToolError.NavigationFailed;
 }
 
@@ -1795,7 +1799,7 @@ fn beginAction(session: *lp.Session) ActionScope {
 fn finalizeAction(arena: std.mem.Allocator, session: *lp.Session, registry: *CDPNode.Registry, scope: ActionScope, body: []const u8) ToolError![]const u8 {
     const before = scope.frame;
     if (before) |b| {
-        try awaitQueuedNavigation(session, b._frame_id);
+        try awaitQueuedNavigation(session, b);
     }
     var page = try requireFrame(session);
     // A queued navigation that swaps the root frame tears down the previous
@@ -1944,7 +1948,7 @@ fn execWaitForScript(arena: std.mem.Allocator, session: *lp.Session, arguments: 
 
     // script may have queued a navigation (e.g. top.location=…); drain it so
     // the next command reads post-navigation state
-    try awaitQueuedNavigation(session, frame._frame_id);
+    try awaitQueuedNavigation(session, frame);
 
     return "Script returned truthy.";
 }

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -704,7 +704,10 @@ pub fn open(self: *Window, url_: ?[]const u8, target_: ?[]const u8, features_: ?
         std.ascii.eqlIgnoreCase(target, "_parent") or
         std.ascii.eqlIgnoreCase(target, "_top"))
     {
-        const nav_target = frame.resolveTargetFrame(target) orelse frame;
+        const nav_target = switch (frame.resolveTargetFrame(target)) {
+            .frame => |f| f,
+            .blank => unreachable,
+        };
         const nav_url = if (raw_url.len == 0) "about:blank" else raw_url;
         try frame.scheduleNavigation(nav_url, .{
             .reason = .script,

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -525,6 +525,48 @@ test "MCP - click on a target=_blank link follows the new window" {
     try testing.expectJson(.{ .id = 2, .result = .{
         .content = &.{.{ .type = "text", .text = "http://localhost:9582/src/browser/tests/mcp_actions.html" }},
     } }, out.written());
+
+    // navigation from inside the followed popup
+    out.clearRetainingCapacity();
+    const navigate =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "id": 3,
+        \\  "method": "tools/call",
+        \\  "params": {
+        \\    "name": "evaluate",
+        \\    "arguments": { "script": "location.href = 'mcp_target_blank.html'" }
+        \\  }
+        \\}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, navigate);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "\"isError\":false") != null);
+
+    out.clearRetainingCapacity();
+    try router.handleMessage(server, testing.arena_allocator, get_url);
+    try testing.expectJson(.{ .id = 2, .result = .{
+        .content = &.{.{ .type = "text", .text = "http://localhost:9582/src/browser/tests/mcp_target_blank.html" }},
+    } }, out.written());
+}
+
+test "MCP - submitting a target=_blank form follows the new window" {
+    var out: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_target_blank.html", &out.writer);
+    defer server.deinit();
+
+    const click =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "id": 1,
+        \\  "method": "tools/call",
+        \\  "params": {
+        \\    "name": "click",
+        \\    "arguments": { "selector": "#fs" }
+        \\  }
+        \\}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, click);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "Opened a new window; tools now act on it. Page url: http://localhost:9582/src/browser/tests/mcp_actions.html?q=1") != null);
 }
 
 test "MCP - evaluate: localStorage persists across navigations and is origin-scoped" {

--- a/src/mcp/tools.zig
+++ b/src/mcp/tools.zig
@@ -493,6 +493,40 @@ test "MCP - evaluate: object return serializes as JSON" {
     } }, out.written());
 }
 
+test "MCP - click on a target=_blank link follows the new window" {
+    var out: std.Io.Writer.Allocating = .init(testing.arena_allocator);
+    const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_target_blank.html", &out.writer);
+    defer server.deinit();
+
+    const click =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "id": 1,
+        \\  "method": "tools/call",
+        \\  "params": {
+        \\    "name": "click",
+        \\    "arguments": { "selector": "#nt" }
+        \\  }
+        \\}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, click);
+    try testing.expect(std.mem.indexOf(u8, out.written(), "Opened a new window; tools now act on it. Page url: http://localhost:9582/src/browser/tests/mcp_actions.html") != null);
+
+    out.clearRetainingCapacity();
+    const get_url =
+        \\{
+        \\  "jsonrpc": "2.0",
+        \\  "id": 2,
+        \\  "method": "tools/call",
+        \\  "params": { "name": "getUrl", "arguments": {} }
+        \\}
+    ;
+    try router.handleMessage(server, testing.arena_allocator, get_url);
+    try testing.expectJson(.{ .id = 2, .result = .{
+        .content = &.{.{ .type = "text", .text = "http://localhost:9582/src/browser/tests/mcp_actions.html" }},
+    } }, out.written());
+}
+
 test "MCP - evaluate: localStorage persists across navigations and is origin-scoped" {
     var out: std.Io.Writer.Allocating = .init(testing.arena_allocator);
     const server = try testLoadPage("http://localhost:9582/src/browser/tests/mcp_actions.html", &out.writer);


### PR DESCRIPTION
Clicking a `target="_blank"` link was logged as `not_implemented` and dropped. It now opens a popup `Frame` via `openPopup`, the same top-level context `window.open` creates (#2237 listed this as the missing piece). The opener is withheld unless `rel=opener`, per spec.

Popups aren't visible to the tool layer (agent/MCP act on the root frame), so `finalizeAction` snapshots the popup count before the action and, when one appears, waits for it to load and makes it the session's current frame (`Session._followed_popup`). The result says `Opened a new window; tools now act on it.` Once the popup is gone (closed, or the root navigates), tools fall back to the root. The PandaScript `Runtime` routes through explicit page handles (`_tool_frame_override`), which takes precedence, so scripts are unaffected.

Not covered: popups still don't surface as CDP targets, and `<a download>` is still dropped.

Tests: `frames/target.html` (`_blank` leaves the opener in place) and an MCP test (click → follow → `getUrl`). Full suite: 1328/1328.