### PR TITLE
webapi: clamp text entry selections against the current value

### DIFF
--- a/src/browser/tests/element/html/textarea.html
+++ b/src/browser/tests/element/html/textarea.html
@@ -230,6 +230,42 @@
   }
 </script>
 
+<script id="selection_uses_current_value">
+  {
+    // A <textarea>'s API value is its raw value, which comes from its child
+    // text node until something assigns to `value`. The selection APIs clamp
+    // against that value, not against an assigned one.
+    // https://html.spec.whatwg.org/#dom-textarea-value
+    // https://html.spec.whatwg.org/#dom-textarea/input-setselectionrange
+    const host = document.createElement('div');
+    host.innerHTML = '<textarea>abcdef</textarea>';
+    document.body.appendChild(host);
+    const parsed = host.firstChild;
+
+    parsed.select();
+    testing.expectEqual(0, parsed.selectionStart);
+    testing.expectEqual(6, parsed.selectionEnd);
+
+    parsed.setSelectionRange(2, 4, 'backward');
+    testing.expectEqual(2, parsed.selectionStart);
+    testing.expectEqual(4, parsed.selectionEnd);
+    testing.expectEqual('backward', parsed.selectionDirection);
+
+    // Offsets past the end clamp to the length of the value.
+    parsed.setSelectionRange(99, 99);
+    testing.expectEqual(6, parsed.selectionStart);
+    testing.expectEqual(6, parsed.selectionEnd);
+
+    // Same when the default value came from the defaultValue setter.
+    const seeded = document.createElement('textarea');
+    document.body.appendChild(seeded);
+    seeded.defaultValue = 'hello';
+    seeded.select();
+    testing.expectEqual(0, seeded.selectionStart);
+    testing.expectEqual(5, seeded.selectionEnd);
+  }
+</script>
+
 <script id="select_event">
   {
     const textarea = document.createElement('textarea');

--- a/src/browser/webapi/element/text_entry.zig
+++ b/src/browser/webapi/element/text_entry.zig
@@ -30,7 +30,7 @@ const InputEvent = @import("../event/InputEvent.zig");
 pub fn TextEntry(comptime T: type) type {
     return struct {
         pub fn select(self: *T, frame: *Frame) !void {
-            const len = if (self._value) |v| @as(u32, @intCast(v.len)) else 0;
+            const len: u32 = @intCast(self.getValue().len);
             try setSelectionRange(self, 0, len, null, frame);
             const event = try Event.init("select", .{ .bubbles = true }, frame._page);
             try frame._event_manager.dispatch(self.asElement().asEventTarget(), event);
@@ -165,14 +165,7 @@ pub fn TextEntry(comptime T: type) type {
                 } else break :blk .none;
             };
 
-            const value = self._value orelse {
-                self._selection_start = 0;
-                self._selection_end = 0;
-                self._selection_direction = .none;
-                return;
-            };
-
-            const len_u32: u32 = @intCast(value.len);
+            const len_u32: u32 = @intCast(self.getValue().len);
             var start: u32 = if (selection_start > len_u32) len_u32 else selection_start;
             const end: u32 = if (selection_end > len_u32) len_u32 else selection_end;
 
@@ -194,15 +187,17 @@ pub fn TextEntry(comptime T: type) type {
             if (self.selectionAvailable() == false) {
                 return .none;
             }
-            const value = self._value orelse return .none;
+            const value_len: u32 = @intCast(self.getValue().len);
+            const start = @min(self._selection_start, value_len);
+            const end = @min(self._selection_end, value_len);
 
-            if (self._selection_start == self._selection_end) {
+            if (start == end) {
                 return .none;
             }
-            if (self._selection_start == 0 and self._selection_end == value.len) {
+            if (start == 0 and end == value_len) {
                 return .full;
             }
-            return .{ .partial = .{ self._selection_start, self._selection_end } };
+            return .{ .partial = .{ start, end } };
         }
 
         fn dispatchSelectionChangeEvent(self: *T, frame: *Frame) !void {

--- a/src/server/cdp/domains/input.zig
+++ b/src/server/cdp/domains/input.zig
@@ -478,3 +478,47 @@ test "cdp.input: dispatchKeyEvent beforeinput can veto the edit" {
         \\clone.value === 'abc' && window.seen.join(',') === 'input:false'
     , null)).isTrue());
 }
+
+test "cdp.input: editing keys honor the selection of a default-valued textarea" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{});
+    const page = try bc.session.createPage();
+    const frame = page.frame().?;
+
+    try frame.navigate("http://localhost:9582/src/browser/tests/mcp_actions.html", .{ .reason = .address_bar, .kind = .{ .push = null } });
+    try testing.waitForPage(bc);
+
+    var ls: lp.js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    // This <textarea>'s value comes from its child text node — nothing assigns
+    // to `value` — so the selection has to clamp against the parsed text.
+    _ = try ls.local.compileAndRun(
+        \\document.body.innerHTML = '<textarea id="ta">abcdef</textarea>';
+        \\const ta = document.getElementById('ta');
+        \\ta.focus();
+        \\ta.setSelectionRange(2, 4);
+    , null);
+    try testing.expect((try ls.local.compileAndRun("ta.selectionStart === 2 && ta.selectionEnd === 4", null)).isTrue());
+
+    // Backspace over a range deletes the range, leaving the caret at its start.
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Backspace", .code = "Backspace" },
+    });
+    try testing.expect((try ls.local.compileAndRun("ta.value === 'abef'", null)).isTrue());
+    try testing.expect((try ls.local.compileAndRun("ta.selectionStart === 2 && ta.selectionEnd === 2", null)).isTrue());
+
+    // Collapsed caret: Backspace removes the character on its left.
+    _ = try ls.local.compileAndRun("ta.setSelectionRange(3, 3)", null);
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Input.dispatchKeyEvent",
+        .params = .{ .type = "keyDown", .key = "Backspace", .code = "Backspace" },
+    });
+    try testing.expect((try ls.local.compileAndRun("ta.value === 'abf'", null)).isTrue());
+}


### PR DESCRIPTION
Closes #3421

## Problem

`select()` and `setSelectionRange()` on a `<textarea>` whose value comes from its child text node collapse the selection to `[0, 0]` instead of clamping against that value. `textarea.value` returns the text correctly the whole time — only the selection APIs miss it.

Three sites in the `TextEntry` mixin read the `_value` slot directly. That slot holds the *assigned* value only; a `<textarea>abcdef</textarea>` straight out of the parser has `_value == null`, and `TextArea.getValue()` is what falls back to the child text node. `<input value="abcdef">` populates `_value` from the content attribute at build time, so inputs never showed the bug and the two controls disagreed on identical-looking markup.

`innerDelete()` in the same file already read `getValue()`, which is the inconsistency this aligns.

```mermaid
flowchart TD
    A["setSelectionRange(2, 4)"] --> B{"self._value"}

    B -->|"before: null"| C["selection = 0, 0<br/>direction = none<br/>early return"]
    C --> D["caret pinned at 0<br/>Backspace is a no-op"]

    B -->|"before: assigned"| E["clamp to _value.len"]
    E --> F["selection = 2, 4"]

    A --> G["after: getValue().len"]
    G --> H["clamp to the current value<br/>_value orelse the child text node"]
    H --> F

    style C fill:#7d1a1a,color:#fff
    style D fill:#7d1a1a,color:#fff
    style G fill:#1a5c2e,color:#fff
    style H fill:#1a5c2e,color:#fff
    style F fill:#1a5c2e,color:#fff
```

## Fix

`src/browser/webapi/element/text_entry.zig`:

- `select()` — take the length from `getValue()` rather than `_value`.
- `setSelectionRange()` — drop the `_value orelse { zero the selection; return; }` branch and clamp against `getValue().len`. There is no branch in the spec that zeroes a selection; out-of-range offsets clamp.
- `howSelected()` — same current-value rule, plus clamping. `selectionStart`/`selectionEnd` store their argument verbatim, so an offset can outlive a shorter value; without the clamp such an offset reaches `innerInsert()`'s `.partial` arm as an out-of-range slice index.

Behavior for `<input>` is unchanged: for every type where `selectionAvailable()` is true, `getValue()`'s fallback chain past `_value` is `_default_value orelse ""`, and `_default_value` is what `_value` was already initialized from.

## Spec

- [HTML §`textarea.value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value) — a textarea's API value is its raw value, initialized from the element's child text content, not conditional on an assignment.
- [HTML §`setSelectionRange()`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea/input-setselectionrange) — "set the selection range" clamps `start`/`end` to the length of the element's API value.
- [HTML §`select()`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea/input-select) — "set the selection range with 0 and infinity".

## Tests

- `src/browser/tests/element/html/textarea.html` — new `selection_uses_current_value` block: `select()` over a parser-built textarea, `setSelectionRange()` with a direction, out-of-range clamping, and the same through the `defaultValue` setter. The existing selection blocks in this file all build their element with `textarea.value = '...'`, which is why the gap went unnoticed.
- `src/server/cdp/domains/input.zig` — new `cdp.input: editing keys honor the selection of a default-valued textarea`: a trusted Backspace over a range deletes the range and leaves the caret at its start, then a collapsed caret deletes the character on its left. This is the path that exercises `howSelected()`, which is not reachable from page script.

Verified by reverting only `text_entry.zig`: both tests fail, and pass again with it restored. `TEST_FILTER='WebApi'` 164/164 and `TEST_FILTER='cdp'` 166/166 locally. The full run also trips `server: http connections stay ordered by deadline`, which panics identically on an unmodified `main` on this machine (macOS aarch64) and is unrelated.

## Notes

The `howSelected()` clamp is defensive rather than a behavior change in itself — it is required because the fix makes that function reachable with a non-null value on controls where it previously bailed out. Tightening the `selectionStart`/`selectionEnd` setters to clamp on write (the spec routes both through "set the selection range") is a separate change and is not included here.
