### PR TITLE
js: reject module evaluation before instantiation

### DIFF
--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -406,7 +406,10 @@ pub fn module(self: *Context, comptime want_result: bool, local: *const js.Local
 }
 
 fn evaluateModule(self: *Context, comptime want_result: bool, mod: js.Module, url: []const u8, cacheable: bool) !(if (want_result) ModuleEntry else void) {
-    const evaluated = mod.evaluate() catch {
+    const evaluated = mod.evaluate() catch |err| {
+        if (err == error.InvalidModuleStatus) {
+            return err;
+        }
         if (comptime lp.IS_DEBUG) {
             std.debug.assert(mod.getStatus() == .kErrored);
         }
@@ -1031,6 +1034,47 @@ fn resolveDynamicModule(self: *Context, state: *DynamicModuleResolveState, modul
 }
 
 const testing = @import("../../testing.zig");
+test "Context: evaluating a module before instantiation returns an error" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const uninstantiated = try compileModule(local, "export const value = 1", "https://example.com/uninstantiated.js");
+    try testing.expectEqual(js.Module.Status.kUninstantiated, uninstantiated.getStatus());
+    try testing.expectError(error.InvalidModuleStatus, uninstantiated.evaluate());
+
+    const instantiating = try compileModule(local, "import './dependency.js'", "https://example.com/instantiating.js");
+    var try_catch: js.TryCatch = undefined;
+    try_catch.init(local);
+    defer try_catch.deinit();
+    try testing.expectError(error.JsException, instantiating.instantiate(struct {
+        fn resolve(
+            c_context: ?*const v8.Context,
+            _: ?*const v8.String,
+            _: ?*const v8.FixedArray,
+            c_referrer: ?*const v8.Module,
+        ) callconv(.c) ?*const v8.Module {
+            const ctx = Context.fromC(c_context.?).?;
+            const callback_local = js.Local{
+                .ctx = ctx,
+                .handle = c_context.?,
+                .isolate = ctx.isolate,
+                .call_arena = ctx.call_arena,
+            };
+            const current = js.Module{ .local = &callback_local, .handle = c_referrer.? };
+            testing.expectEqual(js.Module.Status.kUninstantiated, current.getStatus()) catch @panic("unexpected module status");
+            testing.expectError(error.InvalidModuleStatus, current.evaluate()) catch @panic("module evaluation did not fail");
+            return null;
+        }
+    }.resolve));
+
+    try testing.expectEqual(2, try (try local.exec("1 + 1", null)).toI32());
+}
+
 test "Context: terminated async module completion does not re-enter V8" {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -408,6 +408,11 @@ pub fn module(self: *Context, comptime want_result: bool, local: *const js.Local
 fn evaluateModule(self: *Context, comptime want_result: bool, mod: js.Module, url: []const u8, cacheable: bool) !(if (want_result) ModuleEntry else void) {
     const evaluated = mod.evaluate() catch |err| {
         if (err == error.InvalidModuleStatus) {
+            log.err(.js, "evaluate module status", .{
+                .specifier = url,
+                .status = @tagName(mod.getStatus()),
+                .note = "please report this issue: https://github.com/lightpanda-io/browser/issues",
+            });
             return err;
         }
         if (comptime lp.IS_DEBUG) {
@@ -886,8 +891,14 @@ fn _dynamicModuleCallback(self: *Context, specifier: [:0]const u8, referrer: []c
                 }
             }
 
-            const evaluated = mod.evaluate() catch {
-                if (comptime lp.IS_DEBUG) {
+            const evaluated = mod.evaluate() catch |err| {
+                if (err == error.InvalidModuleStatus) {
+                    log.err(.js, "dynamic module status", .{
+                        .specifier = specifier,
+                        .status = @tagName(mod.getStatus()),
+                        .note = "please report this issue: https://github.com/lightpanda-io/browser/issues",
+                    });
+                } else if (comptime lp.IS_DEBUG) {
                     std.debug.assert(mod.getStatus() == .kErrored);
                 }
                 _ = resolver.reject("module evaluation", local.newString("Module evaluation failed"));
@@ -1034,47 +1045,6 @@ fn resolveDynamicModule(self: *Context, state: *DynamicModuleResolveState, modul
 }
 
 const testing = @import("../../testing.zig");
-test "Context: evaluating a module before instantiation returns an error" {
-    const frame = try testing.createFrame();
-    defer testing.test_session.closeAllPages();
-
-    var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
-    defer ls.deinit();
-    const local = &ls.local;
-
-    const uninstantiated = try compileModule(local, "export const value = 1", "https://example.com/uninstantiated.js");
-    try testing.expectEqual(js.Module.Status.kUninstantiated, uninstantiated.getStatus());
-    try testing.expectError(error.InvalidModuleStatus, uninstantiated.evaluate());
-
-    const instantiating = try compileModule(local, "import './dependency.js'", "https://example.com/instantiating.js");
-    var try_catch: js.TryCatch = undefined;
-    try_catch.init(local);
-    defer try_catch.deinit();
-    try testing.expectError(error.JsException, instantiating.instantiate(struct {
-        fn resolve(
-            c_context: ?*const v8.Context,
-            _: ?*const v8.String,
-            _: ?*const v8.FixedArray,
-            c_referrer: ?*const v8.Module,
-        ) callconv(.c) ?*const v8.Module {
-            const ctx = Context.fromC(c_context.?).?;
-            const callback_local = js.Local{
-                .ctx = ctx,
-                .handle = c_context.?,
-                .isolate = ctx.isolate,
-                .call_arena = ctx.call_arena,
-            };
-            const current = js.Module{ .local = &callback_local, .handle = c_referrer.? };
-            testing.expectEqual(js.Module.Status.kUninstantiated, current.getStatus()) catch @panic("unexpected module status");
-            testing.expectError(error.InvalidModuleStatus, current.evaluate()) catch @panic("module evaluation did not fail");
-            return null;
-        }
-    }.resolve));
-
-    try testing.expectEqual(2, try (try local.exec("1 + 1", null)).toI32());
-}
-
 test "Context: terminated async module completion does not re-enter V8" {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();

--- a/src/browser/js/Module.zig
+++ b/src/browser/js/Module.zig
@@ -60,6 +60,11 @@ pub fn instantiate(self: Module, cb: v8.ResolveModuleCallback) !bool {
 }
 
 pub fn evaluate(self: Module) !js.Value {
+    switch (self.getStatus()) {
+        .kUninstantiated, .kInstantiating => return error.InvalidModuleStatus,
+        .kInstantiated, .kEvaluating, .kEvaluated, .kErrored => {},
+    }
+
     const res = v8.v8__Module__Evaluate(self.handle, self.local.handle) orelse return error.JsException;
 
     if (self.getStatus() == .kErrored) {

--- a/src/browser/js/Module.zig
+++ b/src/browser/js/Module.zig
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+const std = @import("std");
+const lp = @import("lightpanda");
 const js = @import("js.zig");
 const v8 = js.v8;
 
@@ -60,9 +62,26 @@ pub fn instantiate(self: Module, cb: v8.ResolveModuleCallback) !bool {
 }
 
 pub fn evaluate(self: Module) !js.Value {
-    switch (self.getStatus()) {
-        .kUninstantiated, .kInstantiating => return error.InvalidModuleStatus,
-        .kInstantiated, .kEvaluating, .kEvaluated, .kErrored => {},
+    const status = self.getStatus();
+    switch (status) {
+        .kInstantiated, .kEvaluated, .kErrored => {},
+        .kUninstantiated, .kInstantiating, .kEvaluating => {
+            // V8 aborts the process (a CHECK, not an exception) on any of these.
+            // This CHECK has been reported in production (https://github.com/lightpanda-io/browser/pull/3343)
+            // but I can't see how we're getting there. Digging through v8's
+            // source code, it would appear that we're reaching here when
+            // status == kEvaluating (the other status' would fail differently).
+            // There's no harm in adding this (it will cause a JS module error
+            // but not a process crash).
+            // NOTE to future me: yes, the dynamic module path can legitimately
+            // try to evaluate a module when status == .kEvaluating and we DO
+            // guard against that, but that's via a reentrant path that
+            // shoulnd't be possible here.
+            if (comptime lp.IS_DEBUG) {
+                std.debug.panic("Module.evaluate on {s}", .{@tagName(status)});
+            }
+            return error.InvalidModuleStatus;
+        },
     }
 
     const res = v8.v8__Module__Evaluate(self.handle, self.local.handle) orelse return error.JsException;


### PR DESCRIPTION
## Why

Browser processes have been observed terminating in V8 with this fatal API check while loading ES modules:

```text
Check failed: module_status == kLinked ||
              module_status == kEvaluatingAsync ||
              module_status == kEvaluated
```

This is a process-level abort, not a recoverable JavaScript exception. In a server handling multiple CDP connections, one raced module evaluation therefore disconnects every unrelated context on that process.

The earlier termination guard in #3260 prevents late async module completions from entering V8 during teardown. The remaining signature can occur without a pending termination, so the lower-level `Module.evaluate` wrapper also needs to enforce V8's documented state precondition.

## Root cause

The module cache publishes a compiled module before dependency instantiation has completed. During re-entrant/asynchronous module loading, another path can observe that entry while V8 still reports it as uninstantiated or instantiating. Calling `v8::Module::Evaluate` in either state triggers the fatal check above.

## Fix

Reject evaluation with `InvalidModuleStatus` before entering V8 when the module is uninstantiated or currently instantiating. Existing script and dynamic-import paths already convert evaluation errors into a failed script or rejected import, keeping the browser process and other contexts alive.

The regression test covers both a newly compiled module and re-entrant evaluation from inside its dependency resolver. Without the guard, the test aborts in `Module::Evaluate` with `Expected instantiated module`; with it, both calls return the typed error and subsequent JavaScript still runs.

## Tests

- `make test` — 1341/1341
- `zig fmt --check ./*.zig ./**/*.zig`