### PR TITLE
webapi: Report correct content-type for blob

### DIFF
--- a/src/browser/Mime.zig
+++ b/src/browser/Mime.zig
@@ -34,6 +34,9 @@ const default_charset_len = 5;
 /// Mime with unknown Content-Type, empty params and empty charset.
 pub const unknown = Mime{ .content_type = .{ .unknown = {} } };
 
+/// The fallback for a Content-Type that fails to parse.
+pub const octet_stream = Mime{ .content_type = .{ .application_octet_stream = {} } };
+
 pub const ContentTypeEnum = enum {
     text_xml,
     text_html,

--- a/src/browser/tests/net/xhr.html
+++ b/src/browser/tests/net/xhr.html
@@ -667,6 +667,44 @@ handler runs, abort() cancels the re-send and no load is delivered.
   }
 </script>
 
+<script id=xhr_blob_type type=module>
+  {
+    // The blob's type is the final MIME type with its parameters, not the
+    // essence Mime.zig keeps. The spec re-serializes it ("text/html;charset=utf-8");
+    // we report the header text as-is, lowercased by Blob.
+    const state = await testing.async();
+
+    const blobType = (path, override) => new Promise((resolve) => {
+      const req = new XMLHttpRequest();
+      req.onload = () => { resolve(req.response.type) };
+      req.open('GET', 'http://127.0.0.1:9582' + path);
+      req.responseType = 'blob';
+      if (override !== undefined) {
+        req.overrideMimeType(override);
+      }
+      req.send();
+    });
+
+    let types;
+    Promise.all([
+      blobType('/xhr'),
+      blobType('/xhr/no_content_type'),
+      blobType('/xhr', 'text/plain;charset=iso-8859-1'),
+      blobType('/xhr', 'nonsense'),
+    ]).then((t) => { types = t; state.resolve() });
+
+    await state.done(() => {
+      testing.expectEqual('text/html; charset=utf-8', types[0]);
+      // Absent a Content-Type, "get a response MIME type" yields text/xml.
+      testing.expectEqual('text/xml', types[1]);
+      // overrideMimeType() wins over the response's own Content-Type.
+      testing.expectEqual('text/plain;charset=iso-8859-1', types[2]);
+      // An unparseable override is application/octet-stream.
+      testing.expectEqual('application/octet-stream', types[3]);
+    });
+  }
+</script>
+
 <script id=xhr_blob_reopen type=module>
   {
     // open() discards the cached response, dropping the XHR's reference to the

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -68,8 +68,10 @@ _response_data: std.ArrayList(u8) = .empty,
 _response_status: u16 = 0,
 _response_len: ?usize = 0,
 _response_url: [:0]const u8 = "",
-_response_mime: ?Mime = null,
 _override_mime: ?Mime = null,
+_response_mime: ?Mime = null,
+_override_mime_raw: ?[]const u8 = null,
+_response_mime_raw: ?[]const u8 = null,
 _response_xml: ?*Node.Document = null,
 _response_headers: std.ArrayList([]const u8) = .empty,
 _response_type: ResponseType = .default,
@@ -231,6 +233,7 @@ pub fn open(self: *XMLHttpRequest, method_: []const u8, url: [:0]const u8, async
     self._response_len = 0;
     self._response_url = "";
     self._response_mime = null;
+    self._response_mime_raw = null;
     self._response_headers.clearRetainingCapacity();
     self._request_body = null;
     self._async = async_ orelse true;
@@ -259,8 +262,14 @@ pub fn overrideMimeType(self: *XMLHttpRequest, mime: []const u8) !void {
     if (self._ready_state == .loading or self._ready_state == .done) {
         return error.InvalidStateError;
     }
-    self._override_mime = Mime.parse(mime) catch
-        Mime.parse("application/octet-stream") catch unreachable;
+    if (Mime.parse(mime)) |parsed| {
+        self._override_mime = parsed;
+        self._override_mime_raw = try self._arena.dupe(u8, std.mem.trim(u8, mime, &std.ascii.whitespace));
+    } else |_| {
+        // An unparseable override is application/octet-stream.
+        self._override_mime = .octet_stream;
+        self._override_mime_raw = "application/octet-stream";
+    }
 }
 
 pub fn send(self: *XMLHttpRequest, body_: ?BodyInit, exec_: *const Execution) !void {
@@ -543,8 +552,7 @@ pub fn getResponse(self: *XMLHttpRequest, exec: *const Execution) !?Response {
         },
         .arraybuffer => .{ .arraybuffer = .{ .values = data } },
         .blob => blk: {
-            const mime = self._override_mime orelse self._response_mime;
-            const content_type = if (mime) |m| m.contentTypeString() else "";
+            const content_type = self._override_mime_raw orelse self._response_mime_raw orelse "text/xml";
             const blob = try Blob.initFromBytes(data, content_type, exec);
             blob.acquireRef();
             break :blk .{ .blob = blob };
@@ -621,6 +629,7 @@ fn httpHeaderDoneCallback(transfer: *Transfer) !Transfer.HeaderResult {
             });
             return .abort;
         };
+        self._response_mime_raw = try self._arena.dupe(u8, std.mem.trim(u8, ct, &std.ascii.whitespace));
     }
 
     var it = transfer.responseHeaderIterator();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -841,6 +841,10 @@ fn testHTTPHandler(req: *std.http.Server.Request) !void {
         });
     }
 
+    if (std.mem.eql(u8, path, "/xhr/no_content_type")) {
+        return req.respond("untyped", .{});
+    }
+
     if (std.mem.eql(u8, path, "/xhr/binary")) {
         return req.respond(&.{ 0, 0, 1, 2, 0, 0, 9 }, .{
             .extra_headers = &.{


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/3320 made Mime.zig aware of `application/octet-stream`, but Mime is still lossy, e.g. "text/html; charset=utf-8" -> "text/html".

This commit dupes the response's content-type in the XHR's arena and use that value as-is.