### PR TITLE
webapi: don't upgrade custom elements in a windowless document

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -240,11 +240,19 @@ _upgrading_element: ?*Node = null,
 // during upgrade is a TypeError.
 _upgrading_consumed: bool = false,
 
-// Set when materializing the fragment parser's context element. The element
-// is never inserted into the tree so if its a custom element ,we must not run
-// its constructor (else we'll end up in an endless loop if the constructor
-// sets this.innerHTML = '...', which happens).
-_skip_custom_element_upgrade: bool = false,
+// How node_factory creates an element with a hyphenated HTML tag name.
+_custom_element_creation: enum {
+    // Look the definition up in this frame's registry and run the
+    // constructor synchronously.
+    construct,
+    // Fragment-parse context element. Not inserted into the tree, so its
+    // constructor must not run (you end up in an endless loop if the constructor
+    // does this.innerHTML = '...', which happens).
+    bare_context,
+    // The target document has no custom element registry (e.g. DOMParser). The
+    // element stays undefined until it's inserted into the frame's document.
+    undefined,
+} = .construct,
 
 // List of custom elements that were created before their definition was registered
 _undefined_custom_elements: std.ArrayList(*Element.Html.Custom) = .empty,

--- a/src/browser/frame/node_factory.zig
+++ b/src/browser/frame/node_factory.zig
@@ -823,19 +823,27 @@ pub fn createElementNS(frame: *Frame, namespace: Element.Namespace, name: []cons
             // Check if this is a custom element (must have hyphen for HTML namespace)
             const has_hyphen = std.mem.indexOfScalar(u8, name, '-') != null;
             if (has_hyphen and namespace == .html) {
-                const definition = frame.window._custom_elements._definitions.get(name);
+                const creation = frame._custom_element_creation;
+                const definition = switch (creation) {
+                    .construct, .bare_context => frame.window._custom_elements._definitions.get(name),
+                    // A windowless document has no registry.
+                    .undefined => null,
+                };
 
                 // Fragment-parse context element. It will not be inserted and
                 // we should not run the custom element's constructor.
                 //
                 // Undefined elements are created in the "undefined" state and
                 // upgraded later, when a matching definition is registered.
-                if (frame._skip_custom_element_upgrade or definition == null) {
+                // Only elements created for this frame's document are
+                // candidates: a windowless document's element is upgraded on
+                // insertion into this frame's document instead.
+                if (creation != .construct or definition == null) {
                     const node = try createHtmlElementT(frame, Element.Html.Custom, namespace, attribute_iterator, .{
                         ._tag_name = tag_name,
                         ._definition = definition,
                     });
-                    if (frame._skip_custom_element_upgrade == false) {
+                    if (creation == .construct) {
                         try frame._undefined_custom_elements.append(frame.arena, node.as(Element).is(Element.Html.Custom).?);
                     }
                     return node;

--- a/src/browser/frame/parse.zig
+++ b/src/browser/frame/parse.zig
@@ -50,6 +50,18 @@ fn htmlAsChildrenInner(frame: *Frame, node: *Node, html: []const u8, opts: Fragm
     frame._parse_mode = .fragment;
     defer frame._parse_mode = previous_parse_mode;
 
+    // A context element in a document without a browsing context
+    // (createHTMLDocument, new Document, DOMParser output) has no custom
+    // element registry.
+    const previous_creation = frame._custom_element_creation;
+    const document = node.ownerDocument(frame) orelse node.as(Document);
+    if (document._frame == null) {
+        // a document without a browsing context (DOMParser et al.) has
+        // no custom element and should stay undefined.
+        frame._custom_element_creation = .undefined;
+    }
+    defer frame._custom_element_creation = previous_creation;
+
     // The html5ever wrapper-unwrap below rebinds children without going
     // through the insertion path, so recompute slot assignments for any
     // shadow tree this fragment landed in (idempotent; signals only on diff).
@@ -108,6 +120,11 @@ pub fn xmlDocument(frame: *Frame, xml: []const u8) !?*Document.XMLDocument {
     const previous_parse_mode = frame._parse_mode;
     frame._parse_mode = .fragment;
     defer frame._parse_mode = previous_parse_mode;
+
+    // No browsing context, so no custom element registry.
+    const previous_creation = frame._custom_element_creation;
+    frame._custom_element_creation = .undefined;
+    defer frame._custom_element_creation = previous_creation;
 
     const doc = try frame._factory.document(Document.XMLDocument{ ._proto = undefined });
     const doc_node = doc.asNode();

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -485,8 +485,9 @@ fn createXMLElementCallback(ctx: *anyopaque, data: *anyopaque, qname: h5e.QualNa
 // create.
 fn createContextElementCallback(ctx: *anyopaque, data: *anyopaque, qname: h5e.QualName, attributes: h5e.AttributeIterator) callconv(.c) ?*anyopaque {
     const self: *Parser = @ptrCast(@alignCast(ctx));
-    self.frame._skip_custom_element_upgrade = true;
-    defer self.frame._skip_custom_element_upgrade = false;
+    const previous_creation = self.frame._custom_element_creation;
+    self.frame._custom_element_creation = .bare_context;
+    defer self.frame._custom_element_creation = previous_creation;
     return self._createElementCallback(data, qname, attributes, .unknown) catch |err| {
         self.err = .{ .err = err, .source = .create_element };
         return null;

--- a/src/browser/tests/custom_elements/windowless_document.html
+++ b/src/browser/tests/custom_elements/windowless_document.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<body>
+<script src="../testing.js"></script>
+
+<!-- A document without a browsing context (DOMParser, createHTMLDocument,
+     new Document) has no custom element registry: its elements are created
+     undefined and only upgraded once inserted into this document. -->
+
+<script id="domparser">
+{
+    let calls = [];
+
+    class ParsedComponent extends HTMLElement {
+        constructor() {
+            super();
+            calls.push('constructor:' + this.childNodes.length);
+        }
+        connectedCallback() {
+            calls.push('connected:' + this.querySelectorAll('[ref]').length);
+        }
+        disconnectedCallback() {
+            calls.push('disconnected');
+        }
+    }
+    customElements.define('parsed-component', ParsedComponent);
+
+    const doc = new DOMParser().parseFromString(
+        '<div id="wrap"><parsed-component><span ref="a"></span><span ref="b"></span></parsed-component></div>',
+        'text/html',
+    );
+    const parsed = doc.querySelector('parsed-component');
+    testing.expectEqual('', calls.join(','));
+    testing.expectEqual(true, parsed instanceof HTMLElement);
+    testing.expectEqual(false, parsed instanceof ParsedComponent);
+
+    // Inserting into this document upgrades it with its subtree in place:
+    // the constructor and connectedCallback run once, and the existing
+    // wrapper is the one that gets upgraded.
+    document.body.appendChild(doc.getElementById('wrap'));
+    testing.expectEqual('constructor:2,connected:2', calls.join(','));
+    testing.expectEqual(true, parsed instanceof ParsedComponent);
+    testing.expectEqual(parsed, document.querySelector('parsed-component'));
+}
+</script>
+
+<script id="createHTMLDocument">
+{
+    let constructed = 0;
+
+    const other = document.implementation.createHTMLDocument('other');
+    other.body.innerHTML = '<inner-html-element></inner-html-element>';
+    const created = other.createElement('created-element');
+    other.body.appendChild(created);
+
+    class InnerHtmlElement extends HTMLElement {
+        constructor() { super(); constructed++; }
+    }
+    class CreatedElement extends HTMLElement {
+        constructor() { super(); constructed++; }
+    }
+    // A later definition does not upgrade elements owned by the other
+    // document, connected there or not.
+    customElements.define('inner-html-element', InnerHtmlElement);
+    customElements.define('created-element', CreatedElement);
+    testing.expectEqual(0, constructed);
+
+    const inner = other.querySelector('inner-html-element');
+    testing.expectEqual(false, inner instanceof InnerHtmlElement);
+    testing.expectEqual(false, created instanceof CreatedElement);
+
+    // Elements created after the definition stay undefined too.
+    const late = other.createElement('created-element');
+    testing.expectEqual(false, late instanceof CreatedElement);
+    other.body.innerHTML = '<inner-html-element></inner-html-element>';
+    testing.expectEqual(false, other.querySelector('inner-html-element') instanceof InnerHtmlElement);
+    testing.expectEqual(0, constructed);
+
+    document.body.appendChild(late);
+    testing.expectEqual(true, late instanceof CreatedElement);
+    testing.expectEqual(1, constructed);
+}
+</script>
+
+<script id="newDocument">
+{
+    let constructed = 0;
+    class BareDocElement extends HTMLElement {
+        constructor() { super(); constructed++; }
+    }
+    customElements.define('bare-doc-element', BareDocElement);
+
+    const bare = new Document();
+    bare.appendChild(bare.createElement('html'));
+    bare.documentElement.innerHTML = '<bare-doc-element></bare-doc-element>';
+
+    const el = bare.querySelector('bare-doc-element');
+    testing.expectEqual(0, constructed);
+    testing.expectEqual(true, el instanceof Element);
+    testing.expectEqual(false, el instanceof BareDocElement);
+}
+</script>
+</body>

--- a/src/browser/webapi/DOMParser.zig
+++ b/src/browser/webapi/DOMParser.zig
@@ -59,6 +59,11 @@ pub fn parseFromString(
             frame._parse_mode = .fragment;
             defer frame._parse_mode = previous_parse_mode;
 
+            // No browsing context, so no custom element registry.
+            const previous_creation = frame._custom_element_creation;
+            frame._custom_element_creation = .undefined;
+            defer frame._custom_element_creation = previous_creation;
+
             // Create a new HTMLDocument
             const doc = try frame._factory.document(HTMLDocument{
                 ._proto = undefined,

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -25,12 +25,12 @@ const public_suffix_list = @import("../../data/public_suffix_list.zig");
 const URL = @import("../URL.zig");
 const js = @import("../js/js.zig");
 const Frame = @import("../Frame.zig");
+const Parser = @import("../parser/Parser.zig");
 
 const Node = @import("Node.zig");
 const Window = @import("Window.zig");
 const Element = @import("Element.zig");
 const Location = @import("Location.zig");
-const Parser = @import("../parser/Parser.zig");
 const collections = @import("collections.zig");
 const Selector = @import("selector/Selector.zig");
 const DOMTreeWalker = @import("DOMTreeWalker.zig");
@@ -373,13 +373,8 @@ pub fn createElement(self: *Document, name: []const u8, options_: ?CreateElement
     };
     // HTML documents are case-insensitive - lowercase the tag name
 
-    const node = try Frame.node_factory.createElementNS(frame, ns, normalized_name, null);
+    const node = try self.createElementNode(ns, normalized_name, frame);
     const element = node.as(Element);
-
-    // Track owner document if it's not the main document
-    if (self != frame.document) {
-        try frame.setNodeOwnerDocument(node, self);
-    }
 
     const options = options_ orelse return element;
     if (options.is) |is_value| {
@@ -394,7 +389,7 @@ pub fn createElementNS(self: *Document, namespace: ?[]const u8, name: []const u8
     _ = try validateAndExtract(namespace, name, .element);
     const ns = Element.Namespace.parse(namespace);
     // Per spec, createElementNS does NOT lowercase (unlike createElement).
-    const node = try Frame.node_factory.createElementNS(frame, ns, name, null);
+    const node = try self.createElementNode(ns, name, frame);
 
     // Store original URI for unknown namespaces so lookupNamespaceURI can return it
     if (ns == .unknown) {
@@ -403,12 +398,25 @@ pub fn createElementNS(self: *Document, namespace: ?[]const u8, name: []const u8
             try frame._element_namespace_uris.put(frame.arena, node.as(Element), duped);
         }
     }
+    return node.as(Element);
+}
+
+fn createElementNode(self: *Document, ns: Element.Namespace, name: []const u8, frame: *Frame) !*Node {
+    const previous_creation = frame._custom_element_creation;
+    if (self._frame == null) {
+        // a document without a browser context, e.g. DOMParser, has no custom
+        // element registry
+        frame._custom_element_creation = .undefined;
+    }
+    defer frame._custom_element_creation = previous_creation;
+
+    const node = try Frame.node_factory.createElementNS(frame, ns, name, null);
 
     // Track owner document if it's not the main document
     if (self != frame.document) {
         try frame.setNodeOwnerDocument(node, self);
     }
-    return node.as(Element);
+    return node;
 }
 
 pub fn createAttribute(_: *const Document, name: String.Global, frame: *Frame) !?*Element.Attribute {

--- a/src/browser/webapi/element/html/Custom.zig
+++ b/src/browser/webapi/element/html/Custom.zig
@@ -22,14 +22,15 @@ const lp = @import("lightpanda");
 const js = @import("../../../js/js.zig");
 const Factory = @import("../../../Factory.zig");
 const Frame = @import("../../../Frame.zig");
+const Reaction = @import("../../../CustomElementReactions.zig").Reaction;
 
 const Node = @import("../../Node.zig");
 const Element = @import("../../Element.zig");
-const TreeWalker = @import("../../TreeWalker.zig");
 const Document = @import("../../Document.zig");
-const HtmlElement = @import("../Html.zig");
+const TreeWalker = @import("../../TreeWalker.zig");
 const CustomElementDefinition = @import("../../CustomElementDefinition.zig");
-const Reaction = @import("../../../CustomElementReactions.zig").Reaction;
+
+const HtmlElement = @import("../Html.zig");
 
 const log = lp.log;
 const String = lp.String;
@@ -58,7 +59,6 @@ pub fn asNode(self: *Custom) *Node {
 // we queue a reaction so that a redundant enqueue (already-in-this-state)
 // is dropped, and a remove+re-insert in the same scope queues both reactions
 // in order. Fire-time is unconditional.
-
 pub fn enqueueConnectedCallbackOnElement(comptime from_parser: bool, element: *Element, frame: *Frame) error{OutOfMemory}!void {
     // Autonomous custom element
     if (element.is(Custom)) |custom| {
@@ -67,6 +67,16 @@ pub fn enqueueConnectedCallbackOnElement(comptime from_parser: bool, element: *E
             if (custom._upgrade_failed) {
                 return;
             }
+
+            {
+                // a document without a browsing context (DOMParser et al.) has
+                // no custom element.
+                const document = element.asNode().ownerDocument(frame) orelse return;
+                if (document._frame == null) {
+                    return;
+                }
+            }
+
             const name = custom._tag_name.str();
             if (frame.window._custom_elements._definitions.get(name)) |definition| {
                 const CustomElementRegistry = @import("../../CustomElementRegistry.zig");


### PR DESCRIPTION
A custom element created in a windowless document (think DOMParser, or new Document(), ...) doesn't have a custom element registry and thus should remain undefined.

This repurposes the existing Frame._skip_custom_element_upgrade boolean into a tri-state enum to capture the 3 possible states: `construct` and `bare_context` capture the previous boolean state, and `undefined` is now used for this third state.

This fixes (non-fatal) errors on decathlon.com. It also fixes a few WPT cases and advances a few more (which are now failing for a different reason).