### PR TITLE
cli: add --http-version 1.1 / auto flag

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -232,6 +232,11 @@ fn caPathValidator(
     }
 }
 
+pub const HttpVersion = enum {
+    auto,
+    @"1.1",
+};
+
 pub const LoadResources = packed struct(u4) {
     image: bool = false,
     iframe: bool = false,
@@ -249,6 +254,7 @@ const CommonOptions = .{
     .{ .name = "http_nav_delay", .type = ?u32 },
     .{ .name = "http_nav_burst", .type = ?u32 },
     .{ .name = "http_timeout", .type = ?u31 },
+    .{ .name = "http_version", .type = HttpVersion, .default = .auto },
     .{ .name = "http_connect_timeout", .type = ?u31 },
     .{ .name = "http_header", .type = HttpHeader, .multiple = true, .validator = httpHeaderValidator },
     .{ .name = "http_max_response_size", .type = ?usize },
@@ -536,6 +542,13 @@ pub fn tlsVerifyHost(self: *const Config) bool {
 pub fn obeyRobots(self: *const Config) bool {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.obey_robots,
+        else => unreachable,
+    };
+}
+
+pub fn httpVersion(self: *const Config) HttpVersion {
+    return switch (self.mode) {
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_version,
         else => unreachable,
     };
 }
@@ -1165,6 +1178,31 @@ test "Config: parseArgs refuses a mozilla user-agent" {
     const argv = [_][*:0]const u8{ "lightpanda", "fetch", "--user-agent", "mozilla/1.0" };
     const proc_args: std.process.Args = .{ .vector = &argv };
     try std.testing.expectError(error.InvalidArgument, parseArgs(std.testing.allocator, proc_args));
+}
+
+test "Config: parseArgs --http-version" {
+    // parseArgs allocations live for the process; an arena stands in for main's.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "fetch", "https://example.com" };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        const config = try parseArgs(arena.allocator(), proc_args);
+        try std.testing.expectEqual(.auto, config.httpVersion());
+    }
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "serve", "--http-version", "1.1" };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        const config = try parseArgs(arena.allocator(), proc_args);
+        try std.testing.expectEqual(.@"1.1", config.httpVersion());
+    }
+    {
+        log.expectLog(&.{.app});
+        const argv = [_][*:0]const u8{ "lightpanda", "fetch", "--http-version", "3" };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        try std.testing.expectError(error.InvalidArgument, parseArgs(std.testing.allocator, proc_args));
+    }
 }
 
 test "Config: validateUserAgent" {

--- a/src/cdp/domains/lp.zig
+++ b/src/cdp/domains/lp.zig
@@ -78,6 +78,7 @@ fn configureCDP(cmd: *CDP.Command) !void {
     const params = (try cmd.params(struct {
         disableSetCacheDisabled: ?bool = null,
         obeyRobots: ?bool = null,
+        httpVersion: ?lp.Config.HttpVersion = null,
     })) orelse return error.InvalidParams;
 
     if (params.disableSetCacheDisabled) |value| {
@@ -85,6 +86,9 @@ fn configureCDP(cmd: *CDP.Command) !void {
     }
     if (params.obeyRobots) |value| {
         try cmd.cdp.browser.http_client.obeyRobots(value);
+    }
+    if (params.httpVersion) |value| {
+        cmd.cdp.browser.http_client.setHttpVersion(value);
     }
 
     return cmd.sendResult(null, .{});
@@ -453,6 +457,39 @@ test "cdp.lp: configureCDP toggles setCacheDisabled handling" {
     });
     try ctx.expectSentResult(null, .{ .id = 3, .session_id = "BSID-1" });
     try testing.expectEqual(false, ctx.cdp().disable_set_cache_disabled);
+}
+
+test "cdp.lp: configureCDP sets the HTTP version on this connection's client" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const client = &ctx.cdp().browser.http_client;
+    try testing.expectEqual(.auto, client.http_version);
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "LP.configureCDP",
+        .params = .{ .httpVersion = "1.1" },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+    try testing.expectEqual(.@"1.1", client.http_version);
+
+    // Unsupported versions are rejected, not silently ignored.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "LP.configureCDP",
+        .params = .{ .httpVersion = "3" },
+    });
+    try testing.expect((try ctx.getSentMessage(1)).?.object.get("error") != null);
+    try testing.expectEqual(.@"1.1", client.http_version);
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "LP.configureCDP",
+        .params = .{ .httpVersion = "auto" },
+    });
+    try ctx.expectSentResult(null, .{ .id = 3 });
+    try testing.expectEqual(.auto, client.http_version);
 }
 
 test "cdp.lp: getMarkdown" {

--- a/src/help.zon
+++ b/src/help.zon
@@ -418,6 +418,11 @@
     \\  --http-timeout <INT>
     \\          Maximum time in ms the transfer is allowed to complete. 0 means never.
     \\          Defaults to 10000.
+    \\  --http-version <VERSION>
+    \\          HTTP version to negotiate. "1.1" never offers HTTP/2. "auto"
+    \\          picks the best available option.
+    \\          Defaults to "auto".
+    \\          Allowed values: "auto", "1.1".
     \\  --insecure-disable-tls-host-verification
     \\          Disables host verification on all HTTP requests.
     \\          Only set this if you understand and accept the risk.

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -192,6 +192,10 @@ cache: *Cache,
 serve_mode: bool,
 obey_robots: bool,
 
+// Applied to every transfer at configureConn, so a CDP change takes effect
+// on the next request, not on in-flight ones.
+http_version: lp.Config.HttpVersion,
+
 robots: RobotsGate,
 url_blocklist: ?UrlBlocklist,
 
@@ -236,6 +240,7 @@ pub fn init(self: *Client, app: *lp.App, cdp: ?*CDP) !void {
 
         .serve_mode = config.mode == .serve,
         .obey_robots = config.obeyRobots(),
+        .http_version = config.httpVersion(),
         .robots = .{
             .network = network,
             .single_flight = .init(allocator),
@@ -323,6 +328,10 @@ pub fn obeyRobots(self: *Client, enable: bool) !void {
     if (self.obey_robots == enable) return;
     try self.ensureNoActiveConnection();
     self.obey_robots = enable;
+}
+
+pub fn setHttpVersion(self: *Client, version: lp.Config.HttpVersion) void {
+    self.http_version = version;
 }
 
 pub fn disableCache(self: *Client, disable: bool) void {
@@ -2703,6 +2712,7 @@ pub const Transfer = struct {
         try conn.setFollowLocation(false);
         try conn.setProxy(client.http_proxy);
         try conn.setTlsVerify(client.tls_verify, client.use_proxy);
+        try conn.setHttpVersion(client.http_version);
 
         try conn.setURL(req.url);
         try conn.setMethod(req.method);
@@ -3686,6 +3696,7 @@ fn initTestClient(client: *Client, pool: *ArenaPool) void {
     client.cache = &Cache.noop;
     client.serve_mode = false;
     client.obey_robots = false;
+    client.http_version = .auto;
     client.robots = .{
         .network = undefined,
         .single_flight = .init(testing.allocator),

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -530,6 +530,14 @@ pub const Connection = struct {
         try libcurl.curl_easy_setopt(self._easy, .proxy, if (proxy) |p| p.ptr else null);
     }
 
+    pub fn setHttpVersion(self: *const Connection, version: Config.HttpVersion) !void {
+        const v: libcurl.CurlHttpVersion = switch (version) {
+            .auto => .none,
+            .@"1.1" => .v1_1,
+        };
+        try libcurl.curl_easy_setopt(self._easy, .http_version, v);
+    }
+
     pub fn setFollowLocation(self: *const Connection, follow: bool) !void {
         try libcurl.curl_easy_setopt(self._easy, .follow_location, @as(c_long, if (follow) 2 else 0));
     }

--- a/src/sys/libcurl.zig
+++ b/src/sys/libcurl.zig
@@ -199,6 +199,7 @@ pub const CurlOption = enum(c.CURLoption) {
     timeout_ms = c.CURLOPT_TIMEOUT_MS,
     connect_timeout_ms = c.CURLOPT_CONNECTTIMEOUT_MS,
     follow_location = c.CURLOPT_FOLLOWLOCATION,
+    http_version = c.CURLOPT_HTTP_VERSION,
     proxy = c.CURLOPT_PROXY,
     ssl_verify_host = c.CURLOPT_SSL_VERIFYHOST,
     ssl_verify_peer = c.CURLOPT_SSL_VERIFYPEER,
@@ -229,6 +230,11 @@ pub const CurlOption = enum(c.CURLoption) {
     opensocket_data = c.CURLOPT_OPENSOCKETDATA,
     ssl_ctx_function = c.CURLOPT_SSL_CTX_FUNCTION,
     ssl_ctx_data = c.CURLOPT_SSL_CTX_DATA,
+};
+
+pub const CurlHttpVersion = enum(c_long) {
+    none = c.CURL_HTTP_VERSION_NONE, // libcurl's own defaults, picks the best
+    v1_1 = c.CURL_HTTP_VERSION_1_1,
 };
 
 pub const CurlMOption = enum(c.CURLMoption) {
@@ -633,6 +639,8 @@ pub fn curl_easy_setopt(easy: *Curl, comptime option: CurlOption, value: anytype
         => @as(?*anyopaque, @ptrCast(value)),
 
         .ssl_ctx_data => @as(*crypto.X509_STORE, value),
+
+        .http_version => @as(c_long, @intFromEnum(@as(CurlHttpVersion, value))),
 
         .debug_function => @as(CurlDebugFunction, value),
         .opensocket_function => @as(CurlOpenSocketFunction, value),


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/issues/3348

When set to 1.1, libcurl is configured to only offer HTTP 1.1. By default, or when set to "auto", it's up to libcurl to decide how to connect. This maps to libcurl's CURL_HTTP_VERSION_1_1 and CURL_HTTP_VERSION_NONE.

LP.configureCDP now takes an `httpVersion` field which can be "1.1" or "auto" to control that specific browser session. Ideally this is called prior to any navigation.