### PR TITLE
perf: improve nth-* CSS selector performance

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -1132,7 +1132,7 @@ fn countCompoundSpecificity(compound: Selector.Compound, ids: *u32, classes: *u3
 
 fn matchesSelector(el: *Element, selector: Selector.Selector, frame: *Frame) bool {
     const node = el.asNode();
-    return SelectorList.matches(node, selector, node, frame);
+    return SelectorList.matches(node, selector, node, null, frame);
 }
 
 /// Only the values the dumpers act on; everything else is `other`.

--- a/src/browser/webapi/selector/List.zig
+++ b/src/browser/webapi/selector/List.zig
@@ -49,16 +49,17 @@ pub fn collect(
     root: *Node,
     selector: Selector.Selector,
     nodes: *std.AutoArrayHashMapUnmanaged(*Node, void),
+    nth: *NthCache,
     frame: *Frame,
 ) !void {
-    if (optimizeSelector(root, &selector, frame)) |result| {
+    if (optimizeSelector(root, &selector, nth, frame)) |result| {
         var tw = TreeWalker.init(result.root, .{});
         if (result.exclude_root) {
             _ = tw.next();
         }
 
         while (tw.next()) |node| {
-            if (matches(node, result.selector, root, frame)) {
+            if (matches(node, result.selector, root, nth, frame)) {
                 try nodes.put(allocator, node, {});
             }
         }
@@ -66,15 +67,15 @@ pub fn collect(
 }
 
 // used internally to find the first match
-pub fn initOne(root: *Node, selector: Selector.Selector, frame: *Frame) ?*Node {
-    const result = optimizeSelector(root, &selector, frame) orelse return null;
+pub fn initOne(root: *Node, selector: Selector.Selector, nth: *NthCache, frame: *Frame) ?*Node {
+    const result = optimizeSelector(root, &selector, nth, frame) orelse return null;
 
     var tw = TreeWalker.init(result.root, .{});
     if (result.exclude_root) {
         _ = tw.next();
     }
     while (tw.next()) |node| {
-        if (matches(node, result.selector, root, frame)) {
+        if (matches(node, result.selector, root, nth, frame)) {
             return node;
         }
     }
@@ -87,7 +88,7 @@ const OptimizeResult = struct {
     selector: Selector.Selector,
 };
 
-fn optimizeSelector(root: *Node, selector: *const Selector.Selector, frame: *Frame) ?OptimizeResult {
+fn optimizeSelector(root: *Node, selector: *const Selector.Selector, nth: *NthCache, frame: *Frame) ?OptimizeResult {
     const anchor = findIdSelector(selector) orelse return .{
         .root = root,
         .selector = selector.*,
@@ -172,7 +173,7 @@ fn optimizeSelector(root: *Node, selector: *const Selector.Selector, frame: *Fra
         .segments = selector.segments[0 .. seg_idx + 1],
     };
 
-    if (!matches(id_node, prefix_selector, id_node, frame)) {
+    if (!matches(id_node, prefix_selector, id_node, nth, frame)) {
         return null;
     }
 
@@ -251,23 +252,23 @@ fn findIdSelector(selector: *const Selector.Selector) ?IdAnchor {
     return null;
 }
 
-pub fn matches(node: *Node, selector: Selector.Selector, scope: *Node, frame: *Frame) bool {
+pub fn matches(node: *Node, selector: Selector.Selector, scope: *Node, nth: ?*NthCache, frame: *Frame) bool {
     const el = node.is(Node.Element) orelse return false;
 
     if (selector.segments.len == 0) {
-        return matchesCompound(el, selector.first, scope, frame);
+        return matchesCompound(el, selector.first, scope, nth, frame);
     }
 
     const last_segment = selector.segments[selector.segments.len - 1];
-    if (!matchesCompound(el, last_segment.compound, scope, frame)) {
+    if (!matchesCompound(el, last_segment.compound, scope, nth, frame)) {
         return false;
     }
 
-    return matchSegments(node, selector, selector.segments.len - 1, null, scope, frame);
+    return matchSegments(node, selector, selector.segments.len - 1, null, scope, nth, frame);
 }
 
 // Match segments backward, with support for backtracking on subsequent_sibling
-fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize, root: ?*Node, scope: *Node, frame: *Frame) bool {
+fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize, root: ?*Node, scope: *Node, nth: ?*NthCache, frame: *Frame) bool {
     const segment = selector.segments[segment_index];
     const target_compound = if (segment_index == 0)
         selector.first
@@ -275,9 +276,9 @@ fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize,
         selector.segments[segment_index - 1].compound;
 
     const matched: ?*Node = switch (segment.combinator) {
-        .descendant => matchDescendant(node, target_compound, root, scope, frame),
-        .child => matchChild(node, target_compound, root, scope, frame),
-        .next_sibling => matchNextSibling(node, target_compound, scope, frame),
+        .descendant => matchDescendant(node, target_compound, root, scope, nth, frame),
+        .child => matchChild(node, target_compound, root, scope, nth, frame),
+        .next_sibling => matchNextSibling(node, target_compound, scope, nth, frame),
         .subsequent_sibling => {
             // For subsequent_sibling, try all matching siblings with backtracking
             var sibling = node.previousSibling();
@@ -287,13 +288,13 @@ fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize,
                     continue;
                 };
 
-                if (matchesCompound(sibling_el, target_compound, scope, frame)) {
+                if (matchesCompound(sibling_el, target_compound, scope, nth, frame)) {
                     // If we're at the first segment, we found a match
                     if (segment_index == 0) {
                         return true;
                     }
                     // Try to match remaining segments from this sibling
-                    if (matchSegments(s, selector, segment_index - 1, root, scope, frame)) {
+                    if (matchSegments(s, selector, segment_index - 1, root, scope, nth, frame)) {
                         return true;
                     }
                     // This sibling didn't work, try the next one
@@ -310,7 +311,7 @@ fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize,
         if (segment_index == 0) {
             return true;
         }
-        return matchSegments(current, selector, segment_index - 1, root, scope, frame);
+        return matchSegments(current, selector, segment_index - 1, root, scope, nth, frame);
     }
 
     // subsequent_sibling already handled its recursion above
@@ -318,12 +319,12 @@ fn matchSegments(node: *Node, selector: Selector.Selector, segment_index: usize,
 }
 
 // Find an ancestor that matches the compound (any distance up the tree)
-fn matchDescendant(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *Node, frame: *Frame) ?*Node {
+fn matchDescendant(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *Node, nth: ?*NthCache, frame: *Frame) ?*Node {
     var current = node._parent;
 
     while (current) |ancestor| {
         if (ancestor.is(Node.Element)) |ancestor_el| {
-            if (matchesCompound(ancestor_el, compound, scope, frame)) {
+            if (matchesCompound(ancestor_el, compound, scope, nth, frame)) {
                 return ancestor;
             }
         }
@@ -342,7 +343,7 @@ fn matchDescendant(node: *Node, compound: Selector.Compound, root: ?*Node, scope
 }
 
 // Find the direct parent if it matches the compound
-fn matchChild(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *Node, frame: *Frame) ?*Node {
+fn matchChild(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *Node, nth: ?*NthCache, frame: *Frame) ?*Node {
     const parent = node._parent orelse return null;
 
     // Don't match beyond the root boundary
@@ -355,7 +356,7 @@ fn matchChild(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *No
 
     const parent_el = parent.is(Node.Element) orelse return null;
 
-    if (matchesCompound(parent_el, compound, scope, frame)) {
+    if (matchesCompound(parent_el, compound, scope, nth, frame)) {
         return parent;
     }
 
@@ -363,7 +364,7 @@ fn matchChild(node: *Node, compound: Selector.Compound, root: ?*Node, scope: *No
 }
 
 // Find the immediately preceding sibling if it matches the compound
-fn matchNextSibling(node: *Node, compound: Selector.Compound, scope: *Node, frame: *Frame) ?*Node {
+fn matchNextSibling(node: *Node, compound: Selector.Compound, scope: *Node, nth: ?*NthCache, frame: *Frame) ?*Node {
     var sibling = node.previousSibling();
 
     // For next_sibling (+), we need the immediately preceding element sibling
@@ -375,7 +376,7 @@ fn matchNextSibling(node: *Node, compound: Selector.Compound, scope: *Node, fram
         };
 
         // Found an element - check if it matches
-        if (matchesCompound(sibling_el, compound, scope, frame)) {
+        if (matchesCompound(sibling_el, compound, scope, nth, frame)) {
             return s;
         }
         // we found an element, it wasn't a match, we're done
@@ -385,39 +386,17 @@ fn matchNextSibling(node: *Node, compound: Selector.Compound, scope: *Node, fram
     return null;
 }
 
-// Find any preceding sibling that matches the compound
-fn matchSubsequentSibling(node: *Node, compound: Selector.Compound, scope: *Node, frame: *Frame) ?*Node {
-    var sibling = node.previousSibling();
-
-    // For subsequent_sibling (~), check all preceding element siblings
-    while (sibling) |s| {
-        const sibling_el = s.is(Node.Element) orelse {
-            // Skip non-element nodes
-            sibling = s.previousSibling();
-            continue;
-        };
-
-        if (matchesCompound(sibling_el, compound, scope, frame)) {
-            return s;
-        }
-
-        sibling = s.previousSibling();
-    }
-
-    return null;
-}
-
-fn matchesCompound(el: *Node.Element, compound: Selector.Compound, scope: *Node, frame: *Frame) bool {
+fn matchesCompound(el: *Node.Element, compound: Selector.Compound, scope: *Node, nth: ?*NthCache, frame: *Frame) bool {
     // For compound selectors, ALL parts must match
     for (compound.parts) |part| {
-        if (!matchesPart(el, part, scope, frame)) {
+        if (!matchesPart(el, part, scope, nth, frame)) {
             return false;
         }
     }
     return true;
 }
 
-fn matchesPart(el: *Node.Element, part: Part, scope: *Node, frame: *Frame) bool {
+fn matchesPart(el: *Node.Element, part: Part, scope: *Node, nth: ?*NthCache, frame: *Frame) bool {
     switch (part) {
         .id => |id| {
             const element_id = el.getAttributeSafe(comptime .wrap("id")) orelse return false;
@@ -438,7 +417,7 @@ fn matchesPart(el: *Node.Element, part: Part, scope: *Node, frame: *Frame) bool 
             return std.mem.eql(u8, element_tag, tag_name);
         },
         .universal => return true,
-        .pseudo_class => |pseudo| return matchesPseudoClass(el, pseudo, scope, frame),
+        .pseudo_class => |pseudo| return matchesPseudoClass(el, pseudo, scope, nth, frame),
         .attribute => |attr| return matchesAttribute(el, attr),
     }
 }
@@ -528,7 +507,7 @@ fn attributeContainsWord(value: []const u8, word: []const u8) bool {
     return false;
 }
 
-fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *Node, frame: *Frame) bool {
+fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *Node, nth: ?*NthCache, frame: *Frame) bool {
     const node = el.asNode();
     switch (pseudo) {
         // State pseudo-classes
@@ -666,10 +645,10 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
         .first_of_type => return isFirstOfType(el),
         .last_of_type => return isLastOfType(el),
         .only_of_type => return isFirstOfType(el) and isLastOfType(el),
-        .nth_child => |pattern| return matchesNthChild(el, pattern),
-        .nth_last_child => |pattern| return matchesNthLastChild(el, pattern),
-        .nth_of_type => |pattern| return matchesNthOfType(el, pattern),
-        .nth_last_of_type => |pattern| return matchesNthLastOfType(el, pattern),
+        .nth_child => |pattern| return matchesNthChild(el, pattern, nth),
+        .nth_last_child => |pattern| return matchesNthLastChild(el, pattern, nth),
+        .nth_of_type => |pattern| return matchesNthOfType(el, pattern, nth),
+        .nth_last_of_type => |pattern| return matchesNthLastOfType(el, pattern, nth),
 
         // Custom elements
         .defined => {
@@ -715,7 +694,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
         },
         .not => |selectors| {
             for (selectors) |selector| {
-                if (matches(node, selector, scope, frame)) {
+                if (matches(node, selector, scope, nth, frame)) {
                     return false;
                 }
             }
@@ -723,7 +702,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
         },
         .is => |selectors| {
             for (selectors) |selector| {
-                if (matches(node, selector, scope, frame)) {
+                if (matches(node, selector, scope, nth, frame)) {
                     return true;
                 }
             }
@@ -731,7 +710,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
         },
         .where => |selectors| {
             for (selectors) |selector| {
-                if (matches(node, selector, scope, frame)) {
+                if (matches(node, selector, scope, nth, frame)) {
                     return true;
                 }
             }
@@ -752,7 +731,7 @@ fn matchesPseudoClass(el: *Node.Element, pseudo: Selector.PseudoClass, scope: *N
                 var tw = TreeWalker.init(search_root, .{});
                 _ = tw.next(); // the search root itself is never a candidate
                 while (tw.next()) |candidate| {
-                    if (matches(candidate, selector, node, frame)) {
+                    if (matches(candidate, selector, node, nth, frame)) {
                         return true;
                     }
                 }
@@ -856,27 +835,37 @@ fn isLastOfType(el: *Node.Element) bool {
     return true;
 }
 
-fn matchesNthChild(el: *Node.Element, pattern: Selector.NthPattern) bool {
-    const index = getChildIndex(el) orelse return false;
-    return matchesNthPattern(index, pattern);
+fn matchesNthChild(el: *Node.Element, pattern: Selector.NthPattern, nth: ?*NthCache) bool {
+    return matchesNthPattern(getChildIndex(el, nth), pattern);
 }
 
-fn matchesNthLastChild(el: *Node.Element, pattern: Selector.NthPattern) bool {
-    const index = getChildIndexFromEnd(el) orelse return false;
-    return matchesNthPattern(index, pattern);
+fn matchesNthLastChild(el: *Node.Element, pattern: Selector.NthPattern, nth: ?*NthCache) bool {
+    return matchesNthPattern(getChildIndexFromEnd(el, nth), pattern);
 }
 
-fn matchesNthOfType(el: *Node.Element, pattern: Selector.NthPattern) bool {
-    const index = getTypeIndex(el) orelse return false;
-    return matchesNthPattern(index, pattern);
+fn matchesNthOfType(el: *Node.Element, pattern: Selector.NthPattern, nth: ?*NthCache) bool {
+    return matchesNthPattern(getTypeIndex(el, nth), pattern);
 }
 
-fn matchesNthLastOfType(el: *Node.Element, pattern: Selector.NthPattern) bool {
-    const index = getTypeIndexFromEnd(el) orelse return false;
-    return matchesNthPattern(index, pattern);
+fn matchesNthLastOfType(el: *Node.Element, pattern: Selector.NthPattern, nth: ?*NthCache) bool {
+    return matchesNthPattern(getTypeIndexFromEnd(el, nth), pattern);
 }
 
-fn getChildIndex(el: *Node.Element) ?usize {
+fn cachedOrdinals(el: *Node.Element, nth: ?*NthCache) ?NthCache.Ordinals {
+    const cache = nth orelse return null;
+    return cache.lookup(el);
+}
+
+fn indexedOrdinals(el: *Node.Element, nth: ?*NthCache) ?NthCache.Ordinals {
+    const cache = nth orelse return null;
+    return cache.indexAndLookup(el);
+}
+
+fn getChildIndex(el: *Node.Element, nth: ?*NthCache) usize {
+    if (cachedOrdinals(el, nth)) |o| {
+        return o.child;
+    }
+
     const node = el.asNode();
     var index: usize = 1;
     var sibling = node.previousSibling();
@@ -884,6 +873,11 @@ fn getChildIndex(el: *Node.Element) ?usize {
     while (sibling) |s| {
         if (s.is(Node.Element)) |_| {
             index += 1;
+            if (index == NthCache.WALK_LIMIT) {
+                if (indexedOrdinals(el, nth)) |o| {
+                    return o.child;
+                }
+            }
         }
         sibling = s.previousSibling();
     }
@@ -891,7 +885,11 @@ fn getChildIndex(el: *Node.Element) ?usize {
     return index;
 }
 
-fn getChildIndexFromEnd(el: *Node.Element) ?usize {
+fn getChildIndexFromEnd(el: *Node.Element, nth: ?*NthCache) usize {
+    if (cachedOrdinals(el, nth)) |o| {
+        return o.child_from_end;
+    }
+
     const node = el.asNode();
     var index: usize = 1;
     var sibling = node.nextSibling();
@@ -899,6 +897,11 @@ fn getChildIndexFromEnd(el: *Node.Element) ?usize {
     while (sibling) |s| {
         if (s.is(Node.Element)) |_| {
             index += 1;
+            if (index == NthCache.WALK_LIMIT) {
+                if (indexedOrdinals(el, nth)) |o| {
+                    return o.child_from_end;
+                }
+            }
         }
         sibling = s.nextSibling();
     }
@@ -906,11 +909,18 @@ fn getChildIndexFromEnd(el: *Node.Element) ?usize {
     return index;
 }
 
-fn getTypeIndex(el: *Node.Element) ?usize {
+fn getTypeIndex(el: *Node.Element, nth: ?*NthCache) usize {
+    if (cachedOrdinals(el, nth)) |o| {
+        return o.of_type;
+    }
+
     const tag = el.getTag();
     const node = el.asNode();
 
     var index: usize = 1;
+    // The group is as wide as the siblings walked, not as the ones that share
+    // the tag: a tag used once among thousands still has to switch over.
+    var visited: usize = 0;
     var sibling = node.previousSibling();
 
     while (sibling) |s| {
@@ -923,17 +933,31 @@ fn getTypeIndex(el: *Node.Element) ?usize {
             index += 1;
         }
 
+        visited += 1;
+        if (visited == NthCache.WALK_LIMIT) {
+            if (indexedOrdinals(el, nth)) |o| {
+                return o.of_type;
+            }
+        }
+
         sibling = s.previousSibling();
     }
 
     return index;
 }
 
-fn getTypeIndexFromEnd(el: *Node.Element) ?usize {
+fn getTypeIndexFromEnd(el: *Node.Element, nth: ?*NthCache) usize {
+    if (cachedOrdinals(el, nth)) |o| {
+        return o.of_type_from_end;
+    }
+
     const tag = el.getTag();
     const node = el.asNode();
 
     var index: usize = 1;
+    // The group is as wide as the siblings walked, not as the ones that share
+    // the tag: a tag used once among thousands still has to switch over.
+    var visited: usize = 0;
     var sibling = node.nextSibling();
 
     while (sibling) |s| {
@@ -944,6 +968,13 @@ fn getTypeIndexFromEnd(el: *Node.Element) ?usize {
 
         if (sibling_el.getTag() == tag) {
             index += 1;
+        }
+
+        visited += 1;
+        if (visited == NthCache.WALK_LIMIT) {
+            if (indexedOrdinals(el, nth)) |o| {
+                return o.of_type_from_end;
+            }
         }
 
         sibling = s.nextSibling();
@@ -991,5 +1022,73 @@ const Iterator = struct {
         }
         self.index = index + 1;
         return .{ index, self.list._nodes[index] };
+    }
+};
+
+// nth-child matches can be expensive when a node has many children. Whenever
+// we encounter a parent with many children (>= WALK_LIMIT) we cache their
+// ordinal position. (The cache entry has overhead, so if we don't have that
+// many children, it's faster and more memory efficient to just walk).
+pub const NthCache = struct {
+    allocator: std.mem.Allocator,
+    entries: std.AutoHashMapUnmanaged(*const Node, Ordinals) = .empty,
+
+    const WALK_LIMIT = 32;
+    const Ordinals = struct {
+        child: u32,
+        child_from_end: u32,
+        of_type: u32,
+        of_type_from_end: u32,
+    };
+
+    const TypeCounts = [@typeInfo(Node.Element.Tag).@"enum".fields.len]u32;
+
+    pub fn deinit(self: *NthCache) void {
+        self.entries.deinit(self.allocator);
+    }
+
+    fn lookup(self: *NthCache, el: *Node.Element) ?Ordinals {
+        return self.entries.get(el.asNode());
+    }
+
+    fn indexAndLookup(self: *NthCache, el: *Node.Element) ?Ordinals {
+        const node = el.asNode();
+        const parent = node._parent orelse return null;
+        self.index(parent) catch return null; // OOM, it'll just fallback to walk
+        return self.entries.get(node);
+    }
+
+    fn index(self: *NthCache, parent: *Node) !void {
+        var child_count: u32 = 0;
+        var type_counts: TypeCounts = @splat(0);
+
+        var it = parent.childrenIterator();
+        while (it.next()) |child| {
+            const el = child.is(Node.Element) orelse continue;
+            child_count += 1;
+            const of_type = &type_counts[@intFromEnum(el.getTag())];
+            of_type.* += 1;
+            try self.entries.put(self.allocator, child, .{
+                .child = child_count,
+                .of_type = of_type.*,
+                .child_from_end = undefined,
+                .of_type_from_end = undefined,
+            });
+        }
+
+        // The totals are only known once the forward pass is done.
+        var seen_count: u32 = 0;
+        var seen_types: TypeCounts = @splat(0);
+        it = parent.childrenIterator();
+        while (it.next()) |child| {
+            const el = child.is(Node.Element) orelse continue;
+            seen_count += 1;
+            const tag = @intFromEnum(el.getTag());
+            seen_types[tag] += 1;
+
+            const ordinals = self.entries.getPtr(child).?;
+            ordinals.child_from_end = child_count - seen_count + 1;
+            ordinals.of_type_from_end = type_counts[tag] - seen_types[tag] + 1;
+        }
     }
 };

--- a/src/browser/webapi/selector/Selector.zig
+++ b/src/browser/webapi/selector/Selector.zig
@@ -115,8 +115,14 @@ pub const Cache = struct {
 
 fn collectAll(arena: *lp.Arena, selectors: []const Selector, root: *Node, frame: *Frame) !*List {
     var nodes: std.AutoArrayHashMapUnmanaged(*Node, void) = .empty;
+
+    // One cache for the whole list: every selector walks the same root, and it
+    // fills lazily, so a subtree that no selector reaches costs nothing.
+    var nth: List.NthCache = .{ .allocator = frame.local_arena };
+    defer nth.deinit();
+
     for (selectors) |selector| {
-        try List.collect(arena.allocator(), root, selector, &nodes, frame);
+        try List.collect(arena.allocator(), root, selector, &nodes, &nth, frame);
     }
 
     const list = try arena.create(List);
@@ -129,7 +135,7 @@ fn collectAll(arena: *lp.Arena, selectors: []const Selector, root: *Node, frame:
 
 fn matchesAny(selectors: []const Selector, el: *Node.Element, scope: *Node, frame: *Frame) bool {
     for (selectors) |selector| {
-        if (List.matches(el.asNode(), selector, scope, frame)) {
+        if (List.matches(el.asNode(), selector, scope, null, frame)) {
             return true;
         }
     }
@@ -373,6 +379,9 @@ pub const Selector = struct {
 };
 
 pub fn query(selectors: []const Selector, root: *Node, frame: *Frame) !?*Node.Element {
+    var nth: List.NthCache = .{ .allocator = frame.local_arena };
+    defer nth.deinit();
+
     for (selectors) |selector| {
         // Fast path: single compound with only an ID selector
         if (selector.segments.len == 0 and selector.first.parts.len == 1) {
@@ -388,7 +397,7 @@ pub fn query(selectors: []const Selector, root: *Node, frame: *Frame) !?*Node.El
             }
         }
 
-        if (List.initOne(root, selector, frame)) |node| {
+        if (List.initOne(root, selector, &nth, frame)) |node| {
             if (node.is(Node.Element)) |el| {
                 return el;
             }


### PR DESCRIPTION
This adds an NthCache which will cache the ordinal position of elements. Only nodes which have >= 32 sibblings are cached - the cache has performance/memory overhead and for smaller nodes, walking is cheaper.

Using the new benchmark: https://github.com/lightpanda-io/demo/pull/245 under particularly bad conditions (W=4000):

```
main:
  case                      match   iters    us/query
  :nth-child(2n)             2000       2     55862.5
  :nth-of-type(2n)           1999       2     57675.0
  :nth-last-of-type(2n)      1999       2     53935.0
  ancestor :nth-child(2n)    4000       1    111855.0
  list of two nth            2667       1    111180.0
```
```
PR:
  case                      match   iters    us/query
  :nth-child(2n)             2000     258       388.1
  :nth-of-type(2n)           1999     245       409.6
  :nth-last-of-type(2n)      1999     245       409.0
  ancestor :nth-child(2n)    4000     168       596.1
  list of two nth            2667     160       626.8
```
```
Firefox
  case                      match   iters    us/query
  :nth-child(2n)             2000     460       217.4
  :nth-of-type(2n)           1999     445       224.7
  :nth-last-of-type(2n)      1999     260       384.6
  ancestor :nth-child(2n)    4000     246       406.5
  list of two nth            2667     294       340.1
```
With no regressions in the other cases.