### PR TITLE
webapi: Add context when parsing HTML

### DIFF
--- a/src/browser/frame/parse.zig
+++ b/src/browser/frame/parse.zig
@@ -26,26 +26,22 @@ const ShadowRoot = @import("../webapi/ShadowRoot.zig");
 const slotting = @import("../webapi/element/slotting.zig");
 
 pub fn htmlAsChildren(frame: *Frame, node: *Node, html: []const u8) !void {
-    return htmlAsChildrenInner(frame, node, html, .{});
-}
-
-// setHTMLUnsafe variant: parse a fragment that may contain declarative shadow node
-pub fn htmlUnsafeAsChildren(frame: *Frame, node: *Node, html: []const u8) !void {
-    return htmlAsChildrenInner(frame, node, html, .{ .allow_declarative_shadow = true });
+    return fragment(frame, node, html, .{});
 }
 
 // Range.createContextualFragment variant: unlike innerHTML et al., its scripts
 // are run when the fragment is inserted into a document.
 pub fn contextualFragment(frame: *Frame, node: *Node, html: []const u8) !void {
-    return htmlAsChildrenInner(frame, node, html, .{ .scripts_runnable = true });
+    return fragment(frame, node, html, .{ .scripts_runnable = true });
 }
 
-const FragmentParseOpts = struct {
+pub const FragmentParseOpts = struct {
     scripts_runnable: bool = false,
     allow_declarative_shadow: bool = false,
+    context: ?*Element = null, // the parse context when it isn't the supplied `node`
 };
 
-fn htmlAsChildrenInner(frame: *Frame, node: *Node, html: []const u8, opts: FragmentParseOpts) !void {
+pub fn fragment(frame: *Frame, node: *Node, html: []const u8, opts: FragmentParseOpts) !void {
     const previous_parse_mode = frame._parse_mode;
     frame._parse_mode = .fragment;
     defer frame._parse_mode = previous_parse_mode;
@@ -69,7 +65,10 @@ fn htmlAsChildrenInner(frame: *Frame, node: *Node, html: []const u8, opts: Fragm
     frame._fragment_scripts_runnable = opts.scripts_runnable;
     defer frame._fragment_scripts_runnable = previous_scripts_runnable;
 
-    var parser = Parser.init(frame.call_arena, node, frame, .{ .allow_declarative_shadow = opts.allow_declarative_shadow });
+    var parser = Parser.init(frame.call_arena, node, frame, .{
+        .allow_declarative_shadow = opts.allow_declarative_shadow,
+        .context = opts.context,
+    });
     parser.parseFragment(html);
     if (parser.terminated) {
         return error.ExecutionTerminated;

--- a/src/browser/parser/Parser.zig
+++ b/src/browser/parser/Parser.zig
@@ -77,12 +77,19 @@ buf: std.ArrayList(u8),
 // innerHTML and DOMParser (per spec). Set from Options at init.
 allow_declarative_shadow: bool = false,
 
+// Fragment-parse context element when it isn't the container. html5ever picks
+// the insertion mode and tokenizer state from the context's name. For example
+// a <template> context is processed "in template" mode which has specific
+// behavior.
+context: ?*Element = null,
+
 xml_error: bool = false,
 terminated: bool = false,
 appends_until_terminate_check: u16 = TERMINATE_CHECK_INTERVAL,
 
 pub const Options = struct {
     allow_declarative_shadow: bool = false,
+    context: ?*Element = null,
 };
 
 pub fn init(arena: Allocator, node: *Node, frame: *Frame, opts: Options) Parser {
@@ -98,6 +105,7 @@ pub fn init(arena: Allocator, node: *Node, frame: *Frame, opts: Options) Parser 
         .pending_text = null,
         .buf = .empty,
         .allow_declarative_shadow = opts.allow_declarative_shadow,
+        .context = opts.context,
     };
 }
 
@@ -274,7 +282,7 @@ pub fn parseXML(self: *Parser, xml: []const u8) void {
 }
 
 pub fn parseFragment(self: *Parser, html: []const u8) void {
-    const context_name: []const u8 = if (self.container.node.is(Element)) |el|
+    const context_name: []const u8 = if (self.context orelse self.container.node.is(Element)) |el|
         el.getLocalName()
     else
         "";

--- a/src/browser/tests/document/insert_adjacent_html.html
+++ b/src/browser/tests/document/insert_adjacent_html.html
@@ -91,3 +91,42 @@
   // Clean up
   document.body.removeChild(fuzzWrapper);
 </script>
+
+<table id=iah-table><tbody><tr id=iah-tr><td>a</td></tr></tbody></table>
+<div id=iah-host></div>
+<script id=insertAdjacentHTML_context>
+  // beforeend/afterbegin parse with the element as context, beforebegin/
+  // afterend with its parent, so table bits are kept where a body context
+  // would drop them.
+  const tbody = $('#iah-table tbody');
+  tbody.insertAdjacentHTML('beforeend', '<tr id=iah-tr3><td>c</td></tr>');
+  tbody.insertAdjacentHTML('afterbegin', '<tr id=iah-tr0><td>0</td></tr>');
+  $('#iah-tr').insertAdjacentHTML('beforebegin', '<tr id=iah-tr1><td>1</td></tr>');
+  $('#iah-tr').insertAdjacentHTML('afterend', '<tr id=iah-tr2><td>b</td></tr>');
+  testing.expectEqual(
+    '<tbody><tr id="iah-tr0"><td>0</td></tr><tr id="iah-tr1"><td>1</td></tr><tr id="iah-tr"><td>a</td></tr><tr id="iah-tr2"><td>b</td></tr><tr id="iah-tr3"><td>c</td></tr></tbody>',
+    $('#iah-table').innerHTML);
+
+  // A raw text element as context switches the tokenizer state.
+  const script = document.createElement('script');
+  script.type = 'text/plain';
+  document.body.appendChild(script);
+  script.insertAdjacentHTML('beforeend', '<b>x</b>');
+  testing.expectEqual(0, script.children.length);
+  testing.expectEqual('<b>x</b>', script.textContent);
+  script.remove();
+
+  // A shadow root parent is allowed, and is a body context.
+  const shadow = $('#iah-host').attachShadow({ mode: 'open' });
+  shadow.innerHTML = '<span id=iah-in></span>';
+  shadow.firstChild.insertAdjacentHTML('beforebegin', '<i>i</i><tr><td>t</td></tr>');
+  testing.expectEqual('<i>i</i>t<span id="iah-in"></span>', shadow.innerHTML);
+
+  // An <html> context parses as body; a document parent is rejected.
+  document.body.insertAdjacentHTML('beforebegin', '<p id=iah-p>p</p>');
+  testing.expectEqual('HTML', $('#iah-p').parentNode.tagName);
+  $('#iah-p').remove();
+  testing.expectError('NoModificationAllowedError', () => {
+    document.documentElement.insertAdjacentHTML('beforebegin', '<p>p</p>');
+  });
+</script>

--- a/src/browser/tests/element/html/template.html
+++ b/src/browser/tests/element/html/template.html
@@ -250,3 +250,37 @@
   testing.expectEqual('x', wrapperClone.querySelector('template').content.querySelector('#in-template').textContent);
 }
 </script>
+
+<script id=innerHTML_table_roots>
+{
+  // The fragment is parsed with the template as context ("in template"
+  // mode), so table-section roots are kept rather than dropped as they
+  // would be in a div.
+  const t = document.createElement('template');
+  t.innerHTML = '<tr title="a"><td>b</td></tr>';
+  testing.expectEqual(1, t.content.children.length);
+  testing.expectEqual('TR', t.content.firstElementChild.tagName);
+  testing.expectEqual('a', t.content.querySelector('tr').getAttribute('title'));
+  testing.expectEqual('b', t.content.querySelector('td').textContent);
+  testing.expectEqual('<tr title="a"><td>b</td></tr>', t.innerHTML);
+
+  t.innerHTML = '<td>b</td>';
+  testing.expectEqual('<td>b</td>', t.innerHTML);
+
+  t.innerHTML = '<col span=2>';
+  testing.expectEqual('<col span="2">', t.innerHTML);
+
+  t.innerHTML = '<caption>x</caption><colgroup></colgroup><thead></thead><tbody></tbody><tfoot></tfoot>';
+  testing.expectEqual(5, t.content.children.length);
+
+  // Replaces, rather than appends to, the previous contents.
+  t.innerHTML = '<div>y</div>';
+  testing.expectEqual('<div>y</div>', t.innerHTML);
+
+  // Control: the same markup in a div drops the table bits.
+  const d = document.createElement('div');
+  d.innerHTML = '<tr><td>b</td></tr>';
+  testing.expectEqual(0, d.children.length);
+  testing.expectEqual('b', d.innerHTML);
+}
+</script>

--- a/src/browser/tests/element/outer.html
+++ b/src/browser/tests/element/outer.html
@@ -19,3 +19,21 @@
   // testing.expectEqual(null, document.getElementById('p1'));
   // testing.expectEqual(true, document.body.outerHTML.replaceAll(/\n/g, '').startsWith('<body><script id="outerHTML">'));
 </script>
+
+<table id=t1><tbody><tr id=tr1><td>a</td></tr></tbody></table>
+<script id=outerHTML_table_context>
+  // The parent (tr / tbody) is the parse context, so table bits survive.
+  $('#tr1').outerHTML = '<tr id=tr2><td>b</td></tr>';
+  testing.expectEqual('<tbody><tr id="tr2"><td>b</td></tr></tbody>', $('#t1').innerHTML);
+
+  $('#tr2').firstElementChild.outerHTML = '<td>c</td><th>d</th>';
+  testing.expectEqual('<tr id="tr2"><td>c</td><th>d</th></tr>', $('#tr2').outerHTML);
+
+  // A fragment parent is a body context.
+  const frag = document.createDocumentFragment();
+  const span = document.createElement('span');
+  frag.appendChild(span);
+  span.outerHTML = '<tr><td>x</td></tr>';
+  testing.expectEqual(0, frag.children.length);
+  testing.expectEqual('x', frag.textContent);
+</script>

--- a/src/browser/webapi/DocumentFragment.zig
+++ b/src/browser/webapi/DocumentFragment.zig
@@ -162,13 +162,13 @@ pub fn getInnerHTML(self: *DocumentFragment, writer: *std.Io.Writer, frame: *Fra
 
 pub fn setInnerHTML(self: *DocumentFragment, html: []const u8, frame: *Frame) !void {
     const parent = self.asNode();
-    return parent.setHTML(html, false, frame);
+    return parent.setHTML(html, .{}, frame);
 }
 
 /// allows declarative shadow dom
 pub fn setHTMLUnsafe(self: *DocumentFragment, html: []const u8, frame: *Frame) !void {
     const parent = self.asNode();
-    return parent.setHTML(html, true, frame);
+    return parent.setHTML(html, .{ .allow_declarative_shadow = true }, frame);
 }
 
 pub fn cloneFragment(self: *DocumentFragment, deep: bool, frame: *Frame) !*Node {

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -570,7 +570,8 @@ pub fn setOuterHTML(self: *Element, html: []const u8, frame: *Frame) !void {
     var fragment: ?*Node = null;
     if (html.len > 0) {
         const frag = (try Node.DocumentFragment.init(frame)).asNode();
-        try Frame.parse.htmlAsChildren(frame, frag, html);
+        // The parent is the parse context (a fragment parent means body).
+        try Frame.parse.fragment(frame, frag, html, .{ .context = parent.is(Element) });
         fragment = frag;
     }
 
@@ -620,13 +621,13 @@ pub fn getHTML(self: *Element, opts: dump.Opts.Shadow.Declarative, writer: *std.
 
 pub fn setInnerHTML(self: *Element, html: []const u8, frame: *Frame) !void {
     const parent = self.asNode();
-    return parent.setHTML(html, false, frame);
+    return parent.setHTML(html, .{}, frame);
 }
 
 /// allows declarative shadow dom
 pub fn setHTMLUnsafe(self: *Element, html: []const u8, frame: *Frame) !void {
     const parent = self.asNode();
-    return parent.setHTML(html, true, frame);
+    return parent.setHTML(html, .{ .allow_declarative_shadow = true }, frame);
 }
 
 pub fn getId(self: *const Element) []const u8 {

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -200,17 +200,14 @@ pub fn findAdjacentNodes(self: *Node, position: []const u8, variant: AdjacentVar
 }
 
 // beforebegin/afterend insert into the parent, which must exist and, for the
-// html variant, cannot be a document or fragment.
+// html variant, cannot be a document.
 fn adjacentParent(self: *Node, variant: AdjacentVariant) !*Node {
     const parent_node = self.parentNode() orelse switch (variant) {
         .html => return error.NoModificationAllowed,
         .node => return error.AdjacentNoParent,
     };
-    if (variant == .html) {
-        switch (parent_node._type) {
-            .document, .document_fragment => return error.NoModificationAllowed,
-            else => {},
-        }
+    if (variant == .html and parent_node._type == .document) {
+        return error.NoModificationAllowed;
     }
     return parent_node;
 }
@@ -1593,7 +1590,7 @@ fn removeAllChildrenCollecting(self: *Node, notify: bool, frame: *Frame) !std.Ar
 }
 
 /// Shared implementation in Element and DocumentFragment
-pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, frame: *Frame) !void {
+pub fn setHTML(self: *Node, html: []const u8, opts: Frame.parse.FragmentParseOpts, frame: *Frame) !void {
     frame.domChanged();
 
     // Observers of this subtree get one combined "replace all" mutation
@@ -1603,11 +1600,7 @@ pub fn setHTML(self: *Node, html: []const u8, allow_declarative_shadow: bool, fr
     const removed = try self.removeAllChildrenCollecting(notify, frame);
 
     if (html.len > 0) {
-        if (allow_declarative_shadow) {
-            try Frame.parse.htmlUnsafeAsChildren(frame, self, html);
-        } else {
-            try Frame.parse.htmlAsChildren(frame, self, html);
-        }
+        try Frame.parse.fragment(frame, self, html, opts);
     }
 
     if (notify) {

--- a/src/browser/webapi/element/Html.zig
+++ b/src/browser/webapi/element/Html.zig
@@ -381,8 +381,16 @@ pub fn insertAdjacentHTML(
     frame: *Frame,
 ) !void {
     const DocumentFragment = @import("../DocumentFragment.zig");
+
+    // The parse context is the node we insert into
+    const context_node, _ = try self.asNode().findAdjacentNodes(position, .html);
+    const context = if (context_node.is(Element)) |el|
+        if (el.is(Element.Html.Html) == null) el else null
+    else
+        null;
+
     const fragment = (try DocumentFragment.init(frame)).asNode();
-    try Frame.parse.htmlAsChildren(frame, fragment, html);
+    try Frame.parse.fragment(frame, fragment, html, .{ .context = context });
 
     const target_node, const prev_node = try self.asNode().findAdjacentNodes(position, .html);
 

--- a/src/browser/webapi/element/html/Template.zig
+++ b/src/browser/webapi/element/html/Template.zig
@@ -54,7 +54,7 @@ pub fn getContent(self: *Template) *DocumentFragment {
 }
 
 pub fn setInnerHTML(self: *Template, html: []const u8, frame: *Frame) !void {
-    return self._content.setInnerHTML(html, frame);
+    return self._content.asNode().setHTML(html, .{ .context = self.asElement() }, frame);
 }
 
 pub fn getShadowRootMode(self: *const Template) []const u8 {


### PR DESCRIPTION
Parsing HTML has different modes. Parsing HTML when setting innerHTML can be different than parsing HTML inside a template, can be different than ...

html5ever handles this for us, provided we give it the correct context (the tag name that the content is being parsed into). This adds an optional *Element to the Parser which is fed into html5ever (its tagname).

Fixes: https://github.com/lightpanda-io/browser/issues/3336