### PR TITLE
browser: virtual time budget

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -291,6 +291,7 @@ const CommonOptions = .{
     .{ .name = "load_resources", .type = LoadResources, .default = LoadResources{} },
     .{ .name = "v8_flags_unsafe", .type = ?[]const u8 },
     .{ .name = "v8_max_heap_mb", .type = ?u32 },
+    .{ .name = "virtual_time_budget_ms", .type = ?u32 },
     .{ .name = "watchdog_ms", .type = ?u32 },
     .{
         .name = "ca_cert",
@@ -590,6 +591,13 @@ pub fn loadResources(self: *const Config) LoadResources {
     return switch (self.mode) {
         inline .serve, .fetch, .mcp, .agent => |opts| opts.load_resources,
         else => unreachable,
+    };
+}
+
+pub fn virtualTimeBudgetMs(self: *const Config) ?u32 {
+    return switch (self.mode) {
+        inline .fetch, .mcp, .agent => |opts| opts.virtual_time_budget_ms,
+        else => null,
     };
 }
 
@@ -1656,4 +1664,22 @@ pub fn tagJsonArray(comptime E: type) []const u8 {
         s = s ++ (if (i == 0) "\"" else ",\"") ++ f.name ++ "\"";
     }
     return s ++ "]";
+}
+
+test "Config: parseArgs --virtual-time-budget-ms" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "fetch", "--virtual-time-budget-ms", "1000", "https://example.com" };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        const config = try parseArgs(arena.allocator(), proc_args);
+        try std.testing.expectEqual(1000, config.virtualTimeBudgetMs());
+    }
+    {
+        const argv = [_][*:0]const u8{ "lightpanda", "serve", "--virtual-time-budget-ms", "1000" };
+        const proc_args: std.process.Args = .{ .vector = &argv };
+        const config = try parseArgs(arena.allocator(), proc_args);
+        try std.testing.expectEqual(null, config.virtualTimeBudgetMs());
+    }
 }

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -24,6 +24,7 @@ const Mime = @import("Mime.zig");
 const Page = @import("Page.zig");
 const Factory = @import("Factory.zig");
 const Session = @import("Session.zig");
+const VirtualTime = @import("VirtualTime.zig");
 const EventManager = @import("EventManager.zig");
 const ScriptManager = @import("ScriptManager.zig");
 const StyleManager = @import("StyleManager.zig");
@@ -3374,13 +3375,13 @@ const IdleNotification = union(enum) {
                     // the first time after being un-triggered). Record the time
                     // so that if the condition holds for long enough, we can
                     // send a notification.
-                    self.* = .{ .triggered = lp.datetime.milliTimestamp(.boot) };
+                    self.* = .{ .triggered = VirtualTime.milli() };
                 },
                 .triggered => |ms| {
                     // The condition was already triggered and was triggered
                     // again. When this condition holds for 500+ms, we'll send
                     // a notification.
-                    if (lp.datetime.milliTimestamp(.boot) - ms >= 500) {
+                    if (VirtualTime.milli() - ms >= 500) {
                         // This is the only place in this function where we can
                         // return true. The only place where we can tell our caller
                         // "send the notification!".

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -458,8 +458,8 @@ fn hasRunnablePage(session: *Session) bool {
     return false;
 }
 
-/// One tick of a polling wait, then the sleep it recommends. When the page is
-/// idle, poll anyway so `remaining_ms` means "wait up to N ms", not "fail now".
+/// Idle pages still poll, so `remaining_ms` means "wait up to N ms", not
+/// "fail now".
 fn pollFrame(self: *Runner, frame_id: u32, remaining_ms: u32) !void {
     const sleep_ms = switch (try self.tickForFrame(frame_id, remaining_ms, .{ .until = .done })) {
         .done => @min(remaining_ms, 50),
@@ -468,8 +468,7 @@ fn pollFrame(self: *Runner, frame_id: u32, remaining_ms: u32) !void {
     self.idleSleep(sleep_ms);
 }
 
-/// Sleep `ms` of real time, or whatever the virtual clock leaves of it. Only
-/// reached when the last tick made no progress, so jumping the clock here
+/// Only reached when the last tick made no progress, so a clock jump here
 /// cannot reorder a timer ahead of work that tick completed.
 fn idleSleep(self: *Runner, ms: u32) void {
     if (ms == 0) {
@@ -481,9 +480,8 @@ fn idleSleep(self: *Runner, ms: u32) void {
     }
 }
 
-/// Idle except for a timer: jump the page's clock to it instead of sleeping.
-/// Returns the real ms still to sleep. The grant is against the next task,
-/// not `real_wait_ms`, which is clamped to the caller's polling slice.
+/// Returns the real ms still to sleep. Grants against the next task, not
+/// `real_wait_ms`, which is clamped to the caller's polling slice.
 fn advanceVirtualTime(self: *Runner, real_wait_ms: u32) u32 {
     const budget = &(self.session.virtual_time orelse return real_wait_ms);
     if (self.browser.hasBackgroundTasks() or self.http_client.activity().idle() == false) {
@@ -494,7 +492,7 @@ fn advanceVirtualTime(self: *Runner, real_wait_ms: u32) u32 {
     if (granted == 0) {
         return real_wait_ms;
     }
-    VirtualTime.advance(granted);
+    VirtualTime.advance(self.browser.app.platform, granted);
     log.debug(.browser, "virtual time", .{ .advanced_ms = granted, .remaining_ms = budget.remaining_ms });
     return @intCast(@min(real_wait_ms, next_ms - granted));
 }
@@ -685,7 +683,7 @@ test "Runner: virtual time falls back to real time past the budget" {
     try testing.expectEqual(true, elapsed >= 100);
 }
 
-test "Runner: virtual time advances performance.now and event timestamps" {
+test "Runner: virtual time advances performance.now, event timestamps and Date.now" {
     const page = try testing.pageTest("runner/virtual_time_clocks.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
     defer page.close();
 
@@ -694,8 +692,10 @@ test "Runner: virtual time advances performance.now and event timestamps" {
 
     const perf = try std.fmt.parseInt(u64, try textOf(&runner, page.frame_id, "#perf"), 10);
     const evt = try std.fmt.parseInt(u64, try textOf(&runner, page.frame_id, "#evt"), 10);
+    const date = try std.fmt.parseInt(u64, try textOf(&runner, page.frame_id, "#date"), 10);
     try testing.expectEqual(true, perf >= 2990);
     try testing.expectEqual(true, evt >= 2990);
+    try testing.expectEqual(true, date >= 2990);
 }
 
 test "Runner: virtual time satisfies the network idle hold" {

--- a/src/browser/Runner.zig
+++ b/src/browser/Runner.zig
@@ -23,6 +23,7 @@ const js = @import("js/js.zig");
 const Browser = @import("Browser.zig");
 const Session = @import("Session.zig");
 const HttpClient = @import("../network/HttpClient.zig");
+const VirtualTime = @import("VirtualTime.zig");
 
 const Node = @import("webapi/Node.zig");
 const Selector = @import("webapi/selector/Selector.zig");
@@ -179,9 +180,7 @@ fn _wait(self: *Runner, comptime is_cdp: bool, timeout_ms: u32, conditions: []Wa
         if (ms_elapsed >= timeout_ms) {
             return .timeout;
         }
-        if (next_ms > 0) {
-            io.sleep(.fromMilliseconds(@intCast(next_ms)), .awake) catch {};
-        }
+        self.idleSleep(next_ms);
     }
 }
 
@@ -367,15 +366,7 @@ pub fn waitForSelector(self: *Runner, frame_id: u32, input: [:0]const u8, timeou
         if (elapsed >= timeout_ms) {
             return error.Timeout;
         }
-        switch (try self.tickForFrame(frame_id, timeout_ms - elapsed, .{ .until = .done })) {
-            // Idle: poll so `timeout_ms` means "wait up to N ms", not "fail now".
-            .done => lp.io.sleep(.fromMilliseconds(@intCast(@min(timeout_ms - elapsed, 50))), .awake) catch {},
-            .ok => |recommended_sleep_ms| {
-                if (recommended_sleep_ms > 0) {
-                    lp.io.sleep(.fromMilliseconds(@intCast(recommended_sleep_ms)), .awake) catch {};
-                }
-            },
-        }
+        try self.pollFrame(frame_id, timeout_ms - elapsed);
     }
 }
 
@@ -444,15 +435,7 @@ pub fn waitForScript(self: *Runner, frame_id: u32, src: [:0]const u8, timeout_ms
         if (elapsed >= timeout_ms) {
             return error.Timeout;
         }
-        switch (try self.tickForFrame(frame_id, timeout_ms - elapsed, .{ .until = .done })) {
-            // Idle: poll so `timeout_ms` means "wait up to N ms", not "fail now".
-            .done => lp.io.sleep(.fromMilliseconds(@intCast(@min(timeout_ms - elapsed, 50))), .awake) catch {},
-            .ok => |recommended_sleep_ms| {
-                if (recommended_sleep_ms > 0) {
-                    lp.io.sleep(.fromMilliseconds(@intCast(recommended_sleep_ms)), .awake) catch {};
-                }
-            },
-        }
+        try self.pollFrame(frame_id, timeout_ms - elapsed);
     }
 }
 
@@ -475,7 +458,53 @@ fn hasRunnablePage(session: *Session) bool {
     return false;
 }
 
+/// One tick of a polling wait, then the sleep it recommends. When the page is
+/// idle, poll anyway so `remaining_ms` means "wait up to N ms", not "fail now".
+fn pollFrame(self: *Runner, frame_id: u32, remaining_ms: u32) !void {
+    const sleep_ms = switch (try self.tickForFrame(frame_id, remaining_ms, .{ .until = .done })) {
+        .done => @min(remaining_ms, 50),
+        .ok => |recommended_sleep_ms| recommended_sleep_ms,
+    };
+    self.idleSleep(sleep_ms);
+}
+
+/// Sleep `ms` of real time, or whatever the virtual clock leaves of it. Only
+/// reached when the last tick made no progress, so jumping the clock here
+/// cannot reorder a timer ahead of work that tick completed.
+fn idleSleep(self: *Runner, ms: u32) void {
+    if (ms == 0) {
+        return;
+    }
+    const real_ms = self.advanceVirtualTime(ms);
+    if (real_ms > 0) {
+        lp.io.sleep(.fromMilliseconds(@intCast(real_ms)), .awake) catch {};
+    }
+}
+
+/// Idle except for a timer: jump the page's clock to it instead of sleeping.
+/// Returns the real ms still to sleep. The grant is against the next task,
+/// not `real_wait_ms`, which is clamped to the caller's polling slice.
+fn advanceVirtualTime(self: *Runner, real_wait_ms: u32) u32 {
+    const budget = &(self.session.virtual_time orelse return real_wait_ms);
+    if (self.browser.hasBackgroundTasks() or self.http_client.activity().idle() == false) {
+        return real_wait_ms;
+    }
+    const next_ms = self.browser.msToNextTask() orelse return real_wait_ms;
+    const granted = budget.grant(next_ms);
+    if (granted == 0) {
+        return real_wait_ms;
+    }
+    VirtualTime.advance(granted);
+    log.debug(.browser, "virtual time", .{ .advanced_ms = granted, .remaining_ms = budget.remaining_ms });
+    return @intCast(@min(real_wait_ms, next_ms - granted));
+}
+
 const testing = @import("../testing.zig");
+
+fn textOf(runner: *Runner, frame_id: u32, selector: [:0]const u8) ![]const u8 {
+    const el = try runner.waitForSelector(frame_id, selector, 10);
+    return el.asNode().getTextContentAlloc(testing.arena_allocator);
+}
 test "Runner: waitForSelector timeout" {
     const page = try testing.pageTest("runner/runner1.html", .{});
     defer page.close();
@@ -488,8 +517,7 @@ test "Runner: waitForSelector" {
     const page = try testing.pageTest("runner/runner1.html", .{});
 
     var runner = page.session.runner(.{});
-    const el = try runner.waitForSelector(page.frame_id, "#sel1", 10);
-    try testing.expectEqual("selector-1-content", try el.asNode().getTextContentAlloc(testing.arena_allocator));
+    try testing.expectEqual("selector-1-content", try textOf(&runner, page.frame_id, "#sel1"));
 }
 
 test "Runner: waitForScript timeout" {
@@ -612,6 +640,143 @@ test "Runner: waits out a throttled navigation" {
     try testing.expectEqual(true, elapsed >= 250);
     try testing.expectEqual(0, http_client.delayed_count);
 
-    const el = try runner.waitForSelector(page.frame_id, "#sel1", 10);
-    try testing.expectEqual("selector-1-content", try el.asNode().getTextContentAlloc(testing.arena_allocator));
+    try testing.expectEqual("selector-1-content", try textOf(&runner, page.frame_id, "#sel1"));
+}
+
+test "Runner: virtual time jumps to the next timer" {
+    const page = try testing.pageTest("runner/virtual_time.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    const start = lp.datetime.milliTimestamp(.boot);
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+    const elapsed = lp.datetime.milliTimestamp(.boot) - start;
+
+    try testing.expectEqual("virtual-done", try textOf(&runner, page.frame_id, "#out"));
+    try testing.expectEqual(true, elapsed < 1500);
+    // 3000ms skipped, less the real time the page spent before going idle.
+    const remaining = page.session.virtual_time.?.remaining_ms;
+    try testing.expectEqual(true, remaining >= 2000 and remaining < 2500);
+}
+
+test "Runner: virtual time keeps timer order" {
+    const page = try testing.pageTest("runner/virtual_time_order.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+
+    try testing.expectEqual("a,a2,b,c,", try textOf(&runner, page.frame_id, "#out"));
+    const remaining = page.session.virtual_time.?.remaining_ms;
+    try testing.expectEqual(true, remaining >= 4700 and remaining < 4900);
+}
+
+test "Runner: virtual time falls back to real time past the budget" {
+    const page = try testing.pageTest("runner/virtual_time_budget.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 100 });
+    defer page.close();
+
+    const start = lp.datetime.milliTimestamp(.boot);
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+    const elapsed = lp.datetime.milliTimestamp(.boot) - start;
+
+    try testing.expectEqual("budget-done", try textOf(&runner, page.frame_id, "#out"));
+    try testing.expectEqual(0, page.session.virtual_time.?.remaining_ms);
+    try testing.expectEqual(true, elapsed >= 100);
+}
+
+test "Runner: virtual time advances performance.now and event timestamps" {
+    const page = try testing.pageTest("runner/virtual_time_clocks.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+
+    const perf = try std.fmt.parseInt(u64, try textOf(&runner, page.frame_id, "#perf"), 10);
+    const evt = try std.fmt.parseInt(u64, try textOf(&runner, page.frame_id, "#evt"), 10);
+    try testing.expectEqual(true, perf >= 2990);
+    try testing.expectEqual(true, evt >= 2990);
+}
+
+test "Runner: virtual time satisfies the network idle hold" {
+    const page = try testing.pageTest("runner/virtual_time.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    const start = lp.datetime.milliTimestamp(.boot);
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .networkidle });
+    const elapsed = lp.datetime.milliTimestamp(.boot) - start;
+
+    try testing.expectEqual(true, page.frame().?._notified_network_idle == .done);
+    try testing.expectEqual(true, elapsed < 450);
+}
+
+test "Runner: interval repeats do not hold virtual time" {
+    const page = try testing.pageTest("runner/virtual_time_interval.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+
+    try testing.expectEqual("interval-done", try textOf(&runner, page.frame_id, "#out"));
+    const remaining = page.session.virtual_time.?.remaining_ms;
+    try testing.expectEqual(true, remaining >= 4000 and remaining < 4200);
+}
+
+test "Runner: virtual time waits for in-flight transfers" {
+    const page = try testing.pageTest("runner/virtual_time_fetch.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+
+    try testing.expectEqual("true", try textOf(&runner, page.frame_id, "#out"));
+}
+
+test "Runner: virtual time drives a non-blocking poll chain" {
+    const page = try testing.pageTest("runner/virtual_time_poll.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    const start = lp.datetime.milliTimestamp(.boot);
+    var runner = page.session.runner(.{});
+    _ = try runner.waitForSelector(page.frame_id, "#ready", 5000);
+    const elapsed = lp.datetime.milliTimestamp(.boot) - start;
+
+    try testing.expectEqual(true, elapsed < 1000);
+    // 15 hops of 100ms; the last five are past the blocking nesting depth.
+    const remaining = page.session.virtual_time.?.remaining_ms;
+    try testing.expectEqual(true, remaining >= 3500 and remaining < 3700);
+}
+
+test "Runner: virtual time budget resets per navigation" {
+    const page = try testing.pageTest("runner/virtual_time.html", .{ .wait_until_done = false, .virtual_time_budget_ms = 5000 });
+    defer page.close();
+
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+    try testing.expectEqual(true, page.session.virtual_time.?.remaining_ms < 5000);
+
+    try page.session.initiateRootNavigation(page.frame_id, "http://127.0.0.1:9582/src/browser/tests/runner/virtual_time.html", .{});
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .load });
+    try testing.expectEqual(5000, page.session.virtual_time.?.remaining_ms);
+
+    try runner.waitForFrame(page.frame_id, 5000, .{ .until = .done });
+    try testing.expectEqual(true, page.session.virtual_time.?.remaining_ms < 5000);
+
+    const page2 = try page.session.createPage();
+    defer page2.close();
+    try testing.expectEqual(5000, page.session.virtual_time.?.remaining_ms);
+}
+
+test "Runner: timers wait for real time without a budget" {
+    const page = try testing.pageTest("runner/virtual_time.html", .{ .wait_until_done = false });
+    defer page.close();
+
+    const start = lp.datetime.milliTimestamp(.boot);
+    var runner = page.session.runner(.{});
+    try runner.waitForFrame(page.frame_id, 100, .{ .until = .done });
+    const elapsed = lp.datetime.milliTimestamp(.boot) - start;
+
+    try testing.expectEqual(true, elapsed >= 100);
+    try testing.expectEqual("", try textOf(&runner, page.frame_id, "#out"));
 }

--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -32,6 +32,7 @@ const Navigation = @import("webapi/navigation/Navigation.zig");
 const Page = @import("Page.zig");
 const Frame = @import("Frame.zig");
 const Browser = @import("Browser.zig");
+const VirtualTime = @import("VirtualTime.zig");
 pub const Runner = @import("Runner.zig");
 const Notification = @import("../Notification.zig");
 const QueuedNavigation = Frame.QueuedNavigation;
@@ -105,6 +106,9 @@ _console_capture: bool = false,
 // configured external resources (images, stylesheet, worker, iframe) to load
 load_resources: Config.LoadResources,
 
+// Virtual time the current navigation may still skip; null keeps real time.
+virtual_time: ?VirtualTime.Budget = null,
+
 /// Caller-supplied cancellation probe. `Runner._wait` polls it between
 /// ticks; once `check` returns true the wait returns `error.Cancelled`.
 /// The agent installs this so SIGINT can abort an in-flight tool call
@@ -167,6 +171,7 @@ pub fn init(self: *Session, browser: *Browser, notification: *Notification) !voi
         .cookie_jar = storage.Cookie.Jar.init(allocator, notification),
         ._console_messages = .init(allocator),
         .load_resources = browser.app.config.loadResources(),
+        .virtual_time = if (browser.app.config.virtualTimeBudgetMs()) |ms| .init(ms) else null,
     };
     errdefer self._console_messages.deinit();
 }
@@ -364,10 +369,15 @@ fn installNewActivePage(self: *Session, frame_id: u32) !*Frame {
     errdefer _ = self.pages.pop();
 
     const frame = &page.frame;
-    // Inform CDP the main frame has been created so it can point its page
-    // handle at the new frame.
-    self.notification.dispatch(.frame_created, frame);
+    self.publishActivePage(frame);
     return frame;
+}
+
+// Inform CDP the main frame has been created so it can point its page handle
+// at the new frame, and start the navigation's virtual time budget afresh.
+fn publishActivePage(self: *Session, frame: *Frame) void {
+    if (self.virtual_time) |*vt| vt.reset();
+    self.notification.dispatch(.frame_created, frame);
 }
 
 pub fn createPage(self: *Session) !PageHandle {
@@ -948,7 +958,7 @@ pub fn commitPendingPage(self: *Session, replacement: *Page) !void {
     // set, so the session still reports an in-flight nav and CDP's frameCreated
     // skips the captured_responses / frame_arena reset that would wipe the
     // response we just received.
-    self.notification.dispatch(.frame_created, &replacement.frame);
+    self.publishActivePage(&replacement.frame);
 
     // Step 3: promote — clear `replaces` and unlink OLD so  `livePage()`
     // resolve to `replacement` (both share OLD's frame_id). OLD stays allocated

--- a/src/browser/VirtualTime.zig
+++ b/src/browser/VirtualTime.zig
@@ -16,15 +16,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! The page's clock. Timers, performance.now and event timestamps read it;
-//! the watchdog, HTTP client, rate limiter and server read the boot clock
-//! directly. Virtual time advances it past idle stretches so a pending timer
-//! becomes due without sleeping. Process-wide because the V8 platform clock
-//! is process-wide; only the browser thread reads or writes it, and it never
+//! The page's clock: timers, performance.now, event and resource timestamps.
+//! Infrastructure (watchdog, HTTP, rate limiter, server) stays on the boot
+//! clock. Process-wide like V8's platform clock; browser thread only; never
 //! rewinds.
 
 const std = @import("std");
 const lp = @import("lightpanda");
+
+const Platform = @import("js/Platform.zig");
 
 var offset_us: u64 = 0;
 
@@ -36,11 +36,11 @@ pub fn micro() u64 {
     return lp.datetime.microTimestamp(.boot) + offset_us;
 }
 
-pub fn advance(ms: u32) void {
+pub fn advance(platform: Platform, ms: u32) void {
     offset_us += @as(u64, ms) * std.time.us_per_ms;
+    platform.setClockOffsetMillis(@floatFromInt(offset_us / std.time.us_per_ms));
 }
 
-/// How much virtual time a navigation may skip. Consulted by Runner.
 pub const Budget = struct {
     per_navigation_ms: u32,
     remaining_ms: u32,

--- a/src/browser/VirtualTime.zig
+++ b/src/browser/VirtualTime.zig
@@ -1,0 +1,61 @@
+// Copyright (C) 2023-2025  Lightpanda (Selecy SAS)
+//
+// Francis Bouvier <francis@lightpanda.io>
+// Pierre Tachoire <pierre@lightpanda.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! The page's clock. Timers, performance.now and event timestamps read it;
+//! the watchdog, HTTP client, rate limiter and server read the boot clock
+//! directly. Virtual time advances it past idle stretches so a pending timer
+//! becomes due without sleeping. Process-wide because the V8 platform clock
+//! is process-wide; only the browser thread reads or writes it, and it never
+//! rewinds.
+
+const std = @import("std");
+const lp = @import("lightpanda");
+
+var offset_us: u64 = 0;
+
+pub fn milli() u64 {
+    return lp.datetime.milliTimestamp(.boot) + offset_us / std.time.us_per_ms;
+}
+
+pub fn micro() u64 {
+    return lp.datetime.microTimestamp(.boot) + offset_us;
+}
+
+pub fn advance(ms: u32) void {
+    offset_us += @as(u64, ms) * std.time.us_per_ms;
+}
+
+/// How much virtual time a navigation may skip. Consulted by Runner.
+pub const Budget = struct {
+    per_navigation_ms: u32,
+    remaining_ms: u32,
+
+    pub fn init(ms: u32) Budget {
+        return .{ .per_navigation_ms = ms, .remaining_ms = ms };
+    }
+
+    pub fn reset(self: *Budget) void {
+        self.remaining_ms = self.per_navigation_ms;
+    }
+
+    pub fn grant(self: *Budget, wanted_ms: u64) u32 {
+        const granted: u32 = @intCast(@min(wanted_ms, self.remaining_ms));
+        self.remaining_ms -= granted;
+        return granted;
+    }
+};

--- a/src/browser/frame/observers.zig
+++ b/src/browser/frame/observers.zig
@@ -27,6 +27,7 @@ const lp = @import("lightpanda");
 
 const Frame = @import("../Frame.zig");
 const Page = @import("../Page.zig");
+const VirtualTime = @import("../VirtualTime.zig");
 
 const Node = @import("../webapi/Node.zig");
 const Event = @import("../webapi/Event.zig");
@@ -354,7 +355,7 @@ pub fn deliverIntersections(frame: *Frame) void {
     }
     frame._intersection.delivery_scheduled = false;
 
-    const now = lp.datetime.milliTimestamp(.boot);
+    const now = VirtualTime.milli();
     if (now - frame._intersection.last_delivery_ms > INTERSECTION_QUIET_MS) {
         frame._intersection.burst_start_ms = now;
         frame._intersection.burst_deliveries = 0;

--- a/src/browser/js/Platform.zig
+++ b/src/browser/js/Platform.zig
@@ -57,6 +57,11 @@ pub fn init(opts: Options) !Platform {
     return .{ .handle = handle };
 }
 
+/// Date's clock only; V8's monotonic clock stays real.
+pub fn setClockOffsetMillis(self: Platform, offset_ms: f64) void {
+    v8.v8__Platform__SetClockOffsetMillis(self.handle, offset_ms);
+}
+
 pub fn deinit(self: Platform) void {
     _ = v8.v8__V8__Dispose();
     v8.v8__V8__DisposePlatform();

--- a/src/browser/js/Scheduler.zig
+++ b/src/browser/js/Scheduler.zig
@@ -19,6 +19,8 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
+const VirtualTime = @import("../VirtualTime.zig");
+
 const log = lp.log;
 const Allocator = std.mem.Allocator;
 
@@ -91,7 +93,7 @@ pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts
         std.debug.assert(opts.front == false or run_in_ms == 0);
     }
 
-    const run_at = lp.datetime.milliTimestamp(.boot) + run_in_ms;
+    const run_at = VirtualTime.milli() + run_in_ms;
     const task: Task = .{
         .ctx = ctx,
         .callback = cb,
@@ -115,7 +117,8 @@ pub fn add(self: *Scheduler, ctx: *anyopaque, cb: Callback, run_in_ms: u32, opts
 }
 
 pub fn run(self: *Scheduler) !void {
-    const start = lp.datetime.milliTimestamp(.boot);
+    // The virtual offset only moves between ticks, so this is real elapsed too.
+    const start = VirtualTime.milli();
     var now = start;
 
     while (self.popReady(now)) |task_| {
@@ -143,7 +146,7 @@ pub fn run(self: *Scheduler) !void {
             try self.timed.push(self.allocator, task);
         }
 
-        now = lp.datetime.milliTimestamp(.boot);
+        now = VirtualTime.milli();
         if (now - start > 500) {
             return;
         }
@@ -165,7 +168,7 @@ pub fn msToNext(self: *Scheduler) ?u64 {
     }
     const task = self.timed.peek() orelse return null;
     const run_at = task.runAt();
-    const now = lp.datetime.milliTimestamp(.boot);
+    const now = VirtualTime.milli();
     return if (run_at <= now) 0 else run_at - now;
 }
 

--- a/src/browser/tests/runner/virtual_time.html
+++ b/src/browser/tests/runner/virtual_time.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  setTimeout(() => {
+    document.getElementById('out').textContent = 'virtual-done';
+  }, 3000);
+</script>

--- a/src/browser/tests/runner/virtual_time_budget.html
+++ b/src/browser/tests/runner/virtual_time_budget.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  setTimeout(() => {
+    document.getElementById('out').textContent = 'budget-done';
+  }, 250);
+</script>

--- a/src/browser/tests/runner/virtual_time_clocks.html
+++ b/src/browser/tests/runner/virtual_time_clocks.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=perf></div>
+<div id=evt></div>
+<script>
+  const t0 = performance.now();
+  const e0 = new Event('x').timeStamp;
+  setTimeout(() => {
+    document.getElementById('perf').textContent = String(Math.round(performance.now() - t0));
+    document.getElementById('evt').textContent = String(Math.round(new Event('x').timeStamp - e0));
+  }, 3000);
+</script>

--- a/src/browser/tests/runner/virtual_time_clocks.html
+++ b/src/browser/tests/runner/virtual_time_clocks.html
@@ -2,11 +2,14 @@
 <meta charset="UTF-8">
 <div id=perf></div>
 <div id=evt></div>
+<div id=date></div>
 <script>
   const t0 = performance.now();
   const e0 = new Event('x').timeStamp;
+  const d0 = Date.now();
   setTimeout(() => {
     document.getElementById('perf').textContent = String(Math.round(performance.now() - t0));
     document.getElementById('evt').textContent = String(Math.round(new Event('x').timeStamp - e0));
+    document.getElementById('date').textContent = String(Date.now() - d0);
   }, 3000);
 </script>

--- a/src/browser/tests/runner/virtual_time_fetch.html
+++ b/src/browser/tests/runner/virtual_time_fetch.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  fetch('runner1.html?delay_ms=100').then(() => { window.__fetched = true; });
+  setTimeout(() => {
+    document.getElementById('out').textContent = String(!!window.__fetched);
+  }, 3000);
+</script>

--- a/src/browser/tests/runner/virtual_time_interval.html
+++ b/src/browser/tests/runner/virtual_time_interval.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  setInterval(() => {}, 100);
+  setTimeout(() => {
+    document.getElementById('out').textContent = 'interval-done';
+  }, 1000);
+</script>

--- a/src/browser/tests/runner/virtual_time_order.html
+++ b/src/browser/tests/runner/virtual_time_order.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  const out = document.getElementById('out');
+  const mark = (s) => { out.textContent += s + ','; };
+  setTimeout(() => mark('c'), 300);
+  setTimeout(() => {
+    mark('a');
+    setTimeout(() => mark('a2'), 50);
+  }, 100);
+  setTimeout(() => mark('b'), 200);
+</script>

--- a/src/browser/tests/runner/virtual_time_poll.html
+++ b/src/browser/tests/runner/virtual_time_poll.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<div id=out></div>
+<script>
+  let hops = 0;
+  function check() {
+    if (++hops < 15) {
+      setTimeout(check, 100);
+      return;
+    }
+    const el = document.createElement('div');
+    el.id = 'ready';
+    document.getElementById('out').append(el);
+  }
+  setTimeout(check, 100);
+</script>

--- a/src/browser/webapi/Performance.zig
+++ b/src/browser/webapi/Performance.zig
@@ -22,6 +22,7 @@ const lp = @import("lightpanda");
 const js = @import("../js/js.zig");
 const Factory = @import("../Factory.zig");
 const Scheduler = @import("../js/Scheduler.zig");
+const VirtualTime = @import("../VirtualTime.zig");
 
 const Event = @import("Event.zig");
 const EventTarget = @import("EventTarget.zig");
@@ -78,7 +79,7 @@ _delivering: bool = false,
 /// Get high-resolution timestamp in microseconds, rounded to 5μs increments
 /// to match browser behavior (prevents fingerprinting)
 pub fn highResTimestamp() u64 {
-    const micros = lp.datetime.microTimestamp(.boot);
+    const micros = VirtualTime.micro();
     // Round to nearest 5 microseconds (like Firefox default)
     const rounded = @divTrunc(micros + 2, 5) * 5;
     return rounded;

--- a/src/help.zon
+++ b/src/help.zon
@@ -503,6 +503,13 @@
     \\          Maximum V8 heap size in megabytes, per browser instance. Values
     \\          below ~16 are clamped by V8 and all behave the same.
     \\          Defaults to the V8 default (based on available memory).
+    \\  --virtual-time-budget-ms <INT>
+    \\          Experimental. When the page is idle and only timers are pending,
+    \\          advance the page's clock to the next timer instead of waiting
+    \\          for it. Timers fire in order; network requests are never
+    \\          skipped. At most INT virtual milliseconds per navigation, then
+    \\          timers wait for real time again. Date.now is not yet advanced.
+    \\          Ignored by serve. Defaults to off.
     \\  --watchdog-ms <INT>
     \\          Terminates JavaScript when the browser stalls — stays busy for
     \\          this long without returning to its network poll (e.g. a page

--- a/src/help.zon
+++ b/src/help.zon
@@ -508,8 +508,8 @@
     \\          advance the page's clock to the next timer instead of waiting
     \\          for it. Timers fire in order; network requests are never
     \\          skipped. At most INT virtual milliseconds per navigation, then
-    \\          timers wait for real time again. Date.now is not yet advanced.
-    \\          Ignored by serve. Defaults to off.
+    \\          timers wait for real time again. Ignored by serve.
+    \\          Defaults to off.
     \\  --watchdog-ms <INT>
     \\          Terminates JavaScript when the browser stalls — stays busy for
     \\          this long without returning to its network poll (e.g. a page

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -26,6 +26,7 @@ const Notification = @import("../Notification.zig");
 const Driver = @import("../server/Driver.zig");
 
 const URL = @import("../browser/URL.zig");
+const VirtualTime = @import("../browser/VirtualTime.zig");
 const referrer = @import("../browser/referrer.zig");
 const WebSocket = @import("../browser/webapi/net/WebSocket.zig");
 const Cookie = @import("../browser/webapi/storage/Cookie.zig");
@@ -1472,7 +1473,7 @@ fn makeRequest(self: *Client, conn: *http.Connection, transfer: *Transfer) anyer
     };
     transfer._conn = conn;
     transfer.state = .inflight;
-    transfer._timing.hop_start = lp.datetime.microTimestamp(.boot);
+    transfer._timing.hop_start = VirtualTime.micro();
 
     // Start the request (and move along any other request).
     _ = try self.handles.perform();
@@ -2913,7 +2914,7 @@ pub const Transfer = struct {
 
     fn redirectTiming(self: *Transfer, headers: []const http.Header) void {
         const t = &self._timing;
-        const now = lp.datetime.microTimestamp(.boot);
+        const now = VirtualTime.micro();
         if (t.redirect_start == 0) {
             t.redirect_start = t.start_time;
         }
@@ -2981,7 +2982,7 @@ pub const Transfer = struct {
 
         if (t.response_end == 0) {
             // Cache hit, interceptor-fulfilled, or failed: delivered now.
-            t.response_end = lp.datetime.microTimestamp(.boot);
+            t.response_end = VirtualTime.micro();
         }
         // Force phases that never happened to fetch_start
         inline for (.{ "dns_start", "dns_end", "connect_start", "connect_end", "request_start", "response_start" }) |phase| {
@@ -3977,7 +3978,7 @@ const ResourceTiming = struct {
     const CacheState = enum { none, local, validated };
 
     fn start(self: *ResourceTiming, url: [:0]const u8) void {
-        const now = lp.datetime.microTimestamp(.boot);
+        const now = VirtualTime.micro();
         self.url = url;
         self.start_time = now;
         self.fetch_start = now;

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -475,8 +475,11 @@ fn runWebApiTest(test_file: [:0]const u8, timeout_ms: u32) !void {
 
 const PageTestOpts = struct {
     wait_until_done: bool = true,
+    // Set before the page exists so the per-navigation reset is exercised.
+    virtual_time_budget_ms: ?u32 = null,
 };
 pub fn pageTest(comptime test_file: []const u8, opts: PageTestOpts) !Session.PageHandle {
+    test_session.virtual_time = if (opts.virtual_time_budget_ms) |ms| .init(ms) else null;
     const page = try test_session.createPage();
     errdefer page.close();
 


### PR DESCRIPTION
Opt-in `--virtual-time-budget-ms <INT>` (common option; `fetch`, `mcp`, `agent`): when the page is idle except for pending timers, advance the page's clock to the next scheduler task instead of sleeping, up to a per-navigation budget, then fall back to real time. Same model as Chrome's `--virtual-time-budget` with `pauseIfNetworkFetchesPending`.

## Rules

- Jump only to the next due task, never "fire everything now": timers keep their order, nested timers land relative to the jumped clock, and backoff loops stay bounded by the budget.
- Never advance while a transfer is in flight, a rate-limited request is parked, or V8 has background work. The one place that decides to sleep (`Runner._tick`'s idle return, plus the idle arms of `waitForSelector`/`waitForScript`) is the one place the clock moves.
- The budget resets when a root document becomes live and is spent per navigation; after it is spent the caller's real timeout bounds the wait exactly as today.

## Clocks

`src/browser/VirtualTime.zig` is the page's clock: scheduler due times, `performance.now`, event timestamps, resource timing, the network-idle hold and the intersection burst guard read it. Watchdog, HTTP client, rate limiter and server stay on the boot clock. `Date.now()` follows too, through `v8__Platform__SetClockOffsetMillis` from lightpanda-io/zig-v8-fork#203: debounce/throttle helpers re-arm `setTimeout` against `Date.now()` and would spin until real time caught up otherwise.

## Scope

Serve/CDP is deliberately untouched: the CDP loop never reaches the idle sleep (`.done` is inert there and the driver fd keeps the HTTP client polling), so `Emulation.setVirtualTimePolicy` would be a separate change. Ignored-by-serve is documented in the help text.

On a page that keeps fetching (eu.gymshark.com's listing fires an Algolia request as soon as the previous one returns) the budget never engages, by design. It targets pages that wait on timers after the network quiets.

## Numbers

ReleaseFast build against a release V8 carrying the fork shim, `fetch --dump html --wait-until done --wait-ms 15000`, with and without `--virtual-time-budget-ms 30000`:

| Page | Without | With |
|---|---|---|
| developer.mozilla.org/en-US/ (3 runs) | 1.65 s, 1.64 s, 1.76 s | 0.61 s, 0.50 s, 0.51 s |
| local fixture, one 3 s timer (`src/browser/tests/runner/virtual_time_clocks.html`) | 3.04 s | 0.03 s |
| eu.gymshark.com men's listing | 15.1 s, at the cap | 15.1 s, at the cap |

MDN waits on three 1 s timers after the network quiets; the dumps differ only in per-render Lit markers and ad rotation. On the fixture `performance.now`, `Event.timeStamp` and `Date.now` all report 3000 ms inside the callback in both modes. Gymshark never goes network-idle, so the clock never moves. Pages that re-arm polling timers forever (bbc.com, web.dev) drain the budget without reaching `done`, as without the flag.

## Depends on

lightpanda-io/zig-v8-fork#203, pinned by commit in `build.zig.zon`. CI needs a fork tag with the new export before this links; then bump `zig-v8` in `.github/actions/install/action.yml` and repoint `build.zig.zon` at the merge commit.
