### PR TITLE
deps:  upgrade html5ever

### DIFF
--- a/src/browser/tests/domparser.html
+++ b/src/browser/tests/domparser.html
@@ -115,6 +115,19 @@
 }
 </script>
 
+<script id=truncatedMetaCharset>
+{
+  // html5ever < 0.40 indexed past the end of a content attribute that stops
+  // right after "charset", aborting the process.
+  const parser = new DOMParser();
+  for (const content of ['charset', 'charset ', 'text/html;charset', 'text/html; charset', 'text/html;charset=', 'text/html;charset="']) {
+    const markup = '<meta http-equiv="Content-Type" content="' + content.replace(/"/g, '&quot;') + '">';
+    const doc = parser.parseFromString(markup, 'text/html');
+    testing.expectEqual(content, doc.querySelector('meta').getAttribute('content'));
+  }
+}
+</script>
+
 <script id=getElementById>
 {
   const doc = new DOMParser().parseFromString('<div id="new-node">new-node</div>', 'text/html');

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -173,12 +173,13 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+checksum = "a1fb45cc6b576ff3c8053c7a1a4c14b2b24ae166ab6a3e5bc5856aa45d39de70"
 dependencies = [
  "log",
  "markup5ever",
+ "memchr",
 ]
 
 [[package]]
@@ -351,7 +352,6 @@ dependencies = [
  "encoding_rs",
  "html5ever",
  "idna",
- "string_cache",
  "typed-arena",
  "url",
  "xml5ever",
@@ -399,14 +399,20 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "markup5ever"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+checksum = "0ab3dc68ac4a0f5719e560136778c1ee716e296030d75dbd4484e37e39e3a842"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -503,9 +509,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_shared",
  "serde",
@@ -513,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+checksum = "41b585a510fb76fdebead6897982ef2a03a21d8e6cbcca904999742a4afc6ffe"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -523,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -533,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -686,22 +692,21 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "string_cache"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+checksum = "ffa8a5dbe8b3f0bbe29d4c3225daafaeead63afdc1b65fc4c01a1384166038e6"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.6.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+checksum = "d576664ce111e003a5db4748200f838b98043cbc44e6341025cd6a77d40e3944"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -827,9 +832,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "7572660c8890448ba236b7376f27e389c6a7e1c70195622faced601f855c0ada"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -909,9 +914,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xml5ever"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
+checksum = "73290529dc9bc6c6155bf77fdd70ce0061f98ad387586aa3104cddab29206961"
 dependencies = [
  "log",
  "markup5ever",

--- a/src/rust/html5ever/Cargo.toml
+++ b/src/rust/html5ever/Cargo.toml
@@ -8,10 +8,9 @@ name = "lightpanda_html5ever"
 path = "lib.rs"
 
 [dependencies]
-html5ever = "0.39.0"
-string_cache = "0.9.0"
+html5ever = "0.40.0"
 typed-arena = "2.0.2"
-xml5ever = "0.39.0"
+xml5ever = "0.40.0"
 encoding_rs = "0.8"
 idna = "1.1.0"
 url = "2.5.8"

--- a/src/rust/html5ever/sink.rs
+++ b/src/rust/html5ever/sink.rs
@@ -25,7 +25,7 @@ use crate::types::*;
 
 use html5ever::interface::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::tendril::StrTendril;
-use html5ever::{Attribute, QualName};
+use html5ever::{local_name, Attribute, QualName};
 
 type Arena<'arena> = &'arena typed_arena::Arena<ElementData>;
 
@@ -350,7 +350,7 @@ impl<'arena> TreeSink for Sink<'arena> {
         // so anything other than "open" is treated as "closed".
         let mode_is_open = attrs
             .iter()
-            .find(|a| a.name.local.as_ref() == "shadowrootmode")
+            .find(|a| a.name.local == local_name!("shadowrootmode"))
             .map(|a| a.value.as_ref() == "open")
             .unwrap_or(true);
         unsafe {


### PR DESCRIPTION
Specifically for https://github.com/servo/html5ever/commit/a7588d1a94c7f56c7d6e52a4d32c1d330240e809 which addresses an index overflow we saw in prod.