### PR TITLE
logs: demote UrlBlocked errors from err -> warn

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -1951,7 +1951,8 @@ pub fn scriptAddedCallback(self: *Frame, comptime from_parser: bool, script: *El
     }
 
     self._script_manager.addFromElement(from_parser, script, "parsing") catch |err| {
-        log.err(.frame, "frame.scriptAddedCallback", .{
+        const level: log.Level = if (err == error.UrlBlocked) .warn else .err;
+        log.log(.frame, level, "frame.scriptAddedCallback", .{
             .err = err,
             .url = self.url,
             .src = script.asElement().getAttributeInterned("src"),

--- a/src/browser/webapi/net/XMLHttpRequest.zig
+++ b/src/browser/webapi/net/XMLHttpRequest.zig
@@ -763,7 +763,11 @@ fn _handleError(self: *XMLHttpRequest, err: anyerror) !void {
         try self._proto.dispatch(.load_end, null, exec);
     }
 
-    const level: log.Level = if (err == error.TransferCanceled) .debug else .err;
+    const level: log.Level = switch (err) {
+        error.TransferCanceled => .debug,
+        error.UrlBlocked => .warn,
+        else => .err,
+    };
     log.log(.http, level, "error", .{
         .url = self._url,
         .err = err,


### PR DESCRIPTION
Kept a `UrlBlocked` on the main navigation an error, since that seems something worth raising to the user.