### PR TITLE
build: honor macOS SDK root for frameworks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -515,7 +515,13 @@ fn linkCurl(b: *Build, mod: *Build.Module, is_tsan: bool, section: bool) void {
 
     if (target.result.os.tag == .macos) {
         // needed for proxying on mac
-        mod.addSystemFrameworkPath(.{ .cwd_relative = "/System/Library/Frameworks" });
+        const framework_path = if (b.sysroot) |sysroot|
+            b.pathJoin(&.{ sysroot, "System/Library/Frameworks" })
+        else if (b.graph.environ_map.get("SDKROOT")) |sdk_root|
+            b.pathJoin(&.{ sdk_root, "System/Library/Frameworks" })
+        else
+            "/System/Library/Frameworks";
+        mod.addSystemFrameworkPath(.{ .cwd_relative = framework_path });
         mod.linkFramework("CoreFoundation", .{});
         mod.linkFramework("SystemConfiguration", .{});
     }


### PR DESCRIPTION
## Summary

Resolve the macOS framework search path from the explicit Zig `--sysroot` first, then `SDKROOT`, while retaining `/System/Library/Frameworks` as a fallback.

This allows builds to find CoreFoundation and SystemConfiguration when the active SDK is outside the root filesystem, as with Xcode SDK selections and isolated development environments.

## Tests

- `make build` with `SDKROOT` pointing to a macOS SDK
- `SDKROOT=/invalid make build ZIGFLAGS="--sysroot <macOS SDK>"`
- `make test` — 1340/1340
- `zig fmt --check ./*.zig ./**/*.zig`