### PR TITLE
cdp: honor runImmediately, screenWidth/screenHeight and browserContextId

### DIFF
--- a/src/browser/Viewport.zig
+++ b/src/browser/Viewport.zig
@@ -21,6 +21,9 @@ const Viewport = @This();
 width: u32,
 height: u32,
 scale: f32 = 1.0, // for screenshot raster
+// window.screen dimensions; null means the same as the viewport.
+screen_width: ?u32 = null,
+screen_height: ?u32 = null,
 
 pub const default = Viewport{
     .width = 1920,

--- a/src/browser/webapi/Screen.zig
+++ b/src/browser/webapi/Screen.zig
@@ -48,11 +48,13 @@ pub fn getOrientation(self: *Screen, frame: *Frame) !*Orientation {
 }
 
 pub fn getWidth(_: *const Screen, frame: *Frame) u32 {
-    return frame._page.getViewport().width;
+    const viewport = frame._page.getViewport();
+    return viewport.screen_width orelse viewport.width;
 }
 
 pub fn getHeight(_: *const Screen, frame: *Frame) u32 {
-    return frame._page.getViewport().height;
+    const viewport = frame._page.getViewport();
+    return viewport.screen_height orelse viewport.height;
 }
 
 pub const JsApi = struct {

--- a/src/server/cdp/domains/browser.zig
+++ b/src/server/cdp/domains/browser.zig
@@ -86,8 +86,11 @@ fn setDownloadBehavior(cmd: *CDP.Command) !void {
         eventsEnabled: ?bool = null,
     })) orelse return error.InvalidParams;
 
-    if (params.browserContextId != null) {
-        log.warn(.not_implemented, "Browser.setDownloadBehavior", .{ .param = "browserContextId" });
+    if (params.browserContextId) |browser_context_id| {
+        const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
+        if (std.mem.eql(u8, browser_context_id, bc.id) == false) {
+            return error.UnknownBrowserContextId;
+        }
     }
 
     // `default` defers the choice to the browser; we map it to `deny` (no
@@ -331,6 +334,29 @@ test "cdp.browser: setDownloadBehavior stores config on the session" {
     try testing.expectEqual(.deny, bc.session.download_behavior);
     try testing.expect(bc.session.download_path == null);
     try testing.expect(bc.session.download_events_enabled == false);
+}
+
+test "cdp.browser: setDownloadBehavior checks browserContextId" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-DL", .session_id = "SID-DL" });
+
+    try ctx.processMessage(.{
+        .id = 40,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{ .behavior = "allow", .downloadPath = "/tmp/lp-downloads", .browserContextId = "BID-DL" },
+    });
+    try ctx.expectSentResult(null, .{ .id = 40, .session_id = null });
+    try testing.expectEqual(.allow, bc.session.download_behavior);
+
+    try ctx.processMessage(.{
+        .id = 41,
+        .method = "Browser.setDownloadBehavior",
+        .params = .{ .behavior = "deny", .browserContextId = "BID-OTHER" },
+    });
+    try ctx.expectSentError(-31998, "UnknownBrowserContextId", .{ .id = 41 });
+    try testing.expectEqual(.allow, bc.session.download_behavior);
 }
 
 test "cdp.browser: setDownloadBehavior is a no-op when no context is loaded" {

--- a/src/server/cdp/domains/emulation.zig
+++ b/src/server/cdp/domains/emulation.zig
@@ -107,20 +107,6 @@ fn setDeviceMetricsOverride(cmd: *CDP.Command) !void {
             .value = v,
         });
     }
-    if (params.screenWidth) |v| {
-        if (v != 0) log.warn(.not_implemented, "setDeviceMetricsOverride", .{
-            .cdp_cmd = "Emulation.setDeviceMetricsOverride",
-            .param = "screenWidth",
-            .value = v,
-        });
-    }
-    if (params.screenHeight) |v| {
-        if (v != 0) log.warn(.not_implemented, "setDeviceMetricsOverride", .{
-            .cdp_cmd = "Emulation.setDeviceMetricsOverride",
-            .param = "screenHeight",
-            .value = v,
-        });
-    }
 
     // The override is stored on the Browser so it persists across page
     // navigations for the whole CDP connection.
@@ -135,6 +121,8 @@ fn setDeviceMetricsOverride(cmd: *CDP.Command) !void {
         .width = if (params.width > 0) params.width else current.width,
         .height = if (params.height > 0) params.height else current.height,
         .scale = if (dsf > 0) dsf else current.scale,
+        .screen_width = if (params.screenWidth orelse 0 > 0) params.screenWidth else current.screen_width,
+        .screen_height = if (params.screenHeight orelse 0 > 0) params.screenHeight else current.screen_height,
     });
 
     return cmd.sendResult(null, .{});
@@ -306,6 +294,39 @@ test "cdp.Emulation: viewport override fires matchMedia change events" {
     frame.js.localScope(&ls);
     defer ls.deinit();
     const v = try ls.local.exec("events.join() === 'onchange:(max-width: 500px),listener:true,onchange:(max-width: 500px),listener:false'", null);
+    try testing.expect(v.toBool());
+}
+
+test "cdp.Emulation: setDeviceMetricsOverride screenWidth/screenHeight reach window.screen" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-SCR", .url = "hi.html" });
+    const frame = bc.mainFrame().?;
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+
+    try ctx.processMessage(.{
+        .id = 1,
+        .method = "Emulation.setDeviceMetricsOverride",
+        .params = .{ .width = 1280, .height = 720, .deviceScaleFactor = 1, .mobile = false, .screenWidth = 2560, .screenHeight = 1440 },
+    });
+    try ctx.expectSentResult(null, .{ .id = 1 });
+    var v = try ls.local.exec("screen.width === 2560 && screen.height === 1440 && innerWidth === 1280 && innerHeight === 720", null);
+    try testing.expect(v.toBool());
+
+    // 0 keeps the current value, as for width/height.
+    try ctx.processMessage(.{
+        .id = 2,
+        .method = "Emulation.setDeviceMetricsOverride",
+        .params = .{ .width = 1024, .height = 0, .deviceScaleFactor = 0, .mobile = false, .screenWidth = 0, .screenHeight = 0 },
+    });
+    v = try ls.local.exec("screen.width === 2560 && screen.height === 1440 && innerWidth === 1024 && innerHeight === 720", null);
+    try testing.expect(v.toBool());
+
+    try ctx.processMessage(.{ .id = 3, .method = "Emulation.clearDeviceMetricsOverride" });
+    v = try ls.local.exec("screen.width === innerWidth && screen.height === innerHeight", null);
     try testing.expect(v.toBool());
 }
 

--- a/src/server/cdp/domains/page.zig
+++ b/src/server/cdp/domains/page.zig
@@ -154,10 +154,6 @@ fn addScriptToEvaluateOnNewDocument(cmd: *CDP.Command) !void {
 
     const bc = cmd.browser_context orelse return error.BrowserContextNotLoaded;
 
-    if (params.runImmediately) {
-        log.warn(.not_implemented, "addScriptOnNewDocument", .{ .param = "runImmediately" });
-    }
-
     // A worldName registers the world itself.
     var world_name: ?[]const u8 = null;
     if (params.worldName) |name| {
@@ -176,6 +172,30 @@ fn addScriptToEvaluateOnNewDocument(cmd: *CDP.Command) !void {
         .source = source_dupe,
         .world_name = world_name,
     });
+
+    // runImmediately: also evaluate in the current document, in the requested world.
+    if (params.runImmediately) {
+        if (bc.mainFrame()) |frame| {
+            const js_context = if (world_name) |name| blk: {
+                const world = bc.findIsolatedWorld(name) orelse break :blk null;
+                break :blk world.contextFor(frame);
+            } else frame.js;
+            if (js_context) |context| {
+                var ls: js.Local.Scope = undefined;
+                context.localScope(&ls);
+                defer ls.deinit();
+
+                var try_catch: lp.js.TryCatch = undefined;
+                try_catch.init(&ls.local);
+                defer try_catch.deinit();
+
+                ls.local.eval(source_dupe, null) catch |err| {
+                    const caught = try_catch.caughtOrError(cmd.arena, err);
+                    log.warn(.cdp, "script on new doc", .{ .caught = caught });
+                };
+            }
+        }
+    }
 
     var id_buf: [16]u8 = undefined;
     const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{script_id}) catch "1";
@@ -2444,6 +2464,35 @@ test "cdp.frame: address-bar Page.navigate sends no Referer" {
         const v = try ls.local.exec("document.body.innerText.includes('referer=NONE')", null);
         try testing.expect(v.toBool());
     }
+}
+
+test "cdp.frame: addScriptToEvaluateOnNewDocument runImmediately evaluates in the current document" {
+    var ctx = try testing.context();
+    defer ctx.deinit();
+
+    const bc = try ctx.loadBrowserContext(.{ .id = "BID-RI", .url = "hi.html", .target_id = "FID-00000000RI".* });
+
+    try ctx.processMessage(.{
+        .id = 30,
+        .method = "Page.addScriptToEvaluateOnNewDocument",
+        .params = .{ .source = "window.__now = 1", .runImmediately = true },
+    });
+    try ctx.expectSentResult(.{ .identifier = "1" }, .{ .id = 30 });
+
+    // Without the flag the script only runs on the next document.
+    try ctx.processMessage(.{
+        .id = 31,
+        .method = "Page.addScriptToEvaluateOnNewDocument",
+        .params = .{ .source = "window.__later = 1" },
+    });
+    try ctx.expectSentResult(.{ .identifier = "2" }, .{ .id = 31 });
+
+    const f = bc.mainFrame() orelse unreachable;
+    var ls: js.Local.Scope = undefined;
+    f.js.localScope(&ls);
+    defer ls.deinit();
+    const v = try ls.local.exec("window.__now === 1 && window.__later === undefined", null);
+    try testing.expect(v.toBool());
 }
 
 test "cdp.frame: addScriptToEvaluateOnNewDocument" {


### PR DESCRIPTION
Three parameters every Playwright and Stagehand session sends were parsed and then only logged as `not_implemented`:

- `Page.addScriptToEvaluateOnNewDocument` `runImmediately` now also evaluates the script in the current document, in the requested world.
- `Emulation.setDeviceMetricsOverride` `screenWidth`/`screenHeight` now back `window.screen`, stored on the viewport override next to `width`/`height`; `0` keeps the current value, as for the other dimensions.
- `Browser.setDownloadBehavior` `browserContextId` is checked against the loaded context, as the Storage commands already do.

Adds a test for each.

Evidence from the integrations matrix (https://github.com/lightpanda-io/integrations): the "parameters Lightpanda ignores" list on the Playwright detail page goes from four entries to one (`Target.createBrowserContext disposeOnDetach`, which only makes sense with multiple contexts), and on the Stagehand page from three to one (`Page.createIsolatedWorld grantUniveralAccess`). No matrix cell changes.