### PR TITLE
Avoid rearming heap termination during teardown

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -203,13 +203,6 @@ pub fn newSession(self: *Browser, notification: *Notification) !*Session {
 }
 
 pub fn closeSession(self: *Browser) void {
-    const env = &self.env;
-
-    // Teardown GC must not arm a new termination.
-    const was_tearing_down = env.tearing_down;
-    env.tearing_down = true;
-    defer env.tearing_down = was_tearing_down;
-
     if (self.session) |*session| {
         session.deinit();
         self.session = null;

--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -203,6 +203,13 @@ pub fn newSession(self: *Browser, notification: *Notification) !*Session {
 }
 
 pub fn closeSession(self: *Browser) void {
+    const env = &self.env;
+
+    // Teardown GC must not arm a new termination.
+    const was_tearing_down = env.tearing_down;
+    env.tearing_down = true;
+    defer env.tearing_down = was_tearing_down;
+
     if (self.session) |*session| {
         session.deinit();
         self.session = null;

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -243,6 +243,12 @@ pub fn processDestroyQueues(self: *Session) void {
     {
         const queue = self._page_destruction_queue.items;
         if (queue.len > 0) {
+            // Context disposal GC must not arm a new termination.
+            const env = &self.browser.env;
+            const was_tearing_down = env.tearing_down;
+            env.tearing_down = true;
+            defer env.tearing_down = was_tearing_down;
+
             for (queue) |page| {
                 page.deinit();
                 self.browser.page_pool.destroy(page);

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -180,7 +180,14 @@ pub fn deinit(self: *Session) void {
 
     self.cookie_jar.deinit();
 
-    self.browser.env.memoryPressureNotification(.critical);
+    {
+        // Every context is disposed; this GC must not arm a termination.
+        const env = &self.browser.env;
+        const was_tearing_down = env.tearing_down;
+        env.tearing_down = true;
+        defer env.tearing_down = was_tearing_down;
+        env.memoryPressureNotification(.critical);
+    }
 
     self.storage_shed.deinit(self.browser.app.allocator);
     self.idb.deinit();
@@ -243,12 +250,6 @@ pub fn processDestroyQueues(self: *Session) void {
     {
         const queue = self._page_destruction_queue.items;
         if (queue.len > 0) {
-            // Context disposal GC must not arm a new termination.
-            const env = &self.browser.env;
-            const was_tearing_down = env.tearing_down;
-            env.tearing_down = true;
-            defer env.tearing_down = was_tearing_down;
-
             for (queue) |page| {
                 page.deinit();
                 self.browser.page_pool.destroy(page);

--- a/src/browser/js/Context.zig
+++ b/src/browser/js/Context.zig
@@ -206,6 +206,12 @@ pub fn deinit(self: *Context) void {
     const env = self.env;
     defer self.arena.release();
 
+    // Disposal GCs below can trip the near-heap-limit callback. There's no JS
+    // left in this context to stop, so it must not arm a termination.
+    const was_tearing_down = env.tearing_down;
+    env.tearing_down = true;
+    defer env.tearing_down = was_tearing_down;
+
     // Unlink any IndexedDB gate participants first: the session-scoped engine
     // must never wake a waiter into this scheduler once it's torn down.
     self.page.session.idb.detachContext(self);

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -104,7 +104,7 @@ terminate_mutex: std.Io.Mutex = .init,
 // thread making sure terminate hasn't been canceled.
 terminate_requested: std.atomic.Value(bool) = .init(false),
 
-// Set while V8 contexts are being destroyed.
+// Set while a V8 context (or the isolate) is being disposed.
 tearing_down: bool = false,
 
 heap_limit_protected: bool = false,

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -104,6 +104,11 @@ terminate_mutex: std.Io.Mutex = .init,
 // thread making sure terminate hasn't been canceled.
 terminate_requested: std.atomic.Value(bool) = .init(false),
 
+// Set while V8 contexts are being destroyed.
+tearing_down: bool = false,
+
+heap_limit_protected: bool = false,
+
 pub const InitOpts = struct {
     with_inspector: bool = false,
 };
@@ -209,6 +214,10 @@ pub fn init(app: *App, opts: InitOpts) !Env {
 }
 
 pub fn deinit(self: *Env) void {
+    // Prevent callbacks during isolate disposal.
+    self.tearing_down = true;
+    self.releaseHeapLimit();
+
     if (comptime lp.IS_DEBUG) {
         std.debug.assert(self.contexts.items.len == 0);
     }
@@ -576,6 +585,7 @@ pub fn terminate(self: *Env) void {
 
 // We need a stable pointer for *Env, so can't be setup in init.
 pub fn protectHeapLimit(self: *Env) void {
+    self.heap_limit_protected = true;
     v8.v8__Isolate__AddNearHeapLimitCallback(self.isolate.handle, nearHeapLimit, self);
     // TODO: uncomment this when https://github.com/lightpanda-io/zig-v8-fork/pull/187 lands
     // if our nearHeapLimit extends the memory, we want to  restore the original
@@ -599,12 +609,29 @@ pub fn protectHeapLimit(self: *Env) void {
 // V8 expects.
 fn nearHeapLimit(data: ?*anyopaque, current_limit: usize, initial_limit: usize) callconv(.c) usize {
     const self: *Env = @ptrCast(@alignCast(data.?));
+    return self.onNearHeapLimit(current_limit, initial_limit);
+}
+
+fn releaseHeapLimit(self: *Env) void {
+    if (self.heap_limit_protected == false) {
+        return;
+    }
+    self.heap_limit_protected = false;
+    v8.v8__Isolate__RemoveNearHeapLimitCallback(self.isolate.handle, nearHeapLimit, 0);
+}
+
+fn onNearHeapLimit(self: *Env, current_limit: usize, initial_limit: usize) usize {
     lp.metrics.js_heap_limits.incr();
     log.err(.app, "JS heap limit reached", .{
         .initial_limit = initial_limit,
         .current_limit = current_limit,
+        .tearing_down = self.tearing_down,
     });
-    self.requestTerminate();
+
+    // Context disposal can trigger this after execution has ended.
+    if (self.tearing_down == false) {
+        self.requestTerminate();
+    }
 
     const cap = initial_limit + 256 * 1024 * 1024;
     if (current_limit >= cap) {
@@ -718,6 +745,24 @@ const PrivateSymbols = struct {
 };
 
 const testing = @import("../../testing.zig");
+
+test "Env: a heap limit reached during teardown does not arm a termination" {
+    testing.expectLog(&.{.app});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    const env = frame.js.env;
+    const limit: usize = 64 * 1024 * 1024;
+
+    env.tearing_down = true;
+    defer env.tearing_down = false;
+
+    const granted = env.onNearHeapLimit(limit, limit);
+    try testing.expectEqual(false, env.terminatePending());
+    try testing.expect(granted > limit);
+}
+
 test "Env: Worker context " {
     const frame = try testing.createFrame();
     defer testing.test_session.closeAllPages();

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -571,3 +571,44 @@ test "WebApi: MutationObserver requested termination unwinds delivery" {
     env.runMicrotasks();
     try testing.expectEqual(2, try (try local.exec("window.__delivered", null)).toI32());
 }
+
+test "WebApi: MutationObserver terminated page tears down" {
+    testing.expectLog(&.{ .frame, .frame });
+
+    const frame = try testing.createFrame();
+    const env = frame.js.env;
+    defer env.cancelTerminate();
+    {
+        var ls: js.Local.Scope = undefined;
+        frame.js.localScope(&ls);
+        defer ls.deinit();
+        const local = &ls.local;
+
+        const State = struct {
+            env: *js.Env,
+
+            fn kill(self: *@This()) void {
+                self.env.requestTerminate();
+            }
+        };
+        var state = State{ .env = env };
+        const kill_cb = local.newCallback(State.kill, &state);
+        const setup = try local.exec(
+            \\(function(kill) {
+            \\  const target = document.createElement('div');
+            \\  new MutationObserver(() => { kill(); for(;;){} })
+            \\      .observe(target, { attributes: true });
+            \\  target.setAttribute('x', '1');
+            \\})
+        , null);
+        const setup_fn = js.Function{ .local = local, .handle = @ptrCast(setup.handle) };
+        try setup_fn.call(void, .{kill_cb});
+    }
+
+    env.runMicrotasks();
+    try testing.expectEqual(true, env.terminatePending());
+    try testing.expectEqual(false, js.v8.v8__Isolate__IsExecutionTerminating(env.isolate.handle));
+
+    testing.test_session.closeAllPages();
+    try testing.expectEqual(@as(usize, 0), env.contexts.items.len);
+}


### PR DESCRIPTION
## Context

The near-heap-limit callback is intended to stop JavaScript that is actively consuming the heap. It can also run after execution has already terminated, while a V8 context is being disposed:

```text
Browser.closeSession
  -> Session.processDestroyQueues
    -> Page.deinit -> Frame.deinit -> Context.deinit
      -> Env.pumpMessageLoop
        -> TaskOnContextDispose::TryRunMinorGC
          -> Heap::InvokeNearHeapLimitCallback
```

In that path there is no page JavaScript left to interrupt. Calling `requestTerminate()` nevertheless sets the sticky `terminate_requested` flag and posts an isolate interrupt. Since the `Env` can outlive the page/session being destroyed, that pending termination can reject subsequent JavaScript entry and cause a reusable connection to be closed as `pending terminate`.

The callback was also left registered until isolate disposal, allowing it to re-enter V8 from final disposal GCs.

## Reproduction

Save the following as `/tmp/heap-teardown.html`:

```html
<!doctype html>
<div id="target"></div>
<script>
const retained = [];
function fill(mb) {
  const count = Math.floor((mb * 1024 * 1024) / (4096 * 8));
  for (let i = 0; i < count; i++) {
    const array = new Array(4096);
    for (let j = 0; j < 4096; j += 64) array[j] = i * j + 0.5;
    retained.push(array);
  }
}

fill(60);
gc();
gc();

const target = document.getElementById("target");
new MutationObserver(() => {
  fill(42);
  for (;;) {}
}).observe(target, { attributes: true });
target.setAttribute("data-x", "1");
</script>
```

Then run:

```sh
python3 -m http.server 8099 --bind 127.0.0.1 --directory /tmp

./zig-out/bin/lightpanda fetch http://127.0.0.1:8099/heap-teardown.html \
  --wait-ms 20000 \
  --v8-max-heap-mb 128 \
  --watchdog-ms 3000 \
  --v8-flags-unsafe "--expose-gc" \
  --log-format logfmt \
  --log-level info
```

The exact allocation boundary is GC-sensitive, but repeated runs on macOS arm64 produce this ordering on unpatched `main`:

```text
watchdog stall
MutObserver.deliverRecords err=ExecutionTerminated
frame.deliverMutations err=ExecutionTerminated
JS heap limit reached
```

The last line is emitted from `TaskOnContextDispose::TryRunMinorGC`, after the execution termination has already unwound and page destruction has begun.

## Change

- Mark page and session destruction as `tearing_down`.
- Continue granting V8 temporary heap headroom during teardown so cleanup can finish, but do not arm a new termination when there is no JavaScript left to stop.
- Remove the near-heap-limit callback before disposing the isolate.
- Add regressions for MutationObserver termination followed by page destruction and for the teardown-specific heap-limit behavior.
- Include `tearing_down` in the heap-limit log to distinguish active-page and disposal-time callbacks.

Live-page heap-limit callbacks continue to request termination as before.

## Validation

- `make test` — 1398/1398 passed
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`
- Repeated the local fixture after the change; disposal-time callbacks were identified as `tearing_down=true` and did not leave a pending termination.
- Verified that a heavy browser context can be disposed and a subsequent context can evaluate JavaScript on the same CDP connection.
