### PR TITLE
stability: disconnect runaway intersection observers

### DIFF
--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -341,14 +341,11 @@ fn disconnectRunawayIntersectionObservers(frame: *Frame) void {
         log.err(.frame, "frame.IntersectionRunaway", .{ .type = frame._type, .url = frame.url });
     }
 
-    var i = frame._intersection.observers.items.len;
-    while (i > 0) {
-        i -= 1;
-        if (i >= frame._intersection.observers.items.len) {
-            continue;
-        }
-        frame._intersection.observers.items[i].disconnect(frame);
+    for (frame._intersection.observers.items) |observer| {
+        observer.reset(frame._page);
+        observer.releaseRef(frame._page);
     }
+    frame._intersection.observers.clearRetainingCapacity();
 }
 
 pub fn deliverIntersections(frame: *Frame) void {

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -58,9 +58,12 @@ pub const Intersection = struct {
     check_scheduled: bool = false,
     delivery_scheduled: bool = false,
 
-    // Delivery sessions run against this document. Reset per navigation, since
-    // Frame.init re-initializes the whole struct.
-    deliveries: u32 = 0,
+    // Deliveries closer together than INTERSECTION_QUIET_MS form one burst.
+    // Frame.init re-initializes the whole struct, so a navigation starts fresh.
+    burst_start_ms: u64 = 0,
+    last_delivery_ms: u64 = 0,
+    burst_deliveries: u32 = 0,
+    runaway: bool = false,
 };
 
 // ResizeObserver bookkeeping for a frame.
@@ -306,22 +309,35 @@ pub fn performScheduledIntersectionChecks(frame: *Frame) void {
     };
 }
 
-// An element is reported at most once (IntersectionObserver._tracked), so
-// bounded observation means bounded deliveries: measured over a static page, an
-// ad-heavy news hub and a storefront, no document needed more than 7 sessions.
-// A page that observes a fresh sentinel from inside its own callback never
-// settles, because we report every attached element as fully visible and its
-// replacement sentinel therefore intersects immediately. Observed: a storefront
-// paginating itself to page 10 over 68 sessions, exhausting the timer table
-// until the watchdog killed the navigation.
-const INTERSECTION_RUNAWAY_LIMIT = 32;
+// We report every attached element as fully visible, so a page that observes a
+// fresh sentinel from inside its own callback never settles: the replacement
+// intersects the moment it is attached. Observed on a storefront paginating
+// itself past page 18 at ~30 deliveries/s until the watchdog killed the page.
+//
+// A delivery count cannot separate this from a busy but healthy page: airbnb
+// legitimately needs up to ~50 deliveries per load, and the runaway had already
+// exhausted the timer table by ~70. Duration does separate them. Healthy pages
+// go quiet within 5s of their first delivery; the runaway never does. Bursts
+// are measured from their own start rather than from page load so that lazy
+// loading triggered minutes later, by a scroll or a click, is not penalized.
+// Gaps inside a healthy burst stayed under 800ms; the runaway paused once for
+// 1.1s on a network stall.
+//
+// A chain that re-observes synchronously never leaves the microtask checkpoint,
+// so the clock alone would let it spin for the full limit. The per-burst count
+// exists for that case only; at 20x the busiest healthy page it is not a tuning
+// knob.
+pub const INTERSECTION_RUNAWAY_MS = 10_000;
+pub const INTERSECTION_QUIET_MS = 2_000;
+pub const INTERSECTION_BURST_LIMIT = 1024;
 
 // No observer on the frame can make progress once this path is reached.
 fn disconnectRunawayIntersectionObservers(frame: *Frame) void {
     // The page can keep creating observers after the disconnect (a framework
     // re-mounting its lazy loader will), and each one trips this path again, so
     // only the crossing itself is logged.
-    if (frame._intersection.deliveries == INTERSECTION_RUNAWAY_LIMIT + 1) {
+    if (!frame._intersection.runaway) {
+        frame._intersection.runaway = true;
         log.err(.frame, "frame.IntersectionRunaway", .{ .type = frame._type, .url = frame.url });
     }
 
@@ -341,8 +357,17 @@ pub fn deliverIntersections(frame: *Frame) void {
     }
     frame._intersection.delivery_scheduled = false;
 
-    frame._intersection.deliveries += 1;
-    if (frame._intersection.deliveries > INTERSECTION_RUNAWAY_LIMIT) {
+    const now = lp.datetime.milliTimestamp(.boot);
+    if (now - frame._intersection.last_delivery_ms > INTERSECTION_QUIET_MS) {
+        frame._intersection.burst_start_ms = now;
+        frame._intersection.burst_deliveries = 0;
+        frame._intersection.runaway = false;
+    }
+    frame._intersection.last_delivery_ms = now;
+    frame._intersection.burst_deliveries += 1;
+
+    const too_long = now - frame._intersection.burst_start_ms > INTERSECTION_RUNAWAY_MS;
+    if (too_long or frame._intersection.burst_deliveries > INTERSECTION_BURST_LIMIT) {
         disconnectRunawayIntersectionObservers(frame);
         return;
     }

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -57,6 +57,10 @@ pub const Intersection = struct {
     observers: std.ArrayList(*IntersectionObserver) = .empty,
     check_scheduled: bool = false,
     delivery_scheduled: bool = false,
+
+    // Delivery sessions run against this document. Reset per navigation, since
+    // Frame.init re-initializes the whole struct.
+    deliveries: u32 = 0,
 };
 
 // ResizeObserver bookkeeping for a frame.
@@ -129,6 +133,10 @@ pub fn unregisterResizeObserver(frame: *Frame, observer: *ResizeObserver) void {
 
 pub fn hasMutationObservers(frame: *const Frame) bool {
     return frame._mutation.observers.first != null;
+}
+
+pub fn hasIntersectionObservers(frame: *const Frame) bool {
+    return frame._intersection.observers.items.len > 0;
 }
 
 pub fn checkIntersections(frame: *Frame) !void {
@@ -298,11 +306,46 @@ pub fn performScheduledIntersectionChecks(frame: *Frame) void {
     };
 }
 
+// An element is reported at most once (IntersectionObserver._tracked), so
+// bounded observation means bounded deliveries: measured over a static page, an
+// ad-heavy news hub and a storefront, no document needed more than 7 sessions.
+// A page that observes a fresh sentinel from inside its own callback never
+// settles, because we report every attached element as fully visible and its
+// replacement sentinel therefore intersects immediately. Observed: a storefront
+// paginating itself to page 10 over 68 sessions, exhausting the timer table
+// until the watchdog killed the navigation.
+const INTERSECTION_RUNAWAY_LIMIT = 32;
+
+// No observer on the frame can make progress once this path is reached.
+fn disconnectRunawayIntersectionObservers(frame: *Frame) void {
+    // The page can keep creating observers after the disconnect (a framework
+    // re-mounting its lazy loader will), and each one trips this path again, so
+    // only the crossing itself is logged.
+    if (frame._intersection.deliveries == INTERSECTION_RUNAWAY_LIMIT + 1) {
+        log.err(.frame, "frame.IntersectionRunaway", .{ .type = frame._type, .url = frame.url });
+    }
+
+    var i = frame._intersection.observers.items.len;
+    while (i > 0) {
+        i -= 1;
+        if (i >= frame._intersection.observers.items.len) {
+            continue;
+        }
+        frame._intersection.observers.items[i].disconnect(frame);
+    }
+}
+
 pub fn deliverIntersections(frame: *Frame) void {
     if (!frame._intersection.delivery_scheduled) {
         return;
     }
     frame._intersection.delivery_scheduled = false;
+
+    frame._intersection.deliveries += 1;
+    if (frame._intersection.deliveries > INTERSECTION_RUNAWAY_LIMIT) {
+        disconnectRunawayIntersectionObservers(frame);
+        return;
+    }
 
     // Iterate backwards so an observer disconnecting during its callback is safe.
     var i = frame._intersection.observers.items.len;

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -172,17 +172,22 @@ pub fn unobserve(self: *IntersectionObserver, target: *Element, frame: *Frame) v
     }
 }
 
-pub fn disconnect(self: *IntersectionObserver, frame: *Frame) void {
+// Drops every observation without touching the frame's observer list
+pub fn reset(self: *IntersectionObserver, page: *Page) void {
     for (self._pending_entries.items) |entry| {
-        entry.deinit(frame._page);
+        entry.deinit(page);
     }
     self._pending_entries.clearRetainingCapacity();
     self._tracked.clearRetainingCapacity();
+    self._observing.clearRetainingCapacity();
+}
 
-    if (self._observing.items.len > 0) {
+pub fn disconnect(self: *IntersectionObserver, frame: *Frame) void {
+    const registered = self._observing.items.len > 0;
+    self.reset(frame._page);
+    if (registered) {
         Frame.observers.unregisterIntersectionObserver(frame, self);
     }
-    self._observing.clearRetainingCapacity();
 }
 
 pub fn takeRecords(self: *IntersectionObserver, frame: *Frame) ![]*IntersectionObserverEntry {

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -402,6 +402,42 @@ pub const JsApi = struct {
 };
 
 const testing = @import("../../testing.zig");
+
+test "WebApi: runaway IntersectionObserver delivery is disconnected" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    // Infinite scroll: the callback observes a fresh sentinel, which we report
+    // as intersecting the moment it is attached, so the page never settles.
+    try ls.local.eval(
+        \\(function() {
+        \\  const list = document.createElement('div');
+        \\  const io = new IntersectionObserver((entries) => {
+        \\    for (const entry of entries) {
+        \\      if (!entry.isIntersecting) continue;
+        \\      io.unobserve(entry.target);
+        \\      io.observe(list.appendChild(document.createElement('div')));
+        \\    }
+        \\  });
+        \\  io.observe(list.appendChild(document.createElement('div')));
+        \\})()
+    , null);
+
+    for (0..200) |_| {
+        frame.js.env.runMicrotasks();
+        try frame.js.env.runMacrotasks();
+        if (!Frame.observers.hasIntersectionObservers(frame)) break;
+    }
+
+    try testing.expectEqual(false, Frame.observers.hasIntersectionObservers(frame));
+}
+
 test "WebApi: IntersectionObserver" {
     try testing.htmlRunner("intersection_observer", .{});
 }

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -403,39 +403,98 @@ pub const JsApi = struct {
 
 const testing = @import("../../testing.zig");
 
-test "WebApi: runaway IntersectionObserver delivery is disconnected" {
+// Infinite scroll: the callback observes a fresh sentinel, which we report as
+// intersecting the moment it is attached, so the page never settles on its own.
+// Old sentinels stay observed (_tracked keeps them from re-firing) so that the
+// observer stays registered on the frame for as long as it is alive. `deferred`
+// re-observes from a timer, one delivery per macrotask tick, the way a
+// fetch-driven pager behaves; otherwise the chain never leaves the microtask
+// checkpoint.
+fn observeSentinelChain(frame: *Frame, comptime deferred: bool) !void {
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    try ls.local.eval(
+        \\(function(deferred) {
+        \\  const list = document.createElement('div');
+        \\  const observe = () => io.observe(list.appendChild(document.createElement('div')));
+        \\  const io = new IntersectionObserver((entries) => {
+        \\    for (const entry of entries) {
+        \\      if (!entry.isIntersecting) continue;
+        \\      if (deferred) setTimeout(observe, 0); else observe();
+        \\    }
+        \\  });
+        \\  observe();
+        \\})(
+    ++ (if (deferred) "true" else "false") ++ ")", null);
+
+    frame.js.env.runMicrotasks();
+    try frame.js.env.runMacrotasks();
+    try testing.expect(frame._intersection.last_delivery_ms != 0);
+}
+
+// Nested zero-delay timers are clamped to 4ms past a nesting depth of five, so
+// a yielding chain needs real time to pass between ticks.
+fn tick(frame: *Frame) !void {
+    lp.io.sleep(.fromMilliseconds(5), .awake) catch {};
+    frame.js.env.runMicrotasks();
+    try frame.js.env.runMacrotasks();
+}
+
+fn tickUntilDisconnected(frame: *Frame) !void {
+    for (0..200) |_| {
+        try tick(frame);
+        if (!Frame.observers.hasIntersectionObservers(frame)) break;
+    }
+}
+
+test "WebApi: synchronous IntersectionObserver chain is disconnected" {
     testing.silenceLog(&.{.frame});
 
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();
 
-    var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
-    defer ls.deinit();
-
-    // Infinite scroll: the callback observes a fresh sentinel, which we report
-    // as intersecting the moment it is attached, so the page never settles.
-    try ls.local.eval(
-        \\(function() {
-        \\  const list = document.createElement('div');
-        \\  const io = new IntersectionObserver((entries) => {
-        \\    for (const entry of entries) {
-        \\      if (!entry.isIntersecting) continue;
-        \\      io.unobserve(entry.target);
-        \\      io.observe(list.appendChild(document.createElement('div')));
-        \\    }
-        \\  });
-        \\  io.observe(list.appendChild(document.createElement('div')));
-        \\})()
-    , null);
-
-    for (0..200) |_| {
-        frame.js.env.runMicrotasks();
-        try frame.js.env.runMacrotasks();
-        if (!Frame.observers.hasIntersectionObservers(frame)) break;
-    }
+    try observeSentinelChain(frame, false);
+    try tickUntilDisconnected(frame);
 
     try testing.expectEqual(false, Frame.observers.hasIntersectionObservers(frame));
+    try testing.expectEqual(true, frame._intersection.runaway);
+    try testing.expect(frame._intersection.burst_deliveries > Frame.observers.INTERSECTION_BURST_LIMIT);
+}
+
+test "WebApi: IntersectionObserver burst older than the limit is disconnected" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    try observeSentinelChain(frame, true);
+    frame._intersection.burst_start_ms -|= Frame.observers.INTERSECTION_RUNAWAY_MS + 1;
+    try tickUntilDisconnected(frame);
+
+    try testing.expectEqual(false, Frame.observers.hasIntersectionObservers(frame));
+    try testing.expectEqual(true, frame._intersection.runaway);
+    try testing.expect(frame._intersection.burst_deliveries <= Frame.observers.INTERSECTION_BURST_LIMIT);
+}
+
+test "WebApi: IntersectionObserver delivery after a quiet gap starts a new burst" {
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    try observeSentinelChain(frame, true);
+
+    // An old burst that went quiet: its age must not count against what follows.
+    frame._intersection.burst_start_ms -|= Frame.observers.INTERSECTION_RUNAWAY_MS + 1;
+    frame._intersection.last_delivery_ms -|= Frame.observers.INTERSECTION_QUIET_MS + 1;
+    const stale_start = frame._intersection.burst_start_ms;
+
+    try tick(frame);
+
+    try testing.expectEqual(true, Frame.observers.hasIntersectionObservers(frame));
+    try testing.expectEqual(false, frame._intersection.runaway);
+    try testing.expectEqual(1, frame._intersection.burst_deliveries);
+    try testing.expect(frame._intersection.burst_start_ms > stale_start);
 }
 
 test "WebApi: IntersectionObserver" {


### PR DESCRIPTION
## The problem

Without layout we report every attached element as fully visible ([`IntersectionObserver.zig`](https://github.com/lightpanda-io/browser/blob/main/src/browser/webapi/IntersectionObserver.zig) `calculateIntersection`):

```zig
// For a headless browser without real layout, we treat all elements as fully visible.
const intersection_ratio: f64 = if (has_parent) 1.0 else 0.0;
```

That is the right default — the alternative uses `calculateDocumentPosition`'s faux position (preceding-node-count × 5px), which against a 768px viewport would call everything past ~150 nodes invisible and break lazy loading across the board.

Infinite scroll turns it into a loop that never terminates. The page observes a sentinel, we report it intersecting the moment it is attached, the callback loads the next page and observes a *fresh* sentinel, and there is nothing to stop it. `_tracked` already prevents a static element from re-firing, so only this observe-a-new-element pattern gets through, and the chain is async (fetch → render → observe), so the existing depth-style guards would not see it either.

## What it does in production

On a live storefront (`eu.gymshark.com`), roughly **one navigation in seven**: the collection page paginated itself to `?page=10` over **68 delivery sessions** and ~94 requests, exhausted the timer table (`error.TooManyTimeout`), threw a framework client-side exception, and then hung until the watchdog killed it:

```
$scope=frame $level=error $msg="frame.deliverMutations" err=JsException url=.../mens?page=9
$scope=app   $level=error $msg="watchdog stall" stalled_ms=30633
Error: navigation timed out
```

Reproduced offline, deterministically, with a 22-line page that appends a new sentinel per intersection: **50 of 50 pages loaded in a single `goto`**, no scrolling. A real browser loads one, because the replacement sentinel is below the fold.

## The fix

Bound a runaway by how long it keeps delivering, not by how many times, and disconnect the frame's intersection observers past the bound, mirroring `disconnectRunawayMutationObservers` (#105ba20b0).

A delivery count cannot separate a runaway from a busy but healthy page. Uncapped delivery sessions per navigation:

| page | sessions across runs | first to last delivery |
| :---- | :---- | :---- |
| news.ycombinator.com | 0 | none |
| vercel.com, /templates | 0 | none |
| apnews.com hub (ad-heavy) | 5 | under 1 s |
| airbnb.com | 25, 28, 37, 37, 48 | 1.9 to 4.4 s, then quiet |
| airbnb.com/s/Paris/homes | 32, 43, 47, 47, 48 | 1.5 to 2.7 s, then quiet |
| **storefront runaway** | **122 at 4 s, 215 at 7 s** | **never quiet, ~30/s** |

Airbnb legitimately needs up to 48 sessions and the runaway had already exhausted the timer table by 68, with the same URL varying almost 2x run to run. Duration does separate them: every healthy burst went quiet within 4.5 s of its first delivery; the runaway never did.

So deliveries closer than 2 s apart form a burst, and a burst that runs past 10 s disconnects. The clock starts at the beginning of the current burst rather than at the first delivery ever, so lazy loading triggered minutes into a serve or agent session by a scroll or a click is not penalized by page age. The largest gap inside a healthy airbnb burst was 772 ms; the runaway paused once for 1.1 s on a network stall.

A chain that re-observes synchronously never leaves the microtask checkpoint, so the clock alone would let it spin for the full 10 s. A per-burst ceiling of 1024 deliveries exists for that case only; at 20x airbnb's peak it is not a tuning knob.

Logged once per burst rather than per attempt: the framework re-mounts its lazy loader afterwards, and each new observer trips the path again.

## Verification

| check | result |
| :---- | :---- |
| airbnb.com, airbnb.com/s/Paris/homes, 2 loads each | guard never fires |
| HN, apnews, vercel | guard never fires |
| offline sync fixture | disconnected at 1025 deliveries within the first tick |
| offline deferred fixture, burst backdated past 10 s | disconnected on the next delivery |
| offline deferred fixture, quiet gap backdated past 2 s | new burst, observers kept |
| `zig fmt --check ./*.zig ./**/*.zig` | clean |

## Limitations

This bounds the damage; it does not fix the visibility model.

- In fetch mode the storefront runaway is finite: it paginates to page 17 in 4 to 8 s and ends on its own before the 10 s limit, so the guard does not fire and all 17 pages load. The serve-mode hang, which ran 30 s until the watchdog, is cut at 10 s.
- A page that legitimately keeps delivering for more than 10 s without a 2 s pause loses its observers, and the disconnect is as blunt here as it is for mutation observers.
- The 10 s and 2 s constants are not configurable yet.

The follow-up I would want, and did not attempt because it is a bigger design call than a safety valve: report intersections against a real viewport rather than treating every attached element as visible, so `scroll` becomes the thing that legitimately advances pagination.
