### PR TITLE
webapi: option.selected = true deselects its siblings in a single select

### DIFF
--- a/src/browser/tests/element/html/select.html
+++ b/src/browser/tests/element/html/select.html
@@ -491,3 +491,34 @@
     testing.expectEqual('d2', select.options[1].value)
   }
 </script>
+
+<select id="single">
+  <option id="s1" value="1" selected>1</option>
+  <option id="s2" value="2">2</option>
+  <optgroup><option id="s3" value="3">3</option></optgroup>
+</select>
+<select id="multi" multiple>
+  <option id="m1" selected>1</option>
+  <option id="m2">2</option>
+</select>
+
+<script id="option_selected_deselects_siblings">
+{
+  $('#s2').selected = true;
+  testing.expectEqual(true, $('#s2').selected);
+  testing.expectEqual(false, $('#s1').selected);
+  testing.expectEqual('2', $('#single').value);
+
+  $('#s3').selected = true;
+  testing.expectEqual(false, $('#s2').selected);
+  testing.expectEqual('3', $('#single').value);
+
+  $('#m2').selected = true;
+  testing.expectEqual(true, $('#m1').selected);
+  testing.expectEqual(true, $('#m2').selected);
+
+  const orphan = document.createElement('option');
+  orphan.selected = true;
+  testing.expectEqual(true, orphan.selected);
+}
+</script>

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -26,6 +26,7 @@ const Frame = @import("../../../Frame.zig");
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
 const HtmlElement = @import("../Html.zig");
+const Select = @import("Select.zig");
 
 const String = lp.String;
 
@@ -79,10 +80,25 @@ pub fn getSelected(self: *const Option) bool {
 }
 
 pub fn setSelected(self: *Option, selected: bool, frame: *Frame) !void {
-    // TODO: When setting selected=true, may need to unselect other options
-    // in the parent <select> if it doesn't have multiple attribute
     self._selected = selected;
+    if (selected) {
+        if (self.ownerSelect()) |select| {
+            if (!select.asConstElement().hasAttributeSafe(comptime .wrap("multiple"))) {
+                select.deselectOthers(self);
+            }
+        }
+    }
     frame.domChanged();
+}
+
+/// The <select> this option belongs to, directly or through an <optgroup>.
+fn ownerSelect(self: *Option) ?*Select {
+    var node = self.asNode().parentNode();
+    while (node) |n| : (node = n.parentNode()) {
+        if (n.is(Select)) |select| return select;
+        if (n.is(Element.Html.OptGroup) == null) return null;
+    }
+    return null;
 }
 
 pub fn getDefaultSelected(self: *const Option) bool {

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -91,6 +91,13 @@ const OptionIterator = struct {
     }
 };
 
+pub fn deselectOthers(self: *const Select, keep: *const Option) void {
+    var it = OptionIterator.init(self);
+    while (it.next()) |option| {
+        if (option != keep) option._selected = false;
+    }
+}
+
 // Resolves the option whose selectedness contributes to the select's value
 // per HTML §form-elements§selectedness-setting-algorithm: an explicitly
 // selected non-disabled option, falling back to the first non-disabled


### PR DESCRIPTION
Setting `option.selected = true` left the previously selected option selected, so a single-select had two selected options and `select.value` reported the stale one. Now the owning `<select>` (found directly or through an `<optgroup>`) clears the others unless it is `multiple`. Detached options are unaffected.