### PR TITLE
stability: raise timer caps

### DIFF
--- a/src/browser/tests/window/timer_limits.html
+++ b/src/browser/tests/window/timer_limits.html
@@ -20,18 +20,18 @@
   const intervals = [];
   let threw = false;
   try {
-    for (let i = 0; i < 600; i++) {
+    for (let i = 0; i < 2100; i++) {
       intervals.push(window.setInterval(() => {}, 100000));
     }
   } catch (e) {
     threw = true;
   }
   testing.expectEqual(true, threw);
-  testing.expectEqual(512, intervals.length);
+  testing.expectEqual(2048, intervals.length);
 
   window.clearInterval(intervals.pop());
   intervals.push(window.setInterval(() => {}, 100000));
-  testing.expectEqual(512, intervals.length);
+  testing.expectEqual(2048, intervals.length);
 
   for (const id of intervals) {
     window.clearInterval(id);

--- a/src/browser/webapi/Timers.zig
+++ b/src/browser/webapi/Timers.zig
@@ -36,12 +36,14 @@ const CLAMP_NESTING = 5;
 // from considering the page "done" forever (more commonly seen with requestAnimationFrame)
 const BLOCKING_NESTING = 10;
 
-// airbnb has 600+ timers
-const MAX_CALLBACKS = 2048;
+// Every pending timeout, interval, animation frame and setImmediate. Past
+// the cap setTimeout throws, which no browser does; keep it a backstop for
+// runaway pages, not a budget (a paginated storefront listing holds ~2.7k).
+const MAX_CALLBACKS = 8192;
 
 // lower limit for repeating timers since they never clean up
 // (unless clearInterval is called)
-const MAX_REPEATING = 512;
+const MAX_REPEATING = 2048;
 
 const Timers = @This();
 


### PR DESCRIPTION
Split out of #3427, which now carries only the intersection-observer change.

## Problem

A paginated storefront listing (eu.gymshark.com collection page) holds ~2.7k pending timers at once, which crosses the 2048 timer table cap. Past it `setTimeout` throws `TooManyTimeout` into React's scheduler, which catches, retries and turns a busy page into a retry storm.

No browser throws from `setTimeout`. The cap exists as a backstop for runaway pages, not as a budget.

## Fix

Raise `MAX_CALLBACKS` 2048 → 8192 and `MAX_REPEATING` 512 → 2048. The `timer_limits.html` test follows the new interval cap.
