### PR TITLE
Drop the per-call visibility caches

### DIFF
--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -56,6 +56,7 @@ pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) error{WriteFailed}!
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
         .label_index = &label_index,
+        .owner_frame = self.dom_node.ownerFrame(self.frame),
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
         log.err(.app, "semantic tree json dump failed", .{ .err = err });
@@ -75,6 +76,7 @@ pub fn textStringify(self: @This(), writer: *std.Io.Writer) error{WriteFailed}!v
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
         .label_index = &label_index,
+        .owner_frame = self.dom_node.ownerFrame(self.frame),
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
         log.err(.app, "semantic tree text dump failed", .{ .err = err });
@@ -106,6 +108,7 @@ const WalkContext = struct {
     xpath_buffer: *std.ArrayList(u8),
     listener_targets: interactive.ListenerTargetMap,
     label_index: *Label.LabelByForIndex,
+    owner_frame: *Frame, // node's ow frame, not the callers
 };
 
 fn walk(
@@ -129,10 +132,11 @@ fn walk(
 
         // Hidden subtrees are never entered, so below the root only the
         // element's own display matters.
+        const style_manager = &ctx.owner_frame._style_manager;
         const hidden = if (current_depth == 0)
-            !el.isVisible(self.frame, .scan)
+            style_manager.isHidden(el, .{}, .scan)
         else
-            self.frame._style_manager.hasDisplayNone(el, .scan);
+            style_manager.hasDisplayNone(el, .scan);
         if (hidden) {
             return;
         }
@@ -753,6 +757,40 @@ test "SemanticTree backendDOMNodeId" {
     defer testing.allocator.free(json_str);
 
     try testing.expect(std.mem.indexOf(u8, json_str, "\"backendDOMNodeId\":") != null);
+}
+
+test "SemanticTree: styles come from the node's own frame" {
+    var registry: NodeRegistry = .init(testing.allocator);
+    defer registry.deinit();
+
+    // The caller's frame hides #inner; the frame that actually owns the walked
+    // subtree does not. A backendNodeId lookup can hand us a node from another
+    // frame, so the walk must not use the caller's stylesheets.
+    var page_a = try testing.pageTest("cdp/semantic_tree_frame_a.html", .{});
+    defer page_a.close();
+    var page_b = try testing.pageTest("cdp/semantic_tree_frame_b.html", .{});
+    defer page_b.close();
+
+    const frame_a = page_a.frame().?;
+    const frame_b = page_b.frame().?;
+
+    const target = (try frame_b.window._document.querySelector(.wrap("#target"), frame_b)).?.asNode();
+
+    const st: Self = .{
+        .dom_node = target,
+        .registry = &registry,
+        .frame = frame_a,
+        .arena = testing.arena_allocator,
+        .prune = false,
+        .interactive_only = false,
+        .max_depth = std.math.maxInt(u32) - 1,
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try st.textStringify(&aw.writer);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "inner-b") != null);
 }
 
 test "SemanticTree max_depth" {

--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -51,14 +51,10 @@ pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) error{WriteFailed}!
         log.err(.app, "listener map failed", .{ .err = err });
         return error.WriteFailed;
     };
-    var visibility_cache: Element.VisibilityCache = .empty;
-    var pointer_events_cache: Element.PointerEventsCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     var ctx: WalkContext = .{
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
-        .visibility_cache = &visibility_cache,
-        .pointer_events_cache = &pointer_events_cache,
         .label_index = &label_index,
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
@@ -74,14 +70,10 @@ pub fn textStringify(self: @This(), writer: *std.Io.Writer) error{WriteFailed}!v
         log.err(.app, "listener map failed", .{ .err = err });
         return error.WriteFailed;
     };
-    var visibility_cache: Element.VisibilityCache = .empty;
-    var pointer_events_cache: Element.PointerEventsCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     var ctx: WalkContext = .{
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
-        .visibility_cache = &visibility_cache,
-        .pointer_events_cache = &pointer_events_cache,
         .label_index = &label_index,
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
@@ -113,8 +105,6 @@ const NodeData = struct {
 const WalkContext = struct {
     xpath_buffer: *std.ArrayList(u8),
     listener_targets: interactive.ListenerTargetMap,
-    visibility_cache: *Element.VisibilityCache,
-    pointer_events_cache: *Element.PointerEventsCache,
     label_index: *Label.LabelByForIndex,
 };
 
@@ -137,8 +127,13 @@ fn walk(
         // We handle options/optgroups natively inside their parents, skip them in the general walk
         if (tag == .datalist or tag == .option or tag == .optgroup) return;
 
-        // Check visibility using the engine's checkVisibility which handles CSS display: none
-        if (!el.checkVisibilityCached(ctx.visibility_cache, self.frame, .scan)) {
+        // Hidden subtrees are never entered, so below the root only the
+        // element's own display matters.
+        const hidden = if (current_depth == 0)
+            !el.isVisible(self.frame, .scan)
+        else
+            self.frame._style_manager.hasDisplayNone(el, .scan);
+        if (hidden) {
             return;
         }
 
@@ -184,7 +179,7 @@ fn walk(
         }
 
         if (el.is(Element.Html)) |html_el| {
-            if (interactive.classifyInteractivity(self.frame, el, html_el, ctx.listener_targets, ctx.pointer_events_cache) != null) {
+            if (interactive.classifyInteractivity(self.frame, el, html_el, ctx.listener_targets) != null) {
                 is_interactive = true;
             }
         }
@@ -709,8 +704,7 @@ pub fn getNodeDetails(
 
         if (el.is(Element.Html)) |html_el| {
             const listener_targets = try interactive.buildListenerTargetMap(frame, arena);
-            var pointer_events_cache: Element.PointerEventsCache = .empty;
-            if (interactive.classifyInteractivity(frame, el, html_el, listener_targets, &pointer_events_cache) != null) {
+            if (interactive.classifyInteractivity(frame, el, html_el, listener_targets) != null) {
                 is_interactive = true;
             }
         }

--- a/src/browser/StyleManager.zig
+++ b/src/browser/StyleManager.zig
@@ -38,10 +38,6 @@ const log = lp.log;
 const String = lp.String;
 const Allocator = std.mem.Allocator;
 
-pub const ChainCache = std.AutoHashMapUnmanaged(*Element, bool);
-pub const VisibilityCache = ChainCache;
-pub const PointerEventsCache = ChainCache;
-
 // Tracks visibility-relevant CSS rules from <style> elements.
 // Rules are bucketed by their rightmost selector part for fast lookup.
 const StyleManager = @This();
@@ -591,9 +587,9 @@ const Probe = enum { hidden, visibility, pointer_events };
 
 const Memo = std.AutoHashMapUnmanaged(*Element, Props);
 
-pub fn isHidden(self: *StyleManager, el: *Element, cache: ?*VisibilityCache, options: CheckVisibilityOptions, comptime access: InlineAccess) bool {
+pub fn isHidden(self: *StyleManager, el: *Element, options: CheckVisibilityOptions, comptime access: InlineAccess) bool {
     self.rebuildIfDirty() catch return false;
-    return self.anyInChain(el, cache, access, .hidden, options);
+    return self.anyInChain(el, access, .hidden, options);
 }
 
 /// Computed display:none for a single element (own property, no ancestor walk).
@@ -624,33 +620,18 @@ pub fn hasAuthorDisplayNone(self: *StyleManager, el: *Element, comptime access: 
 /// rendered, but its computed `visibility` still reflects inherited visibility.
 pub fn hasVisibilityHiddenInherited(self: *StyleManager, el: *Element) bool {
     self.rebuildIfDirty() catch return false;
-    return self.anyInChain(el, null, .materialize, .visibility, .{});
+    return self.anyInChain(el, .materialize, .visibility, .{});
 }
 
-pub fn hasPointerEventsNone(self: *StyleManager, el: *Element, cache: ?*PointerEventsCache, comptime access: InlineAccess) bool {
+pub fn hasPointerEventsNone(self: *StyleManager, el: *Element, comptime access: InlineAccess) bool {
     self.rebuildIfDirty() catch return false;
-    return self.anyInChain(el, cache, access, .pointer_events, .{});
+    return self.anyInChain(el, access, .pointer_events, .{});
 }
 
-fn anyInChain(self: *StyleManager, el: *Element, cache: ?*ChainCache, comptime access: InlineAccess, comptime what: Probe, options: CheckVisibilityOptions) bool {
+fn anyInChain(self: *StyleManager, el: *Element, comptime access: InlineAccess, comptime what: Probe, options: CheckVisibilityOptions) bool {
     var current: ?*Element = el;
     while (current) |elem| : (current = elem.parentElement()) {
-        if (cache) |c| {
-            if (c.get(elem)) |matched| {
-                if (matched) {
-                    return true;
-                }
-                continue;
-            }
-        }
-
-        const matched = self.ownProps(elem, access).probe(what, options);
-        if (cache) |c| {
-            c.put(self.frame.call_arena, elem, matched) catch |err| {
-                log.warn(.browser, "StyleManager cache", .{ .err = err });
-            };
-        }
-        if (matched) {
+        if (self.ownProps(elem, access).probe(what, options)) {
             return true;
         }
     }
@@ -1474,41 +1455,41 @@ test "StyleManager: memo: reuse and invalidation" {
     const b = p.asNode().firstChild().?.as(Element);
 
     // The walk memoizes the element and every ancestor
-    try testing.expectEqual(false, sm.isHidden(b, null, .{}, .scan));
+    try testing.expectEqual(false, sm.isHidden(b, .{}, .scan));
     try testing.expectEqual(3, sm.memo.count());
-    try testing.expectEqual(false, sm.isHidden(b, null, .{}, .scan));
+    try testing.expectEqual(false, sm.isHidden(b, .{}, .scan));
     try testing.expectEqual(3, sm.memo.count());
 
     // A scan never creates the style object; a materialize hit does
     try testing.expectEqual(null, b.getStyle(frame));
-    try testing.expectEqual(false, sm.isHidden(b, null, .{}, .materialize));
+    try testing.expectEqual(false, sm.isHidden(b, .{}, .materialize));
     try testing.expect(b.getStyle(frame) != null);
     try testing.expectEqual(3, sm.memo.count());
 
     // An attribute change anywhere invalidates the memo
     try p.setAttributeSafe(comptime .wrap("hidden"), .wrap(""), frame);
-    try testing.expectEqual(true, sm.isHidden(b, null, .{}, .scan));
+    try testing.expectEqual(true, sm.isHidden(b, .{}, .scan));
     try testing.expectEqual(false, sm.hasDisplayNone(b, .scan));
     try testing.expectEqual(true, sm.hasDisplayNone(p, .scan));
     try testing.expectEqual(false, sm.hasAuthorDisplayNone(p, .scan));
 
     p.removeAttributeSafe(comptime .wrap("hidden"), frame);
-    try testing.expectEqual(false, sm.isHidden(b, null, .{}, .scan));
+    try testing.expectEqual(false, sm.isHidden(b, .{}, .scan));
 
     try b.setStyle("display: none; pointer-events: none", frame);
     try testing.expectEqual(true, sm.hasAuthorDisplayNone(b, .scan));
-    try testing.expectEqual(true, sm.hasPointerEventsNone(b, null, .scan));
-    try testing.expectEqual(false, sm.hasPointerEventsNone(p, null, .scan));
+    try testing.expectEqual(true, sm.hasPointerEventsNone(b, .scan));
+    try testing.expectEqual(false, sm.hasPointerEventsNone(p, .scan));
 
     try b.setStyle("display: flex; visibility: hidden", frame);
     try testing.expectEqual(.flex, sm.display(b, .scan));
-    try testing.expectEqual(false, sm.isHidden(b, null, .{}, .scan));
-    try testing.expectEqual(true, sm.isHidden(b, null, .{ .check_visibility = true }, .scan));
+    try testing.expectEqual(false, sm.isHidden(b, .{}, .scan));
+    try testing.expectEqual(true, sm.isHidden(b, .{ .check_visibility = true }, .scan));
     try testing.expectEqual(true, sm.hasVisibilityHiddenInherited(b));
-    try testing.expectEqual(false, sm.hasPointerEventsNone(b, null, .scan));
+    try testing.expectEqual(false, sm.hasPointerEventsNone(b, .scan));
 
     // A stylesheet change resets the memo
     sm.sheetModified();
-    try testing.expectEqual(false, sm.isHidden(p, null, .{}, .scan));
+    try testing.expectEqual(false, sm.isHidden(p, .{}, .scan));
     try testing.expectEqual(2, sm.memo.count());
 }

--- a/src/browser/interactive.zig
+++ b/src/browser/interactive.zig
@@ -180,14 +180,13 @@ fn walkInteractive(
     // so classify and getListenerTypes are both O(1) per element.
     const listener_targets = try buildListenerTargetMap(frame, arena);
 
-    var css_cache: Element.PointerEventsCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
 
     var results: std.ArrayList(InteractiveElement) = .empty;
 
     if (root.is(Element)) |root_el| {
         // root is outside of the tree walk, so check its visibility upfront.
-        if (!root_el.checkVisibilityCached(null, frame, .scan)) {
+        if (!root_el.isVisible(frame, .scan)) {
             return &.{};
         }
     }
@@ -213,7 +212,7 @@ fn walkInteractive(
 
         const html_el = el.is(Element.Html) orelse continue;
 
-        const itype = classifyInteractivity(frame, el, html_el, listener_targets, &css_cache) orelse continue;
+        const itype = classifyInteractivity(frame, el, html_el, listener_targets) orelse continue;
 
         const axn = AXNode.fromNode(node);
         const role = axRole(axn);
@@ -298,9 +297,8 @@ pub fn classifyInteractivity(
     el: *Element,
     html_el: *Element.Html,
     listener_targets: ListenerTargetMap,
-    cache: ?*Element.PointerEventsCache,
 ) ?InteractivityType {
-    if (el.hasPointerEventsNone(cache, frame, .scan)) return null;
+    if (el.hasPointerEventsNone(frame, .scan)) return null;
 
     // 1. Native interactive by tag
     switch (el.getTag()) {

--- a/src/browser/links.zig
+++ b/src/browser/links.zig
@@ -62,7 +62,6 @@ pub fn registerNodes(links: []Link, registry: anytype) !void {
 /// semantic tree reports for the node.
 pub fn collectLinks(arena: Allocator, root: *Node, frame: *Frame) ![]Link {
     var links: std.StringArrayHashMapUnmanaged(Link) = .empty;
-    var visibility_cache: Element.VisibilityCache = .empty;
     var labels: Label.LabelByForIndex = .{};
 
     if (Selector.querySelectorAll(root, "a[href]", frame)) |list| {
@@ -71,7 +70,7 @@ pub fn collectLinks(arena: Allocator, root: *Node, frame: *Frame) ![]Link {
         for (list._nodes) |node| {
             const anchor = node.is(Element.Html.Anchor) orelse continue;
             const el = anchor.asElement();
-            if (!el.checkVisibilityCached(&visibility_cache, frame, .scan)) continue;
+            if (!el.isVisible(frame, .scan)) continue;
 
             const href = anchor.getHref(frame) catch |err| {
                 log.err(.app, "resolve href failed", .{ .err = err });

--- a/src/browser/tests/cdp/semantic_tree_frame_a.html
+++ b/src/browser/tests/cdp/semantic_tree_frame_a.html
@@ -1,0 +1,2 @@
+<style>#inner { display: none }</style>
+<p>page-a</p>

--- a/src/browser/tests/cdp/semantic_tree_frame_b.html
+++ b/src/browser/tests/cdp/semantic_tree_frame_b.html
@@ -1,0 +1,1 @@
+<div id=target><p id=inner>inner-b</p></div>

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -917,16 +917,12 @@ fn elementFromPointImpl(self: *Document, x: f64, y: f64, ignore_x: bool, frame: 
     // preorder counter instead of calling calculateDocumentPosition per node
     // (which itself is O(N)). Once the counter's y passes the query y, no
     // later element can contain the point, and we can return.
-    //
-    // We also share a single VisibilityCache across all elements so the
-    // ancestor-walk inside isHidden gets amortized.
     var topmost: ?*Element = null;
 
     const root = self.asNode();
     var stack: std.ArrayList(*Node) = .empty;
     try stack.append(frame.local_arena, root);
 
-    var visibility_cache: Element.VisibilityCache = .{};
     var preorder_index: f64 = 0;
 
     while (stack.items.len > 0) {
@@ -940,7 +936,7 @@ fn elementFromPointImpl(self: *Document, x: f64, y: f64, ignore_x: bool, frame: 
 
         preorder_index += 1;
         if (node.is(Element)) |element| {
-            if (element.checkVisibilityCached(&visibility_cache, frame, .materialize)) {
+            if (element.isVisible(frame, .materialize)) {
                 if (y >= pos and y <= pos + element.boxAxis(frame, .height)) {
                     if (ignore_x) {
                         topmost = element;

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1162,7 +1162,7 @@ pub fn focus(self: *Element, frame: *Frame) !void {
 
     // Per HTML spec §6.4.4, an element must be "being rendered" (not
     // display:none on self or any ancestor) to be focusable.
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return;
     }
 
@@ -1350,29 +1350,15 @@ pub fn parentElement(self: *Element) ?*Element {
     return self.asNode().parentElement();
 }
 
-/// Cache for visibility checks - re-exported from StyleManager for convenience.
-pub const VisibilityCache = StyleManager.VisibilityCache;
-
-/// Cache for pointer-events checks - re-exported from StyleManager for convenience.
-pub const PointerEventsCache = StyleManager.PointerEventsCache;
-
 // Style checks go through the StyleManager of the element's own frame, not
 // the caller's: its stylesheets and materialized inline styles are per-frame,
 // and a same-origin script can reach an element in another frame.
-pub fn hasPointerEventsNone(self: *Element, cache: ?*PointerEventsCache, frame: *Frame, comptime access: StyleManager.InlineAccess) bool {
-    return self.ownerFrame(frame)._style_manager.hasPointerEventsNone(self, cache, access);
+pub fn hasPointerEventsNone(self: *Element, frame: *Frame, comptime access: StyleManager.InlineAccess) bool {
+    return self.ownerFrame(frame)._style_manager.hasPointerEventsNone(self, access);
 }
 
-pub fn checkVisibilityCached(self: *Element, cache: ?*VisibilityCache, frame: *Frame, comptime access: StyleManager.InlineAccess) bool {
-    return !self.ownerFrame(frame)._style_manager.isHidden(self, cache, .{}, access);
-}
-
-// The element's own display:none only, no ancestor walk. For a child or
-// sibling of an element already known to be visible, that is the whole
-// answer: they share the visible ancestor chain — and the owner frame, which
-// the caller resolves once rather than per element.
-fn isVisibleSelf(self: *Element, style_manager: *StyleManager) bool {
-    return !style_manager.hasDisplayNone(self, .materialize);
+pub fn isVisible(self: *Element, frame: *Frame, comptime access: StyleManager.InlineAccess) bool {
+    return !self.ownerFrame(frame)._style_manager.isHidden(self, .{}, access);
 }
 
 const CheckVisibilityOpts = struct {
@@ -1383,7 +1369,7 @@ const CheckVisibilityOpts = struct {
 };
 pub fn checkVisibility(self: *Element, opts_: ?CheckVisibilityOpts, frame: *Frame) bool {
     const opts = opts_ orelse CheckVisibilityOpts{};
-    return !self.ownerFrame(frame)._style_manager.isHidden(self, null, .{
+    return !self.ownerFrame(frame)._style_manager.isHidden(self, .{
         .check_opacity = opts.checkOpacity or opts.opacityProperty,
         .check_visibility = opts.visibilityProperty or opts.checkVisibilityCSS,
     }, .materialize);
@@ -1440,7 +1426,7 @@ pub fn getClientHeight(self: *Element, frame: *Frame) f64 {
 }
 
 fn clientAxis(self: *Element, frame: *Frame, comptime axis: Axis) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
     return self.viewportAxis(frame, axis) orelse self.boxAxis(frame, axis);
@@ -1488,7 +1474,7 @@ pub fn getBoundingClientRect(self: *Element, frame: *Frame) !*DOMRect {
 // getBoundingClientRect, getClientRects, and IntersectionObserver. A DOMRect is
 // only materialized at the JS boundary.
 pub fn boundingClientRectValues(self: *Element, frame: *Frame) DOMRect.Data {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return .{};
     }
     return self.boundingClientRectValuesForVisible(frame);
@@ -1505,7 +1491,7 @@ pub fn boundingClientRectValuesForVisible(self: *Element, frame: *Frame) DOMRect
 }
 
 pub fn getClientRects(self: *Element, frame: *Frame) ![]*DOMRect {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return &.{};
     }
     const rects = try frame.local_arena.alloc(*DOMRect, 1);
@@ -1557,7 +1543,7 @@ pub fn setScrollLeft(self: *Element, value: i32, frame: *Frame) !void {
 }
 
 pub fn getScrollHeight(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
 
@@ -1574,7 +1560,7 @@ pub fn getScrollHeight(self: *Element, frame: *Frame) f64 {
 }
 
 pub fn getScrollWidth(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
 
@@ -1624,7 +1610,7 @@ fn contentAxis(self: *Element, frame: *Frame, comptime axis: Axis) f64 {
     var child = self.asNode().firstChild();
     while (child) |node| : (child = node.nextSibling()) {
         if (node.is(Element)) |el| {
-            if (el.isVisibleSelf(style_manager)) {
+            if (!style_manager.hasDisplayNone(el, .materialize)) {
                 total += el.getElementAxis(frame, axis).value;
             }
         }
@@ -1636,35 +1622,35 @@ fn contentAxis(self: *Element, frame: *Frame, comptime axis: Axis) f64 {
 // Unlike clientHeight, the root's offsetHeight is its box (the document
 // extent), so it stays on the synthetic root default.
 pub fn getOffsetHeight(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
     return self.boxAxis(frame, .height);
 }
 
 pub fn getOffsetWidth(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
     return self.boxAxis(frame, .width);
 }
 
 pub fn getOffsetTop(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
     return calculateDocumentPosition(self.asNode());
 }
 
 pub fn getOffsetLeft(self: *Element, frame: *Frame) f64 {
-    if (!self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.isVisible(frame, .materialize)) {
         return 0.0;
     }
     return self.horizontalPosition(frame);
 }
 
 pub fn getOffsetParent(self: *Element, frame: *Frame) ?*Element {
-    if (!self.asNode().isConnected() or !self.checkVisibilityCached(null, frame, .materialize)) {
+    if (!self.asNode().isConnected() or !self.isVisible(frame, .materialize)) {
         return null;
     }
 
@@ -1803,7 +1789,7 @@ pub fn horizontalPosition(self: *Element, frame: *Frame) f64 {
         while (sibling) |s| : (sibling = s.nextSibling()) {
             if (s == current) break;
             if (s.is(Element)) |el| {
-                if (el.isVisibleSelf(style_manager)) {
+                if (!style_manager.hasDisplayNone(el, .materialize)) {
                     x += el.getElementAxis(frame, .width).value;
                 }
             }

--- a/src/browser/webapi/ResizeObserver.zig
+++ b/src/browser/webapi/ResizeObserver.zig
@@ -154,15 +154,13 @@ pub fn observesWithin(self: *const ResizeObserver, ancestor: *Element) bool {
 // any, invoke the callback.
 pub fn deliverEntries(self: *ResizeObserver, frame: *Frame) !void {
     var entries: std.ArrayList(*ResizeObserverEntry) = .empty;
-    // Observed elements share ancestors, so one cache serves the whole pass.
-    var visibility_cache: Element.VisibilityCache = .empty;
     for (self._observations.items) |*obs| {
         const target = obs.target;
         const connected = target.asNode().isConnected();
         obs.connected = connected;
 
         const width, const height = blk: {
-            if (!connected or !target.checkVisibilityCached(&visibility_cache, frame, .materialize)) {
+            if (!connected or !target.isVisible(frame, .materialize)) {
                 break :blk .{ 0, 0 };
             }
             break :blk .{

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -122,7 +122,7 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
 }
 
 fn resolvedDimension(element: *Element, dimension: enum { width, height }, frame: *Frame) []const u8 {
-    if (!element.checkVisibilityCached(null, frame, .materialize)) {
+    if (!element.isVisible(frame, .materialize)) {
         return "auto";
     }
     const value = switch (dimension) {

--- a/src/server/cdp/AXNode.zig
+++ b/src/server/cdp/AXNode.zig
@@ -43,7 +43,6 @@ pub const Writer = struct {
     root: *const NodeRegistry.Node,
     registry: *NodeRegistry,
     frame: *Frame,
-    visibility_cache: *DOMNode.Element.VisibilityCache,
     label_index: *Label.LabelByForIndex,
     temp_arena: *lp.Arena,
     // When null, emit the full AX tree (getFullAXTree). When set, walk the
@@ -96,7 +95,7 @@ pub const Writer = struct {
     // when a <label> targets a CSS-hidden checkbox/radio. Shared between the
     // tree (writeNode) and query (emitMatch) paths so the two can't drift.
     fn resolveRole(self: *const Writer, axn: AXNode) !ResolvedRole {
-        if (labelPromotionTarget(axn, self.frame, self.visibility_cache)) |input| {
+        if (labelPromotionTarget(axn, self.frame)) |input| {
             return .{
                 .role = switch (input._input_type) {
                     .checkbox => "checkbox",
@@ -147,7 +146,7 @@ pub const Writer = struct {
                     // visibility:hidden, aria-hidden, hidden, inert). Matches
                     // Chromium: these elements aren't exposed to the AX tree.
                     const child_el = dom_node.as(DOMNode.Element);
-                    if (child_in_aria_hidden or isHidden(child_el, self.frame, self.visibility_cache)) {
+                    if (child_in_aria_hidden or isHidden(child_el, self.frame)) {
                         continue;
                     }
                 },
@@ -536,7 +535,7 @@ pub const Writer = struct {
         try w.objectField("role");
         try self.writeAXValue(.{ .role = resolved.role }, w);
 
-        const ignore = axn.isIgnore(self.frame, self.visibility_cache, in_aria_hidden);
+        const ignore = axn.isIgnore(self.frame, in_aria_hidden);
         try w.objectField("ignored");
         try w.write(ignore);
 
@@ -618,7 +617,7 @@ pub const Writer = struct {
                 // Skip hidden element children so childIds matches the
                 // subtree-pruning done in writeNodeChildren.
                 if (child.is(DOMNode.Element)) |child_el| {
-                    if (child_in_aria_hidden or isHidden(child_el, self.frame, self.visibility_cache)) {
+                    if (child_in_aria_hidden or isHidden(child_el, self.frame)) {
                         continue;
                     }
                 }
@@ -713,7 +712,7 @@ pub const Writer = struct {
         }
 
         const node = try self.registry.register(axn.dom);
-        const ignored = axn.isIgnore(self.frame, self.visibility_cache, in_aria_hidden);
+        const ignored = axn.isIgnore(self.frame, in_aria_hidden);
 
         try w.beginObject();
 
@@ -1210,7 +1209,6 @@ fn nameFromContentRole(role_: ?[]const u8) bool {
 fn labelPromotionTarget(
     axn: AXNode,
     frame: *Frame,
-    cache: *DOMNode.Element.VisibilityCache,
 ) ?*DOMNode.Element.Html.Input {
     // Respect an explicit role= on the label.
     if (axn.role_attr != null) return null;
@@ -1224,7 +1222,7 @@ fn labelPromotionTarget(
 
     // Only promote when the control is hidden; otherwise it appears
     // normally and the label stays as-is.
-    if (!isHidden(control, frame, cache)) return null;
+    if (!isHidden(control, frame)) return null;
 
     if (control.getTag() != .input) return null;
     const input = control.as(DOMNode.Element.Html.Input);
@@ -1280,7 +1278,7 @@ fn scratchAllocator(temp_arena: ?*lp.Arena, frame: *Frame) std.mem.Allocator {
     return if (temp_arena) |a| a.allocator() else frame.call_arena;
 }
 
-fn isHidden(elt: *DOMNode.Element, frame: *Frame, cache: *DOMNode.Element.VisibilityCache) bool {
+fn isHidden(elt: *DOMNode.Element, frame: *Frame) bool {
     if (elt.getAttributeInterned("aria-hidden")) |value| {
         if (std.mem.eql(u8, value, "true")) {
             return true;
@@ -1297,7 +1295,7 @@ fn isHidden(elt: *DOMNode.Element, frame: *Frame, cache: *DOMNode.Element.Visibi
 
     // CSS display:none and visibility:hidden (both inherited from ancestors via
     // style computation). Matches Chromium's AX tree which prunes both.
-    if (frame._style_manager.isHidden(elt, cache, .{ .check_visibility = true }, .scan)) {
+    if (frame._style_manager.isHidden(elt, .{ .check_visibility = true }, .scan)) {
         return true;
     }
 
@@ -1346,7 +1344,7 @@ fn ignoreChildren(self: AXNode) bool {
     };
 }
 
-fn isIgnore(self: AXNode, frame: *Frame, cache: *DOMNode.Element.VisibilityCache, in_aria_hidden: bool) bool {
+fn isIgnore(self: AXNode, frame: *Frame, in_aria_hidden: bool) bool {
     const node = self.dom;
     const role_attr = self.role_attr;
 
@@ -1392,7 +1390,7 @@ fn isIgnore(self: AXNode, frame: *Frame, cache: *DOMNode.Element.VisibilityCache
         return true;
     }
 
-    if (isHidden(elt, frame, cache)) {
+    if (isHidden(elt, frame)) {
         return true;
     }
 
@@ -1407,7 +1405,7 @@ fn isIgnore(self: AXNode, frame: *Frame, cache: *DOMNode.Element.VisibilityCache
             var it = node.childrenIterator();
             while (it.next()) |child| {
                 const axn = AXNode.fromNode(child);
-                if (!axn.isIgnore(frame, cache, in_aria_hidden)) {
+                if (!axn.isIgnore(frame, in_aria_hidden)) {
                     return false;
                 }
             }
@@ -1524,7 +1522,6 @@ test "AXNode: writer" {
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1532,7 +1529,6 @@ test "AXNode: writer" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
     }, .{});
@@ -1616,7 +1612,6 @@ test "AXNode: writer prunes hidden and resolves labels" {
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1624,7 +1619,6 @@ test "AXNode: writer prunes hidden and resolves labels" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
     }, .{});
@@ -1751,7 +1745,6 @@ test "AXNode: Writer query filters by role" {
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1760,7 +1753,6 @@ test "AXNode: Writer query filters by role" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
         .filter = .{ .role = "heading" },
@@ -1834,7 +1826,6 @@ test "AXNode: writer maps password input to textbox" {
     try testing.expectEqual("none", hidden_role);
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1842,7 +1833,6 @@ test "AXNode: writer maps password input to textbox" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
     }, .{});
@@ -1887,7 +1877,6 @@ test "AXNode: Writer query filters by accessible name" {
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1896,7 +1885,6 @@ test "AXNode: Writer query filters by accessible name" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
         .filter = .{ .accessible_name = "Search" },
@@ -1928,7 +1916,6 @@ test "AXNode: Writer query combined role+name filter promotes hidden-input label
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1943,7 +1930,6 @@ test "AXNode: Writer query combined role+name filter promotes hidden-input label
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
         .filter = .{ .accessible_name = "Enable feature", .role = "checkbox" },
@@ -1981,7 +1967,6 @@ test "AXNode: Writer query no match returns empty array" {
     var doc = frame.window._document;
 
     const node = try registry.register(doc.asNode());
-    var visibility_cache: DOMNode.Element.VisibilityCache = .empty;
     var label_index: Label.LabelByForIndex = .{};
     const temp_arena = try frame.getArena(.medium, "AXNode");
     defer temp_arena.release();
@@ -1990,7 +1975,6 @@ test "AXNode: Writer query no match returns empty array" {
         .root = node,
         .registry = &registry,
         .frame = frame,
-        .visibility_cache = &visibility_cache,
         .label_index = &label_index,
         .temp_arena = temp_arena,
         .filter = .{ .role = "marquee" },

--- a/src/server/cdp/CDP.zig
+++ b/src/server/cdp/CDP.zig
@@ -703,15 +703,12 @@ pub const BrowserContext = struct {
         // cross-frame queries produces names/visibility from the wrong document.
         const fallback = self.mainFrame() orelse return error.FrameNotLoaded;
         const frame = root.dom.ownerFrame(fallback);
-        const cache = try frame.call_arena.create(Element.VisibilityCache);
-        cache.* = .empty;
         const label_index = try frame.call_arena.create(Label.LabelByForIndex);
         label_index.* = .{};
         return .{
             .frame = frame,
             .root = root,
             .registry = &self.node_registry,
-            .visibility_cache = cache,
             .label_index = label_index,
             .temp_arena = temp_arena,
             .filter = opts.filter,

--- a/src/server/cdp/CDP.zig
+++ b/src/server/cdp/CDP.zig
@@ -31,7 +31,6 @@ const Mime = @import("../../browser/Mime.zig");
 const Frame = @import("../../browser/Frame.zig");
 const Browser = @import("../../browser/Browser.zig");
 const Session = @import("../../browser/Session.zig");
-const Element = @import("../../browser/webapi/Element.zig");
 const Label = @import("../../browser/webapi/element/html/Label.zig");
 
 const WS = @import("../WS.zig");


### PR DESCRIPTION
Stacked on #3467.

With the visibility memo in place, a `VisibilityCache` / `PointerEventsCache` hit costs exactly what a memo hit costs: one hash probe on an `AutoHashMap(*Element, …)`. The per-call caches therefore only added a second probe per ancestor on every whole-document walk, a `call_arena` allocation per element, and plumbing through `SemanticTree.WalkContext`, `AXNode.Writer`, the CDP accessibility writer, `links`, `ResizeObserver` and `elementFromPoint`. They were also strictly weaker: scoped to one call, so a mutation mid-walk left them stale where the memo recomputes.

This removes the cache types and parameters everywhere. `Element.checkVisibilityCached` is renamed `isVisible` since nothing is passed to it any more; `interactive.classifyInteractivity` loses its cache parameter; the one-line `isVisibleSelf` alias goes in favour of calling `hasDisplayNone` directly.

One walk-shape fix that fell out: `SemanticTree.walk` probed the whole ancestor chain for every node although it never enters a hidden subtree, so below the root only the element's own display can change the answer. It now probes the chain once at the root and the own display per node, like `interactive.walkInteractive` already did.

No behaviour change.
