### PR TITLE
webapi: a disabled fieldset disables its controls' activation and validation

### DIFF
--- a/src/browser/tests/element/html/fieldset.html
+++ b/src/browser/tests/element/html/fieldset.html
@@ -33,3 +33,34 @@
     testing.expectEqual('', fs2.name);
   }
 </script>
+
+<fieldset id="fs-off" disabled>
+  <legend><input id="in-legend" type="text"></legend>
+  <input id="in-body" type="text">
+  <div><button id="btn-body" type="submit">go</button></div>
+</fieldset>
+
+<script id="disabled-state">
+  {
+    // The IDL attribute reflects only the element's own attribute; the
+    // disabled state (activation, constraint validation) also comes from a
+    // disabled fieldset ancestor, except through its first <legend>.
+    const body = document.getElementById('in-body');
+    testing.expectEqual(false, body.disabled);
+    testing.expectEqual(false, body.willValidate);
+    testing.expectEqual(false, document.getElementById('btn-body').willValidate);
+    let clicked = false;
+    body.addEventListener('click', () => { clicked = true; });
+    body.click();
+    testing.expectEqual(false, clicked);
+
+    const legend = document.getElementById('in-legend');
+    testing.expectEqual(true, legend.willValidate);
+    legend.addEventListener('click', () => { clicked = true; });
+    legend.click();
+    testing.expectEqual(true, clicked);
+
+    document.getElementById('fs-off').disabled = false;
+    testing.expectEqual(true, body.willValidate);
+  }
+</script>

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -735,7 +735,7 @@ pub fn hasDisabledConcept(self: *const Element) bool {
     };
 }
 
-pub fn isDisabled(self: *Element) bool {
+pub fn isDisabled(self: *const Element) bool {
     if (!self.hasDisabledConcept()) {
         return false;
     }
@@ -749,7 +749,7 @@ pub fn isDisabled(self: *Element) bool {
     // <optgroup disabled>. It does NOT inherit from <select disabled> or
     // an ancestor <fieldset disabled>.
     if (self.getTag() == .option) {
-        if (self.asNode()._parent) |parent_node| {
+        if (self.asConstNode()._parent) |parent_node| {
             if (parent_node.is(Element)) |parent_el| {
                 if (parent_el.getTag() == .optgroup and
                     parent_el.getAttributeSafe(comptime .wrap("disabled")) != null)
@@ -761,7 +761,7 @@ pub fn isDisabled(self: *Element) bool {
         return false;
     }
 
-    const element_node = self.asNode();
+    const element_node = self.asConstNode();
     var current: ?*Node = element_node._parent;
     while (current) |node| {
         current = node._parent;

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -64,7 +64,7 @@ pub fn getComputedLabel(_: *const WebDriver, element: *Element, frame: *Frame) !
 pub fn click(_: *const WebDriver, element: *Element, frame: *Frame) !void {
     if (element.is(Element.Html)) |html| {
         switch (html._type) {
-            .button, .input, .textarea, .select => if (element.isDisabled()) return,
+            .button, .input, .textarea, .select, .option, .optgroup => if (element.isDisabled()) return,
             else => {},
         }
     }

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -64,11 +64,7 @@ pub fn getComputedLabel(_: *const WebDriver, element: *Element, frame: *Frame) !
 pub fn click(_: *const WebDriver, element: *Element, frame: *Frame) !void {
     if (element.is(Element.Html)) |html| {
         switch (html._type) {
-            inline .button, .input, .textarea, .select => |tag| {
-                if (html.subtype(Element.Html.Subtype(tag)).getDisabled()) {
-                    return;
-                }
-            },
+            .button, .input, .textarea, .select => if (element.isDisabled()) return,
             else => {},
         }
     }

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -394,7 +394,7 @@ pub fn insertAdjacentHTML(
 
 pub fn click(self: *HtmlElement, frame: *Frame) !void {
     switch (self._type) {
-        .button, .input, .textarea, .select => if (self.asElement().isDisabled()) return,
+        .button, .input, .textarea, .select, .option, .optgroup => if (self.asElement().isDisabled()) return,
         else => {},
     }
 

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -394,11 +394,7 @@ pub fn insertAdjacentHTML(
 
 pub fn click(self: *HtmlElement, frame: *Frame) !void {
     switch (self._type) {
-        inline .button, .input, .textarea, .select => |tag| {
-            if (self.subtype(Subtype(tag)).getDisabled()) {
-                return;
-            }
-        },
+        .button, .input, .textarea, .select => if (self.asElement().isDisabled()) return,
         else => {},
     }
 

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -145,7 +145,7 @@ pub fn setFormNoValidate(self: *Button, value: bool, frame: *Frame) !void {
 // are barred from constraint validation entirely.
 
 pub fn getWillValidate(self: *const Button) bool {
-    if (self.getDisabled()) return false;
+    if (self.asConstElement().isDisabled()) return false;
     return std.mem.eql(u8, self.getType(), "submit");
 }
 

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -207,7 +207,7 @@ pub fn getWillValidate(self: *const Input) bool {
     // - element has a datalist ancestor
     return switch (self._input_type) {
         .hidden, .button, .reset => false,
-        else => !self.getDisabled() and !self.hasDatalistAncestor(),
+        else => !self.asConstElement().isDisabled() and !self.hasDatalistAncestor(),
     };
 }
 
@@ -582,8 +582,6 @@ fn codepointCount(value: []const u8) usize {
 }
 
 pub fn getDisabled(self: *const Input) bool {
-    // TODO: Also check for disabled fieldset ancestors
-    // (but not if we're inside a <legend> of that fieldset)
     return self.asConstElement().getAttributeSafe(comptime .wrap("disabled")) != null;
 }
 

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -269,7 +269,7 @@ pub fn getLabels(self: *Select, frame: *Frame) !js.Array {
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 
 pub fn getWillValidate(self: *const Select) bool {
-    return !self.getDisabled();
+    return !self.asConstElement().isDisabled();
 }
 
 pub fn getValidity(self: *Select, frame: *Frame) !*ValidityState {

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -169,7 +169,7 @@ pub fn getLabels(self: *TextArea, frame: *Frame) !js.Array {
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
 
 pub fn getWillValidate(self: *const TextArea) bool {
-    return !self.getDisabled();
+    return !self.asConstElement().isDisabled();
 }
 
 pub fn getValidity(self: *TextArea, frame: *Frame) !*ValidityState {


### PR DESCRIPTION
`HTMLElement.click()`, `willValidate` (input/button/select/textarea) and the WebDriver click checked only the control's own `disabled` attribute, so controls inside `<fieldset disabled>` still activated and validated.

They now use `Element.isDisabled()`, the walk #2315 added for `:disabled` (fieldset ancestors, first-`<legend>` exception), which is now `*const`. The `disabled` IDL attribute is untouched: per spec it reflects only the element's own attribute.

Full suite: 1382/1382.