### PR TITLE
v8: call v8__Platform__NotifyIsolateShutdown on isolate shutdown

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.5.4'
+    default: 'v0.5.5'
   v8:
     description: 'v8 version to install'
     required: false

--- a/.github/actions/v8-snapshot/action.yml
+++ b/.github/actions/v8-snapshot/action.yml
@@ -13,7 +13,7 @@ inputs:
   zig-v8:
     description: 'zig-v8 release tag the prebuilt lib came from'
     required: false
-    default: 'v0.5.4'
+    default: 'v0.5.5'
 
 runs:
   using: "composite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG MINISIG=0.12
 ARG ZIG_MINISIG=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 ARG V8=14.9.207.35
-ARG ZIG_V8=v0.5.4
+ARG ZIG_V8=v0.5.5
 ARG TARGETPLATFORM
 
 RUN apt-get update -yq && \

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .v8 = .{
-            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/dca81b538a52d5102181517ad87d9105629f94ec.tar.gz",
-            .hash = "v8-0.0.0-xddH6z0NAwA01BzbfQvo1wkOV6f2CjoNatGvv8mUn92X",
+            .url = "https://github.com/lightpanda-io/zig-v8-fork/archive/31b233ce6162c18eb37cacd001473057f75daad9.tar.gz",
+            .hash = "v8-0.0.0-xddH62IdAwCZid1vyAzg_8IiWG4ovW7DbcnSvZd12I9p",
         },
         // .v8 = .{ .path = "../zig-v8-fork" },
         .brotli = .{

--- a/src/browser/js/Env.zig
+++ b/src/browser/js/Env.zig
@@ -241,6 +241,10 @@ pub fn deinit(self: *Env) void {
     allocator.free(self.eternal_function_templates);
     self.private_symbols.deinit();
 
+    // This has to be before it's destroyed, since the handle has to exist to
+    // be able to notify the platform about it. Documentation hits at this order:
+    // "Notifies the given platform about the Isolate getting deleted soon"
+    v8.v8__Platform__NotifyIsolateShutdown(self.platform.handle, self.isolate.handle);
     self.isolate.exit();
     self.isolate.deinit();
     v8.v8__ArrayBuffer__Allocator__DELETE(self.isolate_params.array_buffer_allocator.?);


### PR DESCRIPTION
The v8 documentation says this "Has to be called", and claude flagged it as a potential leak.

Required a new zig-v8-fork build (v0.5.5) which I released.