### PR TITLE
Fix dataset property presence checks

### DIFF
--- a/src/browser/tests/element/dataset.html
+++ b/src/browser/tests/element/dataset.html
@@ -107,6 +107,20 @@
 }
 </script>
 
+<script id=propertyPresence>
+{
+  const el = document.getElementById('test');
+
+  testing.expectEqual(true, 'foo' in el.dataset);
+  testing.expectEqual(true, Object.hasOwn(el.dataset, 'foo'));
+  testing.expectEqual(true, 'helloWorld' in el.dataset);
+
+  testing.expectEqual(false, 'nonExistent' in el.dataset);
+  testing.expectEqual(false, Object.hasOwn(el.dataset, 'nonExistent'));
+  testing.expectEqual(false, Object.hasOwn(el.dataset, 'fooBar'));
+}
+</script>
+
 <script id=identityCheck>
 {
   const el = document.getElementById('test');

--- a/src/browser/webapi/element/DOMStringMap.zig
+++ b/src/browser/webapi/element/DOMStringMap.zig
@@ -41,6 +41,11 @@ fn setProperty(self: *DOMStringMap, name: String, value: String, frame: *Frame) 
     return self._element.setAttributeSafe(attr_name, value, frame);
 }
 
+fn hasProperty(self: *DOMStringMap, name: String, frame: *Frame) !bool {
+    const attr_name = try camelToKebab(frame.local_arena, name);
+    return self._element.hasAttribute(attr_name, frame);
+}
+
 fn deleteProperty(self: *DOMStringMap, name: String, frame: *Frame) !void {
     const attr_name = try camelToKebab(frame.local_arena, name);
     try self._element.removeAttribute(attr_name, frame);
@@ -135,7 +140,7 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
-    pub const @"[]" = bridge.namedIndexed(getProperty, setProperty, deleteProperty, getNames, null, .{ .null_as_undefined = true, .ce_reactions = true });
+    pub const @"[]" = bridge.namedIndexed(getProperty, setProperty, deleteProperty, getNames, hasProperty, .{ .null_as_undefined = true, .ce_reactions = true });
 
     // The supported property names are the camel-cased names of the
     // element's data-* attributes, in attribute order.


### PR DESCRIPTION
## Why

`DOMStringMap` implements `element.dataset` through a named property getter. When a `data-*` attribute is missing, the getter returns `null`, which `.null_as_undefined = true` exposes to JavaScript as `undefined`. However, the bridge reports the getter as handled by returning `js.Intercepted.yes` (`true`) by default. Without a separate query callback, V8 also uses that getter result for property-presence checks and treats the missing property as present.

Before this change:

```js
Object.hasOwn(element.dataset, "missing"); // true
"missing" in element.dataset;              // true
```

Chrome and Firefox correctly return `false` for both checks when the corresponding `data-*` attribute does not exist.

This surfaced on the [Accacia Raw Honey storefront page](https://0e397c.myshopify.com/products/accacia-raw-honey?_fd=0). Its custom element constructor uses a dataset presence check before moving itself into another container. Because the missing property was reported as present, cloning the document caused each newly constructed element to move into the live subtree being cloned. The clone traversal then encountered the appended element and repeated the process, producing an unbounded loop of custom element construction failures until watchdog termination.

## What

- Add a `DOMStringMap` query callback that maps the requested property to its `data-*` attribute and returns its actual presence.
- Cover `in` and `Object.hasOwn` for present, absent, and camel-cased dataset properties.

## Validation

- `TEST_FILTER="WebApi: Element # dataset.html" make test` — 1 passed
- `make test` — 1,455 passed
- `zig build`
- `zig fmt --check ./*.zig ./**/*.zig`
- The affected page and the minimal constructor-reparenting reproducer now clone without custom element warnings or a watchdog stall
