### PR TITLE
webapi: navigator.sendBeacon returns true

### DIFF
--- a/src/browser/tests/navigator/navigator.html
+++ b/src/browser/tests/navigator/navigator.html
@@ -158,3 +158,10 @@
   testing.expectEqual('undefined', typeof navigator.getBattery);
 </script>
 
+
+<script id=sendBeacon>
+  // Nothing is sent, but "queued" keeps callers off their sync-XHR fallback.
+  testing.expectEqual(true, navigator.sendBeacon('/analytics'));
+  testing.expectEqual(true, navigator.sendBeacon('/analytics', 'payload'));
+  testing.expectEqual(true, navigator.sendBeacon('/analytics', new Blob(['x'])));
+</script>

--- a/src/browser/webapi/Navigator.zig
+++ b/src/browser/webapi/Navigator.zig
@@ -265,7 +265,7 @@ pub const JsApi = struct {
     pub const globalPrivacyControl = bridge.accessor(Navigator.getGlobalPrivacyControl, null, .{});
 
     pub const javaEnabled = bridge.function(Navigator.javaEnabled, .{});
-    pub const sendBeacon = bridge.function(Navigator.sendBeacon, .{ .noop = true });
+    pub const sendBeacon = bridge.function(Navigator.sendBeacon, .{});
     pub const permissions = bridge.accessor(Navigator.getPermissions, null, .{});
     pub const storage = bridge.accessor(Navigator.getStorage, null, .{});
     pub const userAgentData = bridge.accessor(Navigator.getUserAgentData, null, .{});


### PR DESCRIPTION
`sendBeacon` was registered with `.noop = true`, which makes the bridge skip the body entirely, so JS got `undefined` instead of the `true` #2821 intended. `if (!navigator.sendBeacon(...)) fallbackSyncXHR()` therefore always took the fallback. Nothing is sent, as before.