### PR TITLE
webapi: minor fix to select

### DIFF
--- a/src/browser/tests/element/html/option.html
+++ b/src/browser/tests/element/html/option.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <script src="../../testing.js"></script>
 
-<select id="select1">
+<!-- autocomplete=off: Firefox otherwise restores the selection a previous
+     run left behind when the page is reloaded, failing the `selected` test. -->
+<select id="select1" autocomplete="off">
   <option id="opt1" value="val1">Text 1</option>
   <option id="opt2" value="val2" selected>Text 2</option>
   <option id="opt3">Text 3</option>
@@ -58,8 +60,11 @@
   $('#opt1').label = 'Set Label'
   testing.expectEqual('Set Label', $('#opt1').label)
   testing.expectEqual('Set Label', $('#opt1').getAttribute('label'))
-  // An empty label attribute falls back to the text, per spec.
+  // An empty label attribute is returned as-is; only a missing one falls
+  // back to the text (WPT the-option-element/option-label.html).
   $('#opt1').setAttribute('label', '')
+  testing.expectEqual('', $('#opt1').label)
+  $('#opt1').removeAttribute('label')
   testing.expectEqual('Text 1', $('#opt1').label)
 </script>
 
@@ -83,6 +88,87 @@
   testing.expectEqual(false, $('#opt2').selected)
 </script>
 
+<script id="selected_unset_resets_to_default">
+  // A menu-list select always has a selected option: deselecting the last
+  // selected one falls back to the first enabled option (Blink's
+  // ResetToDefaultSelection, HTML's "ask for a reset").
+  {
+    const sel = document.createElement('select')
+    sel.innerHTML = '<option>a</option><option selected>b</option><option>c</option>'
+    const [a, b, c] = sel.options
+
+    b.selected = false
+    testing.expectEqual(false, b.selected)
+    testing.expectEqual(true, a.selected)
+    testing.expectEqual(1, sel.selectedOptions.length)
+    testing.expectEqual('a', sel.value)
+
+    // Deselecting an option that isn't selected changes nothing.
+    c.selected = false
+    testing.expectEqual(true, a.selected)
+    testing.expectEqual(1, sel.selectedOptions.length)
+
+    // Deselecting the fallback re-selects it.
+    a.selected = false
+    testing.expectEqual(true, a.selected)
+    testing.expectEqual(0, sel.selectedIndex)
+  }
+
+  // A disabled first option is skipped.
+  {
+    const sel = document.createElement('select')
+    sel.innerHTML = '<option disabled>a</option><option>b</option><option selected>c</option>'
+    const [a, b, c] = sel.options
+    c.selected = false
+    testing.expectEqual(false, a.selected)
+    testing.expectEqual(true, b.selected)
+    testing.expectEqual(1, sel.selectedIndex)
+  }
+
+  // Every option disabled: nothing to fall back to.
+  {
+    const sel = document.createElement('select')
+    sel.innerHTML = '<option disabled>a</option><option disabled selected>b</option>'
+    sel.options[1].selected = false
+    testing.expectEqual(0, sel.selectedOptions.length)
+  }
+
+  // A list box (size > 1) may have nothing selected.
+  {
+    const sel = document.createElement('select')
+    sel.size = 3
+    sel.innerHTML = '<option>a</option><option selected>b</option>'
+    sel.options[1].selected = false
+    testing.expectEqual(false, sel.options[0].selected)
+    testing.expectEqual(0, sel.selectedOptions.length)
+  }
+
+  // Multiple: plain deselect.
+  {
+    const sel = document.createElement('select')
+    sel.multiple = true
+    sel.innerHTML = '<option>a</option><option selected>b</option>'
+    sel.options[1].selected = false
+    testing.expectEqual(0, sel.selectedOptions.length)
+  }
+
+  // Options inside an optgroup are part of the list.
+  {
+    const sel = document.createElement('select')
+    sel.innerHTML = '<optgroup><option>a</option></optgroup><option selected>b</option>'
+    sel.options[1].selected = false
+    testing.expectEqual(true, sel.options[0].selected)
+  }
+
+  // No owning select: nothing to reset.
+  {
+    const opt = document.createElement('option')
+    opt.selected = true
+    opt.selected = false
+    testing.expectEqual(false, opt.selected)
+  }
+</script>
+
 <script id="defaultSelected">
   testing.expectEqual(false, $('#opt1').defaultSelected)
   testing.expectEqual(true, $('#opt2').defaultSelected)
@@ -104,38 +190,4 @@
 
   $('#opt4').disabled = false
   testing.expectEqual(false, $('#opt4').disabled)
-</script>
-
-<option id="named1" name="choice1">Named option</option>
-<option id="named2">Unnamed option</option>
-
-<script id="name_initial">
-  testing.expectEqual('choice1', $('#named1').name)
-  testing.expectEqual('', $('#named2').name)
-</script>
-
-<script id="name_set">
-  {
-    const option = document.createElement('option')
-    testing.expectEqual('', option.name)
-
-    option.name = 'opt-name'
-    testing.expectEqual('opt-name', option.name)
-    testing.expectEqual('opt-name', option.getAttribute('name'))
-
-    option.name = 'another-name'
-    testing.expectEqual('another-name', option.name)
-    testing.expectEqual('another-name', option.getAttribute('name'))
-  }
-</script>
-
-<script id="name_reflects_to_attribute">
-  {
-    const option = document.createElement('option')
-    testing.expectEqual(null, option.getAttribute('name'))
-
-    option.name = 'fieldname'
-    testing.expectEqual('fieldname', option.getAttribute('name'))
-    testing.expectTrue(option.outerHTML.includes('name="fieldname"'))
-  }
 </script>

--- a/src/browser/tests/element/html/select.html
+++ b/src/browser/tests/element/html/select.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <script src="../../testing.js"></script>
 
-<select id="select1">
+<select id="select1" autocomplete="off">
   <option value="val1">Option 1</option>
   <option value="val2" selected>Option 2</option>
   <option value="val3">Option 3</option>
 </select>
 
-<select id="select2">
+<select id="select2" autocomplete="off">
   <option value="a">A</option>
   <option value="b">B</option>
 </select>
 
-<select id="select3" disabled>
+<select id="select3" disabled autocomplete="off">
   <option value="x">X</option>
 </select>
 
@@ -127,7 +127,7 @@
   }
 </script>
 
-<select id="select_multi" multiple>
+<select id="select_multi" multiple autocomplete="off">
   <option value="opt1">Option 1</option>
   <option value="opt2" selected>Option 2</option>
   <option value="opt3">Option 3</option>

--- a/src/browser/webapi/element/html/Option.zig
+++ b/src/browser/webapi/element/html/Option.zig
@@ -81,11 +81,13 @@ pub fn getSelected(self: *const Option) bool {
 
 pub fn setSelected(self: *Option, selected: bool, frame: *Frame) !void {
     self._selected = selected;
-    if (selected) {
-        if (self.ownerSelect()) |select| {
-            if (!select.asConstElement().hasAttributeSafe(comptime .wrap("multiple"))) {
+    if (self.ownerSelect()) |select| {
+        if (selected) {
+            if (!select.getMultiple()) {
                 select.deselectOthers(self);
             }
+        } else {
+            select.resetToDefaultSelection();
         }
     }
     frame.domChanged();
@@ -115,14 +117,11 @@ pub fn setDefaultSelected(self: *Option, value: bool, frame: *Frame) !void {
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-label
-// On getting, return the `label` content attribute if present and non-empty,
-// otherwise the value of the `text` IDL attribute. On setting, reflect to the
-// `label` content attribute.
+// On getting, return the `label` content attribute if present (verbatim, even
+// when empty), otherwise the value of the `text` IDL attribute. On setting,
+// reflect to the `label` content attribute.
 pub fn getLabel(self: *const Option, frame: *Frame) []const u8 {
-    if (self.asConstElement().getAttributeSafe(comptime .wrap("label"))) |label| {
-        if (label.len != 0) return label;
-    }
-    return self.getText(frame);
+    return self.asConstElement().getAttributeSafe(comptime .wrap("label")) orelse self.getText(frame);
 }
 
 pub fn setLabel(self: *Option, label: []const u8, frame: *Frame) !void {
@@ -146,7 +145,6 @@ pub const JsApi = struct {
     pub const selected = bridge.accessor(Option.getSelected, Option.setSelected, .{});
     pub const defaultSelected = bridge.accessor(Option.getDefaultSelected, Option.setDefaultSelected, .{ .ce_reactions = true });
     pub const disabled = reflect.boolean("disabled");
-    pub const name = reflect.string("name");
 };
 
 pub const Build = struct {

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -17,18 +17,22 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const lp = @import("lightpanda");
-const Factory = @import("../../../Factory.zig");
+
 const js = @import("../../../js/js.zig");
+const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
 
 const Node = @import("../../Node.zig");
-const Element = @import("../../Element.zig");
-const HtmlElement = @import("../Html.zig");
-const collections = @import("../../collections.zig");
-const Form = @import("Form.zig");
 const Event = @import("../../Event.zig");
-const ValidityState = @import("ValidityState.zig");
+const Element = @import("../../Element.zig");
+const collections = @import("../../collections.zig");
+
+const HtmlElement = @import("../Html.zig");
+const reflection = @import("../reflection.zig");
+
+const Form = @import("Form.zig");
 pub const Option = @import("Option.zig");
+const ValidityState = @import("ValidityState.zig");
 
 const Select = @This();
 
@@ -96,6 +100,41 @@ pub fn deselectOthers(self: *const Select, keep: *const Option) void {
     while (it.next()) |option| {
         if (option != keep) option._selected = false;
     }
+}
+
+// A non-multiple select with a display size < 2 always has 1 item selected.
+pub fn resetToDefaultSelection(self: *const Select) void {
+    if (self.getMultiple() or self.displaySize() > 1) {
+        return;
+    }
+
+    var first_enabled: ?*Option = null;
+    var last_selected: ?*Option = null;
+    var it = OptionIterator.init(self);
+    while (it.next()) |option| {
+        if (option._selected) {
+            if (last_selected) |prev| prev._selected = false;
+            last_selected = option;
+        }
+        if (first_enabled == null and !option.asElement().isDisabled()) {
+            first_enabled = option;
+        }
+    }
+
+    if (last_selected == null) {
+        if (first_enabled) |option| {
+            option._selected = true;
+        }
+    }
+}
+
+// The size attribute, as the size IDL attribute parses it (0 when absent or
+// invalid). Whether the select renders as a menu list or a list box hinges on
+// this, and with it whether an option can be deselected outright.
+fn displaySize(self: *const Select) i64 {
+    const value = self.asConstElement().getAttributeSafe(comptime .wrap("size")) orelse return 0;
+    const parsed = reflection.parseInteger(value) orelse return 0;
+    return @max(parsed, 0);
 }
 
 // Resolves the option whose selectedness contributes to the select's value

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -597,12 +597,6 @@ pub fn getResponseXML(self: *XMLHttpRequest, exec: *const Execution) !?*Node.Doc
     }
 }
 
-fn httpHeaderCallback(transfer: *Transfer, header: http.Header) !void {
-    const self: *XMLHttpRequest = @ptrCast(@alignCast(transfer.req.ctx));
-    const joined = try std.fmt.allocPrint(self._arena, "{s}: {s}", .{ header.name, header.value });
-    try self._response_headers.append(self._arena, joined);
-}
-
 fn httpHeaderDoneCallback(transfer: *Transfer) !Transfer.HeaderResult {
     const self: *XMLHttpRequest = @ptrCast(@alignCast(transfer.req.ctx));
 


### PR DESCRIPTION
A non-multi select with a display size of 1, must always have 1 item selected (unless it's set via JS (selectedIndex = -1). Also, some small fixes to options (e.g. there is no .name getter). option.html and select.html now pass in Firefox

Also, XMLHTTPRequest `httpHeaderCallback` was dead code.