### PR TITLE
webapi: improve OffscreenCanvas and fetch

### DIFF
--- a/src/browser/tests/canvas/offscreen_canvas.html
+++ b/src/browser/tests/canvas/offscreen_canvas.html
@@ -35,6 +35,11 @@
   testing.expectEqual(true, ctx instanceof OffscreenCanvasRenderingContext2D);
   // We can't really test rendering but let's try to call it at least.
   ctx.fillRect(0, 0, 10, 10);
+
+  testing.expectEqual(canvas, ctx.canvas);
+  testing.expectEqual(64, ctx.canvas.width);
+  testing.expectEqual(ctx, canvas.getContext("2d"));
+  testing.expectEqual(null, canvas.getContext("webgl"));
 }
 </script>
 

--- a/src/browser/tests/net/request.html
+++ b/src/browser/tests/net/request.html
@@ -247,6 +247,67 @@
   });
 </script>
 
+<script id=stream_body type=module>
+  const state = await testing.async();
+  const enc = new TextEncoder();
+
+  // ky's request-streams probe: an open stream body constructs fine, and
+  // since `duplex` is never read, it concludes uploads can't stream.
+  let duplexRead = false;
+  const probe = new Request('https://empty.invalid', {
+    body: new ReadableStream(),
+    method: 'POST',
+    get duplex() { duplexRead = true; return 'half'; },
+  });
+  const probeHasContentType = probe.headers.has('Content-Type');
+
+  // Drained on first use, so a body enqueued after construction is read.
+  let controller;
+  const req1 = new Request('https://example.com', {
+    method: 'POST',
+    body: new ReadableStream({ start(c) { controller = c; } }),
+  });
+  const usedBefore1 = req1.bodyUsed;
+  controller.enqueue(enc.encode('late'));
+  controller.close();
+  const text1 = await req1.text();
+  const usedAfter1 = req1.bodyUsed;
+
+  // Still open at first use: TypeError.
+  const req2 = new Request('https://example.com', { method: 'POST', body: new ReadableStream() });
+  let rejected2 = false;
+  try { await req2.text(); } catch (e) { rejected2 = e instanceof TypeError; }
+
+  // A Request built from one with a stream body carries it.
+  const req3 = new Request(new Request('https://example.com', {
+    method: 'POST',
+    body: new ReadableStream({ start(c) { c.enqueue(enc.encode('carried')); c.close(); } }),
+  }));
+  const text3 = await req3.text();
+
+  // clone() drains, so both copies read the body.
+  const req4 = new Request('https://example.com', {
+    method: 'POST',
+    body: new ReadableStream({ start(c) { c.enqueue(enc.encode('twice')); c.close(); } }),
+  });
+  const req4b = req4.clone();
+  const text4 = await req4.text();
+  const text4b = await req4b.text();
+
+  state.resolve();
+  await state.done(() => {
+    testing.expectFalse(duplexRead);
+    testing.expectFalse(probeHasContentType);
+    testing.expectFalse(usedBefore1);
+    testing.expectEqual('late', text1);
+    testing.expectTrue(usedAfter1);
+    testing.expectTrue(rejected2);
+    testing.expectEqual('carried', text3);
+    testing.expectEqual('twice', text4);
+    testing.expectEqual('twice', text4b);
+  });
+</script>
+
 <script id=content_type_from_body>
   {
     const req = new Request('https://example.com', { method: 'POST', body: 'x' });

--- a/src/browser/webapi/canvas/OffscreenCanvas.zig
+++ b/src/browser/webapi/canvas/OffscreenCanvas.zig
@@ -31,6 +31,7 @@ pub const _prototype_root = true;
 
 _width: u32,
 _height: u32,
+_cached: ?DrawingContext = null,
 
 /// Since there's no base class rendering contexts inherit from,
 /// we're using tagged union.
@@ -61,10 +62,17 @@ fn setHeight(self: *OffscreenCanvas, value: u32) void {
     self._height = value;
 }
 
-fn getContext(_: *OffscreenCanvas, context_type: []const u8, exec: *Execution) !?DrawingContext {
+fn getContext(self: *OffscreenCanvas, context_type: []const u8, exec: *Execution) !?DrawingContext {
+    if (self._cached) |cached| {
+        return switch (cached) {
+            .@"2d" => if (std.mem.eql(u8, context_type, "2d")) cached else null,
+        };
+    }
+
     if (std.mem.eql(u8, context_type, "2d")) {
-        const ctx = try exec._factory.create(OffscreenCanvasRenderingContext2D{});
-        return .{ .@"2d" = ctx };
+        const ctx = try exec._factory.create(OffscreenCanvasRenderingContext2D{ ._canvas = self });
+        self._cached = .{ .@"2d" = ctx };
+        return self._cached;
     }
 
     return null;

--- a/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
+++ b/src/browser/webapi/canvas/OffscreenCanvasRenderingContext2D.zig
@@ -23,6 +23,7 @@ const js = @import("../../js/js.zig");
 const ImageData = @import("../ImageData.zig");
 const context2d = @import("context2d.zig");
 const TextMetrics = @import("TextMetrics.zig");
+const OffscreenCanvas = @import("OffscreenCanvas.zig");
 const CanvasGradient = @import("CanvasGradient.zig");
 const CanvasPattern = @import("CanvasPattern.zig");
 
@@ -32,7 +33,13 @@ const Execution = js.Execution;
 /// It can be obtained with a call to `OffscreenCanvas#getContext`.
 /// https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D
 const OffscreenCanvasRenderingContext2D = @This();
+/// https://html.spec.whatwg.org/multipage/canvas.html#dom-offscreencanvasrenderingcontext2d-canvas
+_canvas: *OffscreenCanvas,
 _state: context2d.State = .{},
+
+fn getCanvas(self: *const OffscreenCanvasRenderingContext2D) *OffscreenCanvas {
+    return self._canvas;
+}
 
 fn getFillStyle(self: *const OffscreenCanvasRenderingContext2D, exec: *const Execution) !context2d.StyleOutput {
     return self._state.getStyle(.fill, exec);
@@ -177,6 +184,7 @@ pub const JsApi = struct {
         pub var class_id: bridge.ClassId = undefined;
     };
 
+    pub const canvas = bridge.accessor(OffscreenCanvasRenderingContext2D.getCanvas, null, .{});
     pub const font = bridge.accessor(OffscreenCanvasRenderingContext2D.getFont, OffscreenCanvasRenderingContext2D.setFont, .{});
     pub const measureText = bridge.function(OffscreenCanvasRenderingContext2D.measureText, .{});
     pub const setLineDash = bridge.function(OffscreenCanvasRenderingContext2D.setLineDash, .{});

--- a/src/browser/webapi/net/Fetch.zig
+++ b/src/browser/webapi/net/Fetch.zig
@@ -58,15 +58,15 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         return resolver.promise();
     };
 
-    if (request._mode == .navigate) {
-        resolver.rejectError("fetch request mode error", .{ .type_error = "Fetch can't be navigate" });
-        return resolver.promise();
-    }
-
     // This Request is never exposed to JS. makeRequest dupes the url/body
     // into the transfer, so nothing references it once we return.
     request.acquireRef();
     defer request.releaseRef(exec.page);
+
+    if (request._mode == .navigate) {
+        resolver.rejectError("fetch request mode error", .{ .type_error = "Fetch can't be navigate" });
+        return resolver.promise();
+    }
 
     if (request._signal) |signal| {
         if (signal._aborted) {
@@ -74,6 +74,14 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
             return resolver.promise();
         }
     }
+
+    const body = request.bodyBytes() catch |err| switch (err) {
+        error.TypeError => {
+            resolver.rejectError("fetch body error", .{ .type_error = "Failed to read ReadableStream body" });
+            return resolver.promise();
+        },
+        else => return err,
+    };
 
     const response = try Response.initPending(exec);
     errdefer response.deinit(exec.page);
@@ -99,7 +107,7 @@ pub fn init(input: Input, options: ?InitOpts, exec: *const Execution) !js.Promis
         .ctx = fetch,
         .url = request._url,
         .method = request._method,
-        .body = request._body,
+        .body = body,
         .resource_type = .fetch,
         .credentials_mode = switch (request._credentials) {
             .omit => .omit,

--- a/src/browser/webapi/net/Request.zig
+++ b/src/browser/webapi/net/Request.zig
@@ -26,6 +26,7 @@ const URL = @import("../URL.zig");
 const Page = @import("../../Page.zig");
 const Blob = @import("../Blob.zig");
 const AbortSignal = @import("../AbortSignal.zig");
+const ReadableStream = @import("../streams/ReadableStream.zig");
 
 const Headers = @import("Headers.zig");
 const FormData = @import("FormData.zig");
@@ -41,6 +42,7 @@ _url: [:0]const u8,
 _method: http.Method,
 _headers: ?*Headers,
 _body: ?[]const u8,
+_body_stream: ?*ReadableStream = null, // drained into `_body` on first use.
 _arena: *lp.Arena,
 _cache: Cache,
 _credentials: Credentials,
@@ -136,7 +138,13 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         .request => |r| if (r._headers) |h| try Headers.initGuarded(.{ .obj = h }, guard, exec) else null,
     };
 
+    var body_stream: ?*ReadableStream = null;
     const body = if (opts.body) |b| blk: {
+        if (b == .stream) {
+            // Drained on first use, not here: the stream may not be closed yet.
+            body_stream = b.stream;
+            break :blk null;
+        }
         const extracted = try b.extract(arena.allocator());
         // Per Fetch §6.5 step 11, the default Content-Type only applies if
         // the user has not already set one via the headers init dict.
@@ -150,9 +158,12 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         break :blk extracted.bytes;
     } else switch (input) {
         .url => null,
-        // Dupe: the source Request owns its body bytes and may be finalized
-        // before this one.
-        .request => |r| if (r._body) |b| try arena.dupe(u8, b) else null,
+        .request => |r| blk: {
+            body_stream = r._body_stream;
+            // Dupe: the source Request owns its body bytes and may be finalized
+            // before this one.
+            break :blk if (r._body) |b| try arena.dupe(u8, b) else null;
+        },
     };
 
     const signal = if (opts.signal) |s|
@@ -173,6 +184,7 @@ pub fn init(input: Input, opts_: ?InitOpts, exec: *const Execution) !*Request {
         ._redirect = opts.redirect,
         ._mode = mode,
         ._body = body,
+        ._body_stream = body_stream,
         ._signal = signal,
     };
     arena.report();
@@ -254,29 +266,42 @@ fn headerGuard(mode: Mode) Headers.Guard {
 }
 
 fn getBodyUsed(self: *const Request) bool {
-    if (self._body == null) {
+    if (self._body == null and self._body_stream == null) {
         return false;
     }
     return self._body_used;
 }
 
-// Marks a present body consumed; a TypeError if it already was.
-fn consume(self: *Request, local: *const js.Local) !void {
-    if (self._body == null) {
-        return;
+pub fn bodyBytes(self: *Request) !?[]const u8 {
+    if (self._body_stream) |stream| {
+        // drain the stram on first use, TypeError if it can't.
+        self._body = try stream.collectBodyBytes(self._arena.allocator());
+        self._body_stream = null;
+    }
+    return self._body;
+}
+
+// Marks a present body consumed and returns it
+fn consume(self: *Request, local: *const js.Local) ![]const u8 {
+    if (self._body == null and self._body_stream == null) {
+        return "";
     }
 
     if (self._body_used) {
         return local.typeError("Body has already been read");
     }
+    const body = self.bodyBytes() catch |err| switch (err) {
+        error.TypeError => return local.typeError("Failed to read ReadableStream body"),
+        else => return err,
+    };
     self._body_used = true;
+    return body orelse "";
 }
 
 pub fn blob(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
+    const body = try self.consume(local);
 
-    const body = self._body orelse "";
     const headers = try self.getHeaders(exec);
     const content_type = try headers.get("content-type", exec) orelse "";
 
@@ -286,15 +311,15 @@ pub fn blob(self: *Request, exec: *const Execution) !js.Promise {
 
 pub fn text(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
-    return local.resolvePromise(body_init.stripUtf8Bom(self._body orelse ""));
+    const body = try self.consume(local);
+    return local.resolvePromise(body_init.stripUtf8Bom(body));
 }
 
 pub fn json(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
+    const body = try self.consume(local);
 
-    const value = local.parseJSON(body_init.stripUtf8Bom(self._body orelse "")) catch {
+    const value = local.parseJSON(body_init.stripUtf8Bom(body)) catch {
         return local.rejectPromise(.{ .syntax_error = "failed to parse" });
     };
     return local.resolvePromise(try value.persist());
@@ -302,32 +327,37 @@ pub fn json(self: *Request, exec: *const Execution) !js.Promise {
 
 pub fn arrayBuffer(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
-    return local.resolvePromise(js.ArrayBuffer{ .values = self._body orelse "" });
+    const body = try self.consume(local);
+    return local.resolvePromise(js.ArrayBuffer{ .values = body });
 }
 
 pub fn bytes(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
-    return local.resolvePromise(js.TypedArray(u8){ .values = self._body orelse "" });
+    const body = try self.consume(local);
+    return local.resolvePromise(js.TypedArray(u8){ .values = body });
 }
 
 pub fn formData(self: *Request, exec: *const Execution) !js.Promise {
     const local = exec.js.local.?;
-    try self.consume(local);
+    // Per Fetch, a null body acts as an empty byte sequence.
+    const body = try self.consume(local);
 
     const headers = try self.getHeaders(exec);
     const content_type = try headers.get("content-type", exec);
-    // Per Fetch, a null body acts as an empty byte sequence.
-    const form_data = body_init.parseFormData(self._body orelse "", content_type, exec) catch |err| switch (err) {
+    const form_data = body_init.parseFormData(body, content_type, exec) catch |err| switch (err) {
         error.OutOfMemory => return err,
         error.TypeError => return local.typeError("Failed to parse body as FormData"),
     };
     return local.resolvePromise(form_data);
 }
 
-pub fn clone(self: *const Request, exec: *const Execution) !*Request {
-    const arena = try exec.getPinnedArena(if (self._body) |b| b.len else 512, "Request.clone");
+pub fn clone(self: *Request, exec: *const Execution) !*Request {
+    // No stream tee: a stream body is drained so each copy owns its bytes.
+    const body = self.bodyBytes() catch |err| switch (err) {
+        error.TypeError => return exec.js.local.?.typeError("Failed to read ReadableStream body"),
+        else => return err,
+    };
+    const arena = try exec.getPinnedArena(if (body) |b| b.len else 512, "Request.clone");
     errdefer arena.release();
 
     const request = try arena.create(Request);
@@ -340,7 +370,7 @@ pub fn clone(self: *const Request, exec: *const Execution) !*Request {
         ._credentials = self._credentials,
         ._redirect = self._redirect,
         ._mode = self._mode,
-        ._body = if (self._body) |b| try arena.dupe(u8, b) else null,
+        ._body = if (body) |b| try arena.dupe(u8, b) else null,
         ._signal = self._signal,
     };
     arena.report();

--- a/src/browser/webapi/net/body_init.zig
+++ b/src/browser/webapi/net/body_init.zig
@@ -113,8 +113,8 @@ pub const BodyInit = union(enum) {
                 };
             },
             .stream => |stream| {
-                // Response special-cases `.stream` before extract. Request/XHR
-                // paths buffer a closed stream synchronously; a stream that
+                // Response and Request special-case `.stream` before extract.
+                // XHR buffers a closed stream synchronously; a stream that
                 // can't be drained here - still open, or already used as a
                 // body - rejects rather than send Content-Length: 0.
                 const bytes = try stream.collectBodyBytes(arena);


### PR DESCRIPTION
1. Add canvas getter to `OffscreenCanvasRenderingContext2D`, and cached contet to OffscreenCanvas, aligning the OffscreenCanvas* with the non-Offscreens

2. Improve Request's stream support, draining on first use

3. Fix Request leak on error (unlikely to happen, but noticed the ordering was wrong.)

1 and 2 were observed in the scraper logs...#1 happens _a lot_ (a wordpress plugin).