### PR TITLE
chore: dedupe HttpClient.Owner using new GlobalScope

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -76,6 +76,7 @@ const AnimatedPreserveAspectRatio = @import("webapi/svg/AnimatedPreserveAspectRa
 
 const sys_url = @import("../sys/url.zig");
 const HttpClient = @import("../network/HttpClient.zig");
+const GlobalScope = @import("global_scope.zig").GlobalScope;
 
 const GlobalEventHandlersLookup = @import("webapi/global_event_handlers.zig").Lookup;
 
@@ -460,18 +461,7 @@ pub fn init(self: *Frame, frame_id: u32, page: *Page, opts: InitOpts) !void {
     }
     self.window._cross_origin_wrapper = .{ .window = self.window };
 
-    self._http_owner = .{
-        .blob_urls = &page.blob_urls,
-        .origin = &self.origin,
-        .url = &self.url,
-        .parent = if (parent) |p| &p._http_owner else null,
-        .frame_id = frame_id,
-        .document_frame_id = frame_id,
-        .loader_id = self._loader_id,
-        .cookie_jar = &session.cookie_jar,
-        .notification = session.notification,
-        .performance = self.window._performance,
-    };
+    self._http_owner = GlobalScope.initHttpOwner(.{ .frame = self });
 
     self._style_manager = try StyleManager.init(self);
     errdefer self._style_manager.deinit();

--- a/src/browser/global_scope.zig
+++ b/src/browser/global_scope.zig
@@ -19,8 +19,10 @@
 const std = @import("std");
 const lp = @import("lightpanda");
 
+const Notification = @import("../Notification.zig");
 const HttpClient = @import("../network/HttpClient.zig");
 
+const Blob = @import("webapi/Blob.zig");
 const Event = @import("webapi/Event.zig");
 const Console = @import("webapi/Console.zig");
 const Cookie = @import("webapi/storage/Cookie.zig");
@@ -126,6 +128,21 @@ pub const GlobalScope = union(enum) {
         return self.httpOwner().siteForCookies();
     }
 
+    pub fn cookieJar(self: GlobalScope) *Cookie.Jar {
+        return &self.session().cookie_jar;
+    }
+
+    pub fn notification(self: GlobalScope) *Notification {
+        return self.session().notification;
+    }
+
+    // The Page-level blob: URL store, shared by every global on the page.
+    pub fn blobUrls(self: GlobalScope) *const Blob.UrlMap {
+        return switch (self) {
+            inline else => |g| &g._page.blob_urls,
+        };
+    }
+
     // HttpClient.Owner of the current global (Frame or WGS). Used by code
     // that needs to register an in-flight network operation against the
     // owning scope without caring whether it's a Frame or a Worker — e.g.
@@ -133,6 +150,28 @@ pub const GlobalScope = union(enum) {
     pub fn httpOwner(self: GlobalScope) *HttpClient.Owner {
         return switch (self) {
             inline else => |g| &g._http_owner,
+        };
+    }
+
+    // Create an HttpClient.Owner from the GlobalScope
+    pub fn initHttpOwner(self: GlobalScope) HttpClient.Owner {
+        return switch (self) {
+            .frame => |frame| .{
+                .scope = self,
+                .url = &frame.url,
+                .parent = if (frame.parent) |p| &p._http_owner else null,
+                .frame_id = frame._frame_id,
+                .document_frame_id = frame._frame_id,
+                .loader_id = frame._loader_id,
+            },
+            .worker => |worker| .{
+                .scope = self,
+                .url = null,
+                .parent = &worker._frame._http_owner,
+                .frame_id = worker._frame_id,
+                .document_frame_id = worker._frame._frame_id,
+                .loader_id = worker._loader_id,
+            },
         };
     }
 

--- a/src/browser/webapi/WorkerGlobalScope.zig
+++ b/src/browser/webapi/WorkerGlobalScope.zig
@@ -30,6 +30,7 @@ const Frame = @import("../Frame.zig");
 const Factory = @import("../Factory.zig");
 const Session = @import("../Session.zig");
 const HttpClient = @import("../../network/HttpClient.zig");
+const GlobalScope = @import("../global_scope.zig").GlobalScope;
 const EventManagerBase = @import("../EventManagerBase.zig");
 const ScriptManagerBase = @import("../ScriptManagerBase.zig");
 
@@ -174,18 +175,7 @@ pub fn init(
     const self = leaf._proto;
     self._type = @unionInit(Type, @tagName(tag), leaf);
 
-    self._http_owner = .{
-        .blob_urls = &frame._page.blob_urls,
-        .origin = &self.origin,
-        .url = null,
-        .parent = &frame._http_owner,
-        .frame_id = frame_id,
-        .document_frame_id = frame._frame_id,
-        .loader_id = loader_id,
-        .cookie_jar = &session.cookie_jar,
-        .notification = session.notification,
-        .performance = self._performance,
-    };
+    self._http_owner = GlobalScope.initHttpOwner(.{ .worker = self });
 
     self._script_manager = ScriptManagerBase.init(
         arena,

--- a/src/network/HttpClient.zig
+++ b/src/network/HttpClient.zig
@@ -30,6 +30,7 @@ const referrer = @import("../browser/referrer.zig");
 const WebSocket = @import("../browser/webapi/net/WebSocket.zig");
 const Cookie = @import("../browser/webapi/storage/Cookie.zig");
 const Performance = @import("../browser/webapi/Performance.zig");
+const GlobalScope = @import("../browser/global_scope.zig").GlobalScope;
 
 const http = @import("http.zig");
 const Network = @import("Network.zig");
@@ -656,8 +657,8 @@ pub fn newRequest(self: *Client, req: Request, owner: ?*Owner) anyerror!*Transfe
             if (owned.frame_id == 0) owned.frame_id = o.frame_id;
             if (owned.loader_id == 0) owned.loader_id = o.loader_id;
             if (owned.document_frame_id == null) owned.document_frame_id = o.document_frame_id;
-            if (owned.notification == null) owned.notification = o.notification;
-            cookie_jar = o.cookie_jar;
+            if (owned.notification == null) owned.notification = o.scope.notification();
+            cookie_jar = o.scope.cookieJar();
         }
         // Resolved onto the transfer; the request's copy is left null so
         // nothing reads the caller's (possibly short-lived) url through it.
@@ -671,7 +672,7 @@ pub fn newRequest(self: *Client, req: Request, owner: ?*Owner) anyerror!*Transfe
             owned.basic_auth_credentials = try arena.dupeZ(u8, c);
         }
 
-        const raw_origin: ?[]const u8 = req.origin orelse if (owner) |o| o.origin.* else null;
+        const raw_origin: ?[]const u8 = req.origin orelse if (owner) |o| o.scope.origin() else null;
         owned.origin = if (raw_origin) |origin| try arena.dupe(u8, origin) else null;
 
         // The body can be larger, so callers can signal, via the
@@ -2153,15 +2154,12 @@ pub const Owner = struct {
     transfers: std.DoublyLinkedList = .{},
     websockets: std.DoublyLinkedList = .{},
 
-    // The Page-level blob: URL store, shared by every context on the page.
-    blob_urls: *const Blob.UrlMap,
+    // The global these requests are made on behalf of.
+    scope: GlobalScope,
 
-    // The owning Frame's / WorkerGlobalScope's origin slot. Pointer because
-    // it can change during navigation.
-    origin: *const ?[]const u8,
-
-    // The owning Frame's URL slot, a pointer for the same reason. A worker
-    // has none: its site for cookies is its creating document's.
+    // The owning Frame's URL slot. A pointer because it changes during
+    // navigation; a worker has none, its site for cookies is its creating
+    // document's. (We don't use scope beause unit tests fake this, `testOwner`)
     url: ?*const [:0]const u8,
 
     // The parent frame's Owner; for a worker, its creating frame's. Outlives
@@ -2175,9 +2173,6 @@ pub const Owner = struct {
     frame_id: u32,
     document_frame_id: u32,
     loader_id: u32,
-    cookie_jar: *CookieJar,
-    performance: *Performance,
-    notification: *Notification,
 
     const Blob = @import("../browser/webapi/Blob.zig");
 
@@ -2946,7 +2941,7 @@ pub const Transfer = struct {
             owner.parent orelse return null
         else
             owner;
-        return .{ .performance = target.performance, .origin = target.origin.* };
+        return .{ .performance = target.scope.performance(), .origin = target.scope.origin() };
     }
 
     // https://fetch.spec.whatwg.org/#concept-tao-check
@@ -4086,10 +4081,10 @@ const Synthetic = struct {
 
             const owner = transfer.owner orelse return error.BlobNotFound;
             const key = url[0 .. std.mem.indexOfScalar(u8, url, '#') orelse url.len];
-            if (!Owner.Blob.urlBelongsToOrigin(key, owner.origin.*)) {
+            if (!Owner.Blob.urlBelongsToOrigin(key, owner.scope.origin())) {
                 return error.BlobNotFound;
             }
-            const blob = (owner.blob_urls.get(key) orelse return error.BlobNotFound).blob;
+            const blob = (owner.scope.blobUrls().get(key) orelse return error.BlobNotFound).blob;
             // blob can be removed by the time we run, dupe it.
             content_type = try arena.dupe(u8, blob._mime);
             body = try arena.dupe(u8, blob._slice);
@@ -4113,16 +4108,12 @@ const testing = @import("../testing.zig");
 // it: they build their transfers by hand and never go through newRequest.
 fn testOwner(url: ?*const [:0]const u8, parent: ?*const Owner) Owner {
     return .{
-        .blob_urls = undefined,
-        .origin = undefined,
+        .scope = undefined,
         .url = url,
         .parent = parent,
         .frame_id = 0,
         .document_frame_id = 0,
         .loader_id = 0,
-        .cookie_jar = undefined,
-        .notification = undefined,
-        .performance = undefined,
     };
 }
 const AdBlocker = @import("adblock/AdBlocker.zig");


### PR DESCRIPTION
https://github.com/lightpanda-io/browser/pull/3447 made better use of the GlobalScope to simplify various callsites. This changes HttpClient.Owner to contain the global_scope, rather than copying a handful of scope fields.