### PR TITLE
crash: fix null dereference when ReadableStream is used cross-context

### DIFF
--- a/src/browser/tests/frames/cross_realm_stream_body.html
+++ b/src/browser/tests/frames/cross_realm_stream_body.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<head></head>
+<body>
+<script src="../testing.js"></script>
+
+<!--
+A ReadableStream body can be built in one realm and handed to another realm's
+fetch/Request (iframe.contentWindow.fetch(url, {body: rs})). Draining it must
+open a scope on the stream's own context, which has no active local scope at
+that point.
+-->
+
+<iframe id=if_body src="support/cross_realm_collection.html"></iframe>
+
+<script id=cross_realm_stream_request_body type=module>
+{
+  const state = await testing.async();
+  const iframe = document.getElementById('if_body');
+  await new Promise((resolve) => {
+    if (iframe.contentDocument.readyState === 'complete') return resolve();
+    iframe.addEventListener('load', resolve);
+  });
+
+  const rs = new ReadableStream({start(c) {
+    c.enqueue('i am the ');
+    c.enqueue(new TextEncoder().encode('request body'));
+    c.close();
+  }});
+
+  const req = new (iframe.contentWindow.Request)('/', {
+    method: 'POST', body: rs, duplex: 'half'});
+  state.resolve(await req.text());
+
+  await state.done((text) => {
+    testing.expectEqual('i am the request body', text);
+  });
+}
+</script>

--- a/src/browser/webapi/streams/ReadableStream.zig
+++ b/src/browser/webapi/streams/ReadableStream.zig
@@ -156,7 +156,10 @@ pub fn collectBodyBytes(self: *ReadableStream, arena: std.mem.Allocator) ![]cons
         .closed => {},
     }
 
-    const local = self._execution.js.local.?;
+    var ls: js.Local.Scope = undefined;
+    self._execution.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
 
     var buf = std.Io.Writer.Allocating.init(arena);
     const queue = &self._controller._queue;

--- a/src/browser/webapi/streams/ReadableStreamDefaultController.zig
+++ b/src/browser/webapi/streams/ReadableStreamDefaultController.zig
@@ -62,8 +62,8 @@ pub fn init(stream: *ReadableStream, high_water_mark: u32, exec: *const Executio
     });
 }
 
-pub fn addPendingRead(self: *ReadableStreamDefaultController) !js.Promise {
-    const resolver = self._execution.js.local.?.createPromiseResolver();
+pub fn addPendingRead(self: *ReadableStreamDefaultController, local: *const js.Local) !js.Promise {
+    const resolver = local.createPromiseResolver();
     try self._pending_reads.append(self._arena, try resolver.persist());
     return resolver.promise();
 }

--- a/src/browser/webapi/streams/ReadableStreamDefaultReader.zig
+++ b/src/browser/webapi/streams/ReadableStreamDefaultReader.zig
@@ -84,7 +84,7 @@ pub fn read(self: *ReadableStreamDefaultReader, exec: *const Execution) !js.Prom
     }
 
     // No data, but not closed. We need to queue the read for any future data
-    return stream._controller.addPendingRead();
+    return stream._controller.addPendingRead(local);
 }
 
 pub fn releaseLock(self: *ReadableStreamDefaultReader) void {


### PR DESCRIPTION
ReadableStream's assumed collectBodyBytes was being called on the same context that it was created, so that in a cross-context call, the expected LocalScope was null. This creates an explicit local scope.

Fixes crash on WPT /service-workers/service-worker/fetch-event.https.h2.html