### PR TITLE
AGENTS.md: document optional GitNexus code navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ zig-out
 lightpanda.id
 /src/rust/target/
 src/snapshot.bin
+/.gitnexus/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Mirror the patterns in neighboring files. In particular:
 [GitNexus](https://github.com/abhigyanpatwari/GitNexus) builds a call/import graph of the Zig sources and serves it to agents over MCP (`impact`, `trace`, `detect_changes`). Requires GitNexus >= 1.6.11.
 
 ```bash
-npx gitnexus analyze --index-only    # writes only .gitnexus/ (gitignored)
+npx gitnexus@latest analyze --index-only    # writes only .gitnexus/ (gitignored)
 ```
 
 Always pass `--index-only`: without it the tool injects its own section into `AGENTS.md`/`CLAUDE.md` and installs skill files, none of which belong in a PR. The Zig grammar is an npm `optionalDependency`; if its native build fails on your platform, `.zig` files are silently skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,13 @@ Mirror the patterns in neighboring files. In particular:
 
 - `@import` alias case follows the imported file's basename (`const Frame = @import("Frame.zig")`, `const ast = @import("ast.zig")`).
 - Prefer struct-init type inference (`.{ ... }`) where the expected type is known from the function signature or variable annotation.
+
+## Code navigation (optional)
+
+[GitNexus](https://github.com/abhigyanpatwari/GitNexus) builds a call/import graph of the Zig sources and serves it to agents over MCP (`impact`, `trace`, `detect_changes`). Requires GitNexus >= 1.6.11.
+
+```bash
+npx gitnexus analyze --index-only    # writes only .gitnexus/ (gitignored)
+```
+
+Always pass `--index-only`: without it the tool injects its own section into `AGENTS.md`/`CLAUDE.md` and installs skill files, none of which belong in a PR. The Zig grammar is an npm `optionalDependency`; if its native build fails on your platform, `.zig` files are silently skipped.


### PR DESCRIPTION
Optional section pointing contributors and agents at GitNexus for call/import graph navigation now that it parses Zig (abhigyanpatwari/GitNexus#1432). Documents `--index-only` so the tool never rewrites `AGENTS.md`, and gitignores `.gitnexus/`.

**Blocked on an upstream fix — do not merge yet.**

Measured on this repo at GitNexus 1.6.12-rc.7: `impact` on `Element.getNamespaceUri` reports 5 impacted, 2 direct, risk LOW, `epistemic: "exact"` — but that function is `Element.namespaceURI`, bound at `src/browser/webapi/Element.zig:2296` via `bridge.accessor(Element.getNamespaceUri, null, .{})`. The graph's only incoming edges are the two internal Zig call sites (`:452`, `:490`); the binding reference is not an edge. Control: internal-only `getTagNameLower` correctly returns 30 impacted / 10 direct / HIGH.

So the graph is sound on ordinary Zig and blind at exactly the JS↔Zig boundary — 2,047 `bridge.*` declarations across 257 files — while labelling that blindness `exact`.

Holding as draft until the binding table resolves upstream, at which point I'll re-measure and post numbers rather than re-argue the idea.

<sub>Earlier notes in this body are superseded: 1.6.11 shipped to npm on 2026-09-04, and the Zig grammar is no longer an `optionalDependency` — 1.6.12 vendors it (abhigyanpatwari/GitNexus#3180), so the "silently skipped if the native build fails" caveat no longer applies.</sub>
