### PR TITLE
webapi: add basic support for custom properties

### DIFF
--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -60,6 +60,9 @@ other_rules: RuleList = .empty, // universal, attribute, pseudo-class endings
 memo: Memo = .empty,
 memo_version: usize = 0,
 
+// Keyed by property name, pruning to what is (hopefully) one or few rules
+custom_rules: std.StringHashMapUnmanaged(CustomProperty) = .empty,
+
 /// The thing to remember about layers is that we can't determine priority's
 /// layer_rank until everything is parsed. So we need to build up meta data when
 /// rebuilding and do one final pass to apply the resulting layering rank.
@@ -438,34 +441,112 @@ fn finalizeLayerRanks(self: *StyleManager, build_arena: Allocator) Allocator.Err
     while (tag_it.next()) |rules| {
         self.stampRuleList(rules);
     }
+
+    // Even if we lazilly parse custom properties, we need to stamp the priority
+    // now, since the rule_layers only exist during the build
+    var custom_it = self.custom_rules.valueIterator();
+    while (custom_it.next()) |property| {
+        for (property.rules.items) |*rule| {
+            rule.priority |= @as(u64, self.layerRank(rule.priority)) << RANK_SHIFT;
+        }
+    }
 }
 
 fn stampRuleList(self: *StyleManager, rules: *RuleList) void {
-    const layers = self.layers.items;
-    const rule_layers = self.rule_layers.items;
     for (rules.items(.priority)) |*priority| {
-        const doc_order: u32 = @as(u22, @truncate(priority.*));
-        const layer = rule_layers[doc_order - 1];
-        const rank = if (layer == NO_LAYER) UNLAYERED_RANK else layers[layer].rank;
-        priority.* |= @as(u64, rank) << RANK_SHIFT;
+        priority.* |= @as(u64, self.layerRank(priority.*)) << RANK_SHIFT;
     }
 }
 
-fn addRawRule(self: *StyleManager, build_arena: Allocator, selector_text: []const u8, block_text: []const u8, layer: u16) !void {
-    if (selector_text.len == 0) return;
+/// The cascade-layer rank for a packed priority, via its doc_order.
+fn layerRank(self: *const StyleManager, priority: u64) u32 {
+    const doc_order: u32 = @as(u22, @truncate(priority));
+    const layer = self.rule_layers.items[doc_order - 1];
+    return if (layer == NO_LAYER) UNLAYERED_RANK else self.layers.items[layer].rank;
+}
 
-    var props = VisibilityProperties{};
-    var it = CssParser.parseDeclarationsList(block_text);
-    while (it.next()) |decl| {
-        props.apply(decl.name, decl.value);
+fn addRawRule(self: *StyleManager, build_arena: Allocator, selector_text: []const u8, block_text: []const u8, layer: u16) !void {
+    if (selector_text.len == 0) {
+        return;
     }
 
-    if (!props.isRelevant()) return;
+    var props = VisibilityProperties{};
 
-    const selectors = SelectorParser.parseList(self.arena.allocator(), selector_text) catch return;
+    // Keyed rather than appended so a block declaring the same custom property
+    // twice keeps only the winner. Lives in build_arena: addSelectorRules
+    // copies what it needs into the rule arena.
+    var customs: std.StringArrayHashMapUnmanaged(CustomDeclaration) = .empty;
+
+    var it = CssParser.parseDeclarationsList(block_text);
+    while (it.next()) |decl| {
+        if (isCustomProperty(decl.name)) {
+            // Last one wins, except that a normal declaration never overrides
+            // an earlier !important one, same as applyParsedDeclaration.
+            const gop = try customs.getOrPut(build_arena, decl.name);
+            if (gop.found_existing and gop.value_ptr.important and decl.important == false) {
+                continue;
+            }
+            gop.value_ptr.* = .{ .name = decl.name, .value = decl.value, .important = decl.important };
+        } else {
+            props.apply(decl.name, decl.value);
+        }
+    }
+
+    return self.addSelectorRules(build_arena, selector_text, props, customs.values(), layer);
+}
+
+// Visibility rules get one VisibilityRule per selector (not per selector list)
+// so each has correct specificity, bucketed by their rightmost selector part.
+// Custom properties are keyed by name instead, and lazily parse the selector.
+fn addSelectorRules(
+    self: *StyleManager,
+    build_arena: Allocator,
+    selector_text: []const u8,
+    props: VisibilityProperties,
+    customs: []const CustomDeclaration,
+    layer: u16,
+) !void {
+    const relevant = props.isRelevant();
+    if (relevant == false and customs.len == 0) {
+        return;
+    }
+
+    const arena = self.arena.allocator();
+
+    if (customs.len > 0) {
+        const doc_order = @min(self.next_doc_order, MAX_DOC_ORDER);
+        self.next_doc_order += 1;
+        try self.rule_layers.append(build_arena, layer);
+
+        for (customs) |custom| {
+            const gop = try self.custom_rules.getOrPut(arena, custom.name);
+            if (gop.found_existing == false) {
+                gop.value_ptr.* = .{};
+            }
+            try gop.value_ptr.rules.append(arena, .{
+                .value = custom.value,
+                .priority = doc_order,
+                .selector_text = selector_text,
+            });
+        }
+    }
+
+    if (relevant == false) {
+        return;
+    }
+
+    const selectors = SelectorParser.parseList(arena, selector_text) catch return;
+
     for (selectors) |selector| {
-        const rightmost = if (selector.segments.len > 0) selector.segments[selector.segments.len - 1].compound else selector.first;
-        const bucket_key = getBucketKey(rightmost) orelse continue;
+        // Get the rightmost compound (last segment, or first if no segments)
+        const rightmost = if (selector.segments.len > 0)
+            selector.segments[selector.segments.len - 1].compound
+        else
+            selector.first;
+
+        // Find the bucketing key from rightmost compound
+        const bucket_key = getBucketKey(rightmost) orelse continue; // skip if dynamic pseudo-class
+
         const rule = VisibilityRule{
             .props = props,
             .selector = selector,
@@ -476,25 +557,35 @@ fn addRawRule(self: *StyleManager, build_arena: Allocator, selector_text: []cons
 
         switch (bucket_key) {
             .id => |id| {
-                const gop = try self.id_rules.getOrPut(self.arena.allocator(), id);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
+                const gop = try self.id_rules.getOrPut(arena, id);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = .{};
+                }
+                try gop.value_ptr.append(arena, rule);
             },
             .class => |class| {
-                const gop = try self.class_rules.getOrPut(self.arena.allocator(), class);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
+                const gop = try self.class_rules.getOrPut(arena, class);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = .{};
+                }
+                try gop.value_ptr.append(arena, rule);
             },
             .tag => |tag| {
-                const gop = try self.tag_rules.getOrPut(self.arena.allocator(), tag);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
+                const gop = try self.tag_rules.getOrPut(arena, tag);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = .{};
+                }
+                try gop.value_ptr.append(arena, rule);
             },
             .other => {
-                try self.other_rules.append(self.arena.allocator(), rule);
+                try self.other_rules.append(arena, rule);
             },
         }
     }
+}
+
+fn isCustomProperty(name: []const u8) bool {
+    return std.mem.startsWith(u8, name, "--");
 }
 
 pub fn sheetModified(self: *StyleManager) void {
@@ -529,6 +620,7 @@ fn rebuildIfDirty(self: *StyleManager) !void {
     const tag_rules_count = self.tag_rules.count();
     const other_rules_count = self.other_rules.len;
     const memo_count = self.memo.count();
+    const custom_rules_count = self.custom_rules.count();
 
     self.arena.resetRetain();
 
@@ -548,6 +640,9 @@ fn rebuildIfDirty(self: *StyleManager) !void {
 
     self.other_rules = .{};
     try self.other_rules.ensureTotalCapacity(self.arena.allocator(), other_rules_count);
+
+    self.custom_rules = .empty;
+    try self.custom_rules.ensureTotalCapacity(self.arena.allocator(), custom_rules_count);
 
     const sheets = self.frame.document._style_sheets orelse return;
     for (sheets._sheets.items) |sheet| {
@@ -790,70 +885,52 @@ fn matchesUaDisplayNoneRule(el: *Element) bool {
     return false;
 }
 
-// Extracts visibility-relevant rules from a CSS rule.
-// Creates one VisibilityRule per selector (not per selector list) so each has correct specificity.
-// Buckets rules by their rightmost selector part for fast lookup.
+// Extracts visibility-relevant rules and custom properties from a CSSOM rule.
+// Creates one VisibilityRule per selector (not per selector list) so each has
+// correct specificity, bucketed by the rightmost selector part for fast lookup.
+// The raw-text twin of this is addRawRule; both hand off to addSelectorRules.
 fn addRule(self: *StyleManager, build_arena: Allocator, style_rule: *CSSStyleRule) !void {
     const selector_text = style_rule._selector_text;
     if (selector_text.len == 0) {
         return;
     }
 
-    // Check if the rule has visibility-relevant properties
     const style = style_rule._style orelse return;
     const props = extractVisibilityProperties(style);
-    if (!props.isRelevant()) {
-        return;
-    }
+    const customs = try self.extractCustomDeclarations(style);
 
-    // Parse the selector list
-    const selectors = SelectorParser.parseList(self.arena.allocator(), selector_text) catch return;
-    if (selectors.len == 0) {
-        return;
-    }
+    // A custom rule holds selector_text until the property is looked up, but it
+    // doesn't need a copy: setSelectorText allocates the replacement from the
+    // frame arena and never frees the old one. Worst case we match a stale
+    // selector, which is what the rest of this file already does when a rule is
+    // mutated without going through sheetModified().
+    return self.addSelectorRules(build_arena, selector_text, props, customs, NO_LAYER);
+}
 
-    // Create one rule per selector - each has its own specificity
-    // e.g., "#id, .class { display: none }" becomes two rules with different specificities
-    for (selectors) |selector| {
-        // Get the rightmost compound (last segment, or first if no segments)
-        const rightmost = if (selector.segments.len > 0)
-            selector.segments[selector.segments.len - 1].compound
-        else
-            selector.first;
+/// The CSSOM counterpart to addRawRule's `--*` branch. Names within one
+/// declaration block are already unique, so there is nothing to dedup here.
+///
+/// Unlike the selector text, both strings have to be copied: they can point
+/// into the Property itself (small string optimization), and setProperty /
+/// removeProperty destroy it without going through sheetModified(). We'd be
+/// left reading freed memory rather than something merely stale.
+fn extractCustomDeclarations(self: *StyleManager, style: *CSSStyleProperties) ![]const CustomDeclaration {
+    const arena = self.arena.allocator();
 
-        // Find the bucketing key from rightmost compound
-        const bucket_key = getBucketKey(rightmost) orelse continue; // skip if dynamic pseudo-class
-
-        const rule = VisibilityRule{
-            .props = props,
-            .selector = selector,
-            .priority = (@as(u64, computeSpecificity(selector)) << SPEC_SHIFT) | @min(self.next_doc_order, MAX_DOC_ORDER),
-        };
-        self.next_doc_order += 1;
-        try self.rule_layers.append(build_arena, NO_LAYER);
-
-        // Add to appropriate bucket
-        switch (bucket_key) {
-            .id => |id| {
-                const gop = try self.id_rules.getOrPut(self.arena.allocator(), id);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
-            },
-            .class => |class| {
-                const gop = try self.class_rules.getOrPut(self.arena.allocator(), class);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
-            },
-            .tag => |tag| {
-                const gop = try self.tag_rules.getOrPut(self.arena.allocator(), tag);
-                if (!gop.found_existing) gop.value_ptr.* = .{};
-                try gop.value_ptr.append(self.arena.allocator(), rule);
-            },
-            .other => {
-                try self.other_rules.append(self.arena.allocator(), rule);
-            },
+    var customs: std.ArrayList(CustomDeclaration) = .empty;
+    var it = style.asCSSStyleDeclaration().iterator();
+    while (it.next()) |property| {
+        const name = property._name.str();
+        if (isCustomProperty(name) == false) {
+            continue;
         }
+        try customs.append(arena, .{
+            .name = try arena.dupe(u8, name),
+            .value = try arena.dupe(u8, property._value.str()),
+            .important = property._important,
+        });
     }
+    return customs.items;
 }
 
 const BucketKey = union(enum) {
@@ -1030,6 +1107,36 @@ const VisibilityRule = struct {
     priority: u64,
 };
 
+// custom_rules map is property_name -> CustomProperty, loosely:
+//    --color => [(:root, "#ff0"), (.card, "#000")]
+// So when code says "getComputedStyle(el).getPropertyValue("--color")
+// We end up with a relatively small number of rules
+const CustomProperty = struct {
+    rules: std.ArrayList(CustomRule) = .empty,
+    parsed: ?[]const ParsedCustomRule = null, // lazily parsed
+};
+
+const CustomRule = struct {
+    selector_text: []const u8,
+    value: []const u8,
+    priority: u64,
+};
+
+/// Some frameworks define hundreds+ of custom properties, 99% of which are
+/// never accessed via JS. So we don't parse them until something asks for it.
+const ParsedCustomRule = struct {
+    selector: Selector.Selector,
+    value: []const u8,
+    priority: u64, // packed the same way as VisibilityRule.priority
+};
+
+/// A `--*` declaration on its way from a rule block into custom_rules.
+const CustomDeclaration = struct {
+    name: []const u8,
+    value: []const u8,
+    important: bool,
+};
+
 const Layer = struct {
     // dotted path from the root
     path: []const u8,
@@ -1175,6 +1282,84 @@ pub fn inlineStyleValue(self: *StyleManager, el: *Element, property_name: String
     return styleValue(style, property_name);
 }
 
+/// Computed value of a custom property (`--x`) on `el`, or null when nothing
+/// declares it. The value is returned as-is, no var substitution
+pub fn customPropertyValue(self: *StyleManager, el: *Element, property_name: String) ?[]const u8 {
+    self.rebuildIfDirty() catch return null;
+
+    // Only the rules declaring this name; usually a handful, often none. An
+    // element can still shadow them with an inline declaration, so a miss here
+    // means walking for inline styles, not returning early.
+    const rules = self.parsedCustomRules(property_name.str()) catch |err| blk: {
+        log.err(.browser, "StyleManager customProperty", .{ .err = err });
+        break :blk &.{};
+    };
+
+    var current: ?*Element = el;
+    while (current) |elem| : (current = elem.parentElement()) {
+        if (self.inlineStyleValue(elem, property_name)) |value| {
+            return value;
+        }
+
+        var winner: ?[]const u8 = null;
+        var priority: u64 = 0;
+        for (rules) |rule| {
+            if (rule.priority <= priority) {
+                continue;
+            }
+            if (matchesSelector(elem, rule.selector, self.frame) == false) {
+                continue;
+            }
+            winner = rule.value;
+            priority = rule.priority;
+        }
+
+        if (winner) |value| {
+            return value;
+        }
+    }
+
+    return null;
+}
+
+/// Gets the parsed rule for a custom property name
+fn parsedCustomRules(self: *StyleManager, name: []const u8) ![]const ParsedCustomRule {
+    const property = self.custom_rules.getPtr(name) orelse return &.{};
+    if (property.parsed) |parsed| {
+        // the custom property exists, and we already parsed it.
+        return parsed;
+    }
+
+    const arena = self.arena.allocator();
+    var parsed: std.ArrayList(ParsedCustomRule) = .empty;
+
+    for (property.rules.items) |rule| {
+        const selectors = SelectorParser.parseList(arena, rule.selector_text) catch continue;
+        for (selectors) |selector| {
+            const rightmost = if (selector.segments.len > 0)
+                selector.segments[selector.segments.len - 1].compound
+            else
+                selector.first;
+
+            {
+                // we don't use buckets for custom properties (are property name
+                // lookup is more efficient), but we still want to skip dynamic
+                // pseudo-classes just like visibility does
+                _ = getBucketKey(rightmost) orelse continue;
+            }
+
+            try parsed.append(arena, .{
+                .selector = selector,
+                .value = rule.value,
+                .priority = rule.priority | (@as(u64, computeSpecificity(selector)) << SPEC_SHIFT),
+            });
+        }
+    }
+
+    property.parsed = parsed.items;
+    return parsed.items;
+}
+
 /// Bounds computedFontSize's ancestor recursion (the parent walk and
 /// `inherit`/relative-unit chains share it).
 const MAX_FONT_ANCESTOR_DEPTH = 32;
@@ -1226,6 +1411,10 @@ fn parseFontSize(self: *StyleManager, raw: []const u8, parent: ?*Element, depth:
 }
 
 const testing = @import("../testing.zig");
+test "StyleManager: custom properties" {
+    try testing.htmlRunner("css/custom_properties.html", .{});
+}
+
 test "StyleManager: computeSpecificity: element selector" {
     // div -> (0, 0, 1)
     const selector = Selector.Selector{

--- a/src/browser/css/Tokenizer.zig
+++ b/src/browser/css/Tokenizer.zig
@@ -284,6 +284,7 @@ fn isIdentStart(self: *Tokenizer) bool {
     var b = self.nextByteUnchecked();
     if (b == '-') {
         b = if (self.hasAtLeast(1)) self.byteAt(1) else return false;
+        if (b == '-') return true; // --custom-property
     }
 
     return switch (b) {

--- a/src/browser/tests/css/custom_properties.html
+++ b/src/browser/tests/css/custom_properties.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<head>
+  <script src="../testing.js"></script>
+</head>
+
+<!--
+  getComputedStyle().getPropertyValue('--x') resolution.
+
+  Custom properties inherit, so the answer depends on the element asked, not
+  just on the document: the nearest ancestor that declares the property wins
+  outright, and specificity only breaks ties between rules matching that same
+  element. The declared token stream is returned verbatim - `var()` inside a
+  value is NOT substituted.
+-->
+
+<style>
+  :root { --brand: #336699; --theme: light; }
+  html { --from-html: html; }
+
+  .card { --pad: 16px; --dup: from-class; }
+  #card { --dup: from-id; }
+
+  /* Case-sensitive: these are two different properties. */
+  #case { --Token: upper; --token: lower; }
+
+  /* Later normal declaration wins, but never over an earlier !important. */
+  #within-block { --normal-last: first; --normal-last: second; }
+  #within-block { --important-first: kept !important; --important-first: ignored; }
+
+  /* Interaction state can't be resolved statically, so :hover is skipped. */
+  #dynamic:hover { --hover-only: nope; }
+
+  /* Values are stored as declared: no var() substitution. */
+  #alias { --base: 4px; --derived: var(--base); }
+
+  /* Nearest ancestor wins over a more specific rule further up. */
+  #outer.outer.outer { --nearest: far; }
+  .inner { --nearest: near; }
+</style>
+
+<body>
+  <div class="card" id="card" style="--inline: 8px; --pad: inline-wins">card</div>
+  <div class="card">plain card</div>
+  <div id="case">case</div>
+  <div id="within-block">within-block</div>
+  <div id="dynamic">dynamic</div>
+  <div id="alias">alias</div>
+  <div id="outer" class="outer"><div class="inner"><span id="nearest">nearest</span></div></div>
+  <div id="plain">plain</div>
+  <style id="dyn"></style>
+</body>
+
+<script id=custom_property_sources>
+{
+  const card = getComputedStyle($('#card'));
+  // Declared on :root, reached by inheritance.
+  testing.expectEqual('#336699', card.getPropertyValue('--brand'));
+  testing.expectEqual('html', card.getPropertyValue('--from-html'));
+  // Declared on the element's own class rule.
+  testing.expectEqual('16px', getComputedStyle($('.card:not([id])')).getPropertyValue('--pad'));
+  // Inline declaration beats the class rule.
+  testing.expectEqual('inline-wins', card.getPropertyValue('--pad'));
+  testing.expectEqual('8px', card.getPropertyValue('--inline'));
+  // Higher specificity wins between two rules matching the same element.
+  testing.expectEqual('from-id', card.getPropertyValue('--dup'));
+
+  // :root is reachable from the root element itself, not only by inheritance.
+  testing.expectEqual('#336699', getComputedStyle(document.documentElement).getPropertyValue('--brand'));
+
+  // Undeclared names resolve to the empty string.
+  testing.expectEqual('', card.getPropertyValue('--nope'));
+  testing.expectEqual('', getComputedStyle($('#plain')).getPropertyValue('--nope'));
+}
+</script>
+
+<script id=custom_property_case_sensitive>
+{
+  const style = getComputedStyle($('#case'));
+  testing.expectEqual('upper', style.getPropertyValue('--Token'));
+  testing.expectEqual('lower', style.getPropertyValue('--token'));
+  testing.expectEqual('', style.getPropertyValue('--TOKEN'));
+
+  // Same on the inline path: --A and --a are distinct properties.
+  const el = document.createElement('div');
+  el.style.setProperty('--A', 'a-upper');
+  el.style.setProperty('--a', 'a-lower');
+  testing.expectEqual(2, el.style.length);
+  testing.expectEqual('a-upper', el.style.getPropertyValue('--A'));
+  testing.expectEqual('a-lower', el.style.getPropertyValue('--a'));
+}
+</script>
+
+<script id=custom_property_within_block>
+{
+  const style = getComputedStyle($('#within-block'));
+  testing.expectEqual('second', style.getPropertyValue('--normal-last'));
+  testing.expectEqual('kept', style.getPropertyValue('--important-first'));
+}
+</script>
+
+<script id=custom_property_dynamic_pseudo_skipped>
+{
+  testing.expectEqual('', getComputedStyle($('#dynamic')).getPropertyValue('--hover-only'));
+}
+</script>
+
+<script id=custom_property_no_var_substitution>
+{
+  const style = getComputedStyle($('#alias'));
+  testing.expectEqual('4px', style.getPropertyValue('--base'));
+  testing.expectEqual('var(--base)', style.getPropertyValue('--derived'));
+}
+</script>
+
+<script id=custom_property_nearest_ancestor_wins>
+{
+  // #outer.outer.outer is far more specific than .inner, but .inner is nearer,
+  // and inheritance outranks the cascade across elements.
+  testing.expectEqual('near', getComputedStyle($('#nearest')).getPropertyValue('--nearest'));
+  testing.expectEqual('far', getComputedStyle($('#outer')).getPropertyValue('--nearest'));
+}
+</script>
+
+<script id=custom_property_inline_on_ancestor>
+{
+  const parent = document.createElement('div');
+  parent.style.setProperty('--from-ancestor-inline', '4px');
+  const child = document.createElement('div');
+  parent.appendChild(child);
+  document.body.appendChild(parent);
+
+  testing.expectEqual('4px', getComputedStyle(child).getPropertyValue('--from-ancestor-inline'));
+  // Still inherits document-level tokens through the new subtree.
+  testing.expectEqual('light', getComputedStyle(child).getPropertyValue('--theme'));
+}
+</script>
+
+<script id=custom_property_cssom_rules>
+{
+  // The CSSOM path (addRule) has to agree with the raw-text path (addRawRule).
+  const sheet = $('#dyn').sheet;
+  sheet.insertRule('#plain { --Om: om-upper; --om: om-lower }', 0);
+
+  const plain = $('#plain');
+  testing.expectEqual('om-upper', getComputedStyle(plain).getPropertyValue('--Om'));
+  testing.expectEqual('om-lower', getComputedStyle(plain).getPropertyValue('--om'));
+
+  // Mutating the rule's declaration must not leave us serving a freed value.
+  sheet.cssRules[0].style.setProperty('--Om', 'x');
+  sheet.insertRule('#nothing-matches { color: red }', 0);
+  testing.expectEqual('x', getComputedStyle(plain).getPropertyValue('--Om'));
+
+  sheet.deleteRule(0);
+  sheet.deleteRule(0);
+  testing.expectEqual('', getComputedStyle(plain).getPropertyValue('--Om'));
+}
+</script>
+
+<script id=custom_property_not_on_inline_declaration>
+{
+  // A non-computed declaration only ever reports its own inline properties;
+  // it must not start resolving stylesheet rules.
+  testing.expectEqual('', $('#card').style.getPropertyValue('--brand'));
+  testing.expectEqual('8px', $('#card').style.getPropertyValue('--inline'));
+}
+</script>
+
+<script id=custom_property_on_rule_declaration>
+{
+  // A CSSStyleRule's declaration is not a computed style: it reports exactly
+  // the custom properties the rule declares, and nothing inherited.
+  const rule = document.styleSheets[0].cssRules[0];
+  testing.expectEqual(':root', rule.selectorText);
+  testing.expectEqual('#336699', rule.style.getPropertyValue('--brand'));
+  testing.expectEqual('light', rule.style.getPropertyValue('--theme'));
+  testing.expectEqual(2, rule.style.length);
+  testing.expectEqual('--brand', rule.style.item(0));
+  testing.expectEqual('--brand: #336699; --theme: light;', rule.style.cssText);
+  testing.expectEqual('', rule.style.getPropertyValue('--pad'));
+}
+</script>

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -82,11 +82,16 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
     // tree builders (Playwright ariaSnapshot) consult on every element.
     if (self._is_computed) {
         if (self._element) |element| {
-            const style_manager = &element.ownerFrame(frame)._style_manager;
             if (wrapped.eql(comptime .wrap("display"))) {
-                if (style_manager.hasDisplayNone(element, .materialize)) return "none";
+                const style_manager = &element.ownerFrame(frame)._style_manager;
+                if (style_manager.hasDisplayNone(element, .materialize)) {
+                    return "none";
+                }
             } else if (wrapped.eql(comptime .wrap("visibility"))) {
-                if (style_manager.hasVisibilityHiddenInherited(element)) return "hidden";
+                const style_manager = &element.ownerFrame(frame)._style_manager;
+                if (style_manager.hasVisibilityHiddenInherited(element)) {
+                    return "hidden";
+                }
             }
         }
     }
@@ -95,9 +100,15 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
         // Only return default values for computed styles
         if (self._is_computed) {
             if (self._element) |element| {
+                const style_manager = &element.ownerFrame(frame)._style_manager;
+
+                if (isCustomProperty(normalized)) {
+                    return style_manager.customPropertyValue(element, wrapped) orelse "";
+                }
+
                 // Resolve inline `style=` declarations through the element's
                 // parsed inline style, so computed values match `el.style`.
-                if (element.ownerFrame(frame)._style_manager.inlineStyleValue(element, wrapped)) |value| {
+                if (style_manager.inlineStyleValue(element, wrapped)) |value| {
                     return value;
                 }
 
@@ -292,6 +303,20 @@ pub fn format(self: *const CSSStyleDeclaration, writer: *std.Io.Writer) !void {
     }
 }
 
+pub fn iterator(self: *const CSSStyleDeclaration) Iterator {
+    return .{ .node = self._properties.first };
+}
+
+pub const Iterator = struct {
+    node: ?*std.DoublyLinkedList.Node,
+
+    pub fn next(self: *Iterator) ?*Property {
+        const node = self.node orelse return null;
+        self.node = node.next;
+        return Property.fromNodeLink(node);
+    }
+};
+
 pub fn findProperty(self: *const CSSStyleDeclaration, name: String) ?*Property {
     var node = self._properties.first;
     while (node) |n| {
@@ -305,11 +330,20 @@ pub fn findProperty(self: *const CSSStyleDeclaration, name: String) ?*Property {
 }
 
 fn normalizePropertyName(name: []const u8, buf: []u8) []const u8 {
+    if (isCustomProperty(name)) {
+        // Custom properties are case-sensitive
+        return name;
+    }
+
     if (name.len > buf.len) {
         log.info(.dom, "css.long.name", .{ .name = name });
         return name;
     }
     return std.ascii.lowerString(buf, name);
+}
+
+fn isCustomProperty(name: []const u8) bool {
+    return std.mem.startsWith(u8, name, "--");
 }
 
 // Normalize CSS property values for canonical serialization


### PR DESCRIPTION
Attempt to improve https://github.com/lightpanda-io/browser/issues/3199

Meant an leaner alternative to https://github.com/lightpanda-io/browser/pull/3440

3440 is close, but it adds 16 bytes to every VisibilityRule which isn't ideal especially since the majority of these rules have no custom properties.

Let's make a few reasonable assumptions:
1 - Most custom properties don't have many distinct selectors
    (--background-color might be defined on, :root, and .card and a few others)

2 - Most custom properties aren't queried from JS (Tailwind can define thousands
    of custom properties, but they're used by the rendering engine, not from JS)

3 - Most selectors don't have custom properties

The design is to inverse what we do for visibility: lookup per property. We end up with a property-name -> [(selector, value), (selector, value)] lookup. If there's a query for --foreground, we O(1) to get the list of (selector, value) and then iterate through this (hopefully) short list to get the value.

PLUS, we only parse the selector on the first query. So for those sites with thousands of custom-properties, we're not wastefully storing / parsing the selector on every build.