### PR TITLE
Fix `history.state` and `Navigation.currentEntry` crash

### DIFF
--- a/src/browser/Session.zig
+++ b/src/browser/Session.zig
@@ -366,7 +366,20 @@ pub fn createPage(self: *Session) !PageHandle {
     }
 
     const frame_id = self.nextFrameId();
-    _ = try self.installNewActivePage(frame_id);
+    const frame = try self.installNewActivePage(frame_id);
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html --
+    // Creating a new browsing context always produces an initial about:blank
+    // Document with its own session history entry, even before any real
+    // navigation happens. Without this, navigation.currentEntry crashes on
+    // a page that hasn't navigated yet.
+    _ = try self.navigation.pushEntry(
+        frame.url,
+        .{ .source = .navigation, .value = null },
+        frame,
+        false,
+    );
+    self.navigation._initial_entry = true;
 
     return .{ .session = self, .frame_id = frame_id };
 }

--- a/src/browser/webapi/navigation/Navigation.zig
+++ b/src/browser/webapi/navigation/Navigation.zig
@@ -53,6 +53,11 @@ _entries: std.ArrayList(*NavigationHistoryEntry) = .empty,
 _next_entry_id: usize = 0,
 _activation: ?NavigationActivation = null,
 
+// True right after createPage seeds the synthetic initial about:blank
+// entry, and never otherwise. Per spec, the first real navigation away
+// from that initial entry replaces it.
+_initial_entry: bool = false,
+
 fn asEventTarget(self: *Navigation) *EventTarget {
     return self._proto;
 }
@@ -162,14 +167,19 @@ pub fn commitNavigation(self: *Navigation, frame: *Frame) !void {
     defer self._current_navigation_kind = null;
 
     const from_entry = self.getCurrentEntryOrNull();
+    const was_initial_entry = self._initial_entry;
     if (from_entry == null) {
         kind = .{ .push = null };
+    } else if (was_initial_entry) {
+        kind = .{ .replace = null };
     }
+    self._initial_entry = false;
 
     try self.updateEntries(url, kind, frame, false);
 
     self._activation = NavigationActivation{
-        ._from = from_entry,
+        // If we are navigating away from the initial about:blank, we have no from.
+        ._from = if (was_initial_entry) null else from_entry,
         ._entry = self.getCurrentEntry(),
         ._type = kind.toNavigationType(),
     };

--- a/src/server/cdp/domains/page.zig
+++ b/src/server/cdp/domains/page.zig
@@ -2532,28 +2532,30 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         try testing.waitForPage(bc);
     }
 
-    // Three entries (ids 0, 1, 2), currentIndex points at the most-recent.
+    // Three entries (ids 1, 2, 3) — id 0 was the synthetic initial
+    // about:blank entry that loadBrowserContext's navigation to dom1.html
+    // replaced. currentIndex points at the most-recent.
     {
         try ctx.processMessage(.{ .id = 30, .method = "Page.getNavigationHistory" });
         try ctx.expectSentResult(.{
             .currentIndex = 2,
             .entries = &[_]NavigationEntry{
                 .{
-                    .id = 0,
+                    .id = 1,
                     .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html",
                     .userTypedURL = "http://127.0.0.1:9582/src/browser/tests/cdp/dom1.html",
                     .title = "",
                     .transitionType = "other",
                 },
                 .{
-                    .id = 1,
+                    .id = 2,
                     .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom2.html",
                     .userTypedURL = "http://127.0.0.1:9582/src/browser/tests/cdp/dom2.html",
                     .title = "",
                     .transitionType = "other",
                 },
                 .{
-                    .id = 2,
+                    .id = 3,
                     .url = "http://127.0.0.1:9582/src/browser/tests/cdp/dom3.html",
                     .userTypedURL = "http://127.0.0.1:9582/src/browser/tests/cdp/dom3.html",
                     .title = "",
@@ -2568,7 +2570,7 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         try ctx.processMessage(.{
             .id = 40,
             .method = "Page.navigateToHistoryEntry",
-            .params = .{ .entryId = 0 },
+            .params = .{ .entryId = 1 },
         });
         try testing.waitForPage(bc);
 
@@ -2581,7 +2583,7 @@ test "cdp.frame: getNavigationHistory + navigateToHistoryEntry" {
         try ctx.processMessage(.{
             .id = 41,
             .method = "Page.navigateToHistoryEntry",
-            .params = .{ .entryId = 1 },
+            .params = .{ .entryId = 2 },
         });
         try testing.waitForPage(bc);
 

--- a/src/server/cdp/domains/target.zig
+++ b/src/server/cdp/domains/target.zig
@@ -221,13 +221,18 @@ fn createTarget(cmd: *CDP.Command) !void {
         try doAttachtoTarget(cmd, target_id);
     }
 
-    if (!std.mem.eql(u8, "about:blank", params.url)) {
-        const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
-        try frame.navigate(
-            encoded_url,
-            .{ .reason = .address_bar, .kind = .{ .push = null } },
-        );
-    }
+    // https://html.spec.whatwg.org/multipage/document-sequences.html,
+    // Create a new browsing context always produces an initial about:blank
+    // Document with its own session history entry
+    const encoded_url: [:0]const u8 = if (std.mem.eql(u8, "about:blank", params.url))
+        "about:blank"
+    else
+        try URL.resolveNavigation(frame.call_arena, params.url, .{});
+
+    try frame.navigate(
+        encoded_url,
+        .{ .reason = .address_bar, .kind = .{ .push = null } },
+    );
 
     try cmd.sendResult(.{
         .targetId = target_id,

--- a/src/server/cdp/domains/target.zig
+++ b/src/server/cdp/domains/target.zig
@@ -221,18 +221,24 @@ fn createTarget(cmd: *CDP.Command) !void {
         try doAttachtoTarget(cmd, target_id);
     }
 
-    // https://html.spec.whatwg.org/multipage/document-sequences.html,
-    // Create a new browsing context always produces an initial about:blank
-    // Document with its own session history entry
-    const encoded_url: [:0]const u8 = if (std.mem.eql(u8, "about:blank", params.url))
-        "about:blank"
-    else
-        try URL.resolveNavigation(frame.call_arena, params.url, .{});
-
-    try frame.navigate(
-        encoded_url,
-        .{ .reason = .address_bar, .kind = .{ .push = null } },
+    // https://html.spec.whatwg.org/multipage/document-sequences.html --
+    // Creating a new browsing context always produces an initial about:blank
+    // Document with its own session history entry, even before any real
+    // navigation happens.
+    _ = try frame._session.navigation.pushEntry(
+        frame.url,
+        .{ .source = .navigation, .value = null },
+        frame,
+        false,
     );
+
+    if (!std.mem.eql(u8, "about:blank", params.url)) {
+        const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
+        try frame.navigate(
+            encoded_url,
+            .{ .reason = .address_bar, .kind = .{ .push = null } },
+        );
+    }
 
     try cmd.sendResult(.{
         .targetId = target_id,

--- a/src/server/cdp/domains/target.zig
+++ b/src/server/cdp/domains/target.zig
@@ -758,6 +758,22 @@ test "cdp.target: history.state on freshly created blank target doesn't crash" {
     try ctx.expectSentResult(.{ .result = .{ .type = "object", .subtype = "null", .value = null } }, .{ .id = 43 });
 }
 
+test "cdp.target: navigation.currentEntry on freshly created blank target doesn't crash" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    try ctx.processMessage(.{ .id = 40, .method = "Target.setAutoAttach", .params = .{ .autoAttach = true, .waitForDebuggerOnStart = false } });
+    try ctx.processMessage(.{ .id = 41, .method = "Target.createTarget", .params = .{ .url = "about:blank" } });
+    const bc = &ctx.cdp().browser_context.?;
+    const session_id = bc.session_id.?;
+
+    try ctx.processMessage(.{ .id = 42, .method = "Runtime.enable", .sessionId = session_id });
+    try ctx.processMessage(.{ .id = 43, .method = "Runtime.evaluate", .sessionId = session_id, .params = .{
+        .expression = "navigation.currentEntry.url",
+    } });
+    try ctx.expectSentResult(.{ .result = .{ .type = "string", .value = "about:blank" } }, .{ .id = 43 });
+}
+
 // A browser-target session (Target.attachToBrowserTarget) is distinct from
 // the page-target session. It used to be stored in bc.session_id, which broke
 // the "no target => no session_id" invariant asserted in createTarget.

--- a/src/server/cdp/domains/target.zig
+++ b/src/server/cdp/domains/target.zig
@@ -221,17 +221,6 @@ fn createTarget(cmd: *CDP.Command) !void {
         try doAttachtoTarget(cmd, target_id);
     }
 
-    // https://html.spec.whatwg.org/multipage/document-sequences.html --
-    // Creating a new browsing context always produces an initial about:blank
-    // Document with its own session history entry, even before any real
-    // navigation happens.
-    _ = try frame._session.navigation.pushEntry(
-        frame.url,
-        .{ .source = .navigation, .value = null },
-        frame,
-        false,
-    );
-
     if (!std.mem.eql(u8, "about:blank", params.url)) {
         const encoded_url = try URL.resolveNavigation(frame.call_arena, params.url, .{});
         try frame.navigate(

--- a/src/server/cdp/domains/target.zig
+++ b/src/server/cdp/domains/target.zig
@@ -726,6 +726,27 @@ test "cdp.target: createTarget" {
     }
 }
 
+// A freshly created blank target (the default CDP Target.createTarget) is
+// left unnavigated until a real navigation happens, so Navigation._entries
+// is empty. Reading history.state/navigation.currentEntry there used to hit
+// the hard `lp.assert(len > 0, ...)` in Navigation.getCurrentEntry and crash
+// the whole process instead of just failing the one command.
+test "cdp.target: history.state on freshly created blank target doesn't crash" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    try ctx.processMessage(.{ .id = 40, .method = "Target.setAutoAttach", .params = .{ .autoAttach = true, .waitForDebuggerOnStart = false } });
+    try ctx.processMessage(.{ .id = 41, .method = "Target.createTarget", .params = .{ .url = "about:blank" } });
+    const bc = &ctx.cdp().browser_context.?;
+    const session_id = bc.session_id.?;
+
+    try ctx.processMessage(.{ .id = 42, .method = "Runtime.enable", .sessionId = session_id });
+    try ctx.processMessage(.{ .id = 43, .method = "Runtime.evaluate", .sessionId = session_id, .params = .{
+        .expression = "history.state",
+    } });
+    try ctx.expectSentResult(.{ .result = .{ .type = "object", .subtype = "null", .value = null } }, .{ .id = 43 });
+}
+
 // A browser-target session (Target.attachToBrowserTarget) is distinct from
 // the page-target session. It used to be stored in bc.session_id, which broke
 // the "no target => no session_id" invariant asserted in createTarget.


### PR DESCRIPTION
When you create a CDP target, you can have an empty Navigation list. This hits the assert in `Navigation.currentEntry` and `history.state` and causes a crash. This fixes it by pushing an Entry to Navigation when a Target is created.