### PR TITLE
indexeddb: Improve error handling

### DIFF
--- a/src/browser/tests/indexeddb.html
+++ b/src/browser/tests/indexeddb.html
@@ -1189,6 +1189,7 @@
     });
 }
 </script>
+
 <!-- put()/add() structured-clone the value at call time: the record is the
      clone as of the call (later mutation of the argument is not stored), a
      generated key is injected into the clone rather than the caller's object,
@@ -1250,6 +1251,68 @@
     for (const bad of [-1, 0.5, NaN, Infinity, "foo", 2 ** 53]) {
         testing.expectError("TypeError", () => indexedDB.open("big-version-db", bad));
     }
+}
+</script>
+
+<!-- abort() delivers the pending requests' error events and the abort event
+     from a task, so handlers attached right after the call still see them; the
+     abort event bubbles to the connection. -->
+<script id="abort_delivery_is_async" type=module>
+{
+    const state = await testing.async();
+    const open = indexedDB.open("abort-async-db", 1);
+    open.onupgradeneeded = (e) => e.target.result.createObjectStore("s");
+    open.onsuccess = () => {
+        const db = open.result;
+        const tx = db.transaction("s", "readonly");
+        const req = tx.objectStore("s").get(1);
+        tx.abort();
+        const events = [];
+        req.onerror = () => events.push("req:" + req.error.name + ":" + req.readyState);
+        req.onsuccess = () => events.push("req:success");
+        tx.onabort = () => events.push("tx:abort");
+        db.onabort = () => {
+            events.push("db:abort");
+            state.resolve(events);
+        };
+    };
+    await state.done((got) => {
+        testing.expectEqual(["req:AbortError:done", "tx:abort", "db:abort"], got);
+    });
+}
+</script>
+
+<!-- createIndex({unique}) over records that violate it: the index is created,
+     the requests already queued deliver, then the transaction aborts with
+     ConstraintError and the open request fails with AbortError. -->
+<script id="create_unique_index_over_duplicates" type=module>
+{
+    const state = await testing.async();
+    const open = indexedDB.open("unique-dupes-db", 1);
+    const events = [];
+    open.onupgradeneeded = (e) => {
+        const db = e.target.result;
+        const tx = e.target.transaction;
+        const store = db.createObjectStore("s");
+        store.put({ v: "x" }, 1).onsuccess = () => events.push("put1");
+        store.put({ v: "x" }, 2).onsuccess = () => events.push("put2");
+        const index = store.createIndex("by_v", "v", { unique: true });
+        events.push("created:" + (index instanceof IDBIndex));
+        const late = store.put({ v: "y" }, 3);
+        late.onsuccess = () => events.push("put3:success");
+        late.onerror = () => events.push("put3:" + late.error.name);
+        tx.onabort = () => events.push("abort:" + tx.error.name);
+        tx.oncomplete = () => events.push("complete");
+    };
+    open.onsuccess = () => state.resolve({ events, success: true });
+    open.onerror = (e) => {
+        e.preventDefault();
+        state.resolve({ events, error: open.error.name });
+    };
+    await state.done((got) => {
+        testing.expectEqual("AbortError", got.error);
+        testing.expectEqual(["created:true", "put1", "put2", "put3:AbortError", "abort:ConstraintError"], got.events);
+    });
 }
 </script>
 </body>

--- a/src/browser/webapi/storage/idb/IDBDatabase.zig
+++ b/src/browser/webapi/storage/idb/IDBDatabase.zig
@@ -46,6 +46,7 @@ _name: []const u8,
 _version: i64,
 _txn: ?*IDBTransaction = null, // only set during upgradeneeded
 _on_error: ?js.Function.Global = null,
+_on_abort: ?js.Function.Global = null,
 
 pub fn init(exec: *Execution, engine: *Engine, database_id: i64, name: []const u8, version: i64) !*IDBDatabase {
     return exec._factory.eventTarget(IDBDatabase{
@@ -232,6 +233,17 @@ pub fn setOnError(self: *IDBDatabase, setter: ?FunctionSetter) void {
     } else null;
 }
 
+pub fn getOnAbort(self: *const IDBDatabase) ?js.Function.Global {
+    return self._on_abort;
+}
+
+pub fn setOnAbort(self: *IDBDatabase, setter: ?FunctionSetter) void {
+    self._on_abort = if (setter) |s| switch (s) {
+        .func => |f| f,
+        .anything => null,
+    } else null;
+}
+
 pub const JsApi = struct {
     pub const bridge = js.Bridge(IDBDatabase);
 
@@ -249,4 +261,5 @@ pub const JsApi = struct {
     pub const transaction = bridge.function(IDBDatabase.transaction, .{});
     pub const close = bridge.function(IDBDatabase.close, .{});
     pub const onerror = bridge.accessor(IDBDatabase.getOnError, IDBDatabase.setOnError, .{});
+    pub const onabort = bridge.accessor(IDBDatabase.getOnAbort, IDBDatabase.setOnAbort, .{});
 };

--- a/src/browser/webapi/storage/idb/IDBFactory.zig
+++ b/src/browser/webapi/storage/idb/IDBFactory.zig
@@ -152,7 +152,9 @@ const OpenContext = struct {
     // deliver the open request's outcome and clean up.
     fn drainUpgrade(self: *OpenContext) !?u32 {
         const txn = self._upgrade.?;
-        if (txn.settleStep(self.exec)) {
+        if (txn.settleStep(self.exec) or txn.abortDeliveryPending()) {
+            // either settle succeeded, and we have more batches to deliver, or
+            // abortDeliveryPending succeeded and we have an abort event.
             self._scheduled = true;
             return 1;
         }
@@ -176,6 +178,7 @@ const OpenContext = struct {
         txn.releaseRef(exec.page);
 
         if (aborted) {
+            self.request._result = .{ .none = js.Undefined{} };
             self.request.setError(error.AbortError);
             return self.request.deliver(exec);
         }
@@ -248,6 +251,7 @@ const OpenContext = struct {
         self.request.setDatabaseResult(db);
 
         const txn = try IDBTransaction.initVersionChange(db, exec);
+        txn._old_version = existing orelse 0;
         txn.acquireRef();
 
         {
@@ -264,7 +268,12 @@ const OpenContext = struct {
             try self.request.fireUpgradeNeeded(exec, old_version, @intCast(requested));
         }
 
-        if (!txn.aborted() and txn._queue.items.len > 0) {
+        if (!txn.aborted() and txn._queue.items.len == 0) {
+            // Nothing queued, settle synchronously
+            txn.settle(exec);
+        }
+
+        if (txn.aborted() or txn._queue.items.len > 0) {
             // The handler left requests pending (e.g. a keep-alive loop).
             // Deliver their events one batch per scheduler turn — never
             // synchronously — so timer tasks can interleave and observe the
@@ -274,13 +283,6 @@ const OpenContext = struct {
             return true;
         }
 
-        if (!txn.aborted()) {
-            // Nothing queued: settle synchronously (commit + fire `complete`).
-            txn.settle(exec);
-        }
-        // An aborted transaction — the upgradeneeded handler called abort()
-        // (what a jerk!) — already rolled back; finishUpgrade delivers its
-        // AbortError.
         closed = true;
         try self.finishUpgrade(txn);
         return false;

--- a/src/browser/webapi/storage/idb/IDBObjectStore.zig
+++ b/src/browser/webapi/storage/idb/IDBObjectStore.zig
@@ -532,6 +532,7 @@ pub fn createIndex(self: *IDBObjectStore, name: []const u8, key_path: Key.KeyPat
 
     const arena = exec.call_arena;
     const local = exec.js.local.?;
+    var violated = false;
 
     {
         // we reach directly in to _engine.conn here to avoid copying the values out
@@ -542,7 +543,17 @@ pub fn createIndex(self: *IDBObjectStore, name: []const u8, key_path: Key.KeyPat
         var seen: std.ArrayList([]const u8) = .empty;
         while (try rows.next()) |row| {
             const value = try js.Value.deserialize(local, row.get([]const u8, 1));
-            try self.addIndexEntries(local, arena, &seen, index_id, opts.unique, opts.multiEntry, owned_key_path, value, row.get([]const u8, 0));
+            self.addIndexEntries(local, arena, &seen, index_id, opts.unique, opts.multiEntry, owned_key_path, value, row.get([]const u8, 0)) catch |err| switch (err) {
+                error.Constraint => {
+                    // Existing rows violate the new unique index. This doesn't
+                    // surface as an error here. Instead, this will look like it
+                    // succeeded, but we'll asynchronously deliver a constraint
+                    // error
+                    violated = true;
+                    break;
+                },
+                else => return err,
+            };
         }
     }
 
@@ -556,6 +567,9 @@ pub fn createIndex(self: *IDBObjectStore, name: []const u8, key_path: Key.KeyPat
     idb_index._created = true;
     try self._engine.releaseSavepoint();
     try self._indexes.append(txn._arena.allocator(), idb_index);
+    if (violated) {
+        try txn.queueAbort(error.ConstraintError);
+    }
     return idb_index;
 }
 

--- a/src/browser/webapi/storage/idb/IDBRequest.zig
+++ b/src/browser/webapi/storage/idb/IDBRequest.zig
@@ -50,6 +50,7 @@ _txn: Txn = .none,
 // Same request can show up multiple times in txn._requests, but it should only
 // be executed/fired in its last append (to preserve ordering).
 _txn_index: usize = 0,
+_abort_reason: ?anyerror = null,
 _cursor: ?*IDBCursor = null,
 _source: Source = .{ .none = null },
 _ready_state: ReadyState = .pending,
@@ -185,6 +186,23 @@ pub fn failed(self: *const IDBRequest) bool {
     return self._error != null;
 }
 
+// Whether the success/error event for the current operation has fired. A
+// re-armed cursor request (continue/advance) is pending again even though
+// its state is done from the previous iteration; a versionchange request runs
+// eagerly (op cleared) but still awaits delivery.
+pub fn delivered(self: *const IDBRequest) bool {
+    return self._op == .none and self._ready_state == .done;
+}
+
+// The transaction aborted before this request's event fired: it now fails with
+// AbortError and no result. Delivery happens from the abort task.
+pub fn failWithAbort(self: *IDBRequest) void {
+    self._op = .none;
+    self.clearOwnedResult();
+    self._result = .{ .none = js.Undefined{} };
+    self._error = error.AbortError;
+}
+
 pub fn deliver(self: *IDBRequest, exec: *Execution) !void {
     self._ready_state = .done;
     if (self._error != null) {
@@ -202,6 +220,18 @@ pub fn fireUpgradeNeeded(self: *IDBRequest, exec: *Execution, old_version: u64, 
     self._ready_state = .done;
     const event = try IDBVersionChangeEvent.initTrusted(.wrap("upgradeneeded"), old_version, new_version, exec);
     try exec.dispatch(self.asEventTarget(), event.asEvent(), self._on_upgrade_needed, .{ .context = "IDBRequest.upgradeneeded" });
+
+    // A throwing listener aborts the upgrade (after every listener ran).
+    if (event.asEvent()._listeners_did_throw) {
+        switch (self._txn) {
+            .borrowed => |txn| if (!txn.aborted()) {
+                txn.abortWith(exec, error.AbortError) catch |err| {
+                    log.warn(.storage, "idb upgradeneeded abort", .{ .err = err });
+                };
+            },
+            .owned, .none => {},
+        }
+    }
 }
 
 pub fn fireSuccess(self: *IDBRequest, exec: *Execution) !void {

--- a/src/browser/webapi/storage/idb/IDBTransaction.zig
+++ b/src/browser/webapi/storage/idb/IDBTransaction.zig
@@ -87,6 +87,10 @@ _aborted: bool = false,
 _committing: bool = false,
 _error: ?anyerror = null,
 _gate_waiter: Engine.GateWaiter,
+// versionchange only: the version to fall back to if the upgrade aborts.
+_old_version: ?i64 = null,
+_abort_requests: std.ArrayList(*IDBRequest) = .empty,
+_abort_pending: bool = false,
 // A transaction is only active for one execution of a Scheduler's task. We
 // capture the scheduler's generation here and reject any request made in a
 // later generation (see assertActive).
@@ -301,6 +305,9 @@ pub fn abortWith(self: *IDBTransaction, exec: *Execution, reason: ?anyerror) err
                 }
             }
         }
+        if (self._old_version) |old| {
+            self._db._version = old;
+        }
     }
 
     if (self._begun) {
@@ -313,17 +320,103 @@ pub fn abortWith(self: *IDBTransaction, exec: *Execution, reason: ?anyerror) err
 
     for ([_]*std.ArrayList(*IDBRequest){ &self._queue_a, &self._queue_b }) |queue| {
         for (queue.items, 0..) |request, i| {
-            if (i != request._txn_index or request._op == .none) {
+            if (i != request._txn_index or request.delivered() or request._abort_reason != null) {
                 continue;
             }
-            request._op = .none;
-            request.setError(error.AbortError);
-            request.deliver(exec) catch |err| {
-                log.warn(.storage, "idb abort deliver", .{ .err = err });
+            // Fail an undelivered request whose event hasn't fired yet (and
+            // which itself isn't an abort).
+            request.failWithAbort();
+            self._abort_requests.append(self._arena.allocator(), request) catch |err| {
+                log.warn(.storage, "idb abort collect", .{ .err = err });
             };
         }
     }
-    self.fire(exec, comptime .wrap("abort"), self._on_abort);
+    self.scheduleAbortDelivery(exec);
+}
+
+pub fn abortDeliveryPending(self: *const IDBTransaction) bool {
+    return self._abort_pending;
+}
+
+// Pin the transaction for the abort-delivery task (like scheduleDrain).
+fn scheduleAbortDelivery(self: *IDBTransaction, exec: *Execution) void {
+    self.acquireRef();
+    exec.js.scheduler.add(self, deliverAbort, 0, .{
+        .name = "IDBTransaction.abort",
+        .finalizer = abortFinalize,
+    }) catch |err| {
+        log.warn(.storage, "idb schedule abort", .{ .err = err });
+        self.releaseRef(exec.page);
+        return;
+    };
+    self._abort_pending = true;
+}
+
+fn deliverAbort(ctx: *anyopaque) !?u32 {
+    const self: *IDBTransaction = @ptrCast(@alignCast(ctx));
+    const exec = self._exec;
+    // The task pin; may free the transaction — must be the last touch.
+    defer self.releaseRef(exec.page);
+    defer self._abort_pending = false;
+
+    // Scheduler tasks run without a js local; dispatch needs one (see deliverBatch).
+    const prev_local = exec.js.local;
+    defer exec.js.local = prev_local;
+    var ls: js.Local.Scope = undefined;
+    exec.js.localScope(&ls);
+    defer ls.deinit();
+    exec.js.local = &ls.local;
+
+    for (self._abort_requests.items) |request| {
+        request.deliver(exec) catch |err| {
+            log.warn(.storage, "idb abort deliver", .{ .err = err });
+        };
+    }
+    self._abort_requests.clearRetainingCapacity();
+    self.fireAbort(exec);
+    return null;
+}
+
+// Scheduler task finalizer for deliverAbort: the context is going away, the
+// events are lost; drop the task pin.
+fn abortFinalize(ctx: *anyopaque) void {
+    const self: *IDBTransaction = @ptrCast(@alignCast(ctx));
+    self._abort_pending = false;
+    self.releaseRef(self._exec.page);
+}
+
+// The abort event bubbles from the transaction to its connection.
+fn fireAbort(self: *IDBTransaction, exec: *Execution) void {
+    const event = Event.initTrusted(comptime .wrap("abort"), .{ .bubbles = true }, exec.page) catch |err| {
+        log.warn(.storage, "idb abort event", .{ .err = err });
+        return;
+    };
+    event.acquireRef();
+    defer _ = event.releaseRef(exec.page);
+
+    const et = self.asEventTarget();
+    event._target = et;
+    event._dispatch_target = et;
+    exec.dispatch(et, event, self._on_abort, .{ .context = "IDBTransaction.abort", .inject_target = false }) catch |err| {
+        log.warn(.storage, "idb abort dispatch", .{ .err = err });
+    };
+    if (event._stop_propagation) {
+        return;
+    }
+    const db = self._db;
+    exec.dispatch(db.asEventTarget(), event, db._on_abort, .{ .context = "IDBDatabase.abort", .inject_target = false }) catch |err| {
+        log.warn(.storage, "idb abort dispatch", .{ .err = err });
+    };
+}
+
+// Queue an abort at the current position in the request queue: the requests
+// ahead of it deliver normally, the ones behind it fail with AbortError. Used
+// where the spec aborts "asynchronously" from within a synchronous call (e.g.
+// createIndex on data that violates a unique constraint).
+pub fn queueAbort(self: *IDBTransaction, reason: anyerror) !void {
+    const marker = try self.newRequest();
+    marker._abort_reason = reason;
+    try self.enqueue(marker);
 }
 
 pub fn settle(self: *IDBTransaction, exec: *Execution) void {
@@ -367,7 +460,7 @@ fn commitAndComplete(self: *IDBTransaction, exec: *Execution) void {
             self._engine.rollback();
             self._begun = false;
             _ = self._engine.releaseGate(&self._gate_waiter);
-            self.fire(exec, comptime .wrap("abort"), self._on_abort);
+            self.fireAbort(exec);
             return;
         };
         self._begun = false;
@@ -676,9 +769,14 @@ fn deliverBatch(self: *IDBTransaction, exec: *Execution) void {
     self._active_turn = exec.js.scheduler.generation;
 
     for (batch.items) |request| {
-        // A handler may have aborted the transaction mid-delivery; abort() already
-        // delivered AbortError to the remaining requests, so stop here.
+        // A handler may have aborted the transaction mid-delivery; abort()
+        // collected the remaining requests for its own delivery, so stop here.
         if (self._settled) {
+            return;
+        }
+        if (request._abort_reason) |reason| {
+            // see queueAbort
+            self.abortWith(exec, reason) catch {};
             return;
         }
         request.execute(exec) catch |err| {


### PR DESCRIPTION
Three  small compliance (WPT) changes with respect to error handling.

1. When a unique index creation fails due to a constraint violation, the delivery of that failure is asynchronous.

2. When txn.abort() is called, any undelivered request should be aborted asynchronously (see the common theme here?)

3. An failure in an onupgradeneeded handler correctly fires an AbortError AND rollsback the version