### PR TITLE
webapi: move the text entry cursor to the end on value set

### DIFF
--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -557,6 +557,31 @@
     testing.expectEqual(2, input.selectionStart);
     testing.expectEqual(2, input.selectionEnd);
 
+    // Re-assigning the same value leaves the selection alone
+    // (WPT textfieldselection/selection-after-content-change.html).
+    input.value = 'hello';
+    input.setSelectionRange(1, 3, 'backward');
+    input.value = 'hello';
+    testing.expectEqual(1, input.selectionStart);
+    testing.expectEqual(3, input.selectionEnd);
+    testing.expectEqual('backward', input.selectionDirection);
+
+    // ...including when the new value only differs before sanitization.
+    input.value = 'hel\nlo';
+    testing.expectEqual(1, input.selectionStart);
+    testing.expectEqual(3, input.selectionEnd);
+
+    // Assigning a value equal to the default is not a change for the caret,
+    // but it still sets the dirty flag: later attribute edits stay hidden.
+    const dflt = document.createElement('input');
+    dflt.type = 'text';
+    dflt.defaultValue = 'foo';
+    dflt.value = 'foo';
+    testing.expectEqual(0, dflt.selectionStart);
+    testing.expectEqual(0, dflt.selectionEnd);
+    dflt.defaultValue = 'bar';
+    testing.expectEqual('foo', dflt.value);
+
     // Types with no text entry cursor keep reporting null rather than a number.
     const check = document.createElement('input');
     check.type = 'checkbox';

--- a/src/browser/tests/element/html/input.html
+++ b/src/browser/tests/element/html/input.html
@@ -532,3 +532,36 @@
     testing.expectEqual(false, input_checked.checked);
   }
 </script>
+
+<script id="value_setter_moves_caret">
+  {
+    // Setting `value` moves the text entry cursor to the end of the new value,
+    // unselects any selected text and resets the selection direction.
+    // https://html.spec.whatwg.org/#dom-input-value
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+
+    input.value = 'abc';
+    testing.expectEqual(3, input.selectionStart);
+    testing.expectEqual(3, input.selectionEnd);
+
+    input.setSelectionRange(1, 2, 'backward');
+    input.value = 'hello';
+    testing.expectEqual(5, input.selectionStart);
+    testing.expectEqual(5, input.selectionEnd);
+    testing.expectEqual('none', input.selectionDirection);
+
+    // The caret follows the _sanitized_ value: a text input strips CR/LF.
+    input.value = 'a\nb';
+    testing.expectEqual(2, input.selectionStart);
+    testing.expectEqual(2, input.selectionEnd);
+
+    // Types with no text entry cursor keep reporting null rather than a number.
+    const check = document.createElement('input');
+    check.type = 'checkbox';
+    check.value = 'on';
+    testing.expectEqual(null, check.selectionStart);
+    testing.expectEqual(null, check.selectionEnd);
+  }
+</script>

--- a/src/browser/tests/element/html/textarea.html
+++ b/src/browser/tests/element/html/textarea.html
@@ -323,5 +323,23 @@
     testing.expectEqual(5, textarea.selectionStart);
     testing.expectEqual(5, textarea.selectionEnd);
     testing.expectEqual('none', textarea.selectionDirection);
+
+    // Re-assigning the same value leaves the selection alone
+    // (WPT textfieldselection/selection-after-content-change.html).
+    textarea.setSelectionRange(1, 3, 'backward');
+    textarea.value = 'hello';
+    testing.expectEqual(1, textarea.selectionStart);
+    testing.expectEqual(3, textarea.selectionEnd);
+    testing.expectEqual('backward', textarea.selectionDirection);
+
+    // Assigning a value equal to the default is not a change for the caret,
+    // but it still sets the dirty flag: later default edits stay hidden.
+    const dflt = document.createElement('textarea');
+    dflt.defaultValue = 'foo';
+    dflt.value = 'foo';
+    testing.expectEqual(0, dflt.selectionStart);
+    testing.expectEqual(0, dflt.selectionEnd);
+    dflt.defaultValue = 'bar';
+    testing.expectEqual('foo', dflt.value);
   }
 </script>

--- a/src/browser/tests/element/html/textarea.html
+++ b/src/browser/tests/element/html/textarea.html
@@ -305,3 +305,23 @@
     });
   }
 </script>
+
+<script id="value_setter_moves_caret">
+  {
+    // Setting `value` moves the text entry cursor to the end of the new value,
+    // unselects any selected text and resets the selection direction.
+    // https://html.spec.whatwg.org/#dom-textarea-value
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    textarea.value = 'abc';
+    testing.expectEqual(3, textarea.selectionStart);
+    testing.expectEqual(3, textarea.selectionEnd);
+
+    textarea.setSelectionRange(1, 2, 'backward');
+    textarea.value = 'hello';
+    testing.expectEqual(5, textarea.selectionStart);
+    testing.expectEqual(5, textarea.selectionEnd);
+    testing.expectEqual('none', textarea.selectionDirection);
+  }
+</script>

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -157,14 +157,20 @@ pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
         return error.InvalidStateError;
     }
     // This should _not_ call setAttribute. It updates the current state only
-    const sanitized = try self.sanitizeValue(true, value, frame);
-    self._value = sanitized;
+    const sanitized = try self.sanitizeValue(false, value, frame);
+    const changed = std.mem.eql(u8, self.getValue(), sanitized) == false;
+    if (changed == false and self._value != null) {
+        // _value itself isn't changing (not to be mixed up with setValue
+        // being called with the same as the default value, which would need
+        // to dupe)
+        self._user_edited = false;
+        return;
+    }
+    self._value = try frame.dupeString(sanitized);
     self._user_edited = false;
 
-    // "move the text entry cursor position to the end of the text control,
-    // unselecting any selected text and resetting the selection direction to
-    // 'none'" -- https://html.spec.whatwg.org/#dom-input-value
-    if (self.selectionAvailable()) {
+    // move the text entry cursor position to the end of the text control
+    if (changed and self.selectionAvailable()) {
         self._selection_start = @intCast(sanitized.len);
         self._selection_end = @intCast(sanitized.len);
         self._selection_direction = .none;

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -157,8 +157,18 @@ pub fn setValue(self: *Input, value: []const u8, frame: *Frame) !void {
         return error.InvalidStateError;
     }
     // This should _not_ call setAttribute. It updates the current state only
-    self._value = try self.sanitizeValue(true, value, frame);
+    const sanitized = try self.sanitizeValue(true, value, frame);
+    self._value = sanitized;
     self._user_edited = false;
+
+    // "move the text entry cursor position to the end of the text control,
+    // unselecting any selected text and resetting the selection direction to
+    // 'none'" -- https://html.spec.whatwg.org/#dom-input-value
+    if (self.selectionAvailable()) {
+        self._selection_start = @intCast(sanitized.len);
+        self._selection_end = @intCast(sanitized.len);
+        self._selection_direction = .none;
+    }
 }
 
 pub fn setUserValue(self: *Input, value: []const u8, frame: *Frame) !void {

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -82,6 +82,13 @@ pub fn setValue(self: *TextArea, value: []const u8, frame: *Frame) !void {
     const owned = try frame.arena.dupe(u8, value);
     self._value = owned;
     self._user_edited = false;
+
+    // "move the text entry cursor position to the end of the text control,
+    // unselecting any selected text and resetting the selection direction to
+    // 'none'" -- https://html.spec.whatwg.org/#dom-textarea-value
+    self._selection_start = @intCast(owned.len);
+    self._selection_end = @intCast(owned.len);
+    self._selection_direction = .none;
 }
 
 pub fn setUserValue(self: *TextArea, value: []const u8, frame: *Frame) !void {

--- a/src/browser/webapi/element/html/TextArea.zig
+++ b/src/browser/webapi/element/html/TextArea.zig
@@ -79,16 +79,24 @@ pub fn getValue(self: *const TextArea) []const u8 {
 }
 
 pub fn setValue(self: *TextArea, value: []const u8, frame: *Frame) !void {
+    const changed = std.mem.eql(u8, self.getValue(), value) == false;
+    if (changed == false and self._value != null) {
+        // _value itself isn't changing (not to be mixed up with setValue
+        // being called with the same as the default value, which would need
+        // to dupe)
+        self._user_edited = false;
+        return;
+    }
     const owned = try frame.arena.dupe(u8, value);
     self._value = owned;
     self._user_edited = false;
 
-    // "move the text entry cursor position to the end of the text control,
-    // unselecting any selected text and resetting the selection direction to
-    // 'none'" -- https://html.spec.whatwg.org/#dom-textarea-value
-    self._selection_start = @intCast(owned.len);
-    self._selection_end = @intCast(owned.len);
-    self._selection_direction = .none;
+    // move the text entry cursor position to the end of the text control
+    if (changed) {
+        self._selection_start = @intCast(owned.len);
+        self._selection_end = @intCast(owned.len);
+        self._selection_direction = .none;
+    }
 }
 
 pub fn setUserValue(self: *TextArea, value: []const u8, frame: *Frame) !void {


### PR DESCRIPTION
Closes #3419

## Problem

The `value` setter on `<input>` and `<textarea>` writes `_value` but never touches `_selection_start` / `_selection_end` / `_selection_direction`. The HTML Standard requires it to move the text entry cursor to the end of the new value, unselect any selected text, and reset the selection direction to `"none"` — [`#dom-input-value`](https://html.spec.whatwg.org/multipage/input.html#dom-input-value), [`#dom-textarea-value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value).

The user-visible consequence is that the set-then-correct sequence deletes nothing: on a fresh control the caret is still at 0, so the Backspace path from #3298 (`innerDelete`) returns early.

```mermaid
flowchart LR
    subgraph before["before"]
        direction TB
        A1["el.value = 'abcd'"] --> B1["_value = 'abcd'"]
        B1 --> C1["_selection_start = 0<br/>(unchanged)"]
        C1 --> D1["Backspace → innerDelete"]
        D1 --> E1{"caret == 0?"}
        E1 -->|yes| F1["return early<br/>value still 'abcd'"]
    end

    subgraph after["after"]
        direction TB
        A2["el.value = 'abcd'"] --> B2["_value = 'abcd'"]
        B2 --> G2{"selectionAvailable?"}
        G2 -->|no| H2["leave selection alone<br/>(checkbox, file, ...)"]
        G2 -->|yes| C2["_selection_start = _selection_end = 4<br/>_selection_direction = .none"]
        C2 --> D2["Backspace → innerDelete"]
        D2 --> E2{"caret == 0?"}
        E2 -->|no| F2["delete 'd'<br/>value 'abc' + input event"]
    end

    style F1 fill:#ffebeb,stroke:#d1242f
    style F2 fill:#e8f5e9,stroke:#1a7f37
```

## Fix

- **`Input.setValue`** — after sanitizing, collapse the selection to the end of the *sanitized* value (a text input strips CR/LF, so `'a\nb'` must land the caret at 2, not 3) and reset the direction. Guarded by `selectionAvailable()` so types with no text entry cursor — checkbox, radio, file, number, date, … — keep reporting `null` from `selectionStart` / `selectionEnd`, as the spec requires.
- **`TextArea.setValue`** — same, unguarded; a `<textarea>` always has a cursor.

Why the guard placement is safe:

- `setUserValue` delegates to `setValue`. The `text_entry.zig` edit paths that need a *specific* caret — `innerInsert`'s `.full` and `.partial` arms, and `innerDelete` — already assign the selection **after** the `setUserValue` call, so they win and are unchanged.
- `innerInsert`'s `.none` arm appends at the end and did not set a caret; it now correctly leaves the cursor after the inserted text. This is the one behavior change beyond the setter itself, and it matches Chrome.
- Attribute-driven updates and form reset assign `_value` directly (`attributeChanged`, the `_default_value` paths) rather than going through `setValue`, so they keep the caret untouched — also correct, those are not the value setter.

## Tests

New `value_setter_moves_caret` sections in the two fixtures the existing runners already cover:

- `tests/element/html/input.html` — fresh-control caret, re-assign over a `backward` selection, the CR/LF-sanitized offset, and a `type=checkbox` guard asserting `selectionStart`/`selectionEnd` stay `null`.
- `tests/element/html/textarea.html` — fresh-control caret and re-assign over a selection.

Both fixtures fail on `main` and pass on this branch (verified by reverting only the two `.zig` files and re-running).

```
TEST_FILTER='WebApi' zig build test   → 164/164
TEST_FILTER='cdp'    zig build test   → 165/165
zig build check                       → clean
```

`zig build test` without a filter aborts locally in `server: http connections stay ordered by deadline` (`Server.zig:2309`), identically on unmodified `main` — a macOS-only environment failure, not from this branch. Leaving that to CI on Linux.

## Verification against Chrome

A standalone page asserting 11 properties of the caret after `.value =` (both element types, fresh and re-assigned, with `selectionDirection`) run through `lightpanda fetch --dump html`:

| Binary | Result |
| --- | --- |
| nightly `1.0.0-nightly.9204+c5aaafe59` | all 11 FAIL |
| Chrome 149 headless (control) | all 11 pass |
| this branch | all 11 pass |
