### PR TITLE
webapi: scrolling down re-arms capped intersection sentinels

### DIFF
--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -67,13 +67,17 @@ pub const Intersection = struct {
 
     // Times each target was reported intersecting this navigation.
     reported: std.AutoHashMapUnmanaged(*Element, u8) = .{},
+    // Targets a check refused to report because they reached the limit.
+    // Re-armed by the next scroll down, see rearmIntersectionSentinels.
+    capped: std.AutoHashMapUnmanaged(*Element, void) = .{},
     sentinel_logged: bool = false,
 };
 
 // Without layout every attached element intersects, so an infinite-scroll
 // sentinel fires each time the page re-observes it after loading a batch, and
 // the burst guard above only catches that after 10 s. A target reported this
-// many times in one navigation is treated as below the fold from then on.
+// many times in one navigation is treated as below the fold from then on,
+// until the page scrolls down (rearmIntersectionSentinels).
 // Three leaves room for several observers watching one element.
 pub const INTERSECTION_TARGET_REPORT_LIMIT = 3;
 
@@ -156,6 +160,44 @@ pub fn hasIntersectionObservers(frame: *const Frame) bool {
 pub fn checkIntersections(frame: *Frame) !void {
     for (frame._intersection.observers.items) |observer| {
         try observer.checkIntersections(frame);
+    }
+}
+
+// In a real browser a sentinel that stopped firing is below the fold, and
+// scrolling down brings it back into view for one more batch. Model that: a
+// scroll that does not move up grants every capped target one more report per
+// observer still watching it. One, not a reset, so a page that keeps
+// re-observing the same node loads a batch per scroll, the way it does in
+// Chrome, while a page that never scrolls stays at the limit.
+//
+// A scroll to the same position counts. The scrolling element's scrollHeight
+// is a constant here (Element.getScrollHeight), so the usual scrape loop,
+// `scrollTo(0, document.body.scrollHeight)` until nothing new appears, lands on
+// the same offset from its second iteration on.
+pub fn rearmIntersectionSentinels(frame: *Frame, from_y: u32, to_y: u32) !void {
+    if (to_y == 0 or to_y < from_y) {
+        return;
+    }
+    const capped = &frame._intersection.capped;
+    if (capped.count() == 0) {
+        return;
+    }
+
+    var rearmed = false;
+    var it = capped.keyIterator();
+    while (it.next()) |target| {
+        for (frame._intersection.observers.items) |observer| {
+            if (try observer.rearm(target.*)) {
+                rearmed = true;
+            }
+        }
+    }
+    // A target nobody observes anymore is dropped; if it is observed again it
+    // trips the cap and comes back.
+    capped.clearRetainingCapacity();
+
+    if (rearmed) {
+        scheduleIntersectionChecks(frame);
     }
 }
 

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -163,17 +163,12 @@ pub fn checkIntersections(frame: *Frame) !void {
     }
 }
 
-// In a real browser a sentinel that stopped firing is below the fold, and
-// scrolling down brings it back into view for one more batch. Model that: a
-// scroll that does not move up grants every capped target one more report per
-// observer still watching it. One, not a reset, so a page that keeps
-// re-observing the same node loads a batch per scroll, the way it does in
-// Chrome, while a page that never scrolls stays at the limit.
-//
-// A scroll to the same position counts. The scrolling element's scrollHeight
-// is a constant here (Element.getScrollHeight), so the usual scrape loop,
-// `scrollTo(0, document.body.scrollHeight)` until nothing new appears, lands on
-// the same offset from its second iteration on.
+// A scroll that does not move up grants each capped target one more report per
+// observer still watching it: a below-the-fold sentinel comes back into view for
+// one batch per scroll. One, not a reset, so a page that never scrolls stays
+// capped. Per observer, so a lazy loader sharing the node with an analytics
+// observer is not starved. Same offset counts: scrollHeight is constant here, so
+// the usual `scrollTo(0, document.body.scrollHeight)` loop repeats the offset.
 pub fn rearmIntersectionSentinels(frame: *Frame, from_y: u32, to_y: u32) !void {
     if (to_y == 0 or to_y < from_y) {
         return;
@@ -183,22 +178,16 @@ pub fn rearmIntersectionSentinels(frame: *Frame, from_y: u32, to_y: u32) !void {
         return;
     }
 
-    var rearmed = false;
     var it = capped.keyIterator();
     while (it.next()) |target| {
         for (frame._intersection.observers.items) |observer| {
             if (try observer.rearm(target.*)) {
-                rearmed = true;
+                scheduleIntersectionChecks(frame);
             }
         }
     }
-    // A target nobody observes anymore is dropped; if it is observed again it
-    // trips the cap and comes back.
+    // Unobserved targets drop out; re-observing trips the cap again.
     capped.clearRetainingCapacity();
-
-    if (rearmed) {
-        scheduleIntersectionChecks(frame);
-    }
 }
 
 pub fn scheduleMutationDelivery(frame: *Frame) !void {

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1510,6 +1510,7 @@ pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
         gop.value_ptr.* = .{};
     }
     const new_y: u32 = @intCast(@max(0, value));
+    try Frame.observers.rearmIntersectionSentinels(owner, gop.value_ptr.y, new_y);
     if (gop.value_ptr.y != new_y) {
         gop.value_ptr.y = new_y;
         try self.scheduleScrollEvents(owner);
@@ -1911,6 +1912,7 @@ pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
             if (dict.top) |top| gop.value_ptr.y = @intCast(@max(0, top));
         },
     }
+    try Frame.observers.rearmIntersectionSentinels(owner, old_y, gop.value_ptr.y);
     if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
         try self.scheduleScrollEvents(owner);
     }
@@ -1932,6 +1934,7 @@ pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
     const old_y = gop.value_ptr.y;
     gop.value_ptr.x = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.x)) + dx));
     gop.value_ptr.y = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.y)) + dy));
+    try Frame.observers.rearmIntersectionSentinels(owner, old_y, gop.value_ptr.y);
     if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
         try self.scheduleScrollEvents(owner);
     }

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1505,16 +1505,8 @@ pub fn getScrollTop(self: *Element, frame: *Frame) u32 {
 
 pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
     const owner = self.ownerFrame(frame);
-    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
-    if (!gop.found_existing) {
-        gop.value_ptr.* = .{};
-    }
-    const new_y: u32 = @intCast(@max(0, value));
-    try Frame.observers.rearmIntersectionSentinels(owner, gop.value_ptr.y, new_y);
-    if (gop.value_ptr.y != new_y) {
-        gop.value_ptr.y = new_y;
-        try self.scheduleScrollEvents(owner);
-    }
+    const pos = owner._element_scroll_positions.get(self) orelse ScrollPosition{};
+    try self.setScrollPosition(owner, pos.x, @intCast(@max(0, value)));
 }
 
 pub fn getScrollLeft(self: *Element, frame: *Frame) u32 {
@@ -1525,13 +1517,20 @@ pub fn getScrollLeft(self: *Element, frame: *Frame) u32 {
 
 pub fn setScrollLeft(self: *Element, value: i32, frame: *Frame) !void {
     const owner = self.ownerFrame(frame);
+    const pos = owner._element_scroll_positions.get(self) orelse ScrollPosition{};
+    try self.setScrollPosition(owner, @intCast(@max(0, value)), pos.y);
+}
+
+// Shared tail of the scroll setters. `owner` is the element's owner frame.
+fn setScrollPosition(self: *Element, owner: *Frame, new_x: u32, new_y: u32) !void {
     const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
-    const new_x: u32 = @intCast(@max(0, value));
-    if (gop.value_ptr.x != new_x) {
+    try Frame.observers.rearmIntersectionSentinels(owner, gop.value_ptr.y, new_y);
+    if (gop.value_ptr.x != new_x or gop.value_ptr.y != new_y) {
         gop.value_ptr.x = new_x;
+        gop.value_ptr.y = new_y;
         try self.scheduleScrollEvents(owner);
     }
 }
@@ -1896,48 +1895,31 @@ const ScrollToOpts = union(enum) {
 pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
     const owner = self.ownerFrame(frame);
-    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
-    if (!gop.found_existing) {
-        gop.value_ptr.* = .{};
-    }
-    const old_x = gop.value_ptr.x;
-    const old_y = gop.value_ptr.y;
-    switch (o) {
-        .x => |x| {
-            gop.value_ptr.x = @intCast(@max(0, x));
-            gop.value_ptr.y = @intCast(@max(0, y orelse 0));
+    const pos = owner._element_scroll_positions.get(self) orelse ScrollPosition{};
+    const new_x: u32, const new_y: u32 = switch (o) {
+        .x => |x| .{ @intCast(@max(0, x)), @intCast(@max(0, y orelse 0)) },
+        .opts => |dict| .{
+            if (dict.left) |left| @intCast(@max(0, left)) else pos.x,
+            if (dict.top) |top| @intCast(@max(0, top)) else pos.y,
         },
-        .opts => |dict| {
-            if (dict.left) |left| gop.value_ptr.x = @intCast(@max(0, left));
-            if (dict.top) |top| gop.value_ptr.y = @intCast(@max(0, top));
-        },
-    }
-    try Frame.observers.rearmIntersectionSentinels(owner, old_y, gop.value_ptr.y);
-    if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
-        try self.scheduleScrollEvents(owner);
-    }
+    };
+    try self.setScrollPosition(owner, new_x, new_y);
 }
 
 // scrollBy(): like scrollTo() but relative to the current position.
 pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
     const owner = self.ownerFrame(frame);
-    const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
-    if (!gop.found_existing) {
-        gop.value_ptr.* = .{};
-    }
+    const pos = owner._element_scroll_positions.get(self) orelse ScrollPosition{};
     const dx: i32, const dy: i32 = switch (o) {
         .x => |x| .{ x, y orelse 0 },
         .opts => |dict| .{ dict.left orelse 0, dict.top orelse 0 },
     };
-    const old_x = gop.value_ptr.x;
-    const old_y = gop.value_ptr.y;
-    gop.value_ptr.x = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.x)) + dx));
-    gop.value_ptr.y = @intCast(@max(0, @as(i32, @intCast(gop.value_ptr.y)) + dy));
-    try Frame.observers.rearmIntersectionSentinels(owner, old_y, gop.value_ptr.y);
-    if (gop.value_ptr.x != old_x or gop.value_ptr.y != old_y) {
-        try self.scheduleScrollEvents(owner);
-    }
+    try self.setScrollPosition(
+        owner,
+        @intCast(@max(0, @as(i32, @intCast(pos.x)) + dx)),
+        @intCast(@max(0, @as(i32, @intCast(pos.y)) + dy)),
+    );
 }
 
 // Scrolling an element fires a scroll event and then a scrollend event,

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -129,12 +129,18 @@ pub fn acquireRef(self: *IntersectionObserver) void {
     self._rc.acquire();
 }
 
-pub fn observe(self: *IntersectionObserver, target: *Element, frame: *Frame) !void {
-    // Check if already observing this target
+fn isObserving(self: *const IntersectionObserver, target: *Element) bool {
     for (self._observing.items) |elem| {
         if (elem == target) {
-            return;
+            return true;
         }
+    }
+    return false;
+}
+
+pub fn observe(self: *IntersectionObserver, target: *Element, frame: *Frame) !void {
+    if (self.isObserving(target)) {
+        return;
     }
 
     try self._observing.append(self._arena.allocator(), target);
@@ -181,13 +187,11 @@ pub fn unobserve(self: *IntersectionObserver, target: *Element, frame: *Frame) v
 // Tracks `target` again with one report granted past the limit. Returns
 // false when this observer is not observing it.
 pub fn rearm(self: *IntersectionObserver, target: *Element) !bool {
-    for (self._observing.items) |elem| {
-        if (elem == target) {
-            try self._tracked.put(self._arena.allocator(), target, .{ .rearmed = true });
-            return true;
-        }
+    if (!self.isObserving(target)) {
+        return false;
     }
-    return false;
+    try self._tracked.put(self._arena.allocator(), target, .{ .rearmed = true });
+    return true;
 }
 
 // Drops every observation without touching the frame's observer list
@@ -536,9 +540,7 @@ test "WebApi: IntersectionObserver delivery after a quiet gap starts a new burst
 }
 
 // Same-node infinite scroll: `n` observers watch one sentinel. Each callback
-// unobserves it, counts a batch and observes the node again from a timer, the
-// way a fetch-driven pager does. Every observe reports the node until the
-// frame's report limit refuses it.
+// unobserves it, counts a batch and re-observes it from a timer.
 fn observeSameNodeSentinel(local: *const js.Local, n: usize) !void {
     var buf: [1024]u8 = undefined;
     const src = try std.fmt.bufPrint(&buf,
@@ -569,7 +571,7 @@ fn batches(local: *const js.Local, i: usize) !i32 {
     return (try local.exec(src, null)).toI32();
 }
 
-// Ticks until the batch count has been stable for a few ticks, and returns it.
+// Ticks until the batch count has held for two ticks, and returns it.
 fn settleBatches(local: *const js.Local, frame: *Frame) !i32 {
     var total: i32 = -1;
     var stable: u8 = 0;
@@ -578,7 +580,7 @@ fn settleBatches(local: *const js.Local, frame: *Frame) !i32 {
         const now = try (try local.exec("window.__batches.reduce((a, b) => a + b, 0)", null)).toI32();
         if (now == total) {
             stable += 1;
-            if (stable == 4) break;
+            if (stable == 2) break;
         } else {
             total = now;
             stable = 0;
@@ -587,25 +589,7 @@ fn settleBatches(local: *const js.Local, frame: *Frame) !i32 {
     return total;
 }
 
-test "WebApi: IntersectionObserver same-node sentinel stops at the report limit" {
-    testing.silenceLog(&.{.frame});
-
-    const frame = try testing.createFrame();
-    defer testing.test_session.closeAllPages();
-
-    var ls: js.Local.Scope = undefined;
-    frame.js.localScope(&ls);
-    defer ls.deinit();
-    const local = &ls.local;
-
-    try observeSameNodeSentinel(local, 1);
-    try testing.expectEqual(Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT, try settleBatches(local, frame));
-    try testing.expectEqual(1, frame._intersection.capped.count());
-    try testing.expectEqual(true, Frame.observers.hasIntersectionObservers(frame));
-    try testing.expectEqual(false, frame._intersection.runaway);
-}
-
-test "WebApi: IntersectionObserver scrolling down re-arms a capped sentinel once" {
+test "WebApi: IntersectionObserver same-node sentinel stops at the limit, a scroll down re-arms it once" {
     testing.silenceLog(&.{.frame});
 
     const frame = try testing.createFrame();
@@ -619,33 +603,30 @@ test "WebApi: IntersectionObserver scrolling down re-arms a capped sentinel once
     try observeSameNodeSentinel(local, 1);
     const limit = Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT;
     try testing.expectEqual(limit, try settleBatches(local, frame));
+    try testing.expectEqual(1, frame._intersection.capped.count());
+    try testing.expectEqual(true, Frame.observers.hasIntersectionObservers(frame));
+    try testing.expectEqual(false, frame._intersection.runaway);
 
-    // The scrape loop: scroll to the bottom, wait, repeat. One batch per scroll.
-    // (The test document has no root element; on a page this is
-    // `scrollTo(0, document.body.scrollHeight)`.)
+    // Scroll to the bottom: one batch per scroll.
     _ = try local.exec("window.scrollTo(0, 100000)", null);
     try testing.expectEqual(limit + 1, try settleBatches(local, frame));
 
-    // scrollHeight is constant, so the second iteration lands on the same offset.
+    // Same offset again still counts.
     _ = try local.exec("window.scrollTo(0, 100000)", null);
     try testing.expectEqual(limit + 2, try settleBatches(local, frame));
 
     _ = try local.exec("window.scrollBy(0, 10)", null);
     try testing.expectEqual(limit + 3, try settleBatches(local, frame));
 
-    // Scrolling up, or back to the top, reveals nothing below the fold.
+    // Scrolling up reveals nothing below the fold.
     _ = try local.exec("window.scrollTo(0, 100)", null);
     try testing.expectEqual(limit + 3, try settleBatches(local, frame));
-    _ = try local.exec("window.scrollTo(0, 0)", null);
-    try testing.expectEqual(limit + 3, try settleBatches(local, frame));
 
-    // Scrolling an element (the tools' scroll with a node) counts too.
+    // Element scrolls (the tools' scroll with a node) count too.
     _ = try local.exec("window.__list.scrollTop = 500", null);
     try testing.expectEqual(limit + 4, try settleBatches(local, frame));
-    _ = try local.exec("window.__list.scrollBy(0, 500)", null);
-    try testing.expectEqual(limit + 5, try settleBatches(local, frame));
     _ = try local.exec("window.__list.scrollTo(0, 0)", null);
-    try testing.expectEqual(limit + 5, try settleBatches(local, frame));
+    try testing.expectEqual(limit + 4, try settleBatches(local, frame));
 }
 
 test "WebApi: IntersectionObserver re-arm grants one report per observer" {
@@ -659,14 +640,13 @@ test "WebApi: IntersectionObserver re-arm grants one report per observer" {
     defer ls.deinit();
     const local = &ls.local;
 
-    // The limit is shared across observers of one node...
+    // The limit is shared across observers of one node.
     try observeSameNodeSentinel(local, 2);
     try testing.expectEqual(Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT, try settleBatches(local, frame));
     const first = try batches(local, 0);
     const second = try batches(local, 1);
 
-    // ...but a scroll re-arms each observer that still watches it, so a lazy
-    // loader is not starved by an analytics observer on the same element.
+    // A scroll re-arms each observer still watching it.
     _ = try local.exec("window.scrollTo(0, 100000)", null);
     try testing.expectEqual(first + second + 2, try settleBatches(local, frame));
     try testing.expectEqual(first + 1, try batches(local, 0));

--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -47,7 +47,13 @@ _root_margin: []const u8 = "0px",
 _threshold: []const f64 = &.{0.0},
 _pending_entries: std.ArrayList(*IntersectionObserverEntry) = .empty,
 // tracked targets that aren't reported yet
-_tracked: std.AutoHashMapUnmanaged(*Element, void) = .{},
+_tracked: std.AutoHashMapUnmanaged(*Element, Tracked) = .{},
+
+const Tracked = struct {
+    // Granted one report past observers.INTERSECTION_TARGET_REPORT_LIMIT by a
+    // scroll down (observers.rearmIntersectionSentinels).
+    rearmed: bool = false,
+};
 
 // Shared zero rect (plain values) for non-intersecting elements. Materialized
 // into a DOMRect only if it ends up on a delivered entry.
@@ -136,7 +142,7 @@ pub fn observe(self: *IntersectionObserver, target: *Element, frame: *Frame) !vo
         try Frame.observers.registerIntersectionObserver(frame, self);
     }
 
-    try self._tracked.put(self._arena.allocator(), target, {});
+    try self._tracked.put(self._arena.allocator(), target, .{});
 
     // Check intersection for this new target and schedule delivery
     try self.checkIntersection(target, frame);
@@ -170,6 +176,18 @@ pub fn unobserve(self: *IntersectionObserver, target: *Element, frame: *Frame) v
     if (original_length > 0 and self._observing.items.len == 0) {
         Frame.observers.unregisterIntersectionObserver(frame, self);
     }
+}
+
+// Tracks `target` again with one report granted past the limit. Returns
+// false when this observer is not observing it.
+pub fn rearm(self: *IntersectionObserver, target: *Element) !bool {
+    for (self._observing.items) |elem| {
+        if (elem == target) {
+            try self._tracked.put(self._arena.allocator(), target, .{ .rearmed = true });
+            return true;
+        }
+    }
+    return false;
 }
 
 // Drops every observation without touching the frame's observer list
@@ -270,15 +288,16 @@ fn checkIntersection(self: *IntersectionObserver, target: *Element, frame: *Fram
     const reported = try frame._intersection.reported.getOrPut(frame.arena, target);
     if (!reported.found_existing) {
         reported.value_ptr.* = 0;
-    } else if (reported.value_ptr.* >= Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT) {
+    } else if (reported.value_ptr.* >= Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT and !tracked.value_ptr.rearmed) {
         if (!frame._intersection.sentinel_logged) {
             frame._intersection.sentinel_logged = true;
             log.warn(.frame, "IntsctObserver.sentinel", .{ .url = frame.url });
         }
+        try frame._intersection.capped.put(frame.arena, target, {});
         _ = self._tracked.removeByPtr(tracked.key_ptr);
         return;
     }
-    reported.value_ptr.* += 1;
+    reported.value_ptr.* +|= 1;
 
     // Building the entry is the expensive part — getBoundingClientRect walks the
     // document to fake a position (O(node count)) — so it only runs here.
@@ -514,6 +533,144 @@ test "WebApi: IntersectionObserver delivery after a quiet gap starts a new burst
     try testing.expectEqual(false, frame._intersection.runaway);
     try testing.expectEqual(1, frame._intersection.burst_deliveries);
     try testing.expect(frame._intersection.burst_start_ms > stale_start);
+}
+
+// Same-node infinite scroll: `n` observers watch one sentinel. Each callback
+// unobserves it, counts a batch and observes the node again from a timer, the
+// way a fetch-driven pager does. Every observe reports the node until the
+// frame's report limit refuses it.
+fn observeSameNodeSentinel(local: *const js.Local, n: usize) !void {
+    var buf: [1024]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf,
+        \\(function(n) {{
+        \\  const list = document.createElement('div');
+        \\  const sentinel = list.appendChild(document.createElement('div'));
+        \\  window.__list = list;
+        \\  window.__batches = new Array(n).fill(0);
+        \\  for (let i = 0; i < n; i++) {{
+        \\    const io = new IntersectionObserver((entries) => {{
+        \\      for (const entry of entries) {{
+        \\        if (!entry.isIntersecting) continue;
+        \\        io.unobserve(sentinel);
+        \\        window.__batches[i] += 1;
+        \\        setTimeout(() => io.observe(sentinel), 0);
+        \\      }}
+        \\    }});
+        \\    io.observe(sentinel);
+        \\  }}
+        \\}})({d})
+    , .{n});
+    try local.eval(src, null);
+}
+
+fn batches(local: *const js.Local, i: usize) !i32 {
+    var buf: [64]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf, "window.__batches[{d}]", .{i});
+    return (try local.exec(src, null)).toI32();
+}
+
+// Ticks until the batch count has been stable for a few ticks, and returns it.
+fn settleBatches(local: *const js.Local, frame: *Frame) !i32 {
+    var total: i32 = -1;
+    var stable: u8 = 0;
+    for (0..200) |_| {
+        try tick(frame);
+        const now = try (try local.exec("window.__batches.reduce((a, b) => a + b, 0)", null)).toI32();
+        if (now == total) {
+            stable += 1;
+            if (stable == 4) break;
+        } else {
+            total = now;
+            stable = 0;
+        }
+    }
+    return total;
+}
+
+test "WebApi: IntersectionObserver same-node sentinel stops at the report limit" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    try observeSameNodeSentinel(local, 1);
+    try testing.expectEqual(Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT, try settleBatches(local, frame));
+    try testing.expectEqual(1, frame._intersection.capped.count());
+    try testing.expectEqual(true, Frame.observers.hasIntersectionObservers(frame));
+    try testing.expectEqual(false, frame._intersection.runaway);
+}
+
+test "WebApi: IntersectionObserver scrolling down re-arms a capped sentinel once" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    try observeSameNodeSentinel(local, 1);
+    const limit = Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT;
+    try testing.expectEqual(limit, try settleBatches(local, frame));
+
+    // The scrape loop: scroll to the bottom, wait, repeat. One batch per scroll.
+    // (The test document has no root element; on a page this is
+    // `scrollTo(0, document.body.scrollHeight)`.)
+    _ = try local.exec("window.scrollTo(0, 100000)", null);
+    try testing.expectEqual(limit + 1, try settleBatches(local, frame));
+
+    // scrollHeight is constant, so the second iteration lands on the same offset.
+    _ = try local.exec("window.scrollTo(0, 100000)", null);
+    try testing.expectEqual(limit + 2, try settleBatches(local, frame));
+
+    _ = try local.exec("window.scrollBy(0, 10)", null);
+    try testing.expectEqual(limit + 3, try settleBatches(local, frame));
+
+    // Scrolling up, or back to the top, reveals nothing below the fold.
+    _ = try local.exec("window.scrollTo(0, 100)", null);
+    try testing.expectEqual(limit + 3, try settleBatches(local, frame));
+    _ = try local.exec("window.scrollTo(0, 0)", null);
+    try testing.expectEqual(limit + 3, try settleBatches(local, frame));
+
+    // Scrolling an element (the tools' scroll with a node) counts too.
+    _ = try local.exec("window.__list.scrollTop = 500", null);
+    try testing.expectEqual(limit + 4, try settleBatches(local, frame));
+    _ = try local.exec("window.__list.scrollBy(0, 500)", null);
+    try testing.expectEqual(limit + 5, try settleBatches(local, frame));
+    _ = try local.exec("window.__list.scrollTo(0, 0)", null);
+    try testing.expectEqual(limit + 5, try settleBatches(local, frame));
+}
+
+test "WebApi: IntersectionObserver re-arm grants one report per observer" {
+    testing.silenceLog(&.{.frame});
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    // The limit is shared across observers of one node...
+    try observeSameNodeSentinel(local, 2);
+    try testing.expectEqual(Frame.observers.INTERSECTION_TARGET_REPORT_LIMIT, try settleBatches(local, frame));
+    const first = try batches(local, 0);
+    const second = try batches(local, 1);
+
+    // ...but a scroll re-arms each observer that still watches it, so a lazy
+    // loader is not starved by an analytics observer on the same element.
+    _ = try local.exec("window.scrollTo(0, 100000)", null);
+    try testing.expectEqual(first + second + 2, try settleBatches(local, frame));
+    try testing.expectEqual(first + 1, try batches(local, 0));
+    try testing.expectEqual(second + 1, try batches(local, 1));
 }
 
 test "WebApi: IntersectionObserver" {

--- a/src/browser/webapi/Window.zig
+++ b/src/browser/webapi/Window.zig
@@ -942,6 +942,9 @@ pub fn scrollTo(self: *Window, opts: ScrollToOpts, y: ?i32, frame: *Frame) !void
         .opts => |o| .{ @intCast(@max(0, o.left)), @intCast(@max(0, o.top)) },
     };
 
+    // Before the early return: a scroll to the same offset still re-arms.
+    try Frame.observers.rearmIntersectionSentinels(frame, self._scroll_pos.y, new_y);
+
     if (new_x == self._scroll_pos.x and new_y == self._scroll_pos.y) {
         return;
     }


### PR DESCRIPTION
Follow-up to #3427, stacked on its branch so the diff shows only this change. Rebase onto `main` once #3427 lands.

## Problem

The per-target report limit from #3427 turns a same-node infinite-scroll sentinel off for the rest of the navigation, and nothing turns it back on. `window.scrollTo`/`scrollBy` and element scrolls dispatch `scroll` events but never touched the observer state, and without layout the sentinel already counts as in view. So the usual scrape loop (scroll to the bottom, wait for new items, repeat) had no effect past the third batch. See the discussion on #3427.

## Fix

Model what a real browser does: a sentinel that stopped firing is below the fold, and scrolling down brings it back into view for one more batch.

- A check that refuses a target because it reached the limit records it in a per-frame `capped` set.
- A scroll that does not move up (`to_y > 0 and to_y >= from_y`) grants every capped target **one** more report per observer still watching it (`observers.rearmIntersectionSentinels`). One, not a reset to zero, so a page that keeps re-observing the same node loads a batch per scroll the way it does in Chrome, while a page that never scrolls stays at three.
- A scroll to the same offset counts. `document.body.scrollHeight` is a constant here (`Element.getScrollHeight`), so the scrape loop lands on the same offset from its second iteration on.
- The grant is per observer (`_tracked` value gains a `rearmed` flag) so a lazy loader is not starved by an analytics observer on the same element.
- Hooked in `Window.scrollTo` (covers `scrollBy`, `scrollIntoView`, and the tools' window scroll) and in `Element.setScrollTop`/`scrollTo`/`scrollBy` (covers the tools' scroll with a node).

The 10 s burst guard from #3383 stays the backstop for a page that scrolls itself from inside its own observer callback.

## Tests

Three unit tests in `IntersectionObserver.zig` drive a same-node sentinel pager (unobserve, count, re-observe from a timer):

- it stops at the limit and the observer stays registered, no runaway;
- each scroll down, including to the same offset, `scrollBy`, `element.scrollTop`, and `element.scrollBy` yields exactly one more batch, while scrolling up or to the top yields none;
- with two observers on one node each gets one report per scroll.
