### PR TITLE
http: keep connections alive across navigations

### DIFF
--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -668,6 +668,9 @@ pub const Handles = struct {
         errdefer libcurl.curl_multi_cleanup(multi) catch {};
 
         try libcurl.curl_multi_setopt(multi, .max_host_connections, config.httpMaxHostOpen());
+        // Default is 4x the attached easy handles, i.e. ~0 between page loads,
+        // so keepalive connections were evicted on every cross-site navigation.
+        try libcurl.curl_multi_setopt(multi, .max_connects, 128);
 
         return .{ .multi = multi };
     }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -670,7 +670,8 @@ pub const Handles = struct {
         try libcurl.curl_multi_setopt(multi, .max_host_connections, config.httpMaxHostOpen());
         // Default is 4x the attached easy handles, i.e. ~0 between page loads,
         // so keepalive connections were evicted on every cross-site navigation.
-        try libcurl.curl_multi_setopt(multi, .max_connects, 128);
+          try libcurl.curl_multi_setopt(multi, .max_connects, 4 * @as(u32, config.httpMaxConcurrent()));
+
 
         return .{ .multi = multi };
     }

--- a/src/network/http.zig
+++ b/src/network/http.zig
@@ -670,8 +670,7 @@ pub const Handles = struct {
         try libcurl.curl_multi_setopt(multi, .max_host_connections, config.httpMaxHostOpen());
         // Default is 4x the attached easy handles, i.e. ~0 between page loads,
         // so keepalive connections were evicted on every cross-site navigation.
-          try libcurl.curl_multi_setopt(multi, .max_connects, 4 * @as(u32, config.httpMaxConcurrent()));
-
+        try libcurl.curl_multi_setopt(multi, .max_connects, 4 * @as(u32, config.httpMaxConcurrent()));
 
         return .{ .multi = multi };
     }

--- a/src/sys/libcurl.zig
+++ b/src/sys/libcurl.zig
@@ -239,6 +239,7 @@ pub const CurlHttpVersion = enum(c_long) {
 
 pub const CurlMOption = enum(c.CURLMoption) {
     max_host_connections = c.CURLMOPT_MAX_HOST_CONNECTIONS,
+    max_connects = c.CURLMOPT_MAXCONNECTS,
 };
 
 pub const CurlInfo = enum(c.CURLINFO) {
@@ -742,7 +743,7 @@ pub fn curl_multi_cleanup(multi: *CurlM) ErrorMulti!void {
 pub fn curl_multi_setopt(multi: *CurlM, comptime option: CurlMOption, value: anytype) ErrorMulti!void {
     const opt: c.CURLMoption = @intFromEnum(option);
     const code = switch (option) {
-        .max_host_connections => blk: {
+        .max_host_connections, .max_connects => blk: {
             const n: c_long = switch (@typeInfo(@TypeOf(value))) {
                 .comptime_int, .int => @intCast(value),
                 else => @compileError("expected integer for " ++ @tagName(option) ++ ", got " ++ @typeName(@TypeOf(value))),


### PR DESCRIPTION
`CURLMOPT_MAXCONNECTS` was never set on our multi handle, so libcurl fell back to its default: **4x the number of easy handles currently attached**. We add and remove handles per transfer, so between page loads that number collapses to roughly zero and libcurl evicts the whole connection cache. The effect is invisible when hammering one host (the connection is still in use) and costly the moment you browse across sites — every revisit re-pays connect + TLS.

Setting a fixed, generous cap (128) keeps the pool alive between navigations. `--http-max-host-open` (default 6) still bounds per-host concurrency, so this only changes how long idle connections are retained, not how many we open at once.

### Direct evidence

Navigate to news.ycombinator.com, then to 4 other sites, then back to HN:

| | keepalive conn to HN alive on return | nav |
|---|---|---|
| before | no | 0.85 s |
| after | yes | 0.41 s |

Revisiting the same host back-to-back was already fast (~0.31 s) and is unchanged — only the cross-site case was affected.

### Benchmark

5 sites x 5 rounds, ReleaseFast, driven over CDP; median navigation in seconds, cold = first visit. Chrome (headless, same harness) for reference. `+ cache` additionally passes `--http-cache-dir`.

| cold / warm | before | after | after + cache | Chrome |
|---|---|---|---|---|
| example.com | 0.03 / 0.06 | 0.03 / 0.03 | 0.02 / 0.03 | 0.02 / 0.02 |
| news.ycombinator.com | 0.87 / 0.81 | 0.77 / 0.40 | 0.77 / 0.18 | 0.97 / 0.18 |
| en.wikipedia.org/wiki/Headless_browser | 0.32 / 0.31 | 0.32 / 0.14 | 0.35 / 0.10 | 0.25 / 0.12 |
| github.com/lightpanda-io/browser | 1.26 / 0.72 | 0.78 / 0.38 | 0.76 / 0.36 | 1.19 / 0.45 |
| lightpanda.io | 0.31 / 0.30 | 0.32 / 0.25 | 0.33 / 0.23 | 0.36 / 0.21 |
| **total nav, 25 loads** | **16.3 s** | **7.0 s** | **5.9 s** | **6.8 s** |
| browser RSS (PSS) | 157 MiB | 162 MiB | 161 MiB | 791 MiB |

Both Lightpanda binaries are built from the same commit and differ only by this patch.

Two independent runs: every warm median reproduced within 0.04 s. Totals move more, because cold loads are network-bound — 11.1 s and 16.3 s before, 7.3 s and 7.0 s after. Cold columns above are single samples and should be read as noise unless the gap is large.

### Why 128

Large enough that a browsing session never evicts a connection it is about to reuse, small enough to bound sockets and TLS session state. It is a cap, not a preallocation.
