### PR TITLE
Fix select value assignment with no matching option

### DIFF
--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -2691,6 +2691,7 @@ pub fn removeNode(self: *Frame, parent: *Node, child: *Node, opts: RemoveNodeOpt
     const old_id_maps = idMapsForRoot(old_root);
 
     child._parent = null;
+    Element.Html.Select.optionListChanged(parent, child);
 
     // Update live ranges for removal (DOM spec remove steps 4-7)
     if (child_index_for_ranges) |idx| {
@@ -2920,6 +2921,7 @@ fn _insertNodeRelative(self: *Frame, comptime from_parser: bool, parent: *Node, 
         },
     }
     child._parent = parent;
+    Element.Html.Select.optionListChanged(parent, child);
 
     // Update live ranges for insertion (DOM spec insert step 6).
     // For .before/.after the child was inserted at a specific position;

--- a/src/browser/frame/parse.zig
+++ b/src/browser/frame/parse.zig
@@ -107,6 +107,10 @@ pub fn fragment(frame: *Frame, node: *Node, html: []const u8, opts: FragmentPars
     while (it.next()) |child| {
         child._parent = node;
     }
+    it = node.childrenIterator();
+    while (it.next()) |child| {
+        Element.Html.Select.optionListChanged(node, child);
+    }
 }
 
 // Build a detached XMLDocument from `xml` (DOMParser.parseFromString and

--- a/src/browser/tests/element/html/select.html
+++ b/src/browser/tests/element/html/select.html
@@ -544,3 +544,211 @@
   testing.expectEqual(false, Object.getOwnPropertyDescriptor(opts, 'opt_first').enumerable);
 }
 </script>
+
+<select id="value_no_match" autocomplete="off">
+  <option value="a">A</option>
+  <option value="b" selected>B</option>
+</select>
+<script id="value_set_without_match_deselects_all">
+{
+  const select = $('#value_no_match');
+  testing.expectEqual('b', select.value);
+
+  select.value = 'nope';
+  testing.expectEqual('', select.value);
+  testing.expectEqual(-1, select.selectedIndex);
+  testing.expectEqual(false, select.options[0].selected);
+  testing.expectEqual(false, select.options[1].selected);
+
+  select.value = '';
+  testing.expectEqual('', select.value);
+  testing.expectEqual(-1, select.selectedIndex);
+
+  select.value = 'a';
+  testing.expectEqual('a', select.value);
+  testing.expectEqual(0, select.selectedIndex);
+
+  const empty = document.createElement('option');
+  empty.value = '';
+  select.appendChild(empty);
+  select.value = '';
+  testing.expectEqual('', select.value);
+  testing.expectEqual(2, select.selectedIndex);
+  testing.expectTrue(empty.selected);
+}
+</script>
+
+<script id="value_set_selects_first_matching_option_only">
+{
+  const select = document.createElement('select');
+  for (const v of ['x', 'dup', 'dup']) {
+    const option = document.createElement('option');
+    option.value = v;
+    select.appendChild(option);
+  }
+  for (const multiple of [false, true]) {
+    select.multiple = multiple;
+    select.value = 'dup';
+    testing.expectEqual(1, select.selectedIndex);
+    testing.expectFalse(select.options[0].selected);
+    testing.expectTrue(select.options[1].selected);
+    testing.expectFalse(select.options[2].selected);
+  }
+}
+</script>
+
+<script id="empty_listbox_selection_is_preserved">
+{
+  for (const multiple of [false, true]) {
+    const select = document.createElement('select');
+    select.multiple = multiple;
+    select.size = multiple ? 0 : 3;
+    for (const value of ['a', 'b']) {
+      const option = document.createElement('option');
+      option.value = value;
+      select.appendChild(option);
+    }
+    select.value = 'missing';
+    select.options[1].selected = false;
+    testing.expectEqual('', select.value);
+    testing.expectEqual(-1, select.selectedIndex);
+    testing.expectFalse(select.options[0].selected);
+    testing.expectFalse(select.options[1].selected);
+  }
+}
+</script>
+
+<script id="cleared_selection_resets_on_option_list_changes">
+{
+  const select = document.createElement('select');
+  select.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  select.value = 'missing';
+  select.appendChild(document.createTextNode('text'));
+  select.appendChild(document.createComment('comment'));
+  select.appendChild(document.createElement('div'));
+  select.appendChild(document.createElement('optgroup'));
+  testing.expectEqual('', select.value);
+  testing.expectEqual(-1, select.selectedIndex);
+
+  const option = document.createElement('option');
+  option.value = 'c';
+  select.appendChild(option);
+  testing.expectEqual('a', select.value);
+  testing.expectEqual(0, select.selectedIndex);
+  testing.expectTrue(select.options[0].selected);
+
+  select.value = 'missing';
+  select.removeChild(select.options[0]);
+  testing.expectEqual('b', select.value);
+  testing.expectEqual(0, select.selectedIndex);
+  testing.expectTrue(select.options[0].selected);
+
+  select.selectedIndex = -1;
+  select.insertBefore(option, select.firstChild);
+  testing.expectEqual('b', select.value);
+  testing.expectEqual(1, select.selectedIndex);
+
+  select.value = 'missing';
+  select.innerHTML = '<option value="d">D</option><option value="e">E</option>';
+  testing.expectEqual('d', select.value);
+  testing.expectEqual(0, select.selectedIndex);
+  testing.expectTrue(select.options[0].selected);
+}
+</script>
+
+<script id="cleared_selection_resets_on_grouped_option_changes">
+{
+  const select = document.createElement('select');
+  select.innerHTML = '<option value="a">A</option>';
+  const group = document.createElement('optgroup');
+  group.innerHTML = '<option value="b">B</option>';
+  select.value = 'missing';
+  select.appendChild(group);
+  testing.expectEqual('a', select.value);
+
+  select.value = 'missing';
+  const option = document.createElement('option');
+  option.value = 'c';
+  group.appendChild(option);
+  testing.expectEqual('a', select.value);
+
+  const other = document.createElement('select');
+  other.innerHTML = '<option value="x">X</option>';
+  select.value = 'missing';
+  other.value = 'missing';
+  other.appendChild(option);
+  testing.expectEqual('a', select.value);
+  testing.expectEqual('x', other.value);
+
+  select.value = 'missing';
+  select.removeChild(group);
+  testing.expectEqual('a', select.value);
+
+  select.value = 'missing';
+  const selected = document.createElement('option');
+  selected.value = 'selected';
+  selected.selected = true;
+  select.appendChild(selected);
+  testing.expectEqual('selected', select.value);
+  testing.expectEqual(1, select.selectedIndex);
+}
+</script>
+
+<script id="empty_listbox_stays_empty_after_option_insertion">
+{
+  for (const multiple of [false, true]) {
+    const select = document.createElement('select');
+    select.multiple = multiple;
+    select.size = multiple ? 0 : 3;
+    select.innerHTML = '<option value="a">A</option>';
+    select.value = 'missing';
+    const option = document.createElement('option');
+    option.value = 'b';
+    select.appendChild(option);
+    testing.expectEqual('', select.value);
+    testing.expectEqual(-1, select.selectedIndex);
+    testing.expectFalse(select.options[0].selected);
+    testing.expectFalse(select.options[1].selected);
+  }
+}
+</script>
+
+<script id="mirrored_selects_converge">
+{
+  const makeSelect = (values) => {
+    const select = document.createElement('select');
+    for (const v of values) {
+      const option = document.createElement('option');
+      option.value = v;
+      select.appendChild(option);
+    }
+    return select;
+  };
+  const a = makeSelect(['x', 'y']);
+  const b = makeSelect(['x']);
+  let current = 'x';
+  let hops = 0;
+  const subscribers = [a, b];
+  const next = (value) => {
+    current = value;
+    for (const s of subscribers) {
+      if (s.value !== value) {
+        s.value = value;
+        s.dispatchEvent(new Event('change'));
+      }
+    }
+  };
+  for (const s of subscribers) {
+    s.addEventListener('change', () => {
+      if (++hops > 10) return;
+      next(s.value);
+    });
+  }
+  a.value = 'y';
+  a.dispatchEvent(new Event('change'));
+  testing.expectEqual('', current);
+  testing.expectEqual('', a.value);
+  testing.expectEqual('', b.value);
+  testing.expectTrue(hops < 10);
+}
+</script>

--- a/src/browser/webapi/element/html/Select.zig
+++ b/src/browser/webapi/element/html/Select.zig
@@ -39,7 +39,7 @@ const Select = @This();
 pub const Proto = HtmlElement;
 
 _proto_canary: if (lp.IS_DEBUG) *HtmlElement else void = undefined,
-_selected_index_set: bool = false,
+_explicit_selection: bool = false,
 _custom_validity: ?[]const u8 = null,
 _validity: ?*ValidityState = null,
 
@@ -102,7 +102,6 @@ pub fn deselectOthers(self: *const Select, keep: *const Option) void {
     }
 }
 
-// A non-multiple select with a display size < 2 always has 1 item selected.
 pub fn resetToDefaultSelection(self: *const Select) void {
     if (self.getMultiple() or self.displaySize() > 1) {
         return;
@@ -128,6 +127,28 @@ pub fn resetToDefaultSelection(self: *const Select) void {
     }
 }
 
+pub fn optionListChanged(parent: *Node, child: *Node) void {
+    const select = parent.is(Select) orelse blk: {
+        if (parent.is(Element.Html.OptGroup) == null) return;
+        break :blk (parent.parentNode() orelse return).is(Select) orelse return;
+    };
+    if (!select._explicit_selection) return;
+
+    if (child.is(Option) == null) {
+        if (child.is(Element.Html.OptGroup) == null or parent != select.asNode()) return;
+        var children = child.childrenIterator();
+        while (children.next()) |node| {
+            if (node.is(Option) != null) break;
+        } else return;
+    }
+
+    var options = OptionIterator.init(select);
+    while (options.next()) |option| {
+        if (option.getSelected()) return;
+    }
+    select.resetToDefaultSelection();
+}
+
 // The size attribute, as the size IDL attribute parses it (0 when absent or
 // invalid). Whether the select renders as a menu list or a list box hinges on
 // this, and with it whether an option can be deselected outright.
@@ -137,19 +158,11 @@ fn displaySize(self: *const Select) i64 {
     return @max(parsed, 0);
 }
 
-// Resolves the option whose selectedness contributes to the select's value
-// per HTML §form-elements§selectedness-setting-algorithm: an explicitly
-// selected non-disabled option, falling back to the first non-disabled
-// option in tree order. Returns null if there is no candidate (zero options
-// or every option disabled), in which case the select has no selectedness
-// and contributes no entry to a FormData set.
 pub fn effectiveOption(self: *const Select) ?*Option {
     var first_option: ?*Option = null;
     var it = OptionIterator.init(self);
     while (it.next()) |option| {
-        // Element.isDisabled, not Option.getDisabled: an option is also
-        // disabled when its parent is an <optgroup disabled>
-        // (HTML "concept-option-disabled").
+        // Includes disabled optgroups.
         if (option.asElement().isDisabled()) {
             continue;
         }
@@ -157,6 +170,9 @@ pub fn effectiveOption(self: *const Select) ?*Option {
             return option;
         }
         if (first_option == null) first_option = option;
+    }
+    if (self._explicit_selection) {
+        return null;
     }
     return first_option;
 }
@@ -169,13 +185,14 @@ pub fn getValue(self: *Select, frame: *Frame) []const u8 {
 }
 
 pub fn setValue(self: *Select, value: []const u8, frame: *Frame) !void {
-    // Find option with matching value and select it
-    // Note: This updates the current state (_selected), not the default state (attribute)
-    // Setting value always deselects all others, even for multiple selects
+    var matched = false;
     var it = OptionIterator.init(self);
     while (it.next()) |option| {
-        option._selected = std.mem.eql(u8, option.getValue(frame), value);
+        const is_match = !matched and std.mem.eql(u8, option.getValue(frame), value);
+        option._selected = is_match;
+        if (is_match) matched = true;
     }
+    self._explicit_selection = !matched;
     frame.domChanged();
 }
 
@@ -190,17 +207,14 @@ pub fn getSelectedIndex(self: *Select) i32 {
         }
         index += 1;
     }
-    // If selectedIndex was explicitly set and no option is selected, return -1
-    // If selectedIndex was never set, return 0 (first option implicitly selected) if we have options
-    if (self._selected_index_set) {
+    if (self._explicit_selection) {
         return -1;
     }
     return if (has_options) 0 else -1;
 }
 
 pub fn setSelectedIndex(self: *Select, index: i32, frame: *Frame) !void {
-    // Mark that selectedIndex has been explicitly set
-    self._selected_index_set = true;
+    self._explicit_selection = true;
 
     // Select option at given index
     // Note: This updates the current state (_selected), not the default state (attribute)


### PR DESCRIPTION
## Why

Assigning `select.value` with no matching option must clear the selection: `value` becomes `""` and `selectedIndex` becomes `-1`. Lightpanda instead returned the first enabled option because the getters reapplied the default-selection fallback.

This can prevent change-driven select mirroring from converging. On the Melanie Casey storefront, it produced recursive change events and repeated stack-overflow errors during page loading.

## Changes

- Preserve explicitly cleared selections instead of falling back on reads.
- Restore the single-select default when its option list changes, including optgroups, moves, removals, and fragment parsing.
- Keep empty multiple selects and listboxes unselected.
- Select only the first option matching an assigned value.

## Validation

- Regression coverage for missing/empty values, duplicate values, option-list changes, and bounded select mirroring.
- All 60 assertions in the new test blocks pass in Chromium; separate local mutation probes agree with Chromium.
- Full suite: **1517/1517 passed**.
- `zig build`, `zig fmt --check`, and `git diff --check` pass.
