### PR TITLE
mem: Fix leak when JS is terminated during MO/IO delivery

### DIFF
--- a/src/browser/webapi/IntersectionObserver.zig
+++ b/src/browser/webapi/IntersectionObserver.zig
@@ -45,6 +45,7 @@ _observing: std.ArrayList(*Element) = .empty,
 _root: ?*Element = null,
 _root_margin: []const u8 = "0px",
 _threshold: []const f64 = &.{0.0},
+// these are RC'd (by us, and v8)
 _pending_entries: std.ArrayList(*IntersectionObserverEntry) = .empty,
 // tracked targets that aren't reported yet
 _tracked: std.AutoHashMapUnmanaged(*Element, void) = .{},
@@ -107,11 +108,7 @@ pub fn init(callback: js.Function.Global, options: ?ObserverInit, frame: *Frame)
 
 pub fn deinit(self: *IntersectionObserver, page: *Page) void {
     self._callback.release();
-    for (self._pending_entries.items) |entry| {
-        // These were never handed to v8, they do not have a corresponding
-        // FinalizerCallback. We 100% own them.
-        entry.deinit(page);
-    }
+    releaseAll(self._pending_entries.items, page);
     self._arena.release();
 }
 
@@ -153,12 +150,11 @@ fn unobserve(self: *IntersectionObserver, target: *Element, frame: *Frame) void 
             _ = self._tracked.remove(target);
 
             // Remove any pending entries for this target.
-            // Entries will be cleaned up by V8 GC via the finalizer.
             var j: usize = 0;
             while (j < self._pending_entries.items.len) {
                 if (self._pending_entries.items[j]._target == target) {
                     const entry = self._pending_entries.swapRemove(j);
-                    entry.deinit(frame._page);
+                    entry.releaseRef(frame._page);
                 } else {
                     j += 1;
                 }
@@ -174,9 +170,7 @@ fn unobserve(self: *IntersectionObserver, target: *Element, frame: *Frame) void 
 
 // Drops every observation without touching the frame's observer list
 pub fn reset(self: *IntersectionObserver, page: *Page) void {
-    for (self._pending_entries.items) |entry| {
-        entry.deinit(page);
-    }
+    releaseAll(self._pending_entries.items, page);
     self._pending_entries.clearRetainingCapacity();
     self._tracked.clearRetainingCapacity();
     self._observing.clearRetainingCapacity();
@@ -190,10 +184,24 @@ pub fn disconnect(self: *IntersectionObserver, frame: *Frame) void {
     }
 }
 
-pub fn takeRecords(self: *IntersectionObserver, frame: *Frame) ![]*IntersectionObserverEntry {
-    const entries = try frame.local_arena.dupe(*IntersectionObserverEntry, self._pending_entries.items);
+fn takeRecords(self: *IntersectionObserver, frame: *Frame) !js.Value {
+    const local = frame.js.local orelse return error.NotHandled;
+    const entries = try self.takePendingEntries(frame);
+    // whether we safely deliver these to v8 or not, we're done with these
+    defer releaseAll(entries, frame._page);
+    return local.zigValueToJs(entries, .{});
+}
+
+fn takePendingEntries(self: *IntersectionObserver, frame: *Frame) ![]*IntersectionObserverEntry {
+    const entries = try frame.call_arena.dupe(*IntersectionObserverEntry, self._pending_entries.items);
     self._pending_entries.clearRetainingCapacity();
     return entries;
+}
+
+fn releaseAll(entries: []const *IntersectionObserverEntry, page: *Page) void {
+    for (entries) |entry| {
+        entry.releaseRef(page);
+    }
 }
 
 fn calculateIntersection(
@@ -274,6 +282,7 @@ fn checkIntersection(self: *IntersectionObserver, target: *Element, frame: *Fram
 
     const entry = try arena.create(IntersectionObserverEntry);
     entry.* = .{
+        ._rc = .init(1),
         ._arena = arena,
         ._target = target,
         ._time = frame.window._performance.now(),
@@ -306,7 +315,10 @@ pub fn deliverEntries(self: *IntersectionObserver, frame: *Frame) !void {
         return;
     }
 
-    const entries = try self.takeRecords(frame);
+    const entries = try self.takePendingEntries(frame);
+    // whether we safely deliver these to v8 or not, we're done with these
+    defer releaseAll(entries, frame._page);
+
     var caught: js.TryCatch.Caught = .{};
 
     var ls: js.Local.Scope = undefined;

--- a/src/browser/webapi/MutationObserver.zig
+++ b/src/browser/webapi/MutationObserver.zig
@@ -42,8 +42,8 @@ _rc: lp.RC = .{},
 _arena: *lp.Arena,
 _callback: js.Function.Global,
 _observing: std.ArrayList(Observing) = .empty,
+// these are RC'd (by us, and v8)
 _pending_records: std.ArrayList(*MutationRecord) = .empty,
-
 /// Intrusively linked to next element (see Frame.zig).
 node: std.DoublyLinkedList.Node = .{},
 
@@ -85,11 +85,7 @@ pub fn init(callback: js.Function.Global, frame: *Frame) !*MutationObserver {
 }
 
 pub fn deinit(self: *MutationObserver, page: *Page) void {
-    for (self._pending_records.items) |record| {
-        // These were never handed to v8, they do not have a corresponding
-        // FinalizerCallback. We 100% own them.
-        record.deinit(page);
-    }
+    releaseAll(self._pending_records.items, page);
     self._callback.release();
     self._arena.release();
 }
@@ -175,9 +171,7 @@ pub fn observe(self: *MutationObserver, target: *Node, options: ObserveOptions, 
 }
 
 pub fn disconnect(self: *MutationObserver, frame: *Frame) void {
-    for (self._pending_records.items) |record| {
-        record.deinit(frame._page);
-    }
+    releaseAll(self._pending_records.items, frame._page);
     self._pending_records.clearRetainingCapacity();
 
     if (self._observing.items.len > 0) {
@@ -186,10 +180,24 @@ pub fn disconnect(self: *MutationObserver, frame: *Frame) void {
     self._observing.clearRetainingCapacity();
 }
 
-pub fn takeRecords(self: *MutationObserver, frame: *Frame) ![]*MutationRecord {
-    const records = try frame.local_arena.dupe(*MutationRecord, self._pending_records.items);
+fn takeRecords(self: *MutationObserver, frame: *Frame) !js.Value {
+    const local = frame.js.local orelse return error.NotHandled;
+    const records = try self.takePendingRecords(frame);
+    // whether we safely deliver these to v8 or not, we're done with these
+    defer releaseAll(records, frame._page);
+    return local.zigValueToJs(records, .{});
+}
+
+fn takePendingRecords(self: *MutationObserver, frame: *Frame) ![]*MutationRecord {
+    const records = try frame.call_arena.dupe(*MutationRecord, self._pending_records.items);
     self._pending_records.clearRetainingCapacity();
     return records;
+}
+
+fn releaseAll(records: []const *MutationRecord, page: *Page) void {
+    for (records) |record| {
+        record.releaseRef(page);
+    }
 }
 
 // Called when an attribute changes on any element
@@ -227,6 +235,7 @@ pub fn notifyAttributeChange(
         const arena = try frame.getArena(.tiny, "MutationRecord");
         const record = try arena.create(MutationRecord);
         record.* = .{
+            ._rc = .init(1),
             ._arena = arena,
             ._type = .attributes,
             ._target = target_node,
@@ -271,6 +280,7 @@ pub fn notifyCharacterDataChange(
         const arena = try frame.getArena(.tiny, "MutationRecord");
         const record = try arena.create(MutationRecord);
         record.* = .{
+            ._rc = .init(1),
             ._arena = arena,
             ._type = .characterData,
             ._target = target,
@@ -318,6 +328,7 @@ pub fn notifyChildListChange(
         const arena = try frame.getArena(.tiny, "MutationRecord");
         const record = try arena.create(MutationRecord);
         record.* = .{
+            ._rc = .init(1),
             ._arena = arena,
             ._type = .childList,
             ._target = target,
@@ -343,7 +354,10 @@ pub fn deliverRecords(self: *MutationObserver, frame: *Frame) !void {
 
     // Take a copy of the records and clear the list before calling callback
     // This ensures mutations triggered during the callback go into a fresh list
-    const records = try self.takeRecords(frame);
+    const records = try self.takePendingRecords(frame);
+    // whether we safely deliver these to v8 or not, we're done with these
+    defer releaseAll(records, frame._page);
+
     var ls: js.Local.Scope = undefined;
     frame.js.localScope(&ls);
     defer ls.deinit();
@@ -570,6 +584,45 @@ test "WebApi: MutationObserver requested termination unwinds delivery" {
     try local.eval("window.__wedge = false; window.__target.setAttribute('x', '2');", null);
     env.runMicrotasks();
     try testing.expectEqual(2, try (try local.exec("window.__delivered", null)).toI32());
+}
+
+test "WebApi: MutationObserver terminate requested between observers releases records" {
+    testing.expectLog(&.{ .frame, .frame });
+
+    const frame = try testing.createFrame();
+    defer testing.test_session.closeAllPages();
+
+    var ls: js.Local.Scope = undefined;
+    frame.js.localScope(&ls);
+    defer ls.deinit();
+    const local = &ls.local;
+
+    const env = frame.js.env;
+    defer env.cancelTerminate();
+
+    const State = struct {
+        env: *js.Env,
+
+        fn kill(self: *@This()) void {
+            self.env.requestTerminate();
+        }
+    };
+    var state = State{ .env = env };
+    const kill_cb = local.newCallback(State.kill, &state);
+
+    const setup = try local.exec(
+        \\(function(kill) {
+        \\  const target = document.createElement('div');
+        \\  new MutationObserver(() => { kill(); }).observe(target, { attributes: true });
+        \\  new MutationObserver(() => {}).observe(target, { attributes: true });
+        \\  target.setAttribute('x', '1');
+        \\})
+    , null);
+    const setup_fn = js.Function{ .local = local, .handle = @ptrCast(setup.handle) };
+    try setup_fn.call(void, .{kill_cb});
+
+    env.runMicrotasks();
+    try testing.expectEqual(true, env.terminatePending());
 }
 
 test "WebApi: MutationObserver terminated page tears down" {


### PR DESCRIPTION
Both MO and IO assumed an orderly transfer of its pending records to v8. But, failure to transfer these objects to v8 (e.g. if the terminate flag was set) means the records and their .tiny arenas were lost forever.