### PR TITLE
docs: fix typo in benchmark summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [benchmark details](https://github.com/lightpanda-io/demo/blob/main/BENCHMAR
 
 | Metric | Lightpanda | Headless Chrome | Difference |
 | :---- | :---- | :---- | :---- |
-| Memory (peak, 100 pages) | 123MB | 2GB | ~16 less |
+| Memory (peak, 100 pages) | 123MB | 2GB | ~16x less |
 | Execution time (100 pages) | 5s | 46s | ~9x faster |
 
 ## Quick start


### PR DESCRIPTION
## Summary

Just fixed a small typo in the benchmark summary in the `README`

## Details

- missing "x" for multiple: it said "16 less" when it should be "16x less"
  - this also matches the style for the line below which says "9x faster"