### PR TITLE
webapi: img.decode()

### DIFF
--- a/src/browser/tests/element/html/image.html
+++ b/src/browser/tests/element/html/image.html
@@ -170,3 +170,12 @@
     testing.expectEqual(testing.BASE_URL + 'element/html/over%209000!?hello=world%20!', img.src);
   }
 </script>
+
+<script id="decode" type=module>
+  const img = new Image();
+  const p = img.decode();
+  testing.expectEqual(true, p instanceof Promise);
+  testing.expectEqual(undefined, await p);
+  img.src = 'data:image/gif;base64,R0lGODlhAQABAAAAACw=';
+  testing.expectEqual(undefined, await img.decode());
+</script>

--- a/src/browser/webapi/element/html/Image.zig
+++ b/src/browser/webapi/element/html/Image.zig
@@ -82,6 +82,11 @@ pub fn getComplete(self: *const Image) bool {
     return self._complete;
 }
 
+/// Nothing is decoded here, so the image is always ready to insert.
+pub fn decode(_: *const Image, frame: *Frame) !js.Promise {
+    return frame.js.local.?.resolvePromise(js.Undefined{});
+}
+
 /// The one funnel for "this element's src became current": parser-created
 /// images, `img.src = ...` and `setAttribute`/`removeAttribute("src")` all
 /// land here.
@@ -147,6 +152,7 @@ pub const JsApi = struct {
     pub const naturalWidth = bridge.accessor(Image.getNaturalWidth, null, .{});
     pub const naturalHeight = bridge.accessor(Image.getNaturalHeight, null, .{});
     pub const complete = bridge.accessor(Image.getComplete, null, .{});
+    pub const decode = bridge.function(Image.decode, .{});
 };
 
 pub const Build = struct {


### PR DESCRIPTION
`img.decode()` was missing, so Next.js `<Image>` and React lazy-image paths threw `TypeError`. Nothing is decoded here, so it resolves with `undefined` right away. `naturalWidth`/`naturalHeight` stay 0 on purpose (`Image.zig` notes non-zero values would misrepresent the browser).