### PR TITLE
http: tweak http timeouts

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -652,7 +652,7 @@ pub fn httpNavBurst(self: *const Config) u32 {
 
 pub fn httpConnectTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 0,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_connect_timeout orelse 8000,
         .version => 0,
         else => unreachable,
     };
@@ -660,7 +660,7 @@ pub fn httpConnectTimeout(self: *const Config) u31 {
 
 pub fn httpTimeout(self: *const Config) u31 {
     return switch (self.mode) {
-        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 5000,
+        inline .serve, .fetch, .mcp, .agent => |opts| opts.http_timeout orelse 15000,
         .version => 5000,
         else => unreachable,
     };

--- a/src/help.zon
+++ b/src/help.zon
@@ -399,7 +399,7 @@
     \\  --http-connect-timeout <INT>
     \\          Time in ms to establish an HTTP connection before timing out. 0 means
     \\          never.
-    \\          Defaults to 0.
+    \\          Defaults to 8000.
     \\  --http-header <HEADER>
     \\          Extra custom header added to every outgoing HTTP request, including redirections,
     \\          in "Name: Value" form. Can be passed multiple times. The last one is used.
@@ -433,7 +433,7 @@
     \\          Defaults to none.
     \\  --http-timeout <INT>
     \\          Maximum time in ms the transfer is allowed to complete. 0 means never.
-    \\          Defaults to 10000.
+    \\          Defaults to 15000.
     \\  --http-version <VERSION>
     \\          HTTP version to negotiate. "1.1" never offers HTTP/2. "auto"
     \\          picks the best available option.


### PR DESCRIPTION
change --http-timeout default to 15000 (up from 5000) change --http-connect-timeout default to 8000 (down from 300000, curl's default)

5 second _total_ transfer time can be a little tight. I generally don't see a good reason to overly limit this value.

Worth noting that help.zon said the default for --http-timeout was 10000, but it was, in fact, 5000.

Hopefully this improve situations like https://github.com/lightpanda-io/browser/issues/3395 which I believe are due to slow proxies.