### PR TITLE
webapi: better handling of frameless documents

### DIFF
--- a/src/NodeRegistry.zig
+++ b/src/NodeRegistry.zig
@@ -73,7 +73,8 @@ pub fn resetFrame(self: *NodeRegistry, arena: Allocator, frame: *Frame) void {
     var it = self.lookup_by_id.valueIterator();
     while (it.next()) |node_ptr| {
         const node = node_ptr.*;
-        if (node.dom.ownerFrame(frame)._page == page) {
+        const owner = node.dom.ownerFrame(frame) orelse frame;
+        if (owner._page == page) {
             doomed.append(arena, node) catch return;
         }
     }

--- a/src/SemanticTree.zig
+++ b/src/SemanticTree.zig
@@ -56,7 +56,7 @@ pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) error{WriteFailed}!
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
         .label_index = &label_index,
-        .owner_frame = self.dom_node.ownerFrame(self.frame),
+        .owner_frame = self.dom_node.ownerFrame(self.frame) orelse self.frame,
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
         log.err(.app, "semantic tree json dump failed", .{ .err = err });
@@ -76,7 +76,7 @@ pub fn textStringify(self: @This(), writer: *std.Io.Writer) error{WriteFailed}!v
         .xpath_buffer = &xpath_buffer,
         .listener_targets = listener_targets,
         .label_index = &label_index,
-        .owner_frame = self.dom_node.ownerFrame(self.frame),
+        .owner_frame = self.dom_node.ownerFrame(self.frame) orelse self.frame,
     };
     self.walk(&ctx, self.dom_node, null, &visitor, 1, 0) catch |err| {
         log.err(.app, "semantic tree text dump failed", .{ .err = err });
@@ -108,7 +108,7 @@ const WalkContext = struct {
     xpath_buffer: *std.ArrayList(u8),
     listener_targets: interactive.ListenerTargetMap,
     label_index: *Label.LabelByForIndex,
-    owner_frame: *Frame, // node's ow frame, not the callers
+    owner_frame: *Frame, // node's own frame, not the caller's (the dumped frame when the node's document has none)
 };
 
 fn walk(

--- a/src/browser/Frame.zig
+++ b/src/browser/Frame.zig
@@ -590,6 +590,10 @@ pub fn deinit(self: *Frame) void {
         worker.deinit();
     }
 
+    // The document outlives the frame (it's nodes stay reachable from any other
+    // live frame)
+    self.document._frame = null;
+
     self._script_manager.base.shutdown = true;
 
     self._script_manager.deinit();
@@ -3249,31 +3253,31 @@ fn nodeIsReady(self: *Frame, comptime from_parser: bool, node: *Node) !void {
             }
         }
 
-        const frame = if (comptime from_parser) self else node.ownerFrame(self);
+        const frame = if (comptime from_parser) self else (node.ownerFrame(self) orelse return);
         frame.scriptAddedCallback(from_parser, script) catch |err| {
             log.err(.frame, "frame.nodeIsReady", .{ .err = err, .element = "script", .type = frame._type, .url = frame.url });
             return err;
         };
     } else if (node.is(IFrame)) |iframe| {
-        const frame = if (comptime from_parser) self else node.ownerFrame(self);
+        const frame = if (comptime from_parser) self else (node.ownerFrame(self) orelse return);
         frame.iframeAddedCallback(iframe) catch |err| {
             log.err(.frame, "frame.nodeIsReady", .{ .err = err, .element = "iframe", .type = frame._type, .url = frame.url });
             return err;
         };
     } else if (node.is(Element.Html.Meta)) |meta| {
-        const frame = if (comptime from_parser) self else node.ownerFrame(self);
+        const frame = if (comptime from_parser) self else (node.ownerFrame(self) orelse return);
         meta.processRefresh(frame) catch |err| {
             log.err(.frame, "frame.nodeIsReady", .{ .err = err, .element = "meta", .type = frame._type, .url = frame.url });
             return err;
         };
     } else if (node.is(Element.Html.Link)) |link| {
-        const frame = if (comptime from_parser) self else node.ownerFrame(self);
+        const frame = if (comptime from_parser) self else (node.ownerFrame(self) orelse return);
         link.linkAddedCallback(frame) catch |err| {
             log.err(.frame, "frame.nodeIsReady", .{ .err = err, .element = "link", .type = frame._type });
             return error.LinkLoadError;
         };
     } else if (node.is(Element.Html.Style)) |style| {
-        const frame = if (comptime from_parser) self else node.ownerFrame(self);
+        const frame = if (comptime from_parser) self else (node.ownerFrame(self) orelse return);
         style.styleAddedCallback(frame) catch |err| {
             log.err(.frame, "frame.nodeIsReady", .{ .err = err, .element = "style", .type = frame._type });
             return error.StyleLoadError;
@@ -3609,7 +3613,7 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
 
     const target: TargetFrame = blk: {
         const target_name = target_name_ orelse {
-            break :blk .{ .frame = form_element.ownerFrame(self) };
+            break :blk .{ .frame = form_element.ownerFrame(self) orelse return };
         };
         break :blk self.resolveTargetFrame(target_name);
     };
@@ -3776,7 +3780,7 @@ pub fn submitForm(self: *Frame, submitter_: ?*Element, form_: ?*Element.Html.For
     // no stray window.
     const target_frame = switch (target) {
         .frame => |f| f,
-        .blank => try form_element.ownerFrame(self).openBlankTarget(form_element, ""),
+        .blank => try (form_element.ownerFrame(self) orelse return).openBlankTarget(form_element, ""),
     };
     return self.scheduleNavigationWithArena(arena, action, opts, .{ .form = target_frame });
 }

--- a/src/browser/frame/user_input.zig
+++ b/src/browser/frame/user_input.zig
@@ -631,7 +631,7 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
         // Navigating to a javascript: URL evaluates the script in the
         // node's frame as a queued task. (A string completion value
         // would replace the document; we ignore results.)
-        return runJavascriptUrl(target.ownerFrame(frame), href["javascript:".len..]);
+        return runJavascriptUrl(target.ownerFrame(frame) orelse return, href["javascript:".len..]);
     }
 
     if (try element.hasAttribute(comptime .wrap("download"), frame)) {
@@ -641,13 +641,13 @@ fn followLink(frame: *Frame, target: *Node, element: *Element, href: []const u8,
 
     const target_frame = blk: {
         if (target_name.len == 0) {
-            break :blk target.ownerFrame(frame);
+            break :blk target.ownerFrame(frame) orelse return;
         }
         break :blk switch (frame.resolveTargetFrame(target_name)) {
             .frame => |f| f,
             .blank => {
                 try element.focus(frame);
-                _ = try target.ownerFrame(frame).openBlankTarget(element, href);
+                _ = try (target.ownerFrame(frame) orelse return).openBlankTarget(element, href);
                 return;
             },
         };

--- a/src/browser/webapi/Document.zig
+++ b/src/browser/webapi/Document.zig
@@ -923,7 +923,7 @@ fn elementFromPointImpl(self: *Document, x: f64, y: f64, ignore_x: bool, frame: 
     var topmost: ?*Element = null;
 
     const root = self.asNode();
-    const style_manager = &root.ownerFrame(frame)._style_manager;
+    const style_manager = &(root.ownerFrame(frame) orelse return null)._style_manager;
     const Entry = struct { node: *Node, hidden: bool };
     var stack: std.ArrayList(Entry) = .empty;
     try stack.append(frame.local_arena, .{ .node = root, .hidden = false });

--- a/src/browser/webapi/Element.zig
+++ b/src/browser/webapi/Element.zig
@@ -1001,7 +1001,7 @@ pub fn getAttributeNamedNodeMap(self: *Element, frame: *Frame) !*Attribute.Named
 // the caller's: attributeChange (which resyncs it) is dispatched on the owner
 // frame, and a same-origin script can reach an element in another frame.
 pub fn getOrCreateStyle(self: *Element, frame: *Frame) !*CSSStyleProperties {
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse frame;
     const gop = try owner._element_styles.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = try CSSStyleProperties.init(self, false, owner);
@@ -1014,7 +1014,7 @@ pub fn existingStyle(self: *Element, frame: *Frame) ?*CSSStyleProperties {
     if (!self._flags.has_inline_style) {
         return null;
     }
-    return self.ownerFrame(frame)._element_styles.get(self);
+    return (self.ownerFrame(frame) orelse frame)._element_styles.get(self);
 }
 
 /// The inline style object, parsed from the style attribute on first use;
@@ -1405,11 +1405,13 @@ pub fn parentElement(self: *Element) ?*Element {
 // the caller's: its stylesheets and materialized inline styles are per-frame,
 // and a same-origin script can reach an element in another frame.
 pub fn hasPointerEventsNone(self: *Element, frame: *Frame) bool {
-    return self.ownerFrame(frame)._style_manager.hasPointerEventsNone(self);
+    const owner = self.ownerFrame(frame) orelse return false;
+    return owner._style_manager.hasPointerEventsNone(self);
 }
 
 pub fn isVisible(self: *Element, frame: *Frame) bool {
-    return !self.ownerFrame(frame)._style_manager.isHidden(self, .{});
+    const owner = self.ownerFrame(frame) orelse return false;
+    return !owner._style_manager.isHidden(self, .{});
 }
 
 const CheckVisibilityOpts = struct {
@@ -1420,7 +1422,8 @@ const CheckVisibilityOpts = struct {
 };
 pub fn checkVisibility(self: *Element, opts_: ?CheckVisibilityOpts, frame: *Frame) bool {
     const opts = opts_ orelse CheckVisibilityOpts{};
-    return !self.ownerFrame(frame)._style_manager.isHidden(self, .{
+    const owner = self.ownerFrame(frame) orelse return false;
+    return !owner._style_manager.isHidden(self, .{
         .check_opacity = opts.checkOpacity or opts.opacityProperty,
         .check_visibility = opts.visibilityProperty or opts.checkVisibilityCSS,
     });
@@ -1556,13 +1559,13 @@ pub fn getClientRects(self: *Element, frame: *Frame) ![]*DOMRect {
 // owner frame first so the state, the fired events and the document
 // comparison stay in the element's frame.
 pub fn getScrollTop(self: *Element, frame: *Frame) u32 {
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return 0;
     const pos = owner._element_scroll_positions.get(self) orelse return 0;
     return pos.y;
 }
 
 pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return;
     const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
@@ -1575,13 +1578,13 @@ pub fn setScrollTop(self: *Element, value: i32, frame: *Frame) !void {
 }
 
 pub fn getScrollLeft(self: *Element, frame: *Frame) u32 {
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return 0;
     const pos = owner._element_scroll_positions.get(self) orelse return 0;
     return pos.x;
 }
 
 pub fn setScrollLeft(self: *Element, value: i32, frame: *Frame) !void {
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return;
     const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
@@ -1656,7 +1659,8 @@ pub fn getScrollWidth(self: *Element, frame: *Frame) f64 {
 // script actually consists of.
 fn contentAxis(self: *Element, frame: *Frame, comptime axis: Axis) f64 {
     var total: f64 = 0;
-    const style_manager = &self.ownerFrame(frame)._style_manager;
+    const owner = self.ownerFrame(frame) orelse return 0;
+    const style_manager = &owner._style_manager;
 
     var child = self.asNode().firstChild();
     while (child) |node| : (child = node.nextSibling()) {
@@ -1824,7 +1828,8 @@ fn countSubtreeNodes(node: *Node) f64 {
 pub fn horizontalPosition(self: *Element, frame: *Frame) f64 {
     var x: f64 = 0.0;
     var current = self.asNode();
-    const style_manager = &self.ownerFrame(frame)._style_manager;
+    const owner = self.ownerFrame(frame) orelse return 0;
+    const style_manager = &owner._style_manager;
 
     if (self.inlineStyle(frame)) |style| {
         x += CSS.parseTranslateX(style.asCSSStyleDeclaration().getPropertyValue("transform", frame));
@@ -1952,7 +1957,7 @@ const ScrollToOpts = union(enum) {
 
 pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return;
     const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
@@ -1977,7 +1982,7 @@ pub fn scrollTo(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !vo
 // scrollBy(): like scrollTo() but relative to the current position.
 pub fn scrollBy(self: *Element, opts: ?ScrollToOpts, y: ?i32, frame: *Frame) !void {
     const o = opts orelse return;
-    const owner = self.ownerFrame(frame);
+    const owner = self.ownerFrame(frame) orelse return;
     const gop = try owner._element_scroll_positions.getOrPut(owner.arena, self);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
@@ -2187,8 +2192,8 @@ pub fn getTag(self: *const Element) Tag {
     };
 }
 
-pub fn ownerFrame(self: *const Element, default: *Frame) *Frame {
-    return self.asConstNode().ownerFrame(default);
+pub fn ownerFrame(self: *const Element, frame: *const Frame) ?*Frame {
+    return self.asConstNode().ownerFrame(frame);
 }
 
 pub const Tag = enum {

--- a/src/browser/webapi/Node.zig
+++ b/src/browser/webapi/Node.zig
@@ -752,16 +752,14 @@ fn ownerDocumentIncludingSelf(self: *const Node, frame: *const Frame) ?*Document
     return self.ownerDocument(frame);
 }
 
-// Returns the Frame that owns this node's tree. Used to tie cached state of
-// "live" collections (NodeList, HTMLCollection, etc.) to the right frame's DOM
-// version: cross-realm callers must invalidate based on mutations through the
-// node's owning frame, not the caller's frame.
-//
-// Falls back to `default` when the node has no associated document yet (e.g.,
-// freshly created and detached) or its document has no frame.
-pub fn ownerFrame(self: *const Node, default: *Frame) *Frame {
-    const doc = self.ownerDocumentIncludingSelf(default) orelse return default;
-    return doc._frame orelse default;
+// Returns the Frame that owns this node's tree, or null when the node's
+// document has none: a DOMParser/XHR/createHTMLDocument document, or one
+// whose frame has since navigated away. Used to tie per-frame state (the
+// StyleManager, live-collection versions, the event manager, ...) to the
+// right frame: cross-realm callers must not use the calling frame's.
+pub fn ownerFrame(self: *const Node, frame: *const Frame) ?*Frame {
+    const doc = self.ownerDocumentIncludingSelf(frame) orelse return null;
+    return doc._frame;
 }
 
 pub const ResolveURLOpts = struct {
@@ -771,11 +769,12 @@ pub const ResolveURLOpts = struct {
 // Resolve a URL relative to this node's owning document.
 // Uses the document's charset for query string encoding (with NCR fallback for unmappable chars).
 pub fn resolveURL(self: *const Node, url: anytype, frame: *Frame, opts: ResolveURLOpts) ![:0]const u8 {
-    const owner_frame = self.ownerFrame(frame);
     const allocator = opts.allocator orelse frame.call_arena;
     const doc: ?*const Document = self.ownerDocumentIncludingSelf(frame);
-    const encoding = if (doc) |d| d.getCharset() else owner_frame.charset;
-    return URL.resolve(allocator, owner_frame.base(), url, .{ .encoding = encoding });
+    const encoding = if (doc) |d| d.getCharset() else frame.charset;
+    // A frameless document (DOMParser, XHR) has no <base>; its URL is the base.
+    const base = if (self.ownerFrame(frame)) |owner| owner.base() else if (doc) |d| d.getURL(frame) else frame.url;
+    return URL.resolve(allocator, base, url, .{ .encoding = encoding });
 }
 
 // Same as `resolveURL` but can't return `TypeError`, this is needed for multiple

--- a/src/browser/webapi/WebDriver.zig
+++ b/src/browser/webapi/WebDriver.zig
@@ -649,7 +649,7 @@ fn hasNonPassiveListener(el: *Element, typ: []const u8, frame: *Frame) bool {
     // Listeners live in the event manager of the element's own frame (and the
     // propagation path ends at that frame's window), which is not the caller's
     // frame when the element belongs to e.g. an iframe's document.
-    const owner = el.ownerFrame(frame);
+    const owner = el.ownerFrame(frame) orelse return false;
     const base = &owner._event_manager.base;
     var current: ?*@import("Node.zig") = el.asNode();
     while (current) |node| : (current = node.parentNode()) {

--- a/src/browser/webapi/css/CSSStyleDeclaration.zig
+++ b/src/browser/webapi/css/CSSStyleDeclaration.zig
@@ -82,15 +82,16 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
     // tree builders (Playwright ariaSnapshot) consult on every element.
     if (self._is_computed) {
         if (self._element) |element| {
-            if (wrapped.eql(comptime .wrap("display"))) {
-                const style_manager = &element.ownerFrame(frame)._style_manager;
-                if (style_manager.hasDisplayNone(element)) {
-                    return "none";
-                }
-            } else if (wrapped.eql(comptime .wrap("visibility"))) {
-                const style_manager = &element.ownerFrame(frame)._style_manager;
-                if (style_manager.hasVisibilityHiddenInherited(element)) {
-                    return "hidden";
+            if (element.ownerFrame(frame)) |owner| {
+                const style_manager = &owner._style_manager;
+                if (wrapped.eql(comptime .wrap("display"))) {
+                    if (style_manager.hasDisplayNone(element)) {
+                        return "none";
+                    }
+                } else if (wrapped.eql(comptime .wrap("visibility"))) {
+                    if (style_manager.hasVisibilityHiddenInherited(element)) {
+                        return "hidden";
+                    }
                 }
             }
         }
@@ -100,29 +101,31 @@ pub fn getPropertyValue(self: *const CSSStyleDeclaration, property_name: []const
         // Only return default values for computed styles
         if (self._is_computed) {
             if (self._element) |element| {
-                const style_manager = &element.ownerFrame(frame)._style_manager;
+                if (element.ownerFrame(frame)) |owner| {
+                    const style_manager = &owner._style_manager;
 
-                if (isCustomProperty(normalized)) {
-                    return style_manager.customPropertyValue(element, wrapped) orelse "";
-                }
+                    if (isCustomProperty(normalized)) {
+                        return style_manager.customPropertyValue(element, wrapped) orelse "";
+                    }
 
-                // Resolve inline `style=` declarations through the element's
-                // parsed inline style, so computed values match `el.style`.
-                if (style_manager.inlineStyleValue(element, wrapped)) |value| {
-                    return value;
-                }
+                    // Resolve inline `style=` declarations through the element's
+                    // parsed inline style, so computed values match `el.style`.
+                    if (style_manager.inlineStyleValue(element, wrapped)) |value| {
+                        return value;
+                    }
 
-                // Computed width/height must agree with the synthetic layout
-                // metrics. Returning "" makes measurement code see
-                // contradictory sizes — jQuery's "shrink text until it fits"
-                // loops then never terminate. jQuery's .width() reads this
-                // value, so it must also carry clientWidth's content fallback
-                // or append-until-wide marquee loops never terminate.
-                if (wrapped.eql(comptime .wrap("width"))) {
-                    return resolvedDimension(element, .width, frame);
-                }
-                if (wrapped.eql(comptime .wrap("height"))) {
-                    return resolvedDimension(element, .height, frame);
+                    // Computed width/height must agree with the synthetic layout
+                    // metrics. Returning "" makes measurement code see
+                    // contradictory sizes — jQuery's "shrink text until it fits"
+                    // loops then never terminate. jQuery's .width() reads this
+                    // value, so it must also carry clientWidth's content fallback
+                    // or append-until-wide marquee loops never terminate.
+                    if (wrapped.eql(comptime .wrap("width"))) {
+                        return resolvedDimension(element, .width, frame);
+                    }
+                    if (wrapped.eql(comptime .wrap("height"))) {
+                        return resolvedDimension(element, .height, frame);
+                    }
                 }
             }
             return getDefaultPropertyValue(self, wrapped);

--- a/src/browser/webapi/element/Attribute.zig
+++ b/src/browser/webapi/element/Attribute.zig
@@ -221,7 +221,7 @@ pub const List = struct {
     // *Attribute until the attribute is removed. The map must be the
     // element's frame's, not the caller's frame.
     pub fn getOrCreateAttribute(self: *const List, entry: *const Entry, element: ?*Element, frame: *Frame) !*Attribute {
-        const owner = if (element) |el| el.ownerFrame(frame) else frame;
+        const owner = if (element) |el| (el.ownerFrame(frame) orelse frame) else frame;
         const gop = try owner._attribute_lookup.getOrPut(owner.arena, .{ .list = self, .name = entry._name_ptr });
         if (!gop.found_existing) {
             gop.value_ptr.* = try entry.toAttribute(element, owner);
@@ -243,7 +243,7 @@ pub const List = struct {
     // run script which mutates the list, moving or shifting entries. The
     // canonical name is interned, so it stays valid.
     fn _put(self: *List, result: NormalizeAndEntry, value: String, element: *Element, frame: *Frame) ![]const u8 {
-        const owner = element.ownerFrame(frame);
+        const owner = element.ownerFrame(frame) orelse frame;
         const is_id = shouldAddToIdMap(result.normalized, element);
 
         var entry: *Entry = undefined;
@@ -312,7 +312,7 @@ pub const List = struct {
 
         const name = try self.put(attribute._name, attribute._value, element, frame);
         attribute._element = element;
-        const owner = element.ownerFrame(frame);
+        const owner = element.ownerFrame(frame) orelse frame;
         try owner._attribute_lookup.put(owner.arena, .{ .list = self, .name = name.ptr }, attribute);
         return existing_attribute;
     }
@@ -350,7 +350,7 @@ pub const List = struct {
     }
 
     fn _delete(self: *List, entry: *Entry, normalized: String, element: *Element, frame: *Frame) void {
-        const owner = element.ownerFrame(frame);
+        const owner = element.ownerFrame(frame) orelse frame;
         const is_id = shouldAddToIdMap(normalized, element);
         const old_value = entry.value();
 

--- a/src/browser/webapi/element/html/Base.zig
+++ b/src/browser/webapi/element/html/Base.zig
@@ -28,8 +28,8 @@ pub fn getHref(self: *Base, frame: *Frame) ![]const u8 {
     if (href.len == 0) {
         return "";
     }
-    const owner = element.asConstNode().ownerFrame(frame);
-    return URL.resolve(frame.local_arena, owner.url, href, .{});
+    const doc = element.asConstNode().ownerDocument(frame).?;
+    return URL.resolve(frame.local_arena, doc.getURL(frame), href, .{});
 }
 
 pub fn setHref(self: *Base, value: []const u8, frame: *Frame) !void {
@@ -45,7 +45,7 @@ pub fn setHref(self: *Base, value: []const u8, frame: *Frame) !void {
         return;
     }
 
-    const owner = node.ownerFrame(frame);
+    const owner = node.ownerFrame(frame) orelse return;
     const first = (try owner.document.querySelector(comptime .wrap("base[href]"), owner)) orelse {
         owner.base_url = null;
         return;

--- a/src/browser/webapi/element/html/Body.zig
+++ b/src/browser/webapi/element/html/Body.zig
@@ -49,50 +49,50 @@ pub fn asNode(self: *Body) *Node {
 // The aliased Window is the one of the element's node document's frame — not
 // the caller's frame, which differs when a same-origin script reaches into
 // another frame (e.g. the parent setting iframeDoc.body.onblur).
-fn reflectedWindow(self: *Body, frame: *Frame) *Window {
-    return self.asElement().ownerFrame(frame).window;
+fn reflectedWindow(self: *Body, frame: *Frame) ?*Window {
+    return (self.asElement().ownerFrame(frame) orelse return null).window;
 }
 
 fn getOnBlur(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_blur;
+    return (self.reflectedWindow(frame) orelse return null)._on_blur;
 }
 fn setOnBlur(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_blur = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_blur = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnError(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_error;
+    return (self.reflectedWindow(frame) orelse return null)._on_error;
 }
 fn setOnError(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_error = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_error = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnFocus(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_focus;
+    return (self.reflectedWindow(frame) orelse return null)._on_focus;
 }
 fn setOnFocus(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_focus = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_focus = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnLoad(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_load;
+    return (self.reflectedWindow(frame) orelse return null)._on_load;
 }
 fn setOnLoad(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_load = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_load = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnResize(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_resize;
+    return (self.reflectedWindow(frame) orelse return null)._on_resize;
 }
 fn setOnResize(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_resize = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_resize = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnScroll(self: *Body, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_scroll;
+    return (self.reflectedWindow(frame) orelse return null)._on_scroll;
 }
 fn setOnScroll(self: *Body, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_scroll = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub const JsApi = struct {
@@ -127,7 +127,7 @@ pub const Build = struct {
 
     pub fn complete(node: *Node, frame: *Frame) !void {
         const el = node.as(Element);
-        const owner = node.ownerFrame(frame);
+        const owner = node.ownerFrame(frame) orelse return;
         inline for (window_reflecting_attributes) |attr| {
             if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
                 owner.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, owner);
@@ -136,12 +136,12 @@ pub const Build = struct {
     }
 
     pub fn attributeChange(el: *Element, name: String, value: String, frame: *Frame) !void {
-        const owner = el.ownerFrame(frame);
+        const owner = el.ownerFrame(frame) orelse return;
         owner.window.setWindowReflectingHandlerFromAttribute(name, value.str(), owner);
     }
 
     pub fn attributeRemove(el: *Element, name: String, frame: *Frame) !void {
-        const owner = el.ownerFrame(frame);
+        const owner = el.ownerFrame(frame) orelse return;
         owner.window.setWindowReflectingHandlerFromAttribute(name, null, owner);
     }
 };

--- a/src/browser/webapi/element/html/Button.zig
+++ b/src/browser/webapi/element/html/Button.zig
@@ -97,7 +97,7 @@ fn getLabels(self: *Button, frame: *Frame) !js.Array {
 
 fn getFormAction(self: *Button, frame: *Frame) ![]const u8 {
     const element = self.asElement();
-    const owner_url = element.ownerFrame(frame).url;
+    const owner_url = element.asNode().ownerDocument(frame).?.getURL(frame);
     const action = element.getAttributeSafe(comptime .wrap("formaction")) orelse return owner_url;
     if (action.len == 0) {
         return owner_url;

--- a/src/browser/webapi/element/html/Form.zig
+++ b/src/browser/webapi/element/html/Form.zig
@@ -109,7 +109,7 @@ pub fn iterator(self: *Form, frame: *Frame) collections.NodeLive(.form) {
 
 fn getAction(self: *Form, frame: *Frame) ![]const u8 {
     const element = self.asElement();
-    const owner_url = element.ownerFrame(frame).url;
+    const owner_url = element.asNode().ownerDocument(frame).?.getURL(frame);
     const action = element.getAttributeInterned("action") orelse return owner_url;
     if (action.len == 0) {
         return owner_url;

--- a/src/browser/webapi/element/html/FrameSet.zig
+++ b/src/browser/webapi/element/html/FrameSet.zig
@@ -31,50 +31,50 @@ pub fn asNode(self: *FrameSet) *Node {
 // The aliased Window is the one of the element's node document's frame — not
 // the caller's frame, which differs when a same-origin script reaches into
 // another frame (e.g. the parent setting a handler on a child frameset).
-fn reflectedWindow(self: *FrameSet, frame: *Frame) *Window {
-    return self.asElement().ownerFrame(frame).window;
+fn reflectedWindow(self: *FrameSet, frame: *Frame) ?*Window {
+    return (self.asElement().ownerFrame(frame) orelse return null).window;
 }
 
 fn getOnBlur(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_blur;
+    return (self.reflectedWindow(frame) orelse return null)._on_blur;
 }
 fn setOnBlur(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_blur = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_blur = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnError(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_error;
+    return (self.reflectedWindow(frame) orelse return null)._on_error;
 }
 fn setOnError(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_error = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_error = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnFocus(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_focus;
+    return (self.reflectedWindow(frame) orelse return null)._on_focus;
 }
 fn setOnFocus(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_focus = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_focus = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnLoad(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_load;
+    return (self.reflectedWindow(frame) orelse return null)._on_load;
 }
 fn setOnLoad(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_load = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_load = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnResize(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_resize;
+    return (self.reflectedWindow(frame) orelse return null)._on_resize;
 }
 fn setOnResize(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_resize = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_resize = Window.getFunctionFromSetter(setter);
 }
 
 fn getOnScroll(self: *FrameSet, frame: *Frame) ?js.Function.Global {
-    return self.reflectedWindow(frame)._on_scroll;
+    return (self.reflectedWindow(frame) orelse return null)._on_scroll;
 }
 fn setOnScroll(self: *FrameSet, setter: ?Window.FunctionSetter, frame: *Frame) !void {
-    self.reflectedWindow(frame)._on_scroll = Window.getFunctionFromSetter(setter);
+    (self.reflectedWindow(frame) orelse return)._on_scroll = Window.getFunctionFromSetter(setter);
 }
 
 pub const JsApi = struct {
@@ -106,7 +106,7 @@ pub const Build = struct {
 
     pub fn complete(node: *Node, frame: *Frame) !void {
         const el = node.as(Element);
-        const owner = node.ownerFrame(frame);
+        const owner = node.ownerFrame(frame) orelse return;
         inline for (window_reflecting_attributes) |attr| {
             if (el.getAttributeSafe(comptime .wrap(attr))) |value| {
                 owner.window.setWindowReflectingHandlerFromAttribute(comptime .wrap(attr), value, owner);
@@ -115,12 +115,12 @@ pub const Build = struct {
     }
 
     pub fn attributeChange(el: *Element, name: String, value: String, frame: *Frame) !void {
-        const owner = el.ownerFrame(frame);
+        const owner = el.ownerFrame(frame) orelse return;
         owner.window.setWindowReflectingHandlerFromAttribute(name, value.str(), owner);
     }
 
     pub fn attributeRemove(el: *Element, name: String, frame: *Frame) !void {
-        const owner = el.ownerFrame(frame);
+        const owner = el.ownerFrame(frame) orelse return;
         owner.window.setWindowReflectingHandlerFromAttribute(name, null, owner);
     }
 };

--- a/src/browser/webapi/element/html/Input.zig
+++ b/src/browser/webapi/element/html/Input.zig
@@ -708,7 +708,7 @@ pub fn getForm(self: *Input, frame: *Frame) ?*Form {
 
 fn getFormAction(self: *Input, frame: *Frame) ![]const u8 {
     const element = self.asElement();
-    const owner_url = element.ownerFrame(frame).url;
+    const owner_url = element.asNode().ownerDocument(frame).?.getURL(frame);
     const action = element.getAttributeSafe(comptime .wrap("formaction")) orelse return owner_url;
     if (action.len == 0) {
         return owner_url;

--- a/src/browser/webapi/element/html/Meta.zig
+++ b/src/browser/webapi/element/html/Meta.zig
@@ -187,7 +187,7 @@ pub const Build = struct {
         if (!name.eql(comptime .wrap("http-equiv")) and !name.eql(comptime .wrap("content"))) {
             return;
         }
-        return element.as(Meta).processRefresh(element.asNode().ownerFrame(frame));
+        return element.as(Meta).processRefresh(element.asNode().ownerFrame(frame) orelse return);
     }
 };
 

--- a/src/browser/webapi/element/svg/TextContent.zig
+++ b/src/browser/webapi/element/svg/TextContent.zig
@@ -89,7 +89,8 @@ fn text(self: *TextContent, frame: *Frame) []const u8 {
 
 fn fontSize(self: *TextContent, frame: *Frame) f64 {
     const element = self.asElement();
-    return element.ownerFrame(frame)._style_manager.computedFontSize(element);
+    const owner = element.ownerFrame(frame) orelse return frame._style_manager.computedFontSize(null);
+    return owner._style_manager.computedFontSize(element);
 }
 
 fn getTextLength(self: *TextContent, frame: *Frame) !*AnimatedLength {

--- a/src/browser/webapi/svg/Length.zig
+++ b/src/browser/webapi/svg/Length.zig
@@ -290,8 +290,8 @@ fn pageViewportDimension(direction: Direction, frame: *Frame) f64 {
 fn resolveParsedLength(parsed: Parsed, element: *Element, direction: Direction, frame: *Frame, depth: u8) f64 {
     const factor = switch (parsed.unit) {
         .percentage => ancestorViewportDimensionAt(element, direction, frame, depth) / 100.0,
-        .em => element.ownerFrame(frame)._style_manager.computedFontSize(element),
-        .ex => element.ownerFrame(frame)._style_manager.computedFontSize(element) / 2.0,
+        .em => elementFontSize(element, frame),
+        .ex => elementFontSize(element, frame) / 2.0,
         else => units.absoluteLengthFactor(toShared(parsed.unit)).?,
     };
     return parsed.value * factor;
@@ -299,7 +299,12 @@ fn resolveParsedLength(parsed: Parsed, element: *Element, direction: Direction, 
 
 fn fontSize(self: *const Length, frame: *Frame) f64 {
     const element = self._element orelse return frame._style_manager.computedFontSize(null);
-    return element.ownerFrame(frame)._style_manager.computedFontSize(element);
+    return elementFontSize(element, frame);
+}
+
+fn elementFontSize(element: *Element, frame: *Frame) f64 {
+    const owner = element.ownerFrame(frame) orelse return frame._style_manager.computedFontSize(null);
+    return owner._style_manager.computedFontSize(element);
 }
 
 const Parsed = struct {

--- a/src/server/cdp/CDP.zig
+++ b/src/server/cdp/CDP.zig
@@ -712,7 +712,7 @@ pub const BrowserContext = struct {
         // checks (`frame._style_manager`) are per-frame; getting this wrong on
         // cross-frame queries produces names/visibility from the wrong document.
         const fallback = self.mainFrame() orelse return error.FrameNotLoaded;
-        const frame = root.dom.ownerFrame(fallback);
+        const frame = root.dom.ownerFrame(fallback) orelse fallback;
         const label_index = try frame.call_arena.create(Label.LabelByForIndex);
         label_index.* = .{};
         return .{


### PR DESCRIPTION
We've auto-injected `*Frame` into WebApi since forever (used to be called *Page, but then we split *Page / *Frame, but same same). And it worked wonderfully: there was always a single *Frame, so the Frame/Context that the JS was being executed in HAD to be the *Frame that a node belonged to.

But with the addition of iframe and popups, that truth no longer holds. The *Frame executing the JS (which is the frame that we auto-inject) isn't necessarily the *Frame that owns a Node.

This is particularly problematic because the *Frame holds a bunch of node/ element data, e.g. `_element_datasets`. So now the DataSet that you get back depends on the context in which its called..they don't have identity and can fall out of sync. Some code calls node.ownerFrame() / node.ownerDocument(), but not all and the hope is to address this throughout the codebase once and for all.

This is the first in a series of commits meant to fix this long-standing issue. All it does is change the node.ownerFrame() return value from *Frame to ?*Frame. It's up to each caller to decide how to handle a frameless node, e.g. clicking a frameless link should not navigate.