### PR TITLE
CI: Lower MAX_VmHWM to 24 (down from 28)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -237,7 +237,7 @@ jobs:
     needs: zig-build-release
 
     env:
-      MAX_VmHWM: 28000 # 28MB (KB)
+      MAX_VmHWM: 24000 # 24MB (KB)
       MAX_CG_PEAK: 8000 # 8MB (KB)
       MAX_AVG_DURATION: 17
 


### PR DESCRIPTION
orderfile PRs (https://github.com/lightpanda-io/browser/pull/3271 and https://github.com/lightpanda-io/browser/pull/3285) has dropped memory usage to ~23.6. Rather than hitting 28MB in 2-3 months time and not knowing how we got there, I'd rather get slow/incremental notices.