### PR TITLE
Regression test: exception relocated by GC while its TryCatch is read

### DIFF
--- a/src/browser/tests/mutation_observer/callback_exception_moved_by_gc.html
+++ b/src/browser/tests/mutation_observer/callback_exception_moved_by_gc.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../testing.js"></script>
+
+<script id=observerThrowsObjectMovedByGc>
+  {
+    const target = document.createElement('div');
+    new MutationObserver(() => {
+      throw {
+        get message() {
+          const keep = [];
+          for (let round = 0; round < 8; round++) {
+            const junk = [];
+            for (let i = 0; i < 300000; i++) junk.push({ i, s: 'x' + i });
+            keep.push(junk);
+          }
+          return 'moved' + keep.length;
+        },
+        stack: 'stack',
+      };
+    }).observe(target, { attributes: true });
+    target.setAttribute('x', '1');
+    testing.expectEqual('1', target.getAttribute('x'));
+  }
+</script>
+
+<script id=stillAlive>
+  testing.expectEqual(3, 1 + 2);
+</script>


### PR DESCRIPTION
Reduced to the regression test: the code change here was the same as #3497 (`eff118eb2`, "crash: don't copy TryCatch by value"), which landed first.

## Why the test

`TryCatch.caught` allocates on the V8 heap (the `"message"` / `"stack"` key strings) between `TryCatch::Exception()` and `TryCatch::StackTrace()`. If that triggers a scavenge, the GC relocates the freshly thrown exception and updates `exception_` on the TryCatch it registered as a root. Before #3497 the methods took `self` by value, so V8 was handed a copy that still held the old address, and `StackTrace()` read the moved object's map from released new-space memory — a SIGSEGV/SIGBUS at an address inside the pointer-compression cage.

This was near-deterministic on pages that throw in a tight loop (every stack-overflow `RangeError` is a fresh young object). Two crash reports from `https://melaniecasey.myshopify.com/products/blue-sapphire-duet-ring` pinned the faulting instruction in `v8::TryCatch::StackTrace(Context, Value)` reading `exception->map()`, reached from `TryCatch.caughtOrError` via `Window.reportError` → `Function.call` and via MutationObserver delivery.

## Test

`tests/mutation_observer/callback_exception_moved_by_gc.html`: an observer callback throws an object whose `message` getter allocates enough to force several scavenges inside that window. Against a debug V8 the pre-#3497 code failed 7/7 runs (`Debug check failed: LAST_TYPE >= value ([unknown instance type …])`, or an outright segfault at a cage address); with #3497 it passes.
