### PR TITLE
webapi: make trusted beforeinput cancelable

### DIFF
--- a/src/browser/tests/event/input.html
+++ b/src/browser/tests/event/input.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+<script id=constructorDefaults>
+
+  {
+    // Constructed events follow the EventInit dictionary defaults.
+    let evt = new InputEvent('beforeinput');
+    testing.expectEqual(true, evt instanceof InputEvent);
+    testing.expectEqual(true, evt instanceof UIEvent);
+    testing.expectEqual(false, evt.bubbles);
+    testing.expectEqual(false, evt.cancelable);
+    testing.expectEqual(false, evt.composed);
+    testing.expectEqual(null, evt.data);
+    testing.expectEqual('', evt.inputType);
+    testing.expectEqual(false, evt.isComposing);
+  }
+
+</script>
+
+<script id=constructorOptions>
+
+  {
+    let evt = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: 'x',
+      inputType: 'insertText',
+      isComposing: true,
+    });
+    testing.expectEqual(true, evt.bubbles);
+    testing.expectEqual(true, evt.cancelable);
+    testing.expectEqual(true, evt.composed);
+    testing.expectEqual('x', evt.data);
+    testing.expectEqual('insertText', evt.inputType);
+    testing.expectEqual(true, evt.isComposing);
+  }
+
+</script>
+
+<script id=constructorCancelable>
+
+  {
+    // preventDefault() only takes effect on a cancelable event.
+    let cancelable = new InputEvent('beforeinput', {cancelable: true});
+    cancelable.preventDefault();
+    testing.expectEqual(true, cancelable.defaultPrevented);
+
+    let plain = new InputEvent('beforeinput');
+    plain.preventDefault();
+    testing.expectEqual(false, plain.defaultPrevented);
+  }
+
+</script>
+
+<script id=createEvent>
+
+  {
+    // document.createEvent leaves the flags unset until initEvent runs.
+    let evt = document.createEvent('InputEvent');
+    testing.expectEqual(true, evt instanceof InputEvent);
+    testing.expectEqual(false, evt.bubbles);
+    testing.expectEqual(false, evt.cancelable);
+  }
+
+</script>

--- a/src/browser/webapi/event/InputEvent.zig
+++ b/src/browser/webapi/event/InputEvent.zig
@@ -80,11 +80,18 @@ fn initWithTrusted(arena: *lp.Arena, typ: String, _opts: ?Options, trusted: bool
 
     Event.populatePrototypes(event, opts, trusted);
 
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event
-    const rootevt = event._proto._proto;
-    rootevt._bubbles = true;
-    rootevt._cancelable = false;
-    rootevt._composed = true;
+    if (trusted) {
+        // Browser-generated input events bubble and are composed. `beforeinput`
+        // is cancelable — cancelling it vetoes the edit — while `input` is
+        // dispatched after the fact and is not:
+        // https://w3c.github.io/uievents/#event-type-beforeinput
+        // https://w3c.github.io/uievents/#event-type-input
+        // Synthetic ones follow the EventInit dictionary defaults.
+        const rootevt = event._proto._proto;
+        rootevt._bubbles = true;
+        rootevt._cancelable = typ.eqlSlice("beforeinput");
+        rootevt._composed = true;
+    }
 
     // Hold a ref on the DataTransfer (when present) for this event's lifetime;
     // released in deinit. Almost always null for input events, but keeps the
@@ -146,3 +153,8 @@ pub const JsApi = struct {
     pub const inputType = bridge.accessor(InputEvent.getInputType, null, .{});
     pub const isComposing = bridge.accessor(InputEvent.getIsComposing, null, .{});
 };
+
+const testing = @import("../../../testing.zig");
+test "WebApi: InputEvent" {
+    try testing.htmlRunner("event/input.html", .{});
+}

--- a/src/server/cdp/domains/input.zig
+++ b/src/server/cdp/domains/input.zig
@@ -406,3 +406,75 @@ test "cdp.input: dispatchKeyEvent Tab runs sequential focus navigation" {
     });
     try testing.expect((try ls.local.compileAndRun("document.activeElement.id === 'b1'", null)).isTrue());
 }
+
+test "cdp.input: dispatchKeyEvent beforeinput can veto the edit" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+    try frame.navigate("http://localhost:9582/src/browser/tests/mcp_actions.html", .{
+        .reason = .address_bar,
+        .kind = .{ .push = null },
+    });
+    try testing.waitForPage(bc);
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    // A listener that rejects every keystroke, the way masked-input libraries
+    // do. Records what it saw so we can assert the event was cancelable.
+    _ = try ls.local.compileAndRun(
+        \\const inp = document.getElementById('inp');
+        \\inp.value = 'ab';
+        \\inp.focus();
+        \\window.seen = [];
+        \\inp.addEventListener('beforeinput', (e) => {
+        \\  window.seen.push(['beforeinput', e.cancelable].join(':'));
+        \\  e.preventDefault();
+        \\  window.seen.push(['defaultPrevented', e.defaultPrevented].join(':'));
+        \\});
+        \\inp.addEventListener('input', () => window.seen.push('input'));
+    , null);
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "c", .text = "c" },
+    });
+
+    // The veto held: no character inserted and no `input` event followed.
+    try testing.expect((try ls.local.compileAndRun(
+        \\inp.value === 'ab' &&
+        \\window.seen.join(',') === 'beforeinput:true,defaultPrevented:true'
+    , null)).isTrue());
+
+    // Backspace goes through the same pre-edit gate.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Backspace", .code = "Backspace" },
+    });
+    try testing.expect((try ls.local.compileAndRun("inp.value === 'ab'", null)).isTrue());
+
+    // Without the veto, the edit goes through and `input` is dispatched — and
+    // `input` itself is not cancelable.
+    _ = try ls.local.compileAndRun(
+        \\const clone = inp.cloneNode(true);
+        \\inp.replaceWith(clone);
+        \\clone.focus();
+        \\window.seen = [];
+        \\clone.addEventListener('input', (e) => window.seen.push(['input', e.cancelable].join(':')));
+    , null);
+
+    try ctx.processMessage(.{
+        .id = 3,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "c", .text = "c" },
+    });
+    try testing.expect((try ls.local.compileAndRun(
+        \\clone.value === 'abc' && window.seen.join(',') === 'input:false'
+    , null)).isTrue());
+}


### PR DESCRIPTION
## What

A trusted `beforeinput` event was dispatched with `cancelable: false`, so `preventDefault()` inside a listener could not veto a keyboard edit — the character was inserted anyway and `input` fired afterwards. This makes the event cancelable per UI Events, so cancelling it suppresses both the edit and the `input` event.

Closes #3413.

## Root cause

`InputEvent.zig#initWithTrusted` set `_bubbles` / `_cancelable` / `_composed` unconditionally, immediately after `Event.populatePrototypes` had applied the caller's options — so the assignment clobbered whatever the caller asked for. `user_input.zig#allowEdit` builds the pre-edit event with `.cancelable = true` precisely so a listener can reject the keystroke, but that request was discarded and `_prevent_default` could never be set.

The same three lines applied to the untrusted paths too, so `new InputEvent('beforeinput', {cancelable: true})` reported `cancelable === false` and `document.createEvent('InputEvent')` came back already bubbling and composed.

```mermaid
flowchart LR
    A["Input.dispatchKeyEvent<br/>keyDown 'c'"] --> B["allowEdit<br/>asks cancelable: true"]
    B --> C["initWithTrusted<br/>_cancelable = false"]
    C --> D["preventDefault is a no-op<br/>_prevent_default stays false"]
    D --> E["innerInsert runs<br/>input event fires"]
    style C fill:#fdd
    style D fill:#fdd
    style E fill:#fdd
```

## Fix

- `src/browser/webapi/event/InputEvent.zig` — `initWithTrusted`: guard the flag block with `if (trusted)`, matching `KeyboardEvent.zig#initWithTrusted`, and derive `_cancelable` from the event type — [`beforeinput` is cancelable](https://w3c.github.io/uievents/#event-type-beforeinput), [`input` is not](https://w3c.github.io/uievents/#event-type-input). Constructed events now follow the EventInit dictionary defaults.
- `src/server/cdp/domains/input.zig` — new test covering the trusted path end to end.
- `src/browser/tests/event/input.html` — new fixture, registered by a `WebApi: InputEvent` runner block, covering the constructor and `document.createEvent` semantics the same change corrects.

```mermaid
flowchart LR
    A["Input.dispatchKeyEvent<br/>keyDown 'c'"] --> B["allowEdit<br/>asks cancelable: true"]
    B --> C["initWithTrusted<br/>_cancelable = type is beforeinput"]
    C --> D["preventDefault sets<br/>_prevent_default = true"]
    D --> E["allowEdit returns false<br/>no edit, no input event"]
    style C fill:#dfd
    style D fill:#dfd
    style E fill:#dfd
```

## Test

- **`cdp.input: dispatchKeyEvent beforeinput can veto the edit`** — dispatches a printable keydown and a Backspace at a focused `<input>` whose `beforeinput` listener calls `preventDefault()`; asserts the value is untouched, that the listener saw `cancelable === true` / `defaultPrevented === true`, and that no `input` event followed. Then repeats without the veto to assert the edit does go through and that `input` itself is reported as non-cancelable.
- **`WebApi: InputEvent`** (`src/browser/tests/event/input.html`) — constructor defaults, constructor with an explicit `EventInit`, `preventDefault()` on a cancelable vs. plain constructed event, and `document.createEvent('InputEvent')` flags.
- Both fail on `main` and pass with this commit (verified by reverting just the production hunk and re-running each filtered test).
- The `repro.sh` from #3413 exits 1 against nightly `9204` and exits 0 against a binary built from this branch.

## Notes

- The trusted `input` event is unchanged: still bubbling and composed with `cancelable: false`, which is what the spec asks for and what the existing `cdp.dom: setFileInputFiles` test already pins (it asserts `bubbles` on the events it fires).
- The constructor / `createEvent` change is a behavior change beyond the reported bug, but it falls out of the same three lines and moves both paths onto the EventInit dictionary defaults that `KeyboardEvent` already follows. Happy to narrow it to only the `_cancelable` flag if you'd rather keep `new InputEvent(...)` bubbling by default.
- `zig build test` on this branch shows the same pre-existing `server:` socket-test failures that unmodified `main` shows on macOS; no new failures.
