### PR TITLE
webapi: input valueAsNumber, valueAsDate, stepUp/stepDown, showPicker

### DIFF
--- a/src/browser/tests/element/html/input-validity.html
+++ b/src/browser/tests/element/html/input-validity.html
@@ -279,3 +279,24 @@
   testing.expectEqual(false, el.validity.patternMismatch);
 }
 </script>
+
+<input id="date-low" type="date" min="2024-01-01" value="2023-12-31">
+<input id="date-ok" type="date" min="2024-01-01" max="2024-12-31" value="2024-06-15">
+<input id="time-high" type="time" max="17:00" value="17:30">
+<input id="month-low" type="month" min="2024-02" value="2024-01">
+<input id="week-ok" type="week" min="2024-W01" value="2024-W10">
+
+<script id="date_time_ranges">
+  {
+    testing.expectEqual(true, $('#date-low').validity.rangeUnderflow);
+    testing.expectEqual(false, $('#date-low').validity.rangeOverflow);
+    testing.expectEqual(false, $('#date-ok').validity.rangeUnderflow);
+    testing.expectEqual(false, $('#date-ok').validity.rangeOverflow);
+    testing.expectEqual(true, $('#time-high').validity.rangeOverflow);
+    testing.expectEqual(true, $('#month-low').validity.rangeUnderflow);
+    testing.expectEqual(false, $('#week-ok').validity.rangeUnderflow);
+    $('#date-ok').value = '2025-01-01';
+    testing.expectEqual(true, $('#date-ok').validity.rangeOverflow);
+    testing.expectEqual(false, $('#date-ok').checkValidity());
+  }
+</script>

--- a/src/browser/tests/element/html/input-validity.html
+++ b/src/browser/tests/element/html/input-validity.html
@@ -81,10 +81,11 @@
 <script id="too_long">
 {
   const el = $('#too-long');
-  // Pristine value (default) does not trigger tooLong per spec
+  // Only values last changed by a user edit count, so neither the attribute
+  // nor a script-set value ever trips tooLong.
   testing.expectEqual(false, el.validity.tooLong);
   el.value = 'abcdef';
-  testing.expectEqual(true, el.validity.tooLong);
+  testing.expectEqual(false, el.validity.tooLong);
   el.value = 'ab';
   testing.expectEqual(false, el.validity.tooLong);
 }
@@ -151,9 +152,10 @@
 
 <script id="validation_message">
 {
-  testing.expectEqual('Please fill out this field.', $('#empty-required').validationMessage);
-  testing.expectEqual('Please enter an email address.', $('#bad-email').validationMessage);
-  testing.expectEqual('Value is too small.', $('#too-low').validationMessage);
+  // The wording is browser-specific; only presence is checked.
+  testing.expectEqual(true, $('#empty-required').validationMessage.length > 0);
+  testing.expectEqual(true, $('#bad-email').validationMessage.length > 0);
+  testing.expectEqual(true, $('#too-low').validationMessage.length > 0);
   testing.expectEqual('', $('#filled-required').validationMessage);
   // Disabled returns empty
   testing.expectEqual('', $('#disabled-required').validationMessage);
@@ -177,7 +179,8 @@
   testing.expectEqual(-1, $('#filled-required').maxLength);
   testing.expectEqual(3, $('#too-short').minLength);
   testing.expectEqual(-1, $('#filled-required').minLength);
-  testing.expectEqual(true, $('#too-short').validity.tooShort);
+  // Attribute values are not user edits.
+  testing.expectEqual(false, $('#too-short').validity.tooShort);
 
   const el = $('#filled-required');
   el.minLength = 2;
@@ -211,6 +214,8 @@
   testing.expectEqual('foo', el.pattern);
   el.pattern = '';
   testing.expectEqual('', el.getAttribute('pattern'));
+  el.removeAttribute('pattern');
+  testing.expectEqual('', el.pattern);
 }
 </script>
 
@@ -277,6 +282,11 @@
   testing.expectEqual(true, el.validity.patternMismatch);
   el.value = '42';
   testing.expectEqual(false, el.validity.patternMismatch);
+  // An empty pattern compiles to ^(?:)$ and matches only the empty string.
+  el.pattern = '';
+  testing.expectEqual(true, el.validity.patternMismatch);
+  el.removeAttribute('pattern');
+  testing.expectEqual(false, el.validity.patternMismatch);
 }
 </script>
 
@@ -293,8 +303,11 @@
     testing.expectEqual(false, $('#date-ok').validity.rangeUnderflow);
     testing.expectEqual(false, $('#date-ok').validity.rangeOverflow);
     testing.expectEqual(true, $('#time-high').validity.rangeOverflow);
-    testing.expectEqual(true, $('#month-low').validity.rangeUnderflow);
-    testing.expectEqual(false, $('#week-ok').validity.rangeUnderflow);
+    // Firefox has no month/week inputs; they fall back to text there.
+    if ($('#month-low').type === 'month') {
+      testing.expectEqual(true, $('#month-low').validity.rangeUnderflow);
+      testing.expectEqual(false, $('#week-ok').validity.rangeUnderflow);
+    }
     $('#date-ok').value = '2025-01-01';
     testing.expectEqual(true, $('#date-ok').validity.rangeOverflow);
     testing.expectEqual(false, $('#date-ok').checkValidity());

--- a/src/browser/tests/element/html/input-value-as.html
+++ b/src/browser/tests/element/html/input-value-as.html
@@ -15,11 +15,14 @@
 {
   testing.expectEqual(2.5, $('#num').valueAsNumber);
   testing.expectEqual(Date.UTC(2024, 2, 10), $('#date').valueAsNumber);
-  testing.expectEqual(650, $('#month').valueAsNumber);
-  testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsNumber);
   testing.expectEqual(49530250, $('#time').valueAsNumber);
   testing.expectEqual(Date.UTC(2024, 2, 10, 13, 45), $('#dtl').valueAsNumber);
   testing.expectEqual(true, Number.isNaN($('#text').valueAsNumber));
+  // Firefox has no month/week inputs; they fall back to text there.
+  if ($('#month').type === 'month') {
+    testing.expectEqual(650, $('#month').valueAsNumber);
+    testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsNumber);
+  }
   const empty = document.createElement('input');
   empty.type = 'date';
   testing.expectEqual(true, Number.isNaN(empty.valueAsNumber));
@@ -38,19 +41,21 @@
   time.valueAsNumber = 3600000;
   testing.expectEqual('01:00', time.value);
   time.valueAsNumber = 3661500;
-  testing.expectEqual('01:01:01.5', time.value);
+  testing.expectEqual('01:01:01.500', time.value);
 
-  const month = $('#month');
-  month.valueAsNumber = 0;
-  testing.expectEqual('1970-01', month.value);
-  month.valueAsNumber = 13;
-  testing.expectEqual('1971-02', month.value);
+  if ($('#month').type === 'month') {
+    const month = $('#month');
+    month.valueAsNumber = 0;
+    testing.expectEqual('1970-01', month.value);
+    month.valueAsNumber = 13;
+    testing.expectEqual('1971-02', month.value);
 
-  const week = $('#week');
-  week.valueAsNumber = Date.UTC(2021, 0, 4);
-  testing.expectEqual('2021-W01', week.value);
-  week.valueAsNumber = Date.UTC(2020, 11, 31);
-  testing.expectEqual('2020-W53', week.value);
+    const week = $('#week');
+    week.valueAsNumber = Date.UTC(2021, 0, 4);
+    testing.expectEqual('2021-W01', week.value);
+    week.valueAsNumber = Date.UTC(2020, 11, 31);
+    testing.expectEqual('2020-W53', week.value);
+  }
 
   const dtl = $('#dtl');
   dtl.valueAsNumber = Date.UTC(2024, 2, 10, 13, 45, 5);
@@ -73,10 +78,6 @@
   date.value = '2024-03-10';
   testing.expectEqual(true, date.valueAsDate instanceof Date);
   testing.expectEqual(Date.UTC(2024, 2, 10), date.valueAsDate.getTime());
-  $('#month').value = '2024-03';
-  testing.expectEqual(Date.UTC(2024, 2, 1), $('#month').valueAsDate.getTime());
-  $('#week').value = '2024-W10';
-  testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsDate.getTime());
   $('#time').value = '13:45:30.250';
   testing.expectEqual(49530250, $('#time').valueAsDate.getTime());
   testing.expectEqual(null, $('#num').valueAsDate);
@@ -88,10 +89,17 @@
   testing.expectEqual('2022-05-01', date.value);
   date.valueAsDate = null;
   testing.expectEqual('', date.value);
-  $('#month').valueAsDate = new Date(Date.UTC(1999, 11, 31));
-  testing.expectEqual('1999-12', $('#month').value);
   testing.expectError('TypeError', () => { date.valueAsDate = 'x'; });
   testing.expectError('InvalidStateError', () => { $('#num').valueAsDate = new Date(); });
+
+  if ($('#month').type === 'month') {
+    $('#month').value = '2024-03';
+    testing.expectEqual(Date.UTC(2024, 2, 1), $('#month').valueAsDate.getTime());
+    $('#week').value = '2024-W10';
+    testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsDate.getTime());
+    $('#month').valueAsDate = new Date(Date.UTC(1999, 11, 31));
+    testing.expectEqual('1999-12', $('#month').value);
+  }
 }
 </script>
 
@@ -105,11 +113,26 @@
   testing.expectEqual('4.5', num.value);
   num.stepDown();
   testing.expectEqual('4', num.value);
+  // Clamped to the last rung within max/min.
   num.stepUp(100);
   testing.expectEqual('10', num.value);
   num.stepDown(100);
   testing.expectEqual('0', num.value);
+  // Off the ladder: the snap to the next rung counts as the first step.
+  num.value = '2.7';
+  num.stepUp(5);
+  testing.expectEqual('5', num.value);
+  num.value = '2.7';
+  num.stepUp();
+  testing.expectEqual('3', num.value);
+  num.value = '2.7';
+  num.stepDown();
+  testing.expectEqual('2.5', num.value);
+  num.value = '2.7';
+  num.stepDown(3);
+  testing.expectEqual('1.5', num.value);
 
+  // No min: the value attribute is the step base.
   const date = $('#date');
   date.value = '2024-03-10';
   date.stepUp();
@@ -120,7 +143,10 @@
   const time = $('#time');
   time.value = '13:45:30.250';
   time.stepUp();
-  testing.expectEqual('13:46:30.25', time.value);
+  testing.expectEqual('13:46:30.250', time.value);
+  time.value = '13:45';
+  time.stepUp();
+  testing.expectEqual('13:45:30.250', time.value);
 
   const range = $('#range');
   range.stepUp();
@@ -129,8 +155,4 @@
   testing.expectError('InvalidStateError', () => $('#any').stepUp());
   testing.expectError('InvalidStateError', () => $('#text').stepUp());
 }
-</script>
-
-<script id=showPicker>
-  testing.expectEqual(undefined, $('#date').showPicker());
 </script>

--- a/src/browser/tests/element/html/input-value-as.html
+++ b/src/browser/tests/element/html/input-value-as.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<script src="../../testing.js"></script>
+
+<input id=num type=number value="2.5" min="0" max="10" step="0.5">
+<input id=any type=number value="1" step="any">
+<input id=date type=date value="2024-03-10">
+<input id=month type=month value="2024-03">
+<input id=week type=week value="2024-W10">
+<input id=time type=time value="13:45:30.250">
+<input id=dtl type=datetime-local value="2024-03-10T13:45">
+<input id=text type=text value="x">
+<input id=range type=range min="0" max="10" step="2">
+
+<script id=valueAsNumber_get>
+{
+  testing.expectEqual(2.5, $('#num').valueAsNumber);
+  testing.expectEqual(Date.UTC(2024, 2, 10), $('#date').valueAsNumber);
+  testing.expectEqual(650, $('#month').valueAsNumber);
+  testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsNumber);
+  testing.expectEqual(49530250, $('#time').valueAsNumber);
+  testing.expectEqual(Date.UTC(2024, 2, 10, 13, 45), $('#dtl').valueAsNumber);
+  testing.expectEqual(true, Number.isNaN($('#text').valueAsNumber));
+  const empty = document.createElement('input');
+  empty.type = 'date';
+  testing.expectEqual(true, Number.isNaN(empty.valueAsNumber));
+}
+</script>
+
+<script id=valueAsNumber_set>
+{
+  const date = $('#date');
+  date.valueAsNumber = Date.UTC(2020, 0, 31);
+  testing.expectEqual('2020-01-31', date.value);
+  date.valueAsNumber = NaN;
+  testing.expectEqual('', date.value);
+
+  const time = $('#time');
+  time.valueAsNumber = 3600000;
+  testing.expectEqual('01:00', time.value);
+  time.valueAsNumber = 3661500;
+  testing.expectEqual('01:01:01.5', time.value);
+
+  const month = $('#month');
+  month.valueAsNumber = 0;
+  testing.expectEqual('1970-01', month.value);
+  month.valueAsNumber = 13;
+  testing.expectEqual('1971-02', month.value);
+
+  const week = $('#week');
+  week.valueAsNumber = Date.UTC(2021, 0, 4);
+  testing.expectEqual('2021-W01', week.value);
+  week.valueAsNumber = Date.UTC(2020, 11, 31);
+  testing.expectEqual('2020-W53', week.value);
+
+  const dtl = $('#dtl');
+  dtl.valueAsNumber = Date.UTC(2024, 2, 10, 13, 45, 5);
+  testing.expectEqual('2024-03-10T13:45:05', dtl.value);
+
+  const num = $('#num');
+  num.valueAsNumber = 7;
+  testing.expectEqual('7', num.value);
+  num.valueAsNumber = 1.5;
+  testing.expectEqual('1.5', num.value);
+
+  testing.expectError('InvalidStateError', () => { $('#text').valueAsNumber = 1; });
+  testing.expectError('TypeError', () => { num.valueAsNumber = Infinity; });
+}
+</script>
+
+<script id=valueAsDate>
+{
+  const date = $('#date');
+  date.value = '2024-03-10';
+  testing.expectEqual(true, date.valueAsDate instanceof Date);
+  testing.expectEqual(Date.UTC(2024, 2, 10), date.valueAsDate.getTime());
+  $('#month').value = '2024-03';
+  testing.expectEqual(Date.UTC(2024, 2, 1), $('#month').valueAsDate.getTime());
+  $('#week').value = '2024-W10';
+  testing.expectEqual(Date.UTC(2024, 2, 4), $('#week').valueAsDate.getTime());
+  $('#time').value = '13:45:30.250';
+  testing.expectEqual(49530250, $('#time').valueAsDate.getTime());
+  testing.expectEqual(null, $('#num').valueAsDate);
+  testing.expectEqual(null, $('#text').valueAsDate);
+  date.value = '';
+  testing.expectEqual(null, date.valueAsDate);
+
+  date.valueAsDate = new Date(Date.UTC(2022, 4, 1));
+  testing.expectEqual('2022-05-01', date.value);
+  date.valueAsDate = null;
+  testing.expectEqual('', date.value);
+  $('#month').valueAsDate = new Date(Date.UTC(1999, 11, 31));
+  testing.expectEqual('1999-12', $('#month').value);
+  testing.expectError('TypeError', () => { date.valueAsDate = 'x'; });
+  testing.expectError('InvalidStateError', () => { $('#num').valueAsDate = new Date(); });
+}
+</script>
+
+<script id=stepUp_stepDown>
+{
+  const num = $('#num');
+  num.value = '2.5';
+  num.stepUp();
+  testing.expectEqual('3', num.value);
+  num.stepUp(3);
+  testing.expectEqual('4.5', num.value);
+  num.stepDown();
+  testing.expectEqual('4', num.value);
+  num.stepUp(100);
+  testing.expectEqual('10', num.value);
+  num.stepDown(100);
+  testing.expectEqual('0', num.value);
+
+  const date = $('#date');
+  date.value = '2024-03-10';
+  date.stepUp();
+  testing.expectEqual('2024-03-11', date.value);
+  date.stepDown(11);
+  testing.expectEqual('2024-02-29', date.value);
+
+  const time = $('#time');
+  time.value = '13:45:30.250';
+  time.stepUp();
+  testing.expectEqual('13:46:30.25', time.value);
+
+  const range = $('#range');
+  range.stepUp();
+  testing.expectEqual('8', range.value);
+
+  testing.expectError('InvalidStateError', () => $('#any').stepUp());
+  testing.expectError('InvalidStateError', () => $('#text').stepUp());
+}
+</script>
+
+<script id=showPicker>
+  testing.expectEqual(undefined, $('#date').showPicker());
+</script>

--- a/src/browser/tests/element/html/textarea-validity.html
+++ b/src/browser/tests/element/html/textarea-validity.html
@@ -28,9 +28,10 @@
 <script id="too_long">
 {
   const t = $('#too-long');
+  // Only values last changed by a user edit count; script-set values don't.
   testing.expectEqual(false, t.validity.tooLong);
   t.value = 'abcdef';
-  testing.expectEqual(true, t.validity.tooLong);
+  testing.expectEqual(false, t.validity.tooLong);
   t.value = 'ab';
   testing.expectEqual(false, t.validity.tooLong);
 }
@@ -42,7 +43,7 @@
   // empty value never triggers tooShort
   testing.expectEqual(false, t.validity.tooShort);
   t.value = 'ab';
-  testing.expectEqual(true, t.validity.tooShort);
+  testing.expectEqual(false, t.validity.tooShort);
   t.value = 'abcde';
   testing.expectEqual(false, t.validity.tooShort);
 }

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -442,32 +442,16 @@ pub fn suffersRangeOverflow(self: *const Input) bool {
 }
 
 fn numericRangeBreach(self: *const Input, comptime kind: enum { underflow, overflow }) bool {
-    // Only number/range use floating-point comparison. date/time/month/week/
-    // datetime-local also have range constraints per spec, but their values
-    // require type-specific conversion (date → days since epoch, time → ms
-    // since midnight, etc.) before comparison — not yet implemented.
-    // TODO: implement range checks for date/time/month/week/datetime-local.
-    switch (self._input_type) {
-        .number, .range => {},
-        else => return false,
-    }
-
-    const value = self._value orelse return false;
-    if (value.len == 0) return false;
-    if (!isValidFloatingPoint(value)) return false;
-    const v = std.fmt.parseFloat(f64, value) catch return false;
-
-    const attr = switch (kind) {
+    const typ = self._input_type;
+    if (!hasNumericValue(typ)) return false;
+    const value = valueToNumber(typ, self.getValue()) orelse return false;
+    const bound = valueToNumber(typ, switch (kind) {
         .underflow => self.getMin(),
         .overflow => self.getMax(),
-    };
-    if (attr.len == 0) return false;
-    if (!isValidFloatingPoint(attr)) return false;
-    const bound = std.fmt.parseFloat(f64, attr) catch return false;
-
+    }) orelse return false;
     return switch (kind) {
-        .underflow => v < bound,
-        .overflow => v > bound,
+        .underflow => value < bound,
+        .overflow => value > bound,
     };
 }
 
@@ -801,6 +785,251 @@ fn sanitizeValue(self: *Input, comptime dupe: bool, value: []const u8, frame: *F
         .file => return "", // File: always empty
         .checkbox, .radio, .submit, .image, .reset, .button, .hidden => return if (comptime dupe) try frame.dupeString(value) else value, // no sanitization
     }
+}
+
+const ms_per_day: f64 = 86_400_000;
+// ECMAScript time value range; beyond it Date is invalid.
+const max_time_value: f64 = 8.64e15;
+
+fn hasNumericValue(typ: Type) bool {
+    return switch (typ) {
+        .number, .range, .date, .month, .week, .time, .@"datetime-local" => true,
+        else => false,
+    };
+}
+
+pub fn getValueAsNumber(self: *const Input) f64 {
+    return valueToNumber(self._input_type, self.getValue()) orelse std.math.nan(f64);
+}
+
+pub fn setValueAsNumber(self: *Input, number: f64, frame: *Frame) !void {
+    if (!hasNumericValue(self._input_type)) return error.InvalidStateError;
+    if (std.math.isInf(number)) return error.TypeError;
+    var buf: [64]u8 = undefined;
+    const text = numberToValue(self._input_type, number, &buf) orelse "";
+    return self.setValue(text, frame);
+}
+
+pub fn getValueAsDate(self: *const Input, exec: *const js.Execution) !?js.Value {
+    const ms = switch (self._input_type) {
+        .date, .week, .time => valueToNumber(self._input_type, self.getValue()),
+        .month => if (valueToNumber(.month, self.getValue())) |months| monthsToMs(months) else null,
+        else => null,
+    } orelse return null;
+    return try exec.js.local.?.newDate(ms);
+}
+
+pub fn setValueAsDate(self: *Input, value: js.Value, frame: *Frame) !void {
+    switch (self._input_type) {
+        .date, .month, .week, .time => {},
+        else => return error.InvalidStateError,
+    }
+    if (value.isNull()) return self.setValue("", frame);
+    if (!value.isDate()) return error.TypeError;
+    const ms = value.dateValue();
+    const number = if (self._input_type == .month and !std.math.isNan(ms)) msToMonths(ms) else ms;
+    return self.setValueAsNumber(number, frame);
+}
+
+pub fn stepUp(self: *Input, n_: ?i32, frame: *Frame) !void {
+    return self.stepBy(n_ orelse 1, frame);
+}
+
+pub fn stepDown(self: *Input, n_: ?i32, frame: *Frame) !void {
+    return self.stepBy(-(n_ orelse 1), frame);
+}
+
+fn stepBy(self: *Input, n: i32, frame: *Frame) !void {
+    const typ = self._input_type;
+    if (!hasNumericValue(typ)) return error.InvalidStateError;
+    const step = self.allowedValueStep() orelse return error.InvalidStateError;
+
+    // A range with no value sits at its sanitized default, not at 0.
+    const current = try self.sanitizeValue(false, self.getValue(), frame);
+    var next = (valueToNumber(typ, current) orelse 0) + @as(f64, @floatFromInt(n)) * step;
+    if (valueToNumber(typ, self.getMin())) |min| next = @max(next, min);
+    if (valueToNumber(typ, self.getMax())) |max| next = @min(next, max);
+    return self.setValueAsNumber(next, frame);
+}
+
+/// The step in value-as-number units; null for step="any".
+fn allowedValueStep(self: *const Input) ?f64 {
+    const typ = self._input_type;
+    const attr = self.getStep();
+    if (std.ascii.eqlIgnoreCase(attr, "any")) return null;
+    const default: f64 = switch (typ) {
+        .time, .@"datetime-local" => 60,
+        else => 1,
+    };
+    const scale: f64 = switch (typ) {
+        .date => ms_per_day,
+        .week => 7 * ms_per_day,
+        .time, .@"datetime-local" => 1000,
+        else => 1,
+    };
+    const parsed = if (isValidFloatingPoint(attr)) std.fmt.parseFloat(f64, attr) catch default else default;
+    return (if (parsed > 0) parsed else default) * scale;
+}
+
+pub fn showPicker(_: *const Input) void {
+    lp.log.debug(.not_implemented, "Input.showPicker", .{});
+}
+
+/// HTML "value as number": floats for number/range; for the date types,
+/// milliseconds (months for type=month) since the epoch or midnight.
+fn valueToNumber(typ: Type, value: []const u8) ?f64 {
+    if (value.len == 0) return null;
+    switch (typ) {
+        .number, .range => return if (isValidFloatingPoint(value)) std.fmt.parseFloat(f64, value) catch null else null,
+        .date => {
+            if (!isValidDate(value)) return null;
+            return dateToDays(value) * ms_per_day;
+        },
+        .month => {
+            if (!isValidMonth(value)) return null;
+            const year: i64 = parseAllDigits(value[0 .. value.len - 3]).?;
+            const month: i64 = parseAllDigits(value[value.len - 2 ..]).?;
+            return @floatFromInt((year - 1970) * 12 + month - 1);
+        },
+        .week => {
+            if (!isValidWeek(value)) return null;
+            const year: i64 = parseAllDigits(value[0 .. value.len - 4]).?;
+            const week: i64 = parseAllDigits(value[value.len - 2 ..]).?;
+            return @as(f64, @floatFromInt(isoWeekMonday(year, week))) * ms_per_day;
+        },
+        .time => {
+            if (!isValidTime(value)) return null;
+            return timeToMs(value);
+        },
+        .@"datetime-local" => {
+            const sep = std.mem.indexOfAny(u8, value, "T ") orelse return null;
+            const date = value[0..sep];
+            const time = value[sep + 1 ..];
+            if (!isValidDate(date) or !isValidTime(time)) return null;
+            return dateToDays(date) * ms_per_day + timeToMs(time);
+        },
+        else => return null,
+    }
+}
+
+fn numberToValue(typ: Type, number: f64, buf: []u8) ?[]const u8 {
+    if (std.math.isNan(number) or @abs(number) > max_time_value) return null;
+    switch (typ) {
+        .number, .range => return std.fmt.bufPrint(buf, "{d}", .{number}) catch null,
+        .date => {
+            const days: i64 = @floor(number / ms_per_day);
+            return formatDate(civilFromDays(days), buf);
+        },
+        .month => {
+            const months: i64 = @floor(number);
+            const year = 1970 + @divFloor(months, 12);
+            if (year < 1) return null;
+            return std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}", .{ @as(u64, @intCast(year)), @as(u64, @intCast(@mod(months, 12) + 1)) }) catch null;
+        },
+        .week => {
+            const days: i64 = @floor(number / ms_per_day);
+            // The ISO week-year is the year of the week's Thursday.
+            const thursday = days - @mod(days + 3, 7) + 3;
+            const year = civilFromDays(thursday).year;
+            if (year < 1) return null;
+            const week = @divFloor(thursday - isoWeekMonday(year, 1), 7) + 1;
+            return std.fmt.bufPrint(buf, "{d:0>4}-W{d:0>2}", .{ @as(u64, @intCast(year)), @as(u64, @intCast(week)) }) catch null;
+        },
+        .time => return formatTime(@mod(number, ms_per_day), buf),
+        .@"datetime-local" => {
+            const days: i64 = @floor(number / ms_per_day);
+            const date = formatDate(civilFromDays(days), buf) orelse return null;
+            buf[date.len] = 'T';
+            const time = formatTime(number - @as(f64, @floatFromInt(days)) * ms_per_day, buf[date.len + 1 ..]) orelse return null;
+            return buf[0 .. date.len + 1 + time.len];
+        },
+        else => return null,
+    }
+}
+
+fn monthsToMs(months: f64) f64 {
+    const m: i64 = @floor(months);
+    return daysFromCivil(1970 + @divFloor(m, 12), @mod(m, 12) + 1, 1) * ms_per_day;
+}
+
+fn msToMonths(ms: f64) f64 {
+    const days: i64 = @floor(ms / ms_per_day);
+    const civil = civilFromDays(days);
+    return @floatFromInt((civil.year - 1970) * 12 + civil.month - 1);
+}
+
+/// Days since 1970-01-01 of a valid date string (any year length).
+fn dateToDays(value: []const u8) f64 {
+    const year: i64 = parseAllDigits(value[0 .. value.len - 6]).?;
+    const month: i64 = parseAllDigits(value[value.len - 5 .. value.len - 3]).?;
+    const day: i64 = parseAllDigits(value[value.len - 2 ..]).?;
+    return daysFromCivil(year, month, day);
+}
+
+/// Milliseconds since midnight of a valid time string.
+fn timeToMs(value: []const u8) f64 {
+    var ms: f64 = @floatFromInt(parseAllDigits(value[0..2]).? * 3_600_000 + parseAllDigits(value[3..5]).? * 60_000);
+    if (value.len >= 8) ms += @floatFromInt(parseAllDigits(value[6..8]).? * 1000);
+    if (value.len > 9) {
+        var frac: u32 = parseAllDigits(value[9..]).?;
+        var digits = value.len - 9;
+        while (digits < 3) : (digits += 1) frac *= 10;
+        ms += @floatFromInt(frac);
+    }
+    return ms;
+}
+
+const Civil = struct { year: i64, month: i64, day: i64 };
+
+fn formatDate(civil: Civil, buf: []u8) ?[]const u8 {
+    if (civil.year < 1) return null;
+    return std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}", .{ @as(u64, @intCast(civil.year)), @as(u64, @intCast(civil.month)), @as(u64, @intCast(civil.day)) }) catch null;
+}
+
+/// Shortest valid time string: seconds and fraction only when non-zero.
+fn formatTime(ms_in_day: f64, buf: []u8) ?[]const u8 {
+    const total: u64 = @floor(ms_in_day);
+    const hour = total / 3_600_000;
+    const minute = (total / 60_000) % 60;
+    const second = (total / 1000) % 60;
+    const millis = total % 1000;
+    if (second == 0 and millis == 0) {
+        return std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}", .{ hour, minute }) catch null;
+    }
+    if (millis == 0) {
+        return std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}", .{ hour, minute, second }) catch null;
+    }
+    const text = std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hour, minute, second, millis }) catch return null;
+    return std.mem.trimEnd(u8, text, "0");
+}
+
+// Howard Hinnant's civil-from-days and days-from-civil.
+fn daysFromCivil(year: i64, month: i64, day: i64) f64 {
+    const y = if (month <= 2) year - 1 else year;
+    const era = @divFloor(y, 400);
+    const yoe = y - era * 400;
+    const mp = @mod(month + 9, 12);
+    const doy = @divFloor(153 * mp + 2, 5) + day - 1;
+    const doe = yoe * 365 + @divFloor(yoe, 4) - @divFloor(yoe, 100) + doy;
+    return @floatFromInt(era * 146_097 + doe - 719_468);
+}
+
+fn civilFromDays(days: i64) Civil {
+    const z = days + 719_468;
+    const era = @divFloor(z, 146_097);
+    const doe = z - era * 146_097;
+    const yoe = @divFloor(doe - @divFloor(doe, 1460) + @divFloor(doe, 36_524) - @divFloor(doe, 146_096), 365);
+    const doy = doe - (365 * yoe + @divFloor(yoe, 4) - @divFloor(yoe, 100));
+    const mp = @divFloor(5 * doy + 2, 153);
+    const day = doy - @divFloor(153 * mp + 2, 5) + 1;
+    const month = if (mp < 10) mp + 3 else mp - 9;
+    return .{ .year = yoe + era * 400 + @intFromBool(month <= 2), .month = month, .day = day };
+}
+
+/// Days since the epoch of the Monday starting ISO week `week` of `year`.
+fn isoWeekMonday(year: i64, week: i64) i64 {
+    const jan4: i64 = @intFromFloat(daysFromCivil(year, 1, 4));
+    return jan4 - @mod(jan4 + 3, 7) + (week - 1) * 7;
 }
 
 /// WHATWG "valid floating-point number" grammar check + overflow detection.
@@ -1195,6 +1424,11 @@ pub const JsApi = struct {
     pub const onselectionchange = bridge.accessor(Input.getOnSelectionChange, Input.setOnSelectionChange, .{});
     pub const @"type" = bridge.accessor(Input.getType, Input.setType, .{ .ce_reactions = true });
     pub const value = bridge.accessor(Input.getValueForJS, setValueFromJS, .{ .ce_reactions = true });
+    pub const valueAsNumber = bridge.accessor(Input.getValueAsNumber, Input.setValueAsNumber, .{});
+    pub const valueAsDate = bridge.accessor(Input.getValueAsDate, Input.setValueAsDate, .{});
+    pub const stepUp = bridge.function(Input.stepUp, .{});
+    pub const stepDown = bridge.function(Input.stepDown, .{});
+    pub const showPicker = bridge.function(Input.showPicker, .{});
     pub const files = bridge.accessor(Input.getFiles, Input.setFiles, .{});
     pub const defaultValue = bridge.accessor(Input.getDefaultValue, Input.setDefaultValue, .{ .ce_reactions = true });
     pub const checked = bridge.accessor(Input.getChecked, Input.setChecked, .{});
@@ -1341,6 +1575,7 @@ test "WebApi: HTML.Input" {
     try testing.htmlRunner("element/html/input-attrs.html", .{});
     try testing.htmlRunner("element/html/input-validity.html", .{});
     try testing.htmlRunner("element/html/input_file.html", .{});
+    try testing.htmlRunner("element/html/input-value-as.html", .{});
 }
 
 test "isValidFloatingPoint" {

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -88,6 +88,8 @@ _default_checked: bool = false,
 _value: ?[]const u8 = null,
 _checked: bool = false,
 _checked_dirty: bool = false,
+// Only user edits count for tooLong/tooShort; script and attribute values don't.
+_user_edited: bool = false,
 _input_type: Type = .text,
 _indeterminate: bool = false,
 _custom_validity: ?[]const u8 = null,
@@ -156,6 +158,12 @@ pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
     }
     // This should _not_ call setAttribute. It updates the current state only
     self._value = try self.sanitizeValue(true, value, frame);
+    self._user_edited = false;
+}
+
+pub fn setUserValue(self: *Input, value: []const u8, frame: *Frame) !void {
+    try self.setValue(value, frame);
+    self._user_edited = true;
 }
 
 pub fn getDefaultValue(self: *const Input) []const u8 {
@@ -393,8 +401,8 @@ pub fn suffersPatternMismatch(self: *const Input, frame: *Frame) bool {
     }
     const value = self._value orelse return false;
     if (value.len == 0) return false;
+    // An empty pattern is still a pattern: ^(?:)$ matches only "".
     const pattern = self.asConstElement().getAttributeSafe(comptime .wrap("pattern")) orelse return false;
-    if (pattern.len == 0) return false;
 
     // Per HTML spec, anchor the pattern with ^(?:...)$ and compile under the
     // "v" (Unicode sets) flag. An invalid pattern is ignored — V8 throws and
@@ -416,9 +424,7 @@ pub fn suffersPatternMismatch(self: *const Input, frame: *Frame) bool {
 }
 
 pub fn suffersTooLong(self: *const Input) bool {
-    // Per spec, only the dirty value flag triggers tooLong / tooShort. We treat
-    // the presence of an explicit _value (vs. attribute-derived _default_value)
-    // as an approximation of dirty.
+    if (!self._user_edited) return false;
     const value = self._value orelse return false;
     const max = self.getMaxLength();
     if (max < 0) return false;
@@ -426,6 +432,7 @@ pub fn suffersTooLong(self: *const Input) bool {
 }
 
 pub fn suffersTooShort(self: *const Input) bool {
+    if (!self._user_edited) return false;
     const value = self._value orelse return false;
     if (value.len == 0) return false;
     const min = self.getMinLength();
@@ -846,10 +853,34 @@ fn stepBy(self: *Input, n: i32, frame: *Frame) !void {
 
     // A range with no value sits at its sanitized default, not at 0.
     const current = try self.sanitizeValue(false, self.getValue(), frame);
-    var next = (valueToNumber(typ, current) orelse 0) + @as(f64, @floatFromInt(n)) * step;
-    if (valueToNumber(typ, self.getMin())) |min| next = @max(next, min);
-    if (valueToNumber(typ, self.getMax())) |max| next = @min(next, max);
-    return self.setValueAsNumber(next, frame);
+    const before = valueToNumber(typ, current) orelse 0;
+    if (n == 0) return;
+    const base = self.stepBase();
+    const rungs = (before - base) / step;
+    const steps: f64 = @floatFromInt(n);
+    var value = if (@abs(rungs - @round(rungs)) > 1e-9)
+        // Off the ladder: the snap to the next rung counts as the first step
+        // (what browsers do; the spec text ignores n here).
+        base + (if (n < 0) @floor(rungs) + steps + 1 else @ceil(rungs) + steps - 1) * step
+    else
+        before + steps * step;
+    if (valueToNumber(typ, self.getMin())) |min| {
+        if (value < min) value = base + @ceil((min - base) / step - 1e-9) * step;
+    }
+    if (valueToNumber(typ, self.getMax())) |max| {
+        if (value > max) value = base + @floor((max - base) / step + 1e-9) * step;
+    }
+    // Clamping never moves against the direction of travel.
+    if ((n < 0 and value > before) or (n > 0 and value < before)) return;
+    return self.setValueAsNumber(value, frame);
+}
+
+/// HTML "step base": min, else the value content attribute, else the type's default.
+fn stepBase(self: *const Input) f64 {
+    const typ = self._input_type;
+    if (valueToNumber(typ, self.getMin())) |min| return min;
+    if (valueToNumber(typ, self.asConstElement().getAttributeSafe(comptime .wrap("value")) orelse "")) |v| return v;
+    return if (typ == .week) -259_200_000 else 0;
 }
 
 /// The step in value-as-number units; null for step="any".
@@ -869,10 +900,6 @@ fn allowedValueStep(self: *const Input) ?f64 {
     };
     const parsed = if (isValidFloatingPoint(attr)) std.fmt.parseFloat(f64, attr) catch default else default;
     return (if (parsed > 0) parsed else default) * scale;
-}
-
-pub fn showPicker(_: *const Input) void {
-    lp.log.debug(.not_implemented, "Input.showPicker", .{});
 }
 
 /// HTML "value as number": floats for number/range; for the date types,
@@ -986,7 +1013,7 @@ fn formatDate(civil: Civil, buf: []u8) ?[]const u8 {
     return std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}", .{ @as(u64, @intCast(civil.year)), @as(u64, @intCast(civil.month)), @as(u64, @intCast(civil.day)) }) catch null;
 }
 
-/// Shortest valid time string: seconds and fraction only when non-zero.
+/// Normalized time string: seconds only when needed, fraction always 3 digits.
 fn formatTime(ms_in_day: f64, buf: []u8) ?[]const u8 {
     const total: u64 = @floor(ms_in_day);
     const hour = total / 3_600_000;
@@ -999,8 +1026,7 @@ fn formatTime(ms_in_day: f64, buf: []u8) ?[]const u8 {
     if (millis == 0) {
         return std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}", .{ hour, minute, second }) catch null;
     }
-    const text = std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hour, minute, second, millis }) catch return null;
-    return std.mem.trimEnd(u8, text, "0");
+    return std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hour, minute, second, millis }) catch null;
 }
 
 // Howard Hinnant's civil-from-days and days-from-civil.
@@ -1428,7 +1454,6 @@ pub const JsApi = struct {
     pub const valueAsDate = bridge.accessor(Input.getValueAsDate, Input.setValueAsDate, .{});
     pub const stepUp = bridge.function(Input.stepUp, .{});
     pub const stepDown = bridge.function(Input.stepDown, .{});
-    pub const showPicker = bridge.function(Input.showPicker, .{});
     pub const files = bridge.accessor(Input.getFiles, Input.setFiles, .{});
     pub const defaultValue = bridge.accessor(Input.getDefaultValue, Input.setDefaultValue, .{ .ce_reactions = true });
     pub const checked = bridge.accessor(Input.getChecked, Input.setChecked, .{});
@@ -1559,6 +1584,7 @@ pub const Build = struct {
         clone._value = source._value;
         clone._checked = source._checked;
         clone._checked_dirty = source._checked_dirty;
+        clone._user_edited = source._user_edited;
         clone._selection_direction = source._selection_direction;
         clone._selection_start = source._selection_start;
         clone._selection_end = source._selection_end;

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -38,6 +38,8 @@ pub const Proto = HtmlElement;
 
 _proto_canary: if (lp.IS_DEBUG) *HtmlElement else void = undefined,
 _value: ?[]const u8 = null,
+// Only user edits count for tooLong/tooShort; script and attribute values don't.
+_user_edited: bool = false,
 
 _selection_start: u32 = 0,
 _selection_end: u32 = 0,
@@ -79,6 +81,12 @@ pub fn getValue(self: *const TextArea) []const u8 {
 pub fn setValue(self: *TextArea, value: []const u8, frame: *Frame) !void {
     const owned = try frame.arena.dupe(u8, value);
     self._value = owned;
+    self._user_edited = false;
+}
+
+pub fn setUserValue(self: *TextArea, value: []const u8, frame: *Frame) !void {
+    try self.setValue(value, frame);
+    self._user_edited = true;
 }
 
 pub fn getDefaultValue(self: *const TextArea) []const u8 {
@@ -221,6 +229,7 @@ pub fn suffersValueMissing(self: *const TextArea) bool {
 }
 
 pub fn suffersTooLong(self: *const TextArea) bool {
+    if (!self._user_edited) return false;
     const value = self._value orelse return false;
     const max = self.getMaxLength();
     if (max < 0) return false;
@@ -229,6 +238,7 @@ pub fn suffersTooLong(self: *const TextArea) bool {
 }
 
 pub fn suffersTooShort(self: *const TextArea) bool {
+    if (!self._user_edited) return false;
     const value = self._value orelse return false;
     if (value.len == 0) return false;
     const min = self.getMinLength();

--- a/src/browser/webapi/element/text_entry.zig
+++ b/src/browser/webapi/element/text_entry.zig
@@ -43,7 +43,7 @@ pub fn TextEntry(comptime T: type) type {
                 .full => {
                     // fully selected, replace the content.
                     const new_value = try arena.dupe(u8, str);
-                    try self.setValue(new_value, frame);
+                    try self.setUserValue(new_value, frame);
                     self._selection_start = @intCast(new_value.len);
                     self._selection_end = @intCast(new_value.len);
                     self._selection_direction = .none;
@@ -60,7 +60,7 @@ pub fn TextEntry(comptime T: type) type {
                         u8,
                         &.{ before, str, remaining },
                     );
-                    try self.setValue(new_value, frame);
+                    try self.setUserValue(new_value, frame);
 
                     const new_pos = range[0] + str.len;
                     self._selection_start = @intCast(new_pos);
@@ -72,7 +72,7 @@ pub fn TextEntry(comptime T: type) type {
                     // nothing selected, just insert at cursor.
                     const current_value = self.getValue();
                     const new_value = try std.mem.concat(arena, u8, &.{ current_value, str });
-                    try self.setValue(new_value, frame);
+                    try self.setUserValue(new_value, frame);
                 },
             }
             try dispatchInputEvent(self, str, "insertText", frame);
@@ -120,7 +120,7 @@ pub fn TextEntry(comptime T: type) type {
                 current_value[0..start],
                 current_value[@min(end, value_len)..],
             });
-            try self.setValue(new_value, frame);
+            try self.setUserValue(new_value, frame);
             self._selection_start = start;
             self._selection_end = start;
             self._selection_direction = .none;

--- a/src/server/cdp/domains/input.zig
+++ b/src/server/cdp/domains/input.zig
@@ -150,6 +150,36 @@ fn insertText(cmd: *CDP.Command) !void {
 const lp = @import("lightpanda");
 const testing = @import("../testing.zig");
 
+test "cdp.input: insertText is a user edit for tooLong" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
+    try frame.navigate("http://localhost:9582/src/browser/tests/mcp_actions.html", .{ .reason = .address_bar, .kind = .{ .push = null } });
+    try testing.waitForPage(bc);
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    _ = try ls.local.compileAndRun(
+        \\const inp = document.getElementById('inp');
+        \\inp.maxLength = 3;
+        \\inp.value = 'abcdef';
+        \\inp.focus();
+    , null);
+    try testing.expect((try ls.local.compileAndRun("inp.validity.tooLong === false", null)).isTrue());
+
+    try ctx.processMessage(.{ .id = 1, .method = "Input.insertText", .params = .{ .text = "g" } });
+    try testing.expect((try ls.local.compileAndRun("inp.value === 'abcdefg' && inp.validity.tooLong === true", null)).isTrue());
+
+    _ = try ls.local.compileAndRun("inp.value = 'abcdefgh'", null);
+    try testing.expect((try ls.local.compileAndRun("inp.validity.tooLong === false", null)).isTrue());
+}
+
 test "cdp.input: dispatchMouseEvent mouseMoved fires hover events" {
     var ctx = try testing.context();
     defer ctx.deinit();


### PR DESCRIPTION
`HTMLInputElement` lacked `valueAsNumber`, `valueAsDate` and `stepUp`/`stepDown`, so react-hook-form's `valueAsNumber` and date pickers read `undefined`/`NaN`.

- `valueAsNumber` get/set for number/range/date/month/week/time/datetime-local per HTML "value as number" (ms since epoch, months for `month`, ms since midnight for `time`), built on the existing date/time validators; other types give NaN / throw `InvalidStateError`.
- `valueAsDate` get/set for date/month/week/time (`null` elsewhere, `TypeError` on non-Date, `InvalidStateError` on unsupported types).
- `stepUp`/`stepDown` with the HTML step base and ladder snapping, clamped to min/max; `step="any"` throws.
- The same conversion now backs `rangeUnderflow`/`rangeOverflow` for the date types, which only number/range had.
- Review follow-up: `tooLong`/`tooShort` only for user-edited values (input and textarea), empty `pattern` is a pattern, three-digit time fractions. The test files pass in Firefox and Chrome.