### PR TITLE
webapi: document.execCommand and its query/designMode companions

### DIFF
--- a/src/browser/tests/document/document.html
+++ b/src/browser/tests/document/document.html
@@ -443,3 +443,20 @@
     testing.expectEqual(1, acss.length);
   }
 </script>
+
+<script id=execCommand>
+  {
+    // No editing pipeline or clipboard: every command is unsupported, so
+    // callers stay on their feature-detection fallbacks instead of throwing.
+    testing.expectEqual(false, document.queryCommandSupported('copy'));
+    testing.expectEqual(false, document.queryCommandEnabled('copy'));
+    testing.expectEqual(false, document.queryCommandState('bold'));
+    testing.expectEqual(false, document.queryCommandIndeterm('bold'));
+    testing.expectEqual('', document.queryCommandValue('fontName'));
+    testing.expectEqual(false, document.execCommand('copy'));
+    testing.expectEqual(false, document.execCommand('insertText', false, 'x'));
+    testing.expectEqual('off', document.designMode);
+    document.designMode = 'on';
+    testing.expectEqual('off', document.designMode);
+  }
+</script>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -1256,6 +1256,29 @@ pub fn hasFocus(_: *Document) bool {
     return true;
 }
 
+/// No editing pipeline or clipboard, so no command is supported. Reporting
+/// that keeps callers on their feature-detection fallbacks.
+pub fn execCommand(_: *Document, command: []const u8, _: ?bool, _: ?[]const u8) bool {
+    log.debug(.not_implemented, "Document.execCommand", .{ .command = command });
+    return false;
+}
+
+pub fn queryCommandSupported(_: *const Document, _: []const u8) bool {
+    return false;
+}
+
+pub fn queryCommandValue(_: *const Document, _: []const u8) []const u8 {
+    return "";
+}
+
+pub fn getDesignMode(_: *const Document) []const u8 {
+    return "off";
+}
+
+pub fn setDesignMode(_: *Document, value: []const u8) void {
+    log.debug(.not_implemented, "Document.designMode", .{ .value = value });
+}
+
 pub fn setAdoptedStyleSheets(self: *Document, sheets: js.Object) !void {
     self._adopted_style_sheets = try sheets.persist();
 }
@@ -1602,6 +1625,13 @@ pub const JsApi = struct {
         }
     }.defaultView, null, .{});
     pub const hasFocus = bridge.function(Document.hasFocus, .{});
+    pub const execCommand = bridge.function(Document.execCommand, .{});
+    pub const queryCommandSupported = bridge.function(Document.queryCommandSupported, .{});
+    pub const queryCommandEnabled = bridge.function(Document.queryCommandSupported, .{});
+    pub const queryCommandState = bridge.function(Document.queryCommandSupported, .{});
+    pub const queryCommandIndeterm = bridge.function(Document.queryCommandSupported, .{});
+    pub const queryCommandValue = bridge.function(Document.queryCommandValue, .{});
+    pub const designMode = bridge.accessor(Document.getDesignMode, Document.setDesignMode, .{});
 
     pub const prerendering = bridge.property(false, .{ .template = false });
     pub const characterSet = bridge.accessor(Document.getCharset, null, .{});


### PR DESCRIPTION
`document.execCommand`, `queryCommandSupported`/`Enabled`/`State`/`Indeterm`, `queryCommandValue` and `designMode` were absent, so the dominant copy-to-clipboard path and its feature probe both threw `TypeError`.

There's no editing pipeline or clipboard, so every command reports unsupported (`false` / `""`, `designMode` stays `"off"`), which keeps callers on their feature-detection fallbacks.