### PR TITLE
telemetry: track if --obey-robots is used

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -72,7 +72,7 @@ pub fn init(allocator: Allocator, config: *const Config) !*App {
 
     app.app_dir_path = getAndMakeAppDir(allocator);
 
-    app.telemetry = try Telemetry.init(app, config.command, config.interactive());
+    app.telemetry = try Telemetry.init(app);
     errdefer app.telemetry.deinit(allocator);
 
     app.arena_pool = ArenaPool.init(allocator, .{});

--- a/src/telemetry/lightpanda.zig
+++ b/src/telemetry/lightpanda.zig
@@ -46,7 +46,7 @@ writer: std.Io.Writer.Allocating,
 
 iid: ?[36]u8 = null,
 mode: []const u8,
-proxy: u8,
+cli: Header.CLI,
 
 // `mutex` guards the ring buffer (head/tail/dropped), `running`, and the lazy
 // `thread` creation. The sender thread blocks on `cond` while idle.
@@ -70,17 +70,22 @@ running: bool = true,
 pending: std.ArrayList(telemetry.Event) = .empty,
 dropped: u32 = 0,
 
-pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8, run_mode: Config.RunMode, interactive: bool) !void {
+pub fn init(self: *LightPanda, app: *App, iid: ?[36]u8) !void {
+    const config = app.config;
+    const allocator = app.allocator;
     self.* = .{
         .iid = iid,
-        .allocator = app.allocator,
+        .allocator = allocator,
         .network = &app.network,
-        .proxy = if (app.config.httpProxy() != null) 1 else 0,
-        .writer = std.Io.Writer.Allocating.init(app.allocator),
-        .mode = switch (run_mode) {
+        .cli = .{
+            .proxy = config.httpProxy() != null,
+            .robots = config.obeyRobots(),
+        },
+        .writer = std.Io.Writer.Allocating.init(allocator),
+        .mode = switch (config.command) {
             .fetch => "F",
             .serve => "S",
-            .agent => if (interactive == false) "AR" else "A",
+            .agent => if (config.interactive()) "A" else "AR",
             .run => "R",
             .mcp => "M",
             .version => "V",
@@ -266,7 +271,7 @@ fn writeHeader(self: *LightPanda) !bool {
     return self.writeLine(&Header{
         .iid = if (self.iid) |*iid| iid else "00000000-0000-0000-0000-000000000000",
         .mode = self.mode,
-        .proxy = self.proxy,
+        .cli = self.cli,
     });
 }
 
@@ -316,14 +321,20 @@ const EventRow = struct {
 const Header = struct {
     iid: []const u8,
     mode: []const u8,
-    proxy: u8,
+    cli: CLI,
+
+    const CLI = packed struct(u32) {
+        proxy: bool,
+        robots: bool,
+        _reserved: u30 = 0,
+    };
 
     pub fn jsonStringify(self: *const Header, writer: anytype) !void {
         try writer.beginArray();
         try writer.write(self.iid);
         try writer.write("H");
         try writer.write(self.mode);
-        try writer.write(self.proxy);
+        try writer.write(@as(u32, @bitCast(self.cli)));
         try writer.write(OS_CODE);
         try writer.write(ARCH_CODE);
         try writer.write(build_config.version);
@@ -377,7 +388,7 @@ test "Telemetry: header wire format" {
     const header = Header{
         .iid = "the-iid",
         .mode = "S",
-        .proxy = 1,
+        .cli = .{ .proxy = true, .robots = false },
     };
     try std.json.Stringify.value(&header, .{}, &w.writer);
 

--- a/src/telemetry/telemetry.zig
+++ b/src/telemetry/telemetry.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const lp = @import("lightpanda");
 
 const App = @import("../App.zig");
-const Config = @import("../Config.zig");
 const uuidv4 = @import("../id.zig").uuidv4;
 
 const log = lp.log;
@@ -27,7 +26,7 @@ fn TelemetryT(comptime P: type) type {
 
         const Self = @This();
 
-        pub fn init(app: *App, run_mode: Config.RunMode, interactive: bool) !Self {
+        pub fn init(app: *App) !Self {
             const disabled = isDisabled();
             if (lp.IS_DEBUG == false and lp.IS_TEST == false) {
                 log.info(.telemetry, "telemetry status", .{ .disabled = disabled });
@@ -38,7 +37,7 @@ fn TelemetryT(comptime P: type) type {
             const provider = try app.allocator.create(P);
             errdefer app.allocator.destroy(provider);
 
-            try P.init(provider, app, iid, run_mode, interactive);
+            try P.init(provider, app, iid);
 
             return .{
                 .disabled = disabled,
@@ -168,14 +167,14 @@ test "telemetry: always disabled in debug builds" {
     try testing.expectEqual(true, isDisabled());
 
     const FailingProvider = struct {
-        fn init(_: *@This(), _: *App, _: ?[36]u8, _: Config.RunMode, _: bool) !void {}
+        fn init(_: *@This(), _: *App, _: ?[36]u8) !void {}
         fn deinit(_: *@This()) void {}
         pub fn send(_: *@This(), _: Event) !void {
             unreachable;
         }
     };
 
-    var telemetry = try TelemetryT(FailingProvider).init(testing.test_app, .serve, false);
+    var telemetry = try TelemetryT(FailingProvider).init(testing.test_app);
     defer telemetry.deinit(testing.test_app.allocator);
     telemetry.record(.{ .run = {} });
 }
@@ -199,7 +198,7 @@ test "telemetry: getOrCreateId" {
 }
 
 test "telemetry: sends event to provider" {
-    var telemetry = try TelemetryT(MockProvider).init(testing.test_app, .serve, false);
+    var telemetry = try TelemetryT(MockProvider).init(testing.test_app);
     defer telemetry.deinit(testing.test_app.allocator);
     telemetry.disabled = false;
     const mock = telemetry.provider;
@@ -218,7 +217,7 @@ const MockProvider = struct {
     allocator: Allocator,
     events: std.ArrayList(Event),
 
-    fn init(self: *MockProvider, app: *App, _: ?[36]u8, _: Config.RunMode, _: bool) !void {
+    fn init(self: *MockProvider, app: *App, _: ?[36]u8) !void {
         self.* = .{
             .events = .empty,
             .allocator = app.allocator,


### PR DESCRIPTION
Re-purposes the "proxy" integer as a CLI bitmask flag. Requires a server update.