### PR TITLE
stability: stop re-observed infinite-scroll sentinels

### DIFF
--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -64,7 +64,18 @@ pub const Intersection = struct {
     last_delivery_ms: u64 = 0,
     burst_deliveries: u32 = 0,
     runaway: bool = false,
+
+    // Times each target was reported intersecting this navigation.
+    reported: std.AutoHashMapUnmanaged(*Element, u8) = .{},
+    sentinel_logged: bool = false,
 };
+
+// Without layout every attached element intersects, so an infinite-scroll
+// sentinel fires each time the page re-observes it after loading a batch, and
+// the burst guard above only catches that after 10 s. A target reported this
+// many times in one navigation is treated as below the fold from then on.
+// Three leaves room for several observers watching one element.
+pub const INTERSECTION_TARGET_REPORT_LIMIT = 3;
 
 // ResizeObserver bookkeeping for a frame.
 pub const Resize = struct {

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -270,8 +270,7 @@ fn checkIntersection(self: *IntersectionObserver, target: *Element, frame: *Fram
     const reported = try frame._intersection.reported.getOrPut(frame.arena, target);
     if (!reported.found_existing) {
         reported.value_ptr.* = 0;
-    }
-    if (reported.value_ptr.* >= Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT) {
+    } else if (reported.value_ptr.* >= Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT) {
         if (!frame._intersection.sentinel_logged) {
             frame._intersection.sentinel_logged = true;
             log.warn(.frame, "IntsctObserver.sentinel", .{ .url = frame.url });

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -266,6 +266,21 @@ fn checkIntersection(self: *IntersectionObserver, target: *Element, frame: *Fram
         return;
     }
 
+    // See observers.INTERSECTION_TARGET_REPORT_LIMIT.
+    const reported = try frame._intersection.reported.getOrPut(frame.arena, target);
+    if (!reported.found_existing) {
+        reported.value_ptr.* = 0;
+    }
+    if (reported.value_ptr.* >= Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT) {
+        if (!frame._intersection.sentinel_logged) {
+            frame._intersection.sentinel_logged = true;
+            log.warn(.frame, "IntsctObserver.sentinel", .{ .url = frame.url });
+        }
+        _ = self._tracked.removeByPtr(tracked.key_ptr);
+        return;
+    }
+    reported.value_ptr.* += 1;
+
     // Building the entry is the expensive part — getBoundingClientRect walks the
     // document to fake a position (O(node count)) — so it only runs here.
     const data = try self.calculateIntersection(target, has_parent, frame);


### PR DESCRIPTION
The timer cap raise was split out and merged as #3445; this PR is now only the observer change.

## Problem

Without layout every attached element intersects, so a load-more sentinel that the page unobserves, loads a batch for and observes again fires on every observe. `eu.gymshark.com`'s listing paginates to page 17 that way: 250-350 product cards where a browser renders 70, 10x the timers, hundreds of Algolia requests, and a CDP `Runtime.callFunctionOn` issued right after `load` waits 1.6-10 s behind the churn (62 ms on Chrome). The burst-duration guard from #3383 only trips after 10 s.

## Fix

Track per frame how many times each target was reported intersecting; past 3 in one navigation treat it as below the fold for every observer (`observers.INTERSECTION_TARGET_REPORT_LIMIT`). Three leaves room for a lazy loader, a prefetcher and an analytics observer on the same element, and lets a page load its second and third batch.

## Result

Storefront collection page: 130 cards and 4 search requests, deterministic (was 250-350 and 250-1000). Cache-matched A/B of the puppeteer retail flow, 6 interleaved rounds: evaluate after load 27-96 ms (was 34 ms-3.2 s), whole flow 4.5 s median (was 7.8 s).

Offline busy-page shapes (timer chains, microtask chains, a long sync task, 2000 timers due at once, a script chain) behave identically on lightpanda and Chrome, so the serve loop is not involved.
