### PR TITLE
refactor(webapi): remove unused MediaError.init

### DIFF
--- a/src/browser/webapi/media/MediaError.zig
+++ b/src/browser/webapi/media/MediaError.zig
@@ -17,19 +17,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const js = @import("../../js/js.zig");
-const Frame = @import("../../Frame.zig");
 
 const MediaError = @This();
 
 _code: u16,
 _message: []const u8 = "",
-
-pub fn init(code: u16, message: []const u8, frame: *Frame) !*MediaError {
-    return frame.arena.create(MediaError{
-        ._code = code,
-        ._message = try frame.dupeString(message),
-    });
-}
 
 pub fn getCode(self: *const MediaError) u16 {
     return self._code;


### PR DESCRIPTION
## What

`MediaError.init` had no caller and `MediaError` has no JS constructor
exposed (`new MediaError()` is not valid JS), so the helper was
unreachable dead code. Per maintainer review, this PR deletes it instead
of fixing it.

## Background

`init` also had a latent bug: it passed a struct VALUE to
`std.mem.Allocator.create`, which expects a TYPE, not a value. That bug
never surfaced because Zig lazily skips analyzing unreferenced function
bodies, so the broken body was never type-checked. Rather than fix an
unreachable function, the simpler and correct move is to remove it.

## Change

Removes `MediaError.init` and its now-unused `Frame` import. Nothing
else is added. `git diff upstream/main` for the file is a pure deletion.

## Runtime behavior

`HTMLMediaElement.error` still correctly returns null today, since
nothing constructed a `MediaError` before or after this change. No
runtime behavior changes.

## Verification

- `zig fmt --check` on the changed file: clean.
- Scoped build+test: green, 1 of 1 test passed (the remaining
  `WebApi: MediaError` constants test), no leaks.