### PR TITLE
Disarm watchdog before protocol teardown

### DIFF
--- a/src/browser/Browser.zig
+++ b/src/browser/Browser.zig
@@ -142,14 +142,13 @@ pub fn init(self: *Browser, app: *App, opts: InitOpts) !void {
 pub fn deinit(self: *Browser) void {
     const allocator = self.allocator;
 
+    self.prepareForTeardown();
+
     self.closeSession();
 
     lp.metrics.js_heap_physical_bytes.add(-@as(i64, @intCast(self.last_reported_js_bytes)));
     self.last_reported_js_bytes = 0;
 
-    // After this returns, the watchdog thread holds no reference to our env
-    // or http_client — required before either is torn down.
-    self.app.watchdog.unregister(&self.watchdog_entry);
     self.env.deinit();
     // After env.deinit() the Isolate is gone, so no further weak finalizer can
     // fire — only now is it safe to free the pool backing their parameters.
@@ -160,6 +159,12 @@ pub fn deinit(self: *Browser) void {
     self.clearPermissions();
     self.permissions.deinit(allocator);
     self.selector_cache.deinit();
+}
+
+// Wait out a watchdog scan before clearing its termination request.
+pub fn prepareForTeardown(self: *Browser) void {
+    self.app.watchdog.unregister(&self.watchdog_entry);
+    self.env.cancelTerminate();
 }
 
 // Set (or overwrite) the stored state for a permission. The name is duped into

--- a/src/server/Server.zig
+++ b/src/server/Server.zig
@@ -695,13 +695,11 @@ const Worker = struct {
         Worker.notifyLoopOfChange(server, .{ .ws = ws, .op = .{ .attach = driver } });
         driver.run();
         // Release first: until the loop has let go of this websocket it can
-        // still drop the link, and onLinkDisconnect requests a terminate. Doing
-        // it the other way round left that request landing after the cancel,
-        // so the teardown below ran with a pending terminate -- which is the
-        // one thing the cancel is here to prevent (cdp.deinit() and
-        // bidi.deinit() in our caller need V8 in a usable state).
+        // still drop the link, and onLinkDisconnect requests a terminate.
         Worker.releaseConnection(server, ws);
-        driver.browser.env.cancelTerminate();
+
+        // CDP/BiDi close the session before Browser.deinit, so disarm now.
+        driver.browser.prepareForTeardown();
     }
 
     // Worker -> loop: synchronous release. Blocks until the loop has dropped the


### PR DESCRIPTION
## Context

The server teardown order leaves a race:

```text
Worker.releaseConnection
Env.cancelTerminate
CDP/BiDi.deinit -> Browser.closeSession
Browser.deinit -> Watchdog.unregister
```

The watchdog remains registered after termination is canceled and while protocol teardown disposes V8 contexts. A concurrent scan can therefore request another termination during cleanup. CDP and BiDi both close the session before `Browser.deinit`, so moving unregistration within `Browser.deinit` alone does not close the window.

## Change

Add `Browser.prepareForTeardown`, which unregisters the watchdog and then clears termination. `Watchdog.unregister` synchronizes with an in-progress scan, so no watchdog request can land after the cancel. Server workers call it after releasing the connection and before CDP/BiDi teardown. `Browser.deinit` also calls it as an idempotent fallback for other owners.

## Validation

- `TEST_FILTER="WebApi: MutationObserver terminated page tears down" make test`
- `TEST_FILTER="cdp: run sends a close frame on pending terminate" make test`
- `zig build`
- `zig fmt --check ./*.zig ./**/*.zig`
- `git diff --check`