### PR TITLE
Fix `Notification` use-after-free

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -178,6 +178,19 @@ pub fn deinit(self: *Session) void {
 
     self.closeAllPages();
 
+    // CorsGate/RobotsGate fetches are ownerless, so page/frame teardown above
+    // never reaches them.
+    //
+    // They still carry this notification and can outlive it, so clear the pointer here or
+    // Transfer.kill's later notify() dispatches through a freed Notification
+    // once the caller runs notification.deinit() after this returns.
+    var transfer_it = self.browser.http_client.transfers.valueIterator();
+    while (transfer_it.next()) |t| {
+        if (t.*.req.notification == self.notification) {
+            t.*.req.notification = null;
+        }
+    }
+
     self.cookie_jar.deinit();
 
     {

--- a/src/server/cdp/CDP.zig
+++ b/src/server/cdp/CDP.zig
@@ -615,6 +615,18 @@ pub const BrowserContext = struct {
         self.node_registry.deinit();
         self.node_search_list.deinit();
         self.set_child_nodes_sent.deinit(self.cdp.allocator);
+
+        // CorsGate/RobotsGate fetches are ownerless, so closeSession's owner-based teardown never reaches them.
+        //
+        // They still carry this notification (copied for CDP correlation) and can outlive it, so clear
+        // the pointer here or Transfer.kill's later notify() dispatches through a freed Notification when
+        // the http_client itself is torn down.
+        var transfer_it = http_client.transfers.valueIterator();
+        while (transfer_it.next()) |t| {
+            if (t.*.req.notification == self.notification) {
+                t.*.req.notification = null;
+            }
+        }
         self.notification.deinit();
 
         if (self.http_proxy_changed) {

--- a/src/server/cdp/CDP.zig
+++ b/src/server/cdp/CDP.zig
@@ -616,17 +616,8 @@ pub const BrowserContext = struct {
         self.node_search_list.deinit();
         self.set_child_nodes_sent.deinit(self.cdp.allocator);
 
-        // CorsGate/RobotsGate fetches are ownerless, so closeSession's owner-based teardown never reaches them.
-        //
-        // They still carry this notification (copied for CDP correlation) and can outlive it, so clear
-        // the pointer here or Transfer.kill's later notify() dispatches through a freed Notification when
-        // the http_client itself is torn down.
-        var transfer_it = http_client.transfers.valueIterator();
-        while (transfer_it.next()) |t| {
-            if (t.*.req.notification == self.notification) {
-                t.*.req.notification = null;
-            }
-        }
+        // Session.deinit (called via closeSession above) already cleared this
+        // notification off any ownerless CorsGate/RobotsGate transfers.
         self.notification.deinit();
 
         if (self.http_proxy_changed) {


### PR DESCRIPTION
This should clear out the `*Notification` on owner-less Transfers when we de-init the Notification that they are referencing.